### PR TITLE
[MOD-14426] Fix rqe_iter_bench lints

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/union.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/union.rs
@@ -81,7 +81,7 @@ enum Overlap {
 
 impl DataGenParams {
     /// Create params for high overlap scenario.
-    fn high_overlap(num_children: usize) -> Self {
+    const fn high_overlap(num_children: usize) -> Self {
         Self {
             num_children,
             ids_per_child: IDS_PER_CHILD,
@@ -93,7 +93,7 @@ impl DataGenParams {
     }
 
     /// Create params for low overlap scenario.
-    fn low_overlap(num_children: usize) -> Self {
+    const fn low_overlap(num_children: usize) -> Self {
         Self {
             num_children,
             ids_per_child: IDS_PER_CHILD,
@@ -105,7 +105,7 @@ impl DataGenParams {
     }
 
     /// Create params for disjoint scenario.
-    fn disjoint(num_children: usize) -> Self {
+    const fn disjoint(num_children: usize) -> Self {
         Self {
             num_children,
             ids_per_child: IDS_PER_CHILD,
@@ -117,7 +117,7 @@ impl DataGenParams {
     }
 
     /// Create params for varying sizes scenario.
-    fn varying_sizes() -> Self {
+    const fn varying_sizes() -> Self {
         Self {
             num_children: NUM_CHILDREN_FEW,
             ids_per_child: IDS_PER_CHILD,


### PR DESCRIPTION
Fix lints by making functions `const`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes benchmark parameter constructor functions to `const fn` to satisfy lints, without altering runtime logic or production code paths.
> 
> **Overview**
> Makes the `DataGenParams` scenario constructors in `rqe_iterators_bencher`’s union benchmarks (`high_overlap`, `low_overlap`, `disjoint`, `varying_sizes`) `const fn` to address lints and allow compile-time construction where possible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8263ef63052474eb8aa900df190091628502dbb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->