### PR TITLE
Set -eo pipefail on all installation scripts, consistently

### DIFF
--- a/.install/alpine_linux_3.sh
+++ b/.install/alpine_linux_3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 
 $MODE apk update
 

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ARCH=$(uname -m)
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 $MODE yum update -y

--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 $MODE dnf update -y

--- a/.install/common_base_linux_mariner_2.0.sh
+++ b/.install/common_base_linux_mariner_2.0.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip rsync \
                          openssl-devel openssl which clang clang-devel gzip gdb

--- a/.install/debian_gnu_linux_11.sh
+++ b/.install/debian_gnu_linux_11.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 

--- a/.install/debian_gnu_linux_12.sh
+++ b/.install/debian_gnu_linux_12.sh
@@ -1,5 +1,6 @@
 
 #!/usr/bin/env bash
+set -eo pipefail
 ARCH=$(uname -m)
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not

--- a/.install/install_aws.sh
+++ b/.install/install_aws.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-ARCH=$(uname -m)
+set -eo pipefail
 OS_TYPE=$(uname -s)
-OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
-OS_NAME=${OS_NAME#"NAME="}
 MODE=$1 # whether to install using sudo or not
 
 if [[ $OS_TYPE = 'Darwin' ]]
 then
-    curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+    curl -fSL "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
     $MODE installer -pkg AWSCLIV2.pkg -target /
 else
+    OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+    OS_NAME=${OS_NAME#"NAME="}
+    ARCH=$(uname -m)
     if [[ $OS_NAME == 'Alpine Linux' ]]
     then
         $MODE apk add --no-cache aws-cli

--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 VERSION=1.88.0
 BOOST_NAME="boost_${VERSION//./_}"
 BOOST_DIR="boost" # here we search for the boost cached installation if exists. Do not change this value

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 version=3.25.1
 OS_TYPE=$(uname -s)
 MODE=$1 # whether to install using sudo or not

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -exo pipefail
 
 processor=$(uname -m)
 OS_TYPE=$(uname -s)

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
 

--- a/.install/macos_update_profile.sh
+++ b/.install/macos_update_profile.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 # Function to update shell profile with necessary paths
 update_profile() {

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip \

--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 
 $MODE dnf update -y
 

--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 OS_TYPE=$(uname -s)
 MODE=$1 # whether to install using sudo or not
 

--- a/.install/ubuntu_18.04.sh
+++ b/.install/ubuntu_18.04.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 

--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 


### PR DESCRIPTION
## Describe the changes in the pull request

Harden all scripts under `.install` by using `set -eo pipefail` consistently. 
No changes were needed, beyond hardening `curl` flags in .install/install_aws.sh

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk hardening change, but `pipefail`/`-e` may cause early exits in scripts that rely on pipeline behavior or ignore command failures.
> 
> **Overview**
> Standardizes shell error handling across `.install` scripts by switching from `set -e` (or missing flags) to `set -eo pipefail` (and `set -exo pipefail` where tracing is enabled), improving failure detection in CI and local setup.
> 
> Also hardens `.install/install_aws.sh` by using `curl -fSL` and moving Linux-only `OS_NAME`/`ARCH` detection into the non-macOS branch to avoid unnecessary parsing/assignment on Darwin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18c634441e100fd0a1837539c5619b42211412f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->