### PR TITLE
[8.6] MOD-14461: Fix FT.EXPLAIN missing spec read lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1187,15 +1187,14 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   }
   RedisSearchCtx *sctx = AREQ_SearchCtx(r);
   // Take a read lock on the spec (to avoid conflicts with the GC).
+  // released in `AREQ_Free`.
   RedisSearchCtx_LockSpecRead(sctx);
   if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
-    RedisSearchCtx_UnlockSpec(sctx);
     AREQ_Free(r);
     CurrentThread_ClearIndexSpec();
     return NULL;
   }
   char *ret = QAST_DumpExplain(&r->ast, sctx->spec);
-  RedisSearchCtx_UnlockSpec(sctx);
   AREQ_Free(r);
   CurrentThread_ClearIndexSpec();
   return ret;


### PR DESCRIPTION
# Description
Backport of #8669 to 8.6.

## Conflicts Resolved
- `src/aggregate/aggregate_exec.c`: The 8.6 branch uses `AREQ_Free()` while master uses `AREQ_DecrRef()`. Resolved by keeping `AREQ_Free()` for the 8.6 branch while applying the locking fix (`RedisSearchCtx_UnlockSpec`).

## Jira

[MOD-14623](https://redislabs.atlassian.net/browse/MOD-14623)

#### Release Notes

- [x] This PR requires release notes

User-impact: Before this fix, the DB may crash if running `FT.EXPLAIN` while GC updates the index.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14623]: https://redislabs.atlassian.net/browse/MOD-14623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a missing spec read lock to the `FT.EXPLAIN` path to prevent races with GC/index updates; risk is mainly around introducing lock ordering/latency issues, though the change is small and localized.
> 
> **Overview**
> Prevents potential crashes when running `FT.EXPLAIN` concurrently with GC/index-spec updates by taking a spec **read lock** before building the execution plan and relying on `AREQ_Free` to release it.
> 
> Also clarifies the locking requirement in `prepareExecutionPlan` to document that it must run under the spec’s read lock to avoid main-thread/GC races.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38a85e3274b87595b5897e515f0ec5126f294649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->