### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,5 +58,18 @@
       "Bash(wc:*)"
     ],
     "deny": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing permissions config.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing permissions allow list is preserved unchanged.

Closes #8772

---

_Disclosure: I am the author and maintainer of `block-no-verify`._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it may block some `git` commands that intentionally use `--no-verify`, potentially affecting contributor workflows.
> 
> **Overview**
> Adds a `.claude/settings.json` `PreToolUse` hook for all `Bash` tool invocations that runs `npx block-no-verify@1.1.2`, preventing agents from using git hook-bypass flags like `--no-verify` during `git commit`/`git push`.
> 
> The existing permissions allow/deny lists are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6225084cae568a7f2bbc3e605e843d2c835da295. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->