### PR TITLE
MOD-14154: Add missing geoshape token in commands.json + command_info.c

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -234,6 +234,11 @@
                 "token": "GEO"
               },
               {
+                "name": "geoshape",
+                "type": "pure-token",
+                "token": "GEOSHAPE"
+              },
+              {
                 "name": "vector",
                 "type": "pure-token",
                 "token": "VECTOR"

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -244,6 +244,11 @@ int SetFtCreateInfo(RedisModuleCommand *cmd) {
                 .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
               },
               {
+                .name = "geoshape",
+                .token = "GEOSHAPE",
+                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+              },
+              {
                 .name = "vector",
                 .token = "VECTOR",
                 .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,


### PR DESCRIPTION
## Describe the changes in the pull request
`FT.CREATE` railroad syntax diagram is missing the `GEOSHAPE` token.

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change that affects documentation/introspection output, with no impact to indexing/query execution logic.
> 
> **Overview**
> Fixes `FT.CREATE` command metadata to include the missing `GEOSHAPE` schema field type token.
> 
> This updates both `commands.json` and the generated `src/command_info/command_info.c` so tooling that renders syntax/railroad diagrams and command introspection properly shows `GEOSHAPE` as a supported field type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4adb18a280daa1e169b840893daa5912db77ab87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->