### PR TITLE
[MOD-14319] Fix incorrect initialization of SearchResult

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2594,11 +2594,13 @@ typedef struct {
 static void RPDepleter_Deplete(RPDepleter *self) {
   RPStatus rc;
   SearchResult *r = rm_calloc(1, sizeof(*r));
+  *r = SearchResult_New();
 
   // Deplete all results from upstream
   while ((rc = self->base.upstream->Next(self->base.upstream, r)) == RS_RESULT_OK) {
     array_append(self->results, r);
     r = rm_calloc(1, sizeof(*r));
+    *r = SearchResult_New();
     self->depleted_results++;
   }
 


### PR DESCRIPTION
Fix an incorrect allocation of `SearchResult`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change that only affects how `SearchResult` structs are initialized in the synchronous depleter; it should reduce the chance of invalid cleanup/undefined state without changing query logic.
> 
> **Overview**
> Fixes `RPDepleter_Deplete` to properly initialize each newly allocated `SearchResult` with `SearchResult_New()` before it is passed to upstream processors or destroyed, including the final unused allocation after depletion completes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ee526a38edb32bb1be44142ae92ca0e347c8274. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->