### PR TITLE
[MOD-13436] Fix full rust intersection heuristic implementation

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -110,8 +110,8 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
         IteratorType::InvIdxMissing
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -165,8 +165,8 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
         IteratorType::InvIdxNumeric
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -112,8 +112,8 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
         IteratorType::InvIdxTag
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -111,8 +111,8 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
         IteratorType::InvIdxWildcard
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -121,6 +121,10 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
             Self::NotOptimized(it) => it.type_(),
         }
     }
+
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
+    }
 }
 
 impl<'index> rqe_iterators::interop::ProfileChildren<'index> for NotIteratorEnum<'index> {

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -321,7 +321,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         Some(self)
     }
 
-    fn children_count(&self) -> usize {
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
         match self.type_ {
             IteratorType::Intersect => {
                 let ptr = std::ptr::from_ref(self.as_ref());
@@ -333,19 +333,41 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
                 // - `ref_from_header_ptr` uses the compiler-computed field offset for `inner`
                 //   rather than manual `size_of` arithmetic, making it immune to alignment
                 //   padding between `header` and `inner` in `RQEIteratorWrapper`.
-                unsafe {
+                let n = unsafe {
                     RQEIteratorWrapper::<Intersection<'_, CRQEIterator>>::ref_from_header_ptr(ptr)
                         .inner
                         .num_children()
-                }
+                };
+                1.0 / n.max(1) as f64
             }
-            IteratorType::Union => {
+            IteratorType::Union if prioritize_union_children => {
                 let ptr = std::ptr::from_ref(self.as_ref());
                 // SAFETY: `type_` guarantees `ptr` points to a `UnionIterator` whose first field
                 // is the `QueryIterator` base — the cast is valid by C struct layout.
-                unsafe { (*ptr.cast::<ffi::UnionIterator>()).num as usize }
+                let n = unsafe { (*ptr.cast::<ffi::UnionIterator>()).num as usize };
+                n.max(1) as f64
             }
-            _ => 0,
+            IteratorType::InvIdxNumeric => 1.0,
+            IteratorType::InvIdxTerm => 1.0,
+            IteratorType::InvIdxWildcard => 1.0,
+            IteratorType::InvIdxMissing => 1.0,
+            IteratorType::InvIdxTag => 1.0,
+            IteratorType::Hybrid => 1.0,
+            IteratorType::Union => 1.0,
+            IteratorType::Not => 1.0,
+            IteratorType::NotOptimized => 1.0,
+            IteratorType::Optional => 1.0,
+            IteratorType::OptionalOptimized => 1.0,
+            IteratorType::Wildcard => 1.0,
+            IteratorType::Empty => 1.0,
+            IteratorType::IdListSorted => 1.0,
+            IteratorType::IdListUnsorted => 1.0,
+            IteratorType::MetricSortedById => 1.0,
+            IteratorType::MetricSortedByScore => 1.0,
+            IteratorType::Profile => 1.0,
+            IteratorType::Optimus => 1.0,
+            IteratorType::Mock => 1.0,
+            IteratorType::Max => 1.0,
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -67,7 +67,7 @@ impl<'index> RQEIterator<'index> for Empty {
         IteratorType::Empty
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -254,7 +254,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
         }
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -18,32 +18,6 @@ use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, Skip
 use ffi::t_docId;
 use inverted_index::{RSIndexResult, ResultMetrics_Reset_func};
 
-/// Returns the sort weight for a child iterator, used by [`Intersection`] to order its children
-/// before query execution. A lower value causes the child to act as the pivot, minimising
-/// `SkipTo` calls. The final sort key is `num_estimated * sort_weight`.
-///
-/// Heuristics:
-/// - Intersection: `1.0 / num_children`.
-/// - Union: `num_children` when `prioritize_union_children`, else `1.0`.
-/// - Everything else: `1.0`.
-fn sort_weight<'index, I: RQEIterator<'index>>(iter: &I, prioritize_union_children: bool) -> f64 {
-    match iter.type_() {
-        IteratorType::Intersect => {
-            let children_count = iter.children_count();
-            if children_count == 0 {
-                1.0
-            } else {
-                1.0 / children_count as f64
-            }
-        }
-        IteratorType::Union if prioritize_union_children => {
-            let children_count = iter.children_count();
-            children_count.max(1) as f64
-        }
-        _ => 1.0,
-    }
-}
-
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
 ///
 /// Children are sorted by estimated result count (smallest first) to minimize iterations,
@@ -122,8 +96,10 @@ where
             children,
             weight,
             |a, b| {
-                let wa = a.num_estimated() as f64 * sort_weight(a, prioritize_union_children);
-                let wb = b.num_estimated() as f64 * sort_weight(b, prioritize_union_children);
+                let wa = a.num_estimated() as f64
+                    * a.intersection_sort_weight(prioritize_union_children);
+                let wb = b.num_estimated() as f64
+                    * b.intersection_sort_weight(prioritize_union_children);
                 wa.total_cmp(&wb)
             },
             max_slop,
@@ -506,8 +482,8 @@ where
         IteratorType::Intersect
     }
 
-    fn children_count(&self) -> usize {
-        self.children.len()
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0 / self.children.len().max(1) as f64
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -319,7 +319,7 @@ where
         )
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -189,7 +189,7 @@ where
         IteratorType::InvIdxMissing
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -192,7 +192,7 @@ where
         IteratorType::InvIdxNumeric
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -231,7 +231,7 @@ where
         IteratorType::InvIdxTag
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -215,7 +215,7 @@ where
         IteratorType::InvIdxTerm
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -169,7 +169,7 @@ where
         IteratorType::InvIdxWildcard
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -152,8 +152,17 @@ pub trait RQEIterator<'index> {
         None
     }
 
-    /// Returns the amount of children of this iterator.
-    fn children_count(&self) -> usize;
+    /// Returns the sort weight for this iterator when used as a child of an [`Intersection`].
+    ///
+    /// [`Intersection`] uses this to order its children before execution: a lower value makes
+    /// this iterator act as the pivot (minimising `SkipTo` calls). The final sort key is
+    /// `num_estimated * intersection_sort_weight(...)`.
+    ///
+    /// Implementers:
+    /// - [`Intersection`]: `1.0 / num_children` — fewer children means tighter selectivity.
+    /// - [`Union`]: `num_children` when `prioritize_union_children`, else `1.0`.
+    /// - Everything else: `1.0` — neutral, no influence.
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64;
 }
 
 /// Blanket [`RQEIterator`] impl for `Box<I>` where `I` is a concrete iterator type.
