### PR TITLE
Fix macOS 26 CI failures

### DIFF
--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 version=3.25.1
-processor=$(uname -m)
 OS_TYPE=$(uname -s)
-OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
-OS_NAME=${OS_NAME#"NAME="}
 MODE=$1 # whether to install using sudo or not
 
 if [[ $OS_TYPE = 'Darwin' ]]
 then
     brew install cmake
 else
+    OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+    OS_NAME=${OS_NAME#"NAME="}
     if [[ $OS_NAME == 'Alpine Linux' ]]
     then
         $MODE apk add --no-cache cmake
     else
+        processor=$(uname -m)
         if [[ $processor = 'x86_64' ]]
         then
             filename=cmake-${version}-linux-x86_64.sh

--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -xeo pipefail
 
 # Source the profile update utility
 source "$(dirname "$0")/macos_update_profile.sh"
@@ -22,5 +23,9 @@ GNUBIN=$BREW_PREFIX/opt/make/libexec/gnubin
 COREUTILS=$BREW_PREFIX/opt/coreutils/libexec/gnubin
 
 # Update both profile files with all tools
-[[ -f ~/.bash_profile ]] && update_profile ~/.bash_profile "$GNUBIN" "$COREUTILS"
-[[ -f ~/.zshrc ]] && update_profile ~/.zshrc "$GNUBIN" "$COREUTILS"
+if [[ -f ~/.bash_profile ]]; then
+    update_profile ~/.bash_profile "$GNUBIN" "$COREUTILS"
+fi
+if [[ -f ~/.zshrc ]]; then
+    update_profile ~/.zshrc "$GNUBIN" "$COREUTILS"
+fi

--- a/.install/macos_update_profile.sh
+++ b/.install/macos_update_profile.sh
@@ -5,14 +5,14 @@ update_profile() {
     local profile_file=$1
     shift
     local paths=("$@")
-    
+
     echo "Updating $profile_file with PATH additions: ${paths[*]}"
-    
+
     # Check if the profile exists
     if [[ ! -f $profile_file ]]; then
         touch "$profile_file"
     fi
-    
+
     # Add each path to the profile if not already present
     for path in "${paths[@]}"; do
         if ! grep -q "export PATH=\"$path:\$PATH\"" "$profile_file"; then


### PR DESCRIPTION
## Describe the changes in the pull request

We added `set -e` to setup scripts in a previous PR (#8722), and this seems to be causing intermittent issues when running CI setup steps on macOS 26.
This PR adjusts the setup scripts to behave as expected under the new flag for macOS, with additional tracing via `set -x` for easier debugging.

Tested via [this run](https://github.com/RediSearch/RediSearch/actions/runs/23454955536/job/68241604434) on macOS 26 and [this run](https://github.com/RediSearch/RediSearch/actions/runs/23455262119) on macOS 15.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to installation shell scripts and mainly adjust control flow and error handling for CI stability on macOS/Linux.
> 
> **Overview**
> Improves installer script robustness to address macOS CI failures under stricter bash settings.
> 
> On macOS, `macos.sh` now runs with `set -xeo pipefail` and replaces short-circuit `[[ -f ... ]] && ...` profile updates with explicit `if` blocks. On Linux CMake installs, `.install/install_cmake.sh` defers `OS_NAME`/`processor` detection to the non-Darwin path to avoid unnecessary/invalid reads on macOS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d163703fd6503a70daccd70332105aa3fd2cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->