### PR TITLE
skip sanitizer asm tests with background workers

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -531,7 +531,7 @@ def test_ft_search_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_search_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.SEARCH')
@@ -541,7 +541,7 @@ def test_ft_aggregate_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_aggregate_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE')
@@ -551,7 +551,7 @@ def test_ft_aggregate_withcursor_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_aggregate_withcursor_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR')
@@ -576,7 +576,7 @@ def test_ft_search_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.SEARCH', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_search_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.SEARCH', parallel_updates=True)
@@ -586,7 +586,7 @@ def test_ft_aggregate_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_aggregate_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE', parallel_updates=True)
@@ -596,7 +596,7 @@ def test_ft_aggregate_withcursor_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_aggregate_withcursor_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR', parallel_updates=True)
@@ -620,7 +620,7 @@ def test_ft_search_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_search_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.SEARCH')
@@ -630,7 +630,7 @@ def test_ft_aggregate_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_aggregate_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.AGGREGATE')
@@ -640,7 +640,7 @@ def test_ft_aggregate_withcursor_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_aggregate_withcursor_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.AGGREGATE.WITHCURSOR')
@@ -709,7 +709,7 @@ def test_add_shard_and_migrate():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_add_shard_and_migrate_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.SEARCH')
@@ -719,7 +719,7 @@ def test_add_shard_and_migrate_aggregate():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_add_shard_and_migrate_aggregate_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE')
@@ -729,7 +729,7 @@ def test_add_shard_and_migrate_aggregate_withcursor():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_add_shard_and_migrate_aggregate_withcursor_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
@@ -884,19 +884,19 @@ def test_ft_cursors_trimmed_protocol_3_profile():
     env = Env(clusterNodeTimeout=cluster_node_timeout, protocol=protocol)
     _test_ft_cursors_trimmed_profile_warning(env)
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_cursors_trimmed_BG_protocol_2():
     protocol = 2
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2', protocol=protocol)
     _test_ft_cursors_trimmed(env, protocol)
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_cursors_trimmed_BG_protocol_3():
     protocol = 3
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2', protocol=protocol)
     _test_ft_cursors_trimmed(env, protocol)
 
-@skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2, asan=True)
 def test_ft_cursors_trimmed_BG_protocol_3_profile():
     protocol = 3
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2', protocol=protocol)


### PR DESCRIPTION
Skip test ASM tests when run in sanitizer if Background workers are used.

Hypothesis is that the flakiness comes from:

https://github.com/google/sanitizers/issues/774

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk test-only change, but it reduces sanitizer coverage for the background-worker ASM scenarios and could hide ASAN-only issues in those paths.
> 
> **Overview**
> Marks the `*_BG` Atomic Slot Migration tests (those running with `moduleArgs='WORKERS 2'`) as **skipped under ASAN** by adding `asan=True` to their `@skip(...)` decorators.
> 
> This applies across the import-slot-range suites (including *parallel-updates* and *sanity* variants), the add-shard-and-migrate BG tests, and the BG cursor-trimming protocol tests, while leaving the non-BG versions unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8cab1603431e2464335df2f03a878221bdb0836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->