### PR TITLE
MOD-14371 fix move `RLookupLoadOptions` and `RLookupLoadFlags` to `rlookup_load_document.h`

### DIFF
--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -406,54 +406,6 @@ void RLookupRow_Wipe(RLookupRow *row);
  */
 void RLookupRow_Reset(RLookupRow *row);
 
-typedef enum {
-  /* Use keylist (keys/nkeys) for the fields to list */
-  RLOOKUP_LOAD_KEYLIST,
-  /* Load only cached keys (don't open keys) */
-  RLOOKUP_LOAD_SVKEYS,
-  /* Load all keys in the document */
-  RLOOKUP_LOAD_ALLKEYS,
-  /* Load all the keys in the RLookup object */
-  RLOOKUP_LOAD_LKKEYS
-} RLookupLoadFlags;
-
-typedef struct {
-  struct RedisSearchCtx *sctx;
-
-  /** Needed for the key name, and perhaps the sortable */
-  const RSDocumentMetadata *dmd;
-
-  /* Needed for rule filter where dmd does not exist */
-  const char *keyPtr;
-
-  DocumentType type;
-
-  /** Keys to load. If present, then loadNonCached and loadAllFields is ignored */
-  const RLookupKey **keys;
-
-  /** Number of keys in keys array */
-  size_t nkeys;
-
-  /**
-   * The following options control the loading of fields, in case non-SORTABLE
-   * fields are desired.
-   */
-  RLookupLoadFlags mode;
-
-  /**
-   * Don't use sortables when loading documents. This will enforce the loader to load
-   * the fields from the document itself, even if they are sortables and un-normalized.
-   */
-  bool forceLoad;
-
-  /**
-   * Force string return; don't coerce to native type
-   */
-  bool forceString;
-
-  struct QueryError *status;
-} RLookupLoadOptions;
-
 /**
  * Sets the `IndexSpecCache` of the lookup. If cache is provided, then it will be used as an
  * alternate source for lookups whose fields are absent

--- a/src/rlookup_load_document.h
+++ b/src/rlookup_load_document.h
@@ -14,6 +14,54 @@
 extern "C" {
 #endif
 
+typedef enum {
+  /* Use keylist (keys/nkeys) for the fields to list */
+  RLOOKUP_LOAD_KEYLIST,
+  /* Load only cached keys (don't open keys) */
+  RLOOKUP_LOAD_SVKEYS,
+  /* Load all keys in the document */
+  RLOOKUP_LOAD_ALLKEYS,
+  /* Load all the keys in the RLookup object */
+  RLOOKUP_LOAD_LKKEYS
+} RLookupLoadFlags;
+
+typedef struct {
+  struct RedisSearchCtx *sctx;
+
+  /** Needed for the key name, and perhaps the sortable */
+  const RSDocumentMetadata *dmd;
+
+  /* Needed for rule filter where dmd does not exist */
+  const char *keyPtr;
+
+  DocumentType type;
+
+  /** Keys to load. If present, then loadNonCached and loadAllFields is ignored */
+  const RLookupKey **keys;
+
+  /** Number of keys in keys array */
+  size_t nkeys;
+
+  /**
+   * The following options control the loading of fields, in case non-SORTABLE
+   * fields are desired.
+  */
+  RLookupLoadFlags mode;
+
+  /**
+   * Don't use sortables when loading documents. This will enforce the loader to load
+   * the fields from the document itself, even if they are sortables and un-normalized.
+   */
+  bool forceLoad;
+
+  /**
+   * Force string return; don't coerce to native type
+   */
+  bool forceString;
+
+  struct QueryError *status;
+} RLookupLoadOptions;
+
 int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options);
 
 int RLookup_LoadDocument(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *options);


### PR DESCRIPTION
Followup to #8558. Moves the `RLookupLoadOptions` and `RLookupLoadFlags` to `rlookup_load_document.h`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, header-only refactor that primarily affects compilation dependencies and include requirements. Potential issues would be limited to build breaks in code that relied on these types via `rlookup.h` alone.
> 
> **Overview**
> **Refactors header ownership for document loading types.** `RLookupLoadFlags` and `RLookupLoadOptions` are removed from the general `rlookup.h` API and re-declared in `rlookup_load_document.h`, aligning these types with the document-loading interfaces (`RLookup_LoadDocument`, `loadIndividualKeys`, etc.).
> 
> This reduces the surface area of `rlookup.h` and makes consumers explicitly include the document-loading header when using these options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2c1dc6f6743404adee5a67b0ee8a39b2ae0d5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->