### PR TITLE
[MOD-14240] implement Missing inverted index iterator in Rust

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::ptr::NonNull;
+
+use ffi::{RedisSearchCtx, t_docId, t_fieldIndex};
+use inverted_index::{
+    DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
+};
+
+use crate::{ExpirationChecker, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+
+use super::InvIndIterator;
+
+/// An iterator over documents that are missing a specific field.
+///
+/// Used for `ismissing(@field)` queries, where the goal is to match every
+/// document that does not have the specified field indexed. The set of such
+/// documents is maintained per-field in the index spec's `missingFieldDict`.
+///
+/// This iterator supports per-field expiration checks via
+/// [`FieldExpirationChecker`](crate::FieldExpirationChecker) using the
+/// [`Missing`](field::FieldExpirationPredicate::Missing) predicate.
+///
+/// # Type Parameters
+///
+/// * `'index` - The lifetime of the index being iterated over.
+/// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
+/// * `C` - The expiration checker type.
+pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
+    it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
+    context: NonNull<RedisSearchCtx>,
+    field_index: t_fieldIndex,
+}
+
+impl<'index, E, C> Missing<'index, E, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker,
+{
+    /// Create an iterator returning documents missing the given field.
+    ///
+    /// `field_index` is the index of the field in `spec.fields` whose missing
+    /// documents inverted index this iterator reads from.
+    ///
+    /// # Safety
+    ///
+    /// 1. `context` must point to a valid [`RedisSearchCtx`].
+    /// 2. `context.spec` must be a non-null pointer to a valid `IndexSpec`.
+    /// 3. Both 1 and 2 must remain valid for the lifetime of the iterator.
+    /// 4. `field_index` must be a valid index into `context.spec.fields`.
+    /// 5. `context.spec.missingFieldDict` must be a non-null, valid dict pointer.
+    /// 6. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
+    ///    when non-null, must point to an opaque
+    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
+    ///    variant matches `E`.
+    pub unsafe fn new(
+        reader: IndexReaderCore<'index, E>,
+        context: NonNull<RedisSearchCtx>,
+        field_index: t_fieldIndex,
+        expiration_checker: C,
+    ) -> Self {
+        debug_assert!(
+            // SAFETY: pre-condition 1 guarantees `context` is valid.
+            !unsafe { context.as_ref() }.spec.is_null(),
+            "pre-condition 2: context.spec must be non-null",
+        );
+        let result = RSIndexResult::virt()
+            .weight(0.0)
+            .field_mask(ffi::RS_FIELDMASK_ALL)
+            .frequency(1);
+
+        Self {
+            it: InvIndIterator::new(reader, result, expiration_checker),
+            context,
+            field_index,
+        }
+    }
+
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The garbage collector may remove all documents from the missing-field
+    /// inverted index or replace it with a new allocation. In both cases the
+    /// reader's pointer is stale and the iterator must
+    /// [abort](RQEValidateStatus::Aborted).
+    fn should_abort(&self) -> bool {
+        // SAFETY: 1. and 3. guarantee `context` is valid for the iterator's lifetime.
+        let sctx_ref = unsafe { self.context.as_ref() };
+        // SAFETY: 2. and 3. guarantee `spec` is a valid, non-null pointer for the iterator's lifetime.
+        let spec = unsafe { &*sctx_ref.spec };
+
+        debug_assert!(
+            !spec.missingFieldDict.is_null(),
+            "spec.missingFieldDict must be non-null",
+        );
+
+        // SAFETY: 4. guarantees `field_index` is a valid index into `spec.fields`.
+        let field_ptr = unsafe { spec.fields.offset(self.field_index as isize) };
+        // SAFETY: the pointer is valid per the above.
+        let field = unsafe { &*field_ptr };
+        // SAFETY: 5. guarantees the dict is valid.
+        let missing_ii_ptr =
+            unsafe { ffi::RS_dictFetchValue(spec.missingFieldDict, field.fieldName as *mut _) };
+
+        if missing_ii_ptr.is_null() {
+            // The inverted index was removed from the dict (garbage collected).
+            return true;
+        }
+
+        let missing_ii = missing_ii_ptr.cast::<inverted_index::opaque::InvertedIndex>();
+        // SAFETY: 6. guarantees the encoding variant matches E.
+        let ii = E::from_opaque(unsafe { &*missing_ii });
+
+        !self.it.reader.points_to_ii(ii)
+    }
+
+    /// Get a reference to the underlying reader.
+    pub const fn reader(&self) -> &IndexReaderCore<'index, E> {
+        &self.it.reader
+    }
+
+    /// Get a mutable reference to the underlying reader.
+    ///
+    /// This is used by C tests to swap the index pointer for revalidation testing.
+    pub const fn reader_mut(&mut self) -> &mut IndexReaderCore<'index, E> {
+        &mut self.it.reader
+    }
+}
+
+impl<'index, E, C> RQEIterator<'index> for Missing<'index, E, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker,
+{
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.it.current()
+    }
+
+    #[inline(always)]
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        self.it.read()
+    }
+
+    #[inline(always)]
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        self.it.skip_to(doc_id)
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        self.it.rewind()
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        self.it.last_doc_id()
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        self.it.at_eof()
+    }
+
+    #[inline(always)]
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        if self.should_abort() {
+            return Ok(RQEValidateStatus::Aborted);
+        }
+
+        self.it.revalidate()
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -7,14 +7,16 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Supporting types for [`Numeric`], [`Term`], and [`Wildcard`].
+//! Supporting types for [`Missing`], [`Numeric`], [`Term`], and [`Wildcard`].
 
 mod core;