@@ -202,6 +211,10 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
 
     fn as_c_iterator(&self) -> Option<&c2rust::CRQEIterator> {
         (**self).as_c_iterator()
+    }
+
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        (**self).intersection_sort_weight(prioritize_union_children)
     }
 }
 
@@ -254,8 +267,8 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
         (**self).as_c_iterator()
     }
 
-    fn children_count(&self) -> usize {
-        (**self).children_count()
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        (**self).intersection_sort_weight(prioritize_union_children)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -164,10 +164,12 @@ where
         }
     }
 
-    fn children_count(&self) -> usize {
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
         match &self.0 {
-            MaybeEmptyOption::None(empty) => empty.children_count(),
-            MaybeEmptyOption::Some(it) => it.children_count(),
+            MaybeEmptyOption::None(empty) => {
+                empty.intersection_sort_weight(prioritize_union_children)
+            }
+            MaybeEmptyOption::Some(it) => it.intersection_sort_weight(prioritize_union_children),
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -194,8 +194,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
         }
     }
 
-    fn children_count(&self) -> usize {
-        // Metric is a leaf iterator (a scored id-list), not a composite.
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -257,10 +257,8 @@ where
         IteratorType::Not
     }
 
-    fn children_count(&self) -> usize {
-        // Not is not an intersection/union: it yields the complement of its child, so its
-        // selectivity is the inverse of the child's and should not influence sort weights.
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -332,6 +332,10 @@ where
     fn type_(&self) -> IteratorType {
         IteratorType::NotOptimized
     }
+
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
+    }
 }
 
 impl<'index, W> NotIterator<'index>

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -242,10 +242,8 @@ where
         IteratorType::Optional
     }
 
-    fn children_count(&self) -> usize {
-        // Optional is not an intersection/union: it emits virtual results for every document,
-        // so it is never selective and should not influence sort weights in parent intersections.
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -325,4 +325,8 @@ where
     fn type_(&self) -> ffi::IteratorType {
         ffi::IteratorType::OptionalOptimized
     }
+
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -141,7 +141,8 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
         IteratorType::Profile
     }
 
-    fn children_count(&self) -> usize {
-        self.child.children_count()
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        self.child
+            .intersection_sort_weight(prioritize_union_children)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -521,8 +521,12 @@ where
         IteratorType::Union
     }
 
-    fn children_count(&self) -> usize {
-        self.children.len()
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        if prioritize_union_children {
+            self.children.len().max(1) as f64
+        } else {
+            1.0
+        }
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -431,6 +431,14 @@ where
     fn type_(&self) -> IteratorType {
         IteratorType::Union
     }
+
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        if prioritize_union_children {
+            self.children.len().max(1) as f64
+        } else {
+            1.0
+        }
+    }
 }
 
 impl<'index, const QUICK_EXIT: bool> crate::interop::ProfileChildren<'index>

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -104,8 +104,8 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
         IteratorType::Wildcard
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 
@@ -181,6 +181,10 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
     fn as_c_iterator(&self) -> Option<&crate::c2rust::CRQEIterator> {
         (**self).as_c_iterator()
     }
+
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        (**self).intersection_sort_weight(prioritize_union_children)
+    }
 }
 
 impl<'index> WildcardIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> {}
@@ -237,8 +241,8 @@ impl<'index> RQEIterator<'index> for EmptyWildcard {
         IteratorType::Empty
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 
@@ -450,8 +454,8 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
         self.0.type_()
     }
 
