### PR TITLE
[2.6] [CI] Skip flaky vecsim tests in cluster mode

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -665,6 +665,7 @@ def test_memory_info():
         env.assertEqual(cur_vecsim_memory, cur_redisearch_memory)
 
 
+@skip(cluster=True)
 def test_hybrid_query_batches_mode_with_text():
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000')
@@ -744,6 +745,7 @@ def test_hybrid_query_batches_mode_with_text():
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
 
+@skip(cluster=True)
 def test_hybrid_query_batches_mode_with_tags():
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000')
@@ -816,6 +818,7 @@ def test_hybrid_query_batches_mode_with_tags():
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
 
+@skip(cluster=True)
 def test_hybrid_query_with_numeric():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -870,6 +873,7 @@ def test_hybrid_query_with_numeric():
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
 
+@skip(cluster=True)
 def test_hybrid_query_with_geo():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -904,6 +908,7 @@ def test_hybrid_query_with_geo():
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
 
+@skip(cluster=True)
 def test_hybrid_query_batches_mode_with_complex_queries():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
## Describe the changes in the pull request

Skip flaky `test_vecsim` hybrid query tests in cluster mode

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that disables execution in cluster mode; main risk is reduced regression detection for these hybrid-query paths on cluster.
> 
> **Overview**
> Skips a set of VecSim hybrid-query pytest cases when running in Redis Cluster by adding `@skip(cluster=True)` decorators.
> 
> This change affects the hybrid query coverage for batches mode with text/tags/complex queries and hybrid filtering with numeric/geo fields, reducing cluster-mode test surface to stabilize CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f0bd08ff33b89ccc67695fe769f24562da58dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->