### PR TITLE
rqe_iterators: run II skip_to tests with miri

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -165,10 +165,9 @@ fn numeric_read() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 /// test skipping from Numeric iterator
 fn numeric_skip_to() {
-    let test = NumericBaseTest::new(100);
+    let test = NumericBaseTest::new(10);
     let mut it = test.create_iterator();
     test.test.skip_to(&mut it);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -107,10 +107,9 @@ fn term_read() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 /// test skipping from Term iterator
 fn term_skip_to() {
-    let test = TermBaseTest::new(100);
+    let test = TermBaseTest::new(10);
     let mut it = test.create_iterator();
     test.test.skip_to(&mut it);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -55,9 +55,8 @@ fn wildcard_read() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn wildcard_skip_to() {
-    let test = WildcardBaseTest::new(100);
+    let test = WildcardBaseTest::new(10);
     let mut it = test.create_iterator();
     test.test.skip_to(&mut it);
 }


### PR DESCRIPTION
Reduce the number of results so they can be run with miri.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reduce fixture sizes and adjust Miri gating; low risk aside from potentially reducing coverage for skip behavior at larger scales.
> 
> **Overview**
> **Runs `skip_to` iterator integration tests under Miri.** Removes the `#[cfg_attr(miri, ignore = ...)]` guards and reduces the number of indexed documents from `100` to `10` in the `numeric_skip_to`, `term_skip_to`, and `wildcard_skip_to` tests so they complete in Miri.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f41ae1b4c0983a785fefc611feead356fb32a6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->