### PR TITLE
fix valgrind suppression for Rust std lib leak after toolchain update

### DIFF
--- a/src/redisearch_rs/valgrind.supp
+++ b/src/redisearch_rs/valgrind.supp
@@ -7,11 +7,8 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc
-   fun:alloc
-   fun:alloc_impl
-   fun:allocate
-   fun:{closure#0}<std::thread::Inner>
-   fun:allocate_for_layout<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>, alloc::sync::{impl#14}::new_uninit::{closure_env#0}<std::thread::Inner>, fn(*mut u8) -> *mut alloc::sync::ArcInner<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>>>
+   ...
+   fun:*std*thread*Thread*new*
 }
 
 {


### PR DESCRIPTION
The Rust update changed internal symbol names (std::thread::Inner → std::thread::thread::Inner, impl index shift), breaking the exact match. Use broad glob pattern to be resilient to future changes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test tooling-only change (Valgrind suppression patterns) with no runtime, API, or data-path impact; main risk is over-broad suppression potentially hiding real leaks during local valgrind runs.
> 
> **Overview**
> Updates the Rust Valgrind suppression for a std-lib leak to be resilient to toolchain symbol renames by replacing a brittle exact call-stack match with a wildcard/ellipsis pattern (anchored on `*std*thread*Thread*new*`).
> 
> Also fixes the suppression file formatting/termination by ensuring the final block is properly closed with a trailing newline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01bae29b4965d471a8c5a1de2dbc55ce789914ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->