### PR TITLE
check_lints: fix false positives on GitHub line-number anchors

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -204,7 +204,9 @@ class LinkChecker:
             response.raise_for_status()
 
             # If there's an anchor, verify it exists in the HTML
-            if anchor:
+            # GitHub line-number anchors (e.g., #L207, #L207-L226) are rendered
+            # client-side via JavaScript and won't appear in static HTML.
+            if anchor and not re.match(r'^L\d+(-L\d+)?$', anchor):
                 content_type = response.headers.get('content-type', '').lower()
                 if 'text/html' in content_type:
                     soup = BeautifulSoup(response.content, 'html.parser')


### PR DESCRIPTION
GitHub renders line-number anchors (#L207, #L207-L226) client-side via JavaScript, so they don't appear in static HTML fetched by requests. Skip anchor verification for these patterns.

Fixing CI: https://github.com/RediSearch/RediSearch/actions/runs/22662196875/job/65684912307?pr=8585


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to link-checking logic that only skips HTML anchor validation for a specific GitHub-generated fragment pattern.
> 
> **Overview**
> Reduces false positives in `scripts/check_links.py` by skipping anchor existence checks when the URL fragment matches GitHub line-number anchors like `#L207` or `#L207-L226`, which are rendered client-side and don’t appear in the fetched static HTML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac87de42a75d137eae0d0623ebbc1072e9e1d902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->