### PR TITLE
Move SearchResult_New to Rust

### DIFF
--- a/src/redisearch_rs/c_entrypoint/search_result_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/search_result_ffi/src/lib.rs
@@ -11,6 +11,17 @@ use std::{mem, ptr::NonNull};
 
 pub type SearchResult = search_result::SearchResult<'static>;
 
+/// Returns a newly created [`SearchResult`].
+//
+// The `SearchResult` type is technically not FFI-safe due to the `RLookupRow` type of its `_row_data` field.
+// However that type is in practice only exposed as an `OpaqueRLookupRow`, which _is_ FFI-safe.
+// Due to cbindgen limitations we need to put the `allow` attribute on the method itself, rather than on the return type.
+#[allow(improper_ctypes_definitions)]
+#[unsafe(no_mangle)]
+pub const extern "C" fn SearchResult_New() -> SearchResult {
+    SearchResult::new()
+}
+
 /// Overrides the contents of `dst` with those from `src` taking ownership of `src`.
 /// Ensures proper cleanup of any existing data in `dst`.
 ///

--- a/src/redisearch_rs/headers/search_result_rs.h
+++ b/src/redisearch_rs/headers/search_result_rs.h
@@ -48,6 +48,11 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Returns a newly created [`SearchResult`].
+ */
+struct SearchResult SearchResult_New(void);
+
+/**
  * Overrides the contents of `dst` with those from `src` taking ownership of `src`.
  * Ensures proper cleanup of any existing data in `dst`.
  *

--- a/src/search_result.h
+++ b/src/search_result.h
@@ -20,11 +20,6 @@
 extern "C" {
 #endif
 
-static inline SearchResult SearchResult_New() {
-    SearchResult r = {0};
-    return r;
-}
-
 /**
  * Returns the document ID of `res`.
  *


### PR DESCRIPTION
Move SearchResult_New to Rust

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the C/Rust FFI boundary by changing how `SearchResult` is constructed, which could affect initialization semantics and ABI/linking if mismatched across languages.
> 
> **Overview**
> `SearchResult_New` is no longer a C `static inline` zero-initializer; it’s now exported from Rust as an `extern "C"` constructor that returns `SearchResult::new()`.
> 
> The generated C header (`search_result_rs.h`) is updated to declare the new `SearchResult_New` symbol, with an explicit `#[allow(improper_ctypes_definitions)]` added on the Rust side to satisfy cbindgen/FFI-safety constraints around the `_row_data` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 706a55b05d478f145abde8e6d796a31b50160724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->