### PR TITLE
Constrain HyperLogLog to estimate cardinality for a given type T

### DIFF
--- a/src/redisearch_rs/hyperloglog/benches/hyperloglog_operations.rs
+++ b/src/redisearch_rs/hyperloglog/benches/hyperloglog_operations.rs
@@ -104,7 +104,7 @@ const CARDINALITIES: &[u32] = &[100, 1000, 10000, 100000];
 const HASHER_NAMES: &[&str] = &["fnv", "murmur3", "xxhash32", "ahash", "fxhash", "wyhash"];
 
 fn measure_accuracy<H: hash32::Hasher + Default>(n: u32) -> (usize, f64) {
-    let mut hll: HyperLogLog10<H> = HyperLogLog::new();
+    let mut hll: HyperLogLog10<[u8; 4], H> = HyperLogLog::new();
     for i in 0..n {
         hll.add(&i.to_le_bytes());
     }
@@ -119,7 +119,7 @@ fn bench_add(c: &mut Criterion) {
         name: &str,
     ) {
         group.bench_function(name, |b| {
-            let mut hll: HyperLogLog10<H> = HyperLogLog::new();
+            let mut hll: HyperLogLog10<[u8; 4], H> = HyperLogLog::new();
             let mut i = 0u32;
             b.iter(|| {
                 hll.add(black_box(&i.to_le_bytes()));
@@ -145,7 +145,7 @@ fn bench_count(c: &mut Criterion) {
         b.iter_batched(
             || {
                 // Setup: create HyperLogLog with data, cache not yet computed
-                let mut hll: HyperLogLog10<CFnvHasher> = HyperLogLog::new();
+                let mut hll: HyperLogLog10<[u8; 4], CFnvHasher> = HyperLogLog::new();
                 for i in 0..10000u32 {
                     hll.add(&i.to_le_bytes());
                 }
@@ -166,8 +166,8 @@ fn bench_merge(c: &mut Criterion) {
     group.bench_function("fnv", |b| {
         b.iter_batched(
             || {
-                let mut hll1: HyperLogLog10<CFnvHasher> = HyperLogLog::new();
-                let mut hll2: HyperLogLog10<CFnvHasher> = HyperLogLog::new();
+                let mut hll1: HyperLogLog10<[u8; 4], CFnvHasher> = HyperLogLog::new();
+                let mut hll2: HyperLogLog10<[u8; 4], CFnvHasher> = HyperLogLog::new();
                 for i in 0..1000u32 {
                     hll1.add(&i.to_le_bytes());
                     hll2.add(&(i + 500).to_le_bytes());

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -23,7 +23,7 @@ use crate::index::{NumericIndex, NumericIndexReader};
 ///
 /// See the [crate-level documentation](crate#cardinality-estimation) for details
 /// on precision, error rate, and memory usage.
-pub type Hll = HyperLogLog6<WyHasher>;
+pub type Hll = HyperLogLog6<[u8; 8], WyHasher>;
 
 /// A numeric range is a leaf-level storage unit in the numeric range tree.
 ///
@@ -65,7 +65,7 @@ pub struct NumericRange {
 /// representation) rather than the numeric value — see
 /// [`NumericRange::update_cardinality`] for rationale.
 fn update_cardinality(hll: &mut Hll, value: f64) {
-    hll.add(value.to_ne_bytes());
+    hll.add(&value.to_ne_bytes());
 }
 
 impl NumericRange {


### PR DESCRIPTION
## Describe the changes in the pull request

Leverage the type system to ensure that a given `HyperLogLog` instance is never used to count instances of distinct types.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an API-breaking generics change that touches multiple call sites; while behavior should be unchanged, incorrect type parameterization or `add` call updates could cause build failures or subtle hashing mismatches if callers change the hashed representation.
> 
> **Overview**
> **Release note:** `HyperLogLog` is now *type-scoped* via a new generic `T`, preventing a single instance from accidentally mixing different input types at compile time.
> 
> This updates the public API (`add` now takes `&T`, and aliases like `HyperLogLog10` require `T`) and adapts benchmarks/tests plus numeric range-tree cardinality tracking to the new typed HLL signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 334a88e0fa8ae3d8339b3003e85e264fa962482a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->