### PR TITLE
[MOD-13847] Don't error if a numeric index hasn't been initialized yet

### DIFF
--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/debug.rs
@@ -20,20 +20,20 @@ use numeric_range_tree::NumericRangeTree;
 /// Reply with a summary of the numeric range tree (for NUMIDX_SUMMARY).
 ///
 /// This outputs the tree statistics in the format expected by FT.DEBUG NUMIDX_SUMMARY.
+/// When `t` is NULL (index not yet created), all values are reported as zero.
 ///
 /// # Safety
 ///
 /// - `ctx` must be a valid Redis module context.
-/// - `t` must point to a valid [`NumericRangeTree`].
+/// - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
     ctx: *mut RedisModuleCtx,
     t: *const NumericRangeTree,
 ) {
     debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
-    assert!(!t.is_null(), "t cannot be NULL");
-    // SAFETY: Caller ensures `t` is a valid pointer per function safety docs.
-    let tree: &NumericRangeTree = unsafe { &*t };
+    // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
+    let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
     unsafe {
         numeric_range_tree::debug::debug_summary(ctx, tree);
@@ -44,11 +44,12 @@ pub unsafe extern "C" fn NumericRangeTree_DebugSummary(
 ///
 /// This outputs all entries from all ranges in the tree. If `with_headers` is true,
 /// each range's entries are prefixed with header information (numDocs, numEntries, etc).
+/// When `t` is NULL (index not yet created), an empty array is returned.
 ///
 /// # Safety
 ///
 /// - `ctx` must be a valid Redis module context.
-/// - `t` must point to a valid [`NumericRangeTree`].
+/// - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     ctx: *mut RedisModuleCtx,
@@ -56,9 +57,8 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
     with_headers: bool,
 ) {
     debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
-    assert!(!t.is_null(), "t cannot be NULL");
-    // SAFETY: Caller ensures `t` is a valid pointer per function safety docs.
-    let tree: &NumericRangeTree = unsafe { &*t };
+    // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
+    let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
     unsafe {
         numeric_range_tree::debug::debug_dump_index(ctx, tree, with_headers);
@@ -69,11 +69,12 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpIndex(
 ///
 /// This outputs the tree structure as a nested map. If `minimal` is true,
 /// range entry details are omitted (only tree structure is shown).
+/// When `t` is NULL (index not yet created), all values are zero with an empty root.
 ///
 /// # Safety
 ///
 /// - `ctx` must be a valid Redis module context.
-/// - `t` must point to a valid [`NumericRangeTree`].
+/// - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     ctx: *mut RedisModuleCtx,
@@ -81,9 +82,8 @@ pub unsafe extern "C" fn NumericRangeTree_DebugDumpTree(
     minimal: bool,
 ) {
     debug_assert!(!ctx.is_null(), "ctx cannot be NULL");
-    assert!(!t.is_null(), "t cannot be NULL");
-    // SAFETY: Caller ensures `t` is a valid pointer per function safety docs.
-    let tree: &NumericRangeTree = unsafe { &*t };
+    // SAFETY: Caller ensures `t` is either NULL or a valid pointer.
+    let tree = unsafe { t.as_ref() };
     // SAFETY: ctx is valid per function docs
     unsafe {
         numeric_range_tree::debug::debug_dump_tree(ctx, tree, minimal);

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -308,11 +308,12 @@ uintptr_t NumericRangeTree_BaseSize(void);
  * Reply with a summary of the numeric range tree (for NUMIDX_SUMMARY).
  *
  * This outputs the tree statistics in the format expected by FT.DEBUG NUMIDX_SUMMARY.
+ * When `t` is NULL (index not yet created), all values are reported as zero.
  *
  * # Safety
  *
  * - `ctx` must be a valid Redis module context.
- * - `t` must point to a valid [`NumericRangeTree`].
+ * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
  */
 void NumericRangeTree_DebugSummary(RedisModuleCtx *ctx, const struct NumericRangeTree *t);
 
@@ -321,11 +322,12 @@ void NumericRangeTree_DebugSummary(RedisModuleCtx *ctx, const struct NumericRang
  *
  * This outputs all entries from all ranges in the tree. If `with_headers` is true,
  * each range's entries are prefixed with header information (numDocs, numEntries, etc).
+ * When `t` is NULL (index not yet created), an empty array is returned.
  *
  * # Safety
  *
  * - `ctx` must be a valid Redis module context.
- * - `t` must point to a valid [`NumericRangeTree`].
+ * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
  */
 void NumericRangeTree_DebugDumpIndex(RedisModuleCtx *ctx,
                                      const struct NumericRangeTree *t,
@@ -336,11 +338,12 @@ void NumericRangeTree_DebugDumpIndex(RedisModuleCtx *ctx,
  *
  * This outputs the tree structure as a nested map. If `minimal` is true,
  * range entry details are omitted (only tree structure is shown).
+ * When `t` is NULL (index not yet created), all values are zero with an empty root.
  *
  * # Safety
  *
  * - `ctx` must be a valid Redis module context.
- * - `t` must point to a valid [`NumericRangeTree`].
+ * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
  */
 void NumericRangeTree_DebugDumpTree(RedisModuleCtx *ctx,
                                     const struct NumericRangeTree *t,

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/debug.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/debug.rs
@@ -66,7 +66,7 @@ fn test_debug_summary_empty() {
     let tree = NumericRangeTree::new(false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_summary(ctx, &tree) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_summary(ctx, Some(&tree)) });
     insta::assert_debug_snapshot!(reply, @r###"
     [
       "numRanges",
@@ -94,7 +94,7 @@ fn test_debug_summary_populated() {
     let tree = populated_tree(50, 0.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_summary(ctx, &tree) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_summary(ctx, Some(&tree)) });
     insta::assert_debug_snapshot!(reply, @r###"
     [
       "numRanges",
@@ -124,7 +124,8 @@ fn test_debug_dump_index_no_headers() {
     let tree = populated_tree(10, 1.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, &tree, false) });
+    let reply =
+        capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, Some(&tree), false) });
     insta::assert_debug_snapshot!(reply, @"[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]");
 }
 
@@ -133,7 +134,7 @@ fn test_debug_dump_index_with_headers() {
     let tree = populated_tree(10, 1.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, &tree, true) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, Some(&tree), true) });
     insta::assert_debug_snapshot!(reply, @r#"
     [
       [
@@ -162,7 +163,8 @@ fn test_debug_dump_index_with_multivalued_tree() {
     let tree = populated_multivalued_tree(5);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, &tree, false) });
+    let reply =
+        capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, Some(&tree), false) });
     insta::assert_debug_snapshot!(reply, @"[[1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5]]");
 }
 
@@ -171,7 +173,8 @@ fn test_debug_dump_index_no_headers_compressed() {
     let tree = populated_tree(10, 1.0, 1.0, true);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, &tree, false) });
+    let reply =
+        capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, Some(&tree), false) });
     insta::assert_debug_snapshot!(reply, @"[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]");
 }
 
