### PR TITLE
II term iterator: enforce term being passed

### DIFF
--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -396,11 +396,12 @@ static QueryIterator *NewInvIndIterator(const InvertedIndex *idx, enum IteratorT
 
 QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, FieldMaskOrIndex fieldMaskOrIndex,
                                            RSQueryTerm *term, double weight) {
+  RS_ASSERT(term);
   FieldFilterContext fieldCtx = {
     .field = fieldMaskOrIndex,
     .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT,
   };
-  if (term && sctx) {
+  if (sctx) {
     term->idf = CalculateIDF(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
     term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
   }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -110,6 +110,7 @@ impl QueryIterator {
 
     #[inline(always)]
     pub unsafe fn new_term(ii: *mut ffi::InvertedIndex) -> Self {
+        let term: *mut ffi::RSQueryTerm = Box::into_raw(RSQueryTerm::new(b"term", 1, 0)).cast();
         Self(unsafe {
             let field_mask_ffi = ffi::FieldMaskOrIndex {
                 __bindgen_anon_2: ffi::FieldMaskOrIndex__bindgen_ty_2 {
@@ -119,7 +120,7 @@ impl QueryIterator {
                 },
             };
 
-            ffi::NewInvIndIterator_TermQuery(ii, ptr::null(), field_mask_ffi, ptr::null_mut(), 1.0)
+            ffi::NewInvIndIterator_TermQuery(ii, ptr::null(), field_mask_ffi, term, 1.0)
         })
     }
 

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -70,7 +70,8 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
       for (size_t i = 0; i < percent; i++) {
         InvertedIndex *w = createPopulateTermsInvIndex(n, step, i);
         inv_indices[i] = w;
-        its[i] = NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, NULL, 1);
+        RSToken tok = {.str = const_cast<char*>("term"), .len = 4, .flags = 0};
+        its[i] = NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, NewQueryTerm(&tok, 1), 1);
       }
       IteratorsConfig config{};
       iteratorsConfig_init(&config);

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -60,7 +60,8 @@ public:
 
         // Create an index with the specified flags
         createIndex(flags);
-        iterator = NewInvIndIterator_TermQuery(index, &q_mock->sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL}, nullptr, 1.0);
+        RSToken tok = {.str = const_cast<char*>("term"), .len = 4, .flags = 0};
+        iterator = NewInvIndIterator_TermQuery(index, &q_mock->sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL}, NewQueryTerm(&tok, 1), 1.0);
     }
     void TearDown(::benchmark::State &state) {
         if (iterator) {

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -48,7 +48,8 @@ protected:
         }
 
         SetTermsInvIndex();
-        it_base = NewInvIndIterator_TermQuery(idx, &q_mock.sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL}, nullptr, 1.0);
+        RSToken tok = {.str = const_cast<char*>("term"), .len = 4, .flags = 0};
+        it_base = NewInvIndIterator_TermQuery(idx, &q_mock.sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL}, NewQueryTerm(&tok, 1), 1.0);
     }
     void TearDown() override {
         it_base->Free(it_base);
@@ -185,7 +186,8 @@ class IndexIteratorTestExpiration : public ::testing::TestWithParam<IndexFlags> 
           q_mock.sctx.time.current = {100, 100};
 
           // Create the iterator based on the flags
-          it_base = NewInvIndIterator_TermQuery(idx, &q_mock.sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = fieldMask}, nullptr, 1.0);
+          RSToken tok = {.str = const_cast<char*>("term"), .len = 4, .flags = 0};
+          it_base = NewInvIndIterator_TermQuery(idx, &q_mock.sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = fieldMask}, NewQueryTerm(&tok, 1), 1.0);
       }
 
       void TearDown() override {

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -185,7 +185,8 @@ public:
     QueryIterator **children = (QueryIterator **)rm_malloc(sizeof(QueryIterator *) * terms.size());
     for (size_t i = 0; i < terms.size(); i++) {
       ASSERT_NE(invertedIndexes.find(terms[i]), invertedIndexes.end()) << "Term " << terms[i] << " not found in inverted indexes";
-      children[i] = NewInvIndIterator_TermQuery(invertedIndexes[terms[i]], sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL}, NULL, 1.0);
+      RSToken tok = {.str = const_cast<char*>("term"), .len = 4, .flags = 0};
+      children[i] = NewInvIndIterator_TermQuery(invertedIndexes[terms[i]], sctx, {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL}, NewQueryTerm(&tok, 1), 1.0);
     }
     ii_base = NewIntersectionIterator(children, terms.size(), max_slop, in_order, 1.0);
   }


### PR DESCRIPTION
The Rust version will make this mandatory.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to asserting on invalid (`NULL`) term inputs; updates are contained to tests/bench code and should only impact misuse or incorrect FFI callers.
> 
> **Overview**
> `NewInvIndIterator_TermQuery` now **requires a non-NULL `RSQueryTerm`** (asserting instead of silently accepting `NULL`), aligning C behavior with the Rust FFI expectations and preventing invalid iterator construction.
> 
> Tests/benchmarks and the Rust bencher FFI were updated to always create and pass a term (e.g., via `NewQueryTerm`/`RSQueryTerm::new`), including a small C++ helper to centralize term creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 595c399b1a4c52b5751cbaa66bb9bc9a761484a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->