### PR TITLE
[8.4] CI - task-tests.yml: Fix condition to run "Rust tests (MIRI)"

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -494,7 +494,7 @@ jobs:
         run: make pytest ${{ inputs.test-config }}
 
       - name: Rust tests (MIRI)
-        if: ${{ inputs.unit-tests }} && inputs.san == 'address'
+        if: inputs.san == 'address' && inputs.unit-tests
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: rust_unit_tests_miri
         continue-on-error: ${{ !inputs.fail-fast }}
@@ -564,7 +564,7 @@ jobs:
         # Upload artifacts only if node20 is supported and tests failed (including sanitizer failures)
         if: >
           steps.node20.outputs.supported == 'true' &&
-          (failure() || 
+          (failure() ||
             steps.rust_unit_tests_miri.outcome == 'failure' ||
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure' ||


### PR DESCRIPTION
## Describe the changes in the pull request
- The current condition in the backport #7989 is evaluated always as true and the merge queue fails.

   The warning can be found the github action annotation:   
> "Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy."

The condition was modified to be aligned to master.

Test: https://github.com/RediSearch/RediSearch/actions/runs/22115478958/job/63924066975

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only conditional tweak; low risk aside from potentially changing when MIRI runs in CI.
> 
> **Overview**
> Fixes the `task-test.yml` workflow so the `Rust tests (MIRI)` step only runs when both AddressSanitizer (`inputs.san == 'address'`) and unit tests are enabled, avoiding an always-truthy condition in CI.
> 
> Also normalizes whitespace in the node20 artifact-upload `if:` expression (no behavior change intended).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5582fd6a09837ee14b25368382d84cf286ce1ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->