### PR TITLE
[8.4] [MOD-13606] Rename ubuntu:default to ubuntu:latest

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
-      platform: ubuntu:default
+      platform: ubuntu:latest
       architecture: x86_64
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -92,18 +92,18 @@ jobs:
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 
-          # Add coverage job if requested (only on ubuntu:default x86_64)
+          # Add coverage job if requested (only on ubuntu:latest x86_64)
           if include_coverage:
               matrix_items.append({
-                  'platform': 'ubuntu:default',
+                  'platform': 'ubuntu:latest',
                   'architecture': 'x86_64',
                   'job-type': 'coverage'
               })
 
-          # Add sanitize job if requested (only on ubuntu:default x86_64)
+          # Add sanitize job if requested (only on ubuntu:latest x86_64)
           if include_sanitize:
               matrix_items.append({
-                  'platform': 'ubuntu:default',
+                  'platform': 'ubuntu:latest',
                   'architecture': 'x86_64',
                   'job-type': 'sanitize'
               })

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -105,7 +105,7 @@ jobs:
                       'ec2_instance_type': 'c7i.xlarge'
                   }
               },
-              "ubuntu:default": {
+              "ubuntu:latest": {
                   "x86_64": {
                       'name': 'Ubuntu Latest x86_64'
                   },


### PR DESCRIPTION
# Description
Backport of #8783 to `8.4`.

Rename `ubuntu:default` to `ubuntu:latest` in CI files for clarity.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename in GitHub Actions workflow configuration; primary risk is CI jobs failing if any external references still expect `ubuntu:default`.
> 
> **Overview**
> **Release note:** CI labeling has been clarified by renaming the `ubuntu:default` platform identifier to `ubuntu:latest` across the PR test workflow, matrix generation (including coverage/sanitize jobs), and config lookup, without changing the underlying runner/container behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d27d1b88459416aecd8d710c169b59b00bc53962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->