@@ -180,7 +183,7 @@ fn test_debug_dump_index_with_headers_compressed() {
     let tree = populated_tree(10, 1.0, 1.0, true);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, &tree, true) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, Some(&tree), true) });
     insta::assert_debug_snapshot!(reply);
 }
 
@@ -191,7 +194,7 @@ fn test_debug_dump_tree_full() {
     let tree = populated_tree(10, 1.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, &tree, false) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, Some(&tree), false) });
     with_redactions(|| insta::assert_debug_snapshot!(reply));
 }
 
@@ -200,7 +203,7 @@ fn test_debug_dump_tree_minimal() {
     let tree = populated_tree(10, 1.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, &tree, true) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, Some(&tree), true) });
     with_redactions(|| {
         insta::assert_debug_snapshot!(reply, @r###"
         {
@@ -224,7 +227,7 @@ fn test_debug_dump_tree_with_children() {
     let tree = populated_tree(100, 0.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, &tree, false) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, Some(&tree), false) });
     with_redactions(|| insta::assert_debug_snapshot!(reply));
 }
 
@@ -233,7 +236,7 @@ fn test_debug_dump_tree_full_compressed() {
     let tree = populated_tree(10, 1.0, 1.0, true);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, &tree, false) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, Some(&tree), false) });
     with_redactions(|| insta::assert_debug_snapshot!(reply));
 }
 
@@ -242,7 +245,7 @@ fn test_debug_dump_tree_with_children_compressed() {
     let tree = populated_tree(100, 0.0, 1.0, true);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, &tree, false) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, Some(&tree), false) });
     with_redactions(|| insta::assert_debug_snapshot!(reply));
 }
 
@@ -255,6 +258,116 @@ fn test_debug_dump_index_with_splits() {
     let tree = populated_tree(100, 0.0, 1.0, false);
     let ctx = mock_ctx();
     // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
-    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, &tree, true) });
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, Some(&tree), true) });
     with_redactions(|| insta::assert_debug_snapshot!(reply));
