### PR TITLE
Exit early in the optimizer iterator if reading further won't change the outcome

### DIFF
--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "iterators/optimizer_reader.h"
+#include "numeric_index.h"
 #include "iterators_rs.h"
 
 int cmpAsc(const void *v1, const void *v2, const void *udata) {
@@ -80,8 +81,9 @@ static void OPT_Rewind(QueryIterator *self) {
   }
 
   FieldFilterContext filterCtx = {.field = {.index_tag = FieldMaskOrIndex_Index, .index = optIt->numericFieldIndex}, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
-  // create new numeric filter
-  optIt->numericIter = NewNumericFilterIterator(qOpt->sctx, qOpt->nf, INDEXFLD_T_NUMERIC, optIt->config, &filterCtx);
+  // create new numeric filter and refresh range bounds
+  optIt->numericIter = NewNumericFilterIteratorWithBounds(qOpt->sctx, qOpt->nf, INDEXFLD_T_NUMERIC, optIt->config, &filterCtx,
+                                                          &optIt->numericRangeMin, &optIt->numericRangeMax);
 
   optIt->heapOldSize = heap_count(heap);
   optIt->numIterations++;
@@ -186,6 +188,30 @@ IteratorStatus OPT_Read(QueryIterator *self) {
             it->pooledResult = tempRes;
           }
           DMD_Return(it->pooledResult->dmd);
+
+          // Early exit when no remaining doc in the numeric range can
+          // displace the worst item in the heap.
+          //
+          // The heap is a max-heap by cmpAsc (min-heap by cmpDesc), so
+          // heap_peek returns the "worst" selected item — the one with
+          // the highest numeric value (ascending) or lowest (descending).
+          //
+          // For ascending sort: every remaining doc has value >= rangeMin.
+          // If worstVal < rangeMin, no doc can have a value <= worstVal,
+          // so none can displace the peek.
+          //
+          // We use strict comparisons because after OPT_Rewind the heap
+          // retains items with high docIds from prior iterations while
+          // the child iterator restarts from low docIds.  Equal-value
+          // docs with smaller docIds can still win the tiebreaker.
+          //
+          // Symmetrically for descending: worstVal > rangeMax means no
+          // remaining doc can have a low-enough value to displace it.
+          double worstVal = IndexResult_NumValue(heap_peek(it->heap));
+          if (it->optim->asc ? (worstVal < it->numericRangeMin)
+                              : (worstVal > it->numericRangeMax)) {
+            break;
+          }
         }
       }
     }
