### PR TITLE
[MOD-12286] Remove RLookupRow.ndyn assert from test

### DIFF
--- a/tests/cpptests/test_cpp_rlookup.cpp
+++ b/tests/cpptests/test_cpp_rlookup.cpp
@@ -53,7 +53,6 @@ TEST_F(RLookupTest, testRow) {
   RSValue *vtmp = RLookup_GetItem(fook, &rr);
   ASSERT_EQ(vfoo, vtmp);
   ASSERT_EQ(2, RSValue_Refcount(vfoo));
-  ASSERT_EQ(1, rr.ndyn);
 
   // Write a NULL value
   RLookup_WriteKey(fook, &rr, RSValue_NullStatic());


### PR DESCRIPTION
Remove a single `RLookupRow.ndyn` assert from a C unit test. It's the only reference to this property that would remain after migrating `RLookup`, and it's not worth exposing it from the Rust side just for that.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
