### PR TITLE
[MOD-13606] Rewrite install_llvm.sh to support all CI platforms via official tarballs

### DIFF
--- a/.install/LLVM_VERSION.sh
+++ b/.install/LLVM_VERSION.sh
@@ -4,3 +4,4 @@
 # This must match the LLVM version used by Rust for LTO to work
 # Check with: rustc --version --verbose | grep "LLVM version"
 LLVM_VERSION=21
+LLVM_FULL_VERSION=21.1.8

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -1,33 +1,170 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
+
 export DEBIAN_FRONTEND=noninteractive
-
-# Source the profile update utility
-source "$(dirname "$0")/macos_update_profile.sh"
-
-OS_TYPE=$(uname -s)
-# Source $LLVM_VERSION
-source "$(dirname "$0")/LLVM_VERSION.sh"
-MODE=$1
 APT_GET_LOCK_TIMEOUT_SECONDS="${APT_GET_LOCK_TIMEOUT_SECONDS:-600}"
 
-apt_get_cmd() {
-    $MODE apt-get -o DPkg::Lock::Timeout="$APT_GET_LOCK_TIMEOUT_SECONDS" "$@"
-    return $?
+# =============================================================================
+# install_llvm.sh — Install LLVM across all CI platforms
+#
+# Usage:
+#   ./install_llvm.sh [MODE]
+#
+# MODE is an optional privilege-escalation prefix (e.g. "sudo").
+# If empty, commands run unprivileged (useful inside containers).
+#
+# Reads LLVM_VERSION.sh for LLVM_VERSION (major, e.g. "21") and
+# LLVM_FULL_VERSION (e.g. "21.1.8").
+#
+# Environment variables:
+#   LLVM_INSTALL_DIR  — Where to unpack tarball installs (default: /usr/local/llvm)
+# =============================================================================
+
+OS_TYPE=$(uname -s)
+ARCH=$(uname -m)
+
+# Source LLVM_VERSION (major) and LLVM_FULL_VERSION (e.g. 21.1.8)
+source "$(dirname "${BASH_SOURCE[0]}")/LLVM_VERSION.sh"
+LLVM_VER="${LLVM_VERSION}"
+LLVM_FULL_VER="${LLVM_FULL_VERSION}"
+
+INSTALL_DIR="${LLVM_INSTALL_DIR:-/usr/local/llvm}"
+MODE="${1:-}"
+
+# Download and unpack the official LLVM tarball into $INSTALL_DIR.
+# Works on any glibc-based Linux. Will NOT work on musl/Alpine.
+install_from_tarball() {
+    local tarball_name
+    case "$ARCH" in
+        x86_64)  tarball_name="LLVM-${LLVM_FULL_VER}-Linux-X64.tar.xz" ;;
+        aarch64) tarball_name="LLVM-${LLVM_FULL_VER}-Linux-ARM64.tar.xz" ;;
+        *)       echo "ERROR: unsupported arch ${ARCH}"; return 1 ;;
+    esac
+
+    local url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_FULL_VER}/${tarball_name}"
+
+    echo ">>> Downloading LLVM ${LLVM_FULL_VER} from ${url}"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    curl -fSL --retry 3 -o "${tmpdir}/${tarball_name}" "$url"
+
+    echo ">>> Extracting to ${INSTALL_DIR}..."
+    $MODE mkdir -p "$INSTALL_DIR"
+    $MODE tar -xf "${tmpdir}/${tarball_name}" -C "$INSTALL_DIR" --strip-components=1
+    rm -rf "$tmpdir"
+
+    export_path_gha
+    echo ">>> LLVM ${LLVM_FULL_VER} installed to ${INSTALL_DIR}"
 }
 
