### PR TITLE
[MOD-12717] Intersection iterator: add slop and order support

### DIFF
--- a/.skills/run-rust-benchmarks/SKILL.md
+++ b/.skills/run-rust-benchmarks/SKILL.md
@@ -9,7 +9,7 @@ Run Rust benchmarks and compare performance with the C implementation.
 
 ## Arguments
 - `<crate>`: Run the given benchmark crate (e.g., `/run-rust-benchmarks rqe_iterators_bencher`)
-- `<crate> <bench>`: Run specific bench in a benchmakr crate (e.g., `/run-rust-benchmarks rqe_iterators_bencher "Iterator - InvertedIndex - Numeric - Read Dense"`)
+- `<crate> <bench>`: Run specific bench in a benchmark crate (e.g., `/run-rust-benchmarks rqe_iterators_bencher "Iterator - InvertedIndex - Numeric - Read Dense"`)
 
 Arguments provided: `$ARGUMENTS`
 

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -9,13 +9,9 @@
 
 //! Supporting types for [`Intersection`].
 //!
-//! # TODO (MOD-12717)
-//!
-//! The following features from the C++ implementation are not yet ported:
-//! - `max_slop`: Maximum allowed slop between term positions
+//! The intersection iterator supports proximity constraints via two parameters:
+//! - `max_slop`: Maximum allowed slop between term positions (`None` = no constraint)
 //! - `in_order`: Require terms to appear in order
-//!
-//! Currently, the iterator operates with `max_slop = -1` semantics (no slop validation).
 
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
@@ -24,15 +20,28 @@ use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
 ///
-/// Children are sorted by estimated result count (smallest first) to minimize iterations.
-/// A document is only yielded when ALL children have a matching entry for it.
+/// Children are sorted by estimated result count (smallest first) to minimize iterations,
+/// unless `in_order` is set (which preserves the original child order for positional checks).
+/// A document is only yielded when ALL children have a matching entry for it and the
+/// term positions satisfy the `max_slop` / `in_order` proximity constraints:
+///
+/// - `max_slop`: Maximum allowed slop (distance) between term positions. `None` disables proximity
+///   validation entirely.
+/// - `in_order`: When `true`, terms must appear in the same order as the child iterators.
 pub struct Intersection<'index, I> {
-    /// Child iterators, sorted by estimated count (smallest first).
+    /// Child iterators, sorted by estimated count (smallest first) unless `in_order` is set.
     children: Vec<I>,
     /// Last doc_id successfully found in ALL children (returned by [`last_doc_id()`](Self::last_doc_id)).
     last_doc_id: t_docId,
     num_expected: usize,
     is_eof: bool,
+    /// Maximum allowed slop (distance) between term positions. `None` disables proximity
+    /// validation entirely.
+    ///
+    /// Capped to [`i32::MAX`] because of [`ffi::IndexResult_IsWithinRange`]
+    max_slop: Option<u32>,
+    /// When `true`, terms must appear in the same order as the child iterators.
+    in_order: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
     result: RSIndexResult<'index>,
 }
