### PR TITLE
MOD-13832: Fix ft.info fields for disk indexes

### DIFF
--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -22,6 +22,7 @@
 #include "info/info_redis/threads/current_thread.h"
 #include "obfuscation/obfuscation_api.h"
 #include "query_error.h"
+#include "search_disk.h"
 
 static void renderIndexOptions(RedisModule_Reply *reply, const IndexSpec *sp) {
 
@@ -252,8 +253,12 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   RedisModule_Reply_ArrayEnd(reply); // >attributes
 
   REPLY_KVINT("num_docs", sp->stats.scoring.numDocuments);
-  REPLY_KVINT("max_doc_id", sp->docs.maxDocId);
+  t_docId maxDocId = sp->diskSpec ? SearchDisk_GetMaxDocId(sp->diskSpec) : sp->docs.maxDocId;
+  REPLY_KVINT("max_doc_id", maxDocId);
   REPLY_KVINT("num_terms", sp->stats.scoring.numTerms);
+  // NOTE: The following fields are not supported for disk indexes and will report
+  // incorrect values (typically 0).
+  // See MOD-13832 for tracking.
   REPLY_KVINT("num_records", sp->stats.numRecords);
   REPLY_KVNUM("inverted_sz_mb", sp->stats.invertedSize / (float)0x100000);
   size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
@@ -271,8 +276,9 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   REPLY_KVNUM("tag_overhead_sz_mb", tags_overhead / (float)0x100000);
   size_t text_overhead = IndexSpec_collect_text_overhead(sp);
   REPLY_KVNUM("text_overhead_sz_mb", text_overhead / (float)0x100000);
-  REPLY_KVNUM("total_index_memory_sz_mb", IndexSpec_TotalMemUsage(specForOpeningIndexes, dt_tm_size,
-    tags_overhead, text_overhead, vector_indexes_size) / (float)0x100000);
+  size_t total_memory = IndexSpec_TotalMemUsage(specForOpeningIndexes, dt_tm_size,
+    tags_overhead, text_overhead, vector_indexes_size);
+  REPLY_KVNUM("total_index_memory_sz_mb", total_memory / (float)0x100000);
   REPLY_KVNUM("geoshapes_sz_mb", geom_idx_sz / (float)0x100000);
   REPLY_KVNUM("records_per_doc_avg",
               (float)sp->stats.numRecords / (float)sp->stats.scoring.numDocuments);

--- a/src/spec.c
+++ b/src/spec.c
@@ -495,6 +495,12 @@ size_t IndexSpec_collect_text_overhead(const IndexSpec *sp) {
 size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t tags_overhead,
   size_t text_overhead, size_t vector_overhead) {
   size_t res = 0;
+
+  // For disk indexes, add storage + in-memory components.
+  if (sp->diskSpec) {
+    res += SearchDisk_CollectIndexMetrics(sp->diskSpec);
+  }
+
   res += sp->docs.memsize;
   res += sp->docs.sortablesSize;
   res += doctable_tm_size ? doctable_tm_size : TrieMap_MemUsage(sp->docs.dim.tm);


### PR DESCRIPTION
Updates the max-doc-id and total-memory fields of the `FT.INFO` command although not currently fully supported for disk indexes, as these are already supported for disk indexes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts `FT.INFO` reporting for disk-based indexes by pulling doc ID and memory metrics from the disk backend, which could affect monitoring outputs and add minor overhead when collecting metrics.
> 
> **Overview**
> Fixes `FT.INFO` stats for disk-based indexes by reporting `max_doc_id` via `SearchDisk_GetMaxDocId` instead of the in-memory doc table.
> 
> Updates `total_index_memory_sz_mb` to include disk storage/in-memory components for disk indexes by adding `SearchDisk_CollectIndexMetrics` into `IndexSpec_TotalMemUsage`, and documents that several other `FT.INFO` fields remain unsupported/inaccurate for disk indexes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ba762d48280d0f675868f7ffd5e5173f40d17ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->