### PR TITLE
Reject Unsupported vector features for disk specs - [MOD-13180]

### DIFF
--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -2485,7 +2485,7 @@ static YYACTIONTYPE yy_reduce(
     REPORT_WRONG_FIELD_TYPE(yymsp[-4].minor.yy150, SPEC_VECTOR_STR);
     QueryNode_Free(yymsp[-1].minor.yy3);
   } else if (SearchDisk_IsEnabledForValidation()) {
-    reportSyntaxError(ctx->status, &yymsp[-4].minor.yy150.tok, "Syntax error: vector range queries are currently not supported for disk indexes");
+    reportSyntaxError(ctx->status, &yymsp[-4].minor.yy150.tok, "Syntax error: vector range queries are currently not supported in Redis Flex");
     QueryNode_Free(yymsp[-1].minor.yy3);
   } else if (yymsp[-1].minor.yy3) {
     yymsp[-1].minor.yy3->vn.vq->field = yymsp[-4].minor.yy150.fs;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -1132,7 +1132,7 @@ expr(A) ::= modifier(B) COLON LSQB vector_range_command(C) RSQB. {
     REPORT_WRONG_FIELD_TYPE(B, SPEC_VECTOR_STR);
     QueryNode_Free(C);
   } else if (SearchDisk_IsEnabledForValidation()) {
-    reportSyntaxError(ctx->status, &B.tok, "Syntax error: vector range queries are currently not supported for disk indexes");
+    reportSyntaxError(ctx->status, &B.tok, "Syntax error: vector range queries are currently not supported in Redis Flex");
     QueryNode_Free(C);
   } else if (C) {
     C->vn.vq->field = B.fs;

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -121,7 +121,7 @@ static int VectorQuery_ValidateDiskHybridPolicy(const QueryEvalCtx *q, const Vec
 
   if (!VectorQuery_HasParam(vq, VECSIM_HYBRID_POLICY, sizeof(VECSIM_HYBRID_POLICY) - 1)) {
     QueryError_SetError(q->status, QUERY_ERROR_CODE_INVAL,
-                        "Disk pre-filtered vector queries currently require explicit HYBRID_POLICY");
+                        "Redis Flex pre-filtered vector queries currently require explicit HYBRID_POLICY");
     return REDISMODULE_ERR;
   }
 

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -141,7 +141,7 @@ TEST_F(QueryTest, testDiskVectorQueryRestrictions) {
     ast.setContext(&ctx);
     ASSERT_FALSE(ast.parse(range_query, version));
     ASSERT_NE(ast.getError(), nullptr);
-    ASSERT_NE(strstr(ast.getError(), "vector range queries are currently not supported for disk indexes"),
+    ASSERT_NE(strstr(ast.getError(), "vector range queries are currently not supported in Redis Flex"),
               nullptr)
         << ast.getError();
   }

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -386,6 +386,51 @@ def test_flex_disk_hnsw_rerank_requires_true_value(env):
 
 @skip(cluster=True)
 @with_simulate_in_flex(True)
+def test_disk_vector_query_validation(env: Env):
+
+    env.expect(
+        'FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
+        't', 'TEXT',
+        'v', 'VECTOR', 'HNSW', '14',
+        'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2',
+        'M', '16', 'EF_CONSTRUCTION', '100', 'EF_RUNTIME', '10', 'RERANK', 'TRUE',
+    ).ok()
+
+    docs = {
+        'doc:1': ([1.0, 1.0], 'hello'),
+        'doc:2': ([2.0, 2.0], 'hello'),
+        'doc:3': ([50.0, 50.0], 'goodbye'),
+    }
+
+    with env.getClusterConnectionIfNeeded() as conn:
+        for doc_id, (vector, text) in docs.items():
+            conn.execute_command('HSET', doc_id, 'v', create_np_array_typed(vector, 'FLOAT32').tobytes(), 't', text)
+
+    query_blob = create_np_array_typed([1.0, 1.0], 'FLOAT32').tobytes()
+
+    env.expect('FT.SEARCH', 'idx', '@v:[VECTOR_RANGE 10 $b]', 'NOCONTENT',
+                'PARAMS', '2', 'b', query_blob).error().contains(
+                    'vector range queries are currently not supported in Redis Flex')
+
+    env.expect('FT.SEARCH', 'idx', '@t:hello=>[KNN 2 @v $b]', 'NOCONTENT',
+                'PARAMS', '2', 'b', query_blob).error().contains(
+                    'Redis Flex pre-filtered vector queries currently require explicit HYBRID_POLICY')
+
+    valid_queries = [
+        '@t:hello=>[KNN 2 @v $b HYBRID_POLICY BATCHES]',
+        '@t:hello=>[KNN 2 @v $b HYBRID_POLICY ADHOC_BF]',
+        '@t:hello=>[KNN 2 @v $b]=>{$HYBRID_POLICY:BATCHES;}',
+        '@t:hello=>[KNN 2 @v $b]=>{$HYBRID_POLICY:ADHOC_BF;}',
+    ]
+
+    for query in valid_queries:
+        res = env.cmd('FT.SEARCH', 'idx', query, 'NOCONTENT', 'PARAMS', '2', 'b', query_blob)
+        env.assertEqual(res[0], 2, message=f'Expected 2 results for query "{query}"')
+        env.assertEqual(set(res[1:]), {'doc:1', 'doc:2'}, message=f'Expected results doc:1 and doc:2 for query "{query}"')
+
+
+@skip(cluster=True)
+@with_simulate_in_flex(True)
 def test_flex_blocks_alter_command(env):
     _create_flex_search_fixture(env)
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -59,30 +59,6 @@ def execute_hybrid_query(env, query_string, query_data, non_vector_field, sort_b
     return ret
 
 
-def create_disk_hnsw_query_fixture():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 _SIMULATE_IN_FLEX true')
-    conn = getConnectionByEnv(env)
-
-    env.expect(
-        'FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
-        't', 'TEXT',
-        'v', 'VECTOR', 'HNSW', '14',
-        'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2',
-        'M', '16', 'EF_CONSTRUCTION', '100', 'EF_RUNTIME', '10', 'RERANK', 'TRUE',
-    ).ok()
-
-    docs = {
-        'doc:1': ([1.0, 1.0], 'hello'),
-        'doc:2': ([2.0, 2.0], 'hello'),
-        'doc:3': ([50.0, 50.0], 'goodbye'),
-    }
-    for doc_id, (vector, text) in docs.items():
-        conn.execute_command('HSET', doc_id, 'v', create_np_array_typed(vector, 'FLOAT32').tobytes(), 't', text)
-
-    env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
-    return env
-
-
 '''******************* vecsim tests *****************************'''
 
 
@@ -766,33 +742,6 @@ def test_search_errors():
     env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]=>{$EPSILON: 2.71828}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('SEARCH_RANGE_ATTR_NON_RANGE range query attributes were sent for a non-range query (Error parsing vector similarity parameters)')
     env.expect('FT.SEARCH', 'idx', '@s:hello=>[KNN 2 @v $b]=>{$EPSILON: 0.1}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('SEARCH_RANGE_ATTR_NON_RANGE range query attributes were sent for a non-range query (Error parsing vector similarity parameters)')
     env.expect('FT.SEARCH', 'idx', f'@{v_flat}:[vector_range 0.1 $b]=>{{$epsilon:0.1}}', 'PARAMS', '2', 'b', 'abcdefghabcdefgh').equal('SEARCH_OPTION_INVALID Invalid option (Error parsing vector similarity parameters)')
-
-
-@skip(cluster=True)
-def test_disk_vector_query_validation():
-    env = create_disk_hnsw_query_fixture()
-
-    query_blob = create_np_array_typed([1.0, 1.0], 'FLOAT32').tobytes()
-
-    env.expect('FT.SEARCH', 'idx', '@v:[VECTOR_RANGE 10 $b]', 'NOCONTENT',
-                'PARAMS', '2', 'b', query_blob).error().contains(
-                    'vector range queries are currently not supported for disk indexes')
-
-    env.expect('FT.SEARCH', 'idx', '@t:hello=>[KNN 2 @v $b]', 'NOCONTENT',
-                'PARAMS', '2', 'b', query_blob).error().contains(
-                    'Disk pre-filtered vector queries currently require explicit HYBRID_POLICY')
-
-    valid_queries = [
-        '@t:hello=>[KNN 2 @v $b HYBRID_POLICY BATCHES]',
-        '@t:hello=>[KNN 2 @v $b HYBRID_POLICY ADHOC_BF]',
-        '@t:hello=>[KNN 2 @v $b]=>{$HYBRID_POLICY:BATCHES;}',
-        '@t:hello=>[KNN 2 @v $b]=>{$HYBRID_POLICY:ADHOC_BF;}',
-    ]
-
-    for query in valid_queries:
-        res = env.cmd('FT.SEARCH', 'idx', query, 'NOCONTENT', 'PARAMS', '2', 'b', query_blob)
-        env.assertEqual(res[0], 2, message=f'Expected 2 results for query "{query}"')
-        env.assertEqual(set(res[1:]), {'doc:1', 'doc:2'}, message=f'Expected results doc:1 and doc:2 for query "{query}"')
 
 
 def test_with_fields():


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Redis Flex/disk-mode validation checks that turn previously-accepted vector queries into explicit errors, which can break clients relying on `VECTOR_RANGE` or implicit hybrid defaults. Changes touch query parsing and vector iterator setup, so regressions would affect search behavior in Flex mode.
> 
> **Overview**
> Adds **Redis Flex (disk-backed) validation restrictions for vector search**.
> 
> In the v2 query parser, `VECTOR_RANGE` expressions now fail early with a clear syntax error when `SearchDisk_IsEnabledForValidation()` is on. During vector iterator creation, pre-filtered (hybrid) `KNN` queries in Flex now require an explicit `HYBRID_POLICY` parameter; otherwise iteration is rejected with a validation error.
> 
> Improves C++ interoperability by wrapping `src/param.h` declarations in `extern "C"`, and adds new C++ and Python tests covering the Flex-mode `VECTOR_RANGE` rejection and `HYBRID_POLICY` requirement (including query-attributes syntax).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b825f753b41ae9fbeb03bd3b4abd8ea56f1fe8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->