### PR TITLE
[MOD-14426] Fix indent lint

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
@@ -50,7 +50,7 @@ const NUM_DOCS: u64 = 100_000;
 /// - `StoreTermOffsets` is required for positional data; without it `max_slop`/`in_order`
 ///   benchmarks would be meaningless.
 /// - `StoreByteOffsets` instructs the `Full` encoder to also write byte-level offsets per entry (used by
-/// highlighting), keeping the benchmark data representative of a real index.
+///   highlighting), keeping the benchmark data representative of a real index.
 const FLAGS: IndexFlags = IndexFlags_Index_StoreFreqs
     | IndexFlags_Index_StoreTermOffsets
     | IndexFlags_Index_StoreFieldFlags


### PR DESCRIPTION
Fix indent lint

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts a doc-comment indentation/formatting issue in a benchmark file, with no functional or behavior changes.
> 
> **Overview**
> Fixes a minor rustdoc/indentation lint in `intersection.rs` by correcting the alignment of a multi-line comment describing `StoreByteOffsets` in the benchmark `FLAGS` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bff5ff8d0b7a4e1762c403faed3938ffe56b1d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->