### PR TITLE
move MockContext to test_utils

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -17,7 +17,8 @@ use rqe_iterators::{
     NoOpChecker, RQEIterator, RQEValidateStatus, SkipToOutcome, inverted_index::Numeric,
 };
 
-use crate::inverted_index::utils::{BaseTest, MockContext};
+use crate::inverted_index::utils::BaseTest;
+use rqe_iterators_test_utils::MockContext;
 
 /// Builder for creating a Numeric iterator with optional parameters.
 #[allow(dead_code)]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -7,123 +7,12 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ptr;
-
-use ffi::{
-    IndexFlags, IndexSpec, NumericRangeTree, QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId,
-};
+use ffi::{IndexFlags, t_docId};
 use inverted_index::{
     Encoder, InvertedIndex, RSIndexResult, RSResultKind, test_utils::TermRecordCompare,
 };
 use rqe_iterators::{RQEIterator, SkipToOutcome};
-
-/// Mock search context creating fake objects for testing.
-/// It can be used to test expiration but not validation.
-/// Use [`TestContext`] instead to test revalidation.
-///
-/// Uses raw pointers for storage to avoid Stacked Borrows violations.
-/// Box would claim Unique ownership which gets invalidated when the library
-/// code creates references through the pointer chain (e.g., `sctx.spec.as_ref()`).
-/// Raw pointers don't participate in borrow tracking, so they're compatible
-/// with the library's reference creation.
-pub(crate) struct MockContext {
-    #[allow(dead_code)] // Holds allocation that spec.rule points to
-    rule: *mut SchemaRule,
-    spec: *mut IndexSpec,
-    sctx: *mut RedisSearchCtx,
-    #[allow(dead_code)]
-    qctx: *mut QueryEvalCtx,
-    /// fake NumericRangeTree, cannot be used but those tests do not call revalidate()
-    numeric_range_tree: *mut NumericRangeTree,
-}
-
-impl Drop for MockContext {
-    fn drop(&mut self) {
-        // Deallocate all the structs using the global allocator directly.
-        // We can't use Box::from_raw because that would create a Box with a Unique
-        // tag, but the memory's borrow stack may have been modified by SharedReadOnly
-        // tags from the library code's reference creation.
-        unsafe {
-            std::alloc::dealloc(
-                self.rule as *mut u8,
-                std::alloc::Layout::new::<SchemaRule>(),
-            );
-            std::alloc::dealloc(self.spec as *mut u8, std::alloc::Layout::new::<IndexSpec>());
-            std::alloc::dealloc(
-                self.sctx as *mut u8,
-                std::alloc::Layout::new::<RedisSearchCtx>(),
-            );
-            std::alloc::dealloc(
-                self.qctx as *mut u8,
-                std::alloc::Layout::new::<QueryEvalCtx>(),
-            );
-            std::alloc::dealloc(
-                self.numeric_range_tree as *mut u8,
-                std::alloc::Layout::new::<NumericRangeTree>(),
-            );
-        }
-    }
-}
-
-impl MockContext {
-    pub(crate) fn new(max_doc_id: t_docId, num_docs: usize) -> Self {
-        // Allocate each struct using Box::into_raw to get raw pointers.
-        // We store raw pointers (not Boxes) because the library code creates
-        // references through the pointer chain which would invalidate Box's
-        // Unique ownership tag under Stacked Borrows.
-
-        // Create boxes and immediately convert to raw pointers
-        let rule_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<SchemaRule>() }));
-        let spec_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<IndexSpec>() }));
-        let sctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<RedisSearchCtx>() }));
-        let qctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<QueryEvalCtx>() }));
-        let numeric_range_tree_ptr =
-            Box::into_raw(Box::new(unsafe { std::mem::zeroed::<NumericRangeTree>() }));
-
-        // Initialize all structs through raw pointers
-        unsafe {
-            // Initialize SchemaRule
-            (*rule_ptr).index_all = false;
-
-            // Initialize IndexSpec
-            (*spec_ptr).rule = rule_ptr;
-            (*spec_ptr).monitorDocumentExpiration = true; // Only depends on API availability, so always true
-            (*spec_ptr).monitorFieldExpiration = true; // Only depends on API availability, so always true
-            (*spec_ptr).docs.maxDocId = max_doc_id;
-            (*spec_ptr).docs.size = if num_docs > 0 {
-                num_docs
-            } else {
-                max_doc_id as usize
-            };
-            (*spec_ptr).stats.scoring.numDocuments = (*spec_ptr).docs.size;
-
-            // Initialize RedisSearchCtx
-            (*sctx_ptr).spec = spec_ptr;
-
-            // Initialize QueryEvalCtx
-            (*qctx_ptr).sctx = sctx_ptr;
-            (*qctx_ptr).docTable = ptr::addr_of_mut!((*spec_ptr).docs);
-
-            // Store raw pointers directly (don't convert back to Box)
-            Self {
-                rule: rule_ptr,
-                spec: spec_ptr,
-                sctx: sctx_ptr,
-                qctx: qctx_ptr,
-                numeric_range_tree: numeric_range_tree_ptr,
-            }
-        }
-    }
-
-    pub(crate) fn numeric_range_tree(&self) -> ptr::NonNull<NumericRangeTree> {
-        ptr::NonNull::new(self.numeric_range_tree).expect("NumericRangeTree should not be null")
-    }
-
-    /// Get the search context from the TestContext.
-    pub(crate) fn sctx(&self) -> ptr::NonNull<ffi::RedisSearchCtx> {
-        ptr::NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
-    }
-}
+use rqe_iterators_test_utils::MockContext;
 
 /// Test basic read and skip_to functionality for a given iterator.
 pub(super) struct BaseTest<E> {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -13,7 +13,8 @@ use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
 use inverted_index::{RSIndexResult, doc_ids_only::DocIdsOnly};
 use rqe_iterators::{RQEIterator, inverted_index::Wildcard};
 
-use crate::inverted_index::utils::{BaseTest, MockContext};
+use crate::inverted_index::utils::BaseTest;
+use rqe_iterators_test_utils::MockContext;
 
 struct WildcardBaseTest {
     test: BaseTest<DocIdsOnly>,

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
@@ -14,6 +14,10 @@
 
 #[allow(clippy::undocumented_unsafe_blocks)]
 #[allow(clippy::multiple_unsafe_ops_per_block)]
+pub mod mock_context;
+#[allow(clippy::undocumented_unsafe_blocks)]
+#[allow(clippy::multiple_unsafe_ops_per_block)]
 pub mod test_context;
 
+pub use mock_context::MockContext;
 pub use test_context::{GlobalGuard, TestContext};

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::ptr;
+
+use ffi::{IndexSpec, NumericRangeTree, QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId};
+
+/// Mock search context creating fake objects for testing.
+/// It can be used to test expiration but not validation.
+/// Use [`crate::TestContext`] instead to test revalidation.
+///
+/// Uses raw pointers for storage to avoid Stacked Borrows violations.
+/// Box would claim Unique ownership which gets invalidated when the library
+/// code creates references through the pointer chain (e.g., `sctx.spec.as_ref()`).
+/// Raw pointers don't participate in borrow tracking, so they're compatible
+/// with the library's reference creation.
+pub struct MockContext {
+    #[allow(dead_code)] // Holds allocation that spec.rule points to
+    rule: *mut SchemaRule,
+    spec: *mut IndexSpec,
+    sctx: *mut RedisSearchCtx,
+    #[allow(dead_code)]
+    qctx: *mut QueryEvalCtx,
+    /// fake NumericRangeTree, cannot be used but those tests do not call revalidate()
+    numeric_range_tree: *mut NumericRangeTree,
+}
+
+impl Drop for MockContext {
+    fn drop(&mut self) {
+        // Deallocate all the structs using the global allocator directly.
+        // We can't use Box::from_raw because that would create a Box with a Unique
+        // tag, but the memory's borrow stack may have been modified by SharedReadOnly
+        // tags from the library code's reference creation.
+        unsafe {
+            std::alloc::dealloc(
+                self.rule as *mut u8,
+                std::alloc::Layout::new::<SchemaRule>(),
+            );
+            std::alloc::dealloc(self.spec as *mut u8, std::alloc::Layout::new::<IndexSpec>());
+            std::alloc::dealloc(
+                self.sctx as *mut u8,
+                std::alloc::Layout::new::<RedisSearchCtx>(),
+            );
+            std::alloc::dealloc(
+                self.qctx as *mut u8,
+                std::alloc::Layout::new::<QueryEvalCtx>(),
+            );
+            std::alloc::dealloc(
+                self.numeric_range_tree as *mut u8,
+                std::alloc::Layout::new::<NumericRangeTree>(),
+            );
+        }
+    }
+}
+
+impl MockContext {
+    pub fn new(max_doc_id: t_docId, num_docs: usize) -> Self {
+        // Allocate each struct using Box::into_raw to get raw pointers.
+        // We store raw pointers (not Boxes) because the library code creates
+        // references through the pointer chain which would invalidate Box's
+        // Unique ownership tag under Stacked Borrows.
+
+        // Create boxes and immediately convert to raw pointers
+        let rule_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<SchemaRule>() }));
+        let spec_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<IndexSpec>() }));
+        let sctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<RedisSearchCtx>() }));
+        let qctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<QueryEvalCtx>() }));
+        let numeric_range_tree_ptr =
+            Box::into_raw(Box::new(unsafe { std::mem::zeroed::<NumericRangeTree>() }));
+
+        // Initialize all structs through raw pointers
+        unsafe {
+            // Initialize SchemaRule
+            (*rule_ptr).index_all = false;
+
+            // Initialize IndexSpec
+            (*spec_ptr).rule = rule_ptr;
+            (*spec_ptr).monitorDocumentExpiration = true; // Only depends on API availability, so always true
+            (*spec_ptr).monitorFieldExpiration = true; // Only depends on API availability, so always true
+            (*spec_ptr).docs.maxDocId = max_doc_id;
+            (*spec_ptr).docs.size = if num_docs > 0 {
+                num_docs
+            } else {
+                max_doc_id as usize
+            };
+            (*spec_ptr).stats.scoring.numDocuments = (*spec_ptr).docs.size;
+
+            // Initialize RedisSearchCtx
+            (*sctx_ptr).spec = spec_ptr;
+
+            // Initialize QueryEvalCtx
+            (*qctx_ptr).sctx = sctx_ptr;
+            (*qctx_ptr).docTable = ptr::addr_of_mut!((*spec_ptr).docs);
+
+            // Store raw pointers directly (don't convert back to Box)
+            Self {
+                rule: rule_ptr,
+                spec: spec_ptr,
+                sctx: sctx_ptr,
+                qctx: qctx_ptr,
+                numeric_range_tree: numeric_range_tree_ptr,
+            }
+        }
+    }
+
+    pub const fn numeric_range_tree(&self) -> ptr::NonNull<NumericRangeTree> {
+        ptr::NonNull::new(self.numeric_range_tree).expect("NumericRangeTree should not be null")
+    }
+
+    /// Get the search context from the TestContext.
+    pub const fn sctx(&self) -> ptr::NonNull<ffi::RedisSearchCtx> {
+        ptr::NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
+    }
+}


### PR DESCRIPTION
Will be used by the II term benches.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that primarily changes module boundaries/imports; main risk is limited to build/test breakage due to moved symbols or FFI pointer lifetime assumptions staying equivalent.
> 
> **Overview**
> Refactors test infrastructure by moving `MockContext` out of the integration test `inverted_index/utils.rs` module into the shared `rqe_iterators_test_utils` crate (`mock_context.rs`) and re-exporting it from that crate.
> 
> Integration tests (`numeric.rs`, `wildcard.rs`, and `BaseTest`) are updated to import `MockContext` from `rqe_iterators_test_utils`, reducing local test-only FFI scaffolding and enabling reuse by other test/bench code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66403fa1198df8a2fec10adf8b94d57c66ff349b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->