### PR TITLE
[MOD-14319] RLookup - Use field_name instead of name in RLookup::get_key_load

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -623,7 +623,6 @@ mod tests {
 
         // Let's create a cache with one field spec
         let spcache = IndexSpecCache::from_fields([FieldSpecBuilder::new(cache_field_name)
-            .with_field_name(key_name)
             .with_sort_idx(12)
             .with_options(make_bitflags!(FieldSpecOption::{
                 Sortable


### PR DESCRIPTION
```
  Bug: In get_key_load (rlookup/src/lookup.rs:361), the Rust port used &name (the result    
  alias) to look up the field in the IndexSpecCache, but the C original (rlookup.c) uses    
  field_name (the schema field name).                                                       
                                                                                            
  Impact: When RETURN/LOAD uses AS with an alias that looks like a JSON path (starts with   
  $), the spec cache lookup fails because no field named $.attr2 exists in the schema.
  Consequently, update_from_field_spec is never called, the key's path is never set to the
  actual JSON path ($.attr1), and the JSON document loader finds nothing.

  Fix: One-line change — spcache.find_field(&name) → spcache.find_field(field_name) — so the
   spec cache is queried with the schema field name (asa), not the display alias ($.attr2).
  The key then gets the correct JSON path, and the document loader returns the value under
  the requested alias.
```

Two Rust tests updated as well (one of which was failing due to the fix).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes key-loading behavior when aliases are used, which can affect returned field values/paths for queries relying on `RETURN`/`LOAD` and schema caching. The diff is small and covered by updated unit tests, but it touches query result loading logic.
> 
> **Overview**
> Fixes a bug in `RLookup::get_key_load` where the schema cache lookup used the output key `name`/alias instead of the schema `field_name`, preventing `update_from_field_spec` from running and leaving keys with incorrect JSON paths under aliased returns.
> 
> Updates the affected unit tests to build the `IndexSpecCache` using the schema field name (removing `with_field_name(key_name)`), matching the corrected lookup behavior and preserving the `ValAvailable`/`ForceLoad` load/no-load expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44fae9319c6d56fee7a2a4de45eb8903dbff1820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->