### PR TITLE
Update `rustls-webpki` following RustSec advisory

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
RustSec put out an advisory regarding a bug in `rustls-webpki`: https://rustsec.org/advisories/RUSTSEC-2026-0049

Update `rustls-webpki` to `0.103.10` where this issue is fixed.

This fix is required as the current version of `rustls-webpki` in RediSearch is blocking CI runs.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lockfile-only dependency update, but it changes a TLS certificate validation component, which could affect connection behavior in edge cases.
> 
> **Overview**
> Updates the workspace `Cargo.lock` to bump `rustls-webpki` from `0.103.9` to `0.103.10` (new checksum), addressing the referenced RustSec advisory and unblocking CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16556c23a3038b4659c26be82e4d36a24e132ec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->