### PR TITLE
[MOD-12368] Fix ABA problem in inverted index cursor revalidation

### DIFF
--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use thin_vec::ThinVec;
 
+use super::unique_id::IndexUniqueId;
 use crate::{
     BlockCapacity, Encoder, IdDelta, RSIndexResult,
     controlled_cursor::ControlledCursor,
@@ -42,6 +43,12 @@ pub struct InvertedIndex<E> {
     /// A marker used by the garbage collector to determine if the index has been modified since
     /// the last GC pass. This is used to reset a reader if the index has been modified.
     pub(crate) gc_marker: AtomicU32,
+
+    /// A unique identifier for this index instance, assigned at construction time from a global
+    /// monotonic counter. Used together with pointer comparison to detect the ABA problem: when
+    /// an index is freed and a new one is allocated at the same address, the unique ID will
+    /// differ, allowing cursors to detect the replacement.
+    unique_id: IndexUniqueId,
 
     /// The encoder to use when adding new entries to the index
     pub(crate) _encoder: PhantomData<E>,
@@ -168,6 +175,7 @@ impl<E: Encoder> InvertedIndex<E> {
             n_unique_docs: 0,
             flags,
             gc_marker: AtomicU32::new(0),
+            unique_id: IndexUniqueId::next(),
             _encoder: Default::default(),
         }
     }
@@ -196,6 +204,7 @@ impl<E: Encoder> InvertedIndex<E> {
             n_unique_docs,
             flags,
             gc_marker: AtomicU32::new(0),
+            unique_id: IndexUniqueId::next(),
             _encoder: Default::default(),
         }
     }
@@ -386,5 +395,12 @@ impl<E: Encoder> InvertedIndex<E> {
     /// Increment the GC marker of this index. This is only used by the some C tests.
     pub fn gc_marker_inc(&self) {
         self.gc_marker.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+
+    /// Returns the unique identifier for this index instance. This ID is assigned once at
+    /// construction time and never changes. Used to detect the ABA problem in cursor
+    /// revalidation.
+    pub const fn unique_id(&self) -> IndexUniqueId {
+        self.unique_id
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/index/mod.rs
@@ -9,6 +9,7 @@
 
 mod core;
 pub mod opaque;
+pub(crate) mod unique_id;
 mod with_entries;
 mod with_mask;
 

--- a/src/redisearch_rs/inverted_index/src/index/unique_id.rs
+++ b/src/redisearch_rs/inverted_index/src/index/unique_id.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Unique identifier for [`InvertedIndex`](crate::InvertedIndex) instances.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Global counter for unique inverted index IDs.
+static UNIQUE_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Unique identifier for an [`InvertedIndex`](crate::InvertedIndex) instance.
+///
+/// Generated from a global atomic counter and assigned at construction time.
+/// Used together with pointer comparison to detect the ABA problem: when an
+/// index is freed and a new one is allocated at the same address, the unique
+/// IDs will differ, allowing cursors to detect the replacement.
+///
+/// Two distinct indexes are guaranteed to have different IDs (until the
+/// counter wraps).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IndexUniqueId(u32);
+
+impl IndexUniqueId {
+    /// Allocate the next unique ID from the global counter.
+    pub(crate) fn next() -> Self {
+        Self(UNIQUE_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -12,7 +12,7 @@ use std::{io::Cursor, sync::atomic};
 use super::{IndexReader, NumericReader, TermReader};
 use crate::{
     DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, RSIndexResult,
-    TermDecoder, opaque::OpaqueEncoding,
+    TermDecoder, index::unique_id::IndexUniqueId, opaque::OpaqueEncoding,
 };
 use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue, t_docId};
 
@@ -37,6 +37,11 @@ pub struct IndexReaderCore<'index, E> {
     /// detect if the index has been modified since the last read, in which case the reader
     /// should be reset.
     pub(crate) gc_marker: u32,
+
+    /// The unique ID of the inverted index when this reader was created. Used together with
+    /// pointer comparison in [`Self::points_to_ii`] to detect the ABA problem: if the original
+    /// index is freed and a new one is allocated at the same address, the unique IDs will differ.
+    ii_unique_id: IndexUniqueId,
 }
 
 // Automatically implemented if the IndexReaderCore uses a NumericDecoder.
@@ -197,18 +202,22 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReaderCore<'index, E> {
             current_block_idx: 0,
             last_doc_id,
             gc_marker: ii.gc_marker.load(atomic::Ordering::Relaxed),
+            ii_unique_id: ii.unique_id(),
         }
     }
 
-    /// Check if this reader is reading from the given index by comparing their pointers.
+    /// Check if this reader is reading from the given index by comparing both their pointers and
+    /// unique IDs. The dual check prevents the ABA problem: if the original index is freed and a
+    /// new one is allocated at the same address, the unique IDs will differ.
     pub fn points_to_ii(&self, index: &InvertedIndex<E>) -> bool {
-        std::ptr::eq(self.ii, index)
+        std::ptr::eq(self.ii, index) && self.ii_unique_id == index.unique_id()
     }
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
     pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
         std::mem::swap(&mut self.ii, index);
+        self.ii_unique_id = self.ii.unique_id();
     }
 
     /// Get the internal index of the reader. This is only used by some C tests.


### PR DESCRIPTION
Assign each InvertedIndex a unique ID (monotonic AtomicU32 counter) at construction time. During cursor revalidation, check both pointer equality and unique ID equality in points_to_ii(). This prevents the ABA problem where the allocator reuses the same address for a new index after the original was freed by GC, causing the cursor to incorrectly continue reading from the new index.

A u32 counter is used instead of u64 to fit within the existing 4 bytes of struct padding (alignment to 8 bytes), keeping InvertedIndex at 24 bytes with zero size increase.

Fix flaky test `test_tags:testTagGCClearEmptyWithCursorAndMoreData`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cursor revalidation logic used during GC/index swapping; mistakes could cause readers to incorrectly treat replaced indexes as the same, impacting query correctness. Changes are localized but affect a core data-structure path.
> 
> **Overview**
> Fixes an ABA hazard in inverted-index cursor revalidation by assigning each `InvertedIndex` instance a monotonic `IndexUniqueId` at construction and exposing it via `unique_id()`.
> 
> `IndexReaderCore::points_to_ii()` now validates *both* pointer equality and the stored unique ID, and `swap_index()` refreshes the cached ID, preventing cursors from continuing on a newly-allocated index that reused the same address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f62022cc4df7a721dd19ea35ba075ca177ce7b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->