### PR TITLE
[8.6] MOD-13948: Fix indexing discrepancy w.r.t the index filter

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -67,7 +67,7 @@ static int evalFunc(ExprEval *eval, const RSFunctionExpr *f, RSValue *result) {
     // 1. For func_exists, always allow NULL values
     // 2. For all other functions, NULL values are errors
     if (internalRes == EXPR_EVAL_ERR ||
-        (internalRes == EXPR_EVAL_NULL && f->Call != func_exists)) {
+       (internalRes == EXPR_EVAL_NULL && f->Call != func_exists)) {
       goto cleanup;
     }
   }
@@ -330,8 +330,6 @@ EvalCtx *EvalCtx_Create() {
 
   RLookup _lk = {0};
   r->lk = _lk;
-  RLookupRow _row = {0};
-  r->row = _row;
   QueryError _status = QueryError_Default();
   r->status = _status;
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -90,6 +90,15 @@ int SchemaRule_RdbLoad(StrongRef spec_ref, RedisModuleIO *rdb, int encver, Query
 
 bool SchemaRule_ShouldIndex(struct IndexSpec *sp, RedisModuleString *keyname, DocumentType type);
 
+struct EvalCtx;
+/**
+ * Evaluate the filter expression for a schema rule.
+ * @param r The evaluation context (must be initialized with RLookup_LoadRuleFields)
+ * @param filter_exp The filter expression to evaluate
+ * @return true if the document passes the filter (should be indexed), false otherwise
+ */
+bool SchemaRule_FilterPasses(struct EvalCtx *r, const struct RSExpr *filter_exp);
+
 //---------------------------------------------------------------------------------------------
 
 extern TrieMap *SchemaPrefixes_g;

--- a/src/spec.c
+++ b/src/spec.c
@@ -3816,8 +3816,8 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
       if (!r) r = EvalCtx_Create();
       RLookup_LoadRuleFields(ctx, &r->lk, &r->row, spec, key_p);
 
-      if (EvalCtx_EvalExpr(r, spec->rule->filter_exp) == EXPR_EVAL_OK) {
-        if (!RSValue_BoolTest(r->res) && dictFind(specs, spec->specName)) {
+      if (!SchemaRule_FilterPasses(r, spec->rule->filter_exp)) {
+        if (dictFind(specs, spec->specName)) {
           specOp->op = SpecOp_Del;
         }
       }

--- a/tests/pytests/test_filter.py
+++ b/tests/pytests/test_filter.py
@@ -431,3 +431,56 @@ def testFilterWithAliasedFieldsMixedTypes(env):
     # json_idx
     res = env.cmd('FT.SEARCH', 'hash_idx', '*', 'NOCONTENT')
     env.assertEqual(res, [1, 'hash1'])
+
+def testFilterWithMissingFields(env):
+    """
+    Test that documents are not indexed when the filter expression evaluation
+    fails due to missing fields. This is a regression test for a bug where
+    documents added after index creation would be indexed even when the filter
+    expression could not be evaluated (e.g., due to missing fields).
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create a document BEFORE the index exists
+    conn.execute_command('HSET', 'h1', 'd2', '1')
+
+    # Create an index with a filter that references fields d1 and d2
+    # The filter requires both @d1==0 AND @d2==0
+    env.cmd('FT.CREATE', 'idx', 'FILTER', '@d1==0 && @d2==0',
+            'SCHEMA', 'd1', 'NUMERIC', 'd2', 'NUMERIC')
+
+    waitForIndex(env, 'idx')
+
+    # h1 should not be indexed because:
+    # - d1 is missing (filter evaluation should fail or return false)
+    # - d2=1 (doesn't match @d2==0 anyway)
+    env.expect('FT.SEARCH', 'idx', '*').equal([0])
+
+    # Create a document AFTER the index exists with only d2 field
+    # This document should NOT be indexed because d1 is missing
+    conn.execute_command('HSET', 'h2', 'd2', '1')
+
+    # h2 should not be indexed - the filter expression references @d1 which is missing
+    # Filter evaluation should fail, meaning the document should NOT be indexed
+    env.expect('FT.SEARCH', 'idx', '*').equal([0])
+
+    # Create a document that actually matches the filter
+    conn.execute_command('HSET', 'h3', 'd1', '0', 'd2', '0')
+
+    # h3 should be indexed because it matches the filter
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal([1, 'h3'])
+
+    # Update h2 to have d1=0, but d2 is still 1, so it shouldn't match
+    conn.execute_command('HSET', 'h2', 'd1', '0')
+
+    # h2 still shouldn't be indexed (d2=1 != 0)
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal([1, 'h3'])
+
+    # Update h2 to match the filter completely
+    conn.execute_command('HSET', 'h2', 'd2', '0')
+
+    # Now h2 should be indexed
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'NOCONTENT')
+    env.assertEqual(res[0], 2)
+    env.assertContains('h2', res)
+    env.assertContains('h3', res)


### PR DESCRIPTION
## Summary
Backport of commit 2ed184137 from master to 8.6 branch.

This PR fixes an indexing discrepancy where documents were incorrectly indexed when the filter expression evaluation should have failed (e.g., due to missing fields).

Related Jira: [MOD-14330](https://redislabs.atlassian.net/browse/MOD-14330)
Original PR: #8320

## Conflicts Resolved

The following conflicts were encountered during the cherry-pick and resolved as follows:

### 1. `src/aggregate/expr/expression.c`
- **Conflict**: In `EvalCtx_Create()`, the 8.6 branch had `RLookup_Init(&r->lk, NULL)` and `RLookupRow _row = {0}; r->row = _row;` initialization calls that were added by the previous backport (MOD-14063), while the MOD-13948 commit removes these lines.
- **Resolution**: Accepted the incoming change (removed the lines) since the purpose of MOD-13948 is to fix the indexing discrepancy by removing this initialization.

### 2. `tests/pytests/test_filter.py`
- **Conflict**: Modify/delete conflict - the file was deleted in HEAD (8.6 before MOD-14063 backport) and modified in the incoming commit.
- **Resolution**: Kept the modified version from MOD-13948 since the file was re-added by the previous MOD-14063 backport and this commit adds new test cases (`testFilterWithMissingFields`).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14330]: https://redislabs.atlassian.net/browse/MOD-14330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schema-rule filter evaluation during indexing/updates so documents are excluded when the filter can’t be evaluated (e.g., missing fields), which can alter which documents end up indexed. Scope is limited but touches core indexing decision logic.
> 
> **Overview**
> Fixes a discrepancy where documents could be indexed even when an index `FILTER` expression fails to evaluate (for example, when referenced fields are missing).
> 
> Filter evaluation is now centralized via `SchemaRule_FilterPasses()` and used consistently during schema-rule matching, so *only* documents with a successfully-evaluated, truthy filter result are indexed. Adds a regression test covering missing-field filter behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1492d4a92c067e6bb9cf1c28bacb1dcbf5b3cf96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->