### PR TITLE
exclude MKL from libredisearch_all.a to avoid rustc ICE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,6 +236,10 @@ collect_static_libs(redisearch_c LIBS_TO_MERGE VISITED_TARGETS)
 set(_svs_lib_dir "${CMAKE_BINARY_DIR}/_deps/svs-src/lib")
 if(EXISTS "${_svs_lib_dir}")
     file(GLOB _svs_static_libs "${_svs_lib_dir}/*.a")
+    # Exclude MKL from the combined archive — its ~42K object files overflow
+    # the u16 archive member index in rustc's ar_archive_writer.
+    # MKL is linked separately by the Rust build (see build_utils).
+    list(FILTER _svs_static_libs EXCLUDE REGEX "libmkl_static_library\\.a$")
     list(APPEND LIBS_TO_MERGE ${_svs_static_libs})
     message(STATUS "SVS static libraries found: ${_svs_static_libs}")
 else()

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -107,6 +107,7 @@ pub fn run_cbindgen(header_path: impl AsRef<Path>) -> Result<(), Box<dyn std::er
 pub fn bind_foreign_c_symbols() {
     force_link_time_symbol_resolution();
     link_redisearch_all();
+    link_mkl();
     link_c_plusplus();
 }
 
@@ -120,8 +121,13 @@ fn force_link_time_symbol_resolution() {
     }
 }
 
-fn link_redisearch_all() {
-    let bin_root = if let Ok(bin_root) = std::env::var("BINDIR") {
+/// Return the CMake build output directory.
+///
+/// When the top-level build coordinator sets `BINDIR`, that value is used
+/// directly. Otherwise we fall back to the conventional release layout
+/// derived from the git root.
+fn bin_root() -> PathBuf {
+    if let Ok(bin_root) = std::env::var("BINDIR") {
         // The directory changes depending on a variety of factors: target architecture, target OS,
         // optimization level, coverage, etc.
         // We rely on the top-level build coordinator to give us the correct path, rather
@@ -141,9 +147,48 @@ fn link_redisearch_all() {
         root.join(format!(
             "bin/{target_os}-{target_arch}-release/search-community/"
         ))
-    };
+    }
+}
 
-    link_static_lib(&bin_root, "src", "redisearch_all").unwrap();
+/// Link `libredisearch_all.a` using the `-bundle` modifier.
+///
+/// The `-bundle` modifier prevents the (very large) C archive from being
+/// embedded into every Rust rlib in the dependency tree. Instead, the linker
+/// flag `-lredisearch_all` propagates to final binaries (tests, benchmarks)
+/// where the linker selectively pulls only the objects that are actually
+/// needed. This avoids two problems:
+///
+/// 1. Cross-crate rlib contamination during `cargo test --workspace`, where
+///    C objects bundled into one crate's rlib can trigger undefined-symbol
+///    errors in unrelated workspace members.
+/// 2. Archive member counts exceeding `u16::MAX` in rustc's
+///    `ar_archive_writer` when MKL or other large archives are involved.
+fn link_redisearch_all() {
+    let bin_root = bin_root();
+    let lib_dir = bin_root.join("src");
+    let lib = lib_dir.join("libredisearch_all.a");
+    if std::fs::exists(&lib).unwrap_or(false) {
+        println!("cargo::rustc-link-lib=static:-bundle=redisearch_all");
+        println!("cargo::rerun-if-changed={}", lib.display());
+        println!("cargo::rustc-link-search=native={}", lib_dir.display());
+    } else {
+        panic!("Static library not found: {}", lib.display());
+    }
+}
+
+/// Link Intel MKL separately if present.
+///
+/// MKL is excluded from `libredisearch_all.a` because its ~42K object files
+/// overflow the `u16` archive member index in rustc's `ar_archive_writer`.
+/// Like `redisearch_all`, we link with `-bundle` to avoid rlib bloat.
+fn link_mkl() {
+    let svs_lib_dir = bin_root().join("_deps/svs-src/lib");
+    let mkl = svs_lib_dir.join("libmkl_static_library.a");
+    if std::fs::exists(&mkl).unwrap_or(false) {
+        println!("cargo::rerun-if-changed={}", mkl.display());
+        println!("cargo::rustc-link-search=native={}", svs_lib_dir.display());
+        println!("cargo::rustc-link-lib=static:-bundle=mkl_static_library");
+    }
 }
 
 /// Link the C++ standard library using the platform's default.


### PR DESCRIPTION
When BUILD_INTEL_SVS_OPT=yes, Intel MKL (~42K object files) was merged into libredisearch_all.a, causing the total archive member count to exceed 65,535. This overflows a u16 index in rustc's ar_archive_writer during cargo test, triggering an internal compiler error.

Fix by filtering libmkl_static_library.a out of the CMake combined archive and linking it separately in the Rust build with the -bundle modifier, so it remains available for test binaries without being re-bundled into the redisearch_rs staticlib.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/linkage-only changes intended to avoid a compiler crash; risk is limited to environments that enable SVS/MKL and could surface as new link errors if paths or flags are wrong.
> 
> **Overview**
> Fixes `cargo test`/bench failures when Intel MKL is enabled by preventing MKL’s huge static archive from being merged into `libredisearch_all.a` (which can overflow rustc’s archive member index and trigger an ICE).
> 
> CMake now filters out `libmkl_static_library.a` from the combined archive, and the Rust build utils link `libredisearch_all.a` (and MKL, when present) separately using `-bundle` so the final test/benchmark binaries still resolve the needed symbols without bloating intermediate Rust `rlib`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21691fd9f1643c4dac7c7eb6cffed27f133fc4d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->