### PR TITLE
[CI] Run MacOS tests on 26 - [MOD-13851]

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos,alpine:3.22,intel'  # on feature branches this should be 'all'
+      platform: 'ubuntu:noble,macos-15,macos-26,alpine:3.22,intel'  # on feature branches this should be 'all'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -19,7 +19,8 @@ on:
           - mariner:2
           - azurelinux:3
           - alpine:3.22
-          - macos
+          - macos-15
+          - macos-26
         description: 'Platform to build on. Use "all" to build on all'
         default: all
       architecture:

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -48,7 +48,8 @@ on:
           - mariner:2
           - azurelinux:3
           - alpine:3.22
-          - macos
+          - macos-15
+          - macos-26
           - intel
         description: 'Platform to test on. Use "all" to test on all platforms'
         default: all

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -73,7 +73,8 @@ jobs:
               ('azurelinux:3', 'aarch64'),
               ('alpine:3.22', 'x86_64'),
               ('alpine:3.22', 'aarch64'),
-              ('macos', 'aarch64'),
+              ('macos-15', 'aarch64'),
+              ('macos-26', 'aarch64'),
               ('intel', 'x86_64'),  # Self-hosted EC2 runner
           ]
 

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform name (e.g., ubuntu:noble, macos, sanitizer, coverage)'
+        description: 'Platform name (e.g., ubuntu:noble, macos-15, macos-26, sanitizer, coverage)'
         type: string
         required: true
       architecture:
@@ -85,10 +85,16 @@ jobs:
 
           # Platform configurations
           platform_configs = {
-              "macos": {
+              "macos-15": {
                   "aarch64": {
-                      'env': 'macos-26',    # TODO: Revert to 'macos-latest' when 26 becomes the default
-                      'name': 'macOS ARM64'
+                      'env': 'macos-15',
+                      'name': 'macOS 15 ARM64'
+                  }
+              },
+              "macos-26": {
+                  "aarch64": {
+                      'env': 'macos-26',
+                      'name': 'macOS 26 ARM64'
                   }
               },
               "intel": {

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform name (e.g., ubuntu:noble, macos, sanitizer, coverage)'
+        description: 'Platform name (e.g., ubuntu:noble, macos-15, macos-26, sanitizer, coverage)'
         type: string
         required: true
       architecture:

--- a/scripts/collect_nightly_results.py
+++ b/scripts/collect_nightly_results.py
@@ -188,8 +188,8 @@ def simplify_job_name(job_name):
     Special cases (show only title):
     - "coverage / Test ubuntu-latest, Redis unstable" -> "coverage"
     - "sanitize / Test ubuntu-latest, Redis unstable" -> "sanitize"
-    - "test-macos / build-macos (macos-15-intel) / ..." -> "macos-15-intel"
-    - "test-macos / build-macos (macos-latest) / ..." -> "macos-latest"
+    - "test-macos-15 / build-macos-15 (macos-15) / ..." -> "macos-15"
+    - "test-macos-26 / build-macos-26 (macos-26) / ..." -> "macos-26"
     - "run-on-intel / Start self-hosted EC2 runner" -> "run-on-intel"
 
     Container jobs (show as "container arch"):
@@ -202,10 +202,11 @@ def simplify_job_name(job_name):
     if job_name.startswith("coverage /") or job_name.startswith("sanitize /"):
         return job_name.split(" /")[0]
 
-    # Special case: test-macos with macos version
-    if job_name.startswith("test-macos / build-macos"):
-        # Extract macos version from parentheses: "test-macos / build-macos (macos-latest) / ..."
-        match = re.search(r'build-macos \(([^)]+)\)', job_name)
+    # Special case: test-macos-* with macOS runner version.
+    if re.match(r'^test-macos(?:-\d+)? / build-macos(?:-\d+)?', job_name):
+        # Extract macOS runner from parentheses:
+        # "test-macos-15 / build-macos-15 (macos-15) / ..."
+        match = re.search(r'build-macos(?:-\d+)? \(([^)]+)\)', job_name)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
## Describe the changes in the pull request

#### Passing tests CI
- https://github.com/RediSearch/RediSearch/actions/runs/22404880658
- https://github.com/RediSearch/RediSearch/actions/runs/22404846547
- https://github.com/RediSearch/RediSearch/actions/runs/22405217046

#### Passing build CI
- https://github.com/RediSearch/RediSearch/actions/runs/22404846883

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust platform matrix values; risk is limited to CI routing misconfiguration or increased macOS runner usage/failures.
> 
> **Overview**
> Updates CI to run on **explicit macOS runner versions** by replacing the generic `macos` platform with `macos-15` and adding `macos-26` across merge-queue validation, test/build workflow inputs, and the generated platform matrix.
> 
> Extends `task-get-config.yml` to map `macos-15`/`macos-26` to the corresponding GitHub-hosted runners, and updates `scripts/collect_nightly_results.py` job-name simplification to recognize the new `test-macos-*` naming pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4359409c455dbb70606e9d1f7d2134e93f97ce3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->