### PR TITLE
MOD-14438: Hardcode Max Workers To 8192 For AWS Artifacts

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -80,7 +80,7 @@ jobs:
       VERBOSE: 1 # For logging
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
       # Build command
-      BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
+      BUILD_CMD: echo '::group::Build' && make build MAX_WORKER_THREADS=8192 VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
       GITHUB_REPOSITORY: ${{ github.repository }}
       SETUP_RETRY_LOOP: |
         SUCCESS=0


### PR DESCRIPTION
Specify the 8192 value in the build artifacts flow when compiling the module.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters build parallelism; main risk is increased resource usage or build instability on constrained runners.
> 
> **Overview**
> **Build artifacts CI now forces a fixed worker thread cap.** The `task-build-artifacts.yml` workflow updates `BUILD_CMD` to run `make build` with `MAX_WORKER_THREADS=8192` (instead of leaving it unset), standardizing build parallelism for artifact compilation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d845c21bdfcd8fa65499e6cbad1de19b9c72acea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->