### PR TITLE
feat: Add a downcast mechanism for RQEIterators

### DIFF
--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -86,11 +86,23 @@ typedef struct QueryIterator {
 
   /* Rewind the iterator to the beginning and reset its state (including `atEOF` and `lastDocId`) */
   void (*Rewind)(struct QueryIterator *self);
+
+  /* Downcast the iterator to an opaque pointer if it matches the given type */
+  const void* (*DowncastRaw)(const struct QueryIterator *self, IteratorType type);
 } QueryIterator;
 
 static inline ValidateStatus Default_Revalidate(struct QueryIterator *base) {
   // Default implementation does nothing.
   return VALIDATE_OK;
+}
+
+// All C iterators return a pointer to themselves if the type matches.
+static inline const void* DefaultDowncastRaw(const struct QueryIterator *base, IteratorType type) {
+    if (base->type == type) {
+        return base;
+    } else {
+        return NULL;
+    }
 }
 
 #endif

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -13,6 +13,8 @@ use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use inverted_index::{
     IndexReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::downcasting::IteratorTypeKnownAtCompileTime;
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{FieldExpirationChecker, inverted_index::Missing};
 
@@ -53,6 +55,10 @@ macro_rules! dispatch {
             MissingIterator::Raw(m) => m.$method($($arg),*),
         }
     };
+}
+
+impl<'index> IteratorTypeKnownAtCompileTime for MissingIterator<'index> {
+    const TYPE: IteratorType = IteratorType::InvIdxMissing;
 }
 
 impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
@@ -102,6 +108,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
         &mut self,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         dispatch!(self, revalidate)
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        rqe_iterators::downcasting::downcast_as_ref_raw(self, type_)
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -12,6 +12,8 @@ use std::ptr::NonNull;
 use field::{FieldFilterContext, FieldMaskOrIndex};
 use inverted_index::{FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter};
 use numeric_range_tree::{NumericIndex, NumericIndexReader, NumericRange, NumericRangeTree};
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::downcasting::{IteratorTypeKnownAtCompileTime, downcast_as_ref_raw};
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{FieldExpirationChecker, inverted_index::Numeric};
 
@@ -75,6 +77,10 @@ impl<'index> NumericIterator<'index> {
             IteratorVariant::Geo(iter) => iter.range_max(),
         }
     }
+}
+
+impl<'index> IteratorTypeKnownAtCompileTime for NumericIterator<'index> {
+    const TYPE: IteratorType = IteratorType::InvIdxNumeric;
 }
 
 impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
@@ -157,6 +163,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
             IteratorVariant::NumericFiltered(iter) => iter.at_eof(),
             IteratorVariant::Geo(iter) => iter.at_eof(),
         }
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        downcast_as_ref_raw(self, type_)
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -14,6 +14,8 @@ use inverted_index::{
     IndexReader, RSIndexResult, RSQueryTerm, doc_ids_only::DocIdsOnly,
     raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::downcasting::{IteratorTypeKnownAtCompileTime, downcast_as_ref_raw};
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{FieldExpirationChecker, inverted_index::Tag};
 
@@ -55,6 +57,10 @@ macro_rules! tag_it_dispatch {
             TagIterator::Raw(t) => t.$method($($arg),*),
         }
     };
+}
+
+impl<'index> IteratorTypeKnownAtCompileTime for TagIterator<'index> {
+    const TYPE: IteratorType = IteratorType::InvIdxTag;
 }
 
 impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
@@ -104,6 +110,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
         &mut self,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         tag_it_dispatch!(self, revalidate)
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        downcast_as_ref_raw(self, type_)
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -12,6 +12,8 @@ use std::{fmt::Debug, ptr::NonNull};
 use inverted_index::{
     RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::downcasting::{IteratorTypeKnownAtCompileTime, downcast_as_ref_raw};
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::inverted_index::Wildcard;
 
@@ -32,6 +34,10 @@ impl Debug for WildcardIterator<'_> {
         };
         write!(f, "WildcardIterator({variant})")
     }
+}
+
+impl<'index> IteratorTypeKnownAtCompileTime for WildcardIterator<'index> {
+    const TYPE: IteratorType = IteratorType::InvIdxWildcard;
 }
 
 impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
@@ -110,6 +116,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     #[inline(always)]
     fn is_wildcard(&self) -> bool {
         true
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        downcast_as_ref_raw(self, type_)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -159,6 +159,10 @@ impl CRQEIterator {
             self_.Rewind.is_some(),
             "The `Rewind` callback is a NULL function pointer"
         );
+        debug_assert!(
+            self_.DowncastRaw.is_some(),
+            "The `DowncastRaw` callback is a NULL function pointer"
+        );
         self_
     }
 
