### PR TITLE
[MOD-14426] Fix clippy const fn warnings for release

### DIFF
--- a/src/redisearch_rs/hyperloglog/src/lib.rs
+++ b/src/redisearch_rs/hyperloglog/src/lib.rs
@@ -146,6 +146,7 @@ impl<T, const BITS: u8, const SIZE: usize, H: hash32::Hasher + Default>
     /// Creates an HLL from existing register data.
     ///
     /// This is useful for deserializing an HLL or loading from external storage.
+    #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn from_registers(registers: [u8; SIZE]) -> Self {
         // Trigger compile-time checks
         let () = Self::_BITS_RANGE_CHECK;

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -406,6 +406,7 @@ where
     /// # Safety
     ///
     /// 1. `me` must be a well-aligned, valid pointer to a result processor (struct [`Header`]).
+    #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     unsafe fn debug_assert_same_type(_me: NonNull<Header>) {
         #[cfg(debug_assertions)]
         {

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -103,6 +103,7 @@ impl<'a> KeyList<'a> {
     }
 
     /// Return a cursor over an [`RLookup`]'s key list.
+    #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn cursor_front(&self) -> Cursor<'_, 'a> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::cursor_front");
@@ -114,6 +115,7 @@ impl<'a> KeyList<'a> {
     }
 
     /// Return a cursor over an [`RLookup`]'s key list with editing operations.
+    #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn cursor_front_mut(&mut self) -> CursorMut<'_, 'a> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::cursor_front_mut");


### PR DESCRIPTION
Fix clippy const fn warnings for release.

These functions are `const` in _release_, but not in _debug_.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Attribute-only changes to silence a lint; no functional logic or data flow is modified.
> 
> **Overview**
> Suppresses Clippy `missing_const_for_fn` warnings in non-debug builds by adding `#[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]` to a few functions whose bodies differ between debug and release.
> 
> This affects `HyperLogLog::from_registers`, `ResultProcessorWrapper::debug_assert_same_type`, and `KeyList::{cursor_front,cursor_front_mut}`; behavior is unchanged aside from lint handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 542073733564c2ce6a65d04dfc19ff7d0bb3febf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->