### PR TITLE
[MOD-14187] Bring back Term II iterator benches

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
@@ -10,7 +10,6 @@
 //! Benchmark iterators
 
 use criterion::{Criterion, criterion_group, criterion_main};
-/*
 use inverted_index::{
     doc_ids_only::DocIdsOnly,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
@@ -20,7 +19,6 @@ use inverted_index::{
     full::{Full, FullWide},
     offsets_only::OffsetsOnly,
 };
- */
 use rqe_iterators_bencher::benchers;
 
 fn benchmark_empty(c: &mut Criterion) {
@@ -68,7 +66,6 @@ fn benchmark_inverted_index_wildcard(c: &mut Criterion) {
     bencher.bench(c);
 }
 
-/*
 fn benchmark_inverted_index_term(c: &mut Criterion) {
     // Run bench with each decoder producing term results.
     benchers::inverted_index::TermBencher::<Full>::new(
@@ -144,7 +141,6 @@ fn benchmark_inverted_index_term(c: &mut Criterion) {
     )
     .bench(c);
 }
- */
 
 criterion_group!(
     benches,
@@ -157,7 +153,7 @@ criterion_group!(
     benchmark_optional,
     benchmark_inverted_index_numeric,
     benchmark_inverted_index_wildcard,
-    //benchmark_inverted_index_term,
+    benchmark_inverted_index_term,
 );
 
 criterion_main!(benches);

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index.rs
@@ -9,7 +9,7 @@
 
 //! Benchmark inverted index iterator.
 
-use std::{hint::black_box, time::Duration};
+use std::{hint::black_box, marker::PhantomData, time::Duration};
 
 use criterion::{
     BenchmarkGroup, Criterion,
@@ -17,14 +17,20 @@ use criterion::{
 };
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use inverted_index::{
-    IndexReader, RSIndexResult, doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding,
+    DecodedBy, Encoder, HasInnerIndex, IndexReader, InvertedIndex, RSIndexResult, RSOffsetSlice,
+    TermDecoder, doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding,
 };
-use rqe_iterators::{FieldExpirationChecker, RQEIterator, SkipToOutcome, inverted_index::Numeric};
+use query_term::RSQueryTerm;
+use rqe_iterators::{
+    FieldExpirationChecker, NoOpChecker, RQEIterator, SkipToOutcome,
+    inverted_index::{Numeric, Term},
+};
 
-use rqe_iterators_test_utils::TestContext;
+use crate::ffi as bench_ffi;
+use rqe_iterators_test_utils::{MockContext, TestContext};
 
-const MEASUREMENT_TIME: Duration = Duration::from_millis(2000);
-const WARMUP_TIME: Duration = Duration::from_millis(200);
+const MEASUREMENT_TIME: Duration = Duration::from_secs(4);
+const WARMUP_TIME: Duration = Duration::from_millis(500);
 /// The number of documents in the index.
 const INDEX_SIZE: u64 = 1_000_000;
 /// The delta between the document IDs in the sparse index.
@@ -269,7 +275,6 @@ impl NumericBencher {
     }
 }
 
-/*
 pub struct TermBencher<E> {
     /// Name of the benchmark group
     group_name: String,
@@ -277,42 +282,24 @@ pub struct TermBencher<E> {
     ii_flags: u32,
     /// The offsets used in records, need to be kept alive for the duration of the benchmark
     offsets: Vec<u8>,
-    /// The term used in records, need to be kept alive for the duration of the benchmark
-    term: *mut RSQueryTerm,
+    /// context used to create iterators. We do not actually use it so its `max_doc_id` and `num_docs` params are irrelevant.
+    mock_ctx: MockContext,
     /// Needed to carry the encoder used by the benchmark.
     _phantom_enc: PhantomData<E>,
 }
 
-impl<E> Drop for TermBencher<E> {
-    fn drop(&mut self) {
-        unsafe {
-            let _ = Term_Free(self.term);
-        }
-    }
-}
-
 impl<E> TermBencher<E>
 where
-    E: Encoder + DecodedBy,
+    E: Encoder + DecodedBy + OpaqueEncoding,
     E::Decoder: TermDecoder,
+    E::Storage: HasInnerIndex<E>,
 {
     pub fn new(decoder_name: &str, ii_flags: u32) -> Self {
-        let group_name = format!("Term - {decoder_name}");
-        const TEST_STR: &str = "term";
-        let term = QueryTermBuilder {
-            token: TEST_STR,
-            idf: 5.0,
-            id: 1,
-            flags: 0,
-            bm25_idf: 10.0,
-        }
-        .allocate();
-
         Self {
-            group_name,
+            group_name: format!("Term - {decoder_name}"),
             ii_flags,
             offsets: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            term,
+            mock_ctx: MockContext::new(0, 0),
             _phantom_enc: PhantomData,
         }
     }
@@ -344,26 +331,24 @@ where
         group.finish();
     }
 
-    fn c_index(&self, sparse: bool) -> ffi::InvertedIndex {
-        let ii = ffi::InvertedIndex::new(self.ii_flags);
-
+    fn c_index(&self, sparse: bool) -> bench_ffi::InvertedIndex {
+        let ii = bench_ffi::InvertedIndex::new(self.ii_flags);
         let delta = if sparse { SPARSE_DELTA } else { 1 };
         for doc_id in 1..INDEX_SIZE {
             let actual_doc_id = doc_id * delta;
-            ii.write_term_entry(actual_doc_id, 1, 1, self.term, &self.offsets);
+            ii.write_term_entry(actual_doc_id, 1, 1, None, &self.offsets);
         }
         ii
     }
 
     fn rust_index(&self, sparse: bool) -> InvertedIndex<E> {
         let mut ii = InvertedIndex::<E>::new(self.ii_flags);
-
         let delta = if sparse { SPARSE_DELTA } else { 1 };
         for doc_id in 1..INDEX_SIZE {
             let actual_doc_id = doc_id * delta;
-            let record = RSIndexResult::term_with_term_ptr(
-                self.term,
-                inverted_index::RSOffsetSlice::from_bytes(&self.offsets),
+            let record = RSIndexResult::with_term(
+                None,
+                RSOffsetSlice::from_slice(&self.offsets),
                 actual_doc_id,
                 1,
                 1,
@@ -394,7 +379,16 @@ where
             b.iter_batched_ref(
                 || self.rust_index(false),
                 |ii| {
-                    let mut it = Term::new_simple(ii.reader());
+                    // SAFETY: sctx points to a valid, zeroed RedisSearchCtx with a valid spec.
+                    let mut it = unsafe {
+                        Term::new(
+                            ii.reader(),
+                            self.mock_ctx.sctx(),
+                            RSQueryTerm::new(b"term", 1, 0),
+                            1.0,
+                            NoOpChecker,
+                        )
+                    };
                     while let Ok(Some(current)) = it.read() {
                         black_box(current);
                     }
@@ -445,7 +439,16 @@ where
             b.iter_batched_ref(
                 || self.rust_index(false),
                 |ii| {
-                    let mut it = Term::new_simple(ii.reader());
+                    // SAFETY: sctx points to a valid, zeroed RedisSearchCtx with a valid spec.
+                    let mut it = unsafe {
+                        Term::new(
+                            ii.reader(),
+                            self.mock_ctx.sctx(),
+                            RSQueryTerm::new(b"term", 1, 0),
+                            1.0,
+                            NoOpChecker,
+                        )
+                    };
                     while let Ok(Some(outcome)) = it.skip_to(it.last_doc_id() + SKIP_TO_STEP) {
                         match outcome {
                             SkipToOutcome::Found(current) | SkipToOutcome::NotFound(current) => {
@@ -464,7 +467,16 @@ where
             b.iter_batched_ref(
                 || self.rust_index(true),
                 |ii| {
-                    let mut it = Term::new_simple(ii.reader());
+                    // SAFETY: sctx points to a valid, zeroed RedisSearchCtx with a valid spec.
+                    let mut it = unsafe {
+                        Term::new(
+                            ii.reader(),
+                            self.mock_ctx.sctx(),
+                            RSQueryTerm::new(b"term", 1, 0),
+                            1.0,
+                            NoOpChecker,
+                        )
+                    };
                     while let Ok(Some(outcome)) = it.skip_to(it.last_doc_id() + SKIP_TO_STEP) {
                         match outcome {
                             SkipToOutcome::Found(current) | SkipToOutcome::NotFound(current) => {
@@ -478,7 +490,6 @@ where
         });
     }
 }
- */
 
 /// Benchmarks for the wildcard inverted index iterator.
 pub struct WildcardBencher {


### PR DESCRIPTION
## Describe the changes in the pull request

Bringing back old commented out Term II iterator benches. Updating them according to the latest API changes. 

Rust implementation is always measured as faster.

 | Benchmark | C (avg) | Rust (avg) | Speedup |                                                                               
  |---|---|---|---|                                                                                                            
  | **Full - Read Dense** | 5.722 ms | 4.288 ms | **1.33x** |                                                                  
  | **Full - SkipTo Dense** | 2.223 ms | 2.147 ms | **1.04x** |                                                                
  | **Full - SkipTo Sparse** | 10.100 ms | 5.967 ms | **1.69x** |
  | **FullWide - Read Dense** | 5.682 ms | 4.198 ms | **1.35x** |                                                              
  | **FullWide - SkipTo Dense** | 2.204 ms | 2.141 ms | **1.03x** |
  | **FullWide - SkipTo Sparse** | 9.662 ms | 5.884 ms | **1.64x** |
  | **FreqsFields - Read Dense** | 4.612 ms | 2.442 ms | **1.89x** |
  | **FreqsFields - SkipTo Dense** | 1.484 ms | 1.428 ms | **1.04x** |
  | **FreqsFields - SkipTo Sparse** | 9.065 ms | 4.863 ms | **1.86x** |
  | **FreqsFieldsWide - Read Dense** | 4.842 ms | 2.594 ms | **1.87x** |
  | **FreqsFieldsWide - SkipTo Dense** | 1.380 ms | 1.362 ms | **1.01x** |
  | **FreqsFieldsWide - SkipTo Sparse** | 8.808 ms | 5.009 ms | **1.76x** |
  | **FieldsOnly - Read Dense** | 4.262 ms | 2.234 ms | **1.91x** |
  | **FieldsOnly - SkipTo Dense** | 1.503 ms | 1.308 ms | **1.15x** |
  | **FieldsOnly - SkipTo Sparse** | 8.496 ms | 4.171 ms | **2.04x** |
  | **FieldsOnlyWide - Read Dense** | 4.259 ms | 1.870 ms | **2.28x** |
  | **FieldsOnlyWide - SkipTo Dense** | 989.9 µs | 939.0 µs | **1.05x** |
  | **FieldsOnlyWide - SkipTo Sparse** | 6.898 ms | 2.859 ms | **2.41x** |
  | **FieldsOffsets - Read Dense** | 5.052 ms | 3.801 ms | **1.33x** |
  | **FieldsOffsets - SkipTo Dense** | 1.889 ms | 1.844 ms | **1.02x** |
  | **FieldsOffsets - SkipTo Sparse** | 9.315 ms | 5.518 ms | **1.69x** |
  | **FieldsOffsetsWide - Read Dense** | 5.252 ms | 3.836 ms | **1.37x** |
  | **FieldsOffsetsWide - SkipTo Dense** | 1.757 ms | 1.727 ms | **1.02x** |
  | **FieldsOffsetsWide - SkipTo Sparse** | 9.102 ms | 5.745 ms | **1.58x** |
  | **OffsetsOnly - Read Dense** | 5.426 ms | 3.173 ms | **1.71x** |
  | **OffsetsOnly - SkipTo Dense** | 1.611 ms | 1.553 ms | **1.04x** |
  | **OffsetsOnly - SkipTo Sparse** | 9.578 ms | 5.362 ms | **1.79x** |
  | **FreqsOffsets - Read Dense** | 5.872 ms | 3.800 ms | **1.55x** |
  | **FreqsOffsets - SkipTo Dense** | 1.899 ms | 1.843 ms | **1.03x** |
  | **FreqsOffsets - SkipTo Sparse** | 9.685 ms | 5.760 ms | **1.68x** |
  | **DocIdsOnly - Read Dense** | 3.319 ms | 1.680 ms | **1.98x** |
  | **DocIdsOnly - SkipTo Dense** | 613.8 µs | 396.5 µs | **1.55x** |
  | **DocIdsOnly - SkipTo Sparse** | 6.163 ms | 2.755 ms | **2.24x** |
 
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the `criterion` benchmark harness and test utilities; main risk is minor CI/runtime impact from longer benchmark durations and added `unsafe` setup in benches.
> 
> **Overview**
> Re-enables the previously disabled **Term inverted-index iterator** benchmarks and wires them into the `criterion` suite, running across multiple inverted-index encoder/flag configurations (e.g., `Full`, `FieldsOnly`, `DocIdsOnly`).
> 
> Updates the benchmark implementation to match current APIs: uses `RSQueryTerm` + `MockContext` to construct `Term` iterators, switches term record construction to `RSIndexResult::with_term`/`RSOffsetSlice::from_slice`, and adjusts warmup/measurement times for more stable results while comparing **C vs Rust** paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecb28ff0ed55b611ca727b2029082579c34655cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->