### PR TITLE
Containerize Ubuntu Latest

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -109,9 +109,13 @@ jobs:
               },
               "ubuntu:default": {
                   "x86_64": {
+                      'container': 'ubuntu:latest',
+                      'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest x86_64'
                   },
                   "aarch64": {
+                      'container': 'ubuntu:latest',
+                      'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest ARM64'
                   }
               },


### PR DESCRIPTION
Right now in PR flow we don't cache the env setup because ubuntu latest didn't use a container.
Now using the ubuntu:latest container so we could cache the setup for PR flows and hopefully be less flaky in the setup steps.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the execution environment for the default Ubuntu CI jobs, which can surface differences in available tools/packages and affect build stability.
> 
> **Overview**
> **Containerizes the default Ubuntu CI target.** `ubuntu:default` now runs in the `ubuntu:latest` container for both `x86_64` and `aarch64`.
> 
> Adds a basic setup step (`apt update && apt install -y git`) for these jobs so the environment can be prepared consistently inside the container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc578007bde999debd0db0673cdf86817953c36a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->