### PR TITLE
[8.2] MOD-14067: Use role-based authentication

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -32,9 +32,10 @@ on:
 env:
   REF: ${{ inputs.sha || inputs.ref || github.sha }}  # Define fallbacks for ref to checkout
   BRANCH: ${{ inputs.ref || github.ref_name }}        # Define "branch" name for pack name (used in `make pack`)
-  AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
+  # NOTE: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are NOT set at workflow level
+  # to avoid interfering with OIDC-based authentication.
+  # They are exported dynamically when assuming role.
 
 jobs:
   # Get configuration for this specific platform and architecture
@@ -118,6 +119,9 @@ jobs:
           ref: ${{ env.REF }}
       - name: checkout (node20 not supported)
         if: steps.node20.outputs.supported == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
         run: |
           # Execute the logic based on the detected platform
           CONTAINER="${{ needs.get-config.outputs.container }}"
@@ -126,10 +130,10 @@ jobs:
             amazonlinux:2)
 
               # Configure the safe directory
-              git config --global --add safe.directory "/__w/$GITHUB_REPOSITORY"
+              git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
               # Checkout
-              REPO_URL="https://github.com/$GITHUB_REPOSITORY.git"
+              REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git"
 
               # Initialize a Git repository
               git init
@@ -213,19 +217,58 @@ jobs:
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Configure AWS Credentials Using Role (node20 not supported)
         if: vars.USE_AWS_ROLE == 'true' && steps.node20.outputs.supported == 'false'
+        env:
+          ROLE_ARN: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
+          AWS_REGION: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
         run: |
-          # Variables from the workflow
-          ROLE_ARN="${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}"
-          AWS_REGION="${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}"
-          SESSION_NAME="github-actions-session"
-
-          # Assume the AWS role and configure temporary credentials
-          ASSUME_ROLE_OUTPUT=$(aws sts assume-role --role-arn "$ROLE_ARN" --role-session-name "$SESSION_NAME" --region "$AWS_REGION")
-          if [ $? -ne 0 ]; then
-            echo "Failed to assume AWS role" && exit 1
+          if ! command -v jq &> /dev/null; then
+            echo "Error: jq is not installed."
+            exit 1
           fi
 
-          echo "AWS credentials configured successfully."
+          echo "Requesting GitHub OIDC token..."
+          OIDC_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value // empty') || {
+            echo "Failed to get OIDC token from GitHub"
+            exit 1
+          }
+
+          if [ -z "$OIDC_TOKEN" ]; then
+            echo "Failed to get OIDC token from GitHub"
+            exit 1
+          fi
+
+          echo "Assuming AWS role using OIDC..."
+          CREDS_JSON=$(aws sts assume-role-with-web-identity \
+            --role-arn "$ROLE_ARN" \
+            --role-session-name "GitHubActions" \
+            --web-identity-token "$OIDC_TOKEN" \
+            --region "$AWS_REGION") || {
+            echo "Failed to assume AWS role using OIDC"
+            exit 1
+          }
+
+          AWS_ACCESS_KEY_ID=$(echo "$CREDS_JSON" | jq -r '.Credentials.AccessKeyId')
+          AWS_SECRET_ACCESS_KEY=$(echo "$CREDS_JSON" | jq -r '.Credentials.SecretAccessKey')
+          AWS_SESSION_TOKEN=$(echo "$CREDS_JSON" | jq -r '.Credentials.SessionToken')
+
+          if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_SESSION_TOKEN" ]; then
+            echo "Failed to parse AWS credentials from assume-role response"
+            exit 1
+          fi
+
+          echo "::add-mask::$AWS_ACCESS_KEY_ID"
+          echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
+          echo "::add-mask::$AWS_SESSION_TOKEN"
+
+          {
+            echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+            echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+            echo "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
+            echo "AWS_REGION=$AWS_REGION"
+          } >> "$GITHUB_ENV"
+
+          echo "AWS credentials configured successfully using OIDC."
       - name: Configure AWS Credentials Using Keys (node20)
         if: vars.USE_AWS_ROLE == 'false' && steps.node20.outputs.supported == 'true'
         uses: aws-actions/configure-aws-credentials@v4
@@ -236,22 +279,25 @@ jobs:
       - name: Configure AWS Credentials Using Keys (node20 not supported)
         if: vars.USE_AWS_ROLE == 'false' && steps.node20.outputs.supported == 'false'
         run: |
-          # Variables from the workflow
           AWS_ACCESS_KEY_ID="${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY="${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}"
           AWS_REGION="${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}"
 
-          # Check if the required environment variables are set
           if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_REGION" ]; then
             echo "Missing AWS credentials or region configuration."
             exit 1
           fi
 
-          # Configure AWS CLI with provided credentials and region
-          echo "Configuring AWS CLI with access keys..."
-          aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
-          aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
-          aws configure set region "$AWS_REGION"
+          echo "::add-mask::$AWS_ACCESS_KEY_ID"
+          echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
+
+          {
+            echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+            echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+            echo "AWS_REGION=$AWS_REGION"
+          } >> "$GITHUB_ENV"
+
+          echo "AWS credentials configured successfully using access keys."
       - name: Set Version identifier
         id: set-versions
         run: |

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -15,7 +15,7 @@ $MODE yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/ce
 $MODE sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
 $MODE sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
 
-$MODE yum install -y wget tar gzip git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang llvm-devel spdlog-devel fmt-devel gdb
+$MODE yum install -y wget tar gzip git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang llvm-devel spdlog-devel fmt-devel gdb jq
 
 source /opt/rh/devtoolset-11/enable
 


### PR DESCRIPTION
## Backport of PR #8476

Clean cherry-pick of PR #8476 into `8.2`. No conflicts.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI artifact-upload authentication path to use GitHub OIDC and modifies checkout behavior in the Amazon Linux 2 fallback, which could break builds/uploads if tokens, permissions, or environment assumptions are off.
> 
> **Overview**
> **Release note:** Artifact builds on platforms without `node20` support (notably `amazonlinux:2`) now authenticate to AWS using GitHub OIDC role assumption instead of relying on long-lived access keys, reducing secret exposure.
> 
> The workflow also updates the Amazon Linux 2 manual checkout to use the job `GITHUB_TOKEN` and `GITHUB_WORKSPACE`, and ensures required tooling by installing `jq` in the Amazon Linux 2 setup script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72bf26a8a2f4be865ff79c0a6ce32ebfb68a1162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->