### PR TITLE
[MOD-14317] Add Tag inverted index iterator benchmarks

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
@@ -71,6 +71,11 @@ fn benchmark_inverted_index_missing(c: &mut Criterion) {
     bencher.bench(c);
 }
 
+fn benchmark_inverted_index_tag(c: &mut Criterion) {
+    let bencher = benchers::inverted_index::TagBencher::default();
+    bencher.bench(c);
+}
+
 fn benchmark_inverted_index_term(c: &mut Criterion) {
     // Run bench with each decoder producing term results.
     benchers::inverted_index::TermBencher::<Full>::new(
@@ -159,6 +164,7 @@ criterion_group!(
     benchmark_inverted_index_numeric,
     benchmark_inverted_index_wildcard,
     benchmark_inverted_index_missing,
+    benchmark_inverted_index_tag,
     benchmark_inverted_index_term,
 );
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/mod.rs
@@ -15,11 +15,13 @@ use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 
 mod missing;
 mod numeric;
+mod tag;
 mod term;
 mod wildcard;
 
 pub use missing::MissingBencher;
 pub use numeric::NumericBencher;
+pub use tag::TagBencher;
 pub use term::TermBencher;
 pub use wildcard::WildcardBencher;
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Benchmarks for the tag inverted index iterator.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
+use inverted_index::{RSQueryTerm, doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding};
+use rqe_iterators::{RQEIterator, SkipToOutcome, inverted_index::Tag};
+use rqe_iterators_test_utils::TestContext;
+
+use crate::ffi as bench_ffi;
+
+use super::{INDEX_SIZE, SKIP_TO_STEP, SPARSE_DELTA, benchmark_group};
+
+pub struct TagBencher {
+    context_dense: TestContext,
+    context_sparse: TestContext,
+}
+
+impl Default for TagBencher {
+    fn default() -> Self {
+        let dense_iter = || 1..INDEX_SIZE;
+        let sparse_iter = || (1..INDEX_SIZE).map(|i| i * SPARSE_DELTA);
+
+        Self {
+            context_dense: TestContext::tag(dense_iter()),
+            context_sparse: TestContext::tag(sparse_iter()),
+        }
+    }
+}
+
+impl TagBencher {
+    pub fn bench(&self, c: &mut Criterion) {
+        self.read_dense(c);
+        self.skip_to_dense(c);
+        self.skip_to_sparse(c);
+    }
+
+    fn read_dense(&self, c: &mut Criterion) {
+        let mut group = benchmark_group(c, "Tag", "Read Dense");
+        self.c_read(&mut group, &self.context_dense);
+        self.rust_read(&mut group, &self.context_dense);
+        group.finish();
+    }
+
+    fn skip_to_dense(&self, c: &mut Criterion) {
+        let mut group = benchmark_group(c, "Tag", "SkipTo Dense");
+        self.c_skip_to(&mut group, &self.context_dense);
+        self.rust_skip_to(&mut group, &self.context_dense);
+        group.finish();
+    }
+
+    fn skip_to_sparse(&self, c: &mut Criterion) {
+        let mut group = benchmark_group(c, "Tag", "SkipTo Sparse");
+        self.c_skip_to(&mut group, &self.context_sparse);
+        self.rust_skip_to(&mut group, &self.context_sparse);
+        group.finish();
+    }
+
+    fn c_read<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>, context: &TestContext) {
+        let idx = context.tag_index_ptr();
+        let tag_idx = context.tag_index().as_ptr();
+        let sctx = context.sctx.as_ptr();
+        group.bench_function("C", |b| {
+            b.iter(|| {
+                let term = Box::into_raw(RSQueryTerm::new("test_tag", 0, 0));
+                // SAFETY: `context` provides valid pointers with a valid
+                // `spec` and `TagIndex` that outlive the iterator.
+                // `term` is heap-allocated via `Box::into_raw`.
+                let it =
+                    unsafe { bench_ffi::QueryIterator::new_tag(idx, tag_idx, sctx, term, 0.0) };
+                while it.read() == ::ffi::IteratorStatus_ITERATOR_OK {
+                    black_box(it.current());
+                }
+                it.free();
+            });
+        });
+    }
+
+    fn c_skip_to<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>, context: &TestContext) {
+        let idx = context.tag_index_ptr();
+        let tag_idx = context.tag_index().as_ptr();
+        let sctx = context.sctx.as_ptr();
+        group.bench_function("C", |b| {
+            b.iter(|| {
+                let term = Box::into_raw(RSQueryTerm::new("test_tag", 0, 0));
+                // SAFETY: `context` provides valid pointers with a valid
+                // `spec` and `TagIndex` that outlive the iterator.
+                // `term` is heap-allocated via `Box::into_raw`.
+                let it =
+                    unsafe { bench_ffi::QueryIterator::new_tag(idx, tag_idx, sctx, term, 0.0) };
+                while it.skip_to(it.last_doc_id() + SKIP_TO_STEP)
+                    != ::ffi::IteratorStatus_ITERATOR_EOF
+                {
+                    black_box(it.current());
+                }
+                it.free();
+            });
+        });
+    }
+
+    fn rust_read<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>, context: &TestContext) {
+        group.bench_function("Rust", |b| {
+            let ii = DocIdsOnly::from_opaque(context.tag_inverted_index());
+            b.iter(|| {
+                let term = RSQueryTerm::new("test_tag", 0, 0);
+                // SAFETY: `context` provides a valid `RedisSearchCtx` with a valid
+                // `spec`, `TagIndex` (with valid `values` TrieMap), and a
+                // `DocIdsOnly`-encoded inverted index. All pointers remain valid
+                // for the lifetime of the iterator as `context` outlives it.
+                let mut it = unsafe {
+                    Tag::new(
+                        ii.reader(),
+                        context.sctx,
+                        context.tag_index(),
+                        term,
+                        0.0,
+                        rqe_iterators::NoOpChecker,
+                    )
+                };
+                while let Ok(Some(current)) = it.read() {
+                    black_box(current);
+                }
+            });
+        });
+    }
+
+    fn rust_skip_to<M: Measurement>(
+        &self,
+        group: &mut BenchmarkGroup<'_, M>,
+        context: &TestContext,
+    ) {
+        group.bench_function("Rust", |b| {
+            let ii = DocIdsOnly::from_opaque(context.tag_inverted_index());
+            b.iter(|| {
+                let term = RSQueryTerm::new("test_tag", 0, 0);
+                // SAFETY: `context` provides a valid `RedisSearchCtx` with a valid
+                // `spec`, `TagIndex` (with valid `values` TrieMap), and a
+                // `DocIdsOnly`-encoded inverted index. All pointers remain valid
+                // for the lifetime of the iterator as `context` outlives it.
+                let mut it = unsafe {
+                    Tag::new(
+                        ii.reader(),
+                        context.sctx,
+                        context.tag_index(),
+                        term,
+                        0.0,
+                        rqe_iterators::NoOpChecker,
+                    )
+                };
+                while let Ok(Some(outcome)) = it.skip_to(it.last_doc_id() + SKIP_TO_STEP) {
+                    match outcome {
+                        SkipToOutcome::Found(current) | SkipToOutcome::NotFound(current) => {
+                            black_box(current);
+                        }
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -13,6 +13,7 @@ pub use ffi::{
     IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_OK,
     RedisModule_Alloc, RedisModule_Free, ValidateStatus,
 };
+use inverted_index::RSQueryTerm;
 use inverted_index::{RSIndexResult, t_docId};
 use std::{ffi::c_void, ptr};
 
@@ -81,6 +82,41 @@ impl QueryIterator {
         field_index: ffi::t_fieldIndex,
     ) -> Self {
         Self(unsafe { ffi::NewInvIndIterator_MissingQuery(idx, sctx, field_index) })
+    }
+
+    /// Creates a new tag inverted index iterator via the C path.
+    ///
+    /// # Safety
+    ///
+    /// `idx` must be a valid pointer to a [`DocIdsOnly`](inverted_index::doc_ids_only::DocIdsOnly) inverted index.
+    /// `tag_idx` must be a valid pointer to a [`TagIndex`](ffi::TagIndex).
+    /// `sctx` must be a valid pointer to a [`RedisSearchCtx`](ffi::RedisSearchCtx) with valid `spec`.
+    /// `term` must be a heap-allocated [`RSQueryTerm`] (e.g. created by [`RSQueryTerm::new`]).
+    #[inline(always)]
+    pub unsafe fn new_tag(
+        idx: *const ffi::InvertedIndex,
+        tag_idx: *const ffi::TagIndex,
+        sctx: *const ffi::RedisSearchCtx,
+        term: *mut RSQueryTerm,
+        weight: f64,
+    ) -> Self {
+        // SAFETY: `field::FieldMaskOrIndex` and `ffi::FieldMaskOrIndex` have the
+        // same binary representation.
+        let field_mask_or_index: ffi::FieldMaskOrIndex =
+            unsafe { std::mem::transmute(field::FieldMaskOrIndex::mask_all()) };
+
+        // SAFETY: The caller guarantees that `idx`, `tag_idx`, `sctx`, and
+        // `term` are valid pointers with the required properties.
+        Self(unsafe {
+            ffi::NewInvIndIterator_TagQuery(
+                idx,
+                tag_idx,
+                sctx,
+                field_mask_or_index,
+                term.cast(),
+                weight,
+            )
+        })
     }
 
     /// Creates a new intersection iterator from child ID list iterators.

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -689,6 +689,15 @@ impl TestContext {
         }
     }
 
+    /// Get a raw pointer to the tag inverted index suitable for FFI.
+    /// Panics if this is not a tag context.
+    pub fn tag_index_ptr(&self) -> *const ffi::InvertedIndex {
+        match &self.inner {
+            TestContextInner::Tag { inverted_index, .. } => inverted_index.as_ptr(),
+            _ => panic!("TestContext is not a Tag context"),
+        }
+    }
+
     /// Get the tag index for this context.
     /// Panics if this is not a tag context.
     pub fn tag_index(&self) -> ptr::NonNull<ffi::TagIndex> {


### PR DESCRIPTION
Bench Rust inverted index tag iterator.

  | Benchmark | C | Rust | Speedup |                                                                                           
  |-----------|---|------|---------|      
  | **Read Dense** | 3.3437 ms | 1.8746 ms | **1.78x faster** |                                                                
  | **SkipTo Dense** | 456.04 µs | 405.26 µs | **1.13x faster** |                                                              
  | **SkipTo Sparse** | 6.9455 ms | 2.8265 ms | **2.46x faster** |                                                             
                                          

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bench-only additions plus test/FFI helpers; no production query logic changes, with only minor risk around correctness of the new unsafe FFI call usage.
> 
> **Overview**
> Adds a new Criterion benchmark suite for the inverted-index `Tag` iterator, measuring *read* and *skip_to* performance on both dense and sparse tag indices and comparing Rust vs the C iterator.
> 
> This wires the new `TagBencher` into the main `iterators` bench list, introduces a C FFI constructor `QueryIterator::new_tag`, and extends `TestContext` with `tag_index_ptr()` to expose the tag inverted index pointer needed by the C benchmark path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e40d79bc3e56d14789ecce85336374b0c46edf21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->