### PR TITLE
Fix discarded qualifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,13 +156,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat")
 # gcc
 check_c_compiler_flag("-Werror=discarded-qualifiers" HAS_DISCARDED_QUALIFIERS)
 if(HAS_DISCARDED_QUALIFIERS)
-    add_compile_options(-Werror=discarded-qualifiers)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=discarded-qualifiers>)    
 endif()
 
 # clang
 check_c_compiler_flag("-Werror=incompatible-pointer-types-discards-qualifiers" HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
 if(HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
-    add_compile_options(-Werror=incompatible-pointer-types-discards-qualifiers)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=incompatible-pointer-types-discards-qualifiers>)    
 endif()
 
 add_compile_definitions(


### PR DESCRIPTION
Fix the warnings for unknown compiler argument

>warning: unknown warning option '-Werror=discarded-qualifiers'; did you mean '-Werror=ignored-qualifiers'? [-Wunknown-warning-option]

by setting different flags for `gcc` and `clang` (first checking if they exist at all).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system change that only affects compiler warning flags, but could fail builds on unusual toolchains if flag detection behaves differently.
> 
> **Overview**
> Build configuration now avoids passing unsupported qualifier-discard warning flags to Clang/GCC.
> 
> `CMakeLists.txt` adds `CheckCCompilerFlag` and conditionally enables `-Werror=discarded-qualifiers` (GCC) or `-Werror=incompatible-pointer-types-discards-qualifiers` (Clang), while keeping `-Wformat` enabled without hard-coding the old `-Werror=discarded-qualifiers` into `CMAKE_C_FLAGS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2fa391571da9584338f95a9a5bbfc5c08e53c38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->