### PR TITLE
rqe_iterators_bencher: remove leftovers

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/term.rs
@@ -18,8 +18,6 @@ use query_term::RSQueryTerm;
 use rqe_iterators::{NoOpChecker, RQEIterator, SkipToOutcome, inverted_index::Term};
 use rqe_iterators_test_utils::MockContext;
 
-use crate::ffi as bench_ffi;
-
 use super::{INDEX_SIZE, SKIP_TO_STEP, SPARSE_DELTA, benchmark_group};
 
 pub struct TermBencher<E> {
@@ -59,33 +57,20 @@ where
 
     fn read_dense(&self, c: &mut Criterion) {
         let mut group = benchmark_group(c, &self.group_name, "Read Dense");
-        self.c_read_dense(&mut group);
         self.rust_read_dense(&mut group);
         group.finish();
     }
 
     fn skip_to_dense(&self, c: &mut Criterion) {
         let mut group = benchmark_group(c, &self.group_name, "SkipTo Dense");
-        self.c_skip_to_dense(&mut group);
         self.rust_skip_to_dense(&mut group);
         group.finish();
     }
 
     fn skip_to_sparse(&self, c: &mut Criterion) {
         let mut group = benchmark_group(c, &self.group_name, "SkipTo Sparse");
-        self.c_skip_to_sparse(&mut group);
         self.rust_skip_to_sparse(&mut group);
         group.finish();
-    }
-
-    fn c_index(&self, sparse: bool) -> bench_ffi::InvertedIndex {
-        let ii = bench_ffi::InvertedIndex::new(self.ii_flags);
-        let delta = if sparse { SPARSE_DELTA } else { 1 };
-        for doc_id in 1..INDEX_SIZE {
-            let actual_doc_id = doc_id * delta;
-            ii.write_term_entry(actual_doc_id, 1, 1, None, &self.offsets);
-        }
-        ii
     }
 
     fn rust_index(&self, sparse: bool) -> InvertedIndex<E> {
@@ -108,22 +93,6 @@ where
         ii
     }
 
-    fn c_read_dense<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("C", |b| {
-            b.iter_batched_ref(
-                || self.c_index(false),
-                |ii| {
-                    let it = ii.iterator_term();
-                    while it.read() == ::ffi::IteratorStatus_ITERATOR_OK {
-                        black_box(it.current());
-                    }
-                    it.free();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
     fn rust_read_dense<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
         group.bench_function("Rust", |b| {
             b.iter_batched_ref(
@@ -142,42 +111,6 @@ where
                     while let Ok(Some(current)) = it.read() {
                         black_box(current);
                     }
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
-    fn c_skip_to_dense<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("C", |b| {
-            b.iter_batched_ref(
-                || self.c_index(false),
-                |ii| {
-                    let it = ii.iterator_term();
-                    while it.skip_to(it.last_doc_id() + SKIP_TO_STEP)
-                        != ::ffi::IteratorStatus_ITERATOR_EOF
-                    {
-                        black_box(it.current());
-                    }
-                    it.free();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-
-    fn c_skip_to_sparse<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
-        group.bench_function("C", |b| {
-            b.iter_batched_ref(
-                || self.c_index(true),
-                |ii| {
-                    let it = ii.iterator_term();
-                    while it.skip_to(it.last_doc_id() + SKIP_TO_STEP)
-                        != ::ffi::IteratorStatus_ITERATOR_EOF
-                    {
-                        black_box(it.current());
-                    }
-                    it.free();
                 },
                 criterion::BatchSize::SmallInput,
             );

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -14,7 +14,6 @@ pub use ffi::{
     RedisModule_Alloc, RedisModule_Free, ValidateStatus,
 };
 use inverted_index::{RSIndexResult, t_docId};
-use query_term::RSQueryTerm;
 use std::{ffi::c_void, ptr};
 
 /// Simple wrapper around the C `QueryIterator` type.
@@ -65,20 +64,6 @@ impl QueryIterator {
 
         free_redis_search_ctx(query_eval_ctx);
         Self(it)
-    }
-
-    #[inline(always)]
-    pub unsafe fn new_term(ii: *mut ffi::InvertedIndex, sctx: *const ffi::RedisSearchCtx) -> Self {
-        let term = Box::into_raw(RSQueryTerm::new("term", 1, 0));
-        Self(unsafe {
-            iterators_ffi::inverted_index::NewInvIndIterator_TermQuery(
-                ii.cast_const(),
-                sctx,
-                field::FieldMaskOrIndex::Mask(ffi::RS_FIELDMASK_ALL),
-                term,
-                1.0,
-            )
-        })
     }
 
     /// Creates a new intersection iterator from child ID list iterators.
@@ -175,36 +160,6 @@ impl QueryIterator {
     }
 }
 
-/// Create a minimal zeroed `RedisSearchCtx` with a valid `IndexSpec`.
-///
-/// The caller must call [`free_search_ctx`] to free the memory.
-fn new_search_ctx() -> *mut ffi::RedisSearchCtx {
-    let search_ctx = unsafe {
-        RedisModule_Alloc.unwrap()(std::mem::size_of::<ffi::RedisSearchCtx>())
-            as *mut ffi::RedisSearchCtx
-    };
-    unsafe {
-        (*search_ctx) = std::mem::zeroed();
-    }
-    let spec = unsafe {
-        RedisModule_Alloc.unwrap()(std::mem::size_of::<ffi::IndexSpec>()) as *mut ffi::IndexSpec
-    };
-    unsafe {
-        (*spec) = std::mem::zeroed();
-    }
-    unsafe {
-        (*search_ctx).spec = spec;
-    }
-    search_ctx
-}
-
-fn free_search_ctx(sctx: *mut ffi::RedisSearchCtx) {
-    unsafe {
-        RedisModule_Free.unwrap()((*sctx).spec as *mut c_void);
-        RedisModule_Free.unwrap()(sctx as *mut c_void);
-    }
-}
-
 fn new_redis_search_ctx(max_id: u64) -> *mut ffi::QueryEvalCtx {
     let query_eval_ctx = unsafe {
         RedisModule_Alloc.unwrap()(std::mem::size_of::<ffi::QueryEvalCtx>())
@@ -263,125 +218,4 @@ fn free_redis_search_ctx(ctx: *mut ffi::QueryEvalCtx) {
     unsafe {
         RedisModule_Free.unwrap()(ctx as *mut c_void);
     };
-}
-
-/// Simple wrapper around the C InvertedIndex.
-/// All methods are inlined to avoid the overhead when benchmarking.
-pub struct InvertedIndex {
-    pub ii: *mut ffi::InvertedIndex,
-    sctx: *mut ffi::RedisSearchCtx,
-}
-
-impl Drop for InvertedIndex {
-    fn drop(&mut self) {
-        unsafe { inverted_index_ffi::InvertedIndex_Free(self.ii.cast()) };
-        free_search_ctx(self.sctx);
-    }
-}
-
-impl InvertedIndex {
-    #[inline(always)]
-    pub fn new(flags: ffi::IndexFlags) -> Self {
-        let mut memsize = 0;
-        let ptr = inverted_index_ffi::NewInvertedIndex_Ex(flags, false, false, &mut memsize);
-        Self {
-            ii: ptr.cast(),
-            sctx: new_search_ctx(),
-        }
-    }
-
-    #[inline(always)]
-    pub fn write_numeric_entry(&self, doc_id: u64, value: f64) {
-        unsafe {
-            inverted_index_ffi::InvertedIndex_WriteNumericEntry(self.ii.cast(), doc_id, value);
-        }
-    }
-
-    /// `term_ptr` and `offsets` must be valid for the lifetime of the index.
-    #[inline(always)]
-    pub fn write_term_entry(
-        &self,
-        doc_id: u64,
-        freq: u32,
-        field_mask: u32,
-        term: Option<Box<RSQueryTerm>>,
-        offsets: &[u8],
-    ) {
-        let offsets = inverted_index::RSOffsetSlice::from_slice(offsets);
-        let record = match term {
-            Some(term) => RSIndexResult::with_term(term, offsets, doc_id, field_mask as u128, freq),
-            None => RSIndexResult {
-                doc_id,
-                field_mask: field_mask as u128,
-                freq,
-                data: inverted_index::RSResultData::Term(inverted_index::RSTermRecord::Borrowed {
-                    term: None,
-                    offsets,
-                }),
-                ..Default::default()
-            },
-        };
-        unsafe {
-            inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
-                self.ii.cast(),
-                &record as *const _ as *mut _,
-            );
-        }
-    }
-
-    #[inline(always)]
-    pub fn iterator_term(&self) -> QueryIterator {
-        unsafe { QueryIterator::new_term(self.ii, self.sctx) }
-    }
-}
-
-#[cfg(test)]
-// `miri` can't handle FFI.
-#[cfg(not(miri))]
-mod tests {
-    use super::*;
-    use ffi::{
-        IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND, IteratorStatus_ITERATOR_OK,
-        ValidateStatus_VALIDATE_OK,
-    };
-
-    #[test]
-    fn term_full_iterator() {
-        let ii = InvertedIndex::new(
-            IndexFlags_Index_StoreFreqs
-                | IndexFlags_Index_StoreTermOffsets
-                | IndexFlags_Index_StoreFieldFlags
-                | IndexFlags_Index_StoreByteOffsets,
-        );
-
-        let offsets = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let term = || {
-            let mut t = RSQueryTerm::new("term", 1, 0);
-            t.set_idf(5.0);
-            t.set_bm25_idf(10.0);
-            Some(t)
-        };
-
-        ii.write_term_entry(1, 1, 1, term(), &offsets);
-        ii.write_term_entry(10, 1, 1, term(), &offsets);
-        ii.write_term_entry(100, 1, 1, term(), &offsets);
-
-        let it = ii.iterator_term();
-        assert_eq!(it.num_estimated(), 3);
-
-        assert_eq!(it.read(), IteratorStatus_ITERATOR_OK);
-        assert_eq!(it.read(), IteratorStatus_ITERATOR_OK);
-        assert_eq!(it.read(), IteratorStatus_ITERATOR_OK);
-        assert_eq!(it.read(), IteratorStatus_ITERATOR_EOF);
-        assert!(it.at_eof());
-
-        it.rewind();
-        assert_eq!(it.skip_to(10), IteratorStatus_ITERATOR_OK);
-        assert_eq!(it.skip_to(20), IteratorStatus_ITERATOR_NOTFOUND);
-
-        it.rewind();
-        assert_eq!(it.revalidate(), ValidateStatus_VALIDATE_OK);
-
-        it.free();
-    }
 }


### PR DESCRIPTION
Removing leftovers in iterators benches which are not longer used or relevant.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only cleanup that deletes unused FFI code paths without changing production query/iterator logic.
> 
> **Overview**
> Removes the C/FFI benchmark variants from the term inverted-index benches, so `TermBencher` now runs only the Rust implementations for dense reads and `skip_to` (dense/sparse).
> 
> C-side benchmarking hooks and the custom C `InvertedIndex`/term-iterator wrappers (plus their tests) were deleted from `ffi.rs`, reducing unused FFI surface and benchmark maintenance overhead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc8a9e8d828f00d9bf12b32040aaadfeb7e538d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->