### PR TITLE
MOD-14216: Unlock spec after iterator creation for disk indexes

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -971,6 +971,14 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
     goto error;
   }
 
+  // For disk indexes, release the spec lock immediately after iterator creation.
+  // This is fine, since the disk iterators use snapshots. This allows the main
+  // thread to write while the query iterates over disk data.
+  // NOTE: Revisit as more index types are supported.
+  if (sctx->spec->diskSpec) {
+    RedisSearchCtx_UnlockSpec(sctx);
+  }
+
   if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
     RedisModule_Reply _reply = RedisModule_NewReply(outctx), *reply = &_reply;
     int rc = AREQ_StartCursor(req, reply, execution_ref, &status, false);
@@ -1020,14 +1028,6 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   // check possible optimization after creation of QueryIterator tree
   if (IsOptimized(req)) {
     QOptimizer_Iterators(req, req->optimizer);
-  }
-
-  // For disk indexes, release the spec lock immediately after iterator creation.
-  // This is fine, since the disk iterators use snapshots. This allows the main
-  // thread to write while the query iterates over disk data.
-  // NOTE: Revisit as more index types are supported.
-  if (sctx->spec->diskSpec) {
-    RedisSearchCtx_UnlockSpec(sctx);
   }
 
   if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
@@ -1219,6 +1219,15 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
       CurrentThread_ClearIndexSpec();
       return REDISMODULE_ERR;
     }
+
+    // For disk indexes, release the spec lock immediately after iterator creation.
+    // This is fine, since the disk iterators use snapshots. This allows the main
+    // thread to write while the query iterates over disk data.
+    // NOTE: Revisit as more index types are supported.
+    if (sctx->spec->diskSpec) {
+      RedisSearchCtx_UnlockSpec(sctx);
+    }
+
     if (AREQ_RequestFlags(r) & QEXEC_F_IS_CURSOR) {
       // Since we are still in the main thread, and we already validated the
       // spec'c existence, it is safe to directly get the strong reference from the spec


### PR DESCRIPTION
Continuation (fix) of https://github.com/RediSearch/RediSearch/pull/8549, unlocking the index spec after creating the iterators for the query.

Tests for this mechanism will follow shortly (mainly on the disk side).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes locking lifetime around query execution, which can introduce race/GC issues if assumptions about disk snapshot iterators or `diskSpec` detection are wrong. Scope is limited to disk indexes and only affects when the spec lock is released.
> 
> **Overview**
> For disk-backed indexes (`spec->diskSpec`), this PR **unlocks the index spec immediately after `prepareExecutionPlan` creates the iterator tree**, in both background-thread execution (`AREQ_Execute_Callback`) and main-thread execution (`buildPipelineAndExecute`).
> 
> This reduces lock hold time so the main thread can perform writes while long-running queries iterate over disk snapshot data, with a note to revisit as more index types are supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2f61f45844d0da54737d5b46aabfae3d40b4a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->