### PR TITLE
FT.EXPLAIN unlock touchup

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1599,15 +1599,14 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   }
   RedisSearchCtx *sctx = AREQ_SearchCtx(r);
   // Take a read lock on the spec (to avoid conflicts with the GC).
+  // released in `AREQ_Free`.
   RedisSearchCtx_LockSpecRead(sctx);
   if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
-    RedisSearchCtx_UnlockSpec(sctx);
     AREQ_DecrRef(r);
     CurrentThread_ClearIndexSpec();
     return NULL;
   }
   char *ret = QAST_DumpExplain(&r->ast, sctx->spec);
-  RedisSearchCtx_UnlockSpec(sctx);
   AREQ_DecrRef(r);
   CurrentThread_ClearIndexSpec();
   return ret;


### PR DESCRIPTION
We unlock the index in `AREQ_Free` that is called subsequently, so we can remove the explicit unlocking.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only adjusts spec lock lifetime during `FT.EXPLAIN`; main risk is unintended lock leak or missing unlock on error paths.
> 
> **Overview**
> `RS_GetExplainOutput` no longer explicitly calls `RedisSearchCtx_UnlockSpec()` on failure/success after taking the spec read lock; the lock is now consistently released when the request is freed (via `AREQ_DecrRef` → `AREQ_Free` → `SearchCtx_Free`). This avoids a potential double-unlock and centralizes lock cleanup for the `FT.EXPLAIN` execution-plan path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aced3c0ecb3f64204102d38d0cba23da277e1adb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->