### PR TITLE
[MOD-14241] Add Missing inverted index iterator benchmarks

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
@@ -66,6 +66,11 @@ fn benchmark_inverted_index_wildcard(c: &mut Criterion) {
     bencher.bench(c);
 }
 
+fn benchmark_inverted_index_missing(c: &mut Criterion) {
+    let bencher = benchers::inverted_index::MissingBencher::default();
+    bencher.bench(c);
+}
+
 fn benchmark_inverted_index_term(c: &mut Criterion) {
     // Run bench with each decoder producing term results.
     benchers::inverted_index::TermBencher::<Full>::new(
@@ -153,6 +158,7 @@ criterion_group!(
     benchmark_optional,
     benchmark_inverted_index_numeric,
     benchmark_inverted_index_wildcard,
+    benchmark_inverted_index_missing,
     benchmark_inverted_index_term,
 );
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/missing.rs
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Benchmarks for the missing-field inverted index iterator.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
+use inverted_index::{doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding};
+use rqe_iterators::{RQEIterator, SkipToOutcome, inverted_index::Missing};
+use rqe_iterators_test_utils::TestContext;
+
+use crate::ffi as bench_ffi;
+
+use super::{INDEX_SIZE, SKIP_TO_STEP, SPARSE_DELTA, benchmark_group};
+
+pub struct MissingBencher {
+    context_dense: TestContext,
+    context_sparse: TestContext,
+}
+
+impl Default for MissingBencher {
+    fn default() -> Self {
+        let dense_iter = || 1..INDEX_SIZE;
+        let sparse_iter = || (1..INDEX_SIZE).map(|i| i * SPARSE_DELTA);
+
+        Self {
+            context_dense: TestContext::missing(dense_iter()),
+            context_sparse: TestContext::missing(sparse_iter()),
+        }
+    }
+}
+
+impl MissingBencher {
+    pub fn bench(&self, c: &mut Criterion) {
+        self.read_dense(c);
+        self.skip_to_dense(c);
+        self.skip_to_sparse(c);
+    }
+
+    fn read_dense(&self, c: &mut Criterion) {
+        let mut group = benchmark_group(c, "Missing", "Read Dense");
+        self.c_read(&mut group, &self.context_dense);
+        self.rust_read(&mut group, &self.context_dense);
+        group.finish();
+    }
+
+    fn skip_to_dense(&self, c: &mut Criterion) {
+        let mut group = benchmark_group(c, "Missing", "SkipTo Dense");
+        self.c_skip_to(&mut group, &self.context_dense);
+        self.rust_skip_to(&mut group, &self.context_dense);
+        group.finish();
+    }
+
+    fn skip_to_sparse(&self, c: &mut Criterion) {
+        let mut group = benchmark_group(c, "Missing", "SkipTo Sparse");
+        self.c_skip_to(&mut group, &self.context_sparse);
+        self.rust_skip_to(&mut group, &self.context_sparse);
+        group.finish();
+    }
+
+    fn c_read<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>, context: &TestContext) {
+        let idx = context.missing_index_ptr();
+        let sctx = context.sctx.as_ptr();
+        let field_index = context.field_spec().index;
+        group.bench_function("C", |b| {
+            b.iter(|| {
+                // SAFETY: `context` provides valid pointers with a valid
+                // `spec` and `missingFieldDict` that outlive the iterator.
+                let it = unsafe { bench_ffi::QueryIterator::new_missing(idx, sctx, field_index) };
+                while it.read() == ::ffi::IteratorStatus_ITERATOR_OK {
+                    black_box(it.current());
+                }
+                it.free();
+            });
+        });
+    }
+
+    fn c_skip_to<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>, context: &TestContext) {
+        let idx = context.missing_index_ptr();
+        let sctx = context.sctx.as_ptr();
+        let field_index = context.field_spec().index;
+        group.bench_function("C", |b| {
+            b.iter(|| {
+                // SAFETY: `context` provides valid pointers with a valid
+                // `spec` and `missingFieldDict` that outlive the iterator.
+                let it = unsafe { bench_ffi::QueryIterator::new_missing(idx, sctx, field_index) };
+                while it.skip_to(it.last_doc_id() + SKIP_TO_STEP)
+                    != ::ffi::IteratorStatus_ITERATOR_EOF
+                {
+                    black_box(it.current());
+                }
+                it.free();
+            });
+        });
+    }
+
+    fn rust_read<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>, context: &TestContext) {
+        let ii = DocIdsOnly::from_opaque(context.missing_inverted_index());
+        let field_index = context.field_spec().index;
+        group.bench_function("Rust", |b| {
+            b.iter(|| {
+                // SAFETY: `context` provides a valid `RedisSearchCtx` with a valid
+                // `spec` and `missingFieldDict` that outlive the iterator.
+                let mut it = unsafe {
+                    Missing::new(
+                        ii.reader(),
+                        context.sctx,
+                        field_index,
+                        rqe_iterators::NoOpChecker,
+                    )
+                };
+                while let Ok(Some(current)) = it.read() {
+                    black_box(current);
+                }
+            });
+        });
+    }
+
+    fn rust_skip_to<M: Measurement>(
+        &self,
+        group: &mut BenchmarkGroup<'_, M>,
+        context: &TestContext,
+    ) {
+        let ii = DocIdsOnly::from_opaque(context.missing_inverted_index());
+        let field_index = context.field_spec().index;
+        group.bench_function("Rust", |b| {
+            b.iter(|| {
+                // SAFETY: `context` provides a valid `RedisSearchCtx` with a valid
+                // `spec` and `missingFieldDict` that outlive the iterator.
+                let mut it = unsafe {
+                    Missing::new(
+                        ii.reader(),
+                        context.sctx,
+                        field_index,
+                        rqe_iterators::NoOpChecker,
+                    )
+                };
+                while let Ok(Some(outcome)) = it.skip_to(it.last_doc_id() + SKIP_TO_STEP) {
+                    match outcome {
+                        SkipToOutcome::Found(current) | SkipToOutcome::NotFound(current) => {
+                            black_box(current);
+                        }
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/mod.rs
@@ -13,10 +13,12 @@ use std::time::Duration;
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 
+mod missing;
 mod numeric;
 mod term;
 mod wildcard;
 
+pub use missing::MissingBencher;
 pub use numeric::NumericBencher;
 pub use term::TermBencher;
 pub use wildcard::WildcardBencher;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -66,6 +66,23 @@ impl QueryIterator {
         Self(it)
     }
 
+    /// Creates a new missing-field inverted index iterator via the C path.
+    ///
+    /// # Safety
+    ///
+    /// `idx` must be a valid pointer to a DocIdsOnly inverted index.
+    /// `sctx` must be a valid pointer to a `RedisSearchCtx` with valid `spec`
+    /// and `missingFieldDict`.
+    /// `field_index` must be a valid index into `sctx.spec.fields`.
+    #[inline(always)]
+    pub unsafe fn new_missing(
+        idx: *const ffi::InvertedIndex,
+        sctx: *const ffi::RedisSearchCtx,
+        field_index: ffi::t_fieldIndex,
+    ) -> Self {
+        Self(unsafe { ffi::NewInvIndIterator_MissingQuery(idx, sctx, field_index) })
+    }
+
     /// Creates a new intersection iterator from child ID list iterators.
     ///
     /// # Arguments

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -650,6 +650,15 @@ impl TestContext {
         }
     }
 
+    /// Get a raw pointer to the missing-field inverted index suitable for FFI.
+    /// Panics if this is not a missing context.
+    pub fn missing_index_ptr(&self) -> *const ffi::InvertedIndex {
+        match &self.inner {
+            TestContextInner::Missing { inverted_index, .. } => inverted_index.as_ptr(),
+            _ => panic!("TestContext is not a Missing context"),
+        }
+    }
+
     /// Get the missing-field (doc-ids-only) inverted index for this context.
     /// Returns a reference to the FFI inverted index wrapper.
     /// Panics if this is not a missing context.


### PR DESCRIPTION
Add MissingBencher with read and skip_to benchmarks for dense and sparse index layouts, following the same pattern as WildcardBencher.

Used to be https://github.com/RediSearch/RediSearch/pull/8561 but changed based to `master`.

  | Benchmark | C | Rust | Speedup |
  |-----------|---|------|---------|
  | **Read Dense** | 3.347 ms | 1.709 ms | **1.96x faster** |
  | **SkipTo Dense** | 627.2 µs | 410.1 µs | **1.53x faster** |
  | **SkipTo Sparse** | 6.802 ms | 2.837 ms | **2.40x faster** |



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the benchmarking harness and test utilities, adding new unsafe FFI wiring but not touching production query execution paths.
> 
> **Overview**
> Adds a new `MissingBencher` to benchmark the missing-field inverted index iterator, covering `read` and `skip_to` for both dense and sparse doc-id distributions and comparing Rust vs the existing C iterator.
> 
> Wires the new benchmark into the Criterion runner, exposes it from `benchers::inverted_index`, and adds minimal support utilities: an FFI constructor `QueryIterator::new_missing` plus a `TestContext::missing_index_ptr()` accessor for passing the missing-field index to the C path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94e06f5cd89aeafb5aefab59c097ebab43cd4616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->