### PR TITLE
[MOD-14426] Fix "SVS LVQ is not available"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,15 @@ add_subdirectory(${root}/deps/libuv ${CMAKE_CURRENT_BINARY_DIR}/libuv)
 option(VECSIM_BUILD_TESTS "Build vecsim tests" OFF)
 add_subdirectory(${root}/deps/VectorSimilarity ${CMAKE_CURRENT_BINARY_DIR}/VectorSimilarity)
 
+# Suppress #pragma message warnings from VectorSimilarity (e.g., "SVS LVQ is not available")
+# which become errors with -Werror. These are informational, not actionable, and should not
+# have been warnings in the first place.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(VectorSimilarity PRIVATE "-Wno-#pragma-messages")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(VectorSimilarity PRIVATE "-Wno-cpp")
+endif()
+
 # Workaround: fmt 11.2.0 is missing <cstdlib> include, which is needed for LLVM 21+ on MacOS
 # This was fixed in fmt 12.0.0, but that requires patching several levels upstream.
 if(TARGET fmt)


### PR DESCRIPTION
Fix a ton of "SVS LVQ is not available" warnings.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build-system-only change that adjusts compiler warning flags for the `VectorSimilarity` target and doesn’t affect runtime behavior.
> 
> **Overview**
> Prevents `-Werror` builds from failing due to informational `#pragma message` output emitted by `deps/VectorSimilarity` (e.g., “SVS LVQ is not available”).
> 
> Adds compiler-specific suppression flags to the `VectorSimilarity` target in `src/CMakeLists.txt` (`-Wno-#pragma-messages` for Clang, `-Wno-cpp` for GCC).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fae92608eff46cb1199a64cd6ded78ec1a02c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->