### PR TITLE
[8.6] MOD-14064: Avoid loading and evaluating filter expressions for indexes that do not match the document type

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -182,7 +182,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
     case key_trimmed_cmd:
     case expired_cmd:
     case evicted_cmd:
-      Indexes_DeleteMatchingWithSchemaRules(ctx, key, hashFields);
+      Indexes_DeleteMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
       break;
 
     case change_cmd:
@@ -196,7 +196,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
       if (kType == DocumentType_Unsupported) {
         // in crdt empty key means that key was deleted
         // TODO:FIX
-        Indexes_DeleteMatchingWithSchemaRules(ctx, key, hashFields);
+        Indexes_DeleteMatchingWithSchemaRules(ctx, key, kType, hashFields);
       } else {
         // todo: here we will open the key again, we can optimize it by
         //       somehow passing the key pointer

--- a/src/spec.c
+++ b/src/spec.c
@@ -3748,7 +3748,7 @@ size_t Indexes_Count() {
 }
 
 SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
-                                                   bool runFilters,
+                                                   DocumentType type, bool runFilters,
                                                    RedisModuleString *keyToReadData) {
   if (!keyToReadData) {
     keyToReadData = key;
@@ -3785,6 +3785,12 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
       StrongRef global = node->index_specs[j];
       IndexSpec *spec = StrongRef_Get(global);
       if (spec && !dictFind(specs, spec->specName)) {
+        // skip if document type does not match the index type
+        // The unsupported type is needed for crdt empty keys (deleted)
+        if (type != DocumentType_Unsupported && type != spec->rule->type) {
+          continue;
+        }
+
         SpecOpCtx specOp = {
             .spec = spec,
             .op = SpecOp_Add,
@@ -3862,19 +3868,14 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
                                            RedisModuleString **hashFields) {
   if (type == DocumentType_Unsupported) {
     // COPY could overwrite a hash/json with other types so we must try and remove old doc
-    Indexes_DeleteMatchingWithSchemaRules(ctx, key, hashFields);
+    Indexes_DeleteMatchingWithSchemaRules(ctx, key, type, hashFields);
     return;
   }
 
-  SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, true, NULL);
+  SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, type, true, NULL);
 
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
-
-    // skip if document type does not match the index type
-    if (type != specOp->spec->rule->type) {
-      continue;
-    }
 
     if (hashFieldChanged(specOp->spec, hashFields)) {
       if (specOp->op == SpecOp_Add) {
@@ -3889,8 +3890,9 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
 }
 
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
+                                           DocumentType type,
                                            RedisModuleString **hashFields) {
-  SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, false, NULL);
+  SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, type, false, NULL);
 
   for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
     SpecOpCtx *specOp = specs->specsOps + i;
@@ -3909,8 +3911,8 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
     return;
   }
 
-  SpecOpIndexingCtx *from_specs = Indexes_FindMatchingSchemaRules(ctx, from_key, true, to_key);
-  SpecOpIndexingCtx *to_specs = Indexes_FindMatchingSchemaRules(ctx, to_key, true, NULL);
+  SpecOpIndexingCtx *from_specs = Indexes_FindMatchingSchemaRules(ctx, from_key, type, true, to_key);
+  SpecOpIndexingCtx *to_specs = Indexes_FindMatchingSchemaRules(ctx, to_key, type, true, NULL);
 
   size_t from_len, to_len;
   const char *from_str = RedisModule_StringPtrLen(from_key, &from_len);

--- a/src/spec.h
+++ b/src/spec.h
@@ -724,6 +724,7 @@ void Indexes_Propagate(RedisModuleCtx *ctx);
 void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type,
                                            RedisModuleString **hashFields);
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
+                                           DocumentType type,
                                            RedisModuleString **hashFields);
 void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *from_key,
                                             RedisModuleString *to_key);


### PR DESCRIPTION
## Summary
Backport of commit 27e2e31d6 from master to 8.6 branch.

This PR avoids loading and evaluating filter expressions for indexes that do not match the document type (e.g., HASH vs JSON), improving performance and correctness.

Related Jira: [MOD-14331](https://redislabs.atlassian.net/browse/MOD-14331)
Original PR: #8378

## Conflicts Resolved

**No conflicts** - cherry-pick applied cleanly.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14331]: https://redislabs.atlassian.net/browse/MOD-14331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indexing notification paths and schema matching logic; incorrect type detection or rule matching could cause missed updates/deletes for some indexes, though the change is narrowly scoped to type-based filtering.
> 
> **Overview**
> **Release note:** Improves indexing performance and correctness by only loading/evaluating schema `FILTER` expressions for indexes whose configured document type (HASH vs JSON) matches the updated key.
> 
> This threads the detected `DocumentType` through schema-rule matching and delete/update paths (including rename/copy and CRDT deleted-key cases) so irrelevant indexes are skipped earlier, reducing unnecessary work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc3dde73179ec00cba5b98d2888a25a9100a63d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->