### PR TITLE
doc: Rust: document private items and fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,10 +304,10 @@ endef
 lint:
 	@echo "Running linters for debug..."
 	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --document-private-items
 	@echo "Running linters for release..."
 	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) --release -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --release
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --document-private-items --release
 
 fmt:
 ifeq ($(CHECK),1)

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -114,7 +114,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
 /// # Parameters
 ///
 /// * `idx` - Pointer to the tag's inverted index ([`DocIdsOnly`] or [`RawDocIdsOnly`] encoded).
-/// * `tag_idx` - Pointer to the [`TagIndex`](ffi::TagIndex) containing the [`TrieMap`](triemap_ffi::TrieMap) of tag values.
+/// * `tag_idx` - Pointer to the [`TagIndex`](ffi::TagIndex) containing the `TrieMap` of tag values.
 /// * `sctx` - Pointer to the Redis search context.
 /// * `field_mask_or_index` - Field mask or field index to filter on.
 /// * `term` - Pointer to the query term representing the tag value. Ownership is
@@ -134,7 +134,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
 /// 1. `idx` must be a valid pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
 ///    [`InvertedIndex`](ffi::InvertedIndex) and cannot be NULL.
 /// 2. `idx` must remain valid between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
-///    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) [`TrieMap`](triemap_ffi::TrieMap) lookup.
+///    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) `TrieMap` lookup.
 /// 3. `tag_idx` must be a valid pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
 /// 4. `tag_idx` and `tag_idx.values` must remain valid for the lifetime of the returned
 ///    iterator.

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -124,6 +124,8 @@ pub unsafe extern "C" fn RLookup_EnableOptions(
 ///     1. The entire memory range of this cstr must be contained within a single allocation!
 ///     2. `name` must be non-null even for a zero-length cstr.
 /// 4. The nul terminator must be within `isize::MAX` from `name`
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RLookup_FindFieldInSpecCache(
     lookup: *const OpaqueRLookup,

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/util.rs
@@ -35,7 +35,7 @@ pub(crate) const unsafe fn expect_value<'a>(value: *const RsValue) -> &'a RsValu
 /// the underlying `RsValue`.
 ///
 /// Checks for null in debug mode, directly casts to a
-/// ManuallyDrop<SharedRsValue> in release mode.
+/// [`ManuallyDrop<SharedRsValue>`] in release mode.
 ///
 /// # Safety
 ///

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -244,7 +244,7 @@ struct NumericRangeIteratorsResult CreateNumericRangeIterators(const NumericRang
  * # Parameters
  *
  * * `idx` - Pointer to the tag's inverted index ([`DocIdsOnly`] or [`RawDocIdsOnly`] encoded).
- * * `tag_idx` - Pointer to the [`TagIndex`](ffi::TagIndex) containing the [`TrieMap`](triemap_ffi::TrieMap) of tag values.
+ * * `tag_idx` - Pointer to the [`TagIndex`](ffi::TagIndex) containing the `TrieMap` of tag values.
  * * `sctx` - Pointer to the Redis search context.
  * * `field_mask_or_index` - Field mask or field index to filter on.
  * * `term` - Pointer to the query term representing the tag value. Ownership is
@@ -264,7 +264,7 @@ struct NumericRangeIteratorsResult CreateNumericRangeIterators(const NumericRang
  * 1. `idx` must be a valid pointer to a [`DocIdsOnly`] or [`RawDocIdsOnly`]
  *    [`InvertedIndex`](ffi::InvertedIndex) and cannot be NULL.
  * 2. `idx` must remain valid between [`revalidate()`](rqe_iterators::RQEIterator::revalidate) calls, since the revalidation
- *    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) [`TrieMap`](triemap_ffi::TrieMap) lookup.
+ *    mechanism detects when the index has been replaced via [`TagIndex`](ffi::TagIndex) `TrieMap` lookup.
  * 3. `tag_idx` must be a valid pointer to a [`TagIndex`](ffi::TagIndex) and cannot be NULL.
  * 4. `tag_idx` and `tag_idx.values` must remain valid for the lifetime of the returned
  *    iterator.

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -343,6 +343,8 @@ void RLookup_EnableOptions(struct RLookup *lookup, uint32_t options);
  *     1. The entire memory range of this cstr must be contained within a single allocation!
  *     2. `name` must be non-null even for a zero-length cstr.
  * 4. The nul terminator must be within `isize::MAX` from `name`
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const FieldSpec *RLookup_FindFieldInSpecCache(const struct RLookup *lookup, const char *name);
 

--- a/src/redisearch_rs/inverted_index/src/controlled_cursor.rs
+++ b/src/redisearch_rs/inverted_index/src/controlled_cursor.rs
@@ -58,7 +58,7 @@ unsafe fn vec_write_all_unchecked(pos: usize, vec: &mut Vec<u8>, buf: &[u8]) -> 
     pos + buf.len()
 }
 
-/// Resizing `write_all` implementation for [`Cursor`].
+/// Resizing `write_all` implementation for [`ControlledCursor`].
 ///
 /// Cursor is allowed to have a pre-allocated and initialised
 /// vector body, but with a position of 0. This means the [`Write`]
@@ -92,7 +92,7 @@ fn vec_write_all(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> std::io::R
     Ok(buf_len)
 }
 
-/// Resizing `write_all_vectored` implementation for [`Cursor`].
+/// Resizing `write_all_vectored` implementation for [`ControlledCursor`].
 ///
 /// Cursor is allowed to have a pre-allocated and initialised
 /// vector body, but with a position of 0. This means the [`Write`]

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -441,7 +441,7 @@ impl NumericRangeTree {
 ///
 /// Captures the new depth and any delta changes caused by a rotation
 /// (e.g. dropped ranges). Callers apply the relevant fields to their
-/// own result type ([`AddResult`] or [`TrimEmptyLeavesResult`]).
+/// own result type ([`AddResult`] or [`super::TrimEmptyLeavesResult`]).
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct BalanceResult {
     /// The new `max_depth` for the balanced node.

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -145,7 +145,7 @@ pub struct NumericRangeTree {
     ///
     /// When `revision_id != 0`, it indicates the tree nodes have changed and
     /// concurrent iteration may not be safe. Iterators like
-    /// [`NumericRangeTreeIterator`](crate::NumericRangeTreeIterator) should check this value and abort if it
+    /// `NumericRangeTreeIterator` should check this value and abort if it
     /// changes during iteration, as the tree structure they were traversing
     /// may no longer be valid.
     revision_id: u32,

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -205,7 +205,7 @@ impl Upstream<'_> {
 /// For intrusive data types like this we need to tell the compiler "don't move this please I have pointers to it" which is called
 /// pinning in Rust.
 ///
-/// We wrap a reference in the Pin<T> type (Pin<&mut T>) which disallows moving the pointee from its location in memory.
+/// We wrap a reference in the `Pin<T>` type (Pin<&mut T>) which disallows moving the pointee from its location in memory.
 /// Crucially though, the way Pin disallows is not magic, it simply doesn't implement any methods and traits that would
 /// allow a caller to move the value. Unfortunately this means banning all mutable access to the value T (you cannot get a
 /// &mut T from a Pin<&mut T> for example) since with a &mut T you can always move the value very easily (via mem::replace for example).
@@ -233,7 +233,7 @@ struct Header {
     /// not read, so it is the responsibility of the caller to ensure that there
     /// are no refcount leaks in the structure.
     ///
-    /// Users can use [`ffi::SearchResult_Clear`] to reset the structure without freeing it.
+    /// Users can use [`search_result::SearchResult::clear`] to reset the structure without freeing it.
     ///
     /// The populated structure (if [`ffi::RPStatus_RS_RESULT_OK`] is returned) does contain references
     /// to document data. Callers *MUST* ensure they are eventually freed.

--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -81,7 +81,7 @@ pub type RLookupKeyFlags = BitFlags<RLookupKeyFlag>;
 pub const GET_KEY_FLAGS: RLookupKeyFlags =
     make_bitflags!(RLookupKeyFlag::{Override | Hidden | ExplicitReturn | ForceLoad});
 
-/// Flags do not persist to the key, they are just options to [`RLookup::get_key_read`], [`RLookup::get_key_write`], or [`RLookup::get_key_load`].
+/// Flags do not persist to the key, they are just options to [`super::RLookup::get_key_read`], [`super::RLookup::get_key_write`], or [`super::RLookup::get_key_load`].
 pub const TRANSIENT_FLAGS: RLookupKeyFlags =
     make_bitflags!(RLookupKeyFlag::{Override | ForceLoad | NameAlloc});
 
@@ -245,7 +245,7 @@ impl<'a> RLookupKey<'a> {
     /// Constructs a `Pin<Box<RLookupKey>>` from a raw pointer.
     ///
     /// The returned `Box` will own the raw pointer, in particular dropping the `Box`
-    /// will deallocate the `RLookupKey`. This function should only be used by [`RLookup::drop`].
+    /// will deallocate the `RLookupKey`. This function should only be used by [`super::key_list::KeyList`]'s `drop` implementation.
     ///
     /// # Safety
     ///

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -102,7 +102,7 @@ impl<'a> KeyList<'a> {
         unsafe { Pin::new_unchecked(key) }
     }
 
-    /// Return a cursor over an [`RLookup`]'s key list.
+    /// Return a cursor over an [`super::RLookup`]'s key list.
     #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn cursor_front(&self) -> Cursor<'_, 'a> {
         #[cfg(debug_assertions)]
@@ -114,7 +114,7 @@ impl<'a> KeyList<'a> {
         }
     }
 
-    /// Return a cursor over an [`RLookup`]'s key list with editing operations.
+    /// Return a cursor over an [`super::RLookup`]'s key list with editing operations.
     #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn cursor_front_mut(&mut self) -> CursorMut<'_, 'a> {
         #[cfg(debug_assertions)]

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -9,7 +9,7 @@
 
 //! Primitives to manage the expected memory layout of the heap-allocated buffer for each [`Node`].
 //!
-//! Check out [`NodeLayout`]'s documentation for more details.
+//! Check out [`PtrMetadata`]'s documentation for more details.
 use crate::node::Node;
 use std::{alloc::Layout, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 
@@ -17,7 +17,7 @@ use std::{alloc::Layout, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 #[derive(Clone, Copy, Debug)]
 /// The first field in the allocated buffer for a [`Node`].
 ///
-/// [`NodeHeader::layout`] can be used to compute the layout of
+/// [`NodeHeader::metadata`] can be used to compute the layout of
 /// the buffer allocated for a [`Node`].
 pub(super) struct NodeHeader {
     /// The length of the label associated with this node.
@@ -106,7 +106,7 @@ impl NodeHeader {
 /// to align our type.
 ///
 /// We have optimized, in particular, for `Data=NonNull<*mut c_void>`, the scenario we have in
-/// [`crate::ffi`]. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
+/// the FFI layer. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
 /// located between the end of the array of children first bytes and the start of the
 /// array of children pointers.
 ///
@@ -357,7 +357,7 @@ impl<Data> PtrMetadata<Data> {
     /// a. `ptr` must point to an allocation with the same alignment and size of [`Self::layout`].
     /// b. `ptr` must have been allocated via the global allocator.
     /// c. `ptr` must satisfy all the requirements laid out in [`std::ptr::drop_in_place`]
-    /// d. If [`DeallocOption::drop_children`] is set to `Some(n_children)`, then
+    /// d. If [`DeallocOptions::drop_children`] is set to `Some(n_children)`, then
     ///    the children buffer length is greater than or equal to `n_children` and all
     ///    entries up to `n_children` are initialized.
     pub unsafe fn dealloc(&mut self, ptr: NonNull<NodeHeader>, options: DeallocOptions) {
@@ -519,7 +519,7 @@ impl<Data> PtrWithMetadata<Data> {
     ///
     /// a. The layout of the allocation behind [`Self::ptr`] matches *exactly* the layout it was allocated with.
     /// b. `ptr` must satisfy all the requirements laid out in [`std::ptr::drop_in_place`]
-    /// c. If [`DeallocOption::drop_children`] is set to `Some(n_children)`, then
+    /// c. If [`DeallocOptions::drop_children`] is set to `Some(n_children)`, then
     ///    the children buffer length is greater than or equal to `n_children` and all
     ///    entries up to `n_children` are initialized.
     pub unsafe fn dealloc(&mut self, options: DeallocOptions) {

--- a/src/redisearch_rs/trie_rs/src/utils.rs
+++ b/src/redisearch_rs/trie_rs/src/utils.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::is_prefix`].
+/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::all::is_prefix`].
 #[inline(always)]
 pub(crate) fn strip_prefix<'a>(haystack: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
     if !memchr::arch::all::is_prefix(haystack, prefix) {


### PR DESCRIPTION
Some links were incorrectly resolved, indicating some documentation that needs updating.

We can check this by running `cargo doc --document-private-items`.
- This PR adds this flag to `make lint`, which is run in CI.
- Existing warning have been fixed

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation generation flags and doc comment/link fixes, with no functional code or API behavior modifications.
> 
> **Overview**
> **CI lint now validates Rust docs more strictly** by running `cargo doc` with `--document-private-items` (debug and release) so rustdoc warnings/links are caught.
> 
> Fixes various rustdoc issues across Rust and generated C headers (broken intra-doc links, incorrect type names/paths, and added missing `[valid]` link targets), plus a few comment-only clarifications (e.g., `ControlledCursor`, `NumericRangeTreeIterator`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f72f84b3843b1b1659881527176a3e93f130d3bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->