### PR TITLE
[MOD-12286] RLookup - Clear sorting vector in RLookupRow::wipe

### DIFF
--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -255,11 +255,13 @@ impl<'a> RLookupRow<'a> {
     /// Wipes the row, retaining its memory but decrementing the ref count of any included instance of `T`.
     /// This does not free all the memory consumed by the row, but simply resets
     /// the row data (preserving any caches) so that it may be refilled.
+    /// Also clears the sorting vector.
     pub fn wipe(&mut self) {
         for value in self.dyn_values.iter_mut().filter(|v| v.is_some()) {
             *value = None;
             self.num_dyn_values -= 1;
         }
+        self.sorting_vector = None;
     }
 
     /// Resets the row, clearing the dynamic values. This effectively wipes the row and deallocates the memory used for dynamic values.

--- a/src/redisearch_rs/rlookup/tests/row.rs
+++ b/src/redisearch_rs/rlookup/tests/row.rs
@@ -184,6 +184,7 @@ fn wipe() {
     assert_eq!(row.num_dyn_values(), 0);
     assert_eq!(row.len(), 10);
     assert!(row.dyn_values().iter().all(|v| v.is_none()));
+    assert!(row.sorting_vector().is_none());
 
     // create the same 10 entries in the row
     for i in 0..10 {


### PR DESCRIPTION
Clear the sorting vector in `RLookupRow::wipe`, as caught in https://github.com/RediSearch/RediSearch/pull/8667#discussion_r2917921038.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small behavioral change limited to row lifecycle cleanup; main risk is if callers previously relied on `wipe()` preserving the sorting vector reference.
> 
> **Overview**
> `RLookupRow::wipe()` now also drops the row’s `sorting_vector` (in addition to clearing dynamic values), ensuring reused rows don’t retain stale sorting-vector state.
> 
> Updates the `wipe` unit test to assert the sorting vector is cleared after wiping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 014a54c76c0adf5a0838050fd9f3cf718248a8c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->