### PR TITLE
chore: Don't compile no-op test binaries for FFI crates if there are no tests

### DIFF
--- a/src/redisearch_rs/c_entrypoint/document_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/document_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/fnv_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/fnv_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/idf_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/idf_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [dependencies]
 idf = { workspace = true }
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [dependencies]
 tracing_redismodule.workspace = true
 tracing = { workspace = true }

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
@@ -6,6 +6,8 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
 test = false
 bench = false
 

--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [dependencies]
 c_ffi_utils.workspace = true
 query_error.workspace = true

--- a/src/redisearch_rs/c_entrypoint/query_term_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/query_term_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/search_result_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/search_result_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [dependencies]
 search_result.workspace = true
 inverted_index.workspace = true

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/Cargo.toml
@@ -6,6 +6,8 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
 test = false
 bench = false
 

--- a/src/redisearch_rs/c_entrypoint/thin_vec_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/thin_vec_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no tests nor benches.
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Describe the changes in the pull request

Avoid linking issues for our FFI crates.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-only change that just prevents Cargo from compiling no-op test/bench artifacts for several FFI crates; runtime code and public APIs are unchanged.
> 
> **Overview**
> Prevents Cargo from building default test/bench binaries for multiple `c_entrypoint/*_ffi` crates by adding/standardizing a `[lib]` section with `test = false` and `bench = false`.
> 
> This is intended to avoid C linking issues caused by compiling no-op test/bench targets in FFI crates that have no tests/benches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db1e652d12a3b2e960c5395f26a07defbd094e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->