### PR TITLE
[MOD-13957] add FFI wrapper for II Wildcard iterator

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index.rs
@@ -12,9 +12,13 @@ use std::ptr::NonNull;
 use field::{FieldFilterContext, FieldMaskOrIndex};
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, IndexReaderCore, NumericFilter,
-    NumericReader, RSIndexResult, t_docId,
+    NumericReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly,
+    t_docId,
 };
-use rqe_iterators::{FieldExpirationChecker, inverted_index::Numeric};
+use rqe_iterators::{
+    FieldExpirationChecker,
+    inverted_index::{Numeric, Wildcard},
+};
 use rqe_iterators_interop::RQEIteratorWrapper;
 
 /// Wrapper around different numeric reader types to avoid generics in FFI code.
@@ -102,6 +106,100 @@ impl<'index> IndexReader<'index> for NumericIndexReader<'index> {
 }
 
 impl<'index> NumericReader<'index> for NumericIndexReader<'index> {}
+
+/// Wrapper around different II wildcard iterator encoding types to avoid generics in FFI code.
+///
+/// Handles both the standard variable-length encoding ([`DocIdsOnly`]) and the
+/// fixed 4-byte raw encoding ([`RawDocIdsOnly`]).
+enum WildcardIterator<'index> {
+    Encoded(Wildcard<'index, DocIdsOnly>),
+    Raw(Wildcard<'index, RawDocIdsOnly>),
+}
+
+impl WildcardIterator<'_> {
+    /// Get the flags from the underlying reader.
+    #[allow(dead_code)]
+    fn flags(&self) -> ffi::IndexFlags {
+        match self {
+            WildcardIterator::Encoded(w) => w.reader().flags(),
+            WildcardIterator::Raw(w) => w.reader().flags(),
+        }
+    }
+}
+
+impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        match self {
+            WildcardIterator::Encoded(w) => w.current(),
+            WildcardIterator::Raw(w) => w.current(),
+        }
+    }
+
+    #[inline(always)]
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        match self {
+            WildcardIterator::Encoded(w) => w.read(),
+            WildcardIterator::Raw(w) => w.read(),
+        }
+    }
+
+    #[inline(always)]
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        match self {
+            WildcardIterator::Encoded(w) => w.skip_to(doc_id),
+            WildcardIterator::Raw(w) => w.skip_to(doc_id),
+        }
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        match self {
+            WildcardIterator::Encoded(w) => w.rewind(),
+            WildcardIterator::Raw(w) => w.rewind(),
+        }
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        match self {
+            WildcardIterator::Encoded(w) => w.num_estimated(),
+            WildcardIterator::Raw(w) => w.num_estimated(),
+        }
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        match self {
+            WildcardIterator::Encoded(w) => w.last_doc_id(),
+            WildcardIterator::Raw(w) => w.last_doc_id(),
+        }
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        match self {
+            WildcardIterator::Encoded(w) => w.at_eof(),
+            WildcardIterator::Raw(w) => w.at_eof(),
+        }
+    }
+
+    #[inline(always)]
+    fn revalidate(
+        &mut self,
+    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
+        match self {
+            WildcardIterator::Encoded(w) => w.revalidate(),
+            WildcardIterator::Raw(w) => w.revalidate(),
+        }
+    }
+}
 
 /// Enum holding either a numeric or geo iterator variant.
 /// This allows all iterator types to share the same iterator wrapper structure.
@@ -546,4 +644,62 @@ pub unsafe extern "C" fn InvIndIterator_Rs_SwapIndex(
             reader_ref.swap_index(ii_ref);
         }
     }
+}
+
+/// Creates a new wildcard inverted index iterator for querying all existing documents.
+///
+/// # Parameters
+///
+/// * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+/// * `sctx` - Pointer to the Redis search context.
+/// * `weight` - Weight to apply to all results.
+///
+/// # Returns
+///
+/// A pointer to a `QueryIterator` that can be used from C code.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+///
+/// 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+/// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+///    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
+///    comparison.
+/// 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+/// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NewInvIndIterator_WildcardQuery_Rs(
+    idx: *const ffi::InvertedIndex,
+    sctx: *const ffi::RedisSearchCtx,
+    weight: f64,
+) -> *mut ffi::QueryIterator {
+    debug_assert!(!idx.is_null(), "idx must not be null");
+
+    // Cast to the FFI wrapper enum which handles type dispatch
+    let idx_ffi: *const inverted_index_ffi::InvertedIndex = idx.cast();
+    // SAFETY: 1. guarantees idx is valid and non-null
+    let ii_ref = unsafe { &*idx_ffi };
+
+    debug_assert!(!sctx.is_null(), "sctx must not be null");
+    // SAFETY: 3. guarantees sctx is valid and non-null
+    let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
+
+    // Create the appropriate wildcard iterator variant based on the encoding type
+    let iterator = match ii_ref {
+        inverted_index_ffi::InvertedIndex::DocIdsOnly(ii) => {
+            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
+            WildcardIterator::Encoded(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
+        }
+        inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
+            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
+            WildcardIterator::Raw(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
+        }
+        _ => panic!(
+            "Wildcard iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",
+            std::mem::discriminant(ii_ref)
+        ),
+    };
+
+    RQEIteratorWrapper::boxed_new(ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR, iterator)
 }

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -164,6 +164,34 @@ double NumericInvIndIterator_GetProfileRangeMax(const NumericInvIndIterator *it)
 void InvIndIterator_Rs_SwapIndex(InvIndIterator *it, const InvertedIndex *ii);
 
 /**
+ * Creates a new wildcard inverted index iterator for querying all existing documents.
+ *
+ * # Parameters
+ *
+ * * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+ * * `sctx` - Pointer to the Redis search context.
+ * * `weight` - Weight to apply to all results.
+ *
+ * # Returns
+ *
+ * A pointer to a `QueryIterator` that can be used from C code.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *
+ * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ *    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
+ *    comparison.
+ * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ */
+QueryIterator *NewInvIndIterator_WildcardQuery_Rs(const InvertedIndex *idx,
+                                                  const RedisSearchCtx *sctx,
+                                                  double weight);
+
+/**
  * Creates a new metric iterator sorted by ID.
  *
  * # Safety


### PR DESCRIPTION
## Describe the changes in the pull request

Add the FFI function NewInvIndIterator_WildcardQuery in Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new unsafe FFI entrypoint and type-dispatch logic for wildcard iterators; incorrect index type/ownership or NULL pointers can cause panics or UB if the safety contract is violated.
> 
> **Overview**
> **Release note:** Adds a Rust FFI API, `NewInvIndIterator_WildcardQuery_Rs`, to create an optimized wildcard iterator over `spec.existingDocs` from C.
> 
> The new wrapper supports both `DocIdsOnly` and `RawDocIdsOnly` encodings via an internal `WildcardIterator` dispatcher and exposes the function in `iterators_rs.h` for consumers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 678a4563499062a72bde0b42c0416af546c0797e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->