### PR TITLE
Fix wording

### DIFF
--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -185,9 +185,9 @@ typedef Size_40 OpaqueRLookupSize;
 #endif
 
 /**
- * An opaque query error which can be passed by value to C.
+ * An opaque lookup which can be passed by value to C.
  *
- * The size and alignment of this struct must match the Rust `QueryError`
+ * The size and alignment of this struct must match the Rust `RLookup`
  * structure exactly.
  */
 typedef struct ALIGNED(8) RLookup {
@@ -203,7 +203,7 @@ typedef Size_40 OpaqueRLookupRowSize;
 #endif
 
 /**
- * An lookup row which can be passed by value to C.
+ * An opaque lookup row which can be passed by value to C.
  *
  * The size and alignment of this struct must match the Rust `RLookupRow`
  * structure exactly.

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -504,9 +504,9 @@ pub mod opaque {
     #[cfg(not(debug_assertions))]
     type OpaqueRLookupSize = Size<40>;
 
-    /// An opaque query error which can be passed by value to C.
+    /// An opaque lookup which can be passed by value to C.
     ///
-    /// The size and alignment of this struct must match the Rust `QueryError`
+    /// The size and alignment of this struct must match the Rust `RLookup`
     /// structure exactly.
     #[repr(C, align(8))]
     pub struct OpaqueRLookup(OpaqueRLookupSize);

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -368,7 +368,7 @@ pub mod opaque {
     use c_ffi_utils::opaque::Size;
     use value::RSValueFFI;
 
-    /// An lookup row which can be passed by value to C.
+    /// An opaque lookup row which can be passed by value to C.
     ///
     /// The size and alignment of this struct must match the Rust `RLookupRow`
     /// structure exactly.


### PR DESCRIPTION
Fix wording

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to comments in Rust and the generated C header; no runtime behavior or FFI layout is modified.
> 
> **Overview**
> Updates the generated C header (`rlookup_rs.h`) and Rust FFI docs to correct misleading wording: the opaque-by-value wrappers now describe `RLookup` and `RLookupRow` as *opaque lookup* and *opaque lookup row* types (instead of referring to a query error).
> 
> No functional or ABI/layout changes; this is a documentation-only clarification for C/Rust FFI consumers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9b7efd52afe99ed24e8bd0cf1ddafc617e48fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->