### PR TITLE
[8.4] MOD-14062: Notification handler for `rename` is loading the wrong key

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3676,6 +3676,9 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   TrieMapResultBuf_Free(prefixes);
 
   if (runFilters) {
+    // We load the data from the `keyToReadData` key, which is the key the old
+    // key was changed to, since the old key is already deleted.
+    key_p = RedisModule_StringPtrLen(keyToReadData, NULL);
 
     EvalCtx *r = NULL;
     for (size_t i = 0; i < array_len(res->specsOps); ++i) {
@@ -3685,7 +3688,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
         continue;
       }
 
-      // load hash only if required
+      // load document only if required
       if (!r) r = EvalCtx_Create();
       RLookup_LoadRuleFields(ctx, &r->lk, &r->row, spec, key_p);
 

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -194,16 +194,9 @@ def testRename(env):
     env.expect('ft.search things foo').equal([0])
     env.expect('ft.search otherthings foo').equal([1, 'otherthing:foo', ['name', 'foo']])
 
+    # Test that renaming a String key (unrelated type) does not crash
     env.cmd('SET foo bar')
     env.cmd('RENAME foo fubu')
-
-@skip(cluster=True)
-def testRenameChangePrefix(env):
-    env.cmd('ft.create idx1 PREFIX 1 1: SCHEMA name text')
-    env.cmd('ft.create idx2 PREFIX 1 2: SCHEMA name text')
-
-    env.cmd('SET 1:1 bar')
-    env.expect('RENAME 1:1 2:1').ok()
 
 @skip(cluster=True)
 def testCopy(env):
@@ -692,6 +685,101 @@ def testIssue1571WithRename(env):
 
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', 'foo*')), toSortedFlatList([1, 'idx1:{doc}1', ['t', 'foo1', 'index', 'yes']]))
     env.expect('ft.search', 'idx2', 'foo*').equal([0])
+
+@skip(cluster=True)
+def testRenameWithFilterUsingFieldValueBetweenIndexes(env):
+    """
+    Test RENAME between different indexes where both have FILTER expressions
+    that read field values. This tests that filters are correctly evaluated
+    using the data from the new key location.
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create two indexes with different prefixes but same filter expression
+    env.cmd('ft.create', 'idx1',
+            'PREFIX', '1', 'prefix1:',
+            'FILTER', '@category=="books"',
+            'SCHEMA', 'title', 'TEXT', 'category', 'TAG')
+
+    env.cmd('ft.create', 'idx2',
+            'PREFIX', '1', 'prefix2:',
+            'FILTER', '@category=="books"',
+            'SCHEMA', 'title', 'TEXT', 'category', 'TAG')
+
+    # Add a document that matches idx1's prefix and filter
+    conn.execute_command('hset', 'prefix1:item', 'title', 'mybook', 'category', 'books')
+
+    # Verify it's in idx1 and not in idx2
+    env.expect('ft.search', 'idx1', 'mybook').equal([1, 'prefix1:item', ['title', 'mybook', 'category', 'books']])
+    env.expect('ft.search', 'idx2', 'mybook').equal([0])
+
+    # Rename to idx2's prefix - the filter should still pass because
+    # we read the field value from the new key location
+    env.expect('RENAME prefix1:item prefix2:item').ok()
+
+    # Verify it moved to idx2
+    env.expect('ft.search', 'idx1', 'mybook').equal([0])
+    env.expect('ft.search', 'idx2', 'mybook').equal([1, 'prefix2:item', ['title', 'mybook', 'category', 'books']])
+
+@skip(cluster=True)
+def testRenameWithFilterExcludingDocument(env):
+    """
+    Test RENAME where the target index's filter would exclude the document.
+    The document should not be indexed in the target index.
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a filter that checks field value
+    env.cmd('ft.create', 'idx1',
+            'PREFIX', '1', 'prefix1:',
+            'FILTER', '@type=="allowed"',
+            'SCHEMA', 'data', 'TEXT', 'type', 'TAG')
+
+    env.cmd('ft.create', 'idx2',
+            'PREFIX', '1', 'prefix2:',
+            'FILTER', '@type=="special"',
+            'SCHEMA', 'data', 'TEXT', 'type', 'TAG')
+
+    # Add a document that matches idx1's filter but NOT idx2's filter
+    conn.execute_command('hset', 'prefix1:doc', 'data', 'hello', 'type', 'allowed')
+
+    # Verify it's in idx1
+    env.expect('ft.search', 'idx1', 'hello').equal([1, 'prefix1:doc', ['data', 'hello', 'type', 'allowed']])
+    env.expect('ft.search', 'idx2', 'hello').equal([0])
+
+    # Rename to idx2's prefix - but the filter should NOT pass
+    # because type != "special"
+    env.expect('RENAME prefix1:doc prefix2:doc').ok()
+
+    # Document should be removed from idx1 and NOT added to idx2
+    env.expect('ft.search', 'idx1', 'hello').equal([0])
+    env.expect('ft.search', 'idx2', 'hello').equal([0])
+
+@skip(cluster=True)
+def testRenameToSameName(env):
+    """
+    Test RENAME to the same name (e.g., RENAME prefix1:doc prefix1:doc).
+    This should be a no-op and the document should remain in the index.
+    """
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a filter
+    env.cmd('ft.create', 'idx1',
+            'PREFIX', '1', 'prefix1:',
+            'FILTER', '@type=="allowed"',
+            'SCHEMA', 'data', 'TEXT', 'type', 'TAG')
+
+    # Add a document
+    conn.execute_command('hset', 'prefix1:doc', 'data', 'hello', 'type', 'allowed')
+
+    # Verify it's in idx1
+    env.expect('ft.search', 'idx1', 'hello').equal([1, 'prefix1:doc', ['data', 'hello', 'type', 'allowed']])
+
+    # Rename to same name - should be a no-op
+    env.expect('RENAME prefix1:doc prefix1:doc').ok()
+
+    # Document should still be in idx1
+    env.expect('ft.search', 'idx1', 'hello').equal([1, 'prefix1:doc', ['data', 'hello', 'type', 'allowed']])
 
 @skip(msan=True, no_json=True)
 def testIdxFieldJson(env):


### PR DESCRIPTION
## Summary
Backport of commit ce07ca232 from master to 8.4 branch.

This PR fixes an issue where the notification handler for `rename` was loading the wrong key, causing incorrect indexing behavior when documents are renamed across index prefixes.

Related Jira: [MOD-14333](https://redislabs.atlassian.net/browse/MOD-14333)
Original PR: #8377

## Conflicts Resolved

**No conflicts** - cherry-pick applied cleanly.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14333]: https://redislabs.atlassian.net/browse/MOD-14333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches keyspace notification handling for `RENAME`, which impacts real-time indexing correctness across multiple indexes. Risk is mitigated by added/updated regression tests covering filtered rename scenarios and no-op renames.
> 
> **Overview**
> Fixes a bug where `RENAME` notifications could evaluate index `FILTER` expressions against the *old* (already-deleted) key, leading to incorrect reindexing when moving documents between index prefixes.
> 
> Updates filter evaluation to load fields from the renamed key (`keyToReadData`), and adds regression tests for renames between filtered indexes (both inclusion and exclusion) plus `RENAME` to the same key name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34d2a2291e3af4d006199aac78f5a0970790f11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->