@@ -239,7 +265,8 @@ QueryIterator *NewOptimizerIterator(QOptimizer *qOpt, QueryIterator *root, Itera
 
   FieldFilterContext filterCtx = {.field = {.index_tag = FieldMaskOrIndex_Index, .index = field->index}, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
   oi->numericFieldIndex = field->index;
-  oi->numericIter = NewNumericFilterIterator(qOpt->sctx, qOpt->nf, INDEXFLD_T_NUMERIC, config, &filterCtx);
+  oi->numericIter = NewNumericFilterIteratorWithBounds(qOpt->sctx, qOpt->nf, INDEXFLD_T_NUMERIC, config, &filterCtx,
+                                                       &oi->numericRangeMin, &oi->numericRangeMax);
   if (!oi->numericIter) {
     OptimizerIterator_Free(&oi->base);
     return NewEmptyIterator();

--- a/src/iterators/optimizer_reader.h
+++ b/src/iterators/optimizer_reader.h
@@ -50,6 +50,9 @@ typedef struct {
 
   IteratorsConfig *config;       // Copy of current RSglobalconfig.IteratorsConfig
   t_fieldIndex numericFieldIndex; // field index for numeric filter
+
+  double numericRangeMin;         // min value of current numeric range(s)
+  double numericRangeMax;         // max value of current numeric range(s)
 } OptimizerIterator;
 
 #ifdef __cplusplus

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -26,12 +26,17 @@
 #include "util/misc.h"
 
 /* Create a union iterator from the numeric filter, over all the sub-ranges in the tree that fit
- * the filter */
+ * the filter. If outMin/outMax are non-NULL, they receive the overall min/max values across all
+ * matching ranges. */
 // This function should move over to Rust once the union iterator is ported.
-QueryIterator *createNumericIterator(const RedisSearchCtx *sctx, NumericRangeTree *t,
-                                     const NumericFilter *f, IteratorsConfig *config,
-                                     const FieldFilterContext *filterCtx) {
+static QueryIterator *createNumericIterator(const RedisSearchCtx *sctx, NumericRangeTree *t,
+                                            const NumericFilter *f, IteratorsConfig *config,
+                                            const FieldFilterContext *filterCtx,
+                                            double *outMin, double *outMax) {
   NumericRangeIteratorsResult result = CreateNumericRangeIterators(t, sctx, f, filterCtx);
+
+  if (outMin) *outMin = result.min_val;
+  if (outMax) *outMax = result.max_val;
 
   if (result.len == 0) {
     return NULL;
@@ -64,6 +69,13 @@ NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool cre
 QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const NumericFilter *flt,
                                         FieldType forType, IteratorsConfig *config,
                                         const FieldFilterContext *filterCtx) {
+  return NewNumericFilterIteratorWithBounds(ctx, flt, forType, config, filterCtx, NULL, NULL);
+}
+
+QueryIterator *NewNumericFilterIteratorWithBounds(const RedisSearchCtx *ctx, const NumericFilter *flt,
+                                                  FieldType forType, IteratorsConfig *config,
+                                                  const FieldFilterContext *filterCtx,
+                                                  double *outMin, double *outMax) {
   const FieldSpec *fs = flt->fieldSpec;
 
   NumericRangeTree *t = openNumericOrGeoIndex(ctx->spec, (FieldSpec *)fs, DONT_CREATE_INDEX);
@@ -71,5 +83,5 @@ QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const Numeric
     return NULL;
   }
 
-  return createNumericIterator(ctx, t, flt, config, filterCtx);
+  return createNumericIterator(ctx, t, flt, config, filterCtx, outMin, outMax);
 }

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -32,6 +32,12 @@ extern "C" {
 QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const NumericFilter *flt, FieldType forType,
                                         IteratorsConfig *config, const FieldFilterContext* filterCtx);
 
+// Like NewNumericFilterIterator, but also outputs the overall min/max values of the matching
+// numeric ranges. outMin/outMax may be NULL if the caller doesn't need the bounds.
+QueryIterator *NewNumericFilterIteratorWithBounds(const RedisSearchCtx *ctx, const NumericFilter *flt, FieldType forType,
+                                                  IteratorsConfig *config, const FieldFilterContext* filterCtx,
+                                                  double *outMin, double *outMax);
+
 NumericRangeTree *openNumericOrGeoIndex(IndexSpec* spec, FieldSpec* fs, bool create_if_missing);
 
 // Passes RSGlobalConfig.numericTreeMaxDepthRange automatically

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index.rs
@@ -645,6 +645,10 @@ pub struct NumericRangeIteratorsResult {
     pub iterators: *mut *mut ffi::QueryIterator,
     /// Number of iterators in the array.
     pub len: usize,
+    /// Minimum value across all returned ranges. `INFINITY` when `len == 0`.
+    pub min_val: f64,
+    /// Maximum value across all returned ranges. `NEG_INFINITY` when `len == 0`.
+    pub max_val: f64,
 }
 
 /// Creates numeric range iterators for all ranges in the tree matching the filter.
@@ -688,10 +692,24 @@ pub unsafe extern "C" fn CreateNumericRangeIterators(
 
     let ranges: Vec<&NumericRange> = tree.find(filter);
 
+    // Compute overall min/max across all matching ranges.
+    // When there are no ranges, the fold defaults naturally produce
+    // -INFINITY/+INFINITY (no early-exit will trigger on an empty set).
+    let overall_min = ranges
+        .iter()
+        .map(|r| r.min_val())
+        .fold(f64::INFINITY, f64::min);
+    let overall_max = ranges
+        .iter()
+        .map(|r| r.max_val())
+        .fold(f64::NEG_INFINITY, f64::max);
+
     if ranges.is_empty() {
         return NumericRangeIteratorsResult {
             iterators: std::ptr::null_mut(),
             len: 0,
+            min_val: overall_min,
+            max_val: overall_max,
         };
     }
 
@@ -756,5 +774,7 @@ pub unsafe extern "C" fn CreateNumericRangeIterators(
     NumericRangeIteratorsResult {
         iterators,
         len: ranges.len(),
+        min_val: overall_min,
+        max_val: overall_max,
     }
 }

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -37,6 +37,14 @@ typedef struct NumericRangeIteratorsResult {
    * Number of iterators in the array.
    */
   uintptr_t len;
+  /**
+   * Minimum value across all returned ranges. `INFINITY` when `len == 0`.
+   */
+  double min_val;
+  /**
+   * Maximum value across all returned ranges. `NEG_INFINITY` when `len == 0`.
+   */
+  double max_val;
 } NumericRangeIteratorsResult;
 
 #ifdef __cplusplus

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -221,7 +221,7 @@ def testOptimizer(env):
 
     profiler =  {'Iterators profile':
                     ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
-                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1800, 'Estimated number of matches', 10000]],
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 82, 'Estimated number of matches', 10000]],
                  'Result processors profile': [
                     ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Loader', 'Results processed', 10],
@@ -265,7 +265,7 @@ def testOptimizer(env):
 
     profiler =  {'Iterators profile':
                     ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 1800, 'Estimated number of matches', 10000]],
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 82, 'Estimated number of matches', 10000]],
                  'Result processors profile': [
                     ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Loader', 'Results processed', 10],
@@ -305,7 +305,7 @@ def testOptimizer(env):
 
     profiler =  {'Iterators profile':
                     ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'WILDCARD', 'Number of reading operations', 3400]],
+                        ['Type', 'WILDCARD', 'Number of reading operations', 70]],
                  'Result processors profile': [
                     ['Type', 'Index', 'Results processed', 10],
                     ['Type', 'Loader', 'Results processed', 10],


### PR DESCRIPTION
## Describe the changes in the pull request

A little optimization to minimize the number of reads in the optimizer iterator when we know further values won't change the outcome.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query execution/optimization logic and adds new min/max range data through the C/Rust numeric iterator FFI; mistakes could cause missing or misordered results under edge cases.
> 
> **Overview**
> Improves `SORTBY` query performance by **exiting the optimizer iterator early** once it can prove that reading more matching documents cannot change the current top-N results.
> 
> To enable this, numeric-range iterator creation now returns the overall min/max bounds of the matching numeric ranges, and the optimizer uses these bounds to stop scanning when the heap’s worst item can’t be displaced. Test expectations were updated to reflect the reduced number of iterator read operations seen in profiling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6b3449078eb9b26402ce0097eb0a2441d7592cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->