### PR TITLE
Less constrained RQEIterator Box impl

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -142,8 +142,10 @@ pub trait RQEIterator<'index> {
     }
 }
 
-// Implement RQEIterator for Box<dyn RQEIterator> to support dynamic dispatch
-impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
+// Implement RQEIterator for any Box<I> where I: RQEIterator + ?Sized.
+// This covers Box<dyn RQEIterator> as well as Box<dyn SubTrait> for any
+// subtrait of RQEIterator, without requiring a separate delegation impl per subtrait.
+impl<'index, I: RQEIterator<'index> + ?Sized> RQEIterator<'index> for Box<I> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         (**self).current()
     }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -125,6 +125,8 @@ impl<'index, I: WildcardIterator<'index>> WildcardIterator<'index>
 {
 }
 
+impl<'index> WildcardIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> {}
+
 /// [`Empty`] is used as wildcard in the optimized version if the spec has no document.
 struct EmptyWildcard(Empty);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -11,7 +11,7 @@ use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
 use inverted_index::{RSIndexResult, RSOffsetSlice};
-use rqe_iterators::RQEIterator;
+use rqe_iterators::{RQEIterator, WildcardIterator};
 
 /// Test iterator used in unit tests that expect an [`RQEIterator`]
 /// child which produces a fixed sequence of document identifiers.
@@ -430,6 +430,8 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
         self.next_index >= N
     }
 }
+
+impl<'index, const N: usize> WildcardIterator<'index> for Mock<'index, N> {}
 
 /// Dynamic-size variant of [`Mock`] that uses a [`Vec`] instead of a fixed array.
 ///


### PR DESCRIPTION
- Ground work for https://github.com/RediSearch/RediSearch/pull/8692/changes#r2974474431

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core iterator trait dispatch and trait-object boxing, which could cause subtle trait-coherence/dispatch changes or downstream compile issues despite being behavior-preserving.
> 
> **Overview**
> Generalizes the `RQEIterator` delegation impl from `Box<dyn RQEIterator>` to `Box<I>` where `I: RQEIterator + ?Sized`, so boxed trait objects of *subtraits* can be used transparently without adding new delegation impls.
> 
> Adds explicit `WildcardIterator` support for boxed wildcard trait objects and updates integration test `Mock` iterator to implement `WildcardIterator`, enabling it to be used in wildcard-specific paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69651eab7b1f7f3dd6af136d1afa673f4a4d9512. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->