### PR TITLE
MOD-14370 split `RLookup_LoadDocument` into Individual and All paths

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -912,8 +912,8 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
   }
 
   loadopts = (RLookupLoadOptions){.sctx = sctx, .dmd = dmd, .status = status};
-  if (RLookup_LoadDocument(&lookup_s, &row, &loadopts) != REDISMODULE_OK) {
-    goto done;
+  if (RLookup_LoadDocumentIndividual(&lookup_s, &row, &loadopts) != REDISMODULE_OK) {
+     goto done;
   }
 
   evaluator = (ExprEval){.err = status, .mode = EVAL_MODE_QUERY, .lookup = &lookup_s, .res = NULL, .srcrow = &row, .root = e};

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -470,7 +470,7 @@ fn load_specific_keys<'a>(
         type_: index_spec.rule().type_(),
         status: ptr::from_mut(status),
         forceLoad: true,
-        mode: ffi::RLookupLoadFlags_RLOOKUP_LOAD_KEYLIST,
+        cachedOnly: false,
         dmd: ptr::null(),
         forceString: false,
     };

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -850,6 +850,7 @@ typedef struct {
   ResultProcessor base;
   RLookup *lk;
   RLookupLoadOptions loadopts;
+  bool load_all;
   QueryError status;
 } RPLoader;
 
@@ -884,9 +885,17 @@ static void rpLoader_loadDocument(RPLoader *self, SearchResult *r) {
   }
 
   self->loadopts.dmd = SearchResult_GetDocumentMetadata(r);
+
+  int ret;
+  if (self->load_all) {
+      ret = RLookup_LoadDocumentAll(self->lk, SearchResult_GetRowDataMut(r), &self->loadopts);
+  } else {
+      ret = RLookup_LoadDocumentIndividual(self->lk, SearchResult_GetRowDataMut(r), &self->loadopts);
+  }
+
   // if loading the document has failed, we keep the row as it was.
   // Error code and message are ignored.
