### PR TITLE
instruct to run benchmarks only once in skill file

### DIFF
--- a/.skills/run-rust-benchmarks/SKILL.md
+++ b/.skills/run-rust-benchmarks/SKILL.md
@@ -24,7 +24,8 @@ Arguments provided: `$ARGUMENTS`
      ```bash
      cd src/redisearch_rs && cargo bench -p <crate_name> <bench_name>
      ```
-2. Once the benchmarks are complete, generate a summary comparing the average run times between the Rust and C implementations.
+2. **Run benchmarks only once.** If the output is too large or truncated, extract the timing data from the saved output file rather than re-running the benchmarks.
+3. Once the benchmarks are complete, generate a summary comparing the average run times between the Rust and C implementations.
 
 ## Common Benchmark Commands
 


### PR DESCRIPTION
Claude ran the benchmarks once and then again but this time with the filtering, wasting quite some time.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or shipped artifacts.
> 
> **Overview**
> Updates the `run-rust-benchmarks` skill instructions to **explicitly run benchmarks only once**, and to use saved output to extract timing data if console output is truncated. This reduces wasted CI/local time from accidental re-runs while still enabling Rust vs C performance comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd1340281d602774a2fa9387bc3e76dafb47572e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->