### PR TITLE
Update dev docs and scripts for macOS

### DIFF
--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -4,7 +4,7 @@
 source "$(dirname "$0")/macos_update_profile.sh"
 
 if ! which brew &> /dev/null; then
-    echo "Brew is not installed. Install from https://brew.sh"
+    echo "Homebrew is not installed. Install from https://brew.sh"
     exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)
 #-----------------------------------------------------------------------------
 parse_arguments() {
   for arg in "$@"; do
-    # MacOS only has bash 3.2 built-in, which doesn't support the more modern ${arg^^} syntax.
+    # macOS only has bash 3.2 built-in, which doesn't support the more modern ${arg^^} syntax.
     upper_arg=$(printf '%s' "$arg" | tr '[:lower:]' '[:upper:]')
     case $upper_arg in
       COORD=*)

--- a/developer.md
+++ b/developer.md
@@ -315,7 +315,7 @@ The following operating systems are supported and tested in CI:
 * Amazon linux 2023
 * Mariner 2.0
 * Azure linux 3
-* MacOS
+* macOS
 * Alpine linux 3
 
 ### Platform-specific compiler requirements
@@ -332,5 +332,5 @@ The following operating systems are supported and tested in CI:
 - Amazon Linux 2023: Default GCC is sufficient
 - Mariner 2.0: Default GCC is sufficient
 - Azure Linux 3: Default GCC is sufficient
-- MacOS: Install clang-18 via brew
+- macOS: Install llvm@21 via homebrew
 - Alpine Linux 3: Default GCC is sufficient

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,7 @@ add_subdirectory(${root}/deps/libuv ${CMAKE_CURRENT_BINARY_DIR}/libuv)
 option(VECSIM_BUILD_TESTS "Build vecsim tests" OFF)
 add_subdirectory(${root}/deps/VectorSimilarity ${CMAKE_CURRENT_BINARY_DIR}/VectorSimilarity)
 
-# Workaround: fmt 11.2.0 is missing <cstdlib> include, which is needed for LLVM 21+ on MacOS
+# Workaround: fmt 11.2.0 is missing <cstdlib> include, which is needed for clang 21+ on macOS
 # This was fixed in fmt 12.0.0, but that requires patching several levels upstream.
 if(TARGET fmt)
     target_compile_options(fmt PRIVATE "-include" "cstdlib")


### PR DESCRIPTION
Update dev docs and scripts for macOS

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and comments plus a user-facing message in the macOS install script, with no build or runtime logic modifications.
> 
> **Overview**
> Updates macOS wording across tooling and docs (e.g., Homebrew check message and `macOS` capitalization) for consistency.
> 
> Refreshes developer guidance for macOS compiler setup to use Homebrew `llvm@21`, and aligns CMake/build script comments describing the `fmt`/clang workaround and Bash 3.2 note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00388c5f7a19ce7fb42cfbfc84f6813edf43d700. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->