### PR TITLE
rqe_iterators_bencher: remove read sparse benchmarks

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/id_list.rs
@@ -37,7 +37,6 @@ impl Bencher {
 
     pub fn bench(&self, c: &mut Criterion) {
         self.read_dense(c);
-        self.read_sparse(c);
         self.skip_to_dense(c);
         self.skip_to_sparse(c);
     }
@@ -45,12 +44,6 @@ impl Bencher {
     fn read_dense(&self, c: &mut Criterion) {
         let mut group = self.benchmark_group(c, "Iterator - IdList - Read Dense");
         self.rust_read_dense(&mut group);
-        group.finish();
-    }
-
-    fn read_sparse(&self, c: &mut Criterion) {
-        let mut group = self.benchmark_group(c, "Iterator - IdList - Read Sparse");
-        self.rust_read_sparse(&mut group);
         group.finish();
     }
 
@@ -81,23 +74,6 @@ impl Bencher {
             );
         });
     }
-    fn rust_read_sparse<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("Rust", |b| {
-            b.iter_batched_ref(
-                || {
-                    let data: Vec<_> = (1..1_000_000).map(|x| x * 1000).collect();
-                    IdListSorted::new(data)
-                },
-                |it| {
-                    while let Ok(Some(current)) = it.read() {
-                        black_box(current);
-                    }
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
     fn rust_skip_to_dense<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
         group.bench_function("Rust", |b| {
             let step = 100;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index.rs
@@ -115,13 +115,9 @@ impl Default for NumericBencher {
 impl NumericBencher {
     pub fn bench(&self, c: &mut Criterion) {
         self.read_dense(c);
-        self.read_sparse(c);
         self.read_dense_multi(c);
-        self.read_sparse_multi(c);
         self.read_dense_expired(c);
-        self.read_sparse_expired(c);
         self.read_dense_multi_expired(c);
-        self.read_sparse_multi_expired(c);
         self.skip_to_dense(c);
         self.skip_to_sparse(c);
         self.skip_to_dense_multi(c);
@@ -139,24 +135,10 @@ impl NumericBencher {
         group.finish();
     }
 
-    fn read_sparse(&self, c: &mut Criterion) {
-        let mut group = benchmark_group(c, "Numeric", "Read Sparse");
-        self.c_read(&mut group, &self.context_sparse);
-        self.rust_read(&mut group, &self.context_sparse);
-        group.finish();
-    }
-
     fn read_dense_multi(&self, c: &mut Criterion) {
         let mut group = benchmark_group(c, "Numeric", "Read Dense Multi");
         self.c_read(&mut group, &self.context_dense_multi);
         self.rust_read(&mut group, &self.context_dense_multi);
-        group.finish();
-    }
-
-    fn read_sparse_multi(&self, c: &mut Criterion) {
-        let mut group = benchmark_group(c, "Numeric", "Read Sparse Multi");
-        self.c_read(&mut group, &self.context_sparse_multi);
-        self.rust_read(&mut group, &self.context_sparse_multi);
         group.finish();
     }
 
@@ -167,24 +149,10 @@ impl NumericBencher {
         group.finish();
     }
 
-    fn read_sparse_expired(&self, c: &mut Criterion) {
-        let mut group = benchmark_group(c, "Numeric", "Read Sparse Expired");
-        self.c_read(&mut group, &self.context_sparse_expired);
-        self.rust_read(&mut group, &self.context_sparse_expired);
-        group.finish();
-    }
-
     fn read_dense_multi_expired(&self, c: &mut Criterion) {
         let mut group = benchmark_group(c, "Numeric", "Read Dense Multi Expired");
         self.c_read(&mut group, &self.context_dense_multi_expired);
         self.rust_read(&mut group, &self.context_dense_multi_expired);
-        group.finish();
-    }
-
-    fn read_sparse_multi_expired(&self, c: &mut Criterion) {
-        let mut group = benchmark_group(c, "Numeric", "Read Sparse Multi Expired");
-        self.c_read(&mut group, &self.context_sparse_multi_expired);
-        self.rust_read(&mut group, &self.context_sparse_multi_expired);
         group.finish();
     }
 
@@ -411,7 +379,6 @@ where
 
     pub fn bench(&self, c: &mut Criterion) {
         self.read_dense(c);
-        self.read_sparse(c);
         self.skip_to_dense(c);
         self.skip_to_sparse(c);
     }
@@ -420,13 +387,6 @@ where
         let mut group = benchmark_group(c, &self.group_name, "Read Dense");
         self.c_read_dense(&mut group);
         self.rust_read_dense(&mut group);
-        group.finish();
-    }
-
-    fn read_sparse(&self, c: &mut Criterion) {
-        let mut group = benchmark_group(c, &self.group_name, "Read Sparse");
-        self.c_read_sparse(&mut group);
-        self.rust_read_sparse(&mut group);
         group.finish();
     }
 
@@ -489,41 +449,10 @@ where
         });
     }
 
-    fn c_read_sparse<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("C", |b| {
-            b.iter_batched_ref(
-                || self.c_index(true),
-                |ii| {
-                    let it = ii.iterator_term();
-                    while it.read() == ::ffi::IteratorStatus_ITERATOR_OK {
-                        black_box(it.current());
-                    }
-                    it.free();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
     fn rust_read_dense<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
         group.bench_function("Rust", |b| {
             b.iter_batched_ref(
                 || self.rust_index(false),
-                |ii| {
-                    let mut it = Term::new_simple(ii.reader());
-                    while let Ok(Some(current)) = it.read() {
-                        black_box(current);
-                    }
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
-    fn rust_read_sparse<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("Rust", |b| {
-            b.iter_batched_ref(
-                || self.rust_index(true),
                 |ii| {
                     let mut it = Term::new_simple(ii.reader());
                     while let Ok(Some(current)) = it.read() {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/metric.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/metric.rs
@@ -54,7 +54,6 @@ impl Bencher {
 
     pub fn bench(&self, c: &mut Criterion) {
         self.read_dense(c);
-        self.read_sparse(c);
         self.skip_to_dense(c);
         self.skip_to_sparse(c);
     }
@@ -62,12 +61,6 @@ impl Bencher {
     fn read_dense(&self, c: &mut Criterion) {
         let mut group = self.benchmark_group(c, "Iterator - Metric - Read Dense");
         self.rust_read_dense(&mut group);
-        group.finish();
-    }
-
-    fn read_sparse(&self, c: &mut Criterion) {
-        let mut group = self.benchmark_group(c, "Iterator - Metric - Read Sparse");
-        self.rust_read_sparse(&mut group);
         group.finish();
     }
 
@@ -99,23 +92,6 @@ impl Bencher {
             );
         });
     }
-    fn rust_read_sparse<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("Rust", |b| {
-            b.iter_batched_ref(
-                || {
-                    let BenchInput { ids, metric_data } = sparse_input();
-                    MetricSortedById::new(ids, metric_data)
-                },
-                |it| {
-                    while let Ok(Some(current)) = it.read() {
-                        black_box(current);
-                    }
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
     fn rust_skip_to_dense<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
         group.bench_function("Rust", |b| {
             let step = 100;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional.rs
@@ -45,7 +45,6 @@ impl Bencher {
 
     pub fn bench(&self, c: &mut Criterion) {
         self.read_dense(c);
-        self.read_sparse(c);
         self.skip_to_dense(c);
         self.skip_to_sparse(c);
         self.read_id_list_ratios(c);
@@ -81,39 +80,6 @@ impl Bencher {
                 |it| {
                     while let Ok(Some(current)) = it.read() {
                         // touch fields to avoid elision
-                        black_box(current.doc_id);
-                        black_box(current.weight);
-                        black_box(current.freq);
-                    }
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-
-        group.finish();
-    }
-
-    fn read_sparse(&self, c: &mut Criterion) {
-        let mut group = self.benchmark_group(c, "Iterator - Optional - Read Sparse");
-
-        group.bench_function("C", |b| {
-            b.iter_batched_ref(
-                || ffi::QueryIterator::new_optional_virtual_only(Self::LARGE_MAX, Self::WEIGHT),
-                |it| {
-                    while it.read() == ::ffi::IteratorStatus_ITERATOR_OK {
-                        black_box(it.current());
-                    }
-                    it.free();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-
-        group.bench_function("Rust", |b| {
-            b.iter_batched_ref(
-                || Optional::new(Self::LARGE_MAX, Self::WEIGHT, Empty),
-                |it| {
-                    while let Ok(Some(current)) = it.read() {
                         black_box(current.doc_id);
                         black_box(current.weight);
                         black_box(current.freq);


### PR DESCRIPTION
Read sparse benchmarks provide little additional signal over read dense so remove them to reduce benchmark suite runtime.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only deletions with no impact on production logic; primary risk is reduced performance coverage for sparse read scenarios.
> 
> **Overview**
> Removes the *sparse read* benchmark variants from the `rqe_iterators_bencher` suite, keeping dense read and dense/sparse `skip_to` coverage.
> 
> This deletes the associated helper functions and `bench()` invocations across `id_list`, `metric`, `optional`, `not` (sparse child read), and `inverted_index` (numeric and term) benchers to reduce overall benchmark runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7da021dede4742af055492240f7fe61df5a3e506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->