@@ -51,18 +60,45 @@ impl<'index, I> Intersection<'index, I>
 where
     I: RQEIterator<'index>,
 {
-    /// Creates a new intersection iterator. Children are sorted by estimated count. If `children`
-    /// is empty, returns an iterator immediately at EOF.
+    /// Creates a new intersection iterator without proximity constraints.
+    ///
+    /// Every document matching all children is yielded. Children are sorted by estimated result
+    /// count (smallest first) to minimize iterations.
+    ///
+    /// If `children` is empty, returns an iterator immediately at EOF.
     #[must_use]
-    pub fn new(mut children: Vec<I>) -> Self {
-        children.sort_by_cached_key(|c| c.num_estimated());
+    pub fn new(children: Vec<I>) -> Self {
+        Self::new_with_slop_order(children, None, false)
+    }
 
-        let Some(num_expected) = children.first().map(|c| c.num_estimated()) else {
+    /// Creates a new intersection iterator with proximity constraints.
+    ///
+    /// - `max_slop`: Maximum allowed distance between term positions. `None` disables proximity
+    ///   validation (every document matching all children is yielded).
+    /// - `in_order`: When `true`, terms must appear in the order of the child iterators and
+    ///   children are **not** re-sorted by estimated count (their order is meaningful).
+    ///
+    /// If `children` is empty, returns an iterator immediately at EOF.
+    #[must_use]
+    pub fn new_with_slop_order(
+        mut children: Vec<I>,
+        max_slop: Option<u32>,
+        in_order: bool,
+    ) -> Self {
+        // Only sort by estimated count when order doesn't matter for proximity checks.
+        if !in_order {
+            children.sort_by_cached_key(|c| c.num_estimated());
+        }
+        // FIXME: Capped because of `ffi::IndexResult_IsWithinRange`
+        let max_slop = max_slop.map(|v| v.min(i32::MAX as u32));
+        let Some(num_expected) = children.iter().map(|c| c.num_estimated()).min() else {
             return Self {
                 children,
                 last_doc_id: 0,
                 num_expected: 0,
                 is_eof: true,
+                max_slop,
+                in_order,
                 result: RSIndexResult::build_intersect(0).build(),
             };
         };
@@ -72,7 +108,62 @@ where
             last_doc_id: 0,
             num_expected,
             is_eof: false,
+            max_slop,
+            in_order,
             result: RSIndexResult::build_intersect(num_children).build(),
+        }
+    }
+
+    /// Returns `true` if the current result needs a proximity check after consensus.
+    ///
+    /// The check is skipped only when `max_slop` is `None` and `in_order` is `false` — the
+    /// only case where every document matching all children is trivially within range.
+    const fn needs_relevancy_check(&self) -> bool {
+        self.max_slop.is_some() || self.in_order
+    }
+
+    /// Check if the current aggregate result satisfies the proximity constraints.
+    fn current_is_relevant(&self) -> bool {
+        // SAFETY:
+        // - `self.result` is a valid, fully initialised `RSIndexResult`.
+        // - The C function reads from `r` without taking ownership or storing the pointer.
+        // - `from_ref` gives a `*const` pointer; `cast_mut` is required by the C API, which
+        //   uses a non-const pointer even though it only reads; no mutation occurs.
+        unsafe {
+            ffi::IndexResult_IsWithinRange(
+                std::ptr::from_ref(&self.result).cast_mut().cast(),
+                // `v as i32` is lossless: the constructor caps `max_slop` to
+                // `i32::MAX as u32`, so `v` always fits in `i32`.
+                self.max_slop.map_or(i32::MAX, |v| v as i32),
+                self.in_order as std::ffi::c_int,
+            ) != 0
+        }
+    }
+
+    /// Find consensus on a doc_id and verify that the result satisfies the proximity constraints.
+    ///
+    /// If the agreed-upon document doesn't satisfy the slop/order constraints, advances the first
+    /// child and retries until a relevant result is found or EOF is reached.
+    fn find_consensus_with_relevancy_check(
+        &mut self,
+        mut target: t_docId,
+    ) -> Result<Option<t_docId>, RQEIteratorError> {
+        loop {
+            match self.find_consensus(target)? {
+                Some(doc_id) => {
+                    self.build_aggregate_result(doc_id);
+                    if self.current_is_relevant() {
+                        self.last_doc_id = doc_id;
+                        return Ok(Some(doc_id));
+                    }
+                    // Not relevant — advance past this document and retry.
+                    let Some(next) = self.read_from_first_child()? else {
+                        return Ok(None);
+                    };
+                    target = next;
+                }
+                None => return Ok(None),
+            }
         }
     }
 
@@ -146,8 +237,6 @@ where
     /// - Restructure [`RSAggregateResult`](inverted_index::RSAggregateResult) to not require `'index` on stored references
     /// - Use a different aggregate pattern that doesn't store child references
     fn build_aggregate_result(&mut self, doc_id: t_docId) {
-        self.last_doc_id = doc_id;
-
         if let Some(agg) = self.result.as_aggregate_mut() {
             agg.reset();
         }
@@ -188,13 +277,21 @@ where
         let Some(target) = self.read_from_first_child()? else {
             return Ok(None);
         };
-
-        match self.find_consensus(target)? {
-            Some(doc_id) => {
-                self.build_aggregate_result(doc_id);
-                Ok(Some(&mut self.result))
+        // FIXME: consider using function pointers to remove runtime checks for each reads.
+        if self.needs_relevancy_check() {
+            match self.find_consensus_with_relevancy_check(target)? {
+                Some(_) => Ok(Some(&mut self.result)),
+                None => Ok(None),
             }
-            None => Ok(None),
+        } else {
+            match self.find_consensus(target)? {
+                Some(doc_id) => {
+                    self.build_aggregate_result(doc_id);
+                    self.last_doc_id = doc_id;
+                    Ok(Some(&mut self.result))
+                }
+                None => Ok(None),
+            }
         }
     }
 
@@ -205,17 +302,50 @@ where
         if self.is_eof {
             return Ok(None);
         }
-
-        match self.find_consensus(doc_id)? {
-            Some(found_id) => {
-                self.build_aggregate_result(found_id);
-                if found_id == doc_id {
-                    Ok(Some(SkipToOutcome::Found(&mut self.result)))
-                } else {
-                    Ok(Some(SkipToOutcome::NotFound(&mut self.result)))
+        // FIXME: consider using function pointers to remove runtime checks for each reads.
+        if self.needs_relevancy_check() {
+            // Try to agree on the requested doc_id first.
+            match self.find_consensus(doc_id)? {
+                Some(found_id) => {
+                    self.build_aggregate_result(found_id);
+                    let self_current_is_relevant = self.current_is_relevant();
+                    if found_id == doc_id && self_current_is_relevant {
+                        self.last_doc_id = found_id;
+                        return Ok(Some(SkipToOutcome::Found(&mut self.result)));
+                    }
+                    // Either we landed on a different doc, or the exact match wasn't relevant.
+                    // In both cases, find the next relevant result.
+                    let next_target = if self_current_is_relevant {
+                        // Consensus on a different doc_id that IS relevant — return it.
+                        self.last_doc_id = found_id;
+                        return Ok(Some(SkipToOutcome::NotFound(&mut self.result)));
+                    } else {
+                        // Not relevant — advance past this document.
+                        match self.read_from_first_child()? {
+                            Some(t) => t,
+                            None => return Ok(None),
+                        }
+                    };
+                    match self.find_consensus_with_relevancy_check(next_target)? {
+                        Some(_) => Ok(Some(SkipToOutcome::NotFound(&mut self.result))),
+                        None => Ok(None),
+                    }
                 }
+                None => Ok(None),
             }
-            None => Ok(None),
+        } else {
+            match self.find_consensus(doc_id)? {
+                Some(found_id) => {
+                    self.build_aggregate_result(found_id);
+                    self.last_doc_id = found_id;
+                    if found_id == doc_id {
+                        Ok(Some(SkipToOutcome::Found(&mut self.result)))
+                    } else {
+                        Ok(Some(SkipToOutcome::NotFound(&mut self.result)))
+                    }
+                }
+                None => Ok(None),
+            }
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -8,12 +8,6 @@
 */
 
 //! Integration tests for the Intersection iterator.
-//!
-//! C-Code: These tests are ported from the C++ tests in
-//! `tests/cpptests/test_cpp_iterator_intersection.cpp`.
-//!
-//! C-Code: Tests for `max_slop` and `in_order` are not included in this first
-//! version since those features are not yet implemented in the Rust port.
 
 use ffi::t_docId;
 use rqe_iterators::{
@@ -1059,6 +1053,27 @@ fn num_estimated_is_minimum() {
     );
 }
 
+/// Test: `num_estimated` is the minimum of all children even when `in_order=true` prevents sorting.
+///
+/// When `in_order=true`, children are NOT re-sorted by estimated count (their order is
+/// semantically meaningful for positional checks). The minimum must still be computed
+/// explicitly rather than relying on sort order as a side effect.
+#[test]
+fn num_estimated_is_minimum_in_order() {
+    // Deliberately pass the LARGEST child first — proves we don't rely on sort order.
+    let child1 = IdListSorted::new(vec![1, 2, 3, 4, 5]); // 5 elements — first, but NOT minimum
+    let child2 = IdListSorted::new(vec![1, 2, 3]); // 3 elements — minimum
+    let child3 = IdListSorted::new(vec![1, 2, 3, 4]); // 4 elements
+
+    let ii = Intersection::new_with_slop_order(vec![child1, child2, child3], None, true);
+
+    assert_eq!(
+        ii.num_estimated(),
+        3,
+        "num_estimated must be the minimum of all children, even when in_order=true prevents sorting"
+    );
+}
+
 /// Test: Children are processed in order of estimated count (smallest first)
 /// We can infer this indirectly by checking behavior with asymmetric children
 #[test]
@@ -1162,4 +1177,213 @@ fn revalidate_moved_skip_to_returns_none() {
 
     // Further reads should return EOF
     assert!(matches!(ii.read(), Ok(None)));
+}
+
+// =============================================================================
+// C-Code: Slop and InOrder tests - from IntersectionIteratorTest
+// (Slop, InOrder, SlopAndOrder test cases)
+// =============================================================================
+
+/// Tests for the intersection iterator's `max_slop` and `in_order` proximity constraints.
+///
+/// C-Code: These tests are ported from `IntersectionIteratorTest` in
+/// `tests/cpptests/test_cpp_iterator_intersection.cpp`.
+// Because of `ffi::IndexResult_IsWithinRange`
+#[cfg(not(miri))]
+mod slop_and_order {
+    use crate::utils::Mock;
+    use rqe_iterators::{RQEIterator, SkipToOutcome, intersection::Intersection};
+
+    /// Build the shared foo/bar intersection used by slop/order tests.
+    ///
+    /// | doc | foo pos | bar pos | notes                            |
+    /// |-----|---------|---------|----------------------------------|
+    /// |  1  |    1    |    2    | adjacent, foo before bar         |
+    /// |  2  |    1    |    —    | no bar — excluded by intersection|
+    /// |  3  |    2    |    1    | adjacent, bar before foo         |
+    /// |  4  |    1    |    3    | slop 1, foo before bar           |
+    fn make_intersection(
+        max_slop: Option<u32>,
+        in_order: bool,
+    ) -> Intersection<'static, Box<dyn RQEIterator<'static> + 'static>> {
+        let foo: Mock<'static, 4> = Mock::new_with_positions([1, 2, 3, 4], [1, 1, 2, 1]);
+        let bar: Mock<'static, 3> = Mock::new_with_positions([1, 3, 4], [2, 1, 3]);
+        Intersection::new_with_slop_order(vec![Box::new(foo), Box::new(bar)], max_slop, in_order)
+    }
+
+    /// max_slop=0, in_order=false: only documents where foo and bar appear adjacent
+    /// (in any order) are returned.
+    ///
+    /// Expected results: docs 1 and 3.
+    #[test]
+    fn slop() {
+        let mut ii = make_intersection(Some(0), false);
+
+        // num_estimated = min(foo=4, bar=3) = 3
+        assert_eq!(ii.num_estimated(), 3);
+
+        // Read all results: expected docs 1 and 3
+        let r = ii.read().expect("read failed").expect("expected doc 1");
+        assert_eq!(r.doc_id, 1);
+        assert_eq!(ii.last_doc_id(), 1);
+
+        let r = ii.read().expect("read failed").expect("expected doc 3");
+        assert_eq!(r.doc_id, 3);
+        assert_eq!(ii.last_doc_id(), 3);
+
+        assert!(matches!(ii.read(), Ok(None)));
+        assert!(ii.at_eof());
+        // last_doc_id must remain at the last *successfully returned* doc (3), not the
+        // non-relevant candidate (4) that was scanned internally before hitting EOF.
+        assert_eq!(ii.last_doc_id(), 3);
+        // Reading after EOF should return EOF again
+        assert!(matches!(ii.read(), Ok(None)));
+
+        // Rewind and test SkipTo
+        ii.rewind();
+        assert_eq!(ii.last_doc_id(), 0);
+        assert!(!ii.at_eof());
+
+        // SkipTo(1) → Found
+        let outcome = ii.skip_to(1).expect("skip_to failed");
+        assert!(matches!(outcome, Some(SkipToOutcome::Found(r)) if r.doc_id == 1));
+        assert_eq!(ii.last_doc_id(), 1);
+
+        // SkipTo(2) → NotFound, lands on 3 (doc 2 is not in bar, doc 3 is next valid)
+        let outcome = ii.skip_to(2).expect("skip_to failed");
+        assert!(matches!(outcome, Some(SkipToOutcome::NotFound(r)) if r.doc_id == 3));
+        assert_eq!(ii.last_doc_id(), 3);
+
+        // SkipTo(4) → EOF (doc 4 is in both but fails slop=0)
+        assert!(matches!(ii.skip_to(4), Ok(None)));
+        assert!(ii.at_eof());
+        // last_doc_id must stay at 3, not advance to the non-relevant candidate 4.
+        assert_eq!(ii.last_doc_id(), 3);
+
+        // SkipTo beyond EOF → still EOF
+        assert!(matches!(ii.skip_to(5), Ok(None)));
+        assert!(ii.at_eof());
+    }
+
+    /// C-Code: Equivalent to C++ `TEST_F(IntersectionIteratorTest, InOrder)`
+    ///
+    /// max_slop=None, in_order=true: only documents where foo appears before bar
+    /// (any distance) are returned.
+    ///
+    /// Expected results: docs 1 and 4.
+    #[test]
+    fn in_order() {
+        let mut ii = make_intersection(None, true);
+
+        assert_eq!(ii.num_estimated(), 3); // min(foo=4, bar=3) = 3
+
+        // Read all results: expected docs 1 and 4
+        let r = ii.read().expect("read failed").expect("expected doc 1");
+        assert_eq!(r.doc_id, 1);
+        assert_eq!(ii.last_doc_id(), 1);
+
+        let r = ii.read().expect("read failed").expect("expected doc 4");
+        assert_eq!(r.doc_id, 4);
+        assert_eq!(ii.last_doc_id(), 4);
+
+        assert!(matches!(ii.read(), Ok(None)));
+        assert!(ii.at_eof());
+        // Reading after EOF should return EOF again
+        assert!(matches!(ii.read(), Ok(None)));
+
+        // Rewind and test SkipTo
+        ii.rewind();
+        assert_eq!(ii.last_doc_id(), 0);
+        assert!(!ii.at_eof());
+
+        // SkipTo(1) → Found
+        let outcome = ii.skip_to(1).expect("skip_to failed");
+        assert!(matches!(outcome, Some(SkipToOutcome::Found(r)) if r.doc_id == 1));
+        assert_eq!(ii.last_doc_id(), 1);
+
+        // SkipTo(2) → NotFound, lands on 4 (doc 2 not in bar, doc 3 fails in_order)
+        let outcome = ii.skip_to(2).expect("skip_to failed");
+        assert!(matches!(outcome, Some(SkipToOutcome::NotFound(r)) if r.doc_id == 4));
+        assert_eq!(ii.last_doc_id(), 4);
+
+        // SkipTo(5) → EOF
+        assert!(matches!(ii.skip_to(5), Ok(None)));
+        assert!(ii.at_eof());
+
+        // SkipTo beyond EOF → still EOF
+        assert!(matches!(ii.skip_to(6), Ok(None)));
+        assert!(ii.at_eof());
+    }
+
+    /// C-Code: Equivalent to C++ `TEST_F(IntersectionIteratorTest, SlopAndOrder)`
+    ///
+    /// max_slop=0, in_order=true: only documents where foo immediately precedes
+    /// bar (adjacent and in order) are returned.
+    ///
+    /// Expected results: doc 1 only.
+    #[test]
+    fn slop_and_order() {
+        let mut ii = make_intersection(Some(0), true);
+
+        // num_estimated = min(foo=4, bar=3) = 3
+        assert_eq!(ii.num_estimated(), 3);
+
+        // Read all results: expected doc 1 only
+        let r = ii.read().expect("read failed").expect("expected doc 1");
+        assert_eq!(r.doc_id, 1);
+        assert_eq!(ii.last_doc_id(), 1);
+
+        assert!(matches!(ii.read(), Ok(None)));
+        assert!(ii.at_eof());
+        // last_doc_id must remain at the last *successfully returned* doc (1), not the
+        // non-relevant candidates (3, 4) scanned internally before hitting EOF.
+        assert_eq!(ii.last_doc_id(), 1);
+        // Reading after EOF should return EOF again
+        assert!(matches!(ii.read(), Ok(None)));
+
+        // Rewind and test SkipTo
+        ii.rewind();
+        assert_eq!(ii.last_doc_id(), 0);
+        assert!(!ii.at_eof());
+
+        // SkipTo(1) → Found
+        let outcome = ii.skip_to(1).expect("skip_to failed");
+        assert!(matches!(outcome, Some(SkipToOutcome::Found(r)) if r.doc_id == 1));
+        assert_eq!(ii.last_doc_id(), 1);
+
+        // SkipTo(2) → EOF (no more docs pass slop=0 and in_order)
+        assert!(matches!(ii.skip_to(2), Ok(None)));
+        assert!(ii.at_eof());
+        // last_doc_id must stay at 1, not advance to the non-relevant candidates 3 and 4.
+        assert_eq!(ii.last_doc_id(), 1);
+
+        // SkipTo beyond EOF → still EOF
+        assert!(matches!(ii.skip_to(3), Ok(None)));
+        assert!(ii.at_eof());
+    }
+
+    /// When no doc satisfies the relevancy constraint and the second child runs out of
+    /// docs before the first child does, the iterator must return EOF cleanly.
+    ///
+    /// - foo (first child): doc 1 (pos 3), doc 2 (pos 1)
+    /// - bar (second child): doc 1 (pos 1) only
+    /// - in_order=true (prevents child sorting, so foo stays first): doc 1 fails because
+    ///   bar@1 comes before foo@3; foo then tries doc 2, but bar has no doc ≥ 2 → EOF.
+    #[test]
+    fn relevancy_retry_hits_eof_in_second_consensus() {
+        let foo: Mock<'static, 2> = Mock::new_with_positions([1, 2], [3, 1]);
+        let bar: Mock<'static, 1> = Mock::new_with_positions([1], [1]);
+        let mut ii = Intersection::new_with_slop_order(
+            vec![
+                Box::new(foo) as Box<dyn RQEIterator<'static> + 'static>,
+                Box::new(bar),
+            ],
+            None,
+            true,
+        );
+
+        // No doc satisfies in_order: doc 1 fails (bar@1 < foo@3), doc 2 is only in foo.
+        assert!(matches!(ii.read(), Ok(None)));
+        assert!(ii.at_eof());
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -253,7 +253,6 @@ impl<'index, const N: usize> Mock<'index, N> {
 
     /// Like [`Mock::new`], but each document carries a term position (valid range `1..=127`).
     /// The result produced for each document will be a `Term` record instead of a virtual one,
-    #[expect(unused)]
     pub fn new_with_positions(doc_ids: [t_docId; N], positions: [u8; N]) -> Self {
         debug_assert!(
             positions.iter().all(|&p| (1..=127).contains(&p)),

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
@@ -18,9 +18,18 @@ use criterion::{
     BenchmarkGroup, Criterion,
     measurement::{Measurement, WallTime},
 };
-use rqe_iterators::{Intersection, RQEIterator, id_list::IdListSorted};
+use ffi::{
+    IndexFlags, IndexFlags_Index_StoreByteOffsets, IndexFlags_Index_StoreFieldFlags,
+    IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets,
+};
+use inverted_index::{InvertedIndex, RSIndexResult, RSOffsetSlice, full::Full};
+use query_term::RSQueryTerm;
+use rqe_iterators::{
+    Intersection, NoOpChecker, RQEIterator, id_list::IdListSorted, inverted_index::Term,
+};
+use rqe_iterators_test_utils::MockContext;
 
-use crate::ffi::{self, IteratorStatus_ITERATOR_OK};
+use crate::ffi::{self, InvertedIndex as CInvertedIndex, IteratorStatus_ITERATOR_OK};
 
 #[derive(Default)]
 pub struct Bencher;
@@ -33,6 +42,19 @@ const CHILD_SIZE: u64 = 100_000;
 const WEIGHT: f64 = 1.0;
 /// Step size for skip_to benchmarks.
 const STEP: u64 = 100;
+
+/// Number of documents for slop/order benchmarks.
+const NUM_DOCS: u64 = 100_000;
+
+/// Mirrors `INDEX_DEFAULT_FLAGS` from `spec.h`, a realistic production configuration:
+/// - `StoreTermOffsets` is required for positional data; without it `max_slop`/`in_order`
+///   benchmarks would be meaningless.
+/// - `StoreByteOffsets` instructs the `Full` encoder to also write byte-level offsets per entry (used by
+/// highlighting), keeping the benchmark data representative of a real index.
+const FLAGS: IndexFlags = IndexFlags_Index_StoreFreqs
+    | IndexFlags_Index_StoreTermOffsets
+    | IndexFlags_Index_StoreFieldFlags
+    | IndexFlags_Index_StoreByteOffsets;
 
 /// Generate IDs for high overlap scenario (dense intersection results).
 /// Each child contains IDs 1..CHILD_SIZE, so all documents appear in all children.
@@ -69,6 +91,63 @@ fn ids_to_rust_children(ids: Vec<Vec<u64>>) -> Vec<IdListSorted<'static>> {
     ids.into_iter().map(IdListSorted::new).collect()
 }
 
+fn new_query_term() -> Box<RSQueryTerm> {
+    RSQueryTerm::new("term", 1, 0)
+}
+
+/// Build two Rust `InvertedIndex<Full>` instances.
+///
+/// `first_pos` and `second_pos` are the (constant) positions used for every document.
+///
+/// NOTE: This function exists because intersection logic when using `max_slop` and `in_order`
+/// need positional information, which `IdList` lacks.
+fn make_rust_indexes(first_pos: u8, second_pos: u8) -> (InvertedIndex<Full>, InvertedIndex<Full>) {
+    let mut first = InvertedIndex::<Full>::new(FLAGS);
+    let mut second = InvertedIndex::<Full>::new(FLAGS);
+    for doc_id in 1..=NUM_DOCS {
+        first
+            .add_record(
+                &RSIndexResult::build_term()
+                    .borrowed_record(
+                        Some(RSQueryTerm::new("first", 1, 0)),
+                        RSOffsetSlice::from_slice(&[first_pos]),
+                    )
+                    .doc_id(doc_id)
+                    .field_mask(1u128)
+                    .frequency(1)
+                    .build(),
+            )
+            .unwrap();
+        second
+            .add_record(
+                &RSIndexResult::build_term()
+                    .borrowed_record(
+                        Some(RSQueryTerm::new("second", 2, 0)),
+                        RSOffsetSlice::from_slice(&[second_pos]),
+                    )
+                    .doc_id(doc_id)
+                    .field_mask(1u128)
+                    .frequency(1)
+                    .build(),
+            )
+            .unwrap();
+    }
+    (first, second)
+}
+
+/// Build two C `InvertedIndex` instances.
+///
+/// `first_pos` and `second_pos` are the (constant) positions used for every document.
+fn make_c_indexes(first_pos: u8, second_pos: u8) -> (CInvertedIndex, CInvertedIndex) {
+    let first = CInvertedIndex::new(FLAGS);
+    let second = CInvertedIndex::new(FLAGS);
+    for doc_id in 1..=NUM_DOCS {
+        first.write_term_entry(doc_id, 1, 1, None, &[first_pos]);
+        second.write_term_entry(doc_id, 1, 1, None, &[second_pos]);
+    }
+    (first, second)
+}
+
 impl Bencher {
     const MEASUREMENT_TIME: Duration = Duration::from_millis(3000);
     const WARMUP_TIME: Duration = Duration::from_millis(200);
@@ -90,6 +169,11 @@ impl Bencher {
         self.read_varying_sizes(c);
         self.skip_to_high_overlap(c);
         self.skip_to_low_overlap(c);
+        self.read_slop0_all_pass(c);
+        self.read_slop100_all_pass(c);
+        self.read_in_order_all_pass(c);
+        self.read_in_order_slop100_all_pass(c);
+        self.read_in_order_all_fail(c);
     }
 
     fn read_high_overlap(&self, c: &mut Criterion) {
@@ -119,6 +203,54 @@ impl Bencher {
     fn skip_to_low_overlap(&self, c: &mut Criterion) {
         let mut group = self.benchmark_group(c, "Iterator - Intersection - SkipTo Low Overlap");
         self.bench_skip_to(&mut group, low_overlap_ids);
+        group.finish();
+    }
+
+    /// max_slop=0, in_order=false, adjacent in-order positions → all docs pass.
+    fn read_slop0_all_pass(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - Intersection - Read Slop=0 All Pass");
+        self.bench_read_slop(&mut group, Some(0), false, 1, 2);
+        group.finish();
+    }
+
+    /// max_slop=100, in_order=false, positions with span=48 (first@1, second@50) → all docs pass.
+    ///
+    /// Represents a realistic wide-window phrase query. Comparable to `read_slop0_all_pass`
+    /// to show how slop value affects proximity-check overhead.
+    fn read_slop100_all_pass(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - Intersection - Read Slop=100 All Pass");
+        self.bench_read_slop(&mut group, Some(100), false, 1, 50);
+        group.finish();
+    }
+
+    /// max_slop=None, in_order=true, adjacent in-order positions (first@1, second@2) → all docs pass.
+    ///
+    /// No slop constraint; isolates the cost of pure ordering checks.
+    fn read_in_order_all_pass(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - Intersection - Read In-Order All Pass");
+        self.bench_read_slop(&mut group, None, true, 1, 2);
+        group.finish();
+    }
+
+    /// max_slop=100, in_order=true, positions first@1, second@50 (span=48) → all docs pass.
+    ///
+    /// Combines a wide slop window with ordering constraint; both checks run but all pass.
+    fn read_in_order_slop100_all_pass(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(
+            c,
+            "Iterator - Intersection - Read In-Order Slop=100 All Pass",
+        );
+        self.bench_read_slop(&mut group, Some(100), true, 1, 50);
+        group.finish();
+    }
+
+    /// max_slop=0, in_order=true, adjacent reverse positions → all docs fail.
+    ///
+    /// The iterator must scan the full corpus without yielding any result,
+    /// representing the worst-case cost of the proximity-check rejection path.
+    fn read_in_order_all_fail(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - Intersection - Read In-Order All Fail");
+        self.bench_read_slop(&mut group, Some(0), true, 2, 1);
         group.finish();
     }
 
@@ -181,6 +313,76 @@ impl Bencher {
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + STEP) {
                         black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn bench_read_slop<M: Measurement>(
+        &self,
+        group: &mut BenchmarkGroup<'_, M>,
+        max_slop: Option<u32>,
+        in_order: bool,
+        first_pos: u8,
+        second_pos: u8,
+    ) {
+        let (first_c, second_c) = make_c_indexes(first_pos, second_pos);
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    ffi::QueryIterator::new_intersection_from_term_its(
+                        first_c.iterator_term(),
+                        second_c.iterator_term(),
+                        max_slop.map_or(-1, |v| v as i32),
+                        in_order,
+                    )
+                },
+                |it| {
+                    while it.read() == IteratorStatus_ITERATOR_OK {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        let (first_rust, second_rust) = make_rust_indexes(first_pos, second_pos);
+        let mock_ctx = MockContext::new(NUM_DOCS, NUM_DOCS as usize);
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    let first_reader = first_rust.reader();
+                    let second_reader = second_rust.reader();
+                    let first_iter = unsafe {
+                        Term::new(
+                            first_reader,
+                            mock_ctx.sctx(),
+                            new_query_term(),
+                            1.0,
+                            NoOpChecker,
+                        )
+                    };
+                    let second_iter = unsafe {
+                        Term::new(
+                            second_reader,
+                            mock_ctx.sctx(),
+                            new_query_term(),
+                            1.0,
+                            NoOpChecker,
+                        )
+                    };
+                    let children: Vec<Box<dyn RQEIterator<'_>>> =
+                        vec![Box::new(first_iter), Box::new(second_iter)];
+                    Intersection::new_with_slop_order(children, max_slop, in_order)
+                },
+                |it| {
+                    while let Ok(Some(r)) = it.read() {
+                        black_box(r);
                     }
                 },
                 criterion::BatchSize::SmallInput,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -8,7 +8,7 @@
 */
 
 pub use ffi::{
-    IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreByteOffsets,
+    IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreByteOffsets,
     IndexFlags_Index_StoreFieldFlags, IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreNumeric,
     IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_OK,
     RedisModule_Alloc, RedisModule_Free, ValidateStatus,
@@ -65,6 +65,50 @@ impl QueryIterator {
 
         free_redis_search_ctx(query_eval_ctx);
         Self(it)
+    }
+
+    /// Give up ownership of the raw pointer without calling `Free`.
+    ///
+    /// Used when passing the iterator to a C function that takes ownership
+    /// (e.g. `NewIntersectionIterator`), so that the C side is responsible for freeing it.
+    #[inline(always)]
+    pub const fn into_raw(self) -> *mut ffi::QueryIterator {
+        self.0
+    }
+
+    /// Create a C intersection from two pre-built term `QueryIterator`s.
+    ///
+    /// Takes ownership of both children — they will be freed when the intersection is freed.
+    #[inline(always)]
+    pub fn new_intersection_from_term_its(
+        child1: Self,
+        child2: Self,
+        max_slop: i32,
+        in_order: bool,
+    ) -> Self {
+        let children_ptr = unsafe {
+            RedisModule_Alloc.unwrap()(2 * std::mem::size_of::<*mut ffi::QueryIterator>())
+                as *mut *mut ffi::QueryIterator
+        };
+        unsafe {
+            *children_ptr.add(0) = child1.into_raw();
+            *children_ptr.add(1) = child2.into_raw();
+        }
+        Self(unsafe { ffi::NewIntersectionIterator(children_ptr, 2, max_slop, in_order, 1.0) })
+    }
+
+    #[inline(always)]
+    pub unsafe fn new_term(ii: *mut ffi::InvertedIndex, sctx: *const ffi::RedisSearchCtx) -> Self {
+        let term = Box::into_raw(RSQueryTerm::new("term", 1, 0));
+        Self(unsafe {
+            iterators_ffi::inverted_index::NewInvIndIterator_TermQuery(
+                ii.cast_const(),
+                sctx,
+                field::FieldMaskOrIndex::Mask(ffi::RS_FIELDMASK_ALL),
+                term,
+                1.0,
+            )
+        })
     }
 
     /// Creates a new missing-field inverted index iterator via the C path.
@@ -271,4 +315,97 @@ fn free_redis_search_ctx(ctx: *mut ffi::QueryEvalCtx) {
     unsafe {
         RedisModule_Free.unwrap()(ctx as *mut c_void);
     };
+}
+
+/// Create a minimal zeroed `RedisSearchCtx` with a valid `IndexSpec`.
+///
+/// The caller must call [`free_search_ctx`] to free the memory.
+fn new_search_ctx() -> *mut ffi::RedisSearchCtx {
+    let search_ctx = unsafe {
+        RedisModule_Alloc.unwrap()(std::mem::size_of::<ffi::RedisSearchCtx>())
+            as *mut ffi::RedisSearchCtx
+    };
+    unsafe {
+        (*search_ctx) = std::mem::zeroed();
+    }
+    let spec = unsafe {
+        RedisModule_Alloc.unwrap()(std::mem::size_of::<ffi::IndexSpec>()) as *mut ffi::IndexSpec
+    };
+    unsafe {
+        (*spec) = std::mem::zeroed();
+    }
+    unsafe {
+        (*search_ctx).spec = spec;
+    }
+    search_ctx
+}
+
+fn free_search_ctx(sctx: *mut ffi::RedisSearchCtx) {
+    unsafe {
+        RedisModule_Free.unwrap()((*sctx).spec as *mut c_void);
+        RedisModule_Free.unwrap()(sctx as *mut c_void);
+    }
+}
+
+/// Simple wrapper around the C InvertedIndex.
+/// All methods are inlined to avoid the overhead when benchmarking.
+pub struct InvertedIndex {
+    pub ii: *mut ffi::InvertedIndex,
+    sctx: *mut ffi::RedisSearchCtx,
+}
+
+impl Drop for InvertedIndex {
+    fn drop(&mut self) {
+        unsafe { inverted_index_ffi::InvertedIndex_Free(self.ii.cast()) };
+        free_search_ctx(self.sctx);
+    }
+}
+
+impl InvertedIndex {
+    #[inline(always)]
+    pub fn new(flags: ffi::IndexFlags) -> Self {
+        let mut memsize = 0;
+        let ptr = inverted_index_ffi::NewInvertedIndex_Ex(flags, false, false, &mut memsize);
+        Self {
+            ii: ptr.cast(),
+            sctx: new_search_ctx(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn write_numeric_entry(&self, doc_id: u64, value: f64) {
+        unsafe {
+            inverted_index_ffi::InvertedIndex_WriteNumericEntry(self.ii.cast(), doc_id, value);
+        }
+    }
+
+    /// `term_ptr` and `offsets` must be valid for the lifetime of the index.
+    #[inline(always)]
+    pub fn write_term_entry(
+        &self,
+        doc_id: u64,
+        freq: u32,
+        field_mask: u32,
+        term: Option<Box<RSQueryTerm>>,
+        offsets: &[u8],
+    ) {
+        let offsets = inverted_index::RSOffsetSlice::from_slice(offsets);
+        let record = RSIndexResult::build_term()
+            .borrowed_record(term, offsets)
+            .doc_id(doc_id)
+            .field_mask(field_mask as u128)
+            .frequency(freq)
+            .build();
+        unsafe {
+            inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
+                self.ii.cast(),
+                &record as *const _ as *mut _,
+            );
+        }
+    }
+
+    #[inline(always)]
+    pub fn iterator_term(&self) -> QueryIterator {
+        unsafe { QueryIterator::new_term(self.ii, self.sctx) }
+    }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

- Adds support in Rust code for intersection iterator's max_slop and in_order.
- Adds tests and benchmarks focused on those new (rust) capabilities
- to be noted, I didn't see any benchmarks on cpp focused on those features, so I rolled my own.

## NOT in this PR:

- I used C implementation of `IndexResult_IsWithinRange`  to keep the stop the creeping scope of the PR.

## Benchmarks

| Benchmark | C | Rust | Speedup |
|-----------|---|------|---------|
| Read Slop=0 All Pass | 6.503 ms | 6.025 ms | 1.08x faster |
| Read Slop=100 All Pass | 6.479 ms | 6.000 ms | 1.08x faster |
| Read In-Order All Pass | 6.514 ms | 5.941 ms | 1.10x faster |
| Read In-Order Slop=100 All Pass | 6.539 ms | 5.990 ms | 1.09x faster |
| Read In-Order All Fail | 6.545 ms | 6.112 ms | 1.07x faster |

Not much visible change in perf (probably the C ffi cost actually.), because the logic is still in C within `IndexResult_IsWithinRange`.

It's still interesting to see that no regression occur (especially with the `check_needs_relevancy` opposed to function pointer), which we'll study in a follow up.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `Intersection` iterator semantics by filtering matches via proximity/order constraints and alters child sorting behavior when `in_order=true`, which can impact query result correctness and iteration/EOF edge cases. It also introduces new FFI calls into C for relevancy checks and new benchmark-only C index/iterator wrappers, increasing surface area for subtle memory/ownership bugs.
> 
> **Overview**
> Adds proximity-aware intersection in Rust by extending `Intersection` with `max_slop` and `in_order`, preserving child order when required and filtering agreed doc IDs via `ffi::IndexResult_IsWithinRange` during `read`/`skip_to` (including retry logic when a candidate doc fails relevancy).
> 
> Expands integration coverage with new slop/order tests (including `last_doc_id` stability and EOF retry edge cases) and adjusts mocks to emit positional term results. Updates the benchmarking harness to construct positional term iterators for both C and Rust and adds new slop/order benchmark cases, plus minor docs cleanup in the benchmark skill.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f356215133bd96c63850fa69837886d55b782879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->