### PR TITLE
[MOD-13954] Fix race condition in cursor timeout handling by moving replyState reset to cursorRead

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1313,8 +1313,6 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   AREQ_ProfilePrinterCtx(req)->cursor_reads++;
   // update timeout for current cursor read
   SearchCtx_UpdateTime(AREQ_SearchCtx(req), req->reqConfig.queryTimeoutMS);
-  // Reset Reply state
-  atomic_store_explicit(&req->syncCtx.replyState, ReplyState_NotReplied, memory_order_release);
 
   if (!num) {
     num = req->cursorConfig.chunkSize;
@@ -1399,6 +1397,8 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
   }
 
   if (req) {
+    // Reset Reply state
+    atomic_store_explicit(&req->syncCtx.replyState, ReplyState_NotReplied, memory_order_release);
     RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
     runCursor(reply, cursor, count);
     RedisModule_EndReply(reply);


### PR DESCRIPTION
**Current:** `replyState` was reset in `runCursor()`, which is called for both initial cursor creation and cursor reads.

**Change:** Move `replyState` reset to `cursorRead()` so it only runs for `FT.CURSOR READ`, not initial `AREQ_StartCursor`.

**Outcome:** Prevents timeout callback's `replyState` transition from being overwritten during initial cursor creation with `ON_TIMEOUT FAIL`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cursor execution synchronization by changing when `replyState` is reset, which could impact timeout/reply coordination in threaded execution paths.
> 
> **Overview**
> Fixes cursor read reply/timeout coordination by moving the `replyState` reset out of `runCursor()` and into `cursorRead()` just before starting a new cursor read reply.
> 
> This ensures each `FT.CURSOR READ` begins with a clean reply-ownership state without resetting it during cursor execution, reducing the chance of races between background execution and the timeout callback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 433d61c88480fbb6fd2601dce26c1b3a18a6323f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->