### PR TITLE
Emit a global summary for C/C++ unit tests

### DIFF
--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -527,8 +527,9 @@ print_test_summary() {
         else
             printf "  %-44s FAILED (%d/%d passed)\n" "$label" "$p" "$t"
             any_failed=1
-            eval "local failed_names=(\"\${${block}_FAILED[@]}\")"
-            for name in "${failed_names[@]}"; do
+            local i name
+            for ((i=0; i<f; i++)); do
+                eval "name=\${${block}_FAILED[$i]}"
                 printf "    - %s\n" "$name"
                 if [[ -n $GITHUB_ACTIONS ]]; then
                     echo "::error::${label} failed: ${name}"


### PR DESCRIPTION
## Describe the changes in the pull request

When running C/C++ unit tests, `exit $?` is a must-have to determine _if_ something failed. In particular, it's rather cumbersome to determine _which_ tests failed, since failures for each test group are reported only at the end of the relevant group (e.g., C unit tests). You are forced to scroll all the way up to the relevant block, and that's a lot of scrolling.

To improve our QoL, I have added a coalesced summary at the end. Example:

```
===============================================================================
  TEST RESULTS SUMMARY
===============================================================================

  C Unit Tests                                 FAILED (14/15 passed)
    - test_array
  C++ Unit Tests                               FAILED (1349/1351 passed)
    - HashTest.testSha1Hash
    - ClusterIOThreadsTest.TestIOThreadsResize
  Coordinator Unit Tests                       FAILED (4/5 passed)
    - test_chan
  C++ Coordinator Unit Tests                   FAILED (100/101 passed)
    - ClusterIOThreadsTest.TestIOThreadsResize

-------------------------------------------------------------------------------
  TOTAL: 1467 passed, 5 failed, 1472 total
  STATUS: SOME TESTS FAILED
===============================================================================
```

I've also added GitHub annotations for test failures, so that they show up at the top of the relevant job page and we don't have to scroll through step logs.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-runner output-only changes; risk is limited to mis-parsing `ctest` output or incorrect CI annotations affecting developer diagnostics, not product behavior.
> 
> **Overview**
> `sbin/unit-tests` now tracks pass/fail results per test across C, C++, and coordinator suites and prints a **single consolidated summary at the end** listing failing tests and overall totals.
> 
> C++ `ctest` parsing was updated to reliably capture per-test status (including crash/timeout) without subshell scoping issues, and failures in CI now emit `::error::` annotations to make them visible at the top of the GitHub Actions job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0166de14db213e1d6669c3634c1b65f2bd8d17dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->