+}
+
+// ── None (empty index) snapshots ────────────────────────────────────────
+
+#[test]
+fn test_debug_summary_none() {
+    let ctx = mock_ctx();
+    // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
+    let reply = capture_single_reply(|| unsafe { debug::debug_summary(ctx, None) });
+    insta::assert_debug_snapshot!(reply, @r###"
+    [
+      "numRanges",
+      0,
+      "numLeaves",
+      0,
+      "numEntries",
+      0,
+      "lastDocId",
+      0,
+      "revisionId",
+      0,
+      "emptyLeaves",
+      0,
+      "RootMaxDepth",
+      0,
+      "MemoryUsage",
+      0
+    ]
+    "###);
+}
+
+#[test]
+fn test_debug_dump_index_none() {
+    let ctx = mock_ctx();
+    // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_index(ctx, None, false) });
+    insta::assert_debug_snapshot!(reply, @"[]");
+}
+
+#[test]
+fn test_debug_dump_tree_none() {
+    let ctx = mock_ctx();
+    // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
+    let reply = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, None, true) });
+    insta::assert_debug_snapshot!(reply, @r###"
+    {
+      "numRanges": 0,
+      "numEntries": 0,
+      "lastDocId": 0,
+      "revisionId": 0,
+      "uniqueId": 0,
+      "emptyLeaves": 0,
+      "root": {},
+      "Tree stats": {"Average memory efficiency (numEntries/size)/numRanges": 0}
+    }
+    "###);
+}
+
+// ── Structural consistency: None has same keys as default tree ──────────
+
+#[test]
+fn test_debug_summary_none_has_same_keys_as_default() {
+    let ctx = mock_ctx();
+    let tree = NumericRangeTree::new(false);
+
+    // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
+    let reply_default = capture_single_reply(|| unsafe { debug::debug_summary(ctx, Some(&tree)) });
+    let reply_none = capture_single_reply(|| unsafe { debug::debug_summary(ctx, None) });
+
+    // Extract keys (string elements at even indices in the flat array).
+    fn keys(reply: &ReplyValue) -> Vec<&str> {
+        match reply {
+            ReplyValue::Array(arr) => arr
+                .iter()
+                .step_by(2)
+                .map(|v| match v {
+                    ReplyValue::SimpleString(s) => s.as_str(),
+                    other => panic!("expected string key, got {other:?}"),
+                })
+                .collect(),
+            other => panic!("expected array, got {other:?}"),
+        }
+    }
+    assert_eq!(keys(&reply_default), keys(&reply_none));
+}
+
+#[test]
+fn test_debug_dump_tree_none_has_same_keys_as_default() {
+    let ctx = mock_ctx();
+    let tree = NumericRangeTree::new(false);
+
+    // SAFETY: `ctx` is a mock pointer — `redis_mock` intercepts all Redis module API calls.
+    let reply_default =
+        capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, Some(&tree), true) });
+    let reply_none = capture_single_reply(|| unsafe { debug::debug_dump_tree(ctx, None, true) });
+
+    // Extract top-level map keys.
+    fn keys(reply: &ReplyValue) -> Vec<&str> {
+        match reply {
+            ReplyValue::Map(pairs) => pairs
+                .iter()
+                .map(|(k, _)| match k {
+                    ReplyValue::SimpleString(s) => s.as_str(),
+                    other => panic!("expected string key, got {other:?}"),
+                })
+                .collect(),
+            other => panic!("expected map, got {other:?}"),
+        }
+    }
+    assert_eq!(keys(&reply_default), keys(&reply_none));
 }


### PR DESCRIPTION
## Describe the changes in the pull request

In #8305, I thought I could get away with returning an error for a numeric index that hadn't been initialised yet, but unfortunately it won't fly.
Creating numeric indexes eagerly would result in increased memory usage, and returning an error after the user has correctly issued a `CREATE INDEX` command would be confusing.

So, back to the original: return an empty response with the proper keys. I structured the code to minimise the risk of divergence between empty and non-empty keys, with tests to ensure they have the correct structure.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to debug/diagnostics output handling; main risk is subtle response-format regressions, covered by added snapshot tests.
> 
> **Overview**
> Fixes FT.DEBUG numeric index introspection to **gracefully handle uninitialized numeric indexes**.
> 
> The Rust debug helpers (`debug_summary`, `debug_dump_index`, `debug_dump_tree`) now accept `Option<&NumericRangeTree>` and return *zero/empty* responses when absent, while the C/Rust FFI wrappers and generated header docs explicitly allow `t == NULL` instead of asserting. Integration snapshots add coverage for the `None` case and verify the empty responses keep the same key structure as the default tree outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f8546122279472ba3780fe71b8cf06a169c2d98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->