### PR TITLE
[MOD-14192] take read indexspec lock on RDB load on SAVE

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -4212,12 +4212,12 @@ void Indexes_EndLoading() {
 // Compaction FFI Functions (called by Rust during GC)
 // =============================================================================
 
-// Acquire IndexSpec read/write lock in exclusive mode
+// Acquire IndexSpec write lock
 void IndexSpec_AcquireWriteLock(IndexSpec* sp) {
   pthread_rwlock_wrlock(&sp->rwlock);
 }
 
-// Release IndexSpec read/write
+// Release IndexSpec write lock
 void IndexSpec_ReleaseWriteLock(IndexSpec* sp) {
   pthread_rwlock_unlock(&sp->rwlock);
 }


### PR DESCRIPTION
When we save RDB from the main thread (on SAVE), make sure to lock the IndexSpec to ensure safe concurrent access (Specially with GC)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB save code and introduces conditional locking, which could impact SAVE latency or deadlock behavior if lock ordering is wrong, but the change is small and scoped to disk/SST save flows.
> 
> **Overview**
> Prevents potential crashes/corruption when running `SAVE` with disk (SST) indexes by taking an `IndexSpec` **read lock** while serializing disk-related in-memory structures.
> 
> The lock is only taken when saving from the main process (non-fork); forked child saves keep the previous behavior to avoid unnecessary locking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9c897dc8f5ec1e886b6ef675cfc43443309cfe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->