### PR TITLE
inverted_index_ffi:: split inverted_index.rs into submodules

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/mod.rs
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+mod numeric;
+mod wildcard;
+
+use numeric::NumericIterator;
+use rqe_iterators_interop::RQEIteratorWrapper;
+use wildcard::WildcardIterator;
+
+/// Gets the flags of the underlying IndexReader from a numeric inverted index iterator.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
+/// 2. If `it` iterator type is IteratorType_INV_IDX_NUMERIC_ITERATOR, it has been created using `NewInvIndIterator_NumericQuery`.
+/// 3. If `it` iterator type is IteratorType_INV_IDX_WILDCARD_ITERATOR, it has been created using `NewInvIndIterator_WildcardQuery`.
+/// 4. If `it` has a different iterator type, its `reader` field must be a valid non-NULL pointer to an `IndexReader`.
+///
+/// # Returns
+///
+/// The flags of the `IndexReader`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn InvIndIterator_GetReaderFlags(
+    it: *const ffi::InvIndIterator,
+) -> ffi::IndexFlags {
+    debug_assert!(!it.is_null());
+
+    // SAFETY: 1.
+    let it_ref = unsafe { &*it };
+
+    match it_ref.base.type_ {
+        ffi::IteratorType_INV_IDX_NUMERIC_ITERATOR => {
+            // SAFETY: the numeric iterator is in Rust.
+            let wrapper = unsafe {
+                RQEIteratorWrapper::<NumericIterator<'static>>::ref_from_header_ptr(it.cast())
+            };
+            wrapper.inner.flags()
+        }
+        ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR => {
+            // SAFETY: 3. the wildcard iterator is in Rust.
+            let wrapper = unsafe {
+                RQEIteratorWrapper::<WildcardIterator<'static>>::ref_from_header_ptr(it.cast())
+            };
+            wrapper.inner.flags()
+        }
+        _ => {
+            // C iterator
+            let reader: *mut inverted_index_ffi::IndexReader = it_ref.reader.cast();
+            // SAFETY: 4.
+            let reader_ref = unsafe { &*reader };
+            reader_ref.flags()
+        }
+    }
+}
+
+/// Swap the inverted index of an inverted index iterator. This is only used by C tests
+/// to trigger revalidation on the iterator's underlying reader.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid non-NULL pointer to an `InvIndIterator`.
+/// 2. If `it` iterator type is `IteratorType_INV_IDX_WILDCARD_ITERATOR`, it has been created
+///    using `NewInvIndIterator_WildcardQuery`.
+/// 3. If `it` is a C iterator, its `reader` field must be a valid non-NULL
+///    pointer to an `IndexReader`.
+/// 4. `ii` must be a valid non-NULL pointer to an `InvertedIndex` whose type matches the
+///    iterator's underlying index type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn InvIndIterator_Rs_SwapIndex(
+    it: *mut ffi::InvIndIterator,
+    ii: *const ffi::InvertedIndex,
+) {
+    debug_assert!(!it.is_null());
+    debug_assert!(!ii.is_null());
+
+    // SAFETY: 1.
+    let it_ref = unsafe { &*it };
+
+    match it_ref.base.type_ {
+        ffi::IteratorType_INV_IDX_NUMERIC_ITERATOR => {
+            unimplemented!(
+                "Numeric iterators use revision ID for revalidation, not index swapping"
+            );
+        }
+        ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR => {
+            unimplemented!("Wildcard iterator is tested in Rust which does no use index swapping")
+        }
+        _ => {
+            // C iterator
+            let reader: *mut inverted_index_ffi::IndexReader = it_ref.reader.cast();
+            // SAFETY: 3. guarantees reader is valid.
+            let reader_ref = unsafe { &mut *reader };
+            let ii: *const inverted_index_ffi::InvertedIndex = ii.cast();
+            // SAFETY: 4. guarantees ii is valid and matching.
+            let ii_ref = unsafe { &*ii };
+            reader_ref.swap_index(ii_ref);
+        }
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -7,18 +7,14 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{fmt::Debug, ptr::NonNull};
+use std::ptr::NonNull;
 
 use field::{FieldFilterContext, FieldMaskOrIndex};
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, IndexReaderCore, NumericFilter,
-    NumericReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly,
-    t_docId,
+    NumericReader, RSIndexResult, t_docId,
 };
-use rqe_iterators::{
-    FieldExpirationChecker,
-    inverted_index::{Numeric, Wildcard},
-};
+use rqe_iterators::{FieldExpirationChecker, inverted_index::Numeric};
 use rqe_iterators_interop::RQEIteratorWrapper;
 
 /// Wrapper around different numeric reader types to avoid generics in FFI code.
@@ -107,109 +103,6 @@ impl<'index> IndexReader<'index> for NumericIndexReader<'index> {
 
 impl<'index> NumericReader<'index> for NumericIndexReader<'index> {}
 
-/// Wrapper around different II wildcard iterator encoding types to avoid generics in FFI code.
-///
-/// Handles both the standard variable-length encoding ([`DocIdsOnly`]) and the
-/// fixed 4-byte raw encoding ([`RawDocIdsOnly`]).
-enum WildcardIterator<'index> {
-    Encoded(Wildcard<'index, DocIdsOnly>),
-    Raw(Wildcard<'index, RawDocIdsOnly>),
-}
-
-impl Debug for WildcardIterator<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let variant = match self {
-            WildcardIterator::Encoded(_) => "Encoded",
-            WildcardIterator::Raw(_) => "Raw",
-        };
-        write!(f, "WildcardIterator({variant})")
-    }
-}
-
-impl WildcardIterator<'_> {
-    /// Get the flags from the underlying reader.
-    fn flags(&self) -> ffi::IndexFlags {
-        match self {
-            WildcardIterator::Encoded(w) => w.reader().flags(),
-            WildcardIterator::Raw(w) => w.reader().flags(),
-        }
-    }
-}
-
-impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
-    #[inline(always)]
-    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        match self {
-            WildcardIterator::Encoded(w) => w.current(),
-            WildcardIterator::Raw(w) => w.current(),
-        }
-    }
-
-    #[inline(always)]
-    fn read(
-        &mut self,
-    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
-        match self {
-            WildcardIterator::Encoded(w) => w.read(),
-            WildcardIterator::Raw(w) => w.read(),
-        }
-    }
-
-    #[inline(always)]
-    fn skip_to(
-        &mut self,
-        doc_id: t_docId,
-    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
-    {
-        match self {
-            WildcardIterator::Encoded(w) => w.skip_to(doc_id),
-            WildcardIterator::Raw(w) => w.skip_to(doc_id),
-        }
-    }
-
-    #[inline(always)]
-    fn rewind(&mut self) {
-        match self {
-            WildcardIterator::Encoded(w) => w.rewind(),
-            WildcardIterator::Raw(w) => w.rewind(),
-        }
-    }
-
-    #[inline(always)]
-    fn num_estimated(&self) -> usize {
-        match self {
-            WildcardIterator::Encoded(w) => w.num_estimated(),
-            WildcardIterator::Raw(w) => w.num_estimated(),
-        }
-    }
-
-    #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
-        match self {
-            WildcardIterator::Encoded(w) => w.last_doc_id(),
-            WildcardIterator::Raw(w) => w.last_doc_id(),
-        }
-    }
-
-    #[inline(always)]
-    fn at_eof(&self) -> bool {
-        match self {
-            WildcardIterator::Encoded(w) => w.at_eof(),
-            WildcardIterator::Raw(w) => w.at_eof(),
-        }
-    }
-
-    #[inline(always)]
-    fn revalidate(
-        &mut self,
-    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        match self {
-            WildcardIterator::Encoded(w) => w.revalidate(),
-            WildcardIterator::Raw(w) => w.revalidate(),
-        }
-    }
-}
-
 /// Enum holding either a numeric or geo iterator variant.
 /// This allows all iterator types to share the same iterator wrapper structure.
 enum IteratorVariant<'index> {
