### PR TITLE
return boolean to detect if term removed from trie

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -4213,15 +4213,17 @@ void IndexSpec_ReleaseWriteLock(IndexSpec* sp) {
 
 // Update a term's document count in the Serving Trie
 // Note: term is NOT null-terminated; term_len specifies the length
-void IndexSpec_DecrementTrieTermCount(IndexSpec* sp, const char* term, size_t term_len,
+// Returns true if the term was completely emptied and deleted from the trie.
+bool IndexSpec_DecrementTrieTermCount(IndexSpec* sp, const char* term, size_t term_len,
                                   size_t doc_count_decrement) {
   if (!sp->terms || doc_count_decrement == 0) {
-    return;
+    return false;
   }
   // Decrement the numDocs count for this term in the trie
   // If numDocs reaches 0, the node will be deleted
   TrieDecrResult result = Trie_DecrementNumDocs(sp->terms, term, term_len, doc_count_decrement);
   RS_ASSERT(result != TRIE_DECR_NOT_FOUND);
+  return result == TRIE_DECR_DELETED;
 }
 
 // Update IndexScoringStats based on compaction delta

--- a/src/spec.h
+++ b/src/spec.h
@@ -787,8 +787,9 @@ void IndexSpec_ReleaseWriteLock(IndexSpec* sp);
  * @param term Pointer to term string (NOT null-terminated)
  * @param term_len Length of term in bytes
  * @param doc_count_decrement Number of documents to decrement from the term's count
+ * @return true if the term was completely emptied and deleted from the trie
  */
-void IndexSpec_DecrementTrieTermCount(IndexSpec* sp, const char* term, size_t term_len,
+bool IndexSpec_DecrementTrieTermCount(IndexSpec* sp, const char* term, size_t term_len,
                                       size_t doc_count_decrement);
 
 /**


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API/ABI change isolated to the GC/compaction FFI surface; risk is mainly any out-of-tree callers needing to adapt to the new return type.
> 
> **Overview**
> **Release note:** Improves GC/compaction integration by having `IndexSpec_DecrementTrieTermCount` return whether a term was fully removed from the serving trie, enabling callers to accurately detect and account for terms that become empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6e2fc25cf9d87abc7e1a1be130728ba9967f211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->