### PR TITLE
Fix Pseudo Memory Leak 

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3040,8 +3040,12 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
       RedisModule_InfoAddFieldCString(ctx, "identifier", path);
       RedisModule_InfoAddFieldCString(ctx, "attribute", name);
     } else {
-      RedisModule_InfoAddFieldCString(ctx, "identifier", FieldSpec_FormatPath(fs, obfuscate));
-      RedisModule_InfoAddFieldCString(ctx, "attribute", FieldSpec_FormatName(fs, obfuscate));
+      const char *path = FieldSpec_FormatPath(fs, obfuscate);
+      const char *name = FieldSpec_FormatName(fs, obfuscate);
+      RedisModule_InfoAddFieldCString(ctx, "identifier", path);
+      RedisModule_InfoAddFieldCString(ctx, "attribute", name);
+      rm_free((void*)path);
+      rm_free((void*)name);
     }
 
     if (fs->options & FieldSpec_Dynamic)


### PR DESCRIPTION
Right now code is never reached, but if it was then we would leak some memory.
Fixing it just to be on the safe side.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix that only affects `FT.INFO`/module info formatting; it adds missing `rm_free` calls for heap-allocated formatted strings to prevent a potential leak.
> 
> **Overview**
> Fixes a potential memory leak in `IndexSpec_AddToInfo` (`src/spec.c`) by capturing the heap-allocated results of `FieldSpec_FormatPath`/`FieldSpec_FormatName`, using them for `RedisModule_InfoAddFieldCString`, and then freeing them with `rm_free`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7bf1d6e3764e99ba196b8f70343ed5733b21f7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->