-  if (RLookup_LoadDocument(self->lk, SearchResult_GetRowDataMut(r), &self->loadopts) != REDISMODULE_OK) {
+  if (ret != REDISMODULE_OK) {
     // mark the document as "failed to open" for later loaders or other threads (optimization)
     ((RSDocumentMetadata *)(SearchResult_GetDocumentMetadata(r)))->flags |= Document_FailedToOpen;
     // The result contains an expired document.
@@ -923,13 +932,13 @@ static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLooku
   self->loadopts.status = &self->status;
   self->loadopts.sctx = sctx;
   self->loadopts.dmd = NULL;
-  self->loadopts.keys = rm_malloc(sizeof(*keys) * nkeys);
-  memcpy(self->loadopts.keys, keys, sizeof(*keys) * nkeys);
-  self->loadopts.nkeys = nkeys;
   if (nkeys) {
-    self->loadopts.mode = RLOOKUP_LOAD_KEYLIST;
+    self->loadopts.keys = rm_malloc(sizeof(*keys) * nkeys);
+    memcpy(self->loadopts.keys, keys, sizeof(*keys) * nkeys);
+    self->loadopts.nkeys = nkeys;
+    self->load_all = false;
   } else {
-    self->loadopts.mode = RLOOKUP_LOAD_ALLKEYS;
+    self->load_all = true;
     RLookup_EnableOptions(lk, RLOOKUP_OPT_ALLLOADED); // TODO: turn on only for HASH specs
   }
 

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -177,7 +177,7 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
       }
       if (!options->forceLoad) {
         /* wanted a sort key, but field is not sortable */
-        if ((options->mode & RLOOKUP_LOAD_SVKEYS) && !(RLookupKey_GetFlags(kk) & RLOOKUP_F_SVSRC)) {
+        if ((options->cachedOnly) && !(RLookupKey_GetFlags(kk) & RLOOKUP_F_SVSRC)) {
           continue;
         }
       }
@@ -306,21 +306,28 @@ done:
   return rc;
 }
 
-int RLookup_LoadDocument(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options) {
-  int rv = REDISMODULE_ERR;
-  if (options->dmd) {
-    RLookupRow_SetSortingVector(dst, options->dmd->sortVector);
-  }
+int RLookup_LoadDocumentAll(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options) {
+    int rv = REDISMODULE_ERR;
+    RS_LOG_ASSERT(options->dmd, "must have DocumentMetadata set");
 
-  if (options->mode & RLOOKUP_LOAD_ALLKEYS) {
+    RLookupRow_SetSortingVector(dst, options->dmd->sortVector);
+
     if (options->dmd->type == DocumentType_Hash) {
       rv = RLookup_HGETALL(it, dst, options);
     } else if (options->dmd->type == DocumentType_Json) {
       rv = RLookup_JSON_GetAll(it, dst, options);
     }
-  } else {
-    rv = loadIndividualKeys(it, dst, options);
+
+    return rv;
+}
+
+int RLookup_LoadDocumentIndividual(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options) {
+  int rv = REDISMODULE_ERR;
+  if (options->dmd) {
+    RLookupRow_SetSortingVector(dst, options->dmd->sortVector);
   }
+
+  rv = loadIndividualKeys(it, dst, options);
 
   return rv;
 }
@@ -351,8 +358,7 @@ int RLookup_LoadRuleFields(RedisSearchCtx *sctx, RLookup *it, RLookupRow *dst, I
                             .keyPtr = keyptr,
                             .type = rule->type,
                             .status = status,
-                            .forceLoad = 1,
-                            .mode = RLOOKUP_LOAD_KEYLIST };
+                            .forceLoad = 1 };
   int rv = loadIndividualKeys(it, dst, &opt);
   rm_free(keys);
   return rv;

--- a/src/rlookup_load_document.h
+++ b/src/rlookup_load_document.h
@@ -14,17 +14,6 @@
 extern "C" {
 #endif
 
-typedef enum {
-  /* Use keylist (keys/nkeys) for the fields to list */
-  RLOOKUP_LOAD_KEYLIST,
-  /* Load only cached keys (don't open keys) */
-  RLOOKUP_LOAD_SVKEYS,
-  /* Load all keys in the document */
-  RLOOKUP_LOAD_ALLKEYS,
-  /* Load all the keys in the RLookup object */
-  RLOOKUP_LOAD_LKKEYS
-} RLookupLoadFlags;
-
 typedef struct {
   struct RedisSearchCtx *sctx;
 
@@ -43,10 +32,9 @@ typedef struct {
   size_t nkeys;
 
   /**
-   * The following options control the loading of fields, in case non-SORTABLE
-   * fields are desired.
-  */
-  RLookupLoadFlags mode;
+   * Load only cached keys (don't open keys)
+   */
+  bool cachedOnly;
 
   /**
    * Don't use sortables when loading documents. This will enforce the loader to load
@@ -64,7 +52,8 @@ typedef struct {
 
 int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options);
 
-int RLookup_LoadDocument(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *options);
+int RLookup_LoadDocumentAll(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *options);
+int RLookup_LoadDocumentIndividual(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *options);
 
 int RLookup_LoadRuleFields(RedisSearchCtx *sctx, RLookup *it, RLookupRow *dst,
                            IndexSpec *sp, const char *keyptr, QueryError *status);


### PR DESCRIPTION
This change splits up the `RLookup_LoadDocument` into `RLookup_LoadDocumentAll` and `RLookup_LoadDocumentIndividual` replacing the `RLookupLoadFlags`.

The reason behind this is to simplify the load document functions to make them easier to port to Rust in followup PRs. Making them less polymorphic and easier to reason about as well.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document/field loading used by query execution and expression evaluation, and changes the C/Rust FFI struct layout; mistakes could cause missing fields or load failures at runtime.
> 
> **Overview**
> **Refactors document loading** by replacing the polymorphic `RLookup_LoadDocument` + `RLookupLoadFlags` with two explicit APIs: `RLookup_LoadDocumentAll` (HGETALL/JSON root) and `RLookup_LoadDocumentIndividual` (key-by-key), and updates `RLookupLoadOptions` to use a simple `cachedOnly` boolean.
> 
> Updates the query loader pipeline (`result_processor.c`) and IF-expression evaluation (`document.c`) to select the appropriate load path, and adjusts the Rust `rlookup` FFI caller to populate the new options struct field (`cachedOnly`) and continue using the individual-key loader.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79978ae00fc63857a86e06171e7b3e65526bba61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->