### PR TITLE
No need for manual activation of the venv

### DIFF
--- a/.skills/run-python-tests/SKILL.md
+++ b/.skills/run-python-tests/SKILL.md
@@ -39,13 +39,13 @@ If there are timeouts during a quick verification run, check if the timed-out te
 ### All Tests From A Specific File
 
 ```bash
-source .venv/bin/activate && ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<filename without extension>"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<filename without extension>"
 ```
 
 For example:
 
 ```bash
-source .venv/bin/activate && ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_crash"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_crash"
 ```
 
 for running tests from `tests/pytests/test_crash.py`.
@@ -53,13 +53,13 @@ for running tests from `tests/pytests/test_crash.py`.
 ### All Tests From Multiple Files
 
 ```bash
-source .venv/bin/activate && ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<filename 1> <filename 2>"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<filename 1> <filename 2>"
 ```
 
 For example:
 
 ```bash
-source .venv/bin/activate && ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_crash test_gc"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_crash test_gc"
 ```
 
 for running tests from `tests/pytests/test_crash.py` and `tests/pytests/test_gc.py`.
@@ -67,13 +67,13 @@ for running tests from `tests/pytests/test_crash.py` and `tests/pytests/test_gc.
 ### Specific Test From A Specific File
 
 ```bash
-source .venv/bin/activate && ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<filename without extension>:<test_name>"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<filename without extension>:<test_name>"
 ```
 
 For example:
 
 ```bash
-source .venv/bin/activate && ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_crash:test_query_thread_crash"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_crash:test_query_thread_crash"
 ```
 
 for running the `test_query_thread_crash` test from `tests/pytests/test_crash.py`.

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -217,9 +217,9 @@ run_env() {
 
 	local E=0
 	if [[ $NOP != 1 ]]; then
-		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+		{ $OP uv run python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
-		$OP python3 -m RLTest @$rltest_config
+		$OP uv run python3 -m RLTest @$rltest_config
 	fi
 
 	[[ $KEEP != 1 ]] && rm -f $rltest_config
@@ -326,9 +326,9 @@ run_tests() {
 
 	local E=0
 	if [[ $NOP != 1 ]]; then
-		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+		{ $OP uv run python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
-		$OP python3 -m RLTest @$rltest_config
+		$OP uv run python3 -m RLTest @$rltest_config
 	fi
 
 	[[ $KEEP != 1 ]] && rm -f $rltest_config


### PR DESCRIPTION
## Describe the changes in the pull request

It'll improve, in particular, the workflow for AI agents, since file sourcing isn't easy to blanket-allow due to the use of absolute paths.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test runner and documentation change only; main risk is CI/local test execution breaking if `uv` isn’t available or behaves differently than the activated venv.
> 
> **Overview**
> Removes the need to manually `source .venv/bin/activate` when running Python tests.
> 
> `tests/pytests/runtests.sh` now executes RLTest via `uv run python3 -m RLTest ...`, and the `run-python-tests` skill doc updates all example commands accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01736003c01c5ea81d41b3bf18f6ae049f8b0ba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->