### PR TITLE
update redismodule.h

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -16,6 +16,7 @@ extern "C" {
 
 typedef struct RedisModuleString RedisModuleString;
 typedef struct RedisModuleKey RedisModuleKey;
+typedef int RedisModuleKeyMetaClassId;
 
 /* -------------- Defines NOT common between core and modules ------------- */
 
@@ -51,6 +52,10 @@ typedef long long ustime_t;
 /* Version of the RedisModuleTypeMethods structure. Once the RedisModuleTypeMethods
  * structure is changed, this version number needs to be changed synchronistically. */
 #define REDISMODULE_TYPE_METHOD_VERSION 5
+
+/* Version of the RedisModuleKeyMetaClassConfig structure. Once the RedisModuleKeyMetaClassConfig
+ * structure is changed, this version number needs to be changed synchronistically. */
+#define REDISMODULE_KEY_META_VERSION    1
 
 /* API flags and constants */
 #define REDISMODULE_READ (1<<0)
@@ -399,7 +404,7 @@ typedef uint64_t RedisModuleTimerID;
 
 /* When set, Redis will not call RedisModule_MarkKeyAsDirty(), implicitly in
  * RedisModule_ModuleTypeSetValue, and the module needs to do that when manually when keys
- * are modified from the user's sperspective. */
+ * are modified from the user's perspective. */
 #define REDISMODULE_OPTION_NO_IMPLICIT_MARK_DIRTY (1<<31)
 
 /* Definitions for RedisModule_SetCommandInfo. */
@@ -593,12 +598,14 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_KEY 17
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION 18
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM 19
-#define REDISMODULE_EVENT_SST_REPLICATION 20
-#define _REDISMODULE_EVENT_NEXT 21 /* Next event flag, should be updated if a new event added. */
+#define _REDISMODULE_EVENT_NEXT 20 /* Next event flag, should be updated if a new event added. */
 
 /* RL Extension: Use IDs >= 1000 to maintain ABI compatibility with OSS Redis */
 #define REDISMODULE_EVENT_SHARDING 1000
-#define REDISMODULE_EVENT_SERVER_READY 1010
+
+/* Bigredis Extension: Use IDs >= 1100 to maintain ABI compatibility with OSS Redis */
+#define REDISMODULE_EVENT_SST_REPLICATION 1100
+#define REDISMODULE_EVENT_SERVER_READY 1101
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -808,7 +815,8 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_SST_REPL_PRE_FORK 1
 #define REDISMODULE_SUBEVENT_SST_REPL_POST_FORK 2
 #define REDISMODULE_SUBEVENT_SST_REPL_ABORT 3
-#define _REDISMODULE_SUBEVENT_SST_REPL_NEXT 4
+#define REDISMODULE_SUBEVENT_SST_REPL_POST_CHECKPOINT 4
+#define _REDISMODULE_SUBEVENT_SST_REPL_NEXT 5
 
 #define REDISMODULE_SUBEVENT_FORK_CHILD_BORN 0
 #define REDISMODULE_SUBEVENT_FORK_CHILD_DIED 1
@@ -1173,6 +1181,19 @@ typedef int (*RedisModuleConfigApplyFunc)(RedisModuleCtx *ctx, void *privdata, R
 typedef void (*RedisModuleOnUnblocked)(RedisModuleCtx *ctx, RedisModuleCallReply *reply, void *private_data);
 typedef int (*RedisModuleAuthCallback)(RedisModuleCtx *ctx, RedisModuleString *username, RedisModuleString *password, RedisModuleString **err);
 
+typedef int (*RedisModuleKeyMetaLoadFunc)(RedisModuleIO *rdb, uint64_t *meta, int encver);
+typedef void (*RedisModuleKeyMetaSaveFunc)(RedisModuleIO *rdb, void *value, uint64_t *meta);
+typedef void (*RedisModuleKeyMetaAOFRewriteFunc)(RedisModuleIO *aof, void *value, uint64_t meta);
+typedef void (*RedisModuleKeyMetaFreeFunc)(const char *keyname, uint64_t meta);
+typedef int (*RedisModuleKeyMetaCopyFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);
+typedef int (*RedisModuleKeyMetaRenameFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);
+typedef int (*RedisModuleKeyMetaDefragFunc)(RedisModuleDefragCtx *ctx, RedisModuleString *keyname, uint64_t meta);
+typedef size_t (*RedisModuleKeyMetaMemUsageFunc)(RedisModuleKeyOptCtx *ctx, size_t sample_size, uint64_t meta);
+typedef size_t (*RedisModuleKeyMetaFreeEffortFunc)(RedisModuleKeyOptCtx *ctx, uint64_t meta);
+typedef void (*RedisModuleKeyMetaUnlinkFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);
+typedef int (*RedisModuleKeyMetaMoveFunc)(RedisModuleKeyOptCtx *ctx, uint64_t *meta);
+
+
 typedef struct RedisModuleTypeMethods {
     uint64_t version;
     RedisModuleTypeLoadFunc rdb_load;
@@ -1194,6 +1215,28 @@ typedef struct RedisModuleTypeMethods {
     RedisModuleTypeCopyFunc2 copy2;
     RedisModuleTypeAuxSaveFunc aux_save2;
 } RedisModuleTypeMethods;
+
+
+/* Key metadata class configuration structure.
+ * Must be aligned with KeyMetaConfAllVersions in module.c.
+ * See RM_CreateKeyMetaClass() documentation in module.c for detailed information. */
+typedef struct RedisModuleKeyMetaClassConfig {
+    uint64_t version;
+#define REDISMODULE_META_ALLOW_IGNORE 0
+    uint64_t flags;
+    uint64_t reset_value;
+    RedisModuleKeyMetaCopyFunc copy;
+    RedisModuleKeyMetaRenameFunc rename;
+    RedisModuleKeyMetaMoveFunc move;
+    RedisModuleKeyMetaUnlinkFunc unlink;
+    RedisModuleKeyMetaFreeFunc free;
+    RedisModuleKeyMetaLoadFunc rdb_load;
+    RedisModuleKeyMetaSaveFunc rdb_save;
+    RedisModuleKeyMetaAOFRewriteFunc aof_rewrite;
+    RedisModuleKeyMetaDefragFunc defrag;
+    RedisModuleKeyMetaMemUsageFunc mem_usage;
+    RedisModuleKeyMetaFreeEffortFunc free_effort;
+} RedisModuleKeyMetaClassConfig;
 
 #define REDISMODULE_GET_API(name) \
     RedisModule_GetApi("RedisModule_" #name, ((void **)&RedisModule_ ## name))
@@ -1613,6 +1656,10 @@ REDISMODULE_API int (*RedisModule_ConfigSet)(RedisModuleCtx *ctx, const char *na
 REDISMODULE_API int (*RedisModule_ConfigSetBool)(RedisModuleCtx *ctx, const char *name, int value, RedisModuleString **err) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ConfigSetEnum)(RedisModuleCtx *ctx, const char *name, RedisModuleString *value, RedisModuleString **err) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ConfigSetNumeric)(RedisModuleCtx *ctx, const char *name, long long value, RedisModuleString **err) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleKeyMetaClassId (*RedisModule_CreateKeyMetaClass)(RedisModuleCtx *ctx, const char *metaname, int metaver, RedisModuleKeyMetaClassConfig *conf) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReleaseKeyMetaClass)(RedisModuleKeyMetaClassId id) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetKeyMeta)(RedisModuleKeyMetaClassId id, RedisModuleKey *key, uint64_t metadata) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_GetKeyMeta)(RedisModuleKeyMetaClassId id, RedisModuleKey *key, uint64_t *metadata) REDISMODULE_ATTR;
 
 /* bigredis extensions
  * -------------------*/
