### PR TITLE
MOD-14383: Block Aggregate and Hybrid commands on disk environments

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -33,6 +33,7 @@
 #include "profile/options.h"
 #include "reply_empty.h"
 #include "search_disk.h"
+#include "search_disk_utils.h"
 
 // Multi threading data structure
 typedef struct {
@@ -1241,6 +1242,10 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     return RedisModule_WrongArity(ctx);
   }
 
+  if (type == COMMAND_AGGREGATE &&
+      SearchDisk_MarkUnsupportedCommandIfDiskEnabled(ctx, "FT.AGGREGATE")) {
+    return REDISMODULE_OK;
+  }
   QueryError status = QueryError_Default();
 
   // Memory guardrail
@@ -1584,12 +1589,17 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return RedisModule_WrongArity(ctx);
   }
 
+  if (type == COMMAND_AGGREGATE &&
+      SearchDisk_MarkUnsupportedCommandIfDiskEnabled(ctx, "FT.AGGREGATE")) {
+    return REDISMODULE_OK;
+  }
+  QueryError status = QueryError_Default();
+
   AREQ *r = NULL;
   AREQ_Debug_params debug_params = {0};
   int debug_argv_count = 0;
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
-  QueryError status = QueryError_Default();
   AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
   if (!debug_req) {
     goto error;

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -14,6 +14,7 @@
 #include "result_processor.h"
 #include "rmutil/args.h"
 #include "rmalloc.h"
+#include "search_disk_utils.h"
 
 // Debug parameters structure for hybrid queries
 typedef struct {
@@ -260,6 +261,9 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
     return RedisModule_WrongArity(ctx);
   }
 
+  if (SearchDisk_MarkUnsupportedCommandIfDiskEnabled(ctx, "FT.HYBRID")) {
+    return REDISMODULE_OK;
+  }
   QueryError status = QueryError_Default();
 
   // Get index name and create search context (same pattern as regular hybridCommandHandler)

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -32,6 +32,7 @@
 #include "module.h"
 #include "aggregate/reply_empty.h"
 #include "profile/profile.h"
+#include "search_disk_utils.h"
 
 #include <time.h>
 
@@ -672,6 +673,9 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     return RedisModule_WrongArity(ctx);
   }
 
+  if (SearchDisk_MarkUnsupportedCommandIfDiskEnabled(ctx, "FT.HYBRID")) {
+    return REDISMODULE_OK;
+  }
   QueryError status = QueryError_Default();
 
   // Memory guardrail

--- a/src/module.c
+++ b/src/module.c
@@ -71,6 +71,7 @@
 #include "info/info_redis/threads/main_thread.h"
 #include "legacy_types.h"
 #include "search_disk.h"
+#include "search_disk_utils.h"
 #include "rs_wall_clock.h"
 #include "hybrid/hybrid_exec.h"
 #include "coord/coord_request_ctx.h"
@@ -80,7 +81,6 @@
 #include "aggregate/reply_empty.h"
 #include "module_init.h"
 #include "asm_state_machine.h"
-#include "search_disk_utils.h"
 #include "config.h"
 #ifdef ENABLE_ASSERT
 #include <unistd.h>  // for usleep in coordinator reduce pause
@@ -3588,6 +3588,10 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return RedisModule_WrongArity(ctx);
   }
 
+  if (SearchDisk_MarkUnsupportedCommandIfDiskEnabled(ctx, "FT.AGGREGATE")) {
+    return REDISMODULE_OK;
+  }
+
   // Memory guardrail
   if (QueryMemoryGuard(ctx)) {
     // If we are in a single shard cluster, we should fail the query if we are out of memory
@@ -3667,6 +3671,10 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, CLUSTERDOWN_ERR);
   } else if (argc < 3) {
     return RedisModule_WrongArity(ctx);
+  }
+
+  if (SearchDisk_MarkUnsupportedCommandIfDiskEnabled(ctx, "FT.HYBRID")) {
+    return REDISMODULE_OK;
   }
 
   // Memory guardrail

--- a/src/search_disk_utils.c
+++ b/src/search_disk_utils.c
@@ -24,3 +24,11 @@ bool SearchDisk_MarkUnsupportedFieldIfDiskEnabled(const char *fieldTypeStr, cons
   }
   return true;
 }
