### PR TITLE
iterators_ffi: fix review findings from rust-review

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -67,7 +67,7 @@ unsafe fn new_id_list_iterator<const SORTED: bool>(
         // SAFETY: Safe thanks to 1
         unsafe { OwnedSlice::from_c(ids, num as usize) }
     } else {
-        // SAFETY thanks to 2
+        // Guaranteed by safety requirement 2.
         debug_assert_eq!(
             num, 0,
             "The pointer to the array of IDs is null, but the number of IDs is non-zero."

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -151,7 +151,6 @@ pub(super) type TermIterator<'index> =
 /// 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
 /// 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
 ///    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
-#[allow(improper_ctypes_definitions)] // `field_mask_or_index` contains `t_fieldMask` (u128)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     idx: *const ffi::InvertedIndex,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-#![allow(non_snake_case, non_upper_case_globals)]
+#![expect(non_upper_case_globals)]
 
 use ffi::{
     IteratorType_METRIC_SORTED_BY_ID_ITERATOR, IteratorType_METRIC_SORTED_BY_SCORE_ITERATOR,
@@ -74,7 +74,7 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
     _type: MetricType,
 ) -> *mut QueryIterator {
     let (ids_list, metrics_list) = if ids.is_null() {
-        // Safety: Safe thanks to 3
+        // SAFETY: Safe thanks to 3.
         debug_assert_eq!(
             num, 0,
             "The pointer to the array of IDs is null, but the number of IDs is non-zero."
@@ -87,9 +87,9 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
             "The pointer to the array of metric data is null, but the pointer to the array of IDs is not null."
         );
 
-        // Safety: Safe thanks to 1
+        // SAFETY: Safe thanks to 1.
         let ids_list = unsafe { OwnedSlice::from_c(ids, num) };
-        // Safety: Safe thanks to 2
+        // SAFETY: Safe thanks to 2.
         let metrics_list = unsafe { OwnedSlice::from_c(metrics, num) };
 
         (ids_list, metrics_list)

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
@@ -66,7 +66,8 @@ pub unsafe extern "C" fn GetOptionalNonOptimizedIteratorChild(
 }
 
 #[unsafe(no_mangle)]
-/// Take ownership over the child of the optional (non-optimized) iterator or
+/// Take ownership over the child of the optional (non-optimized) iterator,
+/// or return NULL if there is no child.
 ///
 /// # Safety
 ///

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -33,7 +33,7 @@ pub extern "C" fn NewWildcardIterator_NonOptimized(
 ///
 /// `it`, when non-null, must point to a valid [`QueryIterator`].
 #[unsafe(no_mangle)]
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const unsafe extern "C" fn IsWildcardIterator(it: *const QueryIterator) -> bool {
     // SAFETY: Caller guarantees `it`, when non-null, points to a valid `QueryIterator`.
     let Some(it) = (unsafe { it.as_ref() }) else {

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -364,7 +364,8 @@ QueryIterator *NewOptionalNonOptimizedIterator(QueryIterator *child, t_docId max
 const QueryIterator *GetOptionalNonOptimizedIteratorChild(const QueryIterator *header);
 
 /**
- * Take ownership over the child of the optional (non-optimized) iterator or
+ * Take ownership over the child of the optional (non-optimized) iterator,
+ * or return NULL if there is no child.
  *
  * # Safety
  *


### PR DESCRIPTION
- Fix lowercase // Safety: to // SAFETY: in metric.rs (project convention)
- Fix incomplete doc comment on TakeOptionalNonOptimizedIteratorChild
- Fix misleading SAFETY comment on non-unsafe code in id_list.rs
- Remove unfulfilled #[allow(non_snake_case)] from metric.rs
- Remove unfulfilled #[allow(improper_ctypes_definitions)] from term.rs
- Change #[allow(non_upper_case_globals)] to #[expect(...)] in metric.rs, wildcard.rs

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly comment/doc and lint-attribute cleanup in the Rust FFI iterator wrappers; behavior and ABI are unchanged, so risk is low aside from potential build/lint differences.
> 
> **Overview**
> Aligns `iterators_ffi` with review/convention feedback by tightening *SAFETY* annotations (including fixing a misleading safety note in `id_list.rs`) and standardizing comment casing in `metric.rs`.
> 
> Cleans up lint configuration by removing unneeded `#[allow(...)]` attributes (e.g., `improper_ctypes_definitions` in `term.rs`, `non_snake_case` in `metric.rs`) and switching `#[allow(non_upper_case_globals)]` to `#[expect(...)]` in `metric.rs`/`wildcard.rs`; also clarifies `TakeOptionalNonOptimizedIteratorChild` docs in both Rust and the generated `iterators_rs.h`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 679ece2601c976368d148d179ec7f1f50391dc3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->