### PR TITLE
Speed up Docker image builds by using cargo-binstall

### DIFF
--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 OS_TYPE=$(uname -s)
 MODE=$1 # whether to install using sudo or not
 
@@ -20,14 +20,18 @@ rustup toolchain install $NIGHTLY_VERSION \
     --component miri \
     --component rust-src
 
+# Install a pinned version of `cargo-binstall`,
+# to fetch prebuilt release artefacts for the tools we use
+export BINSTALL_VERSION="1.17.7"
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/4c4aeb61ee54318eba5737b7c07aa509a2ed6d32/install-from-binstall-release.sh | bash
 # Tool required to compute test coverage for Rust code
-cargo install cargo-llvm-cov --locked
+cargo binstall cargo-llvm-cov@0.8.4 -y --locked --strategies="crate-meta-data,compile"
 # Our preferred test runner, instead of the default `cargo test`
-cargo install cargo-nextest --locked
+cargo binstall cargo-nextest@0.9.130 -y --locked --strategies="crate-meta-data,compile"
 # Tool to aggressively unify the feature sets of our dependencies,
 # thus improving the cacheability of our builds
 # See https://docs.rs/cargo-hakari/latest/cargo_hakari/about/
-cargo install cargo-hakari --locked
+cargo binstall cargo-hakari@0.9.37 -y --locked --strategies="crate-meta-data,compile"
 # Make sure `miri` is fully operational before running tests with it.
 # See https://github.com/rust-lang/miri/blob/master/README.md#running-miri-on-ci
 # for more details.


### PR DESCRIPTION
## Describe the changes in the pull request

Rather than repeatedly compiling these tools from source, let's fetch prebuilt binaries from GitHub.
Rather than installing latest (which changes regularly), let's pin versions for consistent results.

It should significantly reduce our Docker image build times. We should save ~4 minutes on average, roughly half the time it takes to build the whole image (10 minutes).

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI/Docker Rust dependency installation path to download prebuilt binaries from the network; failures or supply-chain issues could break builds, but runtime product behavior is unaffected.
> 
> **Overview**
> Updates `.install/test_deps/install_rust_deps.sh` to install a pinned `cargo-binstall` and use it to fetch prebuilt, version-pinned Rust tooling (`cargo-llvm-cov`, `cargo-nextest`, `cargo-hakari`) instead of compiling via `cargo install`.
> 
> Also tightens shell error handling (`set -eo pipefail`) and specifies binstall strategies to fall back to compiling when prebuilt artifacts/metadata aren’t available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50fff34f919f85c4fade229edb2038340ffa35e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->