### PR TITLE
[MOD-12286] Remove unused createTestSearchResult function

### DIFF
--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -1415,24 +1415,6 @@ TEST_F(HybridMergerTest, testHybridMergerRRFFlagMerging) {
 }
 
 /*
- * Helper function to create a test SearchResult with specified flags
- */
-static SearchResult* createTestSearchResult(uint8_t flags) {
-  SearchResult* result = (SearchResult*)rm_calloc(1, sizeof(SearchResult));
-  if (!result) return NULL;
-
-  SearchResult_SetDocId(result, 1);  // Use a dummy docId
-  SearchResult_SetScore(result, 1.0);  // Use a dummy score
-  SearchResult_SetFlags(result, flags);
-  SearchResult_SetScoreExplain(result, NULL);
-  SearchResult_SetDocumentMetadata(result, NULL);
-  SearchResult_SetIndexResult(result, NULL);
-  memset(SearchResult_GetRowDataMut(result), 0, sizeof(RLookupRow));
-
-  return result;
-}
-
-/*
  * Test that return codes are properly captured from upstreams
  */
 TEST_F(HybridMergerTest, testUpstreamReturnCodes) {


### PR DESCRIPTION
Remove unused createTestSearchResult function from C.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only dead-code deletion with no production behavior impact.
> 
> **Overview**
> Removes the unused `createTestSearchResult` helper from `tests/cpptests/test_cpp_hybridmerger.cpp`, leaving the existing hybrid merger tests unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b65b25b81987162f1acc3d6a5a48e36f10f291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->