### PR TITLE
MOD-13766 Rename main as well as master in beta release

### DIFF
--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -179,8 +179,9 @@ s3_upload() {
 
         for file in "${files[@]}"; do
             local base_name=$(basename "$file")
-            # Remove .master. from beta version filename and add BETA_VERSION
+            # Replace .master. or .main. from beta version filename and add BETA_VERSION
             local new_name="${base_name/.master./.${BETA_VERSION}.}"
+            new_name="${new_name/.main./.${BETA_VERSION}.}"
             # Create temp file with new name
             local temp_file="./${new_name%.zip}${VERSION_SUFFIX}.zip"
             cp "$file" "$temp_file"


### PR DESCRIPTION
Update upload artifact of beta release flow to rename `main` branch for RSE as well as `master`.

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to beta artifact filename rewriting in the S3 upload script; main impact is whether beta uploads get the expected name for `main`-based builds.
> 
> **Overview**
> Beta artifact uploads now rewrite filenames containing `.main.` *as well as* `.master.` to include the `BETA_VERSION` suffix before uploading to the S3 `beta` directory, aligning naming across default branch conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd99be03be0861695f70e9918e1af79edccd432. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->