### PR TITLE
Revert "Revert "[Chore] bump minimal redis version""

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1200,8 +1200,8 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 3,
-    .patchVersion = 200,
+    .minorVersion = 5,
+    .patchVersion = 0,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {


### PR DESCRIPTION
Reverts RediSearch/RediSearch#8143, re-apply #8128

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change affecting only the minimum Redis version gate at module load; main risk is operational incompatibility for deployments still on <8.5.0.
> 
> **Overview**
> **Bumps the minimum supported Redis server version to `8.5.0`.**
> 
> Users running Redis older than `8.5.0` will now see a startup warning and the module will refuse to load (except in test/sanitizer scenarios where version detection is skipped).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ea0b6fdc5e62c6983907b81c92f4e04209c0317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->