### PR TITLE
[2.8] MOD-14461: Fix FT.EXPLAIN missing spec read lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1259,16 +1259,15 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   if (buildRequest(ctx, argv, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
-  RedisSearchCtx *sctx = AREQ_SearchCtx(r);
+  RedisSearchCtx *sctx = r->sctx;
   // Take a read lock on the spec (to avoid conflicts with the GC).
+  // released in `AREQ_Free`.
   RedisSearchCtx_LockSpecRead(sctx);
   if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
-    RedisSearchCtx_UnlockSpec(sctx);
     AREQ_Free(r);
     return NULL;
   }
   char *ret = QAST_DumpExplain(&r->ast, sctx->spec);
-  RedisSearchCtx_UnlockSpec(sctx);
   AREQ_Free(r);
   return ret;
 }


### PR DESCRIPTION
# Description
Backport of #8669 to 2.8.

## Conflicts Resolved
- `src/aggregate/aggregate_exec.c`: The 2.8 branch uses `AREQ_Free()` while master uses `AREQ_DecrRef()`. Also 2.8 does not have `CurrentThread_ClearIndexSpec()` calls. Resolved by keeping `AREQ_Free()` for the 2.8 branch, omitting `CurrentThread_ClearIndexSpec()`, while applying the locking fix (`RedisSearchCtx_UnlockSpec`) and using `sctx->spec` consistently.

## Jira

[MOD-14627](https://redislabs.atlassian.net/browse/MOD-14627)

#### Release Notes

- [x] This PR requires release notes

User-impact: Before this fix, the DB may crash if running `FT.EXPLAIN` while GC updates the index.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-14627]: https://redislabs.atlassian.net/browse/MOD-14627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spec locking in query planning/explain paths; although small and targeted, mistakes could cause deadlocks or continued races under concurrent GC/index updates.
> 
> **Overview**
> `FT.EXPLAIN` now explicitly takes a **spec read lock** (`RedisSearchCtx_LockSpecRead`) before `prepareExecutionPlan`/`QAST_DumpExplain`, and relies on `AREQ_Free` to release it.
> 
> Comments were updated to clarify that `prepareExecutionPlan` requires the spec to be guarded by its own read lock to prevent races with GC/main-thread index spec mutations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc3cd7de63447aa9633e8e166265e8b7253fdab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->