### PR TITLE
reexport InvIndIterator

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -14,6 +14,7 @@ mod numeric;
 mod term;
 mod wildcard;
 
+pub use core::InvIndIterator;
 pub use numeric::Numeric;
 pub use term::Term;
 pub use wildcard::Wildcard;


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line public re-export only; no logic changes, but it slightly expands the crate’s public API surface.
> 
> **Overview**
> Re-exports `InvIndIterator` from `inverted_index::mod` (`pub use core::InvIndIterator;`), making the generic inverted-index iterator publicly accessible alongside `Numeric`, `Term`, and `Wildcard` without importing from the private `core` module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc1893751f5cb24e583de4193e0119c43f2f4e19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->