### PR TITLE
[MOD-13588] RsValue: Null Static and Shared value functions

### DIFF
--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/constructors.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/constructors.rs
@@ -10,6 +10,8 @@
 use ffi::RedisModuleString;
 use libc::size_t;
 use std::ffi::{c_char, c_double};
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
 use value::util::str_to_float;
 use value::{RedisString, RsString, RsValue, RsValueTrio, SharedRsValue};
 
@@ -229,4 +231,12 @@ pub extern "C" fn RSValue_NewNumberFromInt64(number: i64) -> *mut RsValue {
     SharedRsValue::new(RsValue::Number(number as f64))
         .into_raw()
         .cast_mut()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_NewReference(src: *const RsValue) -> *mut RsValue {
+    let shared_src = unsafe { SharedRsValue::from_raw(src) };
+    let shared_src = ManuallyDrop::new(shared_src);
+    let ref_value = RsValue::Ref(shared_src.deref().clone());
+    SharedRsValue::new(ref_value).into_raw() as *mut _
 }

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::{mem::ManuallyDrop, ops::Deref};
+
 use value::{RsValue, SharedRsValue};
 
 /// Decrement the reference count of the provided [`RsValue`] object. If this was
@@ -20,4 +22,74 @@ use value::{RsValue, SharedRsValue};
 pub unsafe extern "C" fn RSValue_DecrRef(value: *const RsValue) {
     // Safety: ensured by caller (1.)
     let _ = unsafe { SharedRsValue::from_raw(value) };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_Dereference(value: *const RsValue) -> *mut RsValue {
+    let shared_value = unsafe { SharedRsValue::from_raw(value) };
+    let shared_value = ManuallyDrop::new(shared_value);
+    let dereferenced_value = shared_value.fully_dereferenced();
+    dereferenced_value.as_ptr() as *mut _
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_DereferenceRefAndTrio(value: *const RsValue) -> *mut RsValue {
+    let shared_value = unsafe { SharedRsValue::from_raw(value) };
+    let shared_value = ManuallyDrop::new(shared_value);
+    let dereferenced_value = shared_value.value().fully_dereferenced_ref_and_trio();
+    let value = unsafe { crate::util::expect_shared_value(dereferenced_value) };
+    value.as_ptr() as *mut _
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_Clear(value: *const RsValue) {
+    let shared_value = unsafe { SharedRsValue::from_raw(value) };
+    let mut shared_value = ManuallyDrop::new(shared_value);
+    shared_value.set_value(RsValue::Undefined);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_IncrRef(value: *const RsValue) -> *mut RsValue {
+    let shared_value = unsafe { SharedRsValue::from_raw(value) };
+    let shared_value = ManuallyDrop::new(shared_value);
+    <SharedRsValue as Clone>::clone(&shared_value).into_raw() as *mut _
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_MakeReference(dst: *const RsValue, src: *const RsValue) {
+    let shared_dst = unsafe { SharedRsValue::from_raw(dst) };
+    let mut shared_dst = ManuallyDrop::new(shared_dst);
+    let shared_src = unsafe { SharedRsValue::from_raw(src) };
+    let shared_src = ManuallyDrop::new(shared_src);
+
+    let new_value = RsValue::Ref(shared_src.deref().clone());
+    shared_dst.set_value(new_value);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_MakeOwnReference(dst: *const RsValue, src: *const RsValue) {
+    let shared_dst = unsafe { SharedRsValue::from_raw(dst) };
+    let mut shared_dst = ManuallyDrop::new(shared_dst);
+    let shared_src = unsafe { SharedRsValue::from_raw(src) };
+
+    let new_value = RsValue::Ref(shared_src);
+    shared_dst.set_value(new_value);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_Replace(dstpp: *mut *mut RsValue, src: *const RsValue) {
+    let _shared_dst = unsafe { SharedRsValue::from_raw(*dstpp) };
+    let shared_src = unsafe { SharedRsValue::from_raw(src) };
+    let shared_src = ManuallyDrop::new(shared_src);
+    let shared_src_clone = shared_src.deref().clone();
+    unsafe {
+        *dstpp = shared_src_clone.into_raw() as *mut _;
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_Refcount(value: *const RsValue) -> u16 {
+    let shared_value = unsafe { SharedRsValue::from_raw(value) };
+    let shared_value = ManuallyDrop::new(shared_value);
+    SharedRsValue::refcount(&shared_value) as u16
 }

--- a/src/redisearch_rs/headers/value.h
+++ b/src/redisearch_rs/headers/value.h
@@ -262,6 +262,8 @@ struct RsValue *RSValue_NewParsedNumber(const char *value,
  */
 struct RsValue *RSValue_NewNumberFromInt64(int64_t number);
 
+struct RsValue *RSValue_NewReference(const struct RsValue *src);
+
 /**
  * Convert the [`RsValue`] to a number. Returns `true` when this value is a number
  * or a numeric string that can be converted and writes the number to `d`. If
@@ -574,6 +576,22 @@ void RSValue_SetConstString(struct RsValue *value, const char *str, uint32_t len
  *    `RSValue_*` function returning an owned [`RsValue`] object.
  */
 void RSValue_DecrRef(const struct RsValue *value);
+
+struct RsValue *RSValue_Dereference(const struct RsValue *value);
+
+struct RsValue *RSValue_DereferenceRefAndTrio(const struct RsValue *value);
+
+void RSValue_Clear(const struct RsValue *value);
+
+struct RsValue *RSValue_IncrRef(const struct RsValue *value);
+
+void RSValue_MakeReference(const struct RsValue *dst, const struct RsValue *src);
+
+void RSValue_MakeOwnReference(const struct RsValue *dst, const struct RsValue *src);
+
+void RSValue_Replace(struct RsValue **dstpp, const struct RsValue *src);
+
+uint16_t RSValue_Refcount(const struct RsValue *value);
 
 /**
  * Returns the type of the given [`RsValue`].


### PR DESCRIPTION
Implement new NullStatic setup and other shared value functions

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new unsafe FFI entrypoints that manipulate `SharedRsValue` refcounts and in-place mutation, which can cause leaks or premature frees if misused by C callers. Behavior changes are localized to the `RsValue` C API surface but touch memory-management semantics.
> 
> **Overview**
> **Expands the `RsValue` C API for shared/reference semantics.** Adds `RSValue_NewReference` plus a set of new shared-value utilities (`RSValue_IncrRef`, `RSValue_Refcount`, `RSValue_Replace`, `RSValue_Clear`, `RSValue_MakeReference`/`RSValue_MakeOwnReference`, and dereference helpers) implemented via `SharedRsValue` with `ManuallyDrop` to avoid unintended refcount drops.
> 
> Updates the autogenerated header `value.h` to expose these new functions to C/C++ callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d53e1eeb756c1662ba0e464807a0bab7b74a31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->