### PR TITLE
fix install rust deps issue

### DIFF
--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -28,24 +28,18 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 # Tool required to compute test coverage for Rust code
 cargo binstall cargo-llvm-cov@0.8.4 -y --locked --strategies="crate-meta-data,compile"
 # Our preferred test runner, instead of the default `cargo test`
-cargo binstall cargo-nextest@0.9.130 -y --locked --strategies="crate-meta-data,compile"
-# Use pre-built musl binary for maximum compatibility across glibc versions
-# (cargo install builds dynamically against system glibc which causes issues on older systems)
+# Use musl targets on Linux for maximum compatibility across glibc versions
+# (default builds dynamically against system glibc which causes issues on older systems)
 if [ "$OS_TYPE" = "Linux" ]; then
     if [ "$processor" = "x86_64" ]; then
-        curl -LsSf https://get.nexte.st/latest/linux-musl | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+        cargo binstall --target=x86_64-unknown-linux-musl cargo-nextest@0.9.130 -y --locked --strategies="crate-meta-data,compile"
     elif [ "$processor" = "aarch64" ]; then
-        curl -LsSf https://get.nexte.st/latest/linux-arm-musl | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+        cargo binstall --target=aarch64-unknown-linux-musl cargo-nextest@0.9.130 -y --locked --strategies="crate-meta-data,compile"
     else
-        # Fallback to cargo install for other architectures
-        cargo install cargo-nextest --locked
+        cargo binstall cargo-nextest@0.9.130 -y --locked --strategies="crate-meta-data,compile"
     fi
-elif [ "$OS_TYPE" = "Darwin" ]; then
-    # macOS - use universal binary
-    curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
 else
-    # Fallback to cargo install for other OSes
-    cargo install cargo-nextest --locked
+    cargo binstall cargo-nextest@0.9.130 -y --locked --strategies="crate-meta-data,compile"
 fi
 # Tool to aggressively unify the feature sets of our dependencies,
 # thus improving the cacheability of our builds


### PR DESCRIPTION
## Describe the changes in the pull request

### Problem

CI tests were failing on older Linux distributions (e.g., `amazonlinux:2`, `rockylinux:8`) with:

```
/github/home/.cargo/bin/cargo-nextest: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /github/home/.cargo/bin/cargo-nextest)
/github/home/.cargo/bin/cargo-nextest: /lib64/libc.so.6: version `GLIBC_2.27' not found (required by /github/home/.cargo/bin/cargo-nextest)
```

### Root Cause

The default `cargo binstall` command downloads binaries that are dynamically linked against GLIBC. When the CI cache contains a binary compiled on a newer system (GLIBC 2.27+), it fails to run on older systems like `amazonlinux:2` which only has GLIBC 2.26.

### Solution

Use `cargo binstall` with `--target` flag to specify **musl targets** on Linux systems. The musl binaries are statically linked and have no GLIBC dependency, ensuring compatibility across all Linux distributions:

- **Linux x86_64**: `cargo binstall --target=x86_64-unknown-linux-musl`
- **Linux aarch64**: `cargo binstall --target=aarch64-unknown-linux-musl`
- **Other platforms**: Uses default `cargo binstall` (no GLIBC issues on macOS/other)

This approach:
- Maintains version pinning (`cargo-nextest@0.9.130`) for reproducibility
- Uses the existing `cargo binstall` infrastructure
- Avoids duplicating installation logic

#### Release Notes

- [x] This PR does not require release notes

(CI infrastructure fix only)