### PR TITLE
[2.6] MOD-14151: Add support for Amazon Linux 2023

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -13,6 +13,7 @@ on:
           # - rockylinux:9
           - debian:bullseye
           - amazonlinux:2
+          - amazonlinux:2023
           - mariner:2
           - macos
         description: 'Platform to build on. Use "all" to build on all'

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -46,6 +46,7 @@ on:
           # - rockylinux:9
           - debian:bullseye
           - amazonlinux:2
+          - amazonlinux:2023
           - mariner:2
         description: 'Platform to build on. Use "all" to build on all'
         default: all

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -8,11 +8,14 @@ env:
                     'rockylinux:8',
                     'debian:bullseye',
                     'amazonlinux:2',
+                    'amazonlinux:2023',
                     'mcr.microsoft.com/cbl-mariner/base/core:2.0'
                     ]"
                     # TODO: Add back 'rockylinux:9' when RedisJSON 2.4 supports it
   ALL_ARM_IMAGES: "['ubuntu:jammy',
-                    'ubuntu:focal']"
+                    'ubuntu:focal',
+                    'amazonlinux:2023'
+                    ]"
 
 on:
   workflow_call:
@@ -102,6 +105,16 @@ jobs:
             arm_include.append({
               'OS': 'amazonlinux:2',
               'pre-deps': "yum install -y tar gzip git"})
+
+          # amazonlinux:2023 needs pre-checkout dependencies
+          if x86_platforms.count('amazonlinux:2023') > 0:
+            x86_include.append({
+              'OS': 'amazonlinux:2023',
+              'pre-deps': "dnf install -y tar gzip git"})
+          if 'amazonlinux:2023' in arm_platforms:
+            arm_include.append({
+              'OS': 'amazonlinux:2023',
+              'pre-deps': "dnf install -y tar gzip git"})
 
           # mariner:2 needs pre-checkout dependencies
           if x86_platforms.count('mcr.microsoft.com/cbl-mariner/base/core:2.0') > 0:

--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+MODE=$1 # whether to install using sudo or not
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+$MODE dnf update -y
+$MODE dnf install -y wget tar gzip git which gcc gcc-c++ libstdc++-static make rsync unzip clang clang-devel
+$MODE dnf install -y openssl openssl-devel gdb


### PR DESCRIPTION
## Description

[2.6] Add support for amazonlinux:2023 for amd64 and arm64.

Build and upload artifacts: https://github.com/RediSearch/RediSearch/actions/runs/22308865501

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow/config-only changes that expand the CI matrix; primary risk is CI failures due to missing/incorrect packages on the new distro.
> 
> **Overview**
> Adds **CI support for `amazonlinux:2023`** across build-artifact and Linux test workflows by exposing it as a selectable `platform` and including it in the x86_64 and aarch64 platform matrices.
> 
> Updates `task-get-linux-configurations.yml` to treat `amazonlinux:2023` as a first-class image (including ARM) and to run required pre-checkout deps via `dnf`. Adds a new `.install/amazon_linux_2023.sh` script to install the toolchain and OpenSSL/gdb dependencies on Amazon Linux 2023.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e337f550f4fc02c7220822e0915998bbe7decb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->