+
+bool SearchDisk_MarkUnsupportedCommandIfDiskEnabled(RedisModuleCtx *ctx, const char *command) {
+  if (!SearchDisk_IsEnabledForValidation()) {
+    return false;
+  }
+  RedisModule_ReplyWithErrorFormat(ctx, "%s is not supported in disk mode", command);
+  return true;
+}

--- a/src/search_disk_utils.h
+++ b/src/search_disk_utils.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include "field_spec.h"
 #include "query_error.h"
+#include "redismodule.h"
 
 #define FLEX_MAX_INDEX_COUNT 10
 
@@ -32,3 +33,12 @@ bool SearchDisk_CheckLimitNumberOfIndexes(size_t nIndexes);
  * @return true if the field type is supported, false otherwise
  */
 bool SearchDisk_MarkUnsupportedFieldIfDiskEnabled(const char *fieldTypeStr, const FieldSpec *fs, QueryError *status);
+
+/**
+ * @brief Reply with unsupported-command error if disk mode is enabled.
+ *
+ * @param ctx Redis module context
+ * @param command Command name string
+ * @return true if the command was blocked, false otherwise
+ */
+bool SearchDisk_MarkUnsupportedCommandIfDiskEnabled(RedisModuleCtx *ctx, const char *command);

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -277,3 +277,35 @@ def test_flex_search_rejects_load_with_nocontent_or_return_0(env):
 
     env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '0', 'LOAD', '1', '@t') \
         .error().contains('LOAD is not supported for disk indexes')
+
+
+@skip(cluster=True)
+def test_flex_blocks_aggregate_and_hybrid_commands(env):
+    _create_flex_search_fixture(env)
+
+    env.expect('FT.AGGREGATE', 'idx', '*') \
+        .error().contains('FT.AGGREGATE is not supported in disk mode')
+    env.expect('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*') \
+        .error().contains('FT.AGGREGATE is not supported in disk mode')
+
+    env.expect('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@v', '$BLOB') \
+        .error().contains('FT.HYBRID is not supported in disk mode')
+    env.expect('FT.PROFILE', 'idx', 'HYBRID', 'QUERY', 'SEARCH', '*', 'VSIM', '@v', '$BLOB') \
+        .error().contains('FT.HYBRID is not supported in disk mode')
+
+
+@skip(cluster=True)
+def test_flex_blocks_debug_wrappers_for_aggregate_and_hybrid(env):
+    _create_flex_search_fixture(env)
+
+    env.expect(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'TIMEOUT_AFTER_N', '1', 'DEBUG_PARAMS_COUNT', '2') \
+        .error().contains('FT.AGGREGATE is not supported in disk mode')
+    env.expect(debug_cmd(), 'FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT_AFTER_N', '1', 'DEBUG_PARAMS_COUNT', '2') \
+        .error().contains('FT.AGGREGATE is not supported in disk mode')
+
+    env.expect(debug_cmd(), 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@v', '$BLOB',
+               'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2') \
+        .error().contains('FT.HYBRID is not supported in disk mode')
+    env.expect(debug_cmd(), 'FT.PROFILE', 'idx', 'HYBRID', 'QUERY', 'SEARCH', '*', 'VSIM', '@v', '$BLOB',
+               'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2') \
+        .error().contains('FT.HYBRID is not supported in disk mode')


### PR DESCRIPTION
Block FT.AGGREGATE and FT.HYBRID

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command-dispatch behavior for Flex/disk environments and affects both standalone and cluster coordinator code paths; low functional risk outside disk mode but could break clients relying on these commands in that mode.
> 
> **Overview**
> Prevents `FT.AGGREGATE` and `FT.HYBRID` (including `FT.PROFILE` and debug wrappers) from running when Flex/disk mode validation is enabled, returning a consistent "not supported in disk mode" error instead.
> 
> Introduces `SearchDisk_MarkUnsupportedCommandIfDiskEnabled()` in `search_disk_utils` and wires it into aggregate/hybrid handlers in both standalone and coordinator paths, with new pytests asserting the blocked behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8f337a34d8fe484cc401c48c0d28e99bf0d1380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->