### PR TITLE
Feedbacks on #8280 : Fix a link and cleanup markdown checkmarks

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -8,8 +8,8 @@ For Rust specific guidelines, see [CONTRIBUTING.md](https://github.com/RediSearc
 
 ## TODOs
 
-- [] Get access to Okta/Jira/Confluence.
-- [] Get access to GitHub repository as a contributor with push access (now goes through Okta).
+- [ ] Get access to Okta/Jira/Confluence.
+- [ ] Get access to GitHub repository as a contributor with push access (now goes through Okta).
 
 ## Useful Links
 

--- a/src/redisearch_rs/CONTRIBUTING.md
+++ b/src/redisearch_rs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Rust Unit tests use the regular Rust test harness and test runner. All regular R
 C code uses [`RedisModule_Log`](https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#redismodule_log) to log messages
 while the Rust side uses the standard [`tracing`](https://docs.rs/tracing/latest/tracing/) crate, see below.
 
-The [`tracing_redismodule`](src/redisearch_rs/tracing_redismodule) crate provides a bridge between the two logging systems.
+The [`tracing_redismodule`](tracing_redismodule) crate provides a bridge between the two logging systems.
 It implements a tracing subscriber emitting traces and logs to the RedisModule logging system.
 This subscriber is automatically registered when the RediSearch module is loaded by the Redis server.
 
@@ -78,8 +78,8 @@ By default the log output will be colored to help with reading. The system alrea
 
 ### Logging in Tests
 
-[`tracing_redismodule`](src/redisearch_rs/tracing_redismodule) is not meant to be used in Rust tests.
-Instead, the [`redis_mock`](src/redisearch_rs/redis_mock) crate re-implements the `RedisModule_Log` so logs from C
+[`tracing_redismodule`](tracing_redismodule) is not meant to be used in Rust tests.
+Instead, the [`redis_mock`](redis_mock) crate re-implements the `RedisModule_Log` so logs from C
 are emitted using `tracing`.
 
 Tests can then use the [`test-log`](https://docs.rs/test-log/latest/test_log/) crate to easily initialize `tracing`


### PR DESCRIPTION
Targets #8280

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or build impact; risk is limited to potential link/path typos.
> 
> **Overview**
> Improves developer docs by fixing the onboarding TODO checklist rendering and correcting broken relative links in the Rust `CONTRIBUTING.md` logging section (e.g., `tracing_redismodule`, `redis_mock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05e910038ef90c1ce1673f872c4df18c12391264. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->