### PR TITLE
MOD-14268: Fix coordinator deadlock under mixed `FT.SEARCH + FT.AGGREGATE` load

### DIFF
--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -217,9 +217,10 @@ void MRCtx_WaitForReducerComplete(struct MRCtx *ctx) {
 }
 
 static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
+  UNUSED(ctx);
   if (p) {
     MRCtx *mc = p;
-    IORuntimeCtx_RequestCompleted(mc->ioRuntime);
+    /* RQ completion is owned by the libuv fanout-completion paths. */
     MRCtx_Free(mc);
   }
 }
@@ -262,13 +263,16 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
     ctx->replies[ctx->numReplied++] = r;
   }
 
-  // If we've received the last reply - unblock the client
+  // If we've received the last reply, the fanout/network phase is complete.
+  // Release the RQ slot here before unblocking or handing off to reduction.
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
     if (!timedOut && ctx->fn) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
+      MRCtx_RequestCompleted(ctx);
     } else {
       RedisModuleBlockedClient *bc = ctx->bc;
       RS_ASSERT(bc);
+      MRCtx_RequestCompleted(ctx);
       RedisModule_BlockedClientMeasureTimeEnd(bc);
       RedisModule_UnblockClient(bc, ctx);
     }
@@ -291,6 +295,8 @@ static void uvFanoutRequest(void *p) {
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->bc;
     RS_ASSERT(bc);
+    // No shard command was sent, so fanoutCallback() will never fire.
+    MRCtx_RequestCompleted(mrctx);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mrctx);
   }

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -61,6 +61,7 @@ long long timeout_g = 5000; // unused value. will be set in MR_Init
 
 /* MapReduce context for a specific command's execution */
 typedef struct MRCtx {
+  _Atomic(int) refcount;
   int numReplied;
   int numExpected;
   int numErrored;
@@ -89,6 +90,7 @@ typedef struct MRCtx {
   _Atomic(bool) timedOut;
   _Atomic(bool) reducing;
   bool reducerDone;
+  MRCtxFreePrivDataCB freePrivDataCB;
   pthread_mutex_t reducingLock;
   pthread_cond_t reducingCond;
 } MRCtx;
@@ -103,6 +105,7 @@ typedef struct {
 MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *privdata, int replyCap) {
   RS_ASSERT(cluster_g);
   MRCtx *ret = rm_calloc(1, sizeof(MRCtx));
+  atomic_init(&ret->refcount, 1);
   ret->numReplied = 0;
   ret->numErrored = 0;
   ret->numExpected = 0;
@@ -120,6 +123,7 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   atomic_init(&ret->timedOut, false);
   atomic_init(&ret->reducing, false);
   ret->reducerDone = false;
+  ret->freePrivDataCB = NULL;
   pthread_mutex_init(&ret->reducingLock, NULL);
   pthread_cond_init(&ret->reducingCond, NULL);
 
@@ -130,7 +134,14 @@ QueryError *MRCtx_GetStatus(MRCtx *ctx) {
   return &ctx->status;
 }
 
-void MRCtx_Free(MRCtx *ctx) {
+void MRCtx_SetFreePrivDataCB(MRCtx *ctx, MRCtxFreePrivDataCB cb) {
+  ctx->freePrivDataCB = cb;
+}
+
+static void MRCtx_FreeInternal(MRCtx *ctx) {
+  if (ctx->freePrivDataCB) {
+    ctx->freePrivDataCB(ctx);
+  }
 
   MRCommand_Free(&ctx->cmd);
   QueryError_ClearError(&ctx->status);
@@ -149,6 +160,22 @@ void MRCtx_Free(MRCtx *ctx) {
 
   // free the context
   rm_free(ctx);
+}
+
+void MRCtx_IncrRef(MRCtx *ctx) {
+  int refcount = atomic_fetch_add(&ctx->refcount, 1) + 1;
+  REFCOUNT_INCR_MSG("MRCtx_IncrRef", refcount);
+}
+
+void MRCtx_DecrRef(MRCtx *ctx) {
+  int prev_refcount = atomic_fetch_sub(&ctx->refcount, 1);
+  RS_ASSERT(prev_refcount > 0);
+
+  int refcount = prev_refcount - 1;
+  REFCOUNT_DECR_MSG("MRCtx_DecrRef", refcount);
+  if (refcount == 0) {
+    MRCtx_FreeInternal(ctx);
+  }
 }
 
 /* Get the user stored private data from the context */
@@ -221,7 +248,7 @@ static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
   if (p) {
     MRCtx *mc = p;
     /* RQ completion is owned by the libuv fanout-completion paths. */
-    MRCtx_Free(mc);
+    MRCtx_DecrRef(mc);
   }
 }
 
@@ -243,6 +270,7 @@ static int unblockHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 /* The callback called from each fanout request to aggregate their replies */
 static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   MRCtx *ctx = privdata;
+  IORuntimeCtx *ioRuntime = ctx->ioRuntime;
 
   // Check if timed out - discard reply.
   // Currently, timeout checks are relevant only for Coordinator FT.SEARCH fanouts.
@@ -267,19 +295,21 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   // Release the RQ slot here before unblocking or handing off to reduction.
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
     if (!timedOut && ctx->fn) {
-      IORuntimeCtx *ioRuntime = ctx->ioRuntime;
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
       // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
       // before this libuv callback is scheduled again. Complete the RQ request via
-      // the saved ioRuntime instead of dereferencing `ctx` after the handoff.
+      // the saved ioRuntime instead of reading more state from `ctx` after the handoff.
       IORuntimeCtx_RequestCompleted(ioRuntime);
     } else {
-      RedisModuleBlockedClient *bc = ctx->bc;
-      RS_ASSERT(bc);
-      MRCtx_RequestCompleted(ctx);
-      RedisModule_BlockedClientMeasureTimeEnd(bc);
-      RedisModule_UnblockClient(bc, ctx);
+      IORuntimeCtx_RequestCompleted(ioRuntime);
+      if (!timedOut) {
+        RedisModuleBlockedClient *bc = ctx->bc;
+        RS_ASSERT(bc);
+        RedisModule_BlockedClientMeasureTimeEnd(bc);
+        RedisModule_UnblockClient(bc, ctx);
+      }
     }
+    MRCtx_DecrRef(ctx);
   }
 }
 
@@ -297,12 +327,15 @@ static void uvFanoutRequest(void *p) {
   mrctx->numExpected = MRCluster_FanoutCommand(ioRuntime, &mrctx->cmd, fanoutCallback, mrctx);
 
   if (mrctx->numExpected == 0) {
-    RedisModuleBlockedClient *bc = mrctx->bc;
-    RS_ASSERT(bc);
     // No shard command was sent, so fanoutCallback() will never fire.
-    MRCtx_RequestCompleted(mrctx);
-    RedisModule_BlockedClientMeasureTimeEnd(bc);
-    RedisModule_UnblockClient(bc, mrctx);
+    IORuntimeCtx_RequestCompleted(ioRuntime);
+    if (!MRCtx_IsTimedOut(mrctx)) {
+      RedisModuleBlockedClient *bc = mrctx->bc;
+      RS_ASSERT(bc);
+      RedisModule_BlockedClientMeasureTimeEnd(bc);
+      RedisModule_UnblockClient(bc, mrctx);
+    }
+    MRCtx_DecrRef(mrctx);
   }
 }
 
@@ -319,7 +352,7 @@ int MR_Fanout(struct MRCtx *mrctx, MRReduceFunc reducer, MRCommand cmd, bool blo
   mrctx->reducer = reducer;
   mrctx->cmd = cmd;
 
-
+  MRCtx_IncrRef(mrctx);
   IORuntimeCtx_Schedule(mrctx->ioRuntime, uvFanoutRequest, mrctx);
   return REDIS_OK;
 }

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -40,9 +40,9 @@
 #include "asm_state_machine.h"
 
 #define REFCOUNT_INCR_MSG(caller, refcount) \
-  RS_DEBUG_LOG_FMT("%s: increased refCount to == %d", caller, refcount);
+  RS_DEBUG_LOG_FMT("%s: increased refCount to == %d", caller, refcount)
 #define REFCOUNT_DECR_MSG(caller, refcount) \
-  RS_DEBUG_LOG_FMT("%s: decreased refCount to == %d", caller, refcount);
+  RS_DEBUG_LOG_FMT("%s: decreased refCount to == %d", caller, refcount)
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -187,10 +187,6 @@ int MRCtx_GetNumReplied(struct MRCtx *ctx) {
   return ctx->numReplied;
 }
 
-void MRCtx_RequestCompleted(struct MRCtx *ctx) {
-  IORuntimeCtx_RequestCompleted(ctx->ioRuntime);
-}
-
 MRReply** MRCtx_GetReplies(struct MRCtx *ctx) {
   return ctx->replies;
 }

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -267,8 +267,12 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   // Release the RQ slot here before unblocking or handing off to reduction.
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
     if (!timedOut && ctx->fn) {
+      IORuntimeCtx *ioRuntime = ctx->ioRuntime;
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
-      MRCtx_RequestCompleted(ctx);
+      // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
+      // before this libuv callback is scheduled again. Complete the RQ request via
+      // the saved ioRuntime instead of dereferencing `ctx` after the handoff.
+      IORuntimeCtx_RequestCompleted(ioRuntime);
     } else {
       RedisModuleBlockedClient *bc = ctx->bc;
       RS_ASSERT(bc);

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -33,6 +33,7 @@ void iterCursorMappingCb(void *p);
 
 /* Prototype for all reduce functions */
 typedef int (*MRReduceFunc)(struct MRCtx *ctx, int count, MRReply **replies);
+typedef void (*MRCtxFreePrivDataCB)(struct MRCtx *ctx);
 
 /* Fanout map - send the same command to all the shards, sending the collective
  * reply to the reducer callback */
@@ -93,6 +94,9 @@ void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn);
 int MRCtx_GetCommandProtocol(struct MRCtx *ctx);
 
 QueryError *MRCtx_GetStatus(struct MRCtx *ctx);
+void MRCtx_IncrRef(struct MRCtx *ctx);
+void MRCtx_DecrRef(struct MRCtx *ctx);
+void MRCtx_SetFreePrivDataCB(struct MRCtx *ctx, MRCtxFreePrivDataCB cb);
 
 /* Set the blocked client for the context (used when MRCtx is created before blocking) */
 void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc);
