### PR TITLE
[8.6] MOD-14079: Suppress info when there are zero indices (#8283)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2270,5 +2270,14 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     )
   )
 
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
+      ctx, "search-_info-on-zero-indexes", 0,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.infoEmitOnZeroIndexes)
+    )
+  )
+
   return REDISMODULE_OK;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -203,6 +203,9 @@ typedef struct {
   uint32_t maxTrimDelayMS;
   // Delay between trimming state checks (in milliseconds)
   uint32_t trimmingStateCheckDelayMS;
+  // If false, suppress emitting RediSearch INFO metrics when there are no indexes.
+  // (We still emit the "version" section, and we never suppress crash-report info.)
+  bool infoEmitOnZeroIndexes;
   // Simulate working under Flex conditions. This is used for testing only.
   bool simulateInFlex;
 } RSConfig;
@@ -388,6 +391,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .minTrimDelayMS = DEFAULT_MIN_TRIM_DELAY,                                    \
     .maxTrimDelayMS = DEFAULT_MAX_TRIM_DELAY,                                    \
     .trimmingStateCheckDelayMS = DEFAULT_TRIMMING_STATE_CHECK_DELAY,            \
+    .infoEmitOnZeroIndexes = false,                                            \
     .simulateInFlex = false,           \
   }
 

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -17,6 +17,7 @@
 #include "info/info_redis/types/blocked_queries.h"
 #include "info/info_redis/threads/current_thread.h"
 #include "info/info_redis/threads/main_thread.h"
+#include "spec.h"
 
 /* ========================== PROTOTYPES ============================ */
 // Fields statistics
