### PR TITLE
[MOD-14426] Update outdated github actions

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -68,21 +68,21 @@ jobs:
           echo "Using cache ref: $CACHE_REF"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push (cached)
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .


### PR DESCRIPTION
fix node 20 deprecation warnings by updating outdated github actions

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates GitHub Action versions in CI; main risk is unexpected behavior changes in the newer Docker actions affecting image build/push or caching.
> 
> **Overview**
> Updates `.github/workflows/task-build-cached-container.yml` to bump Docker GitHub Actions to newer major versions: `docker/login-action` v3→v4, `docker/setup-qemu-action` v3→v4, `docker/setup-buildx-action` v3→v4, and `docker/build-push-action` v6→v7.
> 
> No workflow logic changes beyond the action version upgrades; build/push and registry cache configuration stays the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9901e58b3eee346ce9a966e43c79e88b6f6d390a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->