### PR TITLE
[MOD-14315] implement Tag inverted index iterator in Rust

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "thiserror",
+ "trie_rs",
  "types_ffi",
  "value",
  "value_ffi",

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -88,6 +88,7 @@ fn main() {
         src.join("sortable.h"),
         src.join("spec.h"),
         src.join("stopwords.h"),
+        src.join("tag_index.h"),
         src.join("trie").join("trie.h"),
         src.join("trie").join("trie_type.h"),
         src.join("ttl_table").join("ttl_table.h"),

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -23,6 +23,7 @@ numeric_range_tree.workspace = true
 query_error.workspace = true
 query_term.workspace = true
 thiserror.workspace = true
+trie_rs = { path = "../trie_rs" }
 redis_mock.workspace = true
 value_ffi = { path = "../c_entrypoint/value_ffi" }
 types_ffi = { path = "../c_entrypoint/types_ffi" }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -12,11 +12,13 @@
 mod core;
 mod missing;
 mod numeric;
+mod tag;
 mod term;
 mod wildcard;
 
 pub use core::InvIndIterator;
 pub use missing::Missing;
 pub use numeric::Numeric;
+pub use tag::Tag;
 pub use term::Term;
 pub use wildcard::Wildcard;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::ptr::NonNull;
+
+use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, TagIndex, t_docId};
+use inverted_index::{
+    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RSIndexResult, RSOffsetSlice,
+    opaque::OpaqueEncoding,
+};
+use query_term::RSQueryTerm;
+
+use crate::{ExpirationChecker, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+
+use super::InvIndIterator;
+
+/// An iterator over documents matching a specific tag value.
+///
+/// Used for tag queries where the goal is to match every document that has
+/// a specific tag value indexed.
+///
+/// This iterator supports per-field expiration checks via
+/// [`FieldExpirationChecker`](crate::FieldExpirationChecker) using the
+/// [`Default`](field::FieldExpirationPredicate::Default) predicate.
+///
+/// # Type Parameters
+///
+/// * `'index` - The lifetime of the index being iterated over.
+/// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
+/// * `C` - The expiration checker type.
+pub struct Tag<'index, E, C = crate::expiration_checker::NoOpChecker> {
+    it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
+    tag_index: NonNull<TagIndex>,
+}
+
+impl<'index, E, C> Tag<'index, E, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker,
+{
+    /// Create an iterator returning documents matching the given tag value.
+    ///
+    /// `term` is the query term representing the tag value. It is stored in the
+    /// result and used during revalidation to look up the tag's inverted index
+    /// in the [`TagIndex`]'s [`TrieMap`](trie_rs::opaque::TrieMap).
+    ///
+    /// `weight` is the scoring weight applied to the result record.
+    ///
+    /// # Safety
+    ///
+    /// 1. `context` must point to a valid [`RedisSearchCtx`].
+    /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
+    /// 3. `tag_index` must point to a valid [`TagIndex`].
+    /// 4. `tag_index` must remain valid for the lifetime of the iterator.
+    /// 5. `tag_index.values` must be a valid non-null [`TrieMap`](trie_rs::opaque::TrieMap) pointer.
+    /// 6. The entry in `tag_index.values` for the tag value, when non-null,
+    ///    must point to an opaque
+    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
+    ///    variant matches `E`.
+    pub unsafe fn new(
+        reader: IndexReaderCore<'index, E>,
+        context: NonNull<RedisSearchCtx>,
+        tag_index: NonNull<TagIndex>,
+        mut term: Box<RSQueryTerm>,
+        weight: f64,
+        expiration_checker: C,
+    ) -> Self {
+        // Compute IDF scores on the term.
+        // SAFETY: 1. guarantees context is valid.
+        let context_ref = unsafe { context.as_ref() };
+        debug_assert!(!context_ref.spec.is_null(), "context.spec must be non-null",);
+        // SAFETY: 2. guarantees spec is valid.
+        let spec = unsafe { &*context_ref.spec };
+        let total_docs = spec.stats.scoring.numDocuments;
+        let term_docs = reader.unique_docs() as usize;
+        term.set_idf(idf::calculate_idf(total_docs, term_docs));
+        term.set_bm25_idf(idf::calculate_idf_bm25(total_docs, term_docs));
+
+        // Check 6.: the trie entry's encoding variant matches E.
+        debug_assert!(
+            {
+                // SAFETY: 3. and 4. guarantee tag_index is valid.
+                let tag_idx = unsafe { tag_index.as_ref() };
+                if !tag_idx.values.is_null() {
+                    let term_bytes = term
+                        .as_bytes()
+                        .expect("Tag iterator query term should have a non-null string");
+                    // SAFETY: 5. guarantees values is a valid TrieMap.
+                    let trie = unsafe { &*tag_idx.values.cast::<trie_rs::opaque::TrieMap>() };
+                    // If the entry exists, `from_opaque` panics when the variant doesn't match E.
+                    if let Some(idx) = trie.find(term_bytes) {
+                        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
+                        // SAFETY: 6. guarantees the trie entry points to a valid opaque InvertedIndex.
+                        let _ = E::from_opaque(unsafe { &*opaque });
+                    }
+                }
+                true
+            },
+            "tag_index entry for the tag value must have an encoding variant matching E",
+        );
+
+        let result = RSIndexResult::with_term(term, RSOffsetSlice::empty(), 0, RS_FIELDMASK_ALL, 1)
+            .weight(weight);
+
+        Self {
+            it: InvIndIterator::new(reader, result, expiration_checker),
+            tag_index,
+        }
+    }
+
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The garbage collector may remove all documents from a tag value's
+    /// inverted index or replace it with a new allocation. In both cases the
+    /// reader's pointer is stale and the iterator must
+    /// [`abort`](RQEValidateStatus::Aborted).
+    fn should_abort(&self) -> bool {
+        let term = self
+            .it
+            .result
+            .as_term()
+            .expect("Tag iterator should always have a term result")
+            .query_term()
+            .expect("Tag iterator should always have a query term");
+
+        // Look up the tag value in the TagIndex's TrieMap.
+        // SAFETY: 3. and 4. guarantee `tag_index` is valid.
+        let tag_idx = unsafe { self.tag_index.as_ref() };
+
+        debug_assert!(
+            !tag_idx.values.is_null(),
+            "tag_index.values must be non-null",
+        );
+        let term_bytes = term
+            .as_bytes()
+            .expect("Tag iterator query term should have a non-null string");
+        // SAFETY: 5. guarantees `tag_idx.values` is a valid `triemap_ffi::TrieMap`
+        // created by `NewTrieMap`.
+        let trie = unsafe { &*tag_idx.values.cast::<trie_rs::opaque::TrieMap>() };
+
+        let Some(idx) = trie.find(term_bytes) else {
+            // The inverted index was collected entirely by GC, or the
+            // value is a null sentinel (disk mode).
+            return true;
+        };
+
+        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
+        // SAFETY: 6. guarantees the encoding variant matches E.
+        // `find` guarantees the pointer is non-null.
+        let ii = E::from_opaque(unsafe { &*opaque });
+
+        !self.it.reader.points_to_ii(ii)
+    }
+
+    /// Get a reference to the underlying reader.
+    pub const fn reader(&self) -> &IndexReaderCore<'index, E> {
+        &self.it.reader
+    }
+}
+
+impl<'index, E, C> RQEIterator<'index> for Tag<'index, E, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker,
+{
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.it.current()
+    }
+
+    #[inline(always)]
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        self.it.read()
+    }
+
+    #[inline(always)]
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        self.it.skip_to(doc_id)
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        self.it.rewind()
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        self.it.last_doc_id()
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        self.it.at_eof()
+    }
+
+    #[inline(always)]
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        if self.should_abort() {
+            return Ok(RQEValidateStatus::Aborted);
+        }
+
+        self.it.revalidate()
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -32,7 +32,7 @@ pub use empty::Empty;
 pub use expiration_checker::{ExpirationChecker, FieldExpirationChecker, NoOpChecker};
 pub use id_list::IdList;
 pub use intersection::Intersection;
