### PR TITLE
[MOD-14319] RLookup - Fix double cleanup issue

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3932,7 +3932,6 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
     // key was changed to, since the old key is already deleted.
     key_p = RedisModule_StringPtrLen(keyToReadData, NULL);
 
-    EvalCtx *r = NULL;
     for (size_t i = 0; i < array_len(res->specsOps); ++i) {
       SpecOpCtx *specOp = res->specsOps + i;
       IndexSpec *spec = specOp->spec;
@@ -3940,8 +3939,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
         continue;
       }
 
-      // load document only if required
-      if (!r) r = EvalCtx_Create();
+      EvalCtx *r = EvalCtx_Create();
 
       RedisSearchCtx sctx = { .redisCtx = ctx };
       QueryError status = QueryError_Default();
@@ -3954,12 +3952,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
         }
       }
       QueryError_ClearError(r->ee.err);
-      // Clean up the row and lookup between iterations (indexes)
-      RLookup_Cleanup(&r->lk);
-      RLookupRow_Reset(&r->row);
-    }
-
-    if (r) {
+      
       EvalCtx_Destroy(r);
     }
   }


### PR DESCRIPTION
Fixes an issue where `RLookup::Cleanup` and `RLookupRow::Cleanup` were being called twice.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indexing/schema-rule matching code and changes `EvalCtx` lifetime, which could impact performance or expose subtle filter-evaluation regressions despite being a small, targeted memory-safety fix.
> 
> **Overview**
> Prevents a **double cleanup/double-free** scenario when evaluating schema rule filters during indexing (`Indexes_FindMatchingSchemaRules`).
> 
> The filter loop now creates and destroys an `EvalCtx` per spec iteration and removes the manual `RLookup`/row cleanup previously done between iterations, relying on `EvalCtx_Destroy` to perform the cleanup exactly once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc5f0ef070b634d7af2289b75e1e51d28a0f55fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->