@@ -315,5 +319,15 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
             self.type_,
             IteratorType::Wildcard | IteratorType::InvIdxWildcard
         )
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
+        let callback = unsafe { self.DowncastRaw.unwrap_unchecked() };
+        // SAFETY:
+        // - We have a unique handle over this iterator.
+        // - The C code must guarantee, by constructor, that callbacks
+        //   can be called on types that implement its C iterator API.
+        unsafe { callback(self.header.as_ptr(), type_) }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/downcasting.rs
+++ b/src/redisearch_rs/rqe_iterators/src/downcasting.rs
@@ -1,0 +1,50 @@
+use std::ffi::c_void;
+
+use crate::RQEIterator;
+use rqe_iterator_type::IteratorType;
+
+/// A marker trait to associate an [`RQEIterator`] implementation
+/// to a type tag, at compile-time.
+///
+/// # Downcasting
+///
+/// This trait exists to support [`downcast_iterator_as_ref`].
+///
+/// For each variant in [`IteratorType`], there should be at most one
+/// implementation of [`IteratorTypeKnownAtCompileTime`] using it as
+/// its [`Self::TYPE`] value.
+pub trait IteratorTypeKnownAtCompileTime {
+    /// The type of this iterator, known at compile-time.
+    const TYPE: IteratorType;
+}
+
+/// Downcast a reference to a type-erased [`RQEIterator`] into a reference to
+/// a concrete type.
+///
+/// It returns `None` if [`T::TYPE`] doesn't match the iterator type of
+/// `&dyn RQEIterator`, or if the input doesn't support downcasting.
+pub fn downcast_iterator_as_ref<'a, 'b, T>(i: &'a dyn RQEIterator<'b>) -> Option<&'a T>
+where
+    T: IteratorTypeKnownAtCompileTime + RQEIterator<'b>,
+{
+    let raw = i.downcast_as_ref_raw(T::TYPE);
+    if raw.is_null() {
+        None
+    } else {
+        // SAFETY: implementor's contract guarantees that a non-None return
+        // is a valid pointer to T, and the borrow on `iter` keeps it alive.
+        Some(unsafe { &*(raw as *const T) })
+    }
+}
+
+/// An implementation of [`RQEIterator::downcast_as_ref_raw`] that's suitable for
+/// all non-wrapping implementors of the trait, as long as they don't have
+/// unassigned type parameters.
+pub fn downcast_as_ref_raw<'a, I>(self_: &I, type_: IteratorType) -> *const c_void
+where
+    I: IteratorTypeKnownAtCompileTime + RQEIterator<'a>,
+{
+    (I::TYPE == type_)
+        .then(|| std::ptr::from_ref(self_).cast())
+        .unwrap_or(std::ptr::null())
+}

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -12,13 +12,20 @@
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime,
+};
 
 /// An iterator that yields no results.
 ///
 /// The [`Empty`] iterator is a sentinel iterator that represents an empty result set.
 #[derive(Default)]
 pub struct Empty;
+
+impl IteratorTypeKnownAtCompileTime for Empty {
+    const TYPE: IteratorType = IteratorType::Empty;
+}
 
 impl<'index> RQEIterator<'index> for Empty {
     #[inline(always)]
@@ -60,5 +67,9 @@ impl<'index> RQEIterator<'index> for Empty {
     #[inline(always)]
     fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -13,7 +13,10 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 use std::cmp::Ordering;
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, utils::OwnedSlice};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime, utils::OwnedSlice,
+};
 
 /// An iterator that yields results according to a sorted list of unique IDs, specified on construction.
 pub type IdListSorted<'index> = IdList<'index, true>;
@@ -191,6 +194,18 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     }
 }
 
+impl<'index, const SORTED_BY_ID: bool> IteratorTypeKnownAtCompileTime
+    for IdList<'index, SORTED_BY_ID>
+{
+    const TYPE: IteratorType = {
+        if SORTED_BY_ID {
+            IteratorType::IdListSorted
+        } else {
+            IteratorType::IdListUnsorted
+        }
+    };
+}
+
 impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SORTED_BY_ID> {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -240,5 +255,9 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     #[inline(always)]
     fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -54,6 +54,7 @@ where
                 Revalidate: Some(revalidate::<I>),
                 Free: Some(free_iterator::<I>),
                 Rewind: Some(rewind::<I>),
+                DowncastRaw: Some(downcast_raw::<I>),
             },
             inner,
         });
