### PR TITLE
[8.6] MOD-10798, MOD-14094: Support K Ratio argument in FT.HYBRID vector query (#8227)

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2095,6 +2095,13 @@
                     "optional": true
                   },
                   {
+                    "name": "shard_k_ratio",
+                    "type": "double",
+                    "token": "SHARD_K_RATIO",
+                    "optional": true,
+                    "since": "8.6.1"
+                  },
+                  {
                     "name": "yield_score_as",
                     "type": "string",
                     "token": "YIELD_SCORE_AS",

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2348,6 +2348,13 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
                   {
+                    .name = "shard_k_ratio",
+                    .token = "SHARD_K_RATIO",
+                    .since = "8.6.1",
+                    .type = REDISMODULE_ARG_TYPE_DOUBLE,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
+                  {
                     .name = "yield_score_as",
                     .token = "YIELD_SCORE_AS",
                     .type = REDISMODULE_ARG_TYPE_STRING,

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -48,6 +48,7 @@ typedef struct ConcurrentCmdCtx {
   int options;
   WeakRef spec_ref;
   rs_wall_clock_ns_t coordStartTime;  // Time when command was received on coordinator
+  size_t numShards;                   // Number of shards in the cluster (captured from main thread)
 } ConcurrentCmdCtx;
 
 /* Run a function on the concurrent thread pool */
@@ -99,6 +100,10 @@ rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(ConcurrentCmdCtx *cctx) {
   return cctx->coordStartTime;
 }
 
+size_t ConcurrentCmdCtx_GetNumShards(const ConcurrentCmdCtx *cctx) {
+  return cctx->numShards;
+}
+
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                           ConcurrentSearchHandlerCtx *handlerCtx) {
@@ -108,6 +113,7 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler han
   cmdCtx->argc = argc;
   cmdCtx->spec_ref = handlerCtx->spec_ref;
   cmdCtx->coordStartTime = handlerCtx->coordStartTime;
+  cmdCtx->numShards = handlerCtx->numShards;
   cmdCtx->ctx = RedisModule_GetThreadSafeContext(cmdCtx->bc);
   RS_AutoMemory(cmdCtx->ctx);
   cmdCtx->handler = handler;

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -50,6 +50,7 @@ typedef struct ConcurrentSearchHandlerCtx {
   rs_wall_clock_ns_t coordQueueTime;  // Time spent waiting in coordinator thread pool queue
   WeakRef spec_ref;                   // Weak reference to the index spec
   bool isProfile;                     // Whether this is an FT.PROFILE command
+  size_t numShards;                   // Number of shards in the cluster (captured from main thread)
 } ConcurrentSearchHandlerCtx;
 
 #define CMDCTX_KEEP_RCTX 0x01
@@ -72,6 +73,9 @@ WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 
 // Returns the coordinator start time held in the context.
 rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(struct ConcurrentCmdCtx *cctx);
+
+// Returns the number of shards captured from the main thread.
+size_t ConcurrentCmdCtx_GetNumShards(const struct ConcurrentCmdCtx *cctx);
 
 /* Same as handleRedis command, but set flags for the concurrent context */
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -21,6 +21,8 @@
 #include "info/global_stats.h"
 #include "profile/profile.h"
 #include "dist_profile.h"
+#include "shard_window_ratio.h"
+#include "config.h"
 
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
@@ -111,14 +113,26 @@ static int MRCommand_appendVsimFilter(MRCommand *xcmd, RedisModuleString **argv,
 
 /**
  * Appends all VSIM-related arguments to MR command.
- * This includes VSIM keyword, field, vector, KNN/RANGE method, and VSIM FILTER if present.
+ * This includes VSIM keyword, field, vector, KNN/RANGE method, and VSIM FILTER
+ * if present.
+ *
+ * SHARD_K_RATIO is only valid for KNN queries, but this is validated during
+ * parsing - no validation is done here.
  *
  * @param xcmd - destination MR command to append arguments to
  * @param argv - source command arguments array
  * @param argc - total argument count
  * @param vsimOffset - offset where VSIM keyword appears
+ * @param kArgIndex - output parameter for the index of the K value argument in
+ *        the built command (set to -1 if no KNN K argument found). Can be NULL.
  */
-static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv, int argc, int vsimOffset) {
+static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
+                                 int argc, int vsimOffset, int *kArgIndex) {
+  RS_LOG_ASSERT(kArgIndex, "kArgIndex must not be NULL");
+
+  // Initialize output parameter
+  *kArgIndex = -1;
+
   // Add VSIM keyword and field
   MRCommand_AppendRstr(xcmd, argv[vsimOffset]);     // VSIM
   MRCommand_AppendRstr(xcmd, argv[vsimOffset + 1]); // field
@@ -148,9 +162,27 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv, int 
     if (vectorMethodOffset < argc - 2) {
       RedisModule_StringToLongLong(argv[vectorMethodOffset + 1], &methodNargs);
 
-      // Append method name, argument count, and all method arguments
-      for (int i = 0; i < methodNargs + 2; ++i) {
-        MRCommand_AppendRstr(xcmd, argv[vectorMethodOffset + i]);
+      // Append method name (KNN/RANGE) and argument count
+      MRCommand_AppendRstr(xcmd, argv[vectorMethodOffset]);     // KNN or RANGE
+      MRCommand_AppendRstr(xcmd, argv[vectorMethodOffset + 1]); // argument count
+
+      // Append method arguments
+      // Format for KNN: KNN <count> K <value> [EF_RUNTIME <value>]...
+      for (int i = 2; i < methodNargs + 2; ++i) {
+        size_t argLen;
+        const char *argStr = RedisModule_StringPtrLen(argv[vectorMethodOffset + i], &argLen);
+        bool kFound = (argLen == 1 && strncasecmp(argStr, "K", 1) == 0);
+
+        if (*kArgIndex == -1 && kFound && i + 1 < methodNargs + 2) {
+          // Found K keyword - append it and record position of the K value
+          MRCommand_AppendRstr(xcmd, argv[vectorMethodOffset + i]);  // K keyword
+          ++i;  // Move to K value
+          *kArgIndex = xcmd->num;  // Record position where K value will be appended
+          MRCommand_AppendRstr(xcmd, argv[vectorMethodOffset + i]);  // K value
+        } else {
+          // Regular argument - append as-is
+          MRCommand_AppendRstr(xcmd, argv[vectorMethodOffset + i]);
+        }
       }
     }
   }
@@ -193,7 +225,8 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv, int 
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, HybridPipelineParams *hybridParams) {
+                            IndexSpec *sp, const VectorQuery *vq,
+                            size_t numShards) {
   int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
@@ -216,7 +249,17 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   // Add all VSIM-related arguments (VSIM, field, vector, methods, filter)
   int vsimOffset = RMUtil_ArgIndex("VSIM", argv, argc);
-  MRCommand_appendVsim(xcmd, argv, argc, vsimOffset);
+  int kArgIndex = -1;
+  MRCommand_appendVsim(xcmd, argv, argc, vsimOffset, &kArgIndex);
+
+  // Calculate and apply effective K for KNN queries if SHARD_K_RATIO is set
+  if (vq && vq->type == VECSIM_QT_KNN) {
+    double shardWindowRatio = vq->knn.shardWindowRatio;
+    if (shardWindowRatio < MAX_SHARD_WINDOW_RATIO && numShards > 1) {
+      size_t effectiveK = calculateEffectiveK(vq->knn.k, shardWindowRatio, numShards);
+      modifyVsimKNN(xcmd, kArgIndex, effectiveK, vq->knn.k);
+    }
+  }
 
   int combineOffset = RMUtil_ArgIndex("COMBINE", argv + vsimOffset, argc - vsimOffset);
   combineOffset = combineOffset != -1 ? combineOffset + vsimOffset : -1;
@@ -526,8 +569,9 @@ void printDistHybridProfile(RedisModule_Reply *reply, void *ctx) {
                         printDistHybridCoordinatorProfile, ctx);
 }
 
-static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx *ctx,
-        RedisModuleString **argv, int argc, IndexSpec *sp, QueryError *status) {
+static int HybridRequest_prepareForExecution(HybridRequest *hreq,
+        RedisModuleCtx *ctx, RedisModuleString **argv, int argc, IndexSpec *sp,
+        size_t numShards, QueryError *status) {
 
     hreq->tailPipeline->qctx.err = status;
     hreq->profile = printDistHybridProfile;
@@ -598,7 +642,15 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
 
     // Construct the command string
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized, sp, &hybridParams);
+    // Get the VectorQuery from the vector request's AST for SHARD_K_RATIO
+    // optimization
+    // Note: parsedVectorData is only set on shards, not on coordinator
+    // The coordinator has the VectorQuery in the AST after parsing
+    const AREQ *vectorRequest = hreq->requests[VECTOR_INDEX];
+    const VectorQuery *vq = (vectorRequest->ast.root && vectorRequest->ast.root->type == QN_VECTOR)
+                      ? vectorRequest->ast.root->vn.vq : NULL;
+    HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized,
+                                 sp, vq, numShards);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;
@@ -650,7 +702,7 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
 
     // Get the command from the RPNet (it was set during prepareForExecution)
     MRCommand *cmd = &searchRPNet->cmd;
-    int numShards = GetNumShards_UnSafe();
+    int numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
     cmd->coordStartTime = hreq->profileClocks.coordStartTime;
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
@@ -748,7 +800,10 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     // Store coordinator start time for dispatch time tracking
     hreq->profileClocks.coordStartTime = ConcurrentCmdCtx_GetCoordStartTime(cmdCtx);
 
-    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, &status) != REDISMODULE_OK) {
+    // Get numShards captured from main thread for thread-safe access
+    size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
+
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status) != REDISMODULE_OK) {
       DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
       return;
     }

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -17,15 +17,19 @@ extern "C" {
 #include "rmr/command.h"
 #include "dist_plan.h"
 #include "profile/options.h"
+#include "vector_index.h"
 
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
 
 // For testing purposes
+// numShards is passed from the main thread to ensure thread-safe access
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, HybridPipelineParams *hybridParams);
+                            IndexSpec *sp,
+                            const VectorQuery *vq,
+                            size_t numShards);
 
 #ifdef __cplusplus
 }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -21,6 +21,8 @@
 #include "spec.h"
 #include "param.h"
 #include "rmalloc.h"
