### PR TITLE
Min redis version >=8.4.0

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1200,7 +1200,7 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 5,
+    .minorVersion = 4,
     .patchVersion = 0,
 };
 


### PR DESCRIPTION
Revert redis minimal version to 8.4.0 to allow building disk repo
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change that only impacts version gating at module startup; no runtime query/index logic changes.
> 
> **Overview**
> Lowers the module’s minimum supported Redis version from `8.5.0` to `8.4.0` by changing `supportedVersion`, which affects startup version compatibility checks (and the fallback version used when `INFO` is unavailable in tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c33b1c0409c726a7056fa10826b206769967150b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->