-if [[ $OS_TYPE == Darwin ]]; then
-    brew install llvm@$LLVM_VERSION
-    BREW_PREFIX=$(brew --prefix)
-    LLVM="$BREW_PREFIX/opt/llvm@$LLVM_VERSION/bin"
+# Wire up $INSTALL_DIR/bin for GitHub Actions and the current shell.
+export_path_gha() {
+    local bindir="${INSTALL_DIR}/bin"
+    if [[ -n "${GITHUB_PATH:-}" ]]; then
+        echo "${bindir}" >> "$GITHUB_PATH"
+    fi
+    if [[ -n "${GITHUB_ENV:-}" ]]; then
+        echo "LIBCLANG_PATH=${INSTALL_DIR}/lib" >> "$GITHUB_ENV"
+    fi
+    export PATH="${bindir}:${PATH}"
+    export LIBCLANG_PATH="${INSTALL_DIR}/lib"
+}
 
-    # Update profiles with LLVM path
-    [[ -f ~/.bash_profile ]] && update_profile ~/.bash_profile "$LLVM"
-    [[ -f ~/.zshrc ]] && update_profile ~/.zshrc "$LLVM"
+# ---------------------------------------------------------------------------
+# Source the macOS profile updater if present.
+# ---------------------------------------------------------------------------
+if [[ "$OS_TYPE" == "Darwin" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "${SCRIPT_DIR}/macos_update_profile.sh" ]]; then
+        source "${SCRIPT_DIR}/macos_update_profile.sh"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Detect distro and install.
+# ---------------------------------------------------------------------------
+install_llvm() {
+    # ----- macOS (Homebrew) ---------------------------------------------------
+    if [[ "$OS_TYPE" == "Darwin" ]]; then
+        echo ">>> macOS — installing via Homebrew"
+        brew install "llvm@${LLVM_VER}"
+
+        local brew_prefix llvm_bin
+        brew_prefix=$(brew --prefix)
+        llvm_bin="${brew_prefix}/opt/llvm@${LLVM_VER}/bin"
+
+        if type update_profile &>/dev/null; then
+            [[ -f ~/.bash_profile ]] && update_profile ~/.bash_profile "$llvm_bin"
+            [[ -f ~/.zshrc ]]        && update_profile ~/.zshrc "$llvm_bin"
+        fi
+        [[ -n "${GITHUB_PATH:-}" ]] && echo "${llvm_bin}" >> "$GITHUB_PATH"
+        return 0
+    fi
+
+    # ----- Linux: detect distro -----------------------------------------------
+    local distro="" distro_version=""
+    if [[ -f /etc/os-release ]]; then
+        distro=$(. /etc/os-release && echo "${ID:-unknown}")
+        distro_version=$(. /etc/os-release && echo "${VERSION_ID:-}")
+    fi
+    # The GHA Alpine workaround rewrites /etc/os-release ID; detect via apk.
+    if [[ -f /etc/alpine-release ]] && command -v apk &>/dev/null; then
+        distro="alpine"
+        distro_version=$(cat /etc/alpine-release)
+    fi
+
+    echo ">>> Detected distro=${distro} version=${distro_version} arch=${ARCH}"
+
+    case "$distro" in
+
+    # ----- Debian / Ubuntu (apt.llvm.org) ------------------------------------
+    ubuntu|debian)
+        echo ">>> Using apt.llvm.org"
+        $MODE apt-get -o DPkg::Lock::Timeout="$APT_GET_LOCK_TIMEOUT_SECONDS" update -qq
+        $MODE apt-get -o DPkg::Lock::Timeout="$APT_GET_LOCK_TIMEOUT_SECONDS" install -y --no-install-recommends \
+            lsb-release wget software-properties-common gnupg ca-certificates
+        wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+        chmod +x /tmp/llvm.sh
+        $MODE /tmp/llvm.sh "$LLVM_VER"
+        rm -f /tmp/llvm.sh
+        ;;
+
+    # ----- Alpine Linux (apk) ------------------------------------------------
+    alpine)
+        echo ">>> Alpine Linux — trying apk packages"
+        # Alpine 3.23+ has llvm21 in main; 3.22 only has llvm20.
+        # Official tarballs are glibc-based and won't work here.
+        if $MODE apk add --no-cache "llvm${LLVM_VER}" "clang${LLVM_VER}" "lld${LLVM_VER}" 2>/dev/null; then
+            echo ">>> Installed llvm${LLVM_VER} from Alpine repos"
+        elif $MODE apk add --no-cache llvm clang lld; then
+            echo ">>> Installed default llvm/clang (may not be version ${LLVM_VER})"
+        else
+            echo "ERROR: No LLVM package available. Upgrade to Alpine 3.23+ or use edge."
+            return 1
+        fi
+        ;;
+
+    # ----- Everything else: official tarball ----------------------------------
+    # Rocky, CentOS, RHEL, AlmaLinux, Fedora, Amazon Linux, Mariner, Azure Linux
+    *)
+        echo ">>> ${distro} ${distro_version} — installing from official tarball"
+        install_from_tarball
+        ;;
+
+    esac
+}
+
+install_llvm
+
+echo ""
+echo ">>> Verifying..."
+if command -v "clang-${LLVM_VER}" &>/dev/null; then
+    "clang-${LLVM_VER}" --version
+elif command -v clang &>/dev/null; then
+    clang --version
+elif [[ -x "${INSTALL_DIR}/bin/clang" ]]; then
+    "${INSTALL_DIR}/bin/clang" --version
 else