@@ -2074,6 +2121,11 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ConfigSetBool);
     REDISMODULE_GET_API(ConfigSetEnum);
     REDISMODULE_GET_API(ConfigSetNumeric);
+    REDISMODULE_GET_API(CreateKeyMetaClass);
+    REDISMODULE_GET_API(ReleaseKeyMetaClass);
+
+    REDISMODULE_GET_API(SetKeyMeta);
+    REDISMODULE_GET_API(GetKeyMeta);
 
     /* Bigredis Extensions */
     REDISMODULE_GET_API(IsKeyInRam);


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new module-facing API/ABI surface (`RedisModule_CreateKeyMetaClass` and related callbacks) and changes event ID values for BigRedis-specific events, which can break compatibility for modules relying on numeric constants or requiring server support.
> 
> **Overview**
> Adds a new **key metadata class** module API, including `RedisModuleKeyMetaClassConfig`, callback typedefs for meta lifecycle (RDB/AOF, copy/rename/move, defrag, mem usage), and exported functions to create/release classes and set/get per-key metadata (`RedisModule_CreateKeyMetaClass`, `RedisModule_ReleaseKeyMetaClass`, `RedisModule_SetKeyMeta`, `RedisModule_GetKeyMeta`).
> 
> Re-namespaces BigRedis module event IDs by moving `REDISMODULE_EVENT_SST_REPLICATION`/`REDISMODULE_EVENT_SERVER_READY` to the 1100+ range and updates `_REDISMODULE_EVENT_NEXT`; also adds a new SST replication subevent `REDISMODULE_SUBEVENT_SST_REPL_POST_CHECKPOINT` (and bumps `_..._NEXT`). Includes a small comment typo fix ("sperspective" -> "perspective").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e41841a7678ad43a10dbf9e9e711194d407c101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->