### PR TITLE
MOD-14485: Add more datapoints to benchmark baseline computation

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -107,7 +107,6 @@ jobs:
               --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }}
               --redistimeseries_pass '${{ secrets.PERFORMANCE_RTS_AUTH }}'
               --collect_search_memory True
-              --last_n_baseline 20
       - name: Generate Pull Request Performance info
         if: github.event.number
         env:
@@ -122,3 +121,4 @@ jobs:
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}
               --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }}
               --redistimeseries_pass '${{ secrets.PERFORMANCE_RTS_AUTH }}'
+              --last_n_baseline 20


### PR DESCRIPTION
Increases the number of datapoints we use for our benchmark baseline comparison from the default of 7 to 20, in order to increase benchmark comparison stability, as we have many unstable benchmarks currently.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single GitHub Actions workflow flag change that only affects how benchmark baselines are computed, with no product/runtime impact.
> 
> **Overview**
> Benchmark PR comparisons now compute the baseline from the last **20** datapoints instead of the default, by passing `--last_n_baseline 20` to `redisbench-admin compare` in `.github/workflows/benchmark-flow.yml`. This aims to make performance regressions/improvements more stable by smoothing benchmark noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e310ed7f89b61311c57bf9d0a58a3efb59ff11e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->