### PR TITLE
[MOD-14426] Fix return-type warning

### DIFF
--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -730,8 +730,7 @@ VecSimMetric getVecSimMetricFromVectorField(const FieldSpec *vectorField) {
     case VecSimAlgo_BF:
       return algo_params.bfParams.metric;
     default:
-      // Unknown algorithm type
-      RS_ABORT("Unknown algorithm in vector index");
+      RS_ABORT_ALWAYS("Unknown algorithm in vector index");
   }
   __builtin_unreachable();
 }


### PR DESCRIPTION
Fix return-type warning

>/Users/memark/Src/Redis/RediSearch/src/vector_index.c:736:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only affects an error/"should never happen" code path, adding `__builtin_unreachable()` after an unconditional abort to satisfy the compiler.
> 
> **Overview**
> Fixes a `-Wreturn-type` warning in `getVecSimMetricFromVectorField` by making the default switch case use `RS_ABORT_ALWAYS` (explicitly non-returning) and adding `__builtin_unreachable()` after the switch to indicate no control path can fall through without returning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48a04cdad52e97ea9c772ec2968f91877b29710b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->