### PR TITLE
numeric_range_tree: disable slow tests with miri

### DIFF
--- a/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
@@ -508,6 +508,7 @@ fn trim_frees_internal_ranges_when_all_empty(#[values(false, true)] compress_flo
 /// - When only the right subtree is empty,
 ///   it is freed and the left child is promoted in place.
 #[rstest]
+#[cfg_attr(miri, ignore = "Skip miri because too slow")]
 fn trim_promotes_left_when_right_empty(#[values(false, true)] compress_floats: bool) {
     let n = DEEP_TREE_ENTRIES;
     let mut tree = build_tree(n, compress_floats, 0);
@@ -535,6 +536,7 @@ fn trim_promotes_left_when_right_empty(#[values(false, true)] compress_floats: b
 /// (left extremes and right extremes are populated), but the structural change
 /// from trimming triggers the balance path.
 #[rstest]
+#[cfg_attr(miri, ignore = "Skip miri because too slow")]
 fn trim_rebalances_surviving_ancestors(#[values(false, true)] compress_floats: bool) {
     let n = DEEP_TREE_ENTRIES;
     let mut tree = build_tree(DEEP_TREE_ENTRIES, compress_floats, 0);


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 4071aa51968af9cd099dc3e672c113d9efe58d7d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->