### PR TITLE
MOD-14216: Remove read-lock of indexSpec lock in disk index reading flow

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -207,23 +207,25 @@ static void setSearchResult(ResultProcessor *base, SearchResult *res, RSIndexRes
  * * For disk indexes, we skip the lock acquisition because:
  * 1. All in-memory structure accesses (terms Trie, suffix Trie, stats) happen
  *    during QAST_Iterate() which already runs under the read-lock.
- * 2. SpeedB iterators capture an implicit snapshot at creation time, ensuring
+ * 2. Disk iterators capture an implicit snapshot at creation time, ensuring
  *    consistency for disk reads without needing to hold the lock.
  * 3. This avoids blocking the main thread during disk IO operations.
  */
 static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
   RedisSearchCtx *sctx = self->sctx;
+  // For disk indexes, return immediately, since we don't need to acquire the
+  // lock, nor to revalidate the iterators.
+  if (sctx->spec->diskSpec) {
+    return false;
+  }
+
   QueryIterator *it = self->iterator;
 
   if (sctx->flags != RS_CTX_UNSET) {
     return false;
   }
 
-  // For in-memory indexes, take the lock. For disk indexes, skip it -
-  // implicit snapshots provide consistency without blocking main thread.
-  if (!sctx->spec->diskSpec) {
-    RedisSearchCtx_LockSpecRead(sctx);
-  }
+  RedisSearchCtx_LockSpecRead(sctx);
 
   ValidateStatus rc = it->Revalidate(it);
 


### PR DESCRIPTION
This PR removes the locking of the locking of the index for read in the inverted-index reading path for disk indexes, such that we don't potentially block the main-thread on IO.
While for vector RANGE queries we will need to introduce some additional mechanism in order to guarantee consistency among the query iterators, for KNN queries we do not need such a mechanism since the KNN query either uses a pre-filter or stands alone (no intersect/union/etc. with any other iterators). In both cases the query remains consistent, in the sense that the de-facto index-space seen by the iterators is the same (either by filtering according to the other iterators as part of the pre-filter, or by standing alone).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


[MOD-14218]: https://redislabs.atlassian.net/browse/MOD-14218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes locking behavior in the core query iteration path for disk indexes; while intended to reduce main-thread blocking on disk I/O, it could expose subtle consistency or race issues if iterator snapshot assumptions are violated.
> 
> **Overview**
> Removes `IndexSpec` read-lock acquisition and iterator `Revalidate()` for disk-backed indexes by short-circuiting `handleSpecLockAndRevalidate()` when `spec->diskSpec` is set, to avoid holding the lock across disk I/O.
> 
> Adds inline documentation explaining why disk iterators are treated as snapshot-consistent and why skipping the lock should not affect in-memory structure safety.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f04818d6c6e6419837873dc6d4ff5a547e5e4f97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->