### PR TITLE
MOD-14328: [8.6] Notification handler for `rename` is loading the wrong key

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3800,6 +3800,9 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   TrieMapResultBuf_Free(prefixes);
 
   if (runFilters) {
+    // We load the data from the `keyToReadData` key, which is the key the old
+    // key was changed to, since the old key is already deleted.
+    key_p = RedisModule_StringPtrLen(keyToReadData, NULL);
 
     EvalCtx *r = NULL;
     for (size_t i = 0; i < array_len(res->specsOps); ++i) {
@@ -3809,7 +3812,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
         continue;
       }
 
-      // load hash only if required
+      // load document only if required
       if (!r) r = EvalCtx_Create();
       RLookup_LoadRuleFields(ctx, &r->lk, &r->row, spec, key_p);
 

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -194,16 +194,9 @@ def testRename(env):
     env.expect('ft.search things foo').equal([0])
     env.expect('ft.search otherthings foo').equal([1, 'otherthing:foo', ['name', 'foo']])
 
+    # Test that renaming a String key (unrelated type) does not crash
     env.cmd('SET foo bar')
     env.cmd('RENAME foo fubu')
-
-@skip(cluster=True)
-def testRenameChangePrefix(env):
-    env.cmd('ft.create idx1 PREFIX 1 1: SCHEMA name text')
-    env.cmd('ft.create idx2 PREFIX 1 2: SCHEMA name text')
-
-    env.cmd('SET 1:1 bar')
-    env.expect('RENAME 1:1 2:1').ok()
 
 @skip(cluster=True)
 def testCopy(env):
@@ -692,6 +685,101 @@ def testIssue1571WithRename(env):
 
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', 'foo*')), toSortedFlatList([1, 'idx1:{doc}1', ['t', 'foo1', 'index', 'yes']]))
     env.expect('ft.search', 'idx2', 'foo*').equal([0])
+
+@skip(cluster=True)
+def testRenameWithFilterUsingFieldValueBetweenIndexes(env):
+    """
+    Test RENAME between different indexes where both have FILTER expressions
+    that read field values. This tests that filters are correctly evaluated
+    using the data from the new key location.
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create two indexes with different prefixes but same filter expression
+    env.cmd('ft.create', 'idx1',
+            'PREFIX', '1', 'prefix1:',
+            'FILTER', '@category=="books"',
+            'SCHEMA', 'title', 'TEXT', 'category', 'TAG')
+
+    env.cmd('ft.create', 'idx2',
+            'PREFIX', '1', 'prefix2:',
+            'FILTER', '@category=="books"',
+            'SCHEMA', 'title', 'TEXT', 'category', 'TAG')
+
+    # Add a document that matches idx1's prefix and filter
+    conn.execute_command('hset', 'prefix1:item', 'title', 'mybook', 'category', 'books')
+
+    # Verify it's in idx1 and not in idx2
+    env.expect('ft.search', 'idx1', 'mybook').equal([1, 'prefix1:item', ['title', 'mybook', 'category', 'books']])
+    env.expect('ft.search', 'idx2', 'mybook').equal([0])
+
+    # Rename to idx2's prefix - the filter should still pass because
+    # we read the field value from the new key location
+    env.expect('RENAME prefix1:item prefix2:item').ok()
+
+    # Verify it moved to idx2
+    env.expect('ft.search', 'idx1', 'mybook').equal([0])
+    env.expect('ft.search', 'idx2', 'mybook').equal([1, 'prefix2:item', ['title', 'mybook', 'category', 'books']])
+
+@skip(cluster=True)
+def testRenameWithFilterExcludingDocument(env):
+    """
+    Test RENAME where the target index's filter would exclude the document.
+    The document should not be indexed in the target index.
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a filter that checks field value
+    env.cmd('ft.create', 'idx1',
+            'PREFIX', '1', 'prefix1:',
+            'FILTER', '@type=="allowed"',
+            'SCHEMA', 'data', 'TEXT', 'type', 'TAG')
+
+    env.cmd('ft.create', 'idx2',
+            'PREFIX', '1', 'prefix2:',
+            'FILTER', '@type=="special"',
+            'SCHEMA', 'data', 'TEXT', 'type', 'TAG')
+
+    # Add a document that matches idx1's filter but NOT idx2's filter
+    conn.execute_command('hset', 'prefix1:doc', 'data', 'hello', 'type', 'allowed')
+
+    # Verify it's in idx1
+    env.expect('ft.search', 'idx1', 'hello').equal([1, 'prefix1:doc', ['data', 'hello', 'type', 'allowed']])
+    env.expect('ft.search', 'idx2', 'hello').equal([0])
+
+    # Rename to idx2's prefix - but the filter should NOT pass
+    # because type != "special"
+    env.expect('RENAME prefix1:doc prefix2:doc').ok()
+
+    # Document should be removed from idx1 and NOT added to idx2
+    env.expect('ft.search', 'idx1', 'hello').equal([0])
+    env.expect('ft.search', 'idx2', 'hello').equal([0])
+
+@skip(cluster=True)
+def testRenameToSameName(env):
+    """
+    Test RENAME to the same name (e.g., RENAME prefix1:doc prefix1:doc).
+    This should be a no-op and the document should remain in the index.
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a filter
+    env.cmd('ft.create', 'idx1',
+            'PREFIX', '1', 'prefix1:',
+            'FILTER', '@type=="allowed"',
+            'SCHEMA', 'data', 'TEXT', 'type', 'TAG')
+
+    # Add a document
+    conn.execute_command('hset', 'prefix1:doc', 'data', 'hello', 'type', 'allowed')
+
+    # Verify it's in idx1
+    env.expect('ft.search', 'idx1', 'hello').equal([1, 'prefix1:doc', ['data', 'hello', 'type', 'allowed']])
+
+    # Rename to same name - should be a no-op
+    env.expect('RENAME prefix1:doc prefix1:doc').ok()
+
+    # Document should still be in idx1
+    env.expect('ft.search', 'idx1', 'hello').equal([1, 'prefix1:doc', ['data', 'hello', 'type', 'allowed']])
 
 @skip(msan=True, no_json=True)
 def testIdxFieldJson(env):


### PR DESCRIPTION
Backport of #8377 to 8.6 branch.

Original ticket: MOD-14062
Backport ticket: MOD-14328

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=github&utm_medium=pull_request&utm_campaign=github)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches keyspace notification rename handling and filter evaluation, which can affect whether documents are (de)indexed during `RENAME` across prefixes. Risk is mitigated by added coverage for cross-index renames with field-based filters and no-op renames.
> 
> **Overview**
> Fixes a `RENAME` edge case where index `FILTER` expressions could be evaluated against the wrong key after a rename, causing incorrect indexing (or crashes) when moving documents between index prefixes.
> 
> Adds regression tests covering renames between indexes with field-value filters (including cases where the target filter should exclude the document) and `RENAME` no-op behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c5cad6ff524b09ac8b0bf08346ed3987d22455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->