### PR TITLE
rqe_iterator: add wildcard_helper

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -8,4 +8,7 @@
 */
 
 mod mock_iterator;
+mod wildcard_helper;
 pub(crate) use mock_iterator::{Mock, MockData, MockIteratorError, MockRevalidateResult, MockVec};
+#[expect(unused)] // not used yet
+pub(crate) use wildcard_helper::WildcardHelper;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use inverted_index::{InvertedIndex, RSIndexResult, doc_ids_only::DocIdsOnly};
+use rqe_iterators_test_utils::MockContext;
+
+/// Holds an [`InvertedIndex`] and a [`MockContext`] so a
+/// [`Wildcard`](rqe_iterators::inverted_index::Wildcard) iterator can be
+/// created from them.
+pub(crate) struct WildcardHelper {
+    ii: InvertedIndex<DocIdsOnly>,
+    mock_ctx: MockContext,
+}
+
+impl WildcardHelper {
+    /// Create a new helper populated with the given `doc_ids`.
+    #[expect(unused)] // not used yet
+    pub(crate) fn new(doc_ids: &[t_docId]) -> Self {
+        let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+        for &doc_id in doc_ids {
+            let record = RSIndexResult::build_virt().doc_id(doc_id).build();
+            ii.add_record(&record).expect("failed to add record");
+        }
+        let mock_ctx = MockContext::new(0, 0);
+        Self { ii, mock_ctx }
+    }
+
+    /// Create a [`Wildcard`](rqe_iterators::inverted_index::Wildcard)
+    /// iterator from the underlying inverted index.
+    #[expect(unused)] // not used yet
+    pub(crate) fn create_wildcard(
+        &self,
+    ) -> rqe_iterators::inverted_index::Wildcard<'_, DocIdsOnly> {
+        let reader = self.ii.reader();
+        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid
+        // `spec` that outlives the returned iterator.
+        unsafe { rqe_iterators::inverted_index::Wildcard::new(reader, self.mock_ctx.sctx(), 1.0) }
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Test helper which will be used in https://github.com/RediSearch/RediSearch/pull/8790 and https://github.com/RediSearch/RediSearch/pull/8692

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to test-only utilities; the main risk is incorrect test setup due to the new helper’s `unsafe` `Wildcard::new` call and lifetime assumptions.
> 
> **Overview**
> Adds `WildcardHelper` under `tests/integration/utils` to simplify integration tests that need a `rqe_iterators::inverted_index::Wildcard` built from a populated `InvertedIndex<DocIdsOnly>` and a `MockContext`.
> 
> Exports the new helper from `utils/mod.rs`; methods are currently annotated `#[expect(unused)]` as they are introduced ahead of upcoming test additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68a2edca3fe00b0caae0e3a138bb6979c30a9276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->