### PR TITLE
[MOD-13569] test: fix dummy could be accessed while destroyed from stack

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -323,6 +323,7 @@ TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
   // Phase 2: Use static flags for communication with the topo callback
   static std::atomic<bool> topo_started{false};
   static std::atomic<bool> topo_should_finish{false};
+  int dummy_counter = 0;
   topo_started = false;
   topo_should_finish = false;
 
@@ -345,8 +346,7 @@ TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
   };
 
   // Start the IO runtime thread (required for uv loop to process async events)
-  int dummy = 0;
-  IORuntimeCtx_Schedule(ctx, testCallback, &dummy);
+  IORuntimeCtx_Schedule(ctx, testCallback, &dummy_counter);
 
   // Schedule topology update - this calls uv_async_send which triggers topologyAsyncCB
   MRClusterTopology *newTopo = getDummyTopology(9999);
@@ -369,6 +369,11 @@ TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
     return stats.uv_threads_running_topology_update == 0;
   });
   ASSERT_TRUE(success) << "Timeout waiting for metric to return to 0";
+
+  // Phase 5: Wait for testCallback to complete before returning
+  // (it runs asynchronously after topology validation timer fires)
+  success = RS::WaitForCondition([&]() { return dummy_counter >= 1; });
+  ASSERT_TRUE(success) << "Timeout waiting for testCallback to complete";
 
   // Cleanup
   ConcurrentSearch_ThreadPoolDestroy();


### PR DESCRIPTION

## Root Cause Analysis

This test had a use-after-free bug that caused flaky crashes.

### The Race Condition

1. Test declares `int dummy = 0` on the stack
2. Test calls `IORuntimeCtx_Schedule(ctx, testCallback, &dummy)` - passing pointer to stack variable
3. `testCallback` is queued but doesn't run immediately (UV loop blocks until `loop_th_ready` is set)
4. After topology validation completes, `testCallback` runs
5. **Test function returns** - `dummy` goes out of scope, stack memory is now invalid
6. `TearDown` runs
7. `testCallback` finally executes `(*counter)++` - **writing to freed stack memory**
8. This corrupts the stack, causing undefined behavior

### The Fix

1. Move `dummy_counter` declaration to persist until after `testCallback` completes
2. Add explicit wait for `testCallback` to complete before the test returns:
   ```cpp
   success = RS::WaitForCondition([&]() { return dummy_counter >= 1; });
   ```

This ensures the write to `counter` happens while the variable is still valid.

### Reproduction Attempts

We tried to reproduce by enforcing the race condition timing:
- Modified `testCallback` to block until `tear_down_started` is set (ensuring it runs during TearDown)
- Added stack pressure in TearDown to increase overlap probability

We successfully reproduced stack corruption crashes (see PR #8664), but with different stack traces than the original CI failure. This is expected since writing to invalid memory causes undefined behavior that manifests differently based on stack layout.

### If This Test Fails Again

If `IORuntimeCtxCommonTest.ActiveTopologyUpdateThreadsMetric` crashes again after this fix:
1. Reopen MOD-13569
2. The issue is likely a different race condition - investigate other callbacks or shared state
3. Check if any other test callbacks access stack variables that could go out of scope

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because the change is confined to a C++ test and only adds synchronization to avoid a flaky/use-after-free scenario from an async callback.
> 
> **Overview**
> Fixes a lifetime/race bug in `ActiveTopologyUpdateThreadsMetric` by replacing a short-lived stack `dummy` with a persistent `dummy_counter` and explicitly waiting for `testCallback` to run before the test exits.
> 
> This makes the topology-update metric test deterministic and prevents the scheduled async callback from accessing a destroyed stack variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 268edaf04cc5600b935a889eaa36639a9dc2a156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->