-pub use inverted_index::{Missing, Numeric, Term};
+pub use inverted_index::{Missing, Numeric, Tag, Term};
 pub use metric::Metric;
 pub use wildcard::{Wildcard, WildcardIterator};
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/mod.rs
@@ -8,6 +8,7 @@
 */
 mod missing;
 mod numeric;
+mod tag;
 mod term;
 mod utils;
 mod wildcard;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for the tag inverted index iterator.
+
+use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
+use inverted_index::{RSIndexResult, RSResultData, RSTermRecord, doc_ids_only::DocIdsOnly};
+use query_term::RSQueryTerm;
+use rqe_iterators::{NoOpChecker, RQEIterator, inverted_index::Tag};
+use rqe_iterators_test_utils::MockContext;
+
+use crate::inverted_index::utils::BaseTest;
+
+struct TagBaseTest {
+    test: BaseTest<DocIdsOnly>,
+}
+
+impl TagBaseTest {
+    fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        RSIndexResult {
+            data: RSResultData::Term(RSTermRecord::new()),
+            doc_id,
+            field_mask: RS_FIELDMASK_ALL,
+            freq: 1,
+            dmd: std::ptr::null(),
+            metrics: std::ptr::null_mut(),
+            weight: 0.0,
+        }
+    }
+
+    fn new(n_docs: u64) -> Self {
+        Self {
+            test: BaseTest::new(
+                IndexFlags_Index_DocIdsOnly,
+                Box::new(Self::expected_record),
+                n_docs,
+            ),
+        }
+    }
+
+    fn create_term() -> Box<RSQueryTerm> {
+        RSQueryTerm::new("test_tag", 0, 0)
+    }
+
+    fn create_iterator(&self) -> Tag<'_, DocIdsOnly, NoOpChecker> {
+        let reader = self.test.ii.reader();
+        let term = Self::create_term();
+        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
+        // that outlives the returned iterator. The TagIndex pointer points to a
+        // zeroed struct which is fine since NoOpChecker doesn't trigger revalidation
+        // lookups, and `should_abort` is not called in basic tests.
+        unsafe {
+            Tag::new(
+                reader,
+                self.test.mock_ctx.sctx(),
+                self.test.mock_ctx.tag_index(),
+                term,
+                0.0,
+                NoOpChecker,
+            )
+        }
+    }
+}
+
+#[test]
+fn tag_read() {
+    let test = TagBaseTest::new(100);
+    let mut it = test.create_iterator();
+    test.test.read(&mut it, test.test.docs_ids_iter());
+}
+
+#[test]
+fn tag_skip_to() {
+    let test = TagBaseTest::new(10);
+    let mut it = test.create_iterator();
+    test.test.skip_to(&mut it);
+}
+
+#[test]
+fn tag_empty_index() {
+    let ii = inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    let mock_ctx = MockContext::new(0, 0);
+
+    let reader = ii.reader();
+    let term = RSQueryTerm::new("test_tag", 0, 0);
+    // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
+    // that outlives the iterator.
+    let mut it = unsafe {
+        Tag::new(
+            reader,
+            mock_ctx.sctx(),
+            mock_ctx.tag_index(),
+            term,
+            0.0,
+            NoOpChecker,
+        )
+    };
+
+    // Should immediately be at EOF
+    assert!(it.read().expect("read failed").is_none());
+    assert!(it.at_eof());
+}
+
+#[cfg(not(miri))]
+// Creating the [`rqe_iterators_test_utils::TestContext`] requires ffi calls which are not supported by miri.
+mod not_miri {
+    use super::*;
+    use crate::inverted_index::utils::{RevalidateIndexType, RevalidateTest};
+    use inverted_index::opaque::OpaqueEncoding;
+    use rqe_iterators::RQEValidateStatus;
+    use std::ffi::c_void;
+
+    struct TagRevalidateTest {
+        test: RevalidateTest,
+    }
+
+    impl TagRevalidateTest {
+        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+            RSIndexResult {
+                data: RSResultData::Term(RSTermRecord::new()),
+                doc_id,
+                field_mask: RS_FIELDMASK_ALL,
+                freq: 1,
+                dmd: std::ptr::null(),
+                metrics: std::ptr::null_mut(),
+                weight: 0.0,
+            }
+        }
+
+        fn new(n_docs: u64) -> Self {
+            Self {
+                test: RevalidateTest::new(
+                    RevalidateIndexType::Tag,
+                    Box::new(Self::expected_record),
+                    n_docs,
+                ),
+            }
+        }
+
+        fn create_iterator(&self) -> Tag<'_, DocIdsOnly, NoOpChecker> {
+            let ii = DocIdsOnly::from_opaque(self.test.context.tag_inverted_index());
+            let tag_index = self.test.context.tag_index();
+            let term = RSQueryTerm::new("test_tag", 0, 0);
+            // SAFETY: `self.test.context` provides a valid `RedisSearchCtx` with a valid
+            // `spec` and `TagIndex` that outlive the returned iterator.
+            unsafe {
+                Tag::new(
+                    ii.reader(),
+                    self.test.context.sctx,
+                    tag_index,
+                    term,
+                    0.0,
+                    NoOpChecker,
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn tag_revalidate_basic() {
+        let test = TagRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        test.test.revalidate_basic(&mut it);
+    }
+
+    #[test]
+    fn tag_revalidate_at_eof() {
+        let test = TagRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        test.test.revalidate_at_eof(&mut it);
+    }
+
+    #[test]
+    fn tag_revalidate_after_index_disappears() {
+        let test = TagRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+
+        // Verify the iterator works normally and read at least one document
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Ok
+        );
+        assert!(it.read().expect("failed to read").is_some());
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Ok
+        );
+
+        // Simulate the tag's inverted index being garbage collected and
+        // recreated by replacing the TrieMap entry with a new inverted index.
+        let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+            inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+        )));
+
+        // Save the old II pointer so we can free it after the test.
+        let old_ii: *mut inverted_index::opaque::InvertedIndex =
+            (test.test.context.tag_inverted_index() as *mut inverted_index::opaque::InvertedIndex)
+                .cast();
+
+        let tag_index = test.test.context.tag_index();
+
+        // Delete the old entry then add the new one.
+        // The iterator's reader holds a (now-dangling) raw pointer to the
+        // original II, but `should_abort` only compares pointers via
+        // `points_to_ii` (`std::ptr::eq`) without dereferencing it.
+        // SAFETY: `tag_index` is valid (created by `TagIndex_Ensure`), `values`
+        // is a valid TrieMap.
+        let trie = unsafe { &mut *tag_index.as_ref().values.cast::<trie_rs::opaque::TrieMap>() };
+        let old_val = trie.remove(b"test_tag");
+        assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
+        let prev = trie.insert(b"test_tag", new_ii as *mut c_void);
+        assert!(prev.is_none(), "insert should return None for new entry");
+
+        // Revalidate should return Aborted because the tag II no longer
+        // points to the same index the reader was created from.
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Aborted
+        );
+
+        // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
+        // and has not been freed. We are the sole owner after removing it from the TrieMap.
+        // The new II will be freed when the TrieMap is freed during TagIndex cleanup.
+        unsafe { drop(Box::from_raw(old_ii)) };
+    }
+
+    #[test]
+    fn tag_revalidate_after_document_deleted() {
+        let test = TagRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+        let ii = DocIdsOnly::from_mut_opaque(test.test.context.tag_inverted_index());
+
+        test.test.revalidate_after_document_deleted(&mut it, ii);
+    }
+
+    /// Test that revalidation returns `Aborted` when the tag value is removed
+    /// from the TagIndex's TrieMap, simulating the garbage collector removing
+    /// all documents for this tag.
+    #[test]
+    fn tag_revalidate_after_triemap_entry_removed() {
+        let test = TagRevalidateTest::new(10);
+        let mut it = test.create_iterator();
+
+        // Read at least one document so the iterator has a position.
+        assert!(it.read().expect("failed to read").is_some());
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Ok
+        );
+
+        // Save the old II pointer so we can free it after the test.
+        let old_ii: *mut inverted_index::opaque::InvertedIndex =
+            (test.test.context.tag_inverted_index() as *mut inverted_index::opaque::InvertedIndex)
+                .cast();
+
+        // Simulate the garbage collector removing the tag's inverted index
+        // by deleting the TrieMap entry.
+        let tag_index = test.test.context.tag_index();
+        // SAFETY: `tag_index` is valid (created by `TagIndex_Ensure`), `values`
+        // is a valid TrieMap.
+        let trie = unsafe { &mut *tag_index.as_ref().values.cast::<trie_rs::opaque::TrieMap>() };
+        let old_val = trie.remove(b"test_tag");
+        assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
+
+        // `should_abort` sees the tag value is missing and returns true.
+        assert_eq!(
+            it.revalidate().expect("revalidate failed"),
+            RQEValidateStatus::Aborted
+        );
+
+        // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
+        // and has not been freed. We are the sole owner after removing it from the TrieMap.
+        unsafe { drop(Box::from_raw(old_ii)) };
+    }
+
+    /// Test that `reader()` returns a reference to the underlying reader.
+    #[test]
+    fn tag_reader_accessor() {
+        let test = TagRevalidateTest::new(10);
+        let it = test.create_iterator();
+
+        let reader = it.reader();
+        let ii = DocIdsOnly::from_opaque(test.test.context.tag_inverted_index());
+        assert!(reader.points_to_ii(ii));
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -446,6 +446,7 @@ pub enum RevalidateIndexType {
     Term,
     Wildcard,
     Missing,
+    Tag,
 }
 
 /// Test the revalidation of the iterator.
@@ -480,6 +481,7 @@ impl RevalidateTest {
             }
             RevalidateIndexType::Wildcard => TestContext::wildcard(doc_ids.iter().copied()),
             RevalidateIndexType::Missing => TestContext::missing(doc_ids.iter().copied()),
+            RevalidateIndexType::Tag => TestContext::tag(doc_ids.iter().copied()),
         };
 
         Self {

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -27,6 +27,7 @@ pub struct MockContext {
     sctx: *mut RedisSearchCtx,
     qctx: *mut QueryEvalCtx,
     numeric_range_tree: *mut NumericRangeTree,
+    tag_index: *mut ffi::TagIndex,
 }
 
 impl Drop for MockContext {
@@ -50,6 +51,10 @@ impl Drop for MockContext {
                 std::alloc::Layout::new::<QueryEvalCtx>(),
             );
             let _ = Box::from_raw(self.numeric_range_tree);
+            std::alloc::dealloc(
+                self.tag_index as *mut u8,
+                std::alloc::Layout::new::<ffi::TagIndex>(),
+            );
         }
     }
 }
