### PR TITLE
[8.6] [CI] Run MacOS tests on 26 - [MOD-13851]

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos,alpine:3.22,intel'  # on feature branches this should be 'all'
+      platform: 'ubuntu:noble,macos-15,macos-26,alpine:3.22,intel'  # on feature branches this should be 'all'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -19,7 +19,8 @@ on:
           - mariner:2
           - azurelinux:3
           - alpine:3.22
-          - macos
+          - macos-15
+          - macos-26
         description: 'Platform to build on. Use "all" to build on all'
         default: all
       architecture:

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -48,7 +48,8 @@ on:
           - mariner:2
           - azurelinux:3
           - alpine:3.22
-          - macos
+          - macos-15
+          - macos-26
           - intel
         description: 'Platform to test on. Use "all" to test on all platforms'
         default: all

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -73,7 +73,8 @@ jobs:
               ('azurelinux:3', 'aarch64'),
               ('alpine:3.22', 'x86_64'),
               ('alpine:3.22', 'aarch64'),
-              ('macos', 'aarch64'),
+              ('macos-15', 'aarch64'),
+              ('macos-26', 'aarch64'),
               ('intel', 'x86_64'),  # Self-hosted EC2 runner
           ]
 

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform name (e.g., ubuntu:noble, macos, sanitizer, coverage)'
+        description: 'Platform name (e.g., ubuntu:noble, macos-15, macos-26, sanitizer, coverage)'
         type: string
         required: true
       architecture:
@@ -85,10 +85,16 @@ jobs:
 
           # Platform configurations
           platform_configs = {
-              "macos": {
+              "macos-15": {
                   "aarch64": {
-                      'env': 'macos-latest',
-                      'name': 'macOS ARM64'
+                      'env': 'macos-15',
+                      'name': 'macOS 15 ARM64'
+                  }
+              },
+              "macos-26": {
+                  "aarch64": {
+                      'env': 'macos-26',
+                      'name': 'macOS 26 ARM64'
                   }
               },
               "intel": {

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform name (e.g., ubuntu:noble, macos, sanitizer, coverage)'
+        description: 'Platform name (e.g., ubuntu:noble, macos-15, macos-26, sanitizer, coverage)'
         type: string
         required: true
       architecture:


### PR DESCRIPTION
Backport of #8492 to `8.6`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that expands the macOS test/build matrix; main risk is increased CI time/capacity or runner availability differences for the new macOS version.
> 
> **Overview**
> **Release note:** CI now runs macOS validation on **macOS 15 and macOS 26 (ARM64)** runners, improving coverage on newer macOS versions.
> 
> This updates the workflow platform choices, generated matrix, and per-platform runner config (replacing the old generic `macos` target) so merge-queue and manual test/build runs can select `macos-15` and `macos-26` explicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0961089c4065e22f404f04fc478b615cb9016f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->