### PR TITLE
Extend CI benchmarks to include mixed search/write vector benchmarks

### DIFF
--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512-mixed-5pct_updates.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512-mixed-5pct_updates.yml
@@ -1,0 +1,25 @@
+version: 0.5
+name: "vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512-mixed-5pct_updates"
+metadata:
+  component: "vecsim"
+
+timeout_seconds: 1800
+setups:
+  - oss-standalone
+  - oss-standalone-threads-6
+
+
+dbconfig:
+  dataset_name: "vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512"
+  dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/internal.tasks/arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512/vector.arxiv-titles-384-angular-filters.dump.NOINDEX.rdb"
+  dataset_load_timeout_secs: 1000
+  init_commands:
+    - '"FT.CREATE" "idx" "SCHEMA" "vector" "VECTOR" "hnsw" "10" "TYPE" "float32" "DIM" "384" "DISTANCE_METRIC" "COSINE" "M" "32" "EF_CONSTRUCTION" "512" "update_date_ts" "NUMERIC" "SORTABLE" "labels" "TAG" "SEPARATOR" ";" "SORTABLE" "submitter" "TAG" "SEPARATOR" ";" "SORTABLE"'
+
+  check:
+    keyspacelen: 2141205
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 32 -t 1  --hide-histogram --monitor-input https://s3.us-east-1.amazonaws.com/benchmarks.redislabs/redisearch/internal.tasks/arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512/vector.arxiv-titles-384-angular-filters.50K-QUERIES_and_2.5K-UPDATES.monitor.txt --command '__monitor_line@__'"

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512-query-only.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512-query-only.yml
@@ -1,0 +1,25 @@
+version: 0.5
+name: "vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512-query-only"
+metadata:
+  component: "vecsim"
+
+timeout_seconds: 1800
+setups:
+  - oss-standalone
+  - oss-standalone-threads-6
+
+
+dbconfig:
+  dataset_name: "vecsim-arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512"
+  dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/internal.tasks/arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512/vector.arxiv-titles-384-angular-filters.dump.NOINDEX.rdb"
+  dataset_load_timeout_secs: 1000
+  init_commands:
+    - '"FT.CREATE" "idx" "SCHEMA" "vector" "VECTOR" "hnsw" "10" "TYPE" "float32" "DIM" "384" "DISTANCE_METRIC" "COSINE" "M" "32" "EF_CONSTRUCTION" "512" "update_date_ts" "NUMERIC" "SORTABLE" "labels" "TAG" "SEPARATOR" ";" "SORTABLE" "submitter" "TAG" "SEPARATOR" ";" "SORTABLE"'
+
+  check:
+    keyspacelen: 2141205
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 32 -t 1  --hide-histogram --monitor-input https://s3.us-east-1.amazonaws.com/benchmarks.redislabs/redisearch/internal.tasks/arxiv-titles-384-angular-filters-redis-hnsw-m-32-ef-512/vector.arxiv-titles-384-angular-filters.50K-QUERIES.monitor.txt --command '__monitor_line@__'"


### PR DESCRIPTION
This PR relies on the latest memtier feature introduced in https://github.com/redis/memtier_benchmark/commit/1e7877b59dfe7d0f309e4e88ff0d2af6433a76d9, and will only work as soon as we release also support for it in https://github.com/redis-performance/redisbench-admin/pull/502 (being reviewed now). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new benchmark YAML definitions only; main risk is CI instability or skewed results if the external datasets/monitor files or memtier feature compatibility change.
> 
> **Overview**
> Adds two new VecSim benchmark configs for the arxiv-titles HNSW (384-dim, cosine, M=32/EF=512) dataset: a *query-only* workload and a *mixed* workload with ~5% updates.
> 
> Both benchmarks run via `memtier_benchmark` using monitor-input scripts, enabling CI to track vector search performance under read-only vs concurrent search/write conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a068e349c09c7464644a2755df5eed433fcc062e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->