### PR TITLE
use gcc on macos as well

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -476,9 +476,9 @@ prepare_cmake_arguments() {
   # Add caching flags to prevent using old configurations
   CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -UCMAKE_TOOLCHAIN_FILE"
 
-  if [[ "$OS_NAME" == "macos" ]]; then
-    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
-  fi
+  # if [[ "$OS_NAME" == "macos" ]]; then
+  #   CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+  # fi
 
   if [[ "$BUILD_INTEL_SVS_OPT" == "yes" || "$BUILD_INTEL_SVS_OPT" == "1" ]]; then
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DBUILD_INTEL_SVS_OPT=ON"


### PR DESCRIPTION
use gcc on macos as well

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small build-script change that only affects which compiler CMake chooses on macOS, but it may surface macOS-specific toolchain/linking differences in CI or developer builds.
> 
> **Overview**
> Removes the macOS-only CMake flags that explicitly set `CMAKE_C_COMPILER=clang` and `CMAKE_CXX_COMPILER=clang++`, letting the default/externally-configured compiler be used instead (e.g., GCC).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05a6253c45a4b20fb7f821c8575aacd4462a3473. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->