### PR TITLE
Change RSIndexResult::with_term() to take Box<RSQueryTerm> instead of Option

### DIFF
--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -120,13 +120,13 @@ pub unsafe extern "C" fn NewTokenRecord<'result>(
     term: *mut RSQueryTerm,
     weight: f64,
 ) -> *mut RSIndexResult<'result> {
-    let term = if term.is_null() {
-        None
+    let result = if term.is_null() {
+        RSIndexResult::term().frequency(0).weight(weight)
     } else {
         // SAFETY: caller guarantees `term` was created via `NewQueryTerm`.
-        unsafe { Some(Box::from_raw(term)) }
+        let term = unsafe { Box::from_raw(term) };
+        RSIndexResult::with_term(term, RSOffsetSlice::empty(), 0, 0, 0).weight(weight)
     };
-    let result = RSIndexResult::with_term(term, RSOffsetSlice::empty(), 0, 0, 0).weight(weight);
     Box::into_raw(Box::new(result))
 }
 

--- a/src/redisearch_rs/inverted_index/src/index_result/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result/core.rs
@@ -160,7 +160,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Create a new `RSIndexResult` with a given `term`, `offsets`, `doc_id`, `field_mask`, and `freq`.
     pub const fn with_term(
-        term: Option<Box<RSQueryTerm>>,
+        term: Box<RSQueryTerm>,
         offsets: RSOffsetSlice<'index>,
         doc_id: t_docId,
         field_mask: t_fieldMask,

--- a/src/redisearch_rs/inverted_index/src/index_result/term_record.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result/term_record.rs
@@ -65,10 +65,13 @@ impl<'index> RSTermRecord<'index> {
 
     /// Create a new borrowed term record with the given term and offsets.
     pub const fn with_term(
-        term: Option<Box<RSQueryTerm>>,
+        term: Box<RSQueryTerm>,
         offsets: RSOffsetSlice<'index>,
     ) -> RSTermRecord<'index> {
-        Self::Borrowed { term, offsets }
+        Self::Borrowed {
+            term: Some(term),
+            offsets,
+        }
     }
 
     /// Is this term record borrowed or owned?

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -29,7 +29,7 @@ impl<'a> TestTermRecord<'a> {
         term.set_bm25_idf(10.0);
 
         let record = RSIndexResult::with_term(
-            Some(term),
+            term,
             RSOffsetSlice::from_slice(offsets),
             doc_id,
             field_mask,

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -184,7 +184,7 @@ fn to_owned_a_term_index_result() {
     let offsets: [u8; 1] = [0];
     let offsets = RSOffsetSlice::from_slice(&offsets);
 
-    let ir = RSIndexResult::with_term(Some(term), offsets, 7, 1, 1);
+    let ir = RSIndexResult::with_term(term, offsets, 7, 1, 1);
     let mut ir_copy = ir.to_owned();
 
     assert_eq!(ir.doc_id, ir_copy.doc_id);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -75,9 +75,8 @@ where
         term.set_idf(idf::calculate_idf(total_docs, term_docs));
         term.set_bm25_idf(idf::calculate_idf_bm25(total_docs, term_docs));
 
-        let result =
-            RSIndexResult::with_term(Some(term), RSOffsetSlice::empty(), 0, RS_FIELDMASK_ALL, 1)
-                .weight(weight);
+        let result = RSIndexResult::with_term(term, RSOffsetSlice::empty(), 0, RS_FIELDMASK_ALL, 1)
+            .weight(weight);
         Self {
             it: InvIndIterator::new(reader, result, expiration_checker),
             context,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -23,7 +23,7 @@ use crate::inverted_index::utils::{BaseTest, RevalidateIndexType, RevalidateTest
 fn expected_record(
     doc_id: t_docId,
     field_mask: t_fieldMask,
-    term: Option<Box<query_term::RSQueryTerm>>,
+    term: Box<query_term::RSQueryTerm>,
     offsets: &'static [u8],
 ) -> RSIndexResult<'static> {
     RSIndexResult::with_term(
@@ -56,7 +56,7 @@ impl TermBaseTest {
                     term.set_idf(5.0);
                     term.set_bm25_idf(10.0);
                     // Use doc_id as field_mask so we can test FilterMaskReader
-                    expected_record(doc_id, doc_id as t_fieldMask, Some(term), OFFSETS)
+                    expected_record(doc_id, doc_id as t_fieldMask, term, OFFSETS)
                 }),
                 n_docs,
             ),
@@ -159,7 +159,7 @@ mod not_miri {
                         // Use a field mask with all bits set so all docs match the filter
                         // and expiration is actually tested (not just field mask filtering).
                         // Use u32::MAX for non-wide tests to avoid overflow in the encoder.
-                        expected_record(doc_id, u32::MAX as t_fieldMask, Some(term), OFFSETS)
+                        expected_record(doc_id, u32::MAX as t_fieldMask, term, OFFSETS)
                     }),
                     n_docs,
                     multi,
@@ -301,7 +301,7 @@ mod not_miri {
                         term.set_idf(5.0);
                         term.set_bm25_idf(10.0);
                         // Use a field mask with all bits set so all docs match the filter.
-                        expected_record(doc_id, u32::MAX as t_fieldMask, Some(term), OFFSETS)
+                        expected_record(doc_id, u32::MAX as t_fieldMask, term, OFFSETS)
                     }),
                     n_docs,
                 ),

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/term.rs
@@ -93,13 +93,16 @@ where
         let delta = if sparse { SPARSE_DELTA } else { 1 };
         for doc_id in 1..INDEX_SIZE {
             let actual_doc_id = doc_id * delta;
-            let record = RSIndexResult::with_term(
-                None,
-                RSOffsetSlice::from_slice(&self.offsets),
-                actual_doc_id,
-                1,
-                1,
-            );
+            let record = RSIndexResult {
+                doc_id: actual_doc_id,
+                field_mask: 1,
+                freq: 1,
+                data: inverted_index::RSResultData::Term(inverted_index::RSTermRecord::Borrowed {
+                    term: None,
+                    offsets: RSOffsetSlice::from_slice(&self.offsets),
+                }),
+                ..Default::default()
+            };
             ii.add_record(&record).expect("failed to add record");
         }
         ii

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -363,13 +363,20 @@ impl InvertedIndex {
         term: Option<Box<RSQueryTerm>>,
         offsets: &[u8],
     ) {
-        let record = RSIndexResult::with_term(
-            term,
-            inverted_index::RSOffsetSlice::from_slice(offsets),
-            doc_id,
-            field_mask as u128,
-            freq,
-        );
+        let offsets = inverted_index::RSOffsetSlice::from_slice(offsets);
+        let record = match term {
+            Some(term) => RSIndexResult::with_term(term, offsets, doc_id, field_mask as u128, freq),
+            None => RSIndexResult {
+                doc_id,
+                field_mask: field_mask as u128,
+                freq,
+                data: inverted_index::RSResultData::Term(inverted_index::RSTermRecord::Borrowed {
+                    term: None,
+                    offsets,
+                }),
+                ..Default::default()
+            },
+        };
         unsafe {
             inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
                 self.ii.cast(),


### PR DESCRIPTION
 

The whole point of this constructor is to pass a term so there is no reason for it to be None.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a core constructor signature used across crates and touches FFI/benchmark plumbing; mistakes could surface as compile breaks or subtle term-record ownership/lifetime issues.
> 
> **Overview**
> **API change:** `RSIndexResult::with_term` (and `RSTermRecord::with_term`) now requires a `Box<RSQueryTerm>` instead of `Option<Box<RSQueryTerm>>`, eliminating the `None` term path.
> 
> Call sites across iterators, tests, and utilities were updated to pass a term directly; code paths that previously built term results with `None` now use `RSIndexResult::term()` or manually construct a `RSTermRecord::Borrowed { term: None, ... }` (notably in `NewTokenRecord` and the bencher/FFI write helpers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39427963cd8f92cd1b6fa4c476330743c606b293. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->