### PR TITLE
[MOD-14149] RLookup - Expose cursors

### DIFF
--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -617,7 +617,6 @@ pub unsafe extern "C" fn RLookup_Iter(lookup: *const OpaqueRLookup) -> ffi::RLoo
 ///    a. Not move (memcpy/memmove) out of the pointer.
 ///    b. The pointed-to value must remain at its original address in memory and never be relocated.
 ///
-///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_IterMut(
@@ -628,7 +627,8 @@ pub unsafe extern "C" fn RLookup_IterMut(
 
     let current = lookup.cursor_mut().current().map_or(ptr::null_mut(), |c| {
         ptr::from_mut(
-            // Safety: ensured by caller (2., 3.), as well as this function not doing anything with the pointer besides returning it.
+            // Safety: ensured by caller (2., 3.)
+            // Both this function and the caller guarantee that the value behind the pointer is never moved.
             unsafe { Pin::into_inner_unchecked(c) },
         )
         .cast::<ffi::RLookupKey>()

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -643,10 +643,6 @@ RLookupIterator RLookup_Iter(const struct RLookup *lookup);
  *    a. Not move (memcpy/memmove) out of the pointer.
  *    b. The pointed-to value must remain at its original address in memory and never be relocated.
  *
- * Although the internal `Pin` is unwrapped via `into_inner_unchecked`,
- * the pin invariant is still upheld: both this function and the caller
- * guarantee that the value behind the pointer is never moved.///
- *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 RLookupIteratorMut RLookup_IterMut(struct RLookup *lookup);


### PR DESCRIPTION
Expose RLookup cursors.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new unsafe FFI surface area and a pinned-memory contract for mutable iteration, where misuse can cause UB; otherwise changes are additive and localized.
> 
> **Overview**
> Exposes `RLookup` key-list cursors over the C FFI by adding `RLookup_Iter` (read-only) and `RLookup_IterMut` (mutable) entrypoints.
> 
> The mutable iterator path uses Rust `Pin` and documents a *pinned pointer* contract for callers to avoid moving underlying keys, and the generated header (`rlookup_rs.h`) is updated with the new APIs and safety requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bd88b653fadb930aed5f009bd2cb3bb70b9f256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->