@@ -223,4 +224,15 @@ extern "C" fn free_iterator<'index, I: RQEIterator<'index> + 'index>(base: *mut 
         //  return a raw header pointer.
         let _ = unsafe { Box::from_raw(base as *mut RQEIteratorWrapper<I>) };
     }
+}
+
+extern "C" fn downcast_raw<'index, I: RQEIterator<'index> + 'index>(
+    base: *const QueryIterator,
+    type_: IteratorType,
+) -> *const std::ffi::c_void {
+    debug_assert!(!base.is_null());
+    debug_assert!(base.is_aligned());
+    // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
+    let wrapper = unsafe { RQEIteratorWrapper::<I>::ref_from_header_ptr(base) };
+    wrapper.inner.downcast_as_ref_raw(type_)
 }

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -16,7 +16,10 @@
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime,
+};
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
 ///
@@ -260,6 +263,13 @@ where
     }
 }
 
+impl<'index, I> IteratorTypeKnownAtCompileTime for Intersection<'index, I>
+where
+    I: RQEIterator<'index>,
+{
+    const TYPE: IteratorType = IteratorType::Intersect;
+}
+
 impl<'index, I> RQEIterator<'index> for Intersection<'index, I>
 where
     I: RQEIterator<'index>,
@@ -411,5 +421,9 @@ where
             }),
             None => Ok(RQEValidateStatus::Moved { current: None }),
         }
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -11,7 +11,7 @@ use ffi::t_docId;
 use inverted_index::{IndexReader, RSIndexResult};
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 
@@ -246,6 +246,13 @@ where
     R: IndexReader<'index>,
     E: ExpirationChecker,
 {
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
+    }
+
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         Some(&mut self.result)

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -14,7 +14,10 @@ use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
 };
 
-use crate::{ExpirationChecker, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
+    SkipToOutcome,
+};
 
 use super::InvIndIterator;
 
@@ -134,6 +137,13 @@ where
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
+    }
+
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.it.current()

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -14,7 +14,7 @@ use inverted_index::{NumericReader, RSIndexResult};
 use numeric_range_tree::NumericRangeTree;
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 
@@ -140,6 +140,13 @@ where
     R: NumericReader<'index>,
     E: ExpirationChecker,
 {
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
+    }
+
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.it.current()

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -16,7 +16,10 @@ use inverted_index::{
 };
 use query_term::RSQueryTerm;
 
-use crate::{ExpirationChecker, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
+    SkipToOutcome,
+};
 
 use super::InvIndIterator;
 
@@ -176,6 +179,13 @@ where
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
+    }
+
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.it.current()

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -14,7 +14,7 @@ use inverted_index::{RSIndexResult, RSOffsetSlice, TermReader};
 use query_term::RSQueryTerm;
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     expiration_checker::ExpirationChecker,
 };
 
@@ -163,6 +163,13 @@ where
     R: TermReader<'index>,
     E: ExpirationChecker,
 {
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
+    }
+
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.it.current()

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -15,7 +15,7 @@ use inverted_index::{
 };
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     expiration_checker::NoOpChecker,
 };
 
@@ -166,5 +166,12 @@ where
 
     fn is_wildcard(&self) -> bool {
         true
+    }
+
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -8,13 +8,14 @@
 */
 
 use ffi::t_docId;
-use std::sync::OnceLock;
+use std::{ffi::c_void, sync::OnceLock};
 use thiserror::Error;
 
 use ::inverted_index::{RSIndexResult, t_fieldMask};
 use query_term::RSQueryTerm;
 
 pub mod c2rust;
+pub mod downcasting;
 pub mod empty;
 pub mod expiration_checker;
 pub mod id_list;
@@ -127,6 +128,27 @@ pub trait RQEIterator<'index> {
     /// Returns an upper-bound estimation for the number of results the iterator is going to yield.
     fn num_estimated(&self) -> usize;
 
+    /// Downcast `self` to an opaque pointer if it matches the requested `type_`.
+    ///
+    /// # Beware
+    ///
+    /// You should never invoke this method directly.
+    /// Use the higher-level [`downcast_iterator_as_ref`] function instead.
+    ///
+    /// # Implementation Notes
+    ///
+    /// ## Why Do We Need This Method?
+    ///
+    /// In an ideal world, we'd add [`downcast_iterator_as_ref`] to [`RQEIterator`].
+    /// In practice, we need [`RQEIterator`] to be dyn-safe and this forbids us
+    /// from adding new methods to the trait definition with function-level
+    /// generic parameters.
+    ///
+    /// We thus follow the common workaround of splitting the required functionality into
+    /// two chunks: the "dyn-safe" one goes on the trait, the "dyn-unsafe" one goes out of
+    /// it.
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const c_void;
+
     /**************** properties ****************/
 
     /// Returns the last doc id that was read or skipped to.
