### PR TITLE
[MOD-14426] Run linters for release as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,9 +302,12 @@ $(shell grep "EXCLUDE_RUST_BENCHING_CRATES_LINKING_C=" build.sh | cut -d'=' -f2 
 endef
 
 lint:
-	@echo "Running linters..."
+	@echo "Running linters for debug..."
 	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
 	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps
+	@echo "Running linters for release..."
+	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) --release -- -D warnings
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --release
 
 fmt:
 ifeq ($(CHECK),1)


### PR DESCRIPTION
Run linters for release as well, to catch problems. Previously it was only run for debug.
[Suggested by Dax](https://github.com/RediSearch/RediSearch/pull/8652#issuecomment-4032204066).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile change that only expands the `lint` target to also run `clippy`/`cargo doc` under `--release`, potentially increasing CI/runtime but not affecting production code.
> 
> **Overview**
> Updates the `Makefile` `lint` target to run Rust `cargo clippy` and `cargo doc` twice: once in debug (existing behavior) and additionally in `--release` mode, with clearer log messages separating the two runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f03689e24da8c1f1572b0a55da2344cd12d693. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->