### PR TITLE
[MOD-14319] RLookup - Filter out RSValueType_Null in RLookupRow::get

### DIFF
--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -209,7 +209,7 @@ impl<'a> RLookupRow<'a> {
             //   `if (ret != NULL && ret == RSValue_NullStatic()) ret = NULL;`
             self.sorting_vector()?
                 .get(key.svidx as usize)
-                .filter(|v| !v.is_null_static())
+                .filter(|v| v.get_type() != ffi::RSValueType_RSValueType_Null)
         } else {
             None
         }

--- a/src/redisearch_rs/value/src/rs_value_ffi.rs
+++ b/src/redisearch_rs/value/src/rs_value_ffi.rs
@@ -79,26 +79,6 @@ impl RSValueFFI {
         RSValueFFI(NonNull::new(val).expect("RSValue_NullStatic returned a null pointer"))
     }
 
-    /// Returns `true` if this value is the global null sentinel (`RSValue_NullStatic()`).
-    ///
-    /// Sorting vector slots that were never written are initialised to the null sentinel.
-    /// Callers that read from a sorting vector must use this check to distinguish
-    /// "field absent" (null sentinel) from "field present with a real value", mirroring
-    /// the C guard:
-    ///
-    /// ```c
-    /// if (ret != NULL && ret == RSValue_NullStatic()) ret = NULL;
-    /// ```
-    ///
-    /// Using a raw-pointer comparison avoids touching the reference count of the
-    /// global static, which must not be decremented through a temporary `RSValueFFI`.
-    pub fn is_null_static(&self) -> bool {
-        // SAFETY: RSValue_NullStatic() returns a pointer to a process-lifetime global;
-        // it never allocates and the pointer is always valid.
-        let null_ptr = unsafe { ffi::RSValue_NullStatic() };
-        self.as_ptr() == null_ptr
-    }
-
     pub fn new_num(num: f64) -> Self {
         // Safety: RSValue_FromDouble expects a valid double value.
         let num = unsafe { ffi::RSValue_NewNumber(num) };


### PR DESCRIPTION
  When the C code was ported, the guard from memark-base's RLookupRow_Get:
  if (ret != NULL && ret == RSValue_NullStatic()) ret = NULL;
  was not carried over into RLookupRow::get. The sorting vector is initialised with
  null_static() for every slot (RSSortingVector::new → vec![RSValueFFI::null_static();
  len]), so any field that was never written returns Some(&null_static) instead of None. 

  This PR restores the C semantics: absent sortable
  fields appear as None to callers, so they are correctly omitted from search results.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `RLookupRow::get` semantics for sortable fields by treating `RSValueType::Null` in the sorting vector as absent, which can alter which fields are returned in search results. The change is small and localized but impacts query output behavior.
> 
> **Overview**
> Restores C-like `RLookupRow_Get` behavior in `RLookupRow::get` by **filtering the sorting vector’s null sentinel** (`RSValueType::Null`) so sortable fields that were never written return `None` rather than `Some(null_static)`.
> 
> This prevents absent sortable fields from being emitted in downstream result-building paths that treat `Some` as a present field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad7850d5a8fc04e271e64904f5d8a2740f434e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->