### PR TITLE
Enable sccache for C, C++, and Rust builds when available

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -473,6 +473,12 @@ prepare_cmake_arguments() {
   # Ensure output file is always .so even on macOS
   CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_SHARED_LIBRARY_SUFFIX=.so"
 
+  # Enable sccache for C/C++ compilation caching if available
+  if command -v sccache &>/dev/null; then
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+    echo "Using sccache for C/C++ compilation caching"
+  fi
+
   # Add caching flags to prevent using old configurations
   CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -UCMAKE_TOOLCHAIN_FILE"
 
@@ -508,6 +514,12 @@ prepare_cmake_arguments() {
 
   # Export RUSTFLAGS so it's available to the Rust build process
   export RUSTFLAGS
+
+  # Enable sccache for Rust if available
+  if command -v sccache &>/dev/null; then
+    export RUSTC_WRAPPER="sccache"
+    echo "Using sccache for Rust compilation caching"
+  fi
 
   # RUSTFLAGS will be passed as environment variable to avoid quoting issues
   # This prevents CMake argument parsing from truncating complex flag values


### PR DESCRIPTION
Speed up cold build (after wipping `bin/`) on my local machine from 96 seconds to 39 (2.4x faster!).

Could also be used to speed CI by using either the GitHub action cache or setting up a remote cache storage.

See https://github.com/mozilla/sccache


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change that conditionally enables compiler caching when `sccache` is present; primary risk is unexpected environment interactions or cache-related build issues.
> 
> **Overview**
> Builds now automatically use `sccache` when it is installed: CMake is configured with `CMAKE_{C,CXX}_COMPILER_LAUNCHER=sccache` for C/C++ compilation, and Rust builds export `RUSTC_WRAPPER=sccache`.
> 
> This is an opt-in-by-presence change only (no new dependency), with added log messages indicating when caching is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c46c91a7628aae555f4e2a2d397764307f4a4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->