### PR TITLE
[MOD-13956] II iterator: benchmark Rust wildcard

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
@@ -63,6 +63,11 @@ fn benchmark_inverted_index_numeric(c: &mut Criterion) {
     bencher.bench(c);
 }
 
+fn benchmark_inverted_index_wildcard(c: &mut Criterion) {
+    let bencher = benchers::inverted_index::WildcardBencher::default();
+    bencher.bench(c);
+}
+
 /*
 fn benchmark_inverted_index_term(c: &mut Criterion) {
     // Run bench with each decoder producing term results.
@@ -151,6 +156,7 @@ criterion_group!(
     benchmark_intersection,
     benchmark_optional,
     benchmark_inverted_index_numeric,
+    benchmark_inverted_index_wildcard,
     //benchmark_inverted_index_term,
 );
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 use ffi::{IteratorStatus, RedisModule_Alloc, RedisModule_Free, ValidateStatus};
 use inverted_index::{RSIndexResult, t_docId};
 use query_term::RSQueryTerm;
-use std::{ffi::c_void, ptr};
+use std::{ffi::c_void, ptr, ptr::NonNull};
 
 /// Simple wrapper around the C `QueryIterator` type.
 /// All methods are inlined to avoid the overhead when benchmarking.
@@ -91,6 +91,21 @@ impl QueryIterator {
 
         free_redis_search_ctx(query_eval_ctx);
         Self(it)
+    }
+
+    /// Create a wildcard iterator from an inverted index.
+    ///
+    /// # Safety
+    /// - `ii` must be a valid pointer to an `InvertedIndex` created with `Index_DocIdsOnly` flags.
+    /// - `sctx` must be a valid pointer to a `RedisSearchCtx`.
+    #[inline(always)]
+    pub unsafe fn new_wildcard(
+        ii: *const ffi::InvertedIndex,
+        sctx: NonNull<ffi::RedisSearchCtx>,
+        weight: f64,
+    ) -> Self {
+        // SAFETY: The caller guarantees that `ii` and `sctx` are valid pointers.
+        Self(unsafe { ffi::NewInvIndIterator_WildcardQuery(ii, sctx.as_ptr(), weight) })
     }
 
     #[inline(always)]


### PR DESCRIPTION
## Describe the changes in the pull request

Adding Rust micro benchmarks of the inverted index wildcard iterator.

This PR depends on both https://github.com/RediSearch/RediSearch/pull/8390 and https://github.com/RediSearch/RediSearch/pull/8177 in order to prevent conflicts.
It may be easier to review the top commit [add benchmarks for Wildcard iterator](https://github.com/RediSearch/RediSearch/pull/8402/changes/67cfffe708faae1c1d2ddb0caf1c51342b2fd35b) directly.

  | Benchmark      | C         | Rust      | Speedup          |
  | -------------- | --------- | --------- | ---------------- |
  | Read Dense     | 3.43 ms   | 1.77 ms   | **1.94x faster** |
  | Read Sparse    | 3.46 ms   | 1.97 ms   | **1.76x faster** |
  | SkipTo Dense   | 454.97 µs | 416.11 µs | **1.09x faster** |
  | SkipTo Sparse  | 6.44 ms   | 2.87 ms   | **2.25x faster** |

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only changes plus a small FFI helper for creating a wildcard iterator; minimal production impact but the new `unsafe` constructor relies on correct pointer/flag usage.
> 
> **Overview**
> Adds a new Criterion microbenchmark for the **inverted-index-backed** wildcard iterator, comparing `C` (`NewInvIndIterator_WildcardQuery`) vs the Rust `rqe_iterators::inverted_index::Wildcard` implementation across dense read and dense/sparse `skip_to` scenarios.
> 
> To support the C side of the benchmark, the bencher’s FFI wrapper (`QueryIterator`) gains an `unsafe` `new_wildcard` constructor that takes an `InvertedIndex` pointer plus `RedisSearchCtx` (`NonNull`) and wires it into the existing benchmark suite (`benches/iterators.rs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87bba92124ac8f9732a8c2581e9915aeb34afcb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->