+#include "config.h"
+#include "shard_window_ratio.h"
 
 #include "rmutil/args.h"
 #include "rmutil/rm_assert.h"
@@ -121,6 +123,34 @@ static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
   return REDISMODULE_OK;
 }
 
+static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
+                                  QueryError *status) {
+  // VSIM @vectorfield vector KNN <nargs> ... SHARD_K_RATIO <ratio>
+  //                                          ^
+  if (AC_IsAtEnd(ac)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for SHARD_K_RATIO");
+    return REDISMODULE_ERR;
+  }
+
+  const char *ratioStr;
+  size_t ratioStrLen;
+  ratioStr = AC_GetStringNC(ac, &ratioStrLen);
+  double shardKRatio;
+  if (!validateShardKRatio(ratioStr, &shardKRatio, status)) {
+    return REDISMODULE_ERR;
+  }
+
+  // Add as QueryAttribute (will be applied to VectorQuery via QueryNode_ApplyAttributes)
+  QueryAttribute attr = {
+    .name = SHARD_K_RATIO_ATTR,
+    .namelen = strlen(SHARD_K_RATIO_ATTR),
+    .value = rm_strndup(ratioStr, ratioStrLen),
+    .vallen = ratioStrLen
+  };
+  pvd->attributes = array_ensure_append_1(pvd->attributes, attr);
+  return REDISMODULE_OK;
+}
+
 static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd, QueryError *status) {
   // VSIM @vectorfield vector KNN ...
   //                              ^
@@ -139,6 +169,7 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
   }
 
   bool hasEF = false;
+  bool hasShardKRatio = false;
   RS_ASSERT(pvd->vectorScoreFieldAlias == NULL);
 
   for (int i=0; i<argumentCount; i+=2) {
@@ -178,6 +209,16 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
       // Add directly to VectorQuery params
       addVectorQueryParam(vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), value, valueLen);
       hasEF = true;
+
+    } else if (AC_AdvanceIfMatch(ac, "SHARD_K_RATIO")) {
+      if (hasShardKRatio) {
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate SHARD_K_RATIO argument");
+        return REDISMODULE_ERR;
+      }
+      if (parseShardKRatioClause(ac, pvd, status) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+      }
+      hasShardKRatio = true;
 
     } else {
       const char *current;
@@ -452,8 +493,8 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
     }
   }
 
-  // Check for optional YIELD_SCORE_AS clause
-  if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
+  // Check for optional YIELD_SCORE_AS detecting duplicate arguments
+  while (!AC_IsAtEnd(ac) && AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
     if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
       goto error;
     }
@@ -484,6 +525,7 @@ final:
     case VECSIM_QT_KNN:
       vq->knn.vector = (void*)vectorParam;
       vq->knn.vecLen = vectorParamLen;
