### PR TITLE
MOD-14162 add missing RSValue utility methods

### DIFF
--- a/src/redisearch_rs/value/src/lib.rs
+++ b/src/redisearch_rs/value/src/lib.rs
@@ -82,6 +82,17 @@ impl RsValue {
             RsValue::Map(_) => "Map",
         }
     }
+
+    /// Returns the string bytes of the value, if it is a string type.
+    pub fn as_str_bytes(&self) -> Option<&[u8]> {
+        match self {
+            RsValue::RmAllocString(str) => Some(str.as_bytes()),
+            RsValue::ConstString(str) => Some(str.as_bytes()),
+            RsValue::RedisString(str) => Some(str.as_bytes()),
+            RsValue::String(str) => Some(str.as_str().as_bytes()),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/redisearch_rs/value/src/shared.rs
+++ b/src/redisearch_rs/value/src/shared.rs
@@ -64,6 +64,16 @@ impl SharedRsValue {
 
         *value = new_value;
     }
+
+    /// Returns true if the two [`SharedRsValue`]s point to the same allocation in a vein similar to [`ptr::eq`][std::ptr::eq].
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        Arc::ptr_eq(&this.inner, &other.inner)
+    }
+
+    /// Returns the reference count of this [`SharedRsValue`].
+    pub fn refcount(this: &Self) -> usize {
+        Arc::strong_count(&this.inner)
+    }
 }
 
 impl std::fmt::Debug for SharedRsValue {


### PR DESCRIPTION
## Describe the changes in the pull request

This change adds a few utility methods to `RsValue` and `SharedRsValue` that will be required to rebase RLookup code onto the Rust RsValue implementation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive utility APIs only; no existing logic changes beyond exposing pointer equality and refcount introspection.
> 
> **Overview**
> Adds `RsValue::as_str_bytes()` to expose a unified `Option<&[u8]>` view over all string-backed `RsValue` variants.
> 
> Extends `SharedRsValue` with `ptr_eq()` (allocation identity check) and `refcount()` (exposes `Arc` strong count) to support reference/aliasing-aware logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567ea712e2ba1c9e87a17b704eb7e6202acbbebc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->