+mod missing;
 mod numeric;
 mod term;
 mod wildcard;
 
 pub use core::InvIndIterator;
+pub use missing::Missing;
 pub use numeric::Numeric;
 pub use term::Term;
 pub use wildcard::Wildcard;

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -32,7 +32,7 @@ pub use empty::Empty;
 pub use expiration_checker::{ExpirationChecker, FieldExpirationChecker, NoOpChecker};
 pub use id_list::IdList;
 pub use intersection::Intersection;
-pub use inverted_index::{Numeric, Term};
+pub use inverted_index::{Missing, Numeric, Term};
 pub use metric::Metric;
 pub use wildcard::{Wildcard, WildcardIterator};
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for the missing-field inverted index iterator.
+
+use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
+use inverted_index::{RSIndexResult, doc_ids_only::DocIdsOnly};
+use rqe_iterators::{NoOpChecker, RQEIterator, inverted_index::Missing};
+use rqe_iterators_test_utils::MockContext;
+
+use crate::inverted_index::utils::BaseTest;
+
+struct MissingBaseTest {
+    test: BaseTest<DocIdsOnly>,
+}
+
+impl MissingBaseTest {
+    fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        RSIndexResult::virt()
+            .doc_id(doc_id)
+            .field_mask(RS_FIELDMASK_ALL)
+            .frequency(1)
+            .weight(0.0)
+    }
+
+    fn new(n_docs: u64) -> Self {
+        Self {
+            test: BaseTest::new(
+                IndexFlags_Index_DocIdsOnly,
+                Box::new(Self::expected_record),
+                n_docs,
+            ),
+        }
+    }
+
+    fn create_iterator(&self) -> Missing<'_, DocIdsOnly, NoOpChecker> {
+        let reader = self.test.ii.reader();
+        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
+        // that outlives the returned iterator. field_index is 0 (unused with NoOpChecker).
+        unsafe { Missing::new(reader, self.test.mock_ctx.sctx(), 0, NoOpChecker) }
+    }
+}
+
+#[test]
+fn missing_read() {
+    let test = MissingBaseTest::new(100);
+    let mut it = test.create_iterator();
+    test.test.read(&mut it, test.test.docs_ids_iter());
+}
+
+#[test]
+fn missing_skip_to() {
+    let test = MissingBaseTest::new(10);
+    let mut it = test.create_iterator();
+    test.test.skip_to(&mut it);
+}
+
+#[test]
+fn missing_empty_index() {
+    let ii = inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    let mock_ctx = MockContext::new(0, 0);
+
+    let reader = ii.reader();
+    // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
+    // that outlives the iterator.
+    let mut it = unsafe { Missing::new(reader, mock_ctx.sctx(), 0, NoOpChecker) };
+
+    // Should immediately be at EOF
+    assert!(it.read().expect("read failed").is_none());
+    assert!(it.at_eof());
+}
+
+#[cfg(not(miri))]
+mod not_miri {
+    use super::*;
+    use crate::inverted_index::utils::{RevalidateIndexType, RevalidateTest};
+    use inverted_index::opaque::OpaqueEncoding;
+    use rqe_iterators::RQEValidateStatus;
+
+    struct MissingRevalidateTest {
+        test: RevalidateTest,
+    }
+
+    impl MissingRevalidateTest {
+        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+            RSIndexResult::virt()
+                .doc_id(doc_id)
+                .field_mask(RS_FIELDMASK_ALL)
+                .frequency(1)
+                .weight(0.0)
+        }
+
+        fn new(n_docs: u64) -> Self {
+            Self {
+                test: RevalidateTest::new(
+                    RevalidateIndexType::Missing,
+                    Box::new(Self::expected_record),
+                    n_docs,
+                ),
+            }
+        }
+
+        fn create_iterator(&self) -> Missing<'_, DocIdsOnly, NoOpChecker> {
+            let ii = DocIdsOnly::from_opaque(self.test.context.missing_inverted_index());
+            let field_index = self.test.context.field_spec().index;
+            // SAFETY: `self.test.context` provides a valid `RedisSearchCtx` with a valid
+            // `spec` and `missingFieldDict` that outlive the returned iterator.
+            unsafe {
+                Missing::new(
+                    ii.reader(),
+                    self.test.context.sctx,
+                    field_index,
+                    NoOpChecker,
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn missing_revalidate_basic() {
+        let test = MissingRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        test.test.revalidate_basic(&mut it);
+    }
+
+    #[test]
+    fn missing_revalidate_at_eof() {
+        let test = MissingRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        test.test.revalidate_at_eof(&mut it);
+    }
+
+    #[test]
+    fn missing_revalidate_after_index_disappears() {
+        let test = MissingRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+
+        // Verify the iterator works normally and read at least one document
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Ok
+        );
+        assert!(it.read().expect("failed to read").is_some());
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Ok
+        );
+
+        // Simulate the missing-field inverted index being garbage collected and
+        // recreated by replacing the dict entry with a new inverted index.
+        // We create the replacement via `Box::into_raw(Box::new(...))` using
+        // `inverted_index::opaque::InvertedIndex`, which is the same type that
+        // `InvertedIndex_Free` (the dict's value destructor) expects.
+        let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+            inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+        )));
+        let field_name = test.test.context.field_spec().fieldName;
+
+        // Replace the dict entry. `dictDelete` calls the value destructor
+        // which frees the original inverted index. Then add the new one.
+        // Note: the iterator's reader holds a (now-dangling) pointer to the
+        // original II, but `should_abort` only compares pointers via
+        // `is_index` without dereferencing it, so this is safe.
+        unsafe {
+            let dict = (*test.test.context.spec.as_ptr()).missingFieldDict;
+            ffi::RS_dictDelete(dict, field_name as *mut _);
+            let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
+            assert_eq!(rc, 0, "dictAdd failed");
+        }
+
+        // Revalidate should return Aborted because the missing II no longer
+        // points to the same index the reader was created from.
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Aborted
+        );
+
+        // No restore needed: the new II will be freed by `dictRelease` during
+        // `IndexSpec_RemoveFromGlobals` in `TestContext::drop`.
+    }
+
+    #[test]
+    fn missing_revalidate_after_document_deleted() {
+        let test = MissingRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        let ii = DocIdsOnly::from_mut_opaque(test.test.context.missing_inverted_index());
+
+        test.test.revalidate_after_document_deleted(&mut it, ii);
+    }
+
+    /// Test that revalidation returns `Aborted` when the missing-field inverted
+    /// index is removed from the dict (entry deleted), simulating the garbage
+    /// collector removing all documents.
+    #[test]
+    fn missing_revalidate_after_dict_entry_removed() {
+        let test = MissingRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+
+        // Read at least one document so the iterator has a position.
+        assert!(it.read().expect("failed to read").is_some());
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Ok
+        );
+
+        // Simulate the garbage collector removing the missing-field index
+        // by deleting the dict entry. `dictDelete` calls the value destructor
+        // which frees the inverted index.
+        let field_name = test.test.context.field_spec().fieldName;
+        unsafe {
+            let dict = (*test.test.context.spec.as_ptr()).missingFieldDict;
+            ffi::RS_dictDelete(dict, field_name as *mut _);
+        }
+
+        // `should_abort` sees NULL from `dictFetchValue` and returns true.
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Aborted
+        );
+
+        // No restore needed: the entry was properly freed by `dictDelete`.
+        // `TestContext::drop` calls `dictRelease` which is fine with a
+        // missing entry.
+    }
+
+    /// Test that `reader()` returns a reference to the underlying reader.
+    #[test]
+    fn missing_reader_accessor() {
+        let test = MissingRevalidateTest::new(10);
+        let it = test.create_iterator();
+
+        let reader = it.reader();
+        let ii = DocIdsOnly::from_opaque(test.test.context.missing_inverted_index());
+        assert!(reader.points_to_ii(ii));
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/mod.rs
@@ -6,6 +6,7 @@
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
 */
+mod missing;
 mod numeric;
 mod term;
 mod utils;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -445,6 +445,7 @@ pub enum RevalidateIndexType {
     Numeric,
     Term,
     Wildcard,
+    Missing,
 }
 
 /// Test the revalidation of the iterator.
@@ -478,6 +479,7 @@ impl RevalidateTest {
                 TestContext::term(flags, doc_ids.iter().map(|id| expected_record(*id)), false)
             }
             RevalidateIndexType::Wildcard => TestContext::wildcard(doc_ids.iter().copied()),
+            RevalidateIndexType::Missing => TestContext::missing(doc_ids.iter().copied()),
         };
 
         Self {

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -106,6 +106,10 @@ enum TestContextInner {
     Wildcard {
         inverted_index: ptr::NonNull<ffi::InvertedIndex>,
     },
+    Missing {
+        field_spec: ptr::NonNull<ffi::FieldSpec>,
+        inverted_index: ptr::NonNull<ffi::InvertedIndex>,
+    },
 }
 
 /// Create a spec and search context from the given schema and index name.
@@ -336,6 +340,79 @@ impl TestContext {
         }
     }
 
