### PR TITLE
Support PR Auto Resubmission On Stuck Github Merge CI

### DIFF
--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -237,7 +237,9 @@ jobs:
             local jobs_json
             jobs_json=$(gh api "/repos/$REPO/actions/runs/$run_id/jobs?per_page=100")
             echo "$jobs_json" | jq -r '[.jobs[]
-              | select(.name | test("^(get-latest-redis-tag|lint|test-matrix)"))
+              # `get-latest-redis-tag` is currently a fast bootstrap/dummy job and
+              # should not be treated as real validation progress for stuck-run detection.
+              | select(.name | test("^(lint|test-matrix)"))
               | select((.status == "in_progress") or (.started_at != null))
             ] | length > 0'
           }


### PR DESCRIPTION
Sometimes the merge queue CI never starts running and eventually times out,
e.g: https://github.com/RediSearch/RediSearch/pull/8628
After analysis we determined that a mitigation would be to detect this and to resubmit the PR into the queue if something like this happens.
Also needed to align the current PR resubmission detection logic to this new behaviour.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automation that can dequeue/enqueue PRs in the merge queue and writes PR comments/statuses, so mis-detection could cause unintended requeues or extra churn in CI.
> 
> **Overview**
> Improves merge-queue *resubmission detection* in `.github/workflows/event-merge-queue-resubmit.yml` by matching prior failed/cancelled `event-merge-to-queue.yml` runs for the same PR and verifying the PR head SHA is unchanged before alerting Slack (now also includes `PreviousValidationRunId`).
> 
> Adds a new `recover-stuck-merge-group` job that watches for merge-group validations that fail/cancel without any real validation jobs starting and with non-terminal `pr-validation` status, and (when `AUTO_REQUEUE_ENABLED=true`) automatically dequeues/re-enqueues the PR with idempotency markers, concurrency protection, and a circuit breaker to limit repeated retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f1c0c175e2def31d3fdfc9ef5ae65d4c6edead3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->