### PR TITLE
[MOD-14319] RLookup - Don't null path

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -301,7 +301,6 @@ impl<'a> RLookupKey<'a> {
         #[cfg(any(debug_assertions, test))]
         if is_tombstone {
             debug_assert!(self.name_len == usize::MAX);
-            // Note: `path` is intentionally NOT nulled in tombstones — see `make_tombstone`.
             debug_assert!(self.flags.contains(RLookupKeyFlag::Hidden))
         }
 
@@ -358,6 +357,7 @@ impl<'a> RLookupKey<'a> {
         // `RLookup` lifetime, so the pointer remains valid.
         //
         // This mirrors the original C behaviour: `overrideKey` never cleared `_path`.
+
         let path = mem::take(me._path.deref_mut());
 
         // this will exclude it from iteration


### PR DESCRIPTION
```
    Summary: The fix is in make_tombstone (rlookup/src/lookup/key.rs): removed the line that  
  nulled header.path. The C pipeline holds raw pointers to RLookupKey objects that can later
   be tombstoned (e.g. LOAD @price stores a pointer, then APPLY ... AS price tombstones it).
   Those stale C pointers still need a valid path to load the field from the document. Since
   the backing string memory transfers to the new key (same RLookup lifetime), leaving
  header.path as-is is safe — matching what the original C overrideKey did by never clearing
   _path.
```

Let's discuss this fix over a call.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unsafe/FFI-adjacent pointer semantics around key overriding and tombstones; mistakes here could lead to subtle use-after-free or incorrect field lookups, though the change is small and well-scoped.
> 
> **Overview**
> When overriding an `RLookupKey`, tombstoning now **keeps `header.path` intact** instead of nulling it, preserving a valid path string for C callers that may still hold raw pointers to the old key.
> 
> Debug/test assertions in `is_tombstone` were updated accordingly and additional in-code documentation explains the lifetime/ownership rationale and alignment with the original C behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad16d96582cdb3e931cfdf007c802ef4510bd28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->