+    /// Create a new [`TestContext`] with a doc-ids-only inverted index for missing-field queries.
+    ///
+    /// # Arguments
+    /// * `doc_ids` - An iterator over the document IDs to be indexed (documents missing the field).
+    pub fn missing<I>(doc_ids: I) -> Self
+    where
+        I: Iterator<Item = u64>,
+    {
+        // Serialize TestContext creation to avoid concurrent access to C global state
+        let _lock = CONTEXT_MUTEX.lock().unwrap();
+
+        let ctx = ModuleCtx::new();
+        // Create IndexSpec with unique name to avoid parallel test conflicts
+        let index_name = unique_index_name("missing_idx");
+        let (spec, sctx) = create_spec_sctx(&ctx, "SCHEMA text_field TEXT", &index_name);
+
+        // Get the field spec for the text field
+        let field_name = std::ffi::CString::new("text_field").unwrap();
+        let fs = unsafe {
+            ffi::IndexSpec_GetFieldWithLength(
+                spec.as_ptr(),
+                field_name.as_ptr(),
+                field_name.as_bytes().len(),
+            )
+        };
+        let field_spec: ptr::NonNull<ffi::FieldSpec> =
+            ptr::NonNull::new(fs as _).expect("FieldSpec should not be null");
+
+        // Create a DocIdsOnly inverted index for the missing field
+        let mut memsize = 0;
+        let ii_ptr = inverted_index_ffi::NewInvertedIndex_Ex(
+            ffi::IndexFlags_Index_DocIdsOnly,
+            false,
+            false,
+            &mut memsize,
+        );
+        let ii = ptr::NonNull::new(ii_ptr.cast()).expect("Failed to create InvertedIndex");
+
+        // Populate with virtual records for each document ID
+        for doc_id in doc_ids {
+            let record = RSIndexResult::virt().doc_id(doc_id);
+            // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
+            unsafe {
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
+                    ii_ptr,
+                    &record as *const _ as *mut _,
+                );
+            }
+        }
+
+        // Add the inverted index to the spec's missingFieldDict,
+        // keyed by the field's fieldName (a HiddenString pointer used as dict key).
+        unsafe {
+            let field_name_key = (*field_spec.as_ptr()).fieldName;
+            let rc = ffi::RS_dictAdd(
+                (*spec.as_ptr()).missingFieldDict,
+                field_name_key as *mut _,
+                ii_ptr as *mut _,
+            );
+            assert_eq!(rc, 0, "dictAdd failed"); // DICT_OK == 0
+        }
+
+        Self {
+            _ctx: ctx,
+            sctx,
+            spec,
+            inner: TestContextInner::Missing {
+                field_spec,
+                inverted_index: ii,
+            },
+        }
+    }
+
     /// Write a record to an inverted index using the ForwardIndexEntry FFI.
     fn write_forward_index_entry(idx: *mut ffi::InvertedIndex, record: &RSIndexResult) {
         let term = CString::new("term").unwrap();
@@ -400,7 +477,8 @@ impl TestContext {
     pub const fn field_spec(&self) -> &ffi::FieldSpec {
         match self.inner {
             TestContextInner::Numeric { field_spec, .. }
-            | TestContextInner::Term { field_spec, .. } => unsafe { field_spec.as_ref() },
+            | TestContextInner::Term { field_spec, .. }
+            | TestContextInner::Missing { field_spec, .. } => unsafe { field_spec.as_ref() },
             TestContextInner::Wildcard { .. } => panic!("Wildcard context has no field spec"),
         }
     }
@@ -483,6 +561,21 @@ impl TestContext {
         match &self.inner {
             TestContextInner::Wildcard { inverted_index } => inverted_index.as_ptr(),
             _ => panic!("TestContext is not a Wildcard context"),
+        }
+    }
+
+    /// Get the missing-field (doc-ids-only) inverted index for this context.
+    /// Returns a reference to the FFI inverted index wrapper.
+    /// Panics if this is not a missing context.
+    #[expect(clippy::mut_from_ref)] // need to get a mut for the revalidate_after_document_deleted test
+    pub fn missing_inverted_index(&self) -> &mut inverted_index_ffi::InvertedIndex {
+        match &self.inner {
+            TestContextInner::Missing { inverted_index, .. } => {
+                // SAFETY: inverted_index is a valid pointer created via NewInvertedIndex_Ex
+                let ii: *mut inverted_index_ffi::InvertedIndex = inverted_index.as_ptr().cast();
+                unsafe { &mut *ii }
+            }
+            _ => panic!("TestContext is not a Missing context"),
         }
     }
 


### PR DESCRIPTION
Port the inverted index Missing query iterator from C to Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new iterator that dereferences FFI pointers and inspects `missingFieldDict` during `revalidate`, so correctness depends on subtle lifetime/GC assumptions around index/spec mutations. Coverage is improved with integration tests, but failures could surface as aborted queries or unsafe pointer misuse if assumptions break.
> 
> **Overview**
> Adds a new Rust `inverted_index::Missing` iterator to support `ismissing(@field)` by iterating a per-field missing-docs inverted index and delegating read/skip behavior to `InvIndIterator`.
> 
> `Missing::revalidate` now explicitly *aborts* when the underlying missing-field index has been removed or replaced in `spec.missingFieldDict` (e.g., GC), detected via pointer comparison against the current dict entry.
> 
> Exports `Missing` from `rqe_iterators` and adds integration tests plus test harness support (`TestContext::missing`, `RevalidateIndexType::Missing`) to validate read/skip and revalidation behavior when the dict entry disappears or is swapped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75c5739a88cb83a142ea98ca002fda0a889e1ded. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->