### PR TITLE
claude: allow `jj evolog`

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,7 @@
       "Bash(jj describe:*)",
       "Bash(jj diff:*)",
       "Bash(jj duplicate:*)",
+      "Bash(jj evolog:*)",
       "Bash(jj file annotate:*)",
       "Bash(jj file list:*)",
       "Bash(jj file search:*)",


### PR DESCRIPTION
Add it to read-only operations list.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that broadens the set of permitted read-only `jj` commands; no runtime or production code paths are affected.
> 
> **Overview**
> Updates `.claude/settings.json` to allow running `Bash(jj evolog:*)` as an approved command, extending the existing list of permitted read-only `jj` operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd0d25645cd854a2a8e69927db3cf8bc55f03f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->