### PR TITLE
reproduce attemps

### DIFF
--- a/src/coord/rmr/io_runtime_ctx.c
+++ b/src/coord/rmr/io_runtime_ctx.c
@@ -167,6 +167,7 @@ static void sideThread(void *arg) {
   // Run the loop one more time to process close callbacks
   uv_run(&io_runtime_ctx->uv_runtime.loop, UV_RUN_ONCE);
   uv_loop_close(&io_runtime_ctx->uv_runtime.loop);
+  printf("IO Runtime thread finished\n");
 }
 
 uv_loop_t* IORuntimeCtx_GetLoop(IORuntimeCtx *io_runtime_ctx) {
@@ -286,6 +287,7 @@ void IORuntimeCtx_Free(IORuntimeCtx *io_runtime_ctx) {
     uv_mutex_unlock(&io_runtime_ctx->uv_runtime.loop_th_created_mutex);
     if (!io_runtime_ctx->uv_runtime.loop_th_creation_failed) {
       // Make sure IORuntimeCtx Free is not holding the GIL
+      printf("Waiting for IORuntime thread to finish\n");
       uv_thread_join(&io_runtime_ctx->uv_runtime.loop_th);
     }
   } else {

--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -21,13 +21,26 @@
 #include <array>
 #include <initializer_list>
 #include <span>
-
+static std::atomic<bool> tear_down_started = false;
+static std::atomic<bool> testCallback2_incremented = true;
 // Test callback for queue operations
+static void testCallback2(void *privdata) {
+  int *counter = (int *)privdata;
+
+  while (!tear_down_started.load()) {
+    usleep(1); // 1us delay
+  }
+    printf("testCallback: about to access counter at %p\n", counter);
+
+  (*counter)++;
+  testCallback2_incremented = true;
+  printf("testCallback: incremented counter at %p\n", counter);
+}
 static void testCallback(void *privdata) {
   int *counter = (int *)privdata;
+
   (*counter)++;
 }
-
 // Test callback for topology updates
 static void testTopoCallback(void *privdata) {
   struct UpdateTopologyCtx *ctx = (struct UpdateTopologyCtx *)privdata;
@@ -60,9 +73,16 @@ protected:
   }
 
   void TearDown() override {
+
     // Clear any pending topology before shutdown
     IORuntimeCtx_FireShutdown(ctx);
+    tear_down_started = true;
+    while (!testCallback2_incremented.load()) {
+      usleep(1); // 1us delay
+    }
+    printf("TearDown: about to free IORuntimeCtx\n");
     IORuntimeCtx_Free(ctx);
+    tear_down_started = false;
   }
 };
 
@@ -312,6 +332,7 @@ TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
 
 TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
   // Test that uv_threads_running_topology_update metric is tracked correctly
+  int dummy = 0;
 
   // Setup
   ConcurrentSearch_CreatePool(1);
@@ -343,10 +364,10 @@ TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
     }
     rm_free(ctx);
   };
+  testCallback2_incremented = false;
 
   // Start the IO runtime thread (required for uv loop to process async events)
-  int dummy = 0;
-  IORuntimeCtx_Schedule(ctx, testCallback, &dummy);
+  IORuntimeCtx_Schedule(ctx, testCallback2, &dummy);
 
   // Schedule topology update - this calls uv_async_send which triggers topologyAsyncCB
   MRClusterTopology *newTopo = getDummyTopology(9999);


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stdout `printf` calls in the IO runtime thread shutdown/join path and introduces test-side busy-wait synchronization, which could affect runtime output and timing-sensitive shutdown behavior.
> 
> **Overview**
> Adds additional shutdown/join logging in `io_runtime_ctx.c` via `printf` to help trace when the IO runtime thread finishes and when `IORuntimeCtx_Free` waits for it.
> 
> Updates `test_cpp_io_runtime_ctx.cpp` to better reproduce/observe shutdown races by introducing atomic teardown flags, a blocking `testCallback2` used to keep the IO thread busy during teardown/topology-update metric tests, and waiting in `TearDown()` until the callback has completed before freeing the runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b06ec3f480b9b4ff9d84d769cfb5f48442dc7a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->