@@ -182,6 +204,10 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
 
     fn is_wildcard(&self) -> bool {
         (**self).is_wildcard()
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const c_void {
+        (**self).downcast_as_ref_raw(type_)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -12,7 +12,9 @@
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty,
+};
 
 /// An iterator that is either [`Empty`] or the provided [`RQEIterator`].
 pub struct MaybeEmpty<I>(MaybeEmptyOption<I>);
@@ -140,6 +142,13 @@ where
         match &self.0 {
             MaybeEmptyOption::None(empty) => empty.at_eof(),
             MaybeEmptyOption::Some(it) => it.at_eof(),
+        }
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        match &self.0 {
+            MaybeEmptyOption::None(empty) => empty.downcast_as_ref_raw(type_),
+            MaybeEmptyOption::Some(it) => it.downcast_as_ref_raw(type_),
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -10,8 +10,8 @@
 //! Supporting types for [`Metric`].
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, id_list::IdList,
-    utils::OwnedSlice,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime, id_list::IdList, utils::OwnedSlice,
 };
 use ffi::{RLookupKey, RLookupKeyHandle, t_docId};
 use inverted_index::RSIndexResult;
@@ -118,6 +118,18 @@ impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
     }
 }
 
+impl<'index, const SORTED_BY_ID: bool> IteratorTypeKnownAtCompileTime
+    for Metric<'index, SORTED_BY_ID>
+{
+    const TYPE: IteratorType = {
+        if SORTED_BY_ID {
+            IteratorType::MetricSortedById
+        } else {
+            IteratorType::MetricSortedByScore
+        }
+    };
+}
+
 impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SORTED_BY_ID> {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -183,5 +195,9 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     #[inline(always)]
     fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.base.revalidate()
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -15,8 +15,8 @@ use ffi::{RS_FIELDMASK_ALL, t_docId};
 use inverted_index::RSIndexResult;
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, maybe_empty::MaybeEmpty,
-    util::TimeoutContext,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime, maybe_empty::MaybeEmpty, util::TimeoutContext,
 };
 
 /// An iterator that negates the results of its child iterator.
@@ -120,6 +120,13 @@ where
     pub fn take_child(&mut self) -> Option<I> {
         self.child.take_iterator()
     }
+}
+
+impl<'index, I> IteratorTypeKnownAtCompileTime for Not<'index, I>
+where
+    I: RQEIterator<'index>,
+{
+    const TYPE: IteratorType = IteratorType::Not;
 }
 
 impl<'index, I> RQEIterator<'index> for Not<'index, I>
@@ -265,5 +272,9 @@ where
                 Ok(RQEValidateStatus::Ok)
             }
         }
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -13,7 +13,10 @@ use ffi::{RS_FIELDMASK_ALL, t_docId};
 use inverted_index::RSIndexResult;
 use std::cmp;
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime,
+};
 
 /// An iterator that emits a sequence of results with no gaps, up to a given document id.
 /// Results are pulled from an underlying [`RQEIterator`] instance. If there is no entry
@@ -235,4 +238,12 @@ where
     fn at_eof(&self) -> bool {
         self.result.doc_id >= self.max_doc_id
     }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const std::ffi::c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
+    }
+}
+
+impl<'index, I> IteratorTypeKnownAtCompileTime for Optional<'index, I> {
+    const TYPE: IteratorType = IteratorType::Optional;
 }

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -13,9 +13,15 @@
 //! (read/skip counts and wall-clock time) from a child iterator without
 //! modifying its behavior.
 
-use std::time::{Duration, Instant};
+use std::{
+    ffi::c_void,
+    time::{Duration, Instant},
+};
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    downcasting::IteratorTypeKnownAtCompileTime,
+};
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
@@ -83,6 +89,10 @@ impl<'index, I: RQEIterator<'index>> Profile<'index, I> {
     }
 }
 
