### PR TITLE
Update rlookup keylist cursor docs

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -26,13 +26,13 @@ pub struct KeyList<'a> {
     pub(crate) rowlen: u32,
 }
 
-/// A cursor over an [`RLookup`]'s key list.
+/// A cursor over an [`RLookup`][crate::RLookup]'s key list.
 pub struct Cursor<'list, 'a> {
     _rlookup: &'list KeyList<'a>,
     current: Option<NonNull<RLookupKey<'a>>>,
 }
 
-/// A cursor over an [`RLookup`]'s key list with editing operations.
+/// A cursor over an [`RLookup`][crate::RLookup]'s key list with editing operations.
 pub struct CursorMut<'list, 'a> {
     _rlookup: &'list mut KeyList<'a>,
     current: Option<NonNull<RLookupKey<'a>>>,


### PR DESCRIPTION
Update rlookup keylist cursor docs based on our call yesterday.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only changes; no runtime behavior or data handling is modified.
> 
> **Overview**
> Updates the Rust API documentation for `KeyList` cursors (`Cursor`, `CursorMut`, `cursor_front`, `cursor_front_mut`) to better reflect current behavior (including how overridden/hidden keys relate to iteration) and to fix doc link formatting.
> 
> **User impact:** clearer guidance when using rlookup cursors; no functional/code-path changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2377990f46e0ad99a327f656113a42856843cf12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->