@@ -67,6 +72,12 @@ impl MockContext {
         let sctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<RedisSearchCtx>() }));
         let qctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<QueryEvalCtx>() }));
         let numeric_range_tree_ptr = Box::into_raw(Box::new(NumericRangeTree::new(false)));
+        // SAFETY: TagIndex is a C struct where all-zeros is a valid representation.
+        let tag_index_ptr: *mut ffi::TagIndex = unsafe {
+            let ptr = std::alloc::alloc_zeroed(std::alloc::Layout::new::<ffi::TagIndex>());
+            assert!(!ptr.is_null(), "allocation failed");
+            ptr.cast()
+        };
 
         // Initialize all structs through raw pointers
         unsafe {
@@ -99,6 +110,7 @@ impl MockContext {
                 sctx: sctx_ptr,
                 qctx: qctx_ptr,
                 numeric_range_tree: numeric_range_tree_ptr,
+                tag_index: tag_index_ptr,
             }
         }
     }
@@ -110,5 +122,10 @@ impl MockContext {
     /// Get the search context from the TestContext.
     pub const fn sctx(&self) -> NonNull<ffi::RedisSearchCtx> {
         NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
+    }
+
+    /// Get a zeroed [`TagIndex`](ffi::TagIndex) pointer for basic (non-revalidation) tests.
+    pub const fn tag_index(&self) -> NonNull<ffi::TagIndex> {
+        NonNull::new(self.tag_index).expect("TagIndex should not be null")
     }
 }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -110,6 +110,11 @@ enum TestContextInner {
         field_spec: ptr::NonNull<ffi::FieldSpec>,
         inverted_index: ptr::NonNull<ffi::InvertedIndex>,
     },
