### PR TITLE
[MOD-14426] Fix warning tautological-constant-out-of-range-compare

### DIFF
--- a/src/profile/profile.h
+++ b/src/profile/profile.h
@@ -79,23 +79,13 @@ static_assert(PROFILE_WARNING_TYPE_ASM_INACCURATE_RESULTS <= (1 << 7),
 
 static void ProfileWarnings_Add(ProfileWarnings *profileWarnings, ProfileWarningType code) {
   RS_ASSERT(profileWarnings);
-
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
-  RS_ASSERT(code <= (1 << (sizeof(ProfileWarnings) * 8 - 1)));
-  #pragma GCC diagnostic pop
-
+  RS_ASSERT((size_t)code <= (1 << (sizeof(ProfileWarnings) * 8 - 1)));
   *profileWarnings |= code;
 }
 
 static bool ProfileWarnings_Has(const ProfileWarnings *profileWarnings, ProfileWarningType code) {
   RS_ASSERT(profileWarnings);
-
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
-  RS_ASSERT(code <= (1 << (sizeof(ProfileWarnings) * 8 - 1)));
-  #pragma GCC diagnostic pop
-
+  RS_ASSERT((size_t)code <= (1 << (sizeof(ProfileWarnings) * 8 - 1)));
   return *profileWarnings & code;
 }
 


### PR DESCRIPTION
This is a really crude fix for the warning `tautological-constant-out-of-range-compare`, that's been spamming my local builds.

If anyone prefers rewriting (or removing) the assert instead, I'm all for it.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust `RS_ASSERT` type casting in `ProfileWarnings_Add`/`ProfileWarnings_Has` to avoid a compiler warning, with no behavioral change expected aside from the assertion expression type.
> 
> **Overview**
> Updates `ProfileWarnings_Add` and `ProfileWarnings_Has` assertions to cast the `ProfileWarningType` bit value to `size_t` before comparing against the `ProfileWarnings` bitset limit, eliminating the `tautological-constant-out-of-range-compare` build warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4534b44755e648896d31a939d697505123f89543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->