+      vq->knn.shardWindowRatio = DEFAULT_SHARD_WINDOW_RATIO;
       break;
     case VECSIM_QT_RANGE:
       vq->range.vector = (void*)vectorParam;

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -25,7 +25,7 @@ extern "C" {
 typedef struct {
   VectorQuery *query;
   const char *fieldName;       // Field name for later resolution (NOT owned - points to args)
-  QueryAttribute *attributes;  // Non-vector-specific attributes like YIELD_SCORE_AS (OWNED)
+  QueryAttribute *attributes;  // Non-vector-specific attributes like YIELD_SCORE_AS, SHARD_K_RATIO (OWNED)
   bool isParameter;            // true if vector data is a parameter
   bool hasExplicitK;           // Flag to track if K was explicitly set in KNN query
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set

--- a/src/module.c
+++ b/src/module.c
@@ -3553,7 +3553,8 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   ConcurrentSearchHandlerCtx handlerCtx = {
     .coordStartTime = coordInitialTime,
-    .spec_ref = StrongRef_Demote(spec_ref)
+    .spec_ref = StrongRef_Demote(spec_ref),
+    .numShards = NumShards  // Capture NumShards from main thread for thread-safe access
   };
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,

--- a/src/query.c
+++ b/src/query.c
@@ -48,6 +48,7 @@
 #include "iterators/hybrid_reader.h"
 #include "iterators/optimizer_reader.h"
 #include "search_disk.h"
+#include "shard_window_ratio.h"
 
 #ifndef STRINGIFY
 #define __STRINGIFY(x) #x
@@ -2105,29 +2106,12 @@ int QueryNode_ForEach(QueryNode *q, QueryNode_ForEachCallback callback, void *ct
   return retVal;
 }
 
-static int ValidateShardKRatio(const char *value, double *ratio, QueryError *status) {
-  if (!ParseDouble(value, ratio, 1)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
-      "Invalid shard k ratio value", " '%s'", value);
-    return 0;
-  }
-
-  if (*ratio <= MIN_SHARD_WINDOW_RATIO || *ratio > MAX_SHARD_WINDOW_RATIO) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
-      "Invalid shard k ratio value: Shard k ratio must be greater than %g and at most %g (got %g)",
-      MIN_SHARD_WINDOW_RATIO, MAX_SHARD_WINDOW_RATIO, *ratio);
-    return 0;
-  }
-
-  return 1;
-}
-
 // Convert the query attribute into a raw vector param to be resolved by the vector iterator
 // down the road. return 0 in case of an unrecognized parameter.
 static int QueryVectorNode_ApplyAttribute(VectorQuery *vq, QueryAttribute *attr, QueryError *status) {
   if (STR_EQCASE(attr->name, attr->namelen, SHARD_K_RATIO_ATTR)) {
     double ratio;
-    if (!ValidateShardKRatio(attr->value, &ratio, status)) {
+    if (!validateShardKRatio(attr->value, &ratio, status)) {
       return 0;
     }
     vq->knn.shardWindowRatio = ratio;

--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -17,10 +17,24 @@
 #include "coord/special_case_ctx.h"
 #include "config.h"
 #include "vector_index.h"
+#include "query_error.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Validate a SHARD_K_RATIO value string.
+ *
+ * Parses the string as a double and validates it's within the valid range:
+ * (MIN_SHARD_WINDOW_RATIO, MAX_SHARD_WINDOW_RATIO] (exclusive min, inclusive max)
+ *
+ * @param value The string value to parse and validate
+ * @param ratio Output parameter for the parsed ratio value
+ * @param status QueryError to populate on failure
+ * @return true on success, false on failure (with status populated)
+ */
+bool validateShardKRatio(const char *value, double *ratio, QueryError *status);
 
 /**
  * Calculate effective K value for shard window ratio optimization.
@@ -74,6 +88,19 @@ static inline size_t calculateEffectiveK(size_t originalK, double ratio, size_t 
 
  */
 void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq);
+
+/**
+ * Modify VSIM KNN K value in a built command.
+ *
+ * This function replaces the K value argument at the specified index with
+ * the calculated effective K value for shard distribution.
+ *
+ * @param cmd The MRCommand to modify
+ * @param kArgIndex Index of the K value argument in cmd (as returned by MRCommand_appendVsim)
+ * @param effectiveK The calculated effective K value for shards
+ * @param originalK The original K value from the VectorQuery
+ */
+void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK, size_t originalK);
 
 #ifdef __cplusplus
 }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -2,11 +2,15 @@
 #include "redismock/redismock.h"
 #include "redismock/util.h"
 #include "hybrid/hybrid_request.h"
+#include "hybrid/parse_hybrid.h"
 #include "rmr/command.h"
 #include "dist_plan.h"
 #include "index_utils.h"
 #include "common.h"
 #include "profile/options.h"
+#include "vector_index.h"
+#include "shard_window_ratio.h"
+#include "redisearch_rs/headers/query_error.h"
 
 #include <vector>
 
