### PR TITLE
Skip Schedule Topology Test

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -172,6 +172,8 @@ TEST_F(IORuntimeCtxCommonTest, Schedule) {
 }
 
 TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
+  GTEST_SKIP() << "Temporarily skipping ScheduleTopology.";
+
   // Reset the signal before starting
   lastAppliedCapShards.store(0, std::memory_order_relaxed);
 


### PR DESCRIPTION
Looks like the test is flaky, disabling it for now.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only affects test execution by skipping a known flaky `ScheduleTopology` unit test, with no production code impact.
> 
> **Overview**
> Temporarily disables the `IORuntimeCtxCommonTest.ScheduleTopology` C++ test by adding `GTEST_SKIP()`, effectively removing it from CI execution while the flakiness is investigated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8238c16532509cc4e2a338ab7ed7f8c076e640c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->