-    fn children_count(&self) -> usize {
-        self.0.children_count()
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        self.0.intersection_sort_weight(prioritize_union_children)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -12,7 +12,7 @@
 use ffi::t_docId;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome, id_list::IdListSorted,
-    intersection::Intersection,
+    intersection::Intersection, profile::Profile,
 };
 
 use crate::utils::{Mock, MockRevalidateResult};
@@ -1406,6 +1406,44 @@ mod slop_and_order {
     }
 }
 
+/// Same as [`sort_weight_nested_intersection_sorts_first`] but the inner `Intersection` is wrapped
+/// in a [`Profile`].
+///
+/// [`Profile`] forwards [`RQEIterator::intersection_sort_weight`] to its child, so the
+/// reduced `1/num_children` weight is preserved even through the wrapper.
+#[test]
+fn sort_weight_profile_wrapped_nested_intersection_sorts_first() {
+    let docs: Vec<t_docId> = (1..=10).collect();
+
+    // Inner intersection: 5 children, num_estimated = 10 → sort key 10 * (1/5) = 2.0.
+    // Wrapped in Profile → intersection_sort_weight forwards to child, so sort key is still 2.0.
+    let inner_children_count = 5;
+    let inner_children: Vec<Box<dyn RQEIterator<'static> + 'static>> = (0..inner_children_count)
+        .map(|_| {
+            Box::new(IdListSorted::new(docs.clone())) as Box<dyn RQEIterator<'static> + 'static>
+        })
+        .collect();
+    let inner = Profile::new(Intersection::new(inner_children, 1.0, false));
+
+    // Plain child: num_estimated = 10 → sort key 10 * 1.0 = 10.0.
+    let plain = IdListSorted::new(docs);
+
+    // Pass plain first — the Profile-wrapped inner intersection sorts to index 0
+    // because its sort weight (0.2) is lower than the plain child's (1.0).
+    let outer = Intersection::new(
+        vec![
+            Box::new(plain) as Box<dyn RQEIterator<'static> + 'static>,
+            Box::new(inner),
+        ],
+        1.0,
+        false,
+    );
+    assert!(
+        outer.child_at(0).intersection_sort_weight(false) < 1.0,
+        "Profile-wrapped Intersection (sort key 2.0) must sort before plain child (sort key 10.0)"
+    );
+}
+
 /// A nested `Intersection` child (sort key `num_estimated * 1/num_children`) must sort before a
 /// plain child with equal `num_estimated` (sort key `num_estimated * 1.0`).
 #[test]
@@ -1434,7 +1472,7 @@ fn sort_weight_nested_intersection_sorts_first() {
         false,
     );
     assert!(
-        outer.child_at(0).children_count() == inner_children_count,
+        outer.child_at(0).intersection_sort_weight(false) < 1.0,
         "nested Intersection (sort key 2.0) must sort before plain child (sort key 10.0)"
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -60,8 +60,8 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
         IteratorType::Mock
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -975,8 +975,8 @@ mod optional_iterator_non_sequential_reads {
             IteratorType::Mock
         }
 
-        fn children_count(&self) -> usize {
-            0
+        fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+            1.0
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -435,8 +435,8 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
         IteratorType::Mock
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }
 
@@ -600,7 +600,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
         IteratorType::Mock
     }
 
-    fn children_count(&self) -> usize {
-        0
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -99,6 +99,10 @@ impl RQEIterator<'static> for FieldMaskMock {
     fn type_(&self) -> IteratorType {
         IteratorType::Empty
     }
+
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
+    }
 }
 
 use ffi::t_docId;


### PR DESCRIPTION
- Based on #8619

This implements the heuristic feature for intersection iterator children sorting for non c wrapped iterators (namely `Box<dyn RQEIterators>`).

It's currently not used in production, but will be once we swap all iterators to Rust.
This PR also adds a tests for this specific heuristic sorting.

## API choice

We decided to go with a more specific `intersection_sort_weight` into RQEIterator, because :
- The logic is dependent on `type_()`, but should depend on its "logical" type (so `type_()` doesn't fit when profiling)
- Adding a `children_count` getter is not relevant for some iterators, and ambiguous for others.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `Intersection` child-sorting heuristic by introducing a new `RQEIterator::intersection_sort_weight` API and using it to reorder children, which can affect query execution order and performance. While intended as a heuristic-only change, it touches core iterator composition paths (including C-interop) and could expose edge-case behavior differences.
> 
> **Overview**
> `Intersection` now sorts its children using a new per-iterator heuristic hook, `RQEIterator::intersection_sort_weight(prioritize_union_children)`, instead of relying on the previous C-wrapper-only weight calculation.
> 
> All iterator implementations (Rust iterators, C-interop `CRQEIterator`, and FFI wrapper iterators) were updated to implement/forward this method; `Intersection` returns `1.0 / num_children`, `Union` returns `num_children` when prioritization is enabled, and wrappers like `Profile`/`MaybeEmpty` forward to their child.
> 
> Adds integration tests to ensure nested `Intersection` (including when wrapped in `Profile`) sorts ahead of equally-estimated plain children, validating the heuristic for `Box<dyn RQEIterator>` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc08281be3272adcd86b712c10d3014dbf0f9c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->