@@ -14,16 +18,25 @@
 
 extern "C" {
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                            ProfileOptions profileOptions,
-                            MRCommand *xcmd, arrayof(char *) serialized,
-                            IndexSpec *sp, HybridPipelineParams *hybridParams);
+                                  ProfileOptions profileOptions,
+                                  MRCommand *xcmd, arrayof(char *) serialized,
+                                  IndexSpec *sp,
+                                  const VectorQuery *vq,
+                                  size_t numShards);
 }
 
 class HybridBuildMRCommandTest : public ::testing::Test {
 protected:
     void SetUp() override {
         ctx = RedisModule_GetThreadSafeContext(NULL);
-        memset(&hybridParams, 0, sizeof(hybridParams));
+
+        // Create index used by SHARD_K_RATIO tests
+        QueryError qerr = QueryError_Default();
+        RMCK::ArgvList createArgs(ctx, "FT.CREATE", "test_idx", "ON", "HASH",
+                                  "SCHEMA", "title", "TEXT", "vector_field", "VECTOR", "FLAT", "6",
+                                  "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "COSINE");
+        testIndexSpec = IndexSpec_CreateNew(ctx, createArgs, createArgs.size(), &qerr);
+        ASSERT_NE(testIndexSpec, nullptr) << "Failed to create index: " << QueryError_GetDisplayableError(&qerr, false);
     }
 
     void TearDown() override {
@@ -33,28 +46,128 @@ protected:
     }
 
     RedisModuleCtx *ctx = nullptr;
-    HybridPipelineParams hybridParams;
+    IndexSpec *testIndexSpec = nullptr;
 
-    void printMRCommand(const MRCommand *cmd) {
-        printf("MRCommand: ");
-        for (int i = 0; i < cmd->num; i++) {
-            printf("%s ", cmd->strs[i]);
-        }
-        printf("\n");
+    // Helper function to validate VectorQuery from AREQ
+    // Returns the VectorQuery pointer if validation passes, nullptr otherwise
+    VectorQuery* validateVectorQuery(AREQ *vectorReq, size_t expectedK, double expectedShardWindowRatio) {
+        EXPECT_NE(vectorReq->ast.root, nullptr) << "Vector AST root should not be NULL";
+        if (!vectorReq->ast.root) return nullptr;
+
+        EXPECT_EQ(vectorReq->ast.root->type, QN_VECTOR) << "Vector AST root should be QN_VECTOR";
+        if (vectorReq->ast.root->type != QN_VECTOR) return nullptr;
+
+        VectorQuery *vq = vectorReq->ast.root->vn.vq;
+        EXPECT_NE(vq, nullptr) << "VectorQuery should not be NULL";
+        if (!vq) return nullptr;
+
+        EXPECT_EQ(vq->type, VECSIM_QT_KNN);
+        EXPECT_EQ(vq->knn.k, expectedK);
+        EXPECT_DOUBLE_EQ(vq->knn.shardWindowRatio, expectedShardWindowRatio);
+
+        return vq;
     }
 
-    void printArgvList(RedisModuleString **argv, int argc) {
-        printf("ArgvList: ");
-        for (int i = 0; i < argc; i++) {
-            size_t len;
-            const char *str = RedisModule_StringPtrLen(argv[i], &len);
-            printf("%.*s ", (int)len, str);
+    // Helper function to test SHARD_K_RATIO command transformation
+    // Uses stack-allocated variables following the pattern in hybrid_debug.c
+    void testShardKRatioTransformation(const std::vector<const char*>& inputArgs,
+                                       size_t numShards,
+                                       size_t expectedK,
+                                       double expectedRatio,
+                                       long long expectedEffectiveK,
+                                       bool passNullVectorQuery = false) {
+        // Access the global NumShards variable for testing
+        extern size_t NumShards;
+
+        // Save and set NumShards
+        size_t originalNumShards = NumShards;
+        NumShards = numShards;
+
+        // Set up args
+        std::vector<const char*> argsWithNull = inputArgs;
+        argsWithNull.push_back(nullptr);
+        RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
+
+        // Create search context and hybrid request
+        RedisSearchCtx *sctx = NewSearchCtxC(ctx, "test_idx", true);
+        ASSERT_NE(sctx, nullptr) << "Failed to create search context";
+
+        HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+        ASSERT_NE(hreq, nullptr) << "Failed to create hybrid request";
+
+        // Stack-allocated variables (following hybrid_debug.c pattern)
+        HybridPipelineParams hybridParams = {};
+        ParseHybridCommandCtx cmd = {};
+        cmd.search = hreq->requests[0];
+        cmd.vector = hreq->requests[1];
+        cmd.tailPlan = &hreq->tailPipeline->ap;
+        cmd.hybridParams = &hybridParams;
+        cmd.reqConfig = &hreq->reqConfig;
+        cmd.cursorConfig = &hreq->cursorConfig;
+        cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
+
+        ArgsCursor ac = {};
+        HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
+
+        QueryError status = QueryError_Default();
+        if (int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS); rc != REDISMODULE_OK) {
+            if (hybridParams.scoringCtx) {
+                HybridScoringContext_Free(hybridParams.scoringCtx);
+            }
+            HybridRequest_Free(hreq);
+            NumShards = originalNumShards;
+            FAIL() << "Failed to parse hybrid command";
         }
-        printf("\n");
+
+        // Validate VectorQuery
+        const VectorQuery *vq = validateVectorQuery(cmd.vector, expectedK, expectedRatio);
+        ASSERT_NE(vq, nullptr) << "VectorQuery validation failed";
+
+        // Build MR command
+        MRCommand xcmd;
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
+                                     nullptr, testIndexSpec,
+                                     passNullVectorQuery ? nullptr : vq, numShards);
+
+        // Verify the command was built correctly
+        EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
+
+        // Verify K value in output command
+        long long kValue;
+        int kIndex = findKValue(&xcmd, &kValue);
+        EXPECT_NE(kIndex, -1) << "K keyword should be present in output command";
+        EXPECT_EQ(kValue, expectedEffectiveK) << "K value mismatch";
+
+        // Cleanup (following hybrid_debug.c pattern)
+        MRCommand_Free(&xcmd);
+        if (hybridParams.scoringCtx) {
+            HybridScoringContext_Free(hybridParams.scoringCtx);
+        }
+        HybridRequest_Free(hreq);
+        NumShards = originalNumShards;
+    }
+
+    // Helper function to find K value in MRCommand
+    // Returns the index of K keyword, or -1 if not found
+    // If found, kValue will contain the K value as long long
+    int findKValue(const MRCommand *cmd, long long *kValue) {
+        for (int i = 0; i < cmd->num; i++) {
+            bool kFound = (cmd->lens[i] == 1 && strncasecmp(cmd->strs[i], "K", 1) == 0);
+            if (kFound && i + 1 < cmd->num) {
+                if (kValue) {
+                    *kValue = atoll(cmd->strs[i + 1]);
+                }
+                return i;
+            }
+        }
+        return -1;
     }
 
     // Helper function to test command transformation
     void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs) {
+        // Access the global NumShards variable
+        extern size_t NumShards;
+
         // Convert vector to array for ArgvList constructor
         std::vector<const char*> argsWithNull = inputArgs;
         argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
@@ -62,9 +175,11 @@ protected:
         // Create ArgvList from input
         RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
 
-        // Build MR command
+        // Build MR command (pass NULL for VectorQuery - not testing
+        // SHARD_K_RATIO here)
         MRCommand xcmd;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL, nullptr, &hybridParams);
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
+                                     nullptr, nullptr, nullptr, NumShards);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -87,6 +202,9 @@ protected:
 
     // Helper function to test command transformation
     void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs) {
+      // Access the global NumShards variable
+      extern size_t NumShards;
+
       // Convert vector to array for ArgvList constructor
       std::vector<const char*> argsWithNull = inputArgs;
       argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
@@ -102,9 +220,11 @@ protected:
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command
+      // Build MR command (pass NULL for VectorQuery - not testing
+      // SHARD_K_RATIO here)
       MRCommand xcmd;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL, sp, &hybridParams);
+      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
+                                   nullptr, sp, nullptr, NumShards);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
         // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT
@@ -287,4 +407,45 @@ TEST_F(HybridBuildMRCommandTest, testMinimalCommand) {
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "idx", "SEARCH", "test", "VSIM", "@vec", "data"
     });
