### PR TITLE
Add const to printIteratorProfile

### DIFF
--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -99,7 +99,7 @@ void QIter_Free(QueryIterator *self) {
   std::allocator_traits<alloc_type>::destroy(alloc, qi);
   std::allocator_traits<alloc_type>::deallocate(alloc, qi, 1);
 }
-std::size_t QIter_NumEstimated(QueryIterator *ctx) {
+std::size_t QIter_NumEstimated(const QueryIterator *ctx) {
   return reinterpret_cast<CPPQueryIterator const *>(ctx)->len();
 }
 void QIter_Rewind(QueryIterator *ctx) {

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -380,8 +380,8 @@ static IteratorStatus HR_ReadKnnUnsorted(QueryIterator *ctx) {
   return rc;
 }
 
-static size_t HR_NumEstimated(QueryIterator *ctx) {
-  HybridIterator *hr = (HybridIterator *)ctx;
+static size_t HR_NumEstimated(const QueryIterator *ctx) {
+  const HybridIterator *hr = (const HybridIterator *)ctx;
   size_t vec_res_num = MIN(hr->query.k, VecSimIndex_IndexSize(hr->index));
   if (hr->child == NULL) return vec_res_num;
   return MIN(vec_res_num, hr->child->NumEstimated(hr->child));

--- a/src/iterators/intersection_iterator.c
+++ b/src/iterators/intersection_iterator.c
@@ -177,8 +177,8 @@ static IteratorStatus II_SkipTo(QueryIterator *base, t_docId docId) {
   return rc;
 }
 
-static size_t II_NumEstimated(QueryIterator *base) {
-  IntersectionIterator *it = (IntersectionIterator *)base;
+static size_t II_NumEstimated(const QueryIterator *base) {
+  const IntersectionIterator *it = (const IntersectionIterator *)base;
   return it->num_expected;
 }
 
@@ -223,7 +223,7 @@ static inline double iteratorFactor(const QueryIterator *it) {
 }
 
 typedef int (*CompareFunc)(const void *a, const void *b);
-static int cmpIter(QueryIterator **it1, QueryIterator **it2) {
+static int cmpIter(const QueryIterator *const *it1, const QueryIterator *const *it2) {
   double factor1 = iteratorFactor(*it1);
   double factor2 = iteratorFactor(*it2);
   double est1 = (*it1)->NumEstimated(*it1) * factor1;
@@ -238,7 +238,7 @@ static void II_SetEstimation(IntersectionIterator *it) {
   RS_ASSERT(it->num_its); // Ensure there is at least one iterator, so we can set num_expected to SIZE_MAX temporarily
   it->num_expected = SIZE_MAX;
   for (uint32_t i = 0; i < it->num_its; ++i) {
-    QueryIterator *cur = it->its[i];
+    const QueryIterator *cur = it->its[i];
     size_t amount = cur->NumEstimated(cur);
     if (amount < it->num_expected) {
       it->num_expected = amount;

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -27,8 +27,8 @@ void InvIndIterator_Rewind(QueryIterator *base) {
   IndexReader_Reset(it->reader);
 }
 
-size_t InvIndIterator_NumEstimated(QueryIterator *base) {
-  InvIndIterator *it = (InvIndIterator *)base;
+size_t InvIndIterator_NumEstimated(const QueryIterator *base) {
+  const InvIndIterator *it = (const InvIndIterator *)base;
   return IndexReader_NumEstimated(it->reader);
 }
 

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -71,7 +71,7 @@ typedef struct QueryIterator {
   RSIndexResult *current;
 
   /** Return an upper-bound estimation for the number of results the iterator is going to yield */
-  size_t (*NumEstimated)(struct QueryIterator *self);
+  size_t (*NumEstimated)(const struct QueryIterator *self);
 
   /** Read the next entry from the iterator.
    *  On a successful read, the iterator must:

--- a/src/iterators/not_iterator.c
+++ b/src/iterators/not_iterator.c
@@ -32,8 +32,8 @@ static void NI_Free(QueryIterator *base) {
   rm_free(base);
 }
 
-static size_t NI_NumEstimated(QueryIterator *base) {
-  NotIterator *ni = (NotIterator *)base;
+static size_t NI_NumEstimated(const QueryIterator *base) {
+  const NotIterator *ni = (const NotIterator *)base;
   return ni->wcii ? ni->wcii->NumEstimated(ni->wcii) : ni->maxDocId;
 }
 

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -33,8 +33,8 @@ static inline double getSuccessRatio(const OptimizerIterator *optIt) {
 }
 
 
-static size_t OPT_NumEstimated(QueryIterator *self) {
-  OptimizerIterator *opt = (OptimizerIterator *)self;
+static size_t OPT_NumEstimated(const QueryIterator *self) {
+  const OptimizerIterator *opt = (const OptimizerIterator *)self;
   return MIN(opt->child->NumEstimated(opt->child) ,
               opt->numericIter->NumEstimated(opt->numericIter));
 }

--- a/src/iterators/optional_iterator.c
+++ b/src/iterators/optional_iterator.c
@@ -34,8 +34,8 @@ static void OI_Free(QueryIterator *base) {
   rm_free(base);
 }
 
-static size_t OI_NumEstimated(QueryIterator *base) {
-  OptionalOptimizedIterator *oi = (OptionalOptimizedIterator *)base;
+static size_t OI_NumEstimated(const QueryIterator *base) {
+  const OptionalOptimizedIterator *oi = (const OptionalOptimizedIterator *)base;
   return oi->wcii ? oi->wcii->NumEstimated(oi->wcii) : oi->maxDocId;
 }
 

--- a/src/iterators/profile_iterator.c
+++ b/src/iterators/profile_iterator.c
@@ -59,8 +59,8 @@ static void PI_Free(struct QueryIterator *self) {
   rm_free(self);
 }
 
-static size_t PI_NumEstimated(struct QueryIterator *self) {
-  ProfileIterator *pi = (ProfileIterator *)self;
+static size_t PI_NumEstimated(const struct QueryIterator *self) {
+  const ProfileIterator *pi = (const ProfileIterator *)self;
   return pi->child->NumEstimated(pi->child);
 }
 

--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -61,8 +61,8 @@ void UI_SyncIterList(UnionIterator *ui) {
   }
 }
 
-static size_t UI_NumEstimated(QueryIterator *base) {
-  UnionIterator *ui = (UnionIterator *)base;
+static size_t UI_NumEstimated(const QueryIterator *base) {
+  const UnionIterator *ui = (const UnionIterator *)base;
   size_t estimation = 0;
   for (size_t i = 0; i < ui->num_orig; ++i) {
     estimation += ui->its_orig[i]->NumEstimated(ui->its_orig[i]);

--- a/src/iterators/wildcard_iterator.c
+++ b/src/iterators/wildcard_iterator.c
@@ -12,7 +12,7 @@
 #include "iterators_rs.h"
 #include "search_disk.h"
 
-bool IsWildcardIterator(QueryIterator *it) {
+bool IsWildcardIterator(const QueryIterator *it) {
   return (it && (it->type == WILDCARD_ITERATOR || it->type == INV_IDX_WILDCARD_ITERATOR));
 }
 

--- a/src/iterators/wildcard_iterator.h
+++ b/src/iterators/wildcard_iterator.h
@@ -32,7 +32,7 @@ QueryIterator *NewWildcardIterator_Optimized(const RedisSearchCtx *sctx, double 
  */
 QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight);
 
-bool IsWildcardIterator(QueryIterator *it);
+bool IsWildcardIterator(const QueryIterator *it);
 
 #ifdef __cplusplus
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn GetMetricOwnKeyRef(header: *mut QueryIterator) -> *mut 
 /// 1. `header` is a valid non-null pointer to a [`QueryIterator`].
 /// 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn GetMetricType(header: *mut QueryIterator) -> MetricType {
+pub unsafe extern "C" fn GetMetricType(header: *const QueryIterator) -> MetricType {
     debug_assert!(!header.is_null());
 
     // SAFETY: Safe thanks to 1.

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -257,7 +257,7 @@ RLookupKey **GetMetricOwnKeyRef(QueryIterator *header);
  * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
  * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
  */
-enum MetricType GetMetricType(QueryIterator *header);
+enum MetricType GetMetricType(const QueryIterator *header);
 
 /**
  * Create a new non-optimized optional iterator.

--- a/src/redisearch_rs/rqe_iterators_interop/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_interop/src/lib.rs
@@ -205,7 +205,7 @@ extern "C" fn rewind<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIt
 }
 
 extern "C" fn num_estimated<'index, I: RQEIterator<'index> + 'index>(
-    base: *mut QueryIterator,
+    base: *const QueryIterator,
 ) -> usize {
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());

--- a/tests/cpptests/iterator_util.cpp
+++ b/tests/cpptests/iterator_util.cpp
@@ -15,8 +15,8 @@ IteratorStatus MockIterator_Read(QueryIterator *base) {
 IteratorStatus MockIterator_SkipTo(QueryIterator *base, t_docId docId) {
     return reinterpret_cast<MockIterator *>(base)->SkipTo(docId);
 }
-size_t MockIterator_NumEstimated(QueryIterator *base) {
-    return reinterpret_cast<MockIterator *>(base)->NumEstimated();
+size_t MockIterator_NumEstimated(const QueryIterator *base) {
+    return reinterpret_cast<const MockIterator *>(base)->NumEstimated();
 }
 void MockIterator_Rewind(QueryIterator *base) {
     reinterpret_cast<MockIterator *>(base)->Rewind();

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -21,7 +21,7 @@
 extern "C" {
     IteratorStatus MockIterator_Read(QueryIterator *base);
     IteratorStatus MockIterator_SkipTo(QueryIterator *base, t_docId docId);
-    size_t MockIterator_NumEstimated(QueryIterator *base);
+    size_t MockIterator_NumEstimated(const QueryIterator *base);
     void MockIterator_Rewind(QueryIterator *base);
     void MockIterator_Free(QueryIterator *base);
     ValidateStatus MockIterator_Revalidate(QueryIterator *base);
@@ -93,7 +93,7 @@ public:
       return status;
     }
 
-    size_t NumEstimated() {
+    size_t NumEstimated() const {
       return docIds.size();
     }
 


### PR DESCRIPTION
propagate const up to NumEstimated


## Describe the changes in the pull request

- Recreation of https://github.com/RediSearch/RediSearch/pull/8490 to allow CI to do its thing.

This was spawned by a discussion on https://github.com/RediSearch/RediSearch/pull/8463#discussion_r2847670611:

TL;DR: 
- printing an iterator shouldn't need mutability on its parameters.
- Rust migration helps with detecting those incorrect mutability assessments
- changing C code to be more precise on "`const` application" helps with understanding the code, and reduces warnings on above PR.


- Related to https://github.com/RediSearch/RediSearch/pull/8487


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical const-correctness changes across the iterator API and profiling/FFI call sites; primary risk is build breakage or missed signature update rather than runtime behavior changes.
> 
> **Overview**
> Makes iterator profiling and `NumEstimated` calls *read-only* by changing the iterator API to take `const QueryIterator*` for `NumEstimated`, and propagating that constness through core iterators (hybrid/intersection/union/not/optional/inverted index), geometry’s C++ iterator wrapper, and test mocks.
> 
> Updates profiling and Rust/C FFI surfaces accordingly (e.g. `printIteratorProfile`, `GetMetricType`, and Rust interop `num_estimated`) to reduce mutability requirements and improve const-safety without changing query behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b870f2b4e3cb9482696510db29f78c3d49a80d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->