### PR TITLE
test: make sure extern "C" is passed from C++ to  C callbacks

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -22,34 +22,38 @@
 #include <initializer_list>
 #include <span>
 
-// Test callback for queue operations
-static void testCallback(void *privdata) {
-  int *counter = (int *)privdata;
-  (*counter)++;
-}
+extern "C" {
+  // Test callback for queue operations
+  static void testCallback(void *privdata) {
+    int *counter = (int *)privdata;
+    (*counter)++;
+  }
+} // extern "C"
 
 // Test callback for topology updates - signals completion to test thread
 // by storing the capShards value in an atomic, avoiding race conditions
 // where the test thread might read a freed topology pointer.
 static std::atomic<uint32_t> lastAppliedCapShards{0};
 
-static void testTopoCallback(void *privdata) {
-  struct UpdateTopologyCtx *updateCtx = (struct UpdateTopologyCtx *)privdata;
-  IORuntimeCtx *ioRuntime = updateCtx->ioRuntime;
-  //Simulate what the TopologyValidationTimer should do
-  ioRuntime->uv_runtime.loop_th_ready = true;
-  MRClusterTopology *old_topo = ioRuntime->topo;
-  MRClusterTopology *new_topo = updateCtx->new_topo;
-  // Store the capShards value BEFORE updating the pointer, so test can safely check it
-  uint32_t newCapShards = new_topo->capShards;
-  ioRuntime->topo = new_topo;
-  // Signal to the test thread that this topology was applied
-  lastAppliedCapShards.store(newCapShards, std::memory_order_release);
-  rm_free(updateCtx);
-  if (old_topo) {
-    MRClusterTopology_Free(old_topo);
+extern "C" {
+  static void testTopoCallback(void *privdata) {
+    struct UpdateTopologyCtx *updateCtx = (struct UpdateTopologyCtx *)privdata;
+    IORuntimeCtx *ioRuntime = updateCtx->ioRuntime;
+    //Simulate what the TopologyValidationTimer should do
+    ioRuntime->uv_runtime.loop_th_ready = true;
+    MRClusterTopology *old_topo = ioRuntime->topo;
+    MRClusterTopology *new_topo = updateCtx->new_topo;
+    // Store the capShards value BEFORE updating the pointer, so test can safely check it
+    uint32_t newCapShards = new_topo->capShards;
+    ioRuntime->topo = new_topo;
+    // Signal to the test thread that this topology was applied
+    lastAppliedCapShards.store(newCapShards, std::memory_order_release);
+    rm_free(updateCtx);
+    if (old_topo) {
+      MRClusterTopology_Free(old_topo);
+    }
   }
-}
+} // extern "C"
 
 class IORuntimeCtxCommonTest : public ::testing::Test {
 protected:


### PR DESCRIPTION
## Problem

After a recent refactor that introduced `std::atomic<uint32_t> lastAppliedCapShards` in the IO runtime context tests, we observed intermittent "stack smashing detected" crashes on Linux x86-64 release builds in CI. The crash occurred during `uv_thread_join` in `IORuntimeCtx_Free`, specifically in the `IORuntimeCtxCommonTest.ScheduleTopology` test.

## Root Cause Analysis

The `testTopoCallback` function is defined in C++ but passed as a function pointer to C code (`IORuntimeCtx_Schedule_Topology`). Without explicit `extern "C"` linkage:

1. **Name mangling**: C++ compilers apply name mangling to function symbols, while C code expects unmangled names. Though this typically causes linker errors, it can sometimes lead to subtle ABI mismatches.

2. **Calling convention differences**: While x86-64 System V ABI (used by Linux) generally uses the same calling convention for C and C++, there can be subtle differences in:
   - Stack alignment expectations
   - Red zone usage
   - How the compiler generates function prologues/epilogues

3. **Stack protector interaction**: GCC on Linux places stack canaries for buffer overflow detection. If there's any mismatch in how the stack frame is set up between the C caller and C++ callee, the canary check at function return can fail, triggering "stack smashing detected".

4. **Optimization differences**: Release builds with `-O2` or `-O3` may inline or optimize code differently when the compiler doesn't have complete ABI information, potentially leading to stack corruption.

## Why this wasn't caught before

- **macOS uses Clang** which may handle C/C++ interop more gracefully
- **Debug builds** have less aggressive optimizations and may not trigger the issue
- **The issue is timing-dependent** and may not manifest in every run

## Solution

Wrap the callback functions in `extern "C"` blocks to ensure proper C linkage when they are invoked from C code. This is a best practice when passing C++ function pointers to C APIs.

## Note

This is a speculative fix based on analysis of the symptoms. The actual root cause could be related to other factors in the CI environment (compiler version, specific optimization flags, etc.). If this doesn't resolve the issue, further investigation with AddressSanitizer on a Linux environment would be needed.