### PR TITLE
fix assert that does not hold true

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1262,8 +1262,6 @@ static void GetRedisVersion(RedisModuleCtx *ctx) {
   }
 
   isFlex = SearchDisk_CheckEnableConfiguration(ctx);
-  // Flex mode is only available in Redis Enterprise
-  RS_LOG_ASSERT(!isFlex || IsEnterprise(), "Flex mode is only available in Redis Enterprise");
 }
 
 void GetFormattedRedisVersion(char *buf, size_t len) {


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a startup-time assertion only; functional behavior remains the same aside from no longer crashing when Flex is enabled outside Redis Enterprise detection.
> 
> **Overview**
> Removes the `RS_LOG_ASSERT` in `GetRedisVersion()` that enforced *Flex mode requires Redis Enterprise*, allowing `isFlex = SearchDisk_CheckEnableConfiguration(ctx)` to be set without aborting when Enterprise detection is false.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67a40b346ee36884e8ae49f8e6f6a8bc28aa4f00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->