### PR TITLE
fix flaky tests

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -172,10 +172,11 @@ TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
   int counter = 0;
   IORuntimeCtx_Schedule(ctx, testCallback, &counter);
 
-  while (counter < 1) {
-    usleep(1); // 1us delay
-  }
-  ASSERT_EQ(ctx->topo->capShards, 4097);
+  // Wait for topology to be applied. We can't rely on the callback counter since
+  // topology updates are processed via a separate async handle (topologyAsync)
+  // and may complete after regular callbacks
+  bool success = RS::WaitForCondition([&]() { return ctx->topo && ctx->topo->capShards == 4097; });
+  ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, capShards=" << (ctx->topo ? ctx->topo->capShards : 0);
 
   // We don't need to free newTopo here as it's handled by testTopoCallback
 }
@@ -189,15 +190,12 @@ TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
     MRClusterTopology *newTopo = getDummyTopology(4096 + i);
     IORuntimeCtx_Schedule_Topology(ctx, testTopoCallback, newTopo, true);
   }
-
-  // Give some time for the last topology to be applied
   IORuntimeCtx_Schedule(ctx, testCallback, &counter);
-  while (counter < 2) {
-    usleep(1); // 1us delay
-  }
-
-  // Only the last topology should be applied
-  ASSERT_EQ(ctx->topo->capShards, 4101);
+  // Wait for the last topology (4101) to be applied
+  // We can't rely on the callback counter since topology updates are processed
+  // via a separate async handle (topologyAsync) and may complete after regular callbacks
+  bool success = RS::WaitForCondition([&]() { return ctx->topo && ctx->topo->capShards == 4101; });
+  ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, capShards=" << (ctx->topo ? ctx->topo->capShards : 0);
 }
 
 TEST_F(IORuntimeCtxCommonTest, ClearPendingTopo) {


### PR DESCRIPTION
## Describe the changes in the pull request

### Problem

The `ScheduleTopology` and `MultipleTopologyUpdates` tests in `test_cpp_io_runtime_ctx.cpp` were flaky due to a race condition in how they waited for topology updates to be applied.

The tests were using a pattern like:
```cpp
IORuntimeCtx_Schedule_Topology(ctx, testTopoCallback, newTopo, true);
IORuntimeCtx_Schedule(ctx, testCallback, &counter);
while (counter < 1) {
  usleep(1);
}
ASSERT_EQ(ctx->topo->capShards, expectedValue); // Could fail!
```

### Root Cause

The issue is that `IORuntimeCtx_Schedule_Topology` and `IORuntimeCtx_Schedule` use **separate async handles** (`topologyAsync` vs `async`). libuv does NOT guarantee the order in which async callbacks are processed - they depend on internal implementation details, not the order `uv_async_send` was called.

So even though topology was scheduled before the regular callback, the `rqAsyncCb` (regular callback) could run before `topologyAsyncCB` (topology callback), causing the assertion to check `capShards` before the topology was actually applied.

### Solution

Replace the counter-based waiting with `RS::WaitForCondition` that directly waits for the expected topology state:
```cpp
bool success = RS::WaitForCondition([&]() { 
  return ctx->topo && ctx->topo->capShards == expectedValue; 
});
ASSERT_TRUE(success) << "Timeout waiting for topology...";
```

This approach:
1. Waits for the actual condition we care about (topology applied)
2. Includes null-safety check for `ctx->topo`
3. Has built-in timeout with clear error message
4. Eliminates the race condition entirely

#### Main objects this PR modified
1. `tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