+}
+
+// Test SHARD_K_RATIO modifies K value in distributed command with multiple shards
+// With 4 shards, K=100, ratio=0.5:
+// effectiveK = max(100/4, ceil(100*0.5)) = max(25, 50) = 50
+TEST_F(HybridBuildMRCommandTest, testShardKRatioModifiesK) {
+    testShardKRatioTransformation({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello",
+        "VSIM", "@vector_field", "$BLOB",
+        "KNN", "4", "K", "100", "SHARD_K_RATIO", "0.5",
+        "COMBINE", "RRF", "2", "WINDOW", "100",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    }, /*numShards=*/4, /*expectedK=*/100, /*expectedRatio=*/0.5,
+    /*expectedEffectiveK=*/50);
+}
+
+// Test SHARD_K_RATIO with small ratio where min guarantee kicks in
+// With 4 shards, K=100, ratio=0.1:
+// effectiveK = max(100/4, ceil(100*0.1)) = max(25, 10) = 25
+TEST_F(HybridBuildMRCommandTest, testShardKRatioMinGuarantee) {
+    testShardKRatioTransformation({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello",
+        "VSIM", "@vector_field", "$BLOB",
+        "KNN", "4", "K", "100", "SHARD_K_RATIO", "0.1",
+        "COMBINE", "RRF", "2", "WINDOW", "100",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    }, /*numShards=*/4, /*expectedK=*/100, /*expectedRatio=*/0.1,
+    /*expectedEffectiveK=*/25);
+}
+
+// Test SHARD_K_RATIO with ratio = 1.0 (no modification)
+// K value should remain 50 since ratio = 1.0 means no modification
+TEST_F(HybridBuildMRCommandTest, testShardKRatioNoModificationWhenRatioIsOne) {
+    testShardKRatioTransformation({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello",
+        "VSIM", "@vector_field", "$BLOB",
+        "KNN", "4", "K", "50", "SHARD_K_RATIO", "1.0",
+        "COMBINE", "RRF", "2", "WINDOW", "50",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    }, /*numShards=*/4, /*expectedK=*/50, /*expectedRatio=*/1.0,
+    /*expectedEffectiveK=*/50);
 }

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -137,22 +137,24 @@ class ParseHybridTest : public ::testing::Test {
 
 };
 
-#define parseCommand(args) ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed";
+#define parseCommand(args) do { \
+  ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed"; \
+} while(0)
 
 
-#define assertLinearScoringCtx(Weight0, Weight1) { \
+#define assertLinearScoringCtx(Weight0, Weight1) do { \
   ASSERT_EQ(result.hybridParams->scoringCtx->scoringType, HYBRID_SCORING_LINEAR); \
   ASSERT_EQ(result.hybridParams->scoringCtx->linearCtx.numWeights, HYBRID_REQUEST_NUM_SUBQUERIES); \
   ASSERT_TRUE(result.hybridParams->scoringCtx->linearCtx.linearWeights != NULL); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->linearCtx.linearWeights[0], Weight0); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->linearCtx.linearWeights[1], Weight1); \
-}
+} while(0)
 
-#define assertRRFScoringCtx(Constant, Window) { \
+#define assertRRFScoringCtx(Constant, Window) do { \
   ASSERT_EQ(result.hybridParams->scoringCtx->scoringType, HYBRID_SCORING_RRF); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->rrfCtx.constant, Constant); \
   ASSERT_EQ(result.hybridParams->scoringCtx->rrfCtx.window, Window); \
-}
+} while(0)
 
 
 TEST_F(ParseHybridTest, testBasicValidInput) {
@@ -945,7 +947,8 @@ TEST_F(ParseHybridTest, testKNNDuplicateYieldDistanceAs) {
       "KNN", "2", "K", "10",
       "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS: Unknown argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM,
+                "Duplicate YIELD_SCORE_AS argument");
 }
 
 TEST_F(ParseHybridTest, testKNNCountingYieldDistanceAs) {
@@ -1015,7 +1018,8 @@ TEST_F(ParseHybridTest, testRangeDuplicateYieldDistanceAs) {
       "RANGE", "2", "RADIUS", "0.5",
       "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS: Unknown argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM,
+                "Duplicate YIELD_SCORE_AS argument");
 }
 
 TEST_F(ParseHybridTest, testRangeCountingYieldDistanceAs) {
@@ -1408,4 +1412,323 @@ TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalidRange) {
 TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalidKeyword) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "2", "INVALID_KEYWORD", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "2");
   testErrorCode(args,  QUERY_ERROR_CODE_SYNTAX, "SEARCH keyword is required");
