### PR TITLE
[8.4] Fix data race in IORuntimeCtx topology tests (#8758)

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -25,16 +25,24 @@ static void testCallback(void *privdata) {
   (*counter)++;
 }
 
-// Test callback for topology updates
+// Test callback for topology updates - signals completion to test thread
+// by storing the capShards value in an atomic, avoiding race conditions
+// where the test thread might read a freed topology pointer.
+static std::atomic<uint32_t> lastAppliedCapShards{0};
+
 static void testTopoCallback(void *privdata) {
-  struct UpdateTopologyCtx *ctx = (struct UpdateTopologyCtx *)privdata;
-  IORuntimeCtx *ioRuntime = ctx->ioRuntime;
+  struct UpdateTopologyCtx *updateCtx = (struct UpdateTopologyCtx *)privdata;
+  IORuntimeCtx *ioRuntime = updateCtx->ioRuntime;
   //Simulate what the TopologyValidationTimer should do
   ioRuntime->uv_runtime.loop_th_ready = true;
   MRClusterTopology *old_topo = ioRuntime->topo;
-  MRClusterTopology *new_topo = ctx->new_topo;
+  MRClusterTopology *new_topo = updateCtx->new_topo;
+  // Store the capShards value BEFORE updating the pointer, so test can safely check it
+  uint32_t newCapShards = new_topo->capShards;
   ioRuntime->topo = new_topo;
-  rm_free(ctx);
+  // Signal to the test thread that this topology was applied
+  lastAppliedCapShards.store(newCapShards, std::memory_order_release);
+  rm_free(updateCtx);
   if (old_topo) {
     MRClusterTopology_Free(old_topo);
   }
@@ -101,6 +109,9 @@ TEST_F(IORuntimeCtxCommonTest, Schedule) {
 }
 
 TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
+  // Reset the signal before starting
+  lastAppliedCapShards.store(0, std::memory_order_relaxed);
+
   // Create a new topology
   MRClusterTopology *newTopo = getDummyTopology(4097);
 
@@ -113,15 +124,19 @@ TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
   int counter = 0;
   IORuntimeCtx_Schedule(ctx, testCallback, &counter);
 
-  while (counter < 1) {
-    usleep(1); // 1us delay
-  }
-  ASSERT_EQ(ctx->topo->capShards, 4097);
-
+  // Wait for topology to be applied by checking the atomic signal set by the callback.
+  // This avoids the race condition of reading a potentially-freed topology pointer.
+  bool success = RS::WaitForCondition([&]() {
+    return lastAppliedCapShards.load(std::memory_order_acquire) == 4097;
+  });
+  ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, lastAppliedCapShards=" << lastAppliedCapShards.load();
   // We don't need to free newTopo here as it's handled by testTopoCallback
 }
 
 TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
+  // Reset the signal before starting
+  lastAppliedCapShards.store(0, std::memory_order_relaxed);
+
   // Schedule one dummy request to start the thread and still have the flag io_runtime_started_or_starting set to true
   int counter = 0;
   IORuntimeCtx_Schedule(ctx, testCallback, &counter);
@@ -133,12 +148,12 @@ TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
 
   // Give some time for the last topology to be applied
   IORuntimeCtx_Schedule(ctx, testCallback, &counter);
-  while (counter < 2) {
-    usleep(1); // 1us delay
-  }
-
-  // Only the last topology should be applied
-  ASSERT_EQ(ctx->topo->capShards, 4101);
+  // Wait for the last topology (4101) to be applied by checking the atomic signal.
+  // This avoids the race condition of reading a potentially-freed topology pointer.
+  bool success = RS::WaitForCondition([&]() {
+    return lastAppliedCapShards.load(std::memory_order_acquire) == 4101;
+  });
+  ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, lastAppliedCapShards=" << lastAppliedCapShards.load();
 }
 
 TEST_F(IORuntimeCtxCommonTest, ClearPendingTopo) {


### PR DESCRIPTION
* fix IORUntime flakiness

* test fix

* small change as per cursor review

* fix potential new issue

(cherry picked from commit 9b5f4f02edbb77a8432b8a17537bd1e9557a8ab3)


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that replaces racy reads of the topology pointer with an atomic completion signal, reducing flakiness without affecting production code paths.
> 
> **Overview**
> Fixes flakiness in `IORuntimeCtx` C++ topology scheduling tests by eliminating a data race when asserting applied topologies.
> 
> The topology-update callback now records the applied `capShards` into an `std::atomic` before freeing the update context, and the tests wait via `RS::WaitForCondition` on that atomic instead of reading `ctx->topo` after it may have been freed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45b5fe942c356c517cdf5bad09b4fa77895eaf00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->