-    apt_get_cmd update -qq
-    apt_get_cmd install -yqq lsb-release wget software-properties-common gnupg
-    wget https://apt.llvm.org/llvm.sh
-    chmod +x llvm.sh
-    $MODE ./llvm.sh $LLVM_VERSION
+    echo "WARNING: clang not found on PATH. You may need to add ${INSTALL_DIR}/bin to PATH."
 fi

--- a/.install/ubuntu_24.04.sh
+++ b/.install/ubuntu_24.04.sh
@@ -15,4 +15,4 @@ if [ "$(uname -m)" = "aarch64" ]; then
 fi
 
 # Need clang for LTO
-./install_llvm.sh $MODE
+source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ RUN bash retry.sh bash -l -eo pipefail install_script.sh && \
     if [ "$SAN" = "address" ]; then bash retry.sh bash -l -eo pipefail install_llvm.sh; fi
 WORKDIR /project
 # Expose newly-installed Rust and Python tools via PATH
-ENV PATH="/root/.cargo/bin:/root/.local/bin:${PATH}"
+ENV PATH="/usr/local/llvm/bin:/root/.cargo/bin:/root/.local/bin:${PATH}"
 
 WORKDIR /project


### PR DESCRIPTION
## Describe the changes in the pull request

We keep using LLVM-provided apt packages on Debian and Ubuntu, but fallback to tarballs on other distros that don't have packages for LLVM21.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites CI/toolchain installation logic across multiple Linux distros and changes how LLVM is provisioned and placed on PATH, which can break builds if detection or paths differ in target images.
> 
> **Overview**
> **Reworks LLVM installation for CI to be cross-distro.** `install_llvm.sh` is rewritten to detect OS/distro/arch and install LLVM 21 via Homebrew on macOS, `apt.llvm.org` on Debian/Ubuntu, `apk` on Alpine, and otherwise by downloading and unpacking the official LLVM release tarball into `/usr/local/llvm` (configurable via `LLVM_INSTALL_DIR`).
> 
> Adds `LLVM_FULL_VERSION` (e.g. `21.1.8`) to pin tarball downloads, exports `PATH`/`LIBCLANG_PATH` for GitHub Actions environments, adds a post-install clang verification step, updates Ubuntu 24.04 setup to `source` the installer, and updates the `Dockerfile` PATH to include `/usr/local/llvm/bin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bdf30868603a06bcfdaa9a11cda98b841104b13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->