### PR TITLE
Update Disk Term API - pass index result pointer

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -89,9 +89,10 @@ QueryIterator* SearchDisk_NewTermIterator(RedisSearchDiskIndexSpec *index, RSTok
     RSQueryTerm *term = NewQueryTerm(tok, tokenId);
     term->idf = idf;
     term->bm25_idf = bm25_idf;
-    QueryIterator *it = disk->index.newTermIterator(index, term, fieldMask, weight);
+    RSIndexResult *record = NewTokenRecord(term, weight);
+    QueryIterator *it = disk->index.newTermIterator(index, record, fieldMask);
     if (!it) {
-        Term_Free(term);
+        IndexResult_Free(record);
     }
     return it;
 }

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -99,12 +99,11 @@ typedef struct IndexDiskAPI {
    * @brief Creates a new iterator for the inverted index
    *
    * @param index Pointer to the index
-   * @param term Pointer to the query term (contains term string, idf, bm25_idf)
+   * @param record Pointer to the index result (created by NewTokenRecord, takes ownership)
    * @param fieldMask Field mask indicating which fields are present in the document
-   * @param weight Weight for the iterator (used in scoring)
    * @return Pointer to the created iterator, or NULL if creation failed
    */
-  QueryIterator *(*newTermIterator)(RedisSearchDiskIndexSpec* index, RSQueryTerm* term, t_fieldMask fieldMask, double weight);
+  QueryIterator *(*newTermIterator)(RedisSearchDiskIndexSpec* index, RSIndexResult* record, t_fieldMask fieldMask);
 
   /**
    * @brief Returns the number of documents in the index


### PR DESCRIPTION
Simplifies the disk term api

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but breaking C API change to the disk backend interface; mismatched implementations could cause build failures or iterator/ownership bugs at runtime.
> 
> **Overview**
> Updates the disk inverted-index term iterator API to accept an `RSIndexResult` (created via `NewTokenRecord`) rather than separate `RSQueryTerm` and `weight` arguments, simplifying the contract and clarifying ownership.
> 
> This adjusts `SearchDisk_NewTermIterator` to build/free the record appropriately and updates the `newTermIterator` function pointer signature in `search_disk_api.h`; disk backends must be updated to match, but there is no intended end-user behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ae6c7d4ed347f19b51ad8fc9e2b6c4ed43c4f66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->