### PR TITLE
[MOD-14096] FFI-readiness for NumericRangeTree's GC

### DIFF
--- a/src/redisearch_rs/generational_slab/src/lib.rs
+++ b/src/redisearch_rs/generational_slab/src/lib.rs
@@ -156,6 +156,17 @@ impl Key {
     pub const fn generation(self) -> u32 {
         self.generation
     }
+
+    /// Reconstruct a key from its raw position and generation.
+    ///
+    /// This is intended for FFI round-trips where a key was previously
+    /// decomposed via [`Key::position`] and [`Key::generation`].
+    pub const fn from_raw_parts(position: u32, generation: u32) -> Self {
+        Self {
+            position,
+            generation,
+        }
+    }
 }
 
 /// Pre-allocated storage for a uniform data type

--- a/src/redisearch_rs/numeric_range_tree/src/arena.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/arena.rs
@@ -32,6 +32,15 @@ impl NodeIndex {
     pub const fn key(self) -> Key {
         self.0
     }
+
+    /// Reconstruct a `NodeIndex` from the raw position and generation of
+    /// the underlying [`Key`].
+    ///
+    /// Intended for FFI round-trips where the index was previously
+    /// decomposed via [`Key::position`] and [`Key::generation`].
+    pub const fn from_raw_parts(position: u32, generation: u32) -> Self {
+        Self(Key::from_raw_parts(position, generation))
+    }
 }
 
 impl From<Key> for NodeIndex {

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -79,10 +79,11 @@ mod unique_id;
 pub use arena::NodeIndex;
 pub use index::{NumericIndex, NumericIndexReader};
 pub use inverted_index::NumericFilter;
-pub use iter::ReversePreOrderDfsIterator;
+pub use iter::{IndexedReversePreOrderDfsIterator, ReversePreOrderDfsIterator};
 pub use node::{InternalNode, LeafNode, NumericRangeNode};
 pub use range::NumericRange;
 pub use tree::{
-    AddResult, NodeGcDelta, NumericRangeTree, SingleNodeGcResult, TrimEmptyLeavesResult,
+    AddResult, CompactIfSparseResult, NodeGcDelta, NumericRangeTree, SingleNodeGcResult,
+    TrimEmptyLeavesResult,
 };
 pub use unique_id::TreeUniqueId;

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -64,7 +64,7 @@ pub struct NumericRange {
 /// hashed into HyperLogLog registers. We hash the raw bytes (bit
 /// representation) rather than the numeric value — see
 /// [`NumericRange::update_cardinality`] for rationale.
-fn update_cardinality(hll: &mut Hll, value: f64) {
+pub(crate) fn update_cardinality(hll: &mut Hll, value: f64) {
     hll.add(value.to_ne_bytes());
 }
 

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -23,7 +23,7 @@ mod insert;
 #[cfg(all(feature = "unittest", not(miri)))]
 mod invariants;
 
-pub use gc::{NodeGcDelta, SingleNodeGcResult};
+pub use gc::{CompactIfSparseResult, NodeGcDelta, SingleNodeGcResult};
 
 use ffi::t_docId;
 
@@ -284,6 +284,11 @@ impl NumericRangeTree {
     /// Returns an iterator over all nodes in the tree (depth-first traversal).
     pub fn iter(&self) -> crate::ReversePreOrderDfsIterator<'_> {
         crate::ReversePreOrderDfsIterator::new(self)
+    }
+
+    /// Returns an iterator over all nodes in the tree, alongside their indices (depth-first traversal).
+    pub fn indexed_iter(&self) -> crate::IndexedReversePreOrderDfsIterator<'_> {
+        crate::IndexedReversePreOrderDfsIterator::new(self)
     }
 
     /// Calculate the total memory usage of the tree, in bytes.

--- a/src/redisearch_rs/numeric_range_tree/src/unique_id.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/unique_id.rs
@@ -30,6 +30,12 @@ impl TreeUniqueId {
     }
 }
 
+impl std::fmt::Display for TreeUniqueId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl From<TreeUniqueId> for u32 {
     fn from(id: TreeUniqueId) -> Self {
         id.0

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
@@ -83,7 +83,10 @@ fn apply_gc_to_single_leaf(#[values(false, true)] compress_floats: bool) {
     let result = tree.apply_gc_to_node(tree.root_index(), delta).unwrap();
 
     assert_eq!(result.index_gc_info.entries_removed, 5);
-    assert_eq!(tree.num_entries(), entries_before - 5);
+    assert_eq!(
+        tree.num_entries(),
+        entries_before - result.index_gc_info.entries_removed
+    );
     assert!(
         result.index_gc_info.bytes_freed > 0,
         "GC that removes entries should free bytes"

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/helpers.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/helpers.rs
@@ -9,7 +9,7 @@
 
 //! Shared test helpers for the numeric range tree integration tests.
 
-use inverted_index::{Encoder, numeric::Numeric};
+use inverted_index::{Encoder, IndexBlock, RSIndexResult, numeric::Numeric};
 use numeric_range_tree::{NodeGcDelta, NodeIndex, NumericRangeNode, NumericRangeTree};
 
 /// Scan a single node and produce its GC delta, if any.
@@ -30,10 +30,13 @@ pub fn scan_node_delta_with_hll(
 ) -> Option<NodeGcDelta> {
     let node = tree.node(node_idx);
     node.range()
-        .and_then(|range| {
+        .and_then(|range| -> Option<inverted_index::GcScanDelta> {
             range
                 .entries()
-                .scan_gc(doc_exist)
+                .scan_gc(
+                    doc_exist,
+                    None::<for<'index> fn(&RSIndexResult<'index>, &IndexBlock)>,
+                )
                 .expect("scan_gc should not fail")
         })
         .map(|delta| {


### PR DESCRIPTION
## Describe the changes in the pull request

Minor changes to `numeric_range_tree` required ahead of #8401.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GC scan/apply plumbing and cardinality re-estimation paths; while mostly additive/FFI-shaping, mistakes could cause incorrect GC deltas or HLL cardinality after GC.
> 
> **Overview**
> Improves FFI-readiness of `numeric_range_tree` garbage collection by making key/index handles reconstructible (`Key::from_raw_parts`, `NodeIndex::from_raw_parts`) and marking GC-related result structs as `#[repr(C)]`.
> 
> GC scanning is refactored to support a per-entry *repair callback* (`NumericIndex::scan_gc`) and a new `NumericRangeNode::scan_gc` that computes HLL registers during scans for accurate post-GC cardinality resets. The tree API adds `indexed_iter()` / `IndexedReversePreOrderDfsIterator` for traversals that need stable node indices, and introduces `CompactIfSparseResult` as an FFI-friendly return value; integration tests are updated to match the new GC scan signature and assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc36b6d083fc729118528c7bbc9a3aac6004616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->