### PR TITLE
[MOD-14147] Compute the correct cardinality after a GC run on the node of a NumericRangeTree

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -204,23 +204,16 @@ static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
 }
 
 typedef struct {
-  struct HLL majority_card;     // Holds the majority cardinality of all the blocks we've seen so far
-  struct HLL last_block_card;   // Holds the cardinality of the last block we've seen
-  const IndexBlock *last_block; // The last block we've seen, to know when to merge the cardinalities
+  struct HLL majority_card;         // Cardinality of all blocks except the last
+  struct HLL last_block_card;       // Cardinality of the last block only
+  const IndexBlock *actual_last_block; // Pre-computed pointer to the real last block
 } numCbCtx;
 
 static void countRemain(const RSIndexResult *r, const IndexBlock *blk, void *arg) {
   numCbCtx *ctx = arg;
-
-  if (ctx->last_block != blk) {
-    // We are in a new block, merge the last block's cardinality into the majority, and clear the last block
-    hll_merge(&ctx->majority_card, &ctx->last_block_card);
-    hll_clear(&ctx->last_block_card);
-    ctx->last_block = blk;
-  }
-  // Add the current record to the last block's cardinality
   double value = IndexResult_NumValue(r);
-  hll_add(&ctx->last_block_card, &value, sizeof(value));
+  struct HLL *target = (blk == ctx->actual_last_block) ? &ctx->last_block_card : &ctx->majority_card;
+  hll_add(target, &value, sizeof(value));
 }
 
 typedef struct {
@@ -293,11 +286,14 @@ static void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx) {
       if (!currNode->range) {
         continue;
       }
-      nctx.last_block = NULL;
+      InvertedIndex *idx = currNode->range->entries;
+      uintptr_t numBlocks = InvertedIndex_NumBlocks(idx);
+      if (numBlocks == 0) {
+        continue;
+      }
       hll_clear(&nctx.majority_card);
       hll_clear(&nctx.last_block_card);
-
-      InvertedIndex *idx = currNode->range->entries;
+      nctx.actual_last_block = InvertedIndex_BlockRef(idx, numBlocks - 1);
       header.curPtr = currNode;
 
       CTX_II_GC_Callback cbCtx = { .gc = gc, .hdrarg = &header };
@@ -311,8 +307,7 @@ static void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx) {
       );
 
       if (repaired) {
-        // Instead of sending the majority cardinality and the last block's cardinality, we now
-        // merge the majority cardinality into the last block's cardinality, and send its registers
+        // Merge the majority cardinality into the last block's cardinality, and send its registers
         // as the cardinality WITH the last block's cardinality, and then send the majority registers
         // as the cardinality WITHOUT the last block's cardinality. This way, the main process can
         // choose which registers to use without having to merge them itself.

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -870,12 +870,8 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   EXPECT_EQ(cur_cardinality, NumericRange_GetCardinality(rt->root->range));
 }
 
-// Demonstrates the HLL cardinality bug when the last block is fully emptied during GC.
-// The C code's `countRemain` callback tracks block transitions by pointer comparison,
-// but is only called for surviving documents. When the last block is fully emptied,
-// the callback never fires for it, so `last_block_card` holds the penultimate block's
-// data. This causes `registers_without_last_block` to lose the penultimate block's
-// cardinality when `ignored_last_block = true`.
+// Regression test for MOD-14147, an HLL cardinality bug that occurs when the last block
+// is fully emptied during GC.
 TEST_F(FGCTestNumeric, testHllCardinalityWhenLastBlockFullyEmptied) {
   constexpr size_t docs_per_block = 100;
   constexpr size_t first_split_card = 16; // from `numeric_index.c`
@@ -911,7 +907,8 @@ TEST_F(FGCTestNumeric, testHllCardinalityWhenLastBlockFullyEmptied) {
 
   // Step 3: Add a post-fork entry to trigger `ignored_last_block`.
   // This writes to block 2 (still has capacity), changing its `num_entries`.
-  // When the parent applies, this mismatch causes `ignored_last_block = true`.
+  // When the parent applies, this mismatch causes `ignored_last_block = true`,
+  // thus preserving the last block.
   this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, "4.0");
 
   // Step 4: Apply and assert.
@@ -919,7 +916,5 @@ TEST_F(FGCTestNumeric, testHllCardinalityWhenLastBlockFullyEmptied) {
 
   ASSERT_TRUE(rt->root->range);
   // Correct cardinality is 4 (values 1.0, 2.0, 3.0, 4.0).
-  // With the bug, cardinality would be 3 (value 2.0 from block 1 is incorrectly
-  // excluded from `registers_without_last_block`).
   EXPECT_EQ(4u, NumericRange_GetCardinality(rt->root->range));
 }


### PR DESCRIPTION
## Describe the changes in the pull request

The first commit adds a regression test, showcasing the issue when all entries in the last block are deleted _and_ the last block isn't GCed.
The second commit patches the GC logic to track the last block pointer, regardless of whether or not the callback is fired on the last block.

For release notes, perhaps:

> Fixed incorrect cardinality estimation in numeric range fields after garbage collection. In a corner case, we would undercount distinct values, potentially causing suboptimal range tree splits over time.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ForkGC’s numeric cardinality (HLL) repair path, which affects query correctness for numeric fields after GC; logic change is small but in a critical data-structure maintenance flow.
> 
> **Overview**
> Fixes an edge-case where numeric field cardinality could be computed incorrectly after a ForkGC run when the last inverted-index block becomes empty but is preserved (due to parent-side changes).
> 
> The GC numeric repair callback now targets HLL updates based on a precomputed pointer to the actual last block (instead of relying on block-change detection), and a new regression test reproduces the scenario and asserts the corrected cardinality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f140a02f8fa6295126547eafc908e744382a5738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->