### PR TITLE
chore: Clean up installation script for Rust deps

### DIFF
--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -39,7 +39,7 @@ binstall cargo-llvm-cov@0.8.4
 # Use musl targets on Linux for maximum compatibility across glibc versions
 # (default builds dynamically against system glibc which causes issues on older systems)
 NEXTEST_ARGS=()
-if [ "$OS_TYPE" = "Linux" ] && [[ "$processor" =~ ^(x86_64|aarch64)$ ]]; then
+if [[ "$OS_TYPE" = "Linux" ]] && [[ "$processor" =~ ^(x86_64|aarch64)$ ]]; then
     NEXTEST_ARGS+=(--target="${processor}-unknown-linux-musl")
 fi
 binstall "${NEXTEST_ARGS[@]}" cargo-nextest@0.9.130


### PR DESCRIPTION
## Describe the changes in the pull request

Minimize duplication.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of the Rust dependency installation script; main risk is minor CI breakage if argument handling for `cargo binstall`/musl targets differs across shells or platforms.
> 
> **Overview**
> Refactors `.install/test_deps/install_rust_deps.sh` to reduce duplication by introducing a `binstall()` wrapper that standardizes `cargo binstall` flags.
> 
> Simplifies `cargo-nextest` installation by computing optional Linux musl `--target` arguments via an array/regex check, while keeping tool versions and overall install behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9239619a346fb2d484cdd8e22f7b2c096c0ea1af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->