### PR TITLE
Add clickable run links to CI failure report

### DIFF
--- a/scripts/collect_nightly_results.py
+++ b/scripts/collect_nightly_results.py
@@ -444,6 +444,11 @@ def parse_failure_from_logs(log_content, job_name):
     }
 
 
+def get_run_url(repo, run_id):
+    """Generate GitHub Actions run URL."""
+    return f"https://github.com/{repo}/actions/runs/{run_id}"
+
+
 def download_and_analyze_failed_jobs(token, repo, runs, date_str, dir_name=None, workflow_name="merge_queue"):
     """Download logs for failed jobs and analyze failure reasons."""
     failed_runs = [r for r in runs if r["conclusion"] == "failure"]
@@ -626,7 +631,9 @@ def download_and_analyze_failed_jobs(token, repo, runs, date_str, dir_name=None,
 
                 for run_id in sorted(branch_runs[branch].keys()):
                     failures = branch_runs[branch][run_id]
-                    f.write(f"\n Run {run_id} (branch: {branch}) - {len(failures)} failed job(s)\n")
+                    run_url = get_run_url(repo, run_id)
+                    f.write(f"\n Run: {run_url}\n")
+                    f.write(f" {len(failures)} failed job(s)\n")
 
                     for failure in failures:
                         full_job_name = failure['full_job_name']
@@ -662,7 +669,8 @@ def download_and_analyze_failed_jobs(token, repo, runs, date_str, dir_name=None,
             f.write("=" * 80 + "\n\n")
 
             for item in failure_analysis:
-                f.write(f"Run ID: {item['run_id']}\n")
+                run_url = get_run_url(repo, item['run_id'])
+                f.write(f"Run: {run_url}\n")
                 f.write(f"Branch: {item['branch']}\n")
                 f.write(f"Job: {item['job_name']}\n")
                 f.write(f"Full Job Name: {item['full_job_name']}\n")


### PR DESCRIPTION
Replace run IDs with full GitHub Actions URLs in the failure report to make it easier to navigate directly to failed runs from Slack notifications.

Changes:
- Add get_run_url() helper function to generate GitHub Actions URLs
- Update SUMMARY BY BRANCH section to show run links
- Update DETAILED FAILURE LOGS section to show run links


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely changes report formatting/output by adding run URLs; no changes to log fetching, parsing, or external side effects beyond text output.
> 
> **Overview**
> Updates the nightly CI failure report generated by `scripts/collect_nightly_results.py` to print **clickable GitHub Actions run URLs** instead of raw run IDs.
> 
> Adds a small `get_run_url()` helper and uses it in both the *Summary by branch* and *Detailed failure logs* sections so Slack/terminal output links directly to the failing workflow run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be07761874a9d5ed8f64f7b7398d24a5cacc854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->