@@ -24,6 +25,7 @@ static inline void AddToInfo_Fields(RedisModuleInfoCtx *ctx, TotalIndexesFieldsI
 
 // General sections info
 static inline void AddToInfo_Indexes(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
+static inline void AddToInfo_IndexesEmpty(RedisModuleInfoCtx *ctx);
 static inline void AddToInfo_Memory(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
 static inline void AddToInfo_Cursors(RedisModuleInfoCtx *ctx);
 static inline void AddToInfo_GC(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
@@ -51,6 +53,16 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   if (IsEnterprise()) {
     GetFormattedRedisEnterpriseVersion(ver, sizeof(ver));
     RedisModule_InfoAddFieldCString(ctx, "redis_enterprise_version", ver);
+  }
+
+  // On normal INFO runs, optionally suppress RediSearch metrics when there are no indexes.
+  // (We never suppress crash-report info.)
+  if (!for_crash_report && !RSGlobalConfig.infoEmitOnZeroIndexes && Indexes_Count() == 0) {
+    // Still emit the number of indexes and runtime configuration so operators can understand
+    // why metrics are suppressed.
+    AddToInfo_IndexesEmpty(ctx);
+    AddToInfo_RSConfig(ctx);
+    return;
   }
 
   TotalIndexesInfo total_info = IndexesInfo_TotalInfo();
@@ -208,13 +220,24 @@ void AddToInfo_Fields(RedisModuleInfoCtx *ctx, TotalIndexesFieldsInfo *aggregate
 
 void AddToInfo_Indexes(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddSection(ctx, "indexes");
-  RedisModule_InfoAddFieldULongLong(ctx, "number_of_indexes", dictSize(specDict_g));
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_indexes", Indexes_Count());
   RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes", total_info->num_active_indexes);
   RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_running_queries", total_info->num_active_indexes_querying);
   RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_indexing", total_info->num_active_indexes_indexing);
   RedisModule_InfoAddFieldULongLong(ctx, "total_active_write_threads", total_info->total_active_write_threads);
   RedisModule_InfoAddFieldDouble(ctx, "total_indexing_time", (float)total_info->indexing_time / (float)CLOCKS_PER_MILLISEC);
   RedisModule_InfoAddFieldULongLong(ctx, "total_num_docs_in_indexes", total_info->total_num_docs_in_indexes);
+}
+
+static inline void AddToInfo_IndexesEmpty(RedisModuleInfoCtx *ctx) {
+  RedisModule_InfoAddSection(ctx, "indexes");
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_indexes", 0);
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes", 0);
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_running_queries", 0);
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_indexing", 0);
+  RedisModule_InfoAddFieldULongLong(ctx, "total_active_write_threads", 0);
+  RedisModule_InfoAddFieldDouble(ctx, "total_indexing_time", 0);
+  RedisModule_InfoAddFieldULongLong(ctx, "total_num_docs_in_indexes", 0);
 }
 
 void AddToInfo_Memory(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
@@ -357,6 +380,9 @@ void AddToInfo_RSConfig(RedisModuleInfoCtx *ctx) {
                                    RSGlobalConfig.minPhoneticTermLen);
   RedisModule_InfoAddFieldLongLong(ctx, "bm25std_tanh_factor",
                                    RSGlobalConfig.requestConfigParams.BM25STD_TanhFactor);
+
+  RedisModule_InfoAddFieldCString(ctx, "info_on_zero_indexes",
+                                  RSGlobalConfig.infoEmitOnZeroIndexes ? "ON" : "OFF");
 }
 
 // IF the crashing thread worked on a spec, output the spec name and info

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -365,6 +365,33 @@ def verify_command_OK_on_all_shards(env, *args):
     res = run_command_on_all_shards(env, *args)
     env.assertEqual(res, ['OK'] * env.shardsCount)
 
+def allShards_set_info_on_zero_indexes(env, enabled: bool):
+    """
+    Enable/disable INFO MODULES full output when there are zero indexes.
+
+    In cluster mode, applies to all OSS shards. In standalone mode, applies to the single node.
+    Asserts success (all replies are OK).
+    """
+    val = 'yes' if enabled else 'no'
+    if env.isCluster():
+        verify_command_OK_on_all_shards(env, 'CONFIG', 'SET', 'search-_info-on-zero-indexes', val)
+        return
+    res = env.cmd('CONFIG', 'SET', 'search-_info-on-zero-indexes', val)
+    env.assertEqual(res, 'OK')
+    return
+
+def shard_set_info_on_zero_indexes(env, enabled: bool):
+    """
+    Enable/disable INFO MODULES full output when there are zero indexes on the current node.
+
+    Uses `getConnectionByEnv(env)` so callers don't need to pass a shard id.
+    """
+    val = 'yes' if enabled else 'no'
+    conn = getConnectionByEnv(env)
+    res = conn.execute_command('CONFIG', 'SET', 'search-_info-on-zero-indexes', val)
+    env.assertEqual(res, 'OK')
+    return res
+
 def get_vecsim_debug_dict(env, index_name, vector_field):
     return to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_name, vector_field))
 
@@ -457,6 +484,12 @@ MAX_DIALECT = 0
 def set_max_dialect(env):
     global MAX_DIALECT
     if MAX_DIALECT == 0:
+        # Ensure INFO MODULES is not in minimal suppression mode when there are zero indexes.
+        # This keeps dialect discovery simple and consistent across tests.
+        # We only query INFO MODULES on the current connection, so it's enough to set this locally
+        # (no need to broadcast to all shards).
+        shard_set_info_on_zero_indexes(env, True)
+
         info = env.cmd('INFO', 'MODULES')
         prefix = 'search_dialect_'
         MAX_DIALECT = max([int(key.replace(prefix, '')) for key in info.keys() if prefix in key])

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -1372,6 +1372,13 @@ booleanConfigs = [
     ('search-enable-unstable-features', 'ENABLE_UNSTABLE_FEATURES', 'no', False, False),
 ]
 
+# CONFIG-only boolean parameters (no corresponding FT.CONFIG parameter / module argument)
+# These should be validated via CONFIG GET/SET only.
+configOnlyBooleanConfigs = [
+    # configName, defaultValue
+    ('search-_info-on-zero-indexes', 'no'),
+]
+
 @skip(redis_less_than='7.9.227')
 def testConfigAPIRunTimeBooleanParams():
     env = Env(noDefaultModuleArgs=True)
@@ -1417,6 +1424,29 @@ def testConfigAPIRunTimeBooleanParams():
             _testImmutableBooleanConfig(env, configName, ftConfigName, defaultValue)
         else:
             _testBooleanConfig(env, configName, ftConfigName, defaultValue)
+
+@skip(redis_less_than='7.9.227')
+def testConfigAPIConfigOnlyBooleanParams():
+    env = Env(noDefaultModuleArgs=True)
+
+    if env.isCluster():
+        conn = env.getOSSMasterNodesConnectionList()[0]
+        cmd = conn.execute_command
+    else:
+        cmd = env.cmd
+
+    for configName, defaultValue in configOnlyBooleanConfigs:
+        # Default value
+        env.assertEqual(cmd('CONFIG', 'GET', configName), [configName, defaultValue])
+
+        # Toggle ON/OFF
+        for val in ['yes', 'no']:
+            env.assertEqual(cmd('CONFIG', 'SET', configName, val), 'OK')
+            env.assertEqual(cmd('CONFIG', 'GET', configName), [configName, val])
+
+        # Invalid values should fail
+        env.expect('CONFIG', 'SET', configName, 'invalid_boolean').error()\
+            .contains('CONFIG SET failed')
 
 @skip(cluster=True, redis_less_than='7.9.227')
 def testModuleLoadexBooleanParams():

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -952,6 +952,8 @@ def testIndexObfuscatedInfo(env: Env):
 def testPauseOnOOM(env: Env):
     # Change the memory limit to 80% so it can be tested without colliding with redis memory limit
     env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+    # This test reads INFO MODULES metrics before creating any index. Ensure INFO MODULES is in full mode.
+    shard_set_info_on_zero_indexes(env, True)
 
     num_docs = 1000
     for i in range(num_docs):

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -327,6 +327,8 @@ def test_dialect_info():
   # Run with DEFAULT_DIALECT 1 to ensure clean dialect stats for this test
   env = Env(moduleArgs='DEFAULT_DIALECT 1')
   conn = getConnectionByEnv(env)
+  # This test calls INFO MODULES even after FLUSHDB (zero indexes). Ensure dialect stats are emitted.
+  allShards_set_info_on_zero_indexes(env, True)
 
   env.cmd('FT.CREATE', 'idx1', 'SCHEMA', 'business', 'TEXT')
   env.cmd('FT.CREATE', 'idx2', 'SCHEMA', 'country', 'TEXT')


### PR DESCRIPTION
## Summary
- Backport of #8283 to the 8.6 branch.
- Cherry-pick of 95f87e7 with one conflict resolved in `src/info/info_redis/info_redis.c`: the `#include "search_disk.h"` line (present on master but not 8.6) was dropped; only `#include "spec.h"` (needed for `Indexes_Count()`) was added.

## Original PR
https://github.com/RediSearch/RediSearch/pull/8283

## Conflict Resolution
- **`src/info/info_redis/info_redis.c`**: On master, `#include "search_disk.h"` was already present as a context line. On 8.6 it doesn't exist in this file. Since this backport only needs `#include "spec.h"` (for `Indexes_Count()`), the resolution keeps only that include.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of `INFO MODULES` output in the zero-index case, which can affect monitoring/automation expecting specific sections, but is gated by a config flag and covered by new tests.
> 
> **Overview**
> When `search-_info-on-zero-indexes` is **OFF** (default) and there are no indexes, `INFO MODULES` now returns a *minimal* RediSearch payload: `version`, `indexes` (all zeros), and `runtime_configurations`, while still emitting full data for crash reports and whenever at least one index exists.
> 
> This introduces the new boolean config `search-_info-on-zero-indexes` (backed by `RSGlobalConfig.infoEmitOnZeroIndexes`), updates index counting to use `Indexes_Count()`, exposes the flag in the runtime config INFO section, and adds/adjusts pytests (including a new suppression-mode test and helpers to toggle the config across shards).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12ecfdcc4644f9625b5738368a8969d292de34ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

#### Release Notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes