### PR TITLE
[2.10] MOD-14461: Fix FT.EXPLAIN missing spec read lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1262,16 +1262,15 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   if (buildRequest(ctx, argv, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
-  RedisSearchCtx *sctx = AREQ_SearchCtx(r);
+  RedisSearchCtx *sctx = r->sctx;
   // Take a read lock on the spec (to avoid conflicts with the GC).
+  // released in `AREQ_Free`.
   RedisSearchCtx_LockSpecRead(sctx);
   if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
-    RedisSearchCtx_UnlockSpec(sctx);
     AREQ_Free(r);
     return NULL;
   }
   char *ret = QAST_DumpExplain(&r->ast, sctx->spec);
-  RedisSearchCtx_UnlockSpec(sctx);
   AREQ_Free(r);
   return ret;
 }


### PR DESCRIPTION
# Description
Backport of #8669 to 2.10.

## Conflicts Resolved
- `src/aggregate/aggregate_exec.c`: The 2.10 branch uses `AREQ_Free()` while master uses `AREQ_DecrRef()`. Also 2.10 does not have `CurrentThread_ClearIndexSpec()` calls. Resolved by keeping `AREQ_Free()` for the 2.10 branch, omitting `CurrentThread_ClearIndexSpec()`, while applying the locking fix (`RedisSearchCtx_UnlockSpec`) and using `sctx->spec` consistently.

## Jira

[MOD-14626](https://redislabs.atlassian.net/browse/MOD-14626)

#### Release Notes

- [x] This PR requires release notes

User-impact: Before this fix, the DB may crash if running `FT.EXPLAIN` while GC updates the index.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14626]: https://redislabs.atlassian.net/browse/MOD-14626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a spec read-lock around `FT.EXPLAIN` plan preparation, which touches shared locking/concurrency paths and could surface deadlock or performance regressions if misused.
> 
> **Overview**
> **Release note:** Fixes a potential crash when running `FT.EXPLAIN` concurrently with index GC updates by taking a read lock on the index spec while building and dumping the explain plan.
> 
> Also clarifies `prepareExecutionPlan`’s contract that callers must hold the spec’s read lock to avoid races with main-thread/GC updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 752df042962e1a6d5cf58b2a23a72c957171f633. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->