### PR TITLE
[MOD-13606] Rename ubuntu:default to ubuntu:latest

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
-      platform: ubuntu:default
+      platform: ubuntu:latest
       architecture: x86_64
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -110,13 +110,13 @@ jobs:
           for platform, architecture in filtered_combinations:
               add_matrix_entries(matrix_items, platform, architecture, 'test')
 
-          # Add coverage job if requested (only on ubuntu:default x86_64)
+          # Add coverage job if requested (only on ubuntu:latest x86_64)
           if include_coverage:
-              add_matrix_entries(matrix_items, 'ubuntu:default', 'x86_64', 'coverage')
+              add_matrix_entries(matrix_items, 'ubuntu:latest', 'x86_64', 'coverage')
 
-          # Add sanitize job if requested (only on ubuntu:default x86_64)
+          # Add sanitize job if requested (only on ubuntu:latest x86_64)
           if include_sanitize:
-              add_matrix_entries(matrix_items, 'ubuntu:default', 'x86_64', 'sanitize')
+              add_matrix_entries(matrix_items, 'ubuntu:latest', 'x86_64', 'sanitize')
 
           # Check if matrix has any jobs
           has_jobs = len(matrix_items) > 0

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -124,7 +124,7 @@ jobs:
                       'ec2_instance_type': 'c7i.xlarge'
                   }
               },
-              "ubuntu:default": {
+              "ubuntu:latest": {
                   "x86_64": {
                       'container': 'ubuntu:latest',
                       'setup_script': 'apt update && apt install -y git',


### PR DESCRIPTION
Rename `ubuntu:default` to `ubuntu:latest` in CI files for clarity.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename in GitHub Actions workflow configuration; primary risk is unintended CI job selection changes if any references to the old platform name were missed.
> 
> **Overview**
> Renames the CI platform identifier from `ubuntu:default` to `ubuntu:latest` across GitHub Actions workflows.
> 
> This updates PR test job inputs, and adjusts matrix generation so coverage/sanitize jobs target `ubuntu:latest` x86_64, alongside updating `task-get-config.yml` to recognize `ubuntu:latest` as a valid platform key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b70f1aa4e714d88493f34a608667704165166d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->