### PR TITLE
[MOD-14244] Fix flaky test_issues:test_mod_14112

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1880,5 +1880,10 @@ def test_mod_14112(env: Env):
              '127.0.0.1:9',
              'MASTER'
   ).ok()
+  # Wait for the topology to be applied
+  wait_for_condition(
+    lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+    'Failed waiting for topology to be applied'
+  )
   # Verify that `FT.SEARCH` queries return an error (not crash)
   env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')


### PR DESCRIPTION
Fix flaky test_issues:test_mod_14112 by making it wait for the topology to be updated.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts a test to wait for `SEARCH.CLUSTERSET` to propagate before asserting behavior, reducing timing-related flakes without affecting production code paths.
> 
> **Overview**
> Makes `test_mod_14112` deterministic by adding an explicit `wait_for_condition` after `SEARCH.CLUSTERSET` to wait until `SEARCH.CLUSTERINFO` reflects the new (invalid) topology before running `FT.SEARCH`.
> 
> This reduces flakiness by ensuring the test asserts on the intended cluster state rather than racing topology propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea92d21be22e05c0d7b280f668903bb88c5fa933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->