### PR TITLE
[8.2] [MOD-13606] Rename ubuntu:default to ubuntu:latest

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -55,7 +55,7 @@ jobs:
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
-      platform: ubuntu:default
+      platform: ubuntu:latest
       architecture: x86_64
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -92,18 +92,18 @@ jobs:
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 
-          # Add coverage job if requested (only on ubuntu:default x86_64)
+          # Add coverage job if requested (only on ubuntu:latest x86_64)
           if include_coverage:
               matrix_items.append({
-                  'platform': 'ubuntu:default',
+                  'platform': 'ubuntu:latest',
                   'architecture': 'x86_64',
                   'job-type': 'coverage'
               })
 
-          # Add sanitize job if requested (only on ubuntu:default x86_64)
+          # Add sanitize job if requested (only on ubuntu:latest x86_64)
           if include_sanitize:
               matrix_items.append({
-                  'platform': 'ubuntu:default',
+                  'platform': 'ubuntu:latest',
                   'architecture': 'x86_64',
                   'job-type': 'sanitize'
               })

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -105,7 +105,7 @@ jobs:
                       'ec2_instance_type': 'c7i.xlarge'
                   }
               },
-              "ubuntu:default": {
+              "ubuntu:latest": {
                   "x86_64": {
                       'name': 'Ubuntu Latest x86_64'
                   },


### PR DESCRIPTION
# Description
Backport of #8783 to `8.2`.

Rename `ubuntu:default` to `ubuntu:latest` in CI files for clarity.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CI/release workflow refactor (matrix generation, container caching, artifact publishing, and release validation) could cause missed/incorrect builds or releases if any edge-case platform/config is mis-modeled.
> 
> **Overview**
> **CI is reworked around a single generated platform/arch matrix**: adds `generate-matrix.yml`/`flow-test.yml` (plus `generate-basic-matrix.yml`) and updates PR/nightly/queue flows to run lint + tests via the unified matrix (including coverage/sanitize options), removing the old `flow-linux-platforms.yml` and `flow-macos.yml`.
> 
> **Build/artifact workflows now support cached CI containers and consistent versioning**: introduces `task-build-cached-container.yml` + a new `Dockerfile` with a tightened `.dockerignore`, updates `task-test.yml`/`task-build-artifacts.yml` to use `task-get-config.yml` for per-platform setup, adds retry/cleanup steps, and adds a run-wide `version-suffix` used for artifact naming.
> 
> **Release and dependency setup is hardened/modernized**: release validation now resolves the correct release branch from the tag, release artifact selection filters by expected SHA + expected build matrix, and install scripts move Python env setup to `uv` (new `.python-version`, new install scripts, updated OS deps like `gdb`). Separate tweaks update Redis/RedisJSON defaults to `8.2`, pin/upgrade benchmark tooling, and add PR template + workflow enforcement for release-notes checkboxes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a3e436243290fe1f42a2077f5f1e8cbf462b9eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->