### PR TITLE
Simplify RLookupRow::get

### DIFF
--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -191,13 +191,7 @@ impl<'a> RLookupRow<'a> {
     /// If the item is not found in either location, it returns `None`.
     pub fn get(&self, key: &RLookupKey) -> Option<&RSValueFFI> {
         // Check dynamic values first
-        if self.len() > key.dstidx as usize
-            && let Some(val) = self
-                .dyn_values()
-                .get(key.dstidx as usize)
-                .expect("value is not in dynamic values even though dstidx is in bounds")
-                .as_ref()
-        {
+        if let Some(Some(val)) = self.dyn_values().get(key.dstidx as usize) {
             return Some(val);
         }
 
@@ -209,7 +203,7 @@ impl<'a> RLookupRow<'a> {
             //   `if (ret != NULL && ret == RSValue_NullStatic()) ret = NULL;`
             self.sorting_vector()?
                 .get(key.svidx as usize)
-                .filter(|v| v.get_type() != ffi::RSValueType_RSValueType_Null)
+                .filter(|v| !v.is_null())
         } else {
             None
         }


### PR DESCRIPTION
## Describe the changes in the pull request

Simplify the check for dynamic values.
Align with the previous C code, checking against the null static sentinel value rather than null static _and_ null values.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but behavior-affecting change to `RLookupRow::get` value resolution (dynamic slot lookup and sorting-vector null sentinel filtering), which could subtly impact which fields are treated as present/absent in query results.
> 
> **Overview**
> Simplifies `RLookupRow::get` by replacing the manual bounds/unwrap path for dynamic values with a direct `Option<Option<_>>` match on `dyn_values`.
> 
> When falling back to sorting-vector values (`SvSrc`), it now filters out absent fields via `RSValueFFI::is_null()` instead of checking the raw FFI type enum, aligning the Rust behavior with the C-side null-sentinel guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d35511be11838fa88c80a3879255a6d24ab253e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->