### PR TITLE
[MOD-13606] Improve build script for LTO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -388,7 +388,7 @@ prepare_cmake_arguments() {
       fi
     else
       CXX_COMPILER="$CXX"
-      if [[ ! "$CXX_COMPILER" =~ clang(++)?(-[0-9]+)?$ ]]; then
+      if [[ ! "$CXX_COMPILER" =~ clang([+][+])?(-[0-9]+)?$ ]]; then
         echo "Error: LTO requires clang++ as the C++ compiler"
         echo "Current CXX: $CXX_COMPILER"
         echo "Please set CXX to a clang-based compiler (e.g. clang++, clang++-nn)"


### PR DESCRIPTION
Improve build script for LTO.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes LTO compiler/linker validation and LLVM version parsing in `build.sh`, which could affect Linux build configurations that rely on custom `CC`/`CXX`/`LD` values.
> 
> **Overview**
> Improves `build.sh`’s LTO path by **tightening toolchain validation** to accept only `clang`/`clang++`/`lld` (including version-suffixed variants like `clang-<n>` and `lld-<n>`), and updates the user-facing error messages accordingly.
> 
> Also adjusts **LLVM major version detection** for cross-language LTO by switching the `clang --version` parsing to an extended-regex `sed` invocation intended to work on both GNU and BSD `sed`, and clarifies related mismatch/error messages to reference `rustc`/`clang` explicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c82c96e7b91c6a19571e9fa1918148b732b883c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->