+impl<'index, I: RQEIterator<'index>> IteratorTypeKnownAtCompileTime for Profile<'index, I> {
+    const TYPE: IteratorType = IteratorType::Profile;
+}
+
 impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -138,5 +148,9 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
 
     fn is_wildcard(&self) -> bool {
         self.child.is_wildcard()
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -12,7 +12,7 @@
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
-use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 /// Yields documents appearing in ANY child iterator using a flat array scan.
 ///
@@ -534,5 +534,12 @@ where
         } else {
             Ok(RQEValidateStatus::Ok)
         }
+    }
+
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const std::ffi::c_void {
+        // Can't downcast since the type is generic, and therefore the
+        // iterator type tag isn't enough to pin down the exact Rust type
+        // we're working with.
+        std::ptr::null()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -9,11 +9,11 @@
 
 //! Supporting types for [`Wildcard`].
 
-use std::ptr::NonNull;
+use std::{ffi::c_void, ptr::NonNull};
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
 
-use crate::IteratorType;
+use crate::{IteratorType, downcasting::IteratorTypeKnownAtCompileTime};
 use inverted_index::{DocIdsDecoder, RSIndexResult, opaque};
 
 use crate::{
@@ -41,6 +41,10 @@ impl Wildcard<'_> {
                 .build(),
         }
     }
+}
+
+impl IteratorTypeKnownAtCompileTime for Wildcard<'_> {
+    const TYPE: IteratorType = IteratorType::Wildcard;
 }
 
 impl<'index> RQEIterator<'index> for Wildcard<'index> {
@@ -100,6 +104,10 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
     fn is_wildcard(&self) -> bool {
         true
+    }
+
+    fn downcast_as_ref_raw(&self, type_: IteratorType) -> *const c_void {
+        crate::downcasting::downcast_as_ref_raw(self, type_)
     }
 }
 
@@ -174,6 +182,11 @@ impl<'index> RQEIterator<'index> for EmptyWildcard {
     #[inline(always)]
     fn is_wildcard(&self) -> bool {
         true
+    }
+
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const c_void {
+        // Can't downcast since it doesn't have a unique iterator type.
+        std::ptr::null()
     }
 }
 
@@ -381,6 +394,10 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator {
         // strictly speaking this is a wildcard iterator but the current reducers code from other
         // iterators do not account for it.
         false
+    }
+
+    fn downcast_as_ref_raw(&self, _type_: IteratorType) -> *const c_void {
+        std::ptr::null()
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -15,6 +15,10 @@ use rqe_iterators::{
 struct Infinite<'index>(inverted_index::RSIndexResult<'index>);
 
 impl<'index> RQEIterator<'index> for Infinite<'index> {
+    fn downcast_as_ref_raw(&self, _type_: rqe_iterators::IteratorType) -> *const std::ffi::c_void {
+        std::ptr::null()
+    }
+
     fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
         Some(&mut self.0)
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -906,6 +906,13 @@ mod optional_iterator_non_sequential_reads {
     }
 
     impl<'index, const N: usize> RQEIterator<'index> for ReadStepIterator<'index, N> {
+        fn downcast_as_ref_raw(
+            &self,
+            _type_: rqe_iterators::IteratorType,
+        ) -> *const std::ffi::c_void {
+            std::ptr::null()
+        }
+
         fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
             Some(&mut self.result)
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -309,6 +309,10 @@ impl<'index, const N: usize> Mock<'index, N> {
 }
 
 impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
+    fn downcast_as_ref_raw(&self, _type_: rqe_iterators::IteratorType) -> *const std::ffi::c_void {
+        std::ptr::null()
+    }
+
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         Some(&mut self.result)
     }


### PR DESCRIPTION
## Describe the changes in the pull request

Provide a generic downcasting machinery to go from a `QueryIterator*` to a concrete iterator type, defined either in Rust or C.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new required callback in the C `QueryIterator` ABI and a new required method on the Rust `RQEIterator` trait, so any iterator implementations not updated will fail at runtime/compile time and incorrect type tags could cause unsafe casts.
> 
> **Overview**
> Adds a **generic downcasting mechanism** to convert a type-erased `QueryIterator*`/`dyn RQEIterator` into a concrete iterator type when the runtime `IteratorType` matches.
> 
> This extends the C iterator API with a new `DowncastRaw` function pointer (with a `DefaultDowncastRaw` helper), wires it through Rust FFI wrappers (`RQEIteratorWrapper`, `CRQEIterator`), and introduces `rqe_iterators::downcasting` (`IteratorTypeKnownAtCompileTime`, `downcast_iterator_as_ref`) with per-iterator implementations; generic/ambiguous iterator implementations explicitly opt out by returning null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eaa49c341a135ad6ba301612ea140249ae38c06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->