### PR TITLE
[MOD-14319] RLookup - Create new lookup in each iteration

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3956,6 +3956,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
       QueryError_ClearError(r->ee.err);
       // Clean up the row and lookup between iterations (indexes)
       RLookup_Cleanup(&r->lk);
+      r->lk = RLookup_New();
       RLookupRow_Reset(&r->row);
     }
 


### PR DESCRIPTION
Create a new lookup in each iteration of the second loop of `Indexes_FindMatchingSchemaRules` to avoid problems with Cleanup being called twice.

Local benchmarks (2500 idx, 10000 docs)
this branch
254 s, 250 s, 251 s
master
259 s, 264 s, 271 s

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in `Indexes_FindMatchingSchemaRules` that changes how filter evaluation state is reset between iterations. Low risk, but it can affect which indexes a document is added/removed from if the previous lookup cleanup left state inconsistent.
> 
> **Overview**
> Fixes a cleanup/lifecycle issue when evaluating schema-rule `FILTER` expressions in `Indexes_FindMatchingSchemaRules`.
> 
> After each filter evaluation, the code now creates a fresh `RLookup` (`r->lk = RLookup_New()`) after `RLookup_Cleanup(&r->lk)`, preventing reuse of a cleaned-up lookup across iterations (and avoiding potential double-cleanup/state corruption).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59052610eacecae7ed60c64cb41c2e1ba47a51e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->