### PR TITLE
[MOD-12372] Remove `disable_sort_checks_in_idlist` feature flag

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -24,7 +24,7 @@ ffi.workspace = true
 field.workspace = true
 inverted_index.workspace = true
 inverted_index_ffi = { path = "../inverted_index_ffi" }
-rqe_iterators = { workspace = true, features = ["disable_sort_checks_in_idlist"] }
+rqe_iterators.workspace = true
 rqe_iterators_interop.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -9,9 +9,6 @@ publish.workspace = true
 # feature enabled when building tests so they can link the C code in build.rs
 # see https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
 unittest = []
-# They currently trigger a bug in hybrid (MOD-12370). This feature should be removed
-# once the bug has been fixed.
-disable_sort_checks_in_idlist = []
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -57,7 +57,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     pub fn with_result(ids: impl Into<OwnedSlice<t_docId>>, result: RSIndexResult<'index>) -> Self {
         let ids = ids.into();
 
-        if SORTED && !cfg!(feature = "disable_sort_checks_in_idlist") {
+        if SORTED {
             debug_assert!(
                 ids.is_sorted_by(|a, b| a < b),
                 "IDs must be sorted and unique"
@@ -101,7 +101,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// Returns `Some(false)` if there is no document with the given ID in the list.
     /// Returns `None` if the iterator has been advanced past the end of the ID list.
     pub(super) fn _skip_to(&mut self, target_id: t_docId) -> Option<bool> {
-        if !SORTED && !cfg!(feature = "disable_sort_checks_in_idlist") {
+        if !SORTED {
             panic!("Can't skip when working with unsorted document ids");
         }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -38,7 +38,6 @@ fn empty_initialization_works() {
     assert!(i.at_eof());
 }
 
-#[cfg(not(feature = "disable_sort_checks_in_idlist"))]
 #[test]
 #[should_panic(expected = "IDs must be sorted and unique")]
 fn unsorted_initialization_of_sorted_variant_panics() {
@@ -54,7 +53,6 @@ fn unsorted_initialization_of_unsorted_variant_works() {
     assert_eq!(RSResultKind::Virtual, result.kind());
 }
 
-#[cfg(not(feature = "disable_sort_checks_in_idlist"))]
 #[test]
 #[should_panic(expected = "Can't skip when working with unsorted document ids")]
 fn unsorted_variant_cannot_skip() {
@@ -62,7 +60,6 @@ fn unsorted_variant_cannot_skip() {
     let _ = i.skip_to(3);
 }
 
-#[cfg(not(feature = "disable_sort_checks_in_idlist"))]
 #[test]
 #[should_panic(expected = "IDs must be sorted and unique")]
 fn duplicate_initialization() {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -42,7 +42,6 @@ fn score_variant_can_handle_unsorted_ids() {
 }
 
 #[test]
-#[cfg(not(feature = "disable_sort_checks_in_idlist"))]
 #[should_panic(expected = "Can't skip when working with unsorted document ids")]
 fn score_variant_cannot_skip() {
     let ids = vec![5, 3, 1, 4, 2];


### PR DESCRIPTION
MOD-12370 has been fixed so we can remove this workaround.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build/config cleanup that only restores always-on invariant checks; runtime impact is limited to debug assertions and existing panic paths for invalid iterator usage.
> 
> **Overview**
> Removes the `disable_sort_checks_in_idlist` feature flag from `rqe_iterators` and stops enabling it from `iterators_ffi`.
> 
> `IdList` now always performs its sorted/unique `debug_assert!` for the sorted variant and always panics on `skip_to` for unsorted variants, with integration tests updated to validate these behaviors unconditionally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 092db9e02ad03096d521129927e5eaffe53a9f37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->