### PR TITLE
remove term_free from error path

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -105,11 +105,8 @@ QueryIterator* SearchDisk_NewTermIterator(RedisSearchDiskIndexSpec *index, RSTok
     RS_ASSERT(disk && index && tok);
     RSQueryTerm *term = NewQueryTerm(tok, tokenId);
     QueryTerm_SetIDFs(term, idf, bm25_idf);
-    QueryIterator *it = disk->index.newTermIterator(index, term, fieldMask, weight);
-    if (!it) {
-        Term_Free(term);
-    }
-    return it;
+    // Ownership of `term` is transferred to Rust, which handles cleanup on all paths
+    return disk->index.newTermIterator(index, term, fieldMask, weight);
 }
 
 QueryIterator* SearchDisk_NewTagIterator(RedisSearchDiskIndexSpec *index, const RSToken *tok, t_fieldIndex fieldIndex, double weight) {


### PR DESCRIPTION
Disk will take the ownership of Term, so no need to release Term on NULL return

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small ownership/cleanup change in the disk term-iterator wrapper; main risk is a leak or double-free if the Rust side does not consistently own and free the term on all paths.
> 
> **Overview**
> **Release note:** Fixes a potential memory-management issue when creating disk-backed term iterators by transferring `RSQueryTerm` ownership to the disk (Rust) implementation, avoiding an extra free on error paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83eb60dcdaf717e4228dfd8d8c243b25d4cf0865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->