@@ -236,7 +129,7 @@ enum IteratorVariant<'index> {
 /// Wrapper around the actual Numeric iterator.
 /// Needed as we need to keep the `filter` pointer around so it can be returned in
 /// [`NumericInvIndIterator_GetNumericFilter`].
-struct NumericIterator<'index> {
+pub(super) struct NumericIterator<'index> {
     /// The user numeric filter, or None if no filter was provided.
     filter: Option<NonNull<NumericFilter>>,
     /// The iterator variant (numeric or geo).
@@ -245,7 +138,7 @@ struct NumericIterator<'index> {
 
 impl<'index> NumericIterator<'index> {
     /// Get the flags from the underlying reader.
-    fn flags(&self) -> ffi::IndexFlags {
+    pub(super) fn flags(&self) -> ffi::IndexFlags {
         match &self.iterator {
             IteratorVariant::Numeric(iter) => iter.reader().flags(),
             IteratorVariant::NumericFiltered(iter) => iter.reader().flags(),
@@ -506,52 +399,6 @@ pub unsafe extern "C" fn NewInvIndIterator_NumericQuery(
     RQEIteratorWrapper::boxed_new(ffi::IteratorType_INV_IDX_NUMERIC_ITERATOR, iterator)
 }
 
-/// Gets the flags of the underlying IndexReader from a numeric inverted index iterator.
-///
-/// # Safety
-///
-/// 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
-/// 2. If `it` iterator type is IteratorType_INV_IDX_NUMERIC_ITERATOR, it has been created using `NewInvIndIterator_NumericQuery`.
-/// 3. If `it` iterator type is IteratorType_INV_IDX_WILDCARD_ITERATOR, it has been created using `NewInvIndIterator_WildcardQuery`.
-/// 4. If `it` has a different iterator type, its `reader` field must be a valid non-NULL pointer to an `IndexReader`.
-///
-/// # Returns
-///
-/// The flags of the `IndexReader`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvIndIterator_GetReaderFlags(
-    it: *const ffi::InvIndIterator,
-) -> ffi::IndexFlags {
-    debug_assert!(!it.is_null());
-
-    // SAFETY: 1.
-    let it_ref = unsafe { &*it };
-
-    match it_ref.base.type_ {
-        ffi::IteratorType_INV_IDX_NUMERIC_ITERATOR => {
-            // SAFETY: the numeric iterator is in Rust.
-            let wrapper = unsafe {
-                RQEIteratorWrapper::<NumericIterator<'static>>::ref_from_header_ptr(it.cast())
-            };
-            wrapper.inner.flags()
-        }
-        ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR => {
-            // SAFETY: 3. the wildcard iterator is in Rust.
-            let wrapper = unsafe {
-                RQEIteratorWrapper::<WildcardIterator<'static>>::ref_from_header_ptr(it.cast())
-            };
-            wrapper.inner.flags()
-        }
-        _ => {
-            // C iterator
-            let reader: *mut inverted_index_ffi::IndexReader = it_ref.reader.cast();
-            // SAFETY: 4.
-            let reader_ref = unsafe { &*reader };
-            reader_ref.flags()
-        }
-    }
-}
-
 /// Gets the numeric filter from a numeric inverted index iterator.
 ///
 /// # Safety
@@ -621,107 +468,4 @@ pub unsafe extern "C" fn NumericInvIndIterator_GetProfileRangeMax(
     let wrapper =
         unsafe { RQEIteratorWrapper::<NumericIterator<'static>>::ref_from_header_ptr(it.cast()) };
     wrapper.inner.range_max()
-}
-
-/// Swap the inverted index of an inverted index iterator. This is only used by C tests
-/// to trigger revalidation on the iterator's underlying reader.
-///
-/// # Safety
-///
-/// 1. `it` must be a valid non-NULL pointer to an `InvIndIterator`.
-/// 2. If `it` iterator type is `IteratorType_INV_IDX_WILDCARD_ITERATOR`, it has been created
-///    using `NewInvIndIterator_WildcardQuery`.
-/// 3. If `it` is a C iterator, its `reader` field must be a valid non-NULL
-///    pointer to an `IndexReader`.
-/// 4. `ii` must be a valid non-NULL pointer to an `InvertedIndex` whose type matches the
-///    iterator's underlying index type.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvIndIterator_Rs_SwapIndex(
-    it: *mut ffi::InvIndIterator,
-    ii: *const ffi::InvertedIndex,
-) {
-    debug_assert!(!it.is_null());
-    debug_assert!(!ii.is_null());
-
-    // SAFETY: 1.
-    let it_ref = unsafe { &*it };
-
-    match it_ref.base.type_ {
-        ffi::IteratorType_INV_IDX_NUMERIC_ITERATOR => {
-            unimplemented!(
-                "Numeric iterators use revision ID for revalidation, not index swapping"
-            );
-        }
-        ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR => {
-            unimplemented!("Wildcard iterator is tested in Rust which does no use index swapping")
-        }
-        _ => {
-            // C iterator
-            let reader: *mut inverted_index_ffi::IndexReader = it_ref.reader.cast();
-            // SAFETY: 3. guarantees reader is valid.
-            let reader_ref = unsafe { &mut *reader };
-            let ii: *const inverted_index_ffi::InvertedIndex = ii.cast();
-            // SAFETY: 4. guarantees ii is valid and matching.
-            let ii_ref = unsafe { &*ii };
-            reader_ref.swap_index(ii_ref);
-        }
-    }
-}
-
-/// Creates a new wildcard inverted index iterator for querying all existing documents.
-///
-/// # Parameters
-///
-/// * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
-/// * `sctx` - Pointer to the Redis search context.
-/// * `weight` - Weight to apply to all results.
-///
-/// # Returns
-///
-/// A pointer to a `QueryIterator` that can be used from C code.
-///
-/// # Safety
-///
-/// The following invariants must be upheld when calling this function:
-///
-/// 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
-/// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
-///    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
-///    comparison.
-/// 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
-/// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn NewInvIndIterator_WildcardQuery(
-    idx: *const ffi::InvertedIndex,
-    sctx: *const ffi::RedisSearchCtx,
-    weight: f64,
-) -> *mut ffi::QueryIterator {
-    debug_assert!(!idx.is_null(), "idx must not be null");
-
-    // Cast to the FFI wrapper enum which handles type dispatch
-    let idx_ffi: *const inverted_index_ffi::InvertedIndex = idx.cast();
-    // SAFETY: 1. guarantees idx is valid and non-null
-    let ii_ref = unsafe { &*idx_ffi };
-
-    debug_assert!(!sctx.is_null(), "sctx must not be null");
-    // SAFETY: 3. guarantees sctx is valid and non-null
-    let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
-
-    // Create the appropriate wildcard iterator variant based on the encoding type
-    let iterator = match ii_ref {
-        inverted_index_ffi::InvertedIndex::DocIdsOnly(ii) => {
-            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
-            WildcardIterator::Encoded(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
-        }
-        inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
-            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
-            WildcardIterator::Raw(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
-        }
-        _ => panic!(
-            "Wildcard iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",
-            std::mem::discriminant(ii_ref)
-        ),
-    };
-
-    RQEIteratorWrapper::boxed_new(ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR, iterator)
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{fmt::Debug, ptr::NonNull};
+
+use inverted_index::{
+    IndexReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
+};
+use rqe_iterators::inverted_index::Wildcard;
+use rqe_iterators_interop::RQEIteratorWrapper;
+
+/// Wrapper around different II wildcard iterator encoding types to avoid generics in FFI code.
+///
+/// Handles both the standard variable-length encoding ([`DocIdsOnly`]) and the
+/// fixed 4-byte raw encoding ([`RawDocIdsOnly`]).
+pub(super) enum WildcardIterator<'index> {
+    Encoded(Wildcard<'index, DocIdsOnly>),
+    Raw(Wildcard<'index, RawDocIdsOnly>),
+}
+
+impl Debug for WildcardIterator<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let variant = match self {
+            WildcardIterator::Encoded(_) => "Encoded",
+            WildcardIterator::Raw(_) => "Raw",
+        };
+        write!(f, "WildcardIterator({variant})")
+    }
+}
+
+impl WildcardIterator<'_> {
+    /// Get the flags from the underlying reader.
+    pub(super) fn flags(&self) -> ffi::IndexFlags {
+        match self {
+            WildcardIterator::Encoded(w) => w.reader().flags(),
+            WildcardIterator::Raw(w) => w.reader().flags(),
+        }
+    }
+}
+
+impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        match self {
+            WildcardIterator::Encoded(w) => w.current(),
+            WildcardIterator::Raw(w) => w.current(),
+        }
+    }
+
+    #[inline(always)]
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        match self {
+            WildcardIterator::Encoded(w) => w.read(),
+            WildcardIterator::Raw(w) => w.read(),
+        }
+    }
+
+    #[inline(always)]
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        match self {
+            WildcardIterator::Encoded(w) => w.skip_to(doc_id),
+            WildcardIterator::Raw(w) => w.skip_to(doc_id),
+        }
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        match self {
+            WildcardIterator::Encoded(w) => w.rewind(),
+            WildcardIterator::Raw(w) => w.rewind(),
+        }
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        match self {
+            WildcardIterator::Encoded(w) => w.num_estimated(),
+            WildcardIterator::Raw(w) => w.num_estimated(),
+        }
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        match self {
+            WildcardIterator::Encoded(w) => w.last_doc_id(),
+            WildcardIterator::Raw(w) => w.last_doc_id(),
+        }
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        match self {
+            WildcardIterator::Encoded(w) => w.at_eof(),
+            WildcardIterator::Raw(w) => w.at_eof(),
+        }
+    }
+
+    #[inline(always)]
+    fn revalidate(
+        &mut self,
+    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
+        match self {
+            WildcardIterator::Encoded(w) => w.revalidate(),
+            WildcardIterator::Raw(w) => w.revalidate(),
+        }
+    }
+}
+
+/// Creates a new wildcard inverted index iterator for querying all existing documents.
+///
+/// # Parameters
+///
+/// * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+/// * `sctx` - Pointer to the Redis search context.
+/// * `weight` - Weight to apply to all results.
+///
+/// # Returns
+///
+/// A pointer to a `QueryIterator` that can be used from C code.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+///
+/// 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+/// 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+///    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
+///    comparison.
+/// 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+/// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NewInvIndIterator_WildcardQuery(
+    idx: *const ffi::InvertedIndex,
+    sctx: *const ffi::RedisSearchCtx,
+    weight: f64,
+) -> *mut ffi::QueryIterator {
+    debug_assert!(!idx.is_null(), "idx must not be null");
+
+    // Cast to the FFI wrapper enum which handles type dispatch
+    let idx_ffi: *const inverted_index_ffi::InvertedIndex = idx.cast();
+    // SAFETY: 1. guarantees idx is valid and non-null
+    let ii_ref = unsafe { &*idx_ffi };
+
+    debug_assert!(!sctx.is_null(), "sctx must not be null");
+    // SAFETY: 3. guarantees sctx is valid and non-null
+    let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
+
+    // Create the appropriate wildcard iterator variant based on the encoding type
+    let iterator = match ii_ref {
+        inverted_index_ffi::InvertedIndex::DocIdsOnly(ii) => {
+            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
+            WildcardIterator::Encoded(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
+        }
+        inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
+            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
+            WildcardIterator::Raw(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
+        }
+        _ => panic!(
+            "Wildcard iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",
+            std::mem::discriminant(ii_ref)
+        ),
+    };
+
+    RQEIteratorWrapper::boxed_new(ffi::IteratorType_INV_IDX_WILDCARD_ITERATOR, iterator)
+}

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -54,6 +54,38 @@ QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight
 QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 
 /**
+ * Gets the flags of the underlying IndexReader from a numeric inverted index iterator.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
+ * 2. If `it` iterator type is IteratorType_INV_IDX_NUMERIC_ITERATOR, it has been created using `NewInvIndIterator_NumericQuery`.
+ * 3. If `it` iterator type is IteratorType_INV_IDX_WILDCARD_ITERATOR, it has been created using `NewInvIndIterator_WildcardQuery`.
+ * 4. If `it` has a different iterator type, its `reader` field must be a valid non-NULL pointer to an `IndexReader`.
+ *
+ * # Returns
+ *
+ * The flags of the `IndexReader`.
+ */
+IndexFlags InvIndIterator_GetReaderFlags(const InvIndIterator *it);
+
+/**
+ * Swap the inverted index of an inverted index iterator. This is only used by C tests
+ * to trigger revalidation on the iterator's underlying reader.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-NULL pointer to an `InvIndIterator`.
+ * 2. If `it` iterator type is `IteratorType_INV_IDX_WILDCARD_ITERATOR`, it has been created
+ *    using `NewInvIndIterator_WildcardQuery`.
+ * 3. If `it` is a C iterator, its `reader` field must be a valid non-NULL
+ *    pointer to an `IndexReader`.
+ * 4. `ii` must be a valid non-NULL pointer to an `InvertedIndex` whose type matches the
+ *    iterator's underlying index type.
+ */
+void InvIndIterator_Rs_SwapIndex(InvIndIterator *it, const InvertedIndex *ii);
+
+/**
  * Creates a new numeric inverted index iterator for querying numeric fields.
  *
  * # Parameters
@@ -96,22 +128,6 @@ QueryIterator *NewInvIndIterator_NumericQuery(const InvertedIndex *idx,
                                               double range_max);
 
 /**
- * Gets the flags of the underlying IndexReader from a numeric inverted index iterator.
- *
- * # Safety
- *
- * 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
- * 2. If `it` iterator type is IteratorType_INV_IDX_NUMERIC_ITERATOR, it has been created using `NewInvIndIterator_NumericQuery`.
- * 3. If `it` iterator type is IteratorType_INV_IDX_WILDCARD_ITERATOR, it has been created using `NewInvIndIterator_WildcardQuery`.
- * 4. If `it` has a different iterator type, its `reader` field must be a valid non-NULL pointer to an `IndexReader`.
- *
- * # Returns
- *
- * The flags of the `IndexReader`.
- */
-IndexFlags InvIndIterator_GetReaderFlags(const InvIndIterator *it);
-
-/**
  * Gets the numeric filter from a numeric inverted index iterator.
  *
  * # Safety
@@ -149,22 +165,6 @@ double NumericInvIndIterator_GetProfileRangeMin(const NumericInvIndIterator *it)
  * The maximum range value from the filter, or positive infinity if no filter was provided.
  */
 double NumericInvIndIterator_GetProfileRangeMax(const NumericInvIndIterator *it);
-
-/**
- * Swap the inverted index of an inverted index iterator. This is only used by C tests
- * to trigger revalidation on the iterator's underlying reader.
- *
- * # Safety
- *
- * 1. `it` must be a valid non-NULL pointer to an `InvIndIterator`.
- * 2. If `it` iterator type is `IteratorType_INV_IDX_WILDCARD_ITERATOR`, it has been created
- *    using `NewInvIndIterator_WildcardQuery`.
- * 3. If `it` is a C iterator, its `reader` field must be a valid non-NULL
- *    pointer to an `IndexReader`.
- * 4. `ii` must be a valid non-NULL pointer to an `InvertedIndex` whose type matches the
- *    iterator's underlying index type.
- */
-void InvIndIterator_Rs_SwapIndex(InvIndIterator *it, const InvertedIndex *ii);
 
 /**
  * Creates a new wildcard inverted index iterator for querying all existing documents.


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a code-organization refactor around FFI exports; behavior should be unchanged but mistakes would surface as build/link or iterator-type dispatch issues.
> 
> **Overview**
> Refactors the Rust FFI inverted-index iterator implementation by splitting previously co-located logic into separate `inverted_index/numeric.rs` and new `inverted_index/wildcard.rs` submodules, with a new `inverted_index/mod.rs` as the common entrypoint.
> 
> The wildcard iterator wrapper and `NewInvIndIterator_WildcardQuery` constructor are moved out of `numeric.rs`, and shared FFI helpers (`InvIndIterator_GetReaderFlags`, `InvIndIterator_Rs_SwapIndex`) are centralized in `mod.rs` while preserving their behavior (Rust-backed numeric/wildcard vs C-backed iterators). The autogenerated `iterators_rs.h` is updated to reflect the new function ordering/exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 445013f8f41b3ee0a066a8fc45380d7d91e3ccb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->