### PR TITLE
Ensure all operations against TreeStats use checked arithmetic

### DIFF
--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use inverted_index::{GcApplyInfo, GcScanDelta, IndexBlock, RSIndexResult};
 
-use super::{NumericRangeTree, TrimEmptyLeavesResult, apply_signed_delta};
+use super::{NumericRangeTree, TrimEmptyLeavesResult};
 use crate::NumericRangeNode;
 use crate::arena::{NodeArena, NodeIndex};
 use crate::range::Hll;
@@ -164,7 +164,7 @@ impl NumericRangeTree {
         let is_now_empty = range.entries().num_docs() == 0;
         let became_empty = !was_empty && is_now_empty;
         if is_leaf && became_empty {
-            self.stats.empty_leaves = self.stats.empty_leaves.checked_add(1).expect("Overflow!");
+            self.stats.empty_leaves += 1;
         }
 
         // Update tree-level stats.
@@ -172,24 +172,12 @@ impl NumericRangeTree {
         // when max_depth_range > 0, internal nodes retain ranges with duplicate
         // entries, so decrementing for every node would over-subtract.
         if is_leaf {
-            self.stats.num_entries = self
-                .stats
-                .num_entries
-                .checked_sub(info.entries_removed)
-                .expect("Underflow!");
+            self.stats.num_entries -= info.entries_removed;
         }
         if info.bytes_freed > info.bytes_allocated {
-            self.stats.inverted_indexes_size = self
-                .stats
-                .inverted_indexes_size
-                .checked_sub(info.bytes_freed - info.bytes_allocated)
-                .expect("Underflow!");
+            self.stats.inverted_indexes_size -= info.bytes_freed - info.bytes_allocated;
         } else {
-            self.stats.inverted_indexes_size = self
-                .stats
-                .inverted_indexes_size
-                .checked_add(info.bytes_allocated - info.bytes_freed)
-                .expect("Overflow!");
+            self.stats.inverted_indexes_size += info.bytes_allocated - info.bytes_freed;
         }
 
         #[cfg(all(feature = "unittest", not(miri)))]
@@ -205,7 +193,7 @@ impl NumericRangeTree {
     ///
     /// The threshold is: at least half the leaves are empty.
     pub const fn is_sparse(&self) -> bool {
-        self.stats.empty_leaves * 2 >= self.stats.num_leaves
+        self.stats.empty_leaves.get() * 2 >= self.stats.num_leaves.get()
     }
 
     /// Conditionally trim empty leaves and compact the node slab.
@@ -295,14 +283,20 @@ impl NumericRangeTree {
         if rv.changed {
             // Update tree statistics
             self.revision_id = self.revision_id.wrapping_add(1);
-            self.stats.num_ranges =
-                apply_signed_delta(self.stats.num_ranges, rv.num_ranges_delta as i64);
-            self.stats.empty_leaves =
-                apply_signed_delta(self.stats.empty_leaves, rv.num_leaves_delta as i64);
-            self.stats.num_leaves =
-                apply_signed_delta(self.stats.num_leaves, rv.num_leaves_delta as i64);
+            self.stats.num_ranges = self
+                .stats
+                .num_ranges
+                .apply_delta(rv.num_ranges_delta as i64);
+            self.stats.empty_leaves = self
+                .stats
+                .empty_leaves
+                .apply_delta(rv.num_leaves_delta as i64);
+            self.stats.num_leaves = self
+                .stats
+                .num_leaves
+                .apply_delta(rv.num_leaves_delta as i64);
             self.stats.inverted_indexes_size =
-                apply_signed_delta(self.stats.inverted_indexes_size, rv.size_delta);
+                self.stats.inverted_indexes_size.apply_delta(rv.size_delta);
         }
 
         rv

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -16,7 +16,7 @@
 use ffi::t_docId;
 use inverted_index::{IndexReader as _, RSIndexResult};
 
-use super::{AddResult, NumericRangeTree, apply_signed_delta};
+use super::{AddResult, CheckedCount, NumericRangeTree};
 use crate::arena::{NodeArena, NodeIndex};
 use crate::{InternalNode, NumericRange, NumericRangeNode};
 
@@ -117,13 +117,17 @@ impl NumericRangeTree {
             self.revision_id = self.revision_id.wrapping_add(1);
         }
 
-        self.stats.num_ranges =
-            apply_signed_delta(self.stats.num_ranges, rv.num_ranges_delta as i64);
-        self.stats.num_leaves =
-            apply_signed_delta(self.stats.num_leaves, rv.num_leaves_delta as i64);
+        self.stats.num_ranges = self
+            .stats
+            .num_ranges
+            .apply_delta(rv.num_ranges_delta as i64);
+        self.stats.num_leaves = self
+            .stats
+            .num_leaves
+            .apply_delta(rv.num_leaves_delta as i64);
         self.stats.num_entries += 1;
         self.stats.inverted_indexes_size =
-            apply_signed_delta(self.stats.inverted_indexes_size, rv.size_delta);
+            self.stats.inverted_indexes_size.apply_delta(rv.size_delta);
 
         rv
     }
@@ -158,7 +162,7 @@ impl NumericRangeTree {
         depth: usize,
         max_depth_range: usize,
         compress_floats: bool,
-        empty_leaves: &mut usize,
+        empty_leaves: &mut CheckedCount,
     ) -> AddResult {
         match &nodes[node_idx] {
             NumericRangeNode::Internal(_) => {
@@ -219,7 +223,7 @@ impl NumericRangeTree {
                 // If this leaf was emptied (e.g. by the GC) and is about to be re-populated,
                 // update the empty_leaves counter.
                 if leaf.range.num_docs() == 0 {
-                    *empty_leaves = empty_leaves.checked_sub(1).expect("Underflow!");
+                    *empty_leaves -= 1;
                 }
 
                 let size = leaf.range.add(doc_id, value);

--- a/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
@@ -15,7 +15,7 @@
 
 use inverted_index::{IndexReader, NumericFilter, RSIndexResult};
 
-use super::{AddResult, NumericRangeTree, TreeStats, TrimEmptyLeavesResult, apply_signed_delta};
+use super::{AddResult, CheckedCount, NumericRangeTree, TreeStats, TrimEmptyLeavesResult};
 use crate::NumericRange;
 use crate::NumericRangeNode;
 use crate::arena::NodeIndex;
@@ -46,7 +46,9 @@ impl NumericRangeTree {
         result: &AddResult,
     ) {
         assert_eq!(
-            apply_signed_delta(before.num_ranges, result.num_ranges_delta as i64),
+            before
+                .num_ranges
+                .apply_delta(result.num_ranges_delta as i64),
             self.stats.num_ranges,
             "num_ranges mismatch: before={}, delta={}, after={}",
             before.num_ranges,
@@ -54,7 +56,9 @@ impl NumericRangeTree {
             self.stats.num_ranges,
         );
         assert_eq!(
-            apply_signed_delta(before.num_leaves, result.num_leaves_delta as i64),
+            before
+                .num_leaves
+                .apply_delta(result.num_leaves_delta as i64),
             self.stats.num_leaves,
             "num_leaves mismatch: before={}, delta={}, after={}",
             before.num_leaves,
@@ -62,7 +66,7 @@ impl NumericRangeTree {
             self.stats.num_leaves,
         );
         assert_eq!(
-            apply_signed_delta(before.inverted_indexes_size, result.size_delta),
+            before.inverted_indexes_size.apply_delta(result.size_delta),
             self.stats.inverted_indexes_size,
             "inverted_indexes_size mismatch: before={}, delta={}, after={}",
             before.inverted_indexes_size,
@@ -83,8 +87,9 @@ impl NumericRangeTree {
         );
 
         // num_records cross-check
-        let expected_total_records =
-            apply_signed_delta(total_records_before, result.num_records_delta as i64);
+        let expected_total_records = CheckedCount::new(total_records_before)
+            .apply_delta(result.num_records_delta as i64)
+            .get();
         let actual_total_records = self.total_records();
         assert_eq!(
             expected_total_records, actual_total_records,
@@ -105,7 +110,9 @@ impl NumericRangeTree {
         result: &TrimEmptyLeavesResult,
     ) {
         assert_eq!(
-            apply_signed_delta(before.num_ranges, result.num_ranges_delta as i64),
+            before
+                .num_ranges
+                .apply_delta(result.num_ranges_delta as i64),
             self.stats.num_ranges,
             "num_ranges mismatch: before={}, delta={}, after={}",
             before.num_ranges,
@@ -113,7 +120,9 @@ impl NumericRangeTree {
             self.stats.num_ranges,
         );
         assert_eq!(
-            apply_signed_delta(before.num_leaves, result.num_leaves_delta as i64),
+            before
+                .num_leaves
+                .apply_delta(result.num_leaves_delta as i64),
             self.stats.num_leaves,
             "num_leaves mismatch: before={}, delta={}, after={}",
             before.num_leaves,
@@ -121,7 +130,7 @@ impl NumericRangeTree {
             self.stats.num_leaves,
         );
         assert_eq!(
-            apply_signed_delta(before.inverted_indexes_size, result.size_delta),
+            before.inverted_indexes_size.apply_delta(result.size_delta),
             self.stats.inverted_indexes_size,
             "inverted_indexes_size mismatch: before={}, delta={}, after={}",
             before.inverted_indexes_size,
@@ -147,23 +156,33 @@ impl NumericRangeTree {
     /// This is the ground-truth calculation used by [`check_memoized_stats`](Self::check_memoized_stats)
     /// to validate the incrementally maintained `self.stats`.
     fn compute_stats(&self) -> TreeStats {
-        let mut stats = TreeStats::default();
+        let mut num_ranges: usize = 0;
+        let mut num_leaves: usize = 0;
+        let mut num_entries: usize = 0;
+        let mut inverted_indexes_size: usize = 0;
+        let mut empty_leaves: usize = 0;
         for (_, node) in self.nodes.iter() {
             if node.is_leaf() {
-                stats.num_leaves += 1;
+                num_leaves += 1;
             }
             if let Some(range) = node.range() {
-                stats.num_ranges += 1;
-                stats.inverted_indexes_size += range.memory_usage();
+                num_ranges += 1;
+                inverted_indexes_size += range.memory_usage();
                 if node.is_leaf() {
-                    stats.num_entries += range.num_entries();
+                    num_entries += range.num_entries();
                     if range.num_docs() == 0 {
-                        stats.empty_leaves += 1;
+                        empty_leaves += 1;
                     }
                 }
             }
         }
-        stats
+        TreeStats {
+            num_ranges: CheckedCount::new(num_ranges),
+            num_leaves: CheckedCount::new(num_leaves),
+            num_entries: CheckedCount::new(num_entries),
+            inverted_indexes_size: CheckedCount::new(inverted_indexes_size),
+            empty_leaves: CheckedCount::new(empty_leaves),
+        }
     }
 
     /// Assert that every field in `self.stats` matches the ground-truth

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -22,6 +22,9 @@ mod gc;
 mod insert;
 #[cfg(all(feature = "unittest", not(miri)))]
 mod invariants;
+mod util;
+
+pub(crate) use util::CheckedCount;
 
 pub use gc::{CompactIfSparseResult, NodeGcDelta, SingleNodeGcResult};
 
@@ -89,15 +92,15 @@ pub struct TrimEmptyLeavesResult {
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct TreeStats {
     /// Total number of ranges (nodes with inverted indexes).
-    pub num_ranges: usize,
+    pub num_ranges: CheckedCount,
     /// Total number of leaf nodes.
-    pub num_leaves: usize,
+    pub num_leaves: CheckedCount,
     /// Total number of (document, value) entries.
-    pub num_entries: usize,
+    pub num_entries: CheckedCount,
     /// Total memory used by inverted indexes in bytes.
-    pub inverted_indexes_size: usize,
+    pub inverted_indexes_size: CheckedCount,
     /// Number of empty leaves (for GC tracking).
-    pub empty_leaves: usize,
+    pub empty_leaves: CheckedCount,
 }
 
 /// A numeric range tree for efficient range queries over numeric values.
@@ -201,11 +204,11 @@ impl NumericRangeTree {
             root: root_index,
             nodes,
             stats: TreeStats {
-                num_ranges: 1,
-                num_leaves: 1,
-                num_entries: 0,
-                inverted_indexes_size,
-                empty_leaves: 1,
+                num_ranges: CheckedCount::new(1),
+                num_leaves: CheckedCount::new(1),
+                num_entries: CheckedCount::new(0),
+                inverted_indexes_size: CheckedCount::new(inverted_indexes_size),
+                empty_leaves: CheckedCount::new(1),
             },
             last_doc_id: 0,
             revision_id: 0,
@@ -236,22 +239,22 @@ impl NumericRangeTree {
 
     /// Get the total number of ranges in the tree.
     pub const fn num_ranges(&self) -> usize {
-        self.stats.num_ranges
+        self.stats.num_ranges.get()
     }
 
     /// Get the total number of leaf nodes in the tree.
     pub const fn num_leaves(&self) -> usize {
-        self.stats.num_leaves
+        self.stats.num_leaves.get()
     }
 
     /// Get the total number of entries in the tree.
     pub const fn num_entries(&self) -> usize {
-        self.stats.num_entries
+        self.stats.num_entries.get()
     }
 
     /// Get the total memory used by inverted indexes in bytes.
     pub const fn inverted_indexes_size(&self) -> usize {
-        self.stats.inverted_indexes_size
+        self.stats.inverted_indexes_size.get()
     }
 
     /// Get the last document ID added to the tree.
@@ -283,7 +286,7 @@ impl NumericRangeTree {
 
     /// Get the number of empty leaves (for GC tracking).
     pub const fn empty_leaves(&self) -> usize {
-        self.stats.empty_leaves
+        self.stats.empty_leaves.get()
     }
 
     /// Returns an iterator over all nodes in the tree (depth-first traversal).
@@ -298,21 +301,14 @@ impl NumericRangeTree {
 
     /// Calculate the total memory usage of the tree, in bytes.
     pub const fn mem_usage(&self) -> usize {
-        std::mem::size_of::<Self>() + self.stats.inverted_indexes_size + self.nodes.mem_usage()
+        std::mem::size_of::<Self>()
+            + self.stats.inverted_indexes_size.get()
+            + self.nodes.mem_usage()
     }
 }
 
 impl Default for NumericRangeTree {
     fn default() -> Self {
         Self::new(false)
-    }
-}
-
-/// Apply a signed delta to an unsigned value, panicking at bounds instead of wrapping.
-const fn apply_signed_delta(value: usize, delta: i64) -> usize {
-    if delta < 0 {
-        value.checked_sub((-delta) as usize).expect("Underflow!")
-    } else {
-        value.checked_add(delta as usize).expect("Overflow!")
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/util.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/util.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Utility types for the numeric range tree.
+//!
+//! This module provides [`CheckedCount`], a newtype wrapper around `usize`
+//! that enforces checked arithmetic for all mutations. It is used by
+//! [`TreeStats`](super::TreeStats) to make overflow/underflow bugs
+//! impossible to introduce silently.
+
+use std::fmt;
+use std::ops::{AddAssign, SubAssign};
+
+/// A `usize` wrapper that panics on overflow or underflow instead of wrapping.
+///
+/// All [`TreeStats`](super::TreeStats) fields use this type so that
+/// incrementing or decrementing a counter is always bounds-checked,
+/// even when using `+=` / `-=` operators.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct CheckedCount(usize);
+
+impl CheckedCount {
+    /// Create a new `CheckedCount` with the given value.
+    pub const fn new(value: usize) -> Self {
+        Self(value)
+    }
+
+    /// Return the inner `usize` value.
+    pub const fn get(self) -> usize {
+        self.0
+    }
+
+    /// Apply a signed delta, panicking on overflow or underflow.
+    pub const fn apply_delta(self, delta: i64) -> Self {
+        if delta < 0 {
+            Self(self.0.checked_sub((-delta) as usize).expect("Underflow!"))
+        } else {
+            Self(self.0.checked_add(delta as usize).expect("Overflow!"))
+        }
+    }
+}
+
+/// Panics on overflow.
+impl AddAssign<usize> for CheckedCount {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0 = self.0.checked_add(rhs).expect("Overflow!");
+    }
+}
+
+/// Panics on underflow.
+impl SubAssign<usize> for CheckedCount {
+    fn sub_assign(&mut self, rhs: usize) {
+        self.0 = self.0.checked_sub(rhs).expect("Underflow!");
+    }
+}
+
+/// Delegates to the inner `usize`, used in assertion messages.
+impl fmt::Display for CheckedCount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Centralize the checked arithmetic requirement using a new type.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `NumericRangeTree` maintenance/insert paths by changing all `TreeStats` counters to a new checked-arithmetic type, which could introduce panics if any unexpected underflow/overflow occurs, but behavior is otherwise intended to be equivalent.
> 
> **Overview**
> Centralizes bounds-checked counter updates in the numeric range tree by introducing `CheckedCount` and switching all `TreeStats` fields from `usize` to this wrapper.
> 
> Updates insert/GC/trim and unittest invariant code to use `CheckedCount` operators and `apply_delta()`, removes the old `apply_signed_delta` helper, and adjusts public accessors to return `usize` via `.get()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 201d50de67dcc1cb07340035f9aaafa04bf9025e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->