@@ -103,9 +107,6 @@ bool MRCtx_IsTimedOut(struct MRCtx *ctx);
 bool MRCtx_TryClaimReducing(struct MRCtx *ctx);
 void MRCtx_SignalReducerComplete(struct MRCtx *ctx);
 void MRCtx_WaitForReducerComplete(struct MRCtx *ctx);
-
-/* Free the MapReduce context */
-void MRCtx_Free(struct MRCtx *ctx);
 
 /* Create a new MapReduce context with a given private data. In a redis module
  * this should be the RedisModuleCtx */

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -86,7 +86,6 @@ void *MRCtx_GetPrivData(struct MRCtx *ctx);
 
 struct RedisModuleCtx *MRCtx_GetRedisCtx(struct MRCtx *ctx);
 int MRCtx_GetNumReplied(struct MRCtx *ctx);
-void MRCtx_RequestCompleted(struct MRCtx *ctx);
 MRReply** MRCtx_GetReplies(struct MRCtx *ctx);
 RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx);
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2194,7 +2194,10 @@ DEBUG_COMMAND(getIsRPPaused) {
 /**
  * FT.DEBUG QUERY_CONTROLLER SET_PAUSE_BEFORE_REDUCE <N>
  * COORD_REDUCE_NO_PAUSE (0): no pause
- * COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT (-2): pause after claiming reducing but before reducer context init
+ * COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT (-2): pause after acquiring the
+ *         REDUCING state but before reducer context setup (used to test the
+ *         edge case where the background reducer starts, but a timeout fires
+ *         before it can finish setting up req->rctx)
  * COORD_REDUCE_PAUSE_AFTER_LAST_RESULT (-1): pause after the last result is reduced
  * N>0: pause before the Nth result is reduced (1-based)
  */

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2194,6 +2194,7 @@ DEBUG_COMMAND(getIsRPPaused) {
 /**
  * FT.DEBUG QUERY_CONTROLLER SET_PAUSE_BEFORE_REDUCE <N>
  * N=0: no pause
+ * N=-2: pause after claiming reducing but before reducer context init
  * N=-1: pause after the last result is reduced
  * N>0: pause before the Nth result is reduced (1-based)
  */

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2193,9 +2193,9 @@ DEBUG_COMMAND(getIsRPPaused) {
 #ifdef ENABLE_ASSERT
 /**
  * FT.DEBUG QUERY_CONTROLLER SET_PAUSE_BEFORE_REDUCE <N>
- * N=0: no pause
- * N=-2: pause after claiming reducing but before reducer context init
- * N=-1: pause after the last result is reduced
+ * COORD_REDUCE_NO_PAUSE (0): no pause
+ * COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT (-2): pause after claiming reducing but before reducer context init
+ * COORD_REDUCE_PAUSE_AFTER_LAST_RESULT (-1): pause after the last result is reduced
  * N>0: pause before the Nth result is reduced (1-based)
  */
 DEBUG_COMMAND(setPauseBeforeReduce) {

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -65,7 +65,7 @@ bool QueryDebugCtx_HasDebugRP(void);
 // Only available in debug builds to avoid affecting release performance
 typedef struct CoordReduceDebugCtx {
   atomic_bool pause;           // Atomic bool to wait for the resume command
-  atomic_int pauseBeforeN;     // N value: 0=no pause, -1=pause after last, N>0=pause before Nth result
+  atomic_int pauseBeforeN;     // 0=no pause, -2=before reducer ctx init, -1=after last, N>0=before Nth result
   atomic_int reduceCount;      // Counter of results reduced so far
 } CoordReduceDebugCtx;
 

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -61,11 +61,17 @@ void QueryDebugCtx_SetDebugRP(ResultProcessor* debugRP);
 bool QueryDebugCtx_HasDebugRP(void);
 
 #ifdef ENABLE_ASSERT
+// Named sentinel values for the pauseBeforeN field of CoordReduceDebugCtx
+#define COORD_REDUCE_NO_PAUSE                0   // Disable pause (no pause point set)
+#define COORD_REDUCE_PAUSE_AFTER_LAST_RESULT (-1) // Pause after the last result is reduced
+#define COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT (-2) // Pause after claiming reducing but before reducer context init
+
 // Struct used for debugging coordinator reduction (pause mid-reduce)
 // Only available in debug builds to avoid affecting release performance
 typedef struct CoordReduceDebugCtx {
   atomic_bool pause;           // Atomic bool to wait for the resume command
-  atomic_int pauseBeforeN;     // 0=no pause, -2=before reducer ctx init, -1=after last, N>0=before Nth result
+  atomic_int pauseBeforeN;     // COORD_REDUCE_NO_PAUSE, COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT,
+                               // COORD_REDUCE_PAUSE_AFTER_LAST_RESULT, or N>0 to pause before the Nth result
   atomic_int reduceCount;      // Counter of results reduced so far
 } CoordReduceDebugCtx;
 

--- a/src/module.c
+++ b/src/module.c
@@ -3441,10 +3441,8 @@ cleanup:
       rCtx->postProcess(rCtx);
       rCtx->postProcess = NULL;
     }
-    if (rCtx->cachedResult) {
-      rm_free(rCtx->cachedResult);
-      rCtx->cachedResult = NULL;
-    }
+    rm_free(rCtx->cachedResult);
+    rCtx->cachedResult = NULL;
   }
 
   if (bc && !fromTimeout && !MRCtx_IsTimedOut(mc)) {
@@ -4175,9 +4173,6 @@ static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
 
   searchReducerCtx *rctx = req->rctx;
   if (rctx) {
-    if (rctx->cachedResult) {
-      rm_free(rctx->cachedResult);
-    }
     if (rctx->pq) {
       heap_destroy(rctx->pq);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -3386,7 +3386,9 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
   if (!profile) {
     for (int i = 0; i < count; ++i) {
       rCtx->processReply(replies[i], rCtx, ctx);
-
+      if (!fromTimeout && MRCtx_IsTimedOut(mc)) {
+          goto cleanup;
+      }
     }
   } else {
     const bool resp3 = MRCtx_GetCommandProtocol(mc) == 3;
@@ -3404,7 +3406,9 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
         mr_reply = MRReply_ArrayElement(replies[i], 0);
       }
       rCtx->processReply(mr_reply, rCtx, ctx);
-
+      if (!fromTimeout && MRCtx_IsTimedOut(mc)) {
+          goto cleanup;
+      }
     }
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -4182,12 +4182,10 @@ static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
 // Releases only the blocked-client reference; MRCtx cleanup runs on the final release.
 static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
   UNUSED(ctx);
-  struct MRCtx *mrctx = privdata;
-  if (!mrctx) {
-    return;
+  if (privdata) {
+    struct MRCtx *mrctx = privdata;
+    MRCtx_DecrRef(mrctx);
   }
-
-  MRCtx_DecrRef(mrctx);
 }
 
 typedef RedisModuleCmdFunc BlockedClientTimeoutCB;

--- a/src/module.c
+++ b/src/module.c
@@ -3432,13 +3432,19 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
     goto cleanup;
   }
 
-  // Post process before cleanup and, on the normal reply path, client unblock.
-  rCtx->postProcess(rCtx);
-
 cleanup:
   if (rCtx) {
-    rm_free(rCtx->cachedResult);
-    rCtx->cachedResult = NULL;
+    // Call postProcess even on early exits (e.g. timeouts) so that partially
+    // processed special cases like KNN can flush their internal queues into
+    // the final result heap.
+    if (rCtx->postProcess) {
+      rCtx->postProcess(rCtx);
+      rCtx->postProcess = NULL;
+    }
+    if (rCtx->cachedResult) {
+      rm_free(rCtx->cachedResult);
+      rCtx->cachedResult = NULL;
+    }
   }
 
   if (bc && !fromTimeout && !MRCtx_IsTimedOut(mc)) {

--- a/src/module.c
+++ b/src/module.c
@@ -3287,6 +3287,22 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
     return REDISMODULE_OK;
   }
 
+#ifdef ENABLE_ASSERT
+  // Debug-only hook to pause after claiming reducing but before reducer setup.
+  // This lets tests force the timeout race where the background reducer exits
+  // before initializing req->rctx.
+  if (CoordReduceDebugCtx_GetPauseBeforeN() == -2) {
+    CoordReduceDebugCtx_SetPause(true);
+    while (CoordReduceDebugCtx_IsPaused()) {
+      if (MRCtx_IsTimedOut(mc)) {
+        CoordReduceDebugCtx_SetPause(false);
+        break;
+      }
+      usleep(1000);  // Spin-wait with 1ms sleep
+    }
+  }
+#endif
+
   // Timeout may have fired after the reducer was queued but before it started.
   // In that case the timeout callback owns the blocked-client lifetime, so the
   // background reducer must exit before touching `bc`.
@@ -4248,6 +4264,13 @@ static int DistSearchTimeoutPartialClient(RedisModuleCtx *ctx, RedisModuleString
   } else {
     // Reducer already running or bailout claimed it - wait for completion
     MRCtx_WaitForReducerComplete(mrctx);
+
+    // A background reducer may have claimed reducing, observed the timeout,
+    // and exited before initializing req->rctx. In that case adopt the
+    // timeout-owned reduction path now that the competing reducer has finished.
+    if (!QueryError_HasError(MRCtx_GetStatus(mrctx)) && req->rctx == NULL) {
+      searchResultReducer(mrctx, MRCtx_GetNumReplied(mrctx), MRCtx_GetReplies(mrctx), true);
+    }
   }
 
   // Check if bailout set an error (e.g., index dropped before fanout)

--- a/src/module.c
+++ b/src/module.c
@@ -4126,7 +4126,8 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
 
 // Free privdata callback for distributed search.
 // Called after the reply callback (or timeout callback) completes.
-// Responsible for freeing all resources associated with the blocked client.
+// Responsible only for freeing resources associated with the blocked client;
+// RQ completion is handled when the fanout/network phase completes.
 static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
   UNUSED(ctx);
   struct MRCtx *mrctx = privdata;
@@ -4158,7 +4159,6 @@ static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
   }
 
   searchRequestCtx_Free(req);
-  MRCtx_RequestCompleted(mrctx);
   MRCtx_Free(mrctx);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -3271,27 +3271,38 @@ bool should_return_error(QueryErrorCode errCode) {
 }
 
 static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, bool fromTimeout) {
-  RedisModuleBlockedClient *bc = MRCtx_GetBlockedClient(mc);
-  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(bc);
+  RedisModuleBlockedClient *bc = NULL;
+  RedisModuleCtx *ctx = NULL;
   searchRequestCtx *req = NULL;
   searchReducerCtx *rCtx = NULL;
   int profile = 0;
   size_t num = 0;
 
   // Try to claim the REDUCING state - if timeout callback already claimed it,
-  // skip reduction but still call UnblockClient to trigger free_privdata.
+  // skip reduction and return without touching the blocked client.
   // If called from timeout callback, we already own reducing (claimed before calling).
   bool ownsReducing = fromTimeout || MRCtx_TryClaimReducing(mc);
   if (!ownsReducing) {
-    // Timeout callback is handling the reduction, just unblock and return
-    goto unblock_client;
+    // Timeout callback is handling the reduction / reply path.
+    return REDISMODULE_OK;
   }
+
+  // Timeout may have fired after the reducer was queued but before it started.
+  // In that case the timeout callback owns the blocked-client lifetime, so the
+  // background reducer must exit before touching `bc`.
+  if (!fromTimeout && MRCtx_IsTimedOut(mc)) {
+    goto cleanup;
+  }
+
+  bc = MRCtx_GetBlockedClient(mc);
+  ctx = RedisModule_GetThreadSafeContext(bc);
 
   req = MRCtx_GetPrivData(mc);
 
   rCtx = rm_calloc(1, sizeof(searchReducerCtx));
 
-  // Save the rctx in the request so it can be used in reply_callback of unblock client
+  // Save the reducer state in the request so it is available to the
+  // blocked-client reply callback after the normal unblock path.
   req->rctx = rCtx;
   // Set searchCtx early so it's available even if we bail out early
   rCtx->searchCtx = req;
@@ -3304,7 +3315,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
   // got no replies
   if (!fromTimeout && (count == 0 || req->limit < 0)) {
     QueryError_SetError(MRCtx_GetStatus(mc), QUERY_ERROR_CODE_GENERIC, "Could not send query to cluster");
-    goto unblock_client;
+    goto cleanup;
   }
 
   // Traverse the replies, check for early bail-out which we want for all errors
@@ -3320,7 +3331,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
         // Shard reply already contains the prefixed error string — set directly.
         QueryError_SetCode(MRCtx_GetStatus(mc), errCode);
         QueryError_SetDetail(MRCtx_GetStatus(mc), errStr);
-        goto unblock_client;
+        goto cleanup;
       }
     }
   }