+    Tag {
+        field_spec: ptr::NonNull<ffi::FieldSpec>,
+        tag_index: ptr::NonNull<ffi::TagIndex>,
+        inverted_index: ptr::NonNull<ffi::InvertedIndex>,
+    },
 }
 
 /// Create a spec and search context from the given schema and index name.
@@ -414,6 +419,85 @@ impl TestContext {
         }
     }
 
+    /// Create a new [`TestContext`] with a tag inverted index for tag queries.
+    ///
+    /// Creates a TAG field, a `TagIndex` with a TrieMap, and adds a doc-ids-only
+    /// inverted index under the key `"test_tag"`.
+    ///
+    /// # Arguments
+    /// * `doc_ids` - An iterator over the document IDs to be indexed.
+    pub fn tag<I>(doc_ids: I) -> Self
+    where
+        I: Iterator<Item = u64>,
+    {
+        // Serialize TestContext creation to avoid concurrent access to C global state
+        let _lock = CONTEXT_MUTEX.lock().unwrap();
+
+        let ctx = ModuleCtx::new();
+        // Create IndexSpec with TAG field and unique name
+        let index_name = unique_index_name("tag_idx");
+        let (spec, sctx) = create_spec_sctx(&ctx, "SCHEMA tag_field TAG", &index_name);
+
+        // Get the field spec for the tag field
+        let field_name = CString::new("tag_field").unwrap();
+        let fs = unsafe {
+            ffi::IndexSpec_GetFieldWithLength(
+                spec.as_ptr(),
+                field_name.as_ptr(),
+                field_name.as_bytes().len(),
+            )
+        };
+        let field_spec: ptr::NonNull<ffi::FieldSpec> =
+            ptr::NonNull::new(fs as _).expect("FieldSpec should not be null");
+
+        // Create TagIndex via the C API (uses Redis allocator for proper cleanup)
+        let tag_index_raw = unsafe { ffi::TagIndex_Ensure(field_spec.as_ptr(), ptr::null_mut()) };
+        let tag_index = ptr::NonNull::new(tag_index_raw).expect("TagIndex should not be null");
+
+        // Create the tag inverted index for "test_tag" via TagIndex_OpenIndex
+        // (CREATE_INDEX = 1 creates a new DocIdsOnly inverted index in the TrieMap)
+        let tag_key = CString::new("test_tag").unwrap();
+        let mut sz: usize = 0;
+        let ii_ptr = unsafe {
+            ffi::TagIndex_OpenIndex(
+                tag_index_raw,
+                tag_key.as_ptr(),
+                tag_key.as_bytes().len(),
+                1, // CREATE_INDEX
+                &mut sz,
+            )
+        };
+        assert!(!ii_ptr.is_null(), "TagIndex_OpenIndex returned null");
+        let ii = ptr::NonNull::new(ii_ptr.cast()).expect("InvertedIndex should not be null");
+
+        // Populate with virtual records for each document ID.
+        // TagIndex_OpenIndex internally calls NewInvertedIndex_Ex, so the
+        // pointer is actually a Rust opaque InvertedIndex despite the C type.
+        let ii_opaque: *mut inverted_index::opaque::InvertedIndex = ii_ptr.cast();
+        for doc_id in doc_ids {
+            let record = RSIndexResult::virt().doc_id(doc_id);
+            // SAFETY: ii_opaque is a valid pointer created via TagIndex_OpenIndex
+            // which delegates to NewInvertedIndex_Ex (Rust FFI).
+            unsafe {
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
+                    ii_opaque,
+                    &record as *const _ as *mut _,
+                );
+            }
+        }
+
+        Self {
+            _ctx: ctx,
+            sctx,
+            spec,
+            inner: TestContextInner::Tag {
+                field_spec,
+                tag_index,
+                inverted_index: ii,
+            },
+        }
+    }
+
     /// Write a record to an inverted index using the ForwardIndexEntry FFI.
     fn write_forward_index_entry(idx: *mut ffi::InvertedIndex, record: &RSIndexResult) {
         let term = CString::new("term").unwrap();
@@ -479,7 +563,8 @@ impl TestContext {
         match self.inner {
             TestContextInner::Numeric { field_spec, .. }
             | TestContextInner::Term { field_spec, .. }
-            | TestContextInner::Missing { field_spec, .. } => unsafe { field_spec.as_ref() },
+            | TestContextInner::Missing { field_spec, .. }
+            | TestContextInner::Tag { field_spec, .. } => unsafe { field_spec.as_ref() },
             TestContextInner::Wildcard { .. } => panic!("Wildcard context has no field spec"),
         }
     }
@@ -577,6 +662,30 @@ impl TestContext {
                 unsafe { &mut *ii }
             }
             _ => panic!("TestContext is not a Missing context"),
+        }
+    }
+
+    /// Get the tag (doc-ids-only) inverted index for this context.
+    /// Returns a reference to the FFI inverted index wrapper.
+    /// Panics if this is not a tag context.
+    #[expect(clippy::mut_from_ref)] // need to get a mut for the revalidate_after_document_deleted test
+    pub fn tag_inverted_index(&self) -> &mut inverted_index_ffi::InvertedIndex {
+        match &self.inner {
+            TestContextInner::Tag { inverted_index, .. } => {
+                // SAFETY: inverted_index is a valid pointer created via NewInvertedIndex_Ex
+                let ii: *mut inverted_index_ffi::InvertedIndex = inverted_index.as_ptr().cast();
+                unsafe { &mut *ii }
+            }
+            _ => panic!("TestContext is not a Tag context"),
+        }
+    }
+
+    /// Get the tag index for this context.
+    /// Panics if this is not a tag context.
+    pub fn tag_index(&self) -> ptr::NonNull<ffi::TagIndex> {
+        match self.inner {
+            TestContextInner::Tag { tag_index, .. } => tag_index,
+            _ => panic!("TestContext is not a Tag context"),
         }
     }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Implement the inverted index tag query iterator in Rust. Porting the existing C++ tests to Rust as well.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tag-query iterator and supporting FFI/test context plumbing, including unsafe pointer/trie lookups during revalidation; bugs here could affect query correctness or stability under concurrent GC/index changes.
> 
> **Overview**
> Implements a new Rust `Tag` inverted-index iterator for tag queries, including IDF/BM25 term setup and revalidation logic that aborts when the underlying tag value’s index is removed or replaced.
> 
> Wires in required dependencies and FFI surface (`trie_rs`, `tag_index.h` bindgen) and extends integration tests/utilities to construct `TagIndex`/TrieMap-backed indices and validate read/`skip_to`/revalidation behaviors for tag queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd582377918e9c20b253433b921a0d31cbc83a39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->