### PR TITLE
[MOD-14426] Increase required cmake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 include(CheckCCompilerFlag)
 

--- a/src/coord/CMakeLists.txt
+++ b/src/coord/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 get_filename_component(root ${CMAKE_CURRENT_LIST_DIR}/../.. ABSOLUTE)
 get_filename_component(binroot ${CMAKE_CURRENT_BINARY_DIR}/../.. ABSOLUTE)

--- a/src/redisearch_rs/CMakeLists.txt
+++ b/src/redisearch_rs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 # Find Cargo
 find_program(CARGO_EXECUTABLE cargo REQUIRED)


### PR DESCRIPTION
Increase required cmake version to 3.15 to help getting rid of some warnings.

No one seems to be using older than 3.15 anyway.
https://github.com/neovim/neovim/issues/24004#issuecomment-1587741071

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system change that only affects environments using CMake <3.15; no runtime code paths are modified.
> 
> **Overview**
> Raises the project’s `cmake_minimum_required` from **3.13** to **3.15** across the top-level build and the `src/coord` and `src/redisearch_rs` subprojects, aligning the build with newer CMake behavior and reducing older-version warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f432580460533fa1d203c55860a8111e522c8a74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->