### PR TITLE
Fix cmake dev warnings

### DIFF
--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -3,6 +3,10 @@ set(CMAKE_CXX_STANDARD 20)
 # Collect source files
 file(GLOB SOURCES "*.cpp")
 
+# Respect BOOST_ROOT variable
+cmake_policy(SET CMP0144 NEW)
+# Use Boost's own config instead of FindBoost
+cmake_policy(SET CMP0167 NEW)
 # Find Boost (no need to specify `geometry` as it is header-only)
 find_package(Boost REQUIRED)
 

--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -4,9 +4,13 @@ set(CMAKE_CXX_STANDARD 20)
 file(GLOB SOURCES "*.cpp")
 
 # Respect BOOST_ROOT variable
-cmake_policy(SET CMP0144 NEW)
+if(POLICY CMP0144)
+    cmake_policy(SET CMP0144 NEW)
+endif()
 # Use Boost's own config instead of FindBoost
-cmake_policy(SET CMP0167 NEW)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 # Find Boost (no need to specify `geometry` as it is header-only)
 find_package(Boost REQUIRED)
 

--- a/src/util/hash/CMakeLists.txt
+++ b/src/util/hash/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Collect source files
 file(GLOB SOURCES "*.cpp")
 
+# Respect BOOST_ROOT variable
+cmake_policy(SET CMP0144 NEW)
+# Use Boost's own config instead of FindBoost
+cmake_policy(SET CMP0167 NEW)
 # Find Boost
 find_package(Boost REQUIRED)
 

--- a/src/util/hash/CMakeLists.txt
+++ b/src/util/hash/CMakeLists.txt
@@ -7,9 +7,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 file(GLOB SOURCES "*.cpp")
 
 # Respect BOOST_ROOT variable
-cmake_policy(SET CMP0144 NEW)
+if(POLICY CMP0144)
+    cmake_policy(SET CMP0144 NEW)
+endif()
 # Use Boost's own config instead of FindBoost
-cmake_policy(SET CMP0167 NEW)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 # Find Boost
 find_package(Boost REQUIRED)
 


### PR DESCRIPTION
Fix these cmake dev warnings for `geometry` and `hash`

```
CMake Warning (dev) at src/util/hash/CMakeLists.txt:10 (find_package):
  Policy CMP0144 is not set: find_package uses upper-case <PACKAGENAME>_ROOT
  variables.  Run "cmake --help-policy CMP0144" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  CMake variable BOOST_ROOT is set to:

    /Users/memark/Src/Redis/RediSearch/.install/boost

  For compatibility, find_package is ignoring the variable, but code in a
  .cmake module might still use it.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/util/hash/CMakeLists.txt:10 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.
```

by setting relevant cmake policies.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system change that only adjusts CMake policy settings around Boost discovery. Potential impact is limited to environments with older/newer CMake/Boost configurations affecting how Boost is found.
> 
> **Overview**
> Sets CMake policies `CMP0144` and `CMP0167` in `src/geometry/CMakeLists.txt` and `src/util/hash/CMakeLists.txt` to stop developer warnings and ensure `BOOST_ROOT` is respected while using Boost’s config-based package discovery.
> 
> No functional C++ code changes; this only affects how Boost is located during configuration/build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77bfaf1fbc03a5c5ba42726461dd41663ae2227b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->