### PR TITLE
Make RSOffsetSlice::data const-correct (*const u8 instead of *mut u8)

### DIFF
--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -593,7 +593,7 @@ pub unsafe extern "C" fn RSOffsetVector_SetData(
     // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid offset vector.
     let offsets = unsafe { &mut *offsets };
 
-    offsets.data = data.cast::<u8>().cast_mut();
+    offsets.data = data.cast::<u8>();
     offsets.len = len;
 }
 

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -308,7 +308,7 @@ typedef struct RSOffsetVector {
   /**
    * Pointer to the borrowed offset data.
    */
-  uint8_t *data;
+  const uint8_t *data;
   uint32_t len;
 } RSOffsetVector;
 

--- a/src/redisearch_rs/inverted_index/src/index_result/offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result/offsets.rs
@@ -18,7 +18,7 @@ use std::{alloc::Layout, borrow::Borrow, fmt::Debug, marker::PhantomData, ptr};
 #[derive(Copy, Clone)]
 pub struct RSOffsetSlice<'index> {
     /// Pointer to the borrowed offset data.
-    pub data: *mut u8,
+    pub data: *const u8,
     pub len: u32,
     /// The data pointer does not carry a lifetime, so use a `PhantomData` to track it instead.
     _phantom: PhantomData<&'index ()>,
@@ -38,8 +38,7 @@ impl Debug for RSOffsetSlice<'_> {
             return write!(f, "RSOffsetSlice(null)");
         }
         // SAFETY: `len` is guaranteed to be a valid length for the data pointer.
-        let offsets =
-            unsafe { std::slice::from_raw_parts(self.data.cast_const(), self.len as usize) };
+        let offsets = unsafe { std::slice::from_raw_parts(self.data, self.len as usize) };
 
         write!(f, "RSOffsetSlice {offsets:?}")
     }
@@ -69,7 +68,7 @@ impl<'index> RSOffsetSlice<'index> {
             "offset slice length exceeds u32::MAX"
         );
         Self {
-            data: bytes.as_ptr().cast_mut(),
+            data: bytes.as_ptr(),
             len: bytes.len() as u32,
             _phantom: PhantomData,
         }
@@ -80,7 +79,7 @@ impl RSOffsetSlice<'_> {
     /// Create a new, empty offset slice.
     pub const fn empty() -> Self {
         Self {
-            data: ptr::null_mut(),
+            data: ptr::null(),
             len: 0,
             _phantom: PhantomData,
         }


### PR DESCRIPTION
RSOffsetSlice is a borrowed, read-only view of offset data. Its data field was *mut u8 despite never needing write access, causing a const-discard cast in forward_index.c where VVW_GetByteData (which returns const uint8_t *) was assigned to the field.

Change RSOffsetSlice::data from *mut u8 to *const u8, propagating the fix through the FFI layer and regenerated C header.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical const-correctness change to FFI structs; main risk is downstream C compilation fallout where code previously wrote through `offsets.data`.
> 
> **Overview**
> Makes term-offset data pointers **read-only across the Rust↔C FFI boundary** by changing `RSOffsetSlice::data` from `*mut u8` to `*const u8` and updating associated helper code to avoid const-discarding casts.
> 
> Regenerates/updates the exported C header so `RSOffsetVector.data` is now `const uint8_t *`, aligning C consumers (e.g., forward index offset views) with the borrowed, non-owning semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88495878c8cf830d357f125dfe0ea1a882facf16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->