### PR TITLE
MOD-14461: Fix FT.EXPLAIN missing spec read lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1136,7 +1136,8 @@ cleanup:
   blockedClientReqCtx_destroy(BCRctx);
 }
 
-// Assumes the spec is guarded (by its own lock for read or by the global lock)
+// Assumes the spec is guarded by its own lock (for read), such that races with
+// main-thread/GC updates are avoided.
 int prepareExecutionPlan(AREQ *req, QueryError *status) {
   int rc = REDISMODULE_ERR;
   RedisSearchCtx *sctx = AREQ_SearchCtx(req);


### PR DESCRIPTION
## Description

`RS_GetExplainOutput` (used by `FT.EXPLAIN` command) was calling `prepareExecutionPlan` without first acquiring a read lock on the index spec.

The comment on `prepareExecutionPlan` explicitly states:
> "Assumes the spec is guarded (by its own lock for read or by the global lock)"

This could lead to race conditions with the GC modifying spec structures (`spec->terms`, `spec->suffix`, `spec->docs`, `spec->stats`) concurrently.

## Fix

Added `RedisSearchCtx_LockSpecRead`/`RedisSearchCtx_UnlockSpec` around `prepareExecutionPlan` and `QAST_DumpExplain`, following the same pattern used in other callers (e.g., `AREQ_Execute_Callback` and `execCommandCommon`).

## Jira

[MOD-14461](https://redislabs.atlassian.net/browse/MOD-14461)

#### Release Notes

- [x] This PR requires release notes

User-impact: Before this fix, the DB may crash if running `FT.EXPLAIN` while GC updates the index.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14461]: https://redislabs.atlassian.net/browse/MOD-14461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small, targeted concurrency change in query planning; risk is mainly around incorrect lock/unlock ordering potentially causing deadlocks or lingering locks if future edits add new early-return paths.
> 
> **Overview**
> `FT.EXPLAIN` now acquires a spec read lock before calling `prepareExecutionPlan` and holds it through `QAST_DumpExplain`, ensuring the explain path can’t race with GC/main-thread spec mutations.
> 
> Also clarifies `prepareExecutionPlan`’s contract by tightening its comment to explicitly require the spec’s own read lock to avoid concurrent update races.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ba1df4a4a78bb751010c9d7ec911f62346cdd35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->