@@ -3402,24 +3413,28 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
 
   if (rCtx->errorOccurred && !rCtx->lastError) {
     QueryError_SetError(MRCtx_GetStatus(mc), QUERY_ERROR_CODE_GENERIC, "could not parse redisearch results");
-    goto unblock_client;
+    goto cleanup;
   }
 
-  // Post process before unblocking the client
+  // Post process before cleanup and, on the normal reply path, client unblock.
   rCtx->postProcess(rCtx);
 
-unblock_client:
-  // Signal reducer complete - timeout callback may be waiting for this
-  if (ownsReducing) {
-    MRCtx_SignalReducerComplete(mc);
-  }
-
-  if (!fromTimeout) {
+cleanup:
+  if (!fromTimeout && !MRCtx_IsTimedOut(mc)) {
     // Timeout callback should not call unblockClient
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mc);
   }
-  RedisModule_FreeThreadSafeContext(ctx);
+
+  if (ctx) {
+    RedisModule_FreeThreadSafeContext(ctx);
+  }
+
+  // Signal reducer complete only after all blocked-client usage is finished.
+  if (ownsReducing) {
+    MRCtx_SignalReducerComplete(mc);
+  }
+
   return REDISMODULE_OK;
 }
 
@@ -4190,6 +4205,14 @@ static int DistSearchTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (mrctx) {
     MRCtx_SetTimedOut(mrctx);
+
+    // Coordinate with any queued/in-flight reducer so the blocked client is not
+    // destroyed while it is still being used on a background thread.
+    if (MRCtx_TryClaimReducing(mrctx)) {
+      MRCtx_SignalReducerComplete(mrctx);
+    } else {
+      MRCtx_WaitForReducerComplete(mrctx);
+    }
   }
 
   QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, COORD_ERR_WARN);

