### PR TITLE
[8.2] MOD-14461: Fix FT.EXPLAIN missing spec read lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1256,17 +1256,16 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   if (buildRequest(ctx, argv, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
-  RedisSearchCtx *sctx = AREQ_SearchCtx(r);
+  RedisSearchCtx *sctx = r->sctx;
   // Take a read lock on the spec (to avoid conflicts with the GC).
+  // released in `AREQ_Free`.
   RedisSearchCtx_LockSpecRead(sctx);
   if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
-    RedisSearchCtx_UnlockSpec(sctx);
     AREQ_Free(r);
     CurrentThread_ClearIndexSpec();
     return NULL;
   }
   char *ret = QAST_DumpExplain(&r->ast, sctx->spec);
-  RedisSearchCtx_UnlockSpec(sctx);
   AREQ_Free(r);
   CurrentThread_ClearIndexSpec();
   return ret;


### PR DESCRIPTION
# Description
Backport of #8669 to 8.2.

## Conflicts Resolved
- `src/aggregate/aggregate_exec.c`: The 8.2 branch uses `AREQ_Free()` while master uses `AREQ_DecrRef()`. Also uses `r->sctx->spec` vs `AREQ_SearchCtx(r)->spec`. Resolved by keeping `AREQ_Free()` for the 8.2 branch while applying the locking fix (`RedisSearchCtx_UnlockSpec`), and using `sctx->spec` consistently.

## Jira

[MOD-14625](https://redislabs.atlassian.net/browse/MOD-14625)

#### Release Notes

- [x] This PR requires release notes

User-impact: Before this fix, the DB may crash if running `FT.EXPLAIN` while GC updates the index.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14625]: https://redislabs.atlassian.net/browse/MOD-14625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spec locking around query planning, which is concurrency-sensitive and could introduce lock-order/perf regressions if misused. Change is small and scoped to `FT.EXPLAIN`.
> 
> **Overview**
> **Release note:** Fixes a potential crash when running `FT.EXPLAIN` concurrently with index GC/spec updates by acquiring the index spec *read lock* for the duration of explain plan preparation (released via `AREQ_Free`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09e097213a007a1b0c1585a1a9c85d1b6c16eb73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->