+}
+
+// ============================================================================
+// SHARD_K_RATIO TESTS
+// ============================================================================
+
+TEST_F(ParseHybridTest, testShardKRatioValidMinValue) {
+  // Test valid minimum SHARD_K_RATIO value (0.1)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.1",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.1);
+}
+
+TEST_F(ParseHybridTest, testShardKRatioValidMidValue) {
+  // Test valid mid-range SHARD_K_RATIO value (0.5)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.5",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.5);
+}
+
+TEST_F(ParseHybridTest, testShardKRatioValidMaxValue) {
+  // Test valid maximum SHARD_K_RATIO value (1.0)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "1.0",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 1.0);
+}
+
+// Passing SHARD_K_RATIO as a parameter is not yet supported.
+// This test should be updated once it is supported. MOD-12915
+TEST_F(ParseHybridTest, testShardKRatioValidFromParams) {
+  // Test valid maximum SHARD_K_RATIO value (1.0)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "$RATIO",
+    "PARAMS", "4", "BLOB", TEST_BLOB_DATA, "$RATIO", "0.75");
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value '$RATIO'");
+}
+
+// Passing SHARD_K_RATIO as a parameter is not yet supported.
+// This test should be updated once it is supported. MOD-12915
+TEST_F(ParseHybridTest, testShardKRatioInvalidFromParams) {
+  // Test valid maximum SHARD_K_RATIO value (1.0)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "$RATIO",
+    "PARAMS", "4", "BLOB", TEST_BLOB_DATA, "RATIO", "8.1");
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value '$RATIO'");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioInvalidBelowMin) {
+  // Test invalid SHARD_K_RATIO value at exclusive minimum (must be > 0.0)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.0",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value: Shard k ratio must be greater than 0 and at most 1 (got 0)");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioInvalidAboveMax) {
+  // Test invalid SHARD_K_RATIO value above maximum (> 1.0)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "1.5",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value: Shard k ratio must be greater than 0 and at most 1 (got 1.5)");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioInvalidNegative) {
+  // Test invalid negative SHARD_K_RATIO value
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "-0.5",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value: Shard k ratio must be greater than 0 and at most 1 (got -0.5)");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioInvalidNonNumeric) {
+  // Test invalid non-numeric SHARD_K_RATIO value
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "invalid",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value 'invalid'");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioMissingValue) {
+  // Test missing SHARD_K_RATIO value
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value 'PARAMS'");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioMissingValueAtEnd) {
+  // Test missing SHARD_K_RATIO value
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS,
+    "Missing argument value for SHARD_K_RATIO");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioWrongPosition) {
+  // Test missing SHARD_K_RATIO value at end of command (no PARAMS after it)
+  // NOTE: Current implementation doesn't loop to check for SHARD_K_RATIO after PARAMS,
+  // so it's reported as "Unknown argument" instead of "Missing argument value"
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "2", "K", "10",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+    "SHARD_K_RATIO");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS,
+    "SHARD_K_RATIO: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioDuplicate) {
+  // Test duplicate SHARD_K_RATIO argument - proper duplicate detection via
+  // looping through optional args.
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+      "VSIM", "@vector", "$BLOB", "KNN", "6", "K", "10", "SHARD_K_RATIO", "0.5",
+        "SHARD_K_RATIO", "0.7",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM,
+    "Duplicate SHARD_K_RATIO argument");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioWithFilter) {
+  // Test SHARD_K_RATIO with KNN query and FILTER
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.8",
+      "FILTER", "@title:world",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.8);
+}
+
+TEST_F(ParseHybridTest, testShardKRatiowithFilterAndPostFilter) {
+  // Test SHARD_K_RATIO with KNN query, FILTER, and POST-FILTER
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.8",
+      "FILTER", "@title:(world)",
+    "FILTER", "@__key:doc:1",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.8);
+
+  // Verify that the vector node is the child of the filter node
+  QueryNode *vn = vecReq->ast.root;
+  ASSERT_EQ(QueryNode_NumChildren(vn), 1);
+  ASSERT_EQ(vn->children[0]->type, QN_UNION);
+  ASSERT_EQ(vn->children[0]->children[0]->type, QN_TOKEN);
+  ASSERT_STREQ(vn->children[0]->children[0]->tn.str, "world");
+  ASSERT_STREQ(vn->children[0]->children[1]->tn.str, "+world");
+
+  // Verify the post-filter
+  // Post-filters are stored in the tail pipeline, not in the vector AST
+  const AGGPlan *tailPlan = result.tailPlan;
+  ASSERT_NE(tailPlan, nullptr) << "Tail plan should not be NULL";
+
+  // Check that a FILTER step exists in the tail plan
+  ASSERT_TRUE(AGPLN_HasStep(tailPlan, PLN_T_FILTER))
+    << "Post-filter should be present in tail plan";
+
+  // Find the FILTER step
+  const PLN_BaseStep *filterStep = AGPLN_FindStep(tailPlan, nullptr, nullptr, PLN_T_FILTER);
+  ASSERT_NE(filterStep, nullptr)
+    << "Post-filter step should be found in tail plan";
+  ASSERT_EQ(filterStep->type, PLN_T_FILTER)
+    << "Step should be of type PLN_T_FILTER";
+
+  // Cast to PLN_MapFilterStep to access the filter expression
+  const auto *mapFilterStep = (const PLN_MapFilterStep *)filterStep;
+  ASSERT_NE(mapFilterStep->expr, nullptr) << "Filter expression should not be NULL";
+
+  // Verify the expression content
+  size_t exprLen = 0;
+  const char *exprStr = HiddenString_GetUnsafe(mapFilterStep->expr, &exprLen);
+  ASSERT_NE(exprStr, nullptr) << "Expression string should not be NULL";
+  ASSERT_GT(exprLen, 0) << "Expression length should be greater than 0";
+  ASSERT_STREQ(exprStr, "@__key:doc:1") << "Post-filter expression should match expected value";
+}
+
+TEST_F(ParseHybridTest, testShardKRatioAfterYieldScoreAs) {
+  // Test SHARD_K_RATIO combined with YIELD_SCORE_AS
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "2", "K", "10",
+      "YIELD_SCORE_AS", "my_score",
+      "SHARD_K_RATIO", "0.75",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS,
+    "SHARD_K_RATIO: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioBeforeYieldScoreAs) {
+  // Test SHARD_K_RATIO combined with YIELD_SCORE_AS
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB", "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.75",
+    "YIELD_SCORE_AS", "my_score",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.75);
+
+  // YIELD_SCORE_AS is stored in QueryNode opts.distField (not in parsedVectorData)
+  const QueryNode *vn = vecReq->ast.root;
+  ASSERT_STREQ(vn->opts.distField, "my_score");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioDefaultValue) {
+  // Test default SHARD_K_RATIO when not specified (should be 1.0)
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  parseCommand(args);
+
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
+  ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
+
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
+  // Default should be 1.0 (DEFAULT_SHARD_WINDOW_RATIO - no optimization)
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 1.0);
 }

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -1,0 +1,350 @@
+"""
+Tests for SHARD_K_RATIO parameter in FT.HYBRID command.
+
+SHARD_K_RATIO optimizes KNN query execution in distributed/cluster environments
+by controlling how many results each shard returns using the formula:
+    effectiveK = max(K/#shards, ceil(K × ratio))
+
+Valid ratio range: (0.0, 1.0] (exclusive 0, inclusive 1)
+Default ratio: 1.0 (no optimization - each shard returns full K results)
+"""
+
+from common import (
+    skip,
+    Env,
+    getConnectionByEnv,
+    create_np_array_typed,
+    create_random_np_array_typed,
+)
+
+
+def _validate_individual_shard_results(env, profile_response, k, expected_effective_k):
+    """Validate that each shard processed the expected number of results.
+
+    For FT.HYBRID profile, the structure is:
+    - profile_response[8] = ['Shards', [shard_profiles...], 'Coordinator', coordinator_profile]
+    - Each shard_profile = ['Shard ID', id, 'SEARCH', [...], 'VSIM', vsim_profile]
+    - vsim_profile contains 'Result processors profile' with Index RP first
+    """
+    shard_profiles = profile_response[8][1]
+
+    env.assertEqual(len(shard_profiles), env.shardsCount, depth=1,
+                   message="Validate shards count in profile")
+
+    # Parse each shard's results
+    for i, shard_profile in enumerate(shard_profiles):
+        # shard profile has the following structure:
+        # ['Shard ID', id, 'SEARCH', [...], 'VSIM', vsim_profile]
+        vsim_profile = shard_profile[5]  # VSIM profile is at index 5
+        result_processors_profile = vsim_profile[7]
+
+        # Index RP is always first
+        index_rp_profile = result_processors_profile[0]
+        # Result processors profile has the following structure:
+        # ['Type', 'Index', 'Results processed', 5]
+        shard_result_count = index_rp_profile[3]
+        env.assertEqual(
+            shard_result_count, expected_effective_k, depth=1,
+            message=f"Shard {i} expected {expected_effective_k} results, got {shard_result_count}")
+
+
+def _validate_hybrid_error(env, res, expected_error_message, message="", depth=1):
+    """Helper to validate error response from FT.HYBRID command"""
+    env.assertTrue(res.errorRaised, message=message, depth=depth + 1)
+    env.assertContains(expected_error_message, res.res, message=message, depth=depth + 1)
+
+
+def setup_basic_index(env, dim=2, docs_per_shard=None, uniform_vectors=True):
+    """
+    Create a basic index with optional sharded document distribution.
+
+    Args:
+        env: The test environment
+        dim: Vector dimension (default: 2)
+        docs_per_shard:
+            Optional list of integers specifying how many documents each shard
+            should contain (e.g., [1, 1, 5]).
+            If None, creates a single document for simple tests.
+    """
+    env.expect(
+        'FT.CREATE', 'idx', 'SCHEMA',
+        'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim,
+            'DISTANCE_METRIC', 'L2',
+        't', 'TEXT',
+        'tag', 'TAG',
+        'shard_tag', 'TAG').ok()
+
+    if docs_per_shard is not None:
+        setup_sharded_documents(env, docs_per_shard, dim, uniform_vectors)
+    else:
+        conn = getConnectionByEnv(env)
+        vec = create_np_array_typed([1.0] * dim)
+        conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello')
+
+
+def setup_sharded_documents(env, docs_per_shard, dim, uniform_vectors=True):
+    """
+    Set up documents distributed across shards according to a specified target
+    distribution.
+
+    This helper creates documents with hash tags to control shard distribution
+    in a 3-shard cluster. Each document includes a vector field, text field, and
+    shard_tag field for tracking which shard it belongs to.
+
+    Args:
+        env: The test environment
+        docs_per_shard: List of integers specifying how many documents
+                        each shard should contain (e.g., [1, 1, 5])
+        dim: Vector dimension
+
+    Note:
+        - Uses hardcoded hash tags ['{shard:0}', '{shard:1}', '{shard:3}']
+          for 3-shard clusters
+        - Vector values are based on doc_idx only (not shard_idx) to ensure
+          uniform distribution across shards
+        - Verifies each shard has the expected number of documents
+    """
+    env.assertEqual(3, env.shardsCount, message="This test requires exactly 3 shards")
+    # Hash tags that distribute to different shards in a 3-shard cluster
+    shard_hash_tags = ['{shard:0}', '{shard:1}', '{shard:3}']
+    conn = getConnectionByEnv(env)
+    # Create documents with hash tags to control shard distribution
+    # Use the same vector values across all shards so distances are uniform
+    for shard_idx in range(3):
+        hash_tag = shard_hash_tags[shard_idx]
+        shard_tag_value = hash_tag.strip('{}')  # e.g., 'shard:0'
+        for doc_idx in range(docs_per_shard[shard_idx]):
+            doc_key = f'{hash_tag}:doc{doc_idx}'
+
+            if uniform_vectors:
+                # Use doc_idx only (not shard_idx) so all shards have same
+                # vector distribution
+                vector = ([float(doc_idx)] * dim)
+            else:
+                # Use doc_idx + shard_idx offset so each shard has unique vector
+                # distribution
+                vector = ([float(doc_idx) + 5 * shard_idx] * dim)
+
+            vec = create_np_array_typed(vector)
+            conn.execute_command('HSET', doc_key, 'v', vec.tobytes(),
+                                 't', 'some text',
+                                 'shard_tag', shard_tag_value)
+
+    # Verify each shard has the expected number of documents
+    for shard_idx, shard_conn in enumerate(env.getOSSMasterNodesConnectionList()):
+        keys = shard_conn.execute_command('KEYS', '*')
+        env.assertEqual(
+            len(keys), docs_per_shard[shard_idx],
+            message=f"Shard {shard_idx} should have {docs_per_shard[shard_idx]} keys, got {len(keys)}")
+
+
+def test_shard_k_ratio_parameter_validation():
+    """Test SHARD_K_RATIO parameter validation and error handling for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_basic_index(env)
+    query_vec = create_np_array_typed([2.0] * 2)
+
+    # Test invalid ratio values - below minimum, above maximum, negative
+    # Error message is "Invalid shard k ratio value" from ValidateShardKRatio
+    invalid_ratios = [0.0, -0.1, 1.1, 2.0, 0, 7]
+    for ratio in invalid_ratios:
+        res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                         'VSIM', '@v', '$BLOB',
+                           'KNN', '4', 'K', '5', 'SHARD_K_RATIO', ratio,
+                         'PARAMS', '2', 'BLOB', query_vec.tobytes())
+        _validate_hybrid_error(
+            env, res, "Invalid shard k ratio value",
+            message=f"FT.HYBRID expected error for invalid shard k ratio: {ratio}")
+
+    # Test non-numeric value
+    res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                     'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', '5', 'SHARD_K_RATIO', 'invalid',
+                     'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    _validate_hybrid_error(
+        env, res, "Invalid shard k ratio value",
+        message="FT.HYBRID expected error for non-numeric shard k ratio")
+
+
+def test_shard_k_ratio_missing_value():
+    """Test SHARD_K_RATIO with missing value for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_basic_index(env)
+    query_vec = create_np_array_typed([2.0] * 2)
+
+    # Test missing value - SHARD_K_RATIO followed by PARAMS (which is not a
+    # valid ratio)
+    res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                     'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', '5', 'SHARD_K_RATIO',
+                     'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    _validate_hybrid_error(
+        env, res, "Invalid shard k ratio value",
+        message="FT.HYBRID expected error for missing SHARD_K_RATIO value")
+
+
+def test_shard_k_ratio_duplicate():
+    """Test duplicate SHARD_K_RATIO parameter for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    setup_basic_index(env)
+    query_vec = create_np_array_typed([2.0] * 2)
+
+    # Test duplicate SHARD_K_RATIO
+    res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                     'VSIM', '@v', '$BLOB',
+                        'KNN', '6', 'K', '5', 'SHARD_K_RATIO', '0.5',
+                            'SHARD_K_RATIO', '0.8',
+                     'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    _validate_hybrid_error(
+        env, res, "SHARD_K_RATIO",
+        message="FT.HYBRID expected error for duplicate SHARD_K_RATIO")
+
+
+def test_shard_k_ratio_small_k():
+    """Test SHARD_K_RATIO with small K values (1, 2, 3).
+
+    By using a SEARCH query that matches zero documents, only the VSIM
+    subquery results are returned, so K directly controls the output count.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    setup_basic_index(env, dim)
+
+    conn = getConnectionByEnv(env)
+    for i in range(1, 11):
+        vec = create_np_array_typed([float(i)] * dim)
+        conn.execute_command('HSET', f'doc{i}', 'v', vec.tobytes(), 't', 'some text')
+
+    query_vec = create_random_np_array_typed(dim, 'FLOAT32')
+
+    ratio = 0.5
+
+    # Test small K values with a non-matching SEARCH query
+    for k in [1, 2, 3]:
+        res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
+                      'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
+                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+        # Response format: ['total_results', N, 'results', [...], ...]
+        actual_result_count = len(res[3])
+        env.assertEqual(actual_result_count, k,
+                       message=f"FT.HYBRID with K={k}: expected {k} results, got {actual_result_count}")
+
+
+@skip(cluster=False)  # Only relevant for cluster mode
+def test_shard_k_ratio_profile_verification():
+    """Test SHARD_K_RATIO using FT.PROFILE to verify effectiveK per shard.
+
+    This test uses FT.PROFILE HYBRID to verify that SHARD_K_RATIO actually
+    limits the number of documents processed per shard according to the formula:
+        effectiveK = max(K/#shards, ceil(K × ratio))
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 _PRINT_PROFILE_CLOCK false')
+
+    # This test requires exactly 3 shards due to hardcoded hash tags
+    num_shards = 3
+    if env.shardsCount != num_shards:
+        env.skip()
+
+    dim = 2
+    k = 15  # Request 15 results total
+    query_vec = create_np_array_typed([5.0] * dim)
+
+    # Test different ratio values and verify effectiveK per shard
+    # effectiveK = max(K/#shards, ceil(K × ratio))
+    test_cases = [
+        # (ratio, expected_effectiveK)
+        (1.0, k),              # ratio=1.0: effectiveK = max(15/3, ceil(15*1.0)) = max(5, 15) = 15
+        (0.5, 8),              # ratio=0.5: effectiveK = max(15/3, ceil(15*0.5)) = max(5, 8) = 8
+        (0.2, 5),              # ratio=0.2: effectiveK = max(15/3, ceil(15*0.2)) = max(5, 3) = 5
+        (1.0 / num_shards, 5), # ratio=1/3: effectiveK = max(15/3, ceil(15*0.33)) = max(5, 5) = 5
+    ]
+
+    for uniform_vectors in [True, False]:
+        # Set up index with enough docs per shard
+        setup_basic_index(env, dim, [k] * num_shards, uniform_vectors)
+        for ratio, expected_effective_k in test_cases:
+            # Run FT.PROFILE HYBRID with SHARD_K_RATIO
+            res = env.cmd(
+                'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+                'SEARCH', 'nonexistent_term_xyz',
+                'VSIM', '@v', '$BLOB',
+                    'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
+                'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+            _validate_individual_shard_results(env, res, k, expected_effective_k)
+        env.flush()
+
+
+@skip(cluster=False)  # Only relevant for cluster mode
+def test_shard_k_ratio_insufficient_docs():
+    """Test SHARD_K_RATIO when not all shards have enough documents.
+
+    Tests the scenario where some shards don't have enough docs to return
+    effectiveK results. When a shard has fewer documents than effectiveK,
+    it returns all available documents. When a shard has more documents than
+    effectiveK, it should return only effectiveK results.
+
+    Target distribution: [1, 1, 3] docs per shard (5 total)
+    With K=5, ratio=0.1:
+      effectiveK = max(5/3, ceil(5*0.1)) = max(2, 1) = 2
+    Expected results per shard:
+      - Shard 0: 1 (all available docs, less than effectiveK)
+      - Shard 1: 1 (all available docs, less than effectiveK)
+      - Shard 2: 2 (limited by effectiveK, even though 3 docs available)
+    Total expected: 1 + 1 + 2 = 4 results
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    # This test requires exactly 3 shards due to hardcoded hash tags
+    num_shards = 3
+    if env.shardsCount != num_shards:
+        env.skip()
+
+    dim = 2
+    k = 5  # Request 5 results
+    ratio = 0.1
+
+    # Set up index and documents: [1, 1, 5] docs per shard (unequal distribution)
+    target_docs_per_shard = [1, 1, 5]
+    setup_basic_index(env, dim, target_docs_per_shard)
+
+    # Fixed query vector for reproducibility
+    query_vec = create_np_array_typed([0.5] * dim)
+
+    # Use non-matching SEARCH query so only VSIM results are returned
+    # Use GROUPBY @shard_tag with REDUCE COUNT to count results per shard
+    res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
+                  'VSIM', '@v', '$BLOB',
+                    'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
+                  'LOAD', '1', '@shard_tag',
+                  'GROUPBY', '1', '@shard_tag',
+                  'REDUCE', 'COUNT', '0', 'AS', 'count',
+                  'SORTBY', '2', '@shard_tag', 'ASC',
+                  'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+    # Response format: ['total_results', N, 'results', [...], ...]
+    # With GROUPBY, results are grouped rows like:
+    #                   [{'shard_tag': 'shard:0', 'count': '1'}, ...]
+    results = res[3]
+
+    # Expected effectiveK = max(5/3, ceil(5*0.1)) = max(2, 1) = 2
+    # - Shard 0 with 1 doc returns 1 (all available, less than effectiveK)
+    # - Shard 1 with 1 doc returns 1 (all available, less than effectiveK)
+    # - Shard 2 with 3 docs should return only 2 (limited by effectiveK)
+    expected_results = [
+        ['shard_tag', 'shard:0', 'count', '1'],
+        ['shard_tag', 'shard:1', 'count', '1'],
+        ['shard_tag', 'shard:3', 'count', '2']
+    ]
+    env.assertEqual(results, expected_results)
+
+    # Total expected: 1 + 1 + 2 = 4 (same as FT.SEARCH/FT.AGGREGATE)
+    expected_result_count = 4
+    total_count = sum(int(row[3]) for row in results)
+    env.assertEqual(
+        total_count, expected_result_count,
+        message=f"FT.HYBRID with SHARD_K_RATIO: expected {expected_result_count} results, got {total_count}")


### PR DESCRIPTION
## Description
Manual backport #8227 to 8.6
(cherry picked from commit d7ac7d333dfa3824f925094ad585c65560294dd4)

## Describe the changes in the pull request

#### Which additional issues this PR fixes
1. MOD-10798
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hybrid query parsing and distributed command construction, which can change result/performance characteristics in cluster mode; mitigated by strict validation and new unit/integration tests.
> 
> **Overview**
> `FT.HYBRID` KNN queries now accept an optional `SHARD_K_RATIO` parameter (since 8.6.1) to reduce per-shard work in cluster mode by lowering the per-shard `K` used for the distributed VSIM subquery while keeping the user-requested `K` at the coordinator.
> 
> Parsing/validation was added for `SHARD_K_RATIO` (range `(0,1]`, duplicate detection) and the coordinator now safely passes `numShards` into background execution to compute and apply an *effective K* when building the shard MR command. Tests were added/expanded (C++ + Python) to cover correctness, error cases, and per-shard profile behavior; duplicate `YIELD_SCORE_AS` handling was tightened to return a duplicate-parameter error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa7ec231a3b2ce2e6e21ec7c40d6b1998d67d60e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->