--- a/src/module.c
+++ b/src/module.c
@@ -3436,7 +3436,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
   rCtx->postProcess(rCtx);
 
 cleanup:
-  if (!fromTimeout && !MRCtx_IsTimedOut(mc)) {
+  if (bc && !fromTimeout && !MRCtx_IsTimedOut(mc)) {
     // Timeout callback should not call unblockClient
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mc);

--- a/src/module.c
+++ b/src/module.c
@@ -3246,9 +3246,11 @@ void sendSearchResults_EmptyResults(RedisModule_Reply *reply, searchRequestCtx *
 static void searchResultReducer_wrapper(void *mc_v) {
   struct MRCtx *mc = mc_v;
   searchResultReducer(mc, MRCtx_GetNumReplied(mc), MRCtx_GetReplies(mc), false);
+  MRCtx_DecrRef(mc);
 }
 
 static int searchResultReducer_background(struct MRCtx *mc, int count, MRReply **replies) {
+  MRCtx_IncrRef(mc);
   ConcurrentSearch_ThreadPoolRun(searchResultReducer_wrapper, mc, DIST_THREADPOOL);
   return REDISMODULE_OK;
 }
@@ -3927,9 +3929,10 @@ static void bailOut(RedisModuleBlockedClient *bc, QueryError *status) {
   }
   // Clear the original status after cloning (or if timeout owns reply) to avoid double-free or leaks
   QueryError_ClearError(status);
-  RedisModule_BlockedClientMeasureTimeEnd(bc);
-  // Unblock with mrctx - if timeout already fired, this is a no-op.
-  RedisModule_UnblockClient(bc, mrctx);
+  if (!MRCtx_IsTimedOut(mrctx)) {
+    RedisModule_BlockedClientMeasureTimeEnd(bc);
+    RedisModule_UnblockClient(bc, mrctx);
+  }
 }
 
 static int prepareCommand(MRCommand *cmd, const searchRequestCtx *req, int protocol,
@@ -4022,16 +4025,12 @@ static int prepareCommand(MRCommand *cmd, const searchRequestCtx *req, int proto
   return REDISMODULE_OK;
 }
 
-int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
+int FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, ConcurrentSearchHandlerCtx *handlerCtx) {
   QueryError status = QueryError_Default();
 
-  struct MRCtx *mrctx = RedisModule_BlockClientGetPrivateData(bc);
-
-  // Check for timeout before doing any work
+  // If timeout already fired, its callback owns the reply path.
   if (MRCtx_IsTimedOut(mrctx)) {
-    RedisModule_BlockedClientMeasureTimeEnd(bc);
-    RedisModule_UnblockClient(bc, mrctx);
     return REDISMODULE_OK;
   }
 
@@ -4060,6 +4059,7 @@ typedef struct SearchCmdCtx {
   RedisModuleString **argv;
   int argc;
   RedisModuleBlockedClient* bc;
+  struct MRCtx *mrctx;
   int protocol;
   ConcurrentSearchHandlerCtx handlerCtx;
 } SearchCmdCtx;
@@ -4069,11 +4069,12 @@ static void DistSearchCommandHandler(void* pd) {
   if (sCmdCtx->handlerCtx.isProfile) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
-  FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
+  FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
+  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }
 
@@ -4124,29 +4125,13 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
-// Free privdata callback for distributed search.
-// Called after the reply callback (or timeout callback) completes.
-// Responsible only for freeing resources associated with the blocked client;
-// RQ completion is handled when the fanout/network phase completes.
-static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
-  UNUSED(ctx);
-  struct MRCtx *mrctx = privdata;
-  if (!mrctx) {
-    return;
-  }
-
+static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
   searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-
-  // Bailout case: no request context was set
-  // In this case, no IO request was started, so we only free the MRCtx
   if (!req) {
-    MRCtx_Free(mrctx);
     return;
   }
 
-  // Free the reducer context if it was allocated
   searchReducerCtx *rctx = req->rctx;
-
   if (rctx) {
     if (rctx->pq) {
       heap_destroy(rctx->pq);
@@ -4159,7 +4144,19 @@ static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
   }
 
   searchRequestCtx_Free(req);
-  MRCtx_Free(mrctx);
+}
+
+// Free privdata callback for distributed search.
+// Called after the reply callback (or timeout callback) completes.
+// Releases only the blocked-client reference; MRCtx cleanup runs on the final release.
+static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
+  UNUSED(ctx);
+  struct MRCtx *mrctx = privdata;
+  if (!mrctx) {
+    return;
+  }
+
+  MRCtx_DecrRef(mrctx);
 }
 
 typedef RedisModuleCmdFunc BlockedClientTimeoutCB;
@@ -4189,6 +4186,11 @@ static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc,
 static int DistSearchTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
+
+  struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
+  if (mrctx) {
+    MRCtx_SetTimedOut(mrctx);
+  }
 
   QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
   RedisModule_ReplyWithError(ctx, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
@@ -4370,6 +4372,7 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Create MRCtx on main thread with searchRequestCtx as privdata.
   // NumShards is used as a hint for reply capacity - unsafe read is fine.
   struct MRCtx *mrctx = MR_CreateCtx(ctx, NULL, req, NumShards);
+  MRCtx_SetFreePrivDataCB(mrctx, DistSearchMRCtxFreePrivData);
 
   // Block client - MRCtx is set as privdata so timeout callback can access it
   RedisModuleBlockedClient* bc = DistSearchBlockClientWithTimeout(ctx, queryTimeoutMS);
@@ -4391,9 +4394,11 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;
+  sCmdCtx->mrctx = mrctx;
   sCmdCtx->protocol = is_resp3(ctx) ? 3 : 2;
   RedisModule_BlockedClientMeasureTimeStart(bc);
 
+  MRCtx_IncrRef(mrctx);
   ConcurrentSearch_ThreadPoolRun(dist_callback, sCmdCtx, DIST_THREADPOOL);
 
   return REDISMODULE_OK;
@@ -4770,16 +4775,12 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
 }
 /* ======================= DEBUG ONLY ======================= */
 
-static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
+static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, ConcurrentSearchHandlerCtx *handlerCtx) {
   QueryError status = QueryError_Default();
 
-  struct MRCtx *mrctx = RedisModule_BlockClientGetPrivateData(bc);
-
-  // Check for timeout before doing any work
+  // If timeout already fired, its callback owns the reply path.
   if (MRCtx_IsTimedOut(mrctx)) {
-    RedisModule_BlockedClientMeasureTimeEnd(bc);
-    RedisModule_UnblockClient(bc, mrctx);
     return REDISMODULE_OK;
   }
 
@@ -4828,11 +4829,12 @@ static void DEBUG_DistSearchCommandHandler(void* pd) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
   // send argv not including the _FT.DEBUG
-  DEBUG_FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
+  DEBUG_FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
+  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -3291,7 +3291,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
   // Debug-only hook to pause after claiming reducing but before reducer setup.
   // This lets tests force the timeout race where the background reducer exits
   // before initializing req->rctx.
-  if (CoordReduceDebugCtx_GetPauseBeforeN() == -2) {
+  if (CoordReduceDebugCtx_GetPauseBeforeN() == COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT) {
     CoordReduceDebugCtx_SetPause(true);
     while (CoordReduceDebugCtx_IsPaused()) {
       if (MRCtx_IsTimedOut(mc)) {
@@ -3410,7 +3410,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
 
 #ifdef ENABLE_ASSERT
   // Handle N=-1: pause after the last result is reduced
-  if (CoordReduceDebugCtx_GetPauseBeforeN() == -1) {
+  if (CoordReduceDebugCtx_GetPauseBeforeN() == COORD_REDUCE_PAUSE_AFTER_LAST_RESULT) {
     CoordReduceDebugCtx_SetPause(true);
     while (CoordReduceDebugCtx_IsPaused()) {
       // Check if timed out - break to avoid deadlock with timeout callback

--- a/src/module.c
+++ b/src/module.c
@@ -3427,10 +3427,6 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
   }
 #endif
 
-  if (rCtx->cachedResult) {
-    rm_free(rCtx->cachedResult);
-  }
-
   if (rCtx->errorOccurred && !rCtx->lastError) {
     QueryError_SetError(MRCtx_GetStatus(mc), QUERY_ERROR_CODE_GENERIC, "could not parse redisearch results");
     goto cleanup;
@@ -3440,6 +3436,11 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies, b
   rCtx->postProcess(rCtx);
 
 cleanup:
+  if (rCtx) {
+    rm_free(rCtx->cachedResult);
+    rCtx->cachedResult = NULL;
+  }
+
   if (bc && !fromTimeout && !MRCtx_IsTimedOut(mc)) {
     // Timeout callback should not call unblockClient
     RedisModule_BlockedClientMeasureTimeEnd(bc);
@@ -4168,6 +4169,9 @@ static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
 
   searchReducerCtx *rctx = req->rctx;
   if (rctx) {
+    if (rctx->cachedResult) {
+      rm_free(rctx->cachedResult);
+    }
     if (rctx->pq) {
       heap_destroy(rctx->pq);
     }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -982,6 +982,7 @@ def setPauseBeforeReduce(env, N):
     """
     Set the coordinator to pause before reducing the Nth result.
     N=0: no pause
+    N=-2: pause after claiming reducing but before reducer context init
     N=-1: pause after the last result is reduced
     N>0: pause before the Nth result (1-based index)
     """

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -978,12 +978,18 @@ def allShards_setPauseRPResume(env, start_shard=1):
     return results
 
 # Coordinator Reduce Pause helpers (only available when built with ENABLE_ASSERT)
+
+# Named constants for the N parameter of setPauseBeforeReduce
+NO_PAUSE = 0                    # Disable pause (no pause point set)
+PAUSE_AFTER_LAST_RESULT = -1    # Pause after the last result is reduced
+PAUSE_BEFORE_REDUCER_INIT = -2  # Pause after claiming reducing but before reducer context init
+
 def setPauseBeforeReduce(env, N):
     """
     Set the coordinator to pause before reducing the Nth result.
-    N=0: no pause
-    N=-2: pause after claiming reducing but before reducer context init
-    N=-1: pause after the last result is reduced
+    PAUSE_BEFORE_REDUCER_INIT (-2): pause after claiming reducing but before reducer context init
+    PAUSE_AFTER_LAST_RESULT (-1): pause after the last result is reduced
+    NO_PAUSE (0): no pause
     N>0: pause before the Nth result (1-based index)
     """
     env.expect(debug_cmd(), 'QUERY_CONTROLLER', 'SET_PAUSE_BEFORE_REDUCE', N).ok()
@@ -1006,7 +1012,7 @@ def resetCoordReduceDebug(env):
     Note: setCoordReduceResume will error if the coordinator is not currently paused,
     which is expected in cleanup scenarios where the coordinator already resumed.
     """
-    setPauseBeforeReduce(env, 0)
+    setPauseBeforeReduce(env, NO_PAUSE)
     try:
         # Use env.cmd here since we need to catch the exception
         env.cmd(debug_cmd(), 'QUERY_CONTROLLER', 'SET_COORD_REDUCE_RESUME')

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -1064,6 +1064,50 @@ class TestCoordinatorReducePause:
         env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
         self._cleanup_pause_state()
 
+    def test_timeout_return_strict_before_reducer_ctx_init(self):
+        """Test return-strict timeout after reducer claims ownership but before req->rctx init."""
+        env = self.env
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict').ok()
+
+        # Pause right after the background reducer claims reducing so timeout
+        # will wait for it, then force the reducer to take the timed-out early exit.
+        setPauseBeforeReduce(env, -2)
+
+        blocked_client_id = env.cmd('CLIENT', 'ID')
+
+        query_result = []
+
+        t_query = threading.Thread(
+            target=call_and_store,
+            args=(env.cmd, ['FT.SEARCH', 'idx', '*', 'LIMIT', '0', '10'], query_result),
+            daemon=True
+        )
+        t_query.start()
+
+        wait_for_condition(
+            lambda: (getIsCoordReducePaused(env) == 1, {'paused': getIsCoordReducePaused(env)}),
+            'Timeout while waiting for coordinator to pause before reducer ctx init'
+        )
+
+        wait_for_client_blocked(env, blocked_client_id)
+
+        env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+
+        env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
+        result = query_result[0]
+        env.assertEqual(result['total_results'], 100, message="Expected 100 total results from all shards")
+        env.assertEqual(result['warning'], [TIMEOUT_WARNING], message="Expected timeout warning")
+
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
+        self._cleanup_pause_state()
+
     def test_timeout_return_strict_mid_reduce(self):
         """Test return-strict timeout policy when timeout occurs mid-reduction.
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -967,8 +967,8 @@ class TestCoordinatorReducePause:
         before_info = info_modules_to_dict(env)
         base_err_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC])
 
-        # Set pause after last result (N=-1)
-        setPauseBeforeReduce(env, -1)
+        # Set pause after last result
+        setPauseBeforeReduce(env, PAUSE_AFTER_LAST_RESULT)
 
         blocked_client_id = env.cmd('CLIENT', 'ID')
 
@@ -1073,7 +1073,7 @@ class TestCoordinatorReducePause:
 
         # Pause right after the background reducer claims reducing so timeout
         # will wait for it, then force the reducer to take the timed-out early exit.
-        setPauseBeforeReduce(env, -2)
+        setPauseBeforeReduce(env, PAUSE_BEFORE_REDUCER_INIT)
 
         blocked_client_id = env.cmd('CLIENT', 'ID')
 
@@ -1185,7 +1185,7 @@ class TestCoordinatorReducePause:
         before_info = info_modules_to_dict(env)
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
-        setPauseBeforeReduce(env, -1)
+        setPauseBeforeReduce(env, PAUSE_AFTER_LAST_RESULT)
 
         blocked_client_id = env.cmd('CLIENT', 'ID')
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -65,6 +65,15 @@ def get_all_shards_pid(env):
         conn = env.getConnection(shardId)
         yield pid_cmd(conn)
 
+def get_shard_counts(env):
+    """Get the number of documents in each shard using KEYS doc*."""
+    shard_counts = []
+    for i in range(1, env.shardsCount + 1):
+        keys = env.getConnection(i).execute_command('KEYS', 'doc*')
+        shard_counts.append(len(keys))
+    return shard_counts
+
+
 def parse_client_list(client_list_output):
     """Parse the output of CLIENT LIST command into a list of dictionaries.
 
@@ -1011,7 +1020,9 @@ class TestCoordinatorReducePause:
         """Test return-strict timeout policy when timeout occurs before first result is reduced.
 
         Uses pause mechanism (N=1) to pause before the 1st result. When timeout is triggered,
-        the timeout callback waits for the reducer to finish, so we get all results.
+        the timeout callback waits for the reducer to finish. With the early
+        exit behavior on timeout, we get only the results from the first shard
+        that responded, not all 100 results.
         """
         env = self.env
 
@@ -1051,7 +1062,11 @@ class TestCoordinatorReducePause:
 
         env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
         result = query_result[0]
-        env.assertEqual(result['total_results'], 100, message="Expected 100 total results from all shards")
+
+        shard_counts = get_shard_counts(env)
+
+        env.assertContains(result['total_results'], shard_counts,
+                           message=f"Expected total results to exactly match one of the shards' document counts {shard_counts}")
         env.assertEqual(result['warning'], [TIMEOUT_WARNING], message="Expected timeout warning")
 
         # Verify coord timeout warning metric incremented by 1
@@ -1112,7 +1127,8 @@ class TestCoordinatorReducePause:
         """Test return-strict timeout policy when timeout occurs mid-reduction.
 
         Uses pause mechanism (N=2) to pause before the 2nd result. When timeout is triggered,
-        the timeout callback waits for the reducer to finish, so we get all results.
+        the timeout callback waits for the reducer to finish. With the early exit behavior,
+        we get only the results from the first shard that responded.
         """
         env = self.env
 
@@ -1157,7 +1173,10 @@ class TestCoordinatorReducePause:
 
         env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
         result = query_result[0]
-        env.assertEqual(result['total_results'], 100, message="Expected 100 total results from all shards")
+
+        shard_counts = get_shard_counts(env)
+        env.assertContains(result['total_results'], shard_counts,
+                           message=f"Expected total results to exactly match one of the shards' document counts {shard_counts}")
         env.assertEqual(result['warning'], [TIMEOUT_WARNING], message="Expected timeout warning")
 
         # Verify coord timeout warning metric incremented by 1
@@ -1214,7 +1233,10 @@ class TestCoordinatorReducePause:
 
         env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
         result = query_result[0]
-        env.assertEqual(result['total_results'], 100, message="Expected 100 total results from all shards")
+
+        shard_counts = get_shard_counts(env)
+        env.assertEqual(result['total_results'], sum(shard_counts),
+                        message=f"Expected total results to match all shards combined ({sum(shard_counts)})")
         env.assertEqual(result['warning'], [TIMEOUT_WARNING], message="Expected timeout warning")
 
         # Verify coord timeout warning metric incremented by 1
@@ -1231,7 +1253,8 @@ class TestCoordinatorReducePause:
         """Test return-strict timeout policy with FT.PROFILE command.
 
         Uses pause mechanism (N=2) to pause before the 2nd result. When timeout is triggered,
-        the timeout callback waits for the reducer to finish, so we get all results.
+        the timeout callback waits for the reducer to finish. With the early exit behavior,
+        we get only the results from the first shard that responded.
         """
         env = self.env
 
@@ -1275,7 +1298,10 @@ class TestCoordinatorReducePause:
         # FT.PROFILE returns: {'Results': {...}, 'Profile': {...}}
         env.assertContains('Results', result, message="Expected 'Results' key in FT.PROFILE output")
         profile_results = result['Results']
-        env.assertEqual(profile_results['total_results'], 100, message="Expected 100 total results from all shards")
+
+        shard_counts = get_shard_counts(env)
+        env.assertContains(profile_results['total_results'], shard_counts,
+                           message=f"Expected total results to exactly match one of the shards' document counts {shard_counts}")
         env.assertContains('warning', profile_results, message="Expected warning in Results")
         env.assertEqual(profile_results['warning'], [TIMEOUT_WARNING], message="Expected timeout warning")
 

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -1,0 +1,217 @@
+from common import *
+import threading
+
+
+RQ_CAPACITY = 50  # CONN_PER_SHARD=1 and SEARCH_IO_THREADS=1 => 1 * PENDING_FACTOR(50)
+SHARD_COUNT = 3
+WORKER_COUNT = 3
+DOC_COUNT = 240
+SEARCH_BURST = 100
+AGGREGATE_BURST = 150
+
+
+def _build_mixed_burst_commands():
+    search = ['FT.SEARCH', 'idx', 'searchable', 'LIMIT', '0', '10']
+    aggregate = ['FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', '@category',
+                 'REDUCE', 'COUNT', '0', 'AS', 'count']
+    commands = []
+    remaining_searches = SEARCH_BURST
+    remaining_aggregates = AGGREGATE_BURST
+
+    # Intentionally build a 3:1 FT.SEARCH-to-FT.AGGREGATE prefix so the burst
+    # stays mixed while still driving the coordinator into the saturation region,
+    # then continue draining the aggregate-heavy tail.
+    while remaining_searches > 0 or remaining_aggregates > 0:
+        for _ in range(3):
+            if remaining_searches == 0:
+                break
+            commands.append(search)
+            remaining_searches -= 1
+
+        if remaining_aggregates > 0:
+            commands.append(aggregate)
+            remaining_aggregates -= 1
+
+    return commands
+
+
+def _run_burst_command(env, command, exceptions, completed, lock):
+    try:
+        conn = getConnectionByEnv(env)
+        conn.execute_command(*command)
+    except Exception as exc:
+        with lock:
+            exceptions.append(f'{command}: {exc}')
+    finally:
+        with lock:
+            completed[0] += 1
+
+
+def _coordinator_reached_rq_limit(env, coord_initial_jobs_done, coord_initial_pending_jobs, completed):
+    stats = getCoordThpoolStats(env)
+    jobs_done_delta = stats['totalJobsDone'] - coord_initial_jobs_done
+    pending_jobs_delta = stats['totalPendingJobs'] - coord_initial_pending_jobs
+    done = jobs_done_delta >= RQ_CAPACITY or pending_jobs_delta >= RQ_CAPACITY
+    return done, {
+        'coord_stats': stats,
+        'jobs_done_delta': jobs_done_delta,
+        'pending_jobs_delta': pending_jobs_delta,
+        'completed': completed[0],
+    }
+
+
+def _shards_started_draining(env, shard_initial_jobs_done):
+    current = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+    done = all(cur > initial for cur, initial in zip(current, shard_initial_jobs_done))
+    return done, {'current_jobs_done': current, 'initial_jobs_done': shard_initial_jobs_done}
+
+
+def _burst_completed(commands, completed, exceptions):
+    return completed[0] == len(commands), {
+        'completed': completed[0],
+        'total': len(commands),
+        'exceptions': exceptions,
+    }
+
+
+def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pending_jobs,
+                       shard_initial_jobs_done, completed):
+    coord_current_stats = getCoordThpoolStats(env)
+    shard_current_jobs_done = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+    env.debugPrint('-' * 80, force=True)
+    env.debugPrint(
+        f'[{label}] '
+        f'coord_initial_jobs_done={coord_initial_jobs_done} '
+        f'coord_initial_pending_jobs={coord_initial_pending_jobs} '
+        f'shard_initial_jobs_done={shard_initial_jobs_done} '
+        f'coord_current_stats={coord_current_stats} '
+        f'shard_current_jobs_done={shard_current_jobs_done} '
+        f'completed={completed[0]}',
+        force=True,
+    )
+
+
+@skip(cluster=False)
+def test_mixed_search_aggregate_burst_no_deadlock():
+    env = Env(
+        testName='MOD-14268 RQ deadlock regression',
+        shardsCount=SHARD_COUNT,
+        moduleArgs='SEARCH_IO_THREADS 1',
+        enableDebugCommand=True,
+    )
+    verify_shard_init(env)
+    set_workers(env, WORKER_COUNT)
+    env.expect(config_cmd(), 'SET', 'CONN_PER_SHARD', '1').ok()
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'title', 'TEXT',
+               'body', 'TEXT',
+               'category', 'TAG',
+               'price', 'NUMERIC').ok()
+
+    categories = ['books', 'electronics', 'food']
+    for i in range(DOC_COUNT):
+        conn.execute_command(
+            'HSET', f'doc:{i}',
+            'title', f'document {i}',
+            'body', f'searchable body text {i}',
+            'category', categories[i % len(categories)],
+            'price', i,
+        )
+
+    waitForIndex(env, 'idx')
+
+    commands = _build_mixed_burst_commands()
+    exceptions = []
+    completed = [0]
+    lock = threading.Lock()
+    threads = []
+
+    coord_initial_stats = getCoordThpoolStats(env)
+    coord_initial_jobs_done = coord_initial_stats['totalJobsDone']
+    coord_initial_pending_jobs = coord_initial_stats['totalPendingJobs']
+    shard_initial_jobs_done = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+
+    _print_debug_stats(
+        'before_pause',
+        env,
+        coord_initial_jobs_done,
+        coord_initial_pending_jobs,
+        shard_initial_jobs_done,
+        completed,
+    )
+
+    verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'PAUSE')
+
+    try:
+        for i, command in enumerate(commands):
+            thread = threading.Thread(
+                target=_run_burst_command,
+                args=(env, command, exceptions, completed, lock),
+                name=f'mod14268-query-{i}',
+                daemon=True,
+            )
+            thread.start()
+            threads.append(thread)
+
+        wait_for_condition(
+            lambda: _coordinator_reached_rq_limit(
+                env,
+                coord_initial_jobs_done,
+                coord_initial_pending_jobs,
+                completed,
+            ),
+            'Timeout waiting for coordinator to reach the RQ saturation threshold',
+            timeout=20,
+        )
+
+        # Happy-path handoff: once the coordinator is saturated, resume shard
+        # workers so the test can verify queued mixed requests start draining.
+        verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'RESUME')
+
+        wait_for_condition(
+            lambda: _shards_started_draining(env, shard_initial_jobs_done),
+            'Timeout waiting for shard workers to resume processing queued jobs',
+            timeout=20,
+        )
+
+        _print_debug_stats(
+            'after_shards_started_draining',
+            env,
+            coord_initial_jobs_done,
+            coord_initial_pending_jobs,
+            shard_initial_jobs_done,
+            completed,
+        )
+
+        wait_for_condition(
+            lambda: _burst_completed(commands, completed, exceptions),
+            'Timeout waiting for mixed FT.SEARCH/FT.AGGREGATE burst to drain',
+            timeout=15,
+        )
+
+        _print_debug_stats(
+            'after_burst_completed',
+            env,
+            coord_initial_jobs_done,
+            coord_initial_pending_jobs,
+            shard_initial_jobs_done,
+            completed,
+        )
+    # Best-effort cleanup: if the happy-path RESUME was skipped by a failure,
+    # try to leave shard workers runnable before joining the background threads.
+    finally:
+        try:
+            verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'RESUME')
+        except Exception:
+            pass
+        for thread in threads:
+            thread.join(timeout=1)
+
+    env.assertEqual(exceptions, [], message=f'Background burst queries failed: {exceptions}')
+
+    ping_result = env.cmd('PING')
+    env.assertTrue(ping_result in ['PONG', True],
+                   message='Coordinator should remain responsive after burst')
+    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0').equal([DOC_COUNT])

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -6,39 +6,38 @@ RQ_CAPACITY = 50  # CONN_PER_SHARD=1 and SEARCH_IO_THREADS=1 => 1 * PENDING_FACT
 SHARD_COUNT = 3
 WORKER_COUNT = 3
 DOC_COUNT = 240
-SEARCH_BURST = 100
-AGGREGATE_BURST = 150
 
+# FT.SEARCH query and expected result
+search = ['FT.SEARCH', 'idx', 'searchable', 'LIMIT', 0, 3,
+          'SORTBY', 'price', 'DESC', 'NOCONTENT']
+expected_search_res = [240, 'doc:239', 'doc:238', 'doc:237']
+
+# FT.AGGREGATE query and expected result
+aggregate = ['FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', '@category',
+             'REDUCE', 'COUNT', '0', 'AS', 'count',
+             'SORTBY', 2, '@count', 'ASC']
+expected_aggregate_res = [
+                            3,
+                            ['category', 'books', 'count', '80'],
+                            ['category', 'food', 'count', '80'],
+                            ['category', 'electronics', 'count', '80']
+                        ]
 
 def _build_mixed_burst_commands():
-    search = ['FT.SEARCH', 'idx', 'searchable', 'LIMIT', '0', '10']
-    aggregate = ['FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', '@category',
-                 'REDUCE', 'COUNT', '0', 'AS', 'count']
-    commands = []
-    remaining_searches = SEARCH_BURST
-    remaining_aggregates = AGGREGATE_BURST
-
     # Intentionally build a 3:1 FT.SEARCH-to-FT.AGGREGATE prefix so the burst
     # stays mixed while still driving the coordinator into the saturation region,
     # then continue draining the aggregate-heavy tail.
-    while remaining_searches > 0 or remaining_aggregates > 0:
-        for _ in range(3):
-            if remaining_searches == 0:
-                break
-            commands.append(search)
-            remaining_searches -= 1
-
-        if remaining_aggregates > 0:
-            commands.append(aggregate)
-            remaining_aggregates -= 1
-
-    return commands
+    return ([search] * 3 + [aggregate]) * 30 + [aggregate] * 120
 
 
 def _run_burst_command(env, command, exceptions, completed, lock):
     try:
         conn = getConnectionByEnv(env)
-        conn.execute_command(*command)
+        res = conn.execute_command(*command)
+        if command[0] == 'FT.SEARCH':
+            env.assertEqual(res, expected_search_res)
+        elif command[0] == 'FT.AGGREGATE':
+            env.assertEqual(res, expected_aggregate_res)
     except Exception as exc:
         with lock:
             exceptions.append(f'{command}: {exc}')
@@ -209,9 +208,13 @@ def test_search_and_aggregate_burst():
         for thread in threads:
             thread.join(timeout=1)
 
-    env.assertEqual(exceptions, [], message=f'Background burst queries failed: {exceptions}')
+    # Verify all burst queries completed successfully
+    env.assertEqual(exceptions, [],
+                    message=f'Background burst queries failed: {exceptions}')
 
+    # Verify Redis remains responsive after the burst
     ping_result = env.cmd('PING')
     env.assertTrue(ping_result in ['PONG', True],
                    message='Coordinator should remain responsive after burst')
-    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0').equal([DOC_COUNT])
+    env.expect(*search).equal(expected_search_res)
+    env.expect(*aggregate).equal(expected_aggregate_res)

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -92,9 +92,9 @@ def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pendin
 
 
 @skip(cluster=False)
-def test_mixed_search_aggregate_burst_no_deadlock():
+def test_search_and_aggregate_burst():
     env = Env(
-        testName='MOD-14268 RQ deadlock regression',
+        testName='Search and aggregate burst',
         shardsCount=SHARD_COUNT,
         moduleArgs='SEARCH_IO_THREADS 1',
         enableDebugCommand=True,
@@ -149,7 +149,7 @@ def test_mixed_search_aggregate_burst_no_deadlock():
             thread = threading.Thread(
                 target=_run_burst_command,
                 args=(env, command, exceptions, completed, lock),
-                name=f'mod14268-query-{i}',
+                name=f'search-and-aggregate-burst-query-{i}',
                 daemon=True,
             )
             thread.start()


### PR DESCRIPTION
## Description

1. Current:
`FT.SEARCH` was releasing its RQ pending slot too late: only after result reduction, client unblock, and blocked-client cleanup. In contrast, `FT.AGGREGATE` releases its RQ slot as soon as the libuv/network phase completes. Under mixed `FT.SEARCH` + `FT.AGGREGATE` load, this created a circular dependency:

    - `FT.AGGREGATE` could occupy the coordinator threadpool while waiting for libuv replies
    - `FT.SEARCH` could occupy RQ pending slots while waiting for the coordinator threadpool
    - once pending reached maxPending, libuv stopped making forward progress
    - replies could no longer drain, leading to a deadlock


2. Changes:
    - `RQ` completion ownership moved to fanout completion
    - `MRCtx` lifetime is now refcounted
    - Timeout owns the final reply path
    
 3. Outcome:
    - RQ slots are released at the end of network fanout, not delayed until blocked-client cleanup
    - mixed `FT.SEARCH / FT.AGGREGATE` workloads no longer deadlock on RQ pending slots vs. coordinator threadpool availability
    - `MRCtx` remains alive until the last async owner finishes
   
#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core coordinator concurrency/lifetime management (RQ slot completion, blocked-client unblocking, and timeout races) and adds refcounting across threads, which is high-risk for subtle use-after-free or stuck-query regressions.
> 
> **Overview**
> Fixes coordinator deadlocks under mixed `FT.SEARCH`/`FT.AGGREGATE` load by moving RQ pending-slot completion to the end of the libuv fanout phase (in `fanoutCallback`/`uvFanoutRequest`) instead of waiting for reduction/unblock/cleanup.
> 
> Introduces refcounted `MRCtx` lifetime with an optional `freePrivDataCB`, and updates distributed search paths to take/release references across fanout scheduling, background reducers, and blocked-client `free_privdata` handling.
> 
> Hardens coordinator timeout behavior so timeouts own the final reply path: reducers avoid touching blocked clients after timeout, timeout callbacks coordinate with in-flight reducers, and debug/test hooks add a new pause point (`COORD_REDUCE_PAUSE_BEFORE_REDUCER_INIT`) plus new/updated pytests (including a mixed burst regression test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 214f0a49953c5db86e9f9bab560a852104825817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->