### PR TITLE
[MOD-14306] Add diagnostic logs for topology validation failures in coordinator

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -28,6 +28,7 @@ typedef struct MRConn{
   uv_loop_t *loop;
   int protocol; // 0 (undetermined), 2, or 3
   MRConnState state;
+  unsigned authFailCount; // consecutive auth failures, for rate-limited logging
 } MRConn;
 
 static void MRConn_ConnectCallback(const redisAsyncContext *c, int status);
@@ -42,11 +43,17 @@ static int MRConn_SendAuth(MRConn *conn);
 
 #define RSCONN_RECONNECT_TIMEOUT 250
 #define RSCONN_REAUTH_TIMEOUT 1000
+#define AUTH_FAIL_LOG_INTERVAL 100
 #define INTERNALAUTH_USERNAME "internal connection"
 #define UNUSED(x) (void)(x)
 
 #define CONN_LOG(conn, fmt, ...)                                                      \
   RedisModule_Log(RSDummyContext, "debug", "[%p %s:%d %s] " fmt,                      \
+                  conn, conn->ep.host, conn->ep.port, MRConnState_Str((conn)->state), \
+                  ##__VA_ARGS__)
+
+#define CONN_LOG_WARNING(conn, fmt, ...)                                              \
+  RedisModule_Log(RSDummyContext, "warning", "[%p %s:%d %s] " fmt,                    \
                   conn, conn->ep.host, conn->ep.port, MRConnState_Str((conn)->state), \
                   ##__VA_ARGS__)
 
@@ -260,16 +267,33 @@ MRConn *MRConn_Get(MRConnManager *mgr, const char *id) {
   return NULL;
 }
 
+/* Get the state string of the first connection for a specific node by id.
+ * Returns NULL if this node is not in the pool.
+ * Must be called from the uv event loop thread, as mgr->map is not thread-safe. */
+const char *MRConnManager_GetNodeState(MRConnManager *mgr, const char *id) {
+  dictEntry *ptr = dictFind(mgr->map, id);
+  if (ptr) {
+    MRConnPool *pool = dictGetVal(ptr);
+    // All connections in the pool share the same endpoint, so any one is representative.
+    if (pool->num > 0 && pool->conns[0]) {
+      return MRConnState_Str(pool->conns[0]->state);
+    }
+  }
+  return NULL;
+}
+
 /* Send a command to the connection */
 int MRConn_SendCommand(MRConn *c, MRCommand *cmd, redisCallbackFn *fn, void *privdata) {
 
   /* Only send to connected nodes */
   if (c->state != MRConn_Connected) {
+    CONN_LOG_WARNING(c, "Tried to send command to node in state %s", MRConnState_Str(c->state));
     return REDIS_ERR;
   }
 
   if (!cmd->cmd) {
     if (redisFormatSdsCommandArgv(&cmd->cmd, cmd->num, (const char **)cmd->strs, cmd->lens) == REDIS_ERR) {
+      CONN_LOG_WARNING(c, "Failed to format command");
       return REDIS_ERR;
     }
   }
@@ -290,12 +314,15 @@ int MRConnManager_Add(MRConnManager *m, uv_loop_t *loop, const char *id, MREndpo
     MRConnPool *pool = dictGetVal(ptr);
 
     MRConn *conn = pool->conns[0];
-    // the node hasn't changed address, we don't need to do anything */
+    // the node hasn't changed address, we don't need to do anything
     if (!strcmp(conn->ep.host, ep->host) && conn->ep.port == ep->port) {
       return 0;
     }
 
     // Node changed address - disconnect old pool before replacing it.
+    RedisModule_Log(RSDummyContext, "notice",
+                    "MRConnManager_Add: Node %s changed address from %s:%d to %s:%d, reconnecting (state: %s)",
+                    id, conn->ep.host, conn->ep.port, ep->host, ep->port, MRConnState_Str(conn->state));
     MRConnPool_Disconnect(pool);
   }
 
@@ -423,6 +450,10 @@ static void signalCallback(uv_timer_t *tm) {
 
   if (conn->state == MRConn_ReAuth) {
     if (MRConn_SendAuth(conn) != REDIS_OK) {
+      conn->authFailCount++;
+      if (conn->authFailCount == 1 || conn->authFailCount % AUTH_FAIL_LOG_INTERVAL == 0) {
+        CONN_LOG_WARNING(conn, "Failed to send AUTH command (%u consecutive failures)", conn->authFailCount);
+      }
       detachFromConn(conn, true);
       MRConn_SwitchState(conn, MRConn_Connecting);
     }
@@ -503,13 +534,14 @@ static void MRConn_AuthCallback(redisAsyncContext *c, void *r, void *privdata) {
   if (MRReply_Type(rep) == REDIS_REPLY_ERROR) {
     size_t len;
     const char* s = MRReply_String(rep, &len);
-    CONN_LOG(conn, "Error authenticating: %.*s", (int)len, s);
+    CONN_LOG_WARNING(conn, "Error authenticating: %.*s", (int)len, s);
     MRConn_SwitchState(conn, MRConn_ReAuth);
     /*we don't try to reconnect to failed connections */
     goto cleanup;
   }
 
   /* Success! we are now connected! */
+  conn->authFailCount = 0;
   MRConn_SwitchState(conn, MRConn_Connected);
 
 cleanup:
@@ -669,7 +701,9 @@ done:
   return ret;
 }
 
-/* hiredis async connect callback */
+/* hiredis async connect callback.
+ * conn (c->data) can be NULL if detachFromConn was called before the connect completed
+ * (e.g., MRConn_Freeing with deferred disconnect). Both status values are expected. */
 static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
   MRConn *conn = c->data;
   if (!conn) {
@@ -690,7 +724,7 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
 
   // if the connection is not stopped - try to reconnect
   if (status != REDIS_OK) {
-    CONN_LOG(conn, "Error on connect: %s", c->errstr);
+    CONN_LOG_WARNING(conn, "Error on connect: %s", c->errstr);
     // Hiredis will call __redisAsyncDisconnect() after connect-failure callback.
     // We only detach from MRConn here to avoid stale callback data access.
     detachFromConn(conn, false);
@@ -711,7 +745,7 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
     rm_free(ca_cert);
     if (key_file_pass) rm_free(key_file_pass);
     if(ssl_context == NULL || ssl_error != 0) {
-      CONN_LOG(conn, "Error on ssl context creation: %s", (ssl_error != 0) ? redisSSLContextGetError(ssl_error) : "Unknown error");
+      CONN_LOG_WARNING(conn, "Error on ssl context creation: %s", (ssl_error != 0) ? redisSSLContextGetError(ssl_error) : "Unknown error");
       detachFromConn(conn, true);
       MRConn_SwitchState(conn, MRConn_Connecting);
       if (ssl_context) SSL_CTX_free(ssl_context);
@@ -719,7 +753,7 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
     }
     SSL *ssl = SSL_new(ssl_context);
     if (!ssl) {
-      CONN_LOG(conn, "Error creating SSL object");
+      CONN_LOG_WARNING(conn, "Error creating SSL object");
       detachFromConn(conn, true);
       MRConn_SwitchState(conn, MRConn_Connecting);
       SSL_CTX_free(ssl_context);
@@ -734,7 +768,7 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
       // function will not do it for us.
       ((struct redisAsyncContext*)c)->c.funcs = old_callbacks;
 
-      CONN_LOG(conn, "Error on tls auth, %s.", err);
+      CONN_LOG_WARNING(conn, "Error on tls auth, %s.", err);
       detachFromConn(conn, true);
       MRConn_SwitchState(conn, MRConn_Connecting);
       SSL_free(ssl);
@@ -748,6 +782,10 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
   // a password is set to the `default` ACL user.
   if (!IsEnterprise() || conn->ep.password) {
     if (MRConn_SendAuth(conn) != REDIS_OK) {
+      conn->authFailCount++;
+      if (conn->authFailCount == 1 || conn->authFailCount % AUTH_FAIL_LOG_INTERVAL == 0) {
+        CONN_LOG_WARNING(conn, "Failed to send AUTH command (%u consecutive failures)", conn->authFailCount);
+      }
       detachFromConn(conn, true);
       MRConn_SwitchState(conn, MRConn_Connecting);
     }
@@ -772,7 +810,7 @@ static void MRConn_DisconnectCallback(const redisAsyncContext *c, int status) {
 
 static MRConn *MR_NewConn(MREndpoint *ep, uv_loop_t *loop) {
   MRConn *conn = rm_malloc(sizeof(MRConn));
-  *conn = (MRConn){.state = MRConn_Disconnected, .conn = NULL, .protocol = 0, .loop = loop, .timer = NULL};
+  *conn = (MRConn){.state = MRConn_Disconnected, .conn = NULL, .protocol = 0, .loop = loop, .timer = NULL, .authFailCount = 0};
   conn->timer = rm_malloc(sizeof(uv_timer_t));
   uv_timer_init(loop, conn->timer);
   ((uv_timer_t *)conn->timer)->data = conn;
@@ -792,7 +830,7 @@ static int MRConn_Connect(MRConn *conn) {
     return REDIS_ERR;
   }
   if (c->err) {
-    CONN_LOG(conn, "Could not connect to node: %s", c->errstr);
+    CONN_LOG_WARNING(conn, "Could not connect to node: %s", c->errstr);
     redisAsyncFree(c);
     return REDIS_ERR;
   }
@@ -803,7 +841,7 @@ static int MRConn_Connect(MRConn *conn) {
   if (redisLibuvAttach(conn->conn, conn->loop) != REDIS_OK ||
       redisAsyncSetConnectCallback(conn->conn, MRConn_ConnectCallback) != REDIS_OK ||
       redisAsyncSetDisconnectCallback(conn->conn, MRConn_DisconnectCallback) != REDIS_OK) {
-    CONN_LOG(conn, "Failed to attach hiredis context to libuv");
+    CONN_LOG_WARNING(conn, "Failed to attach hiredis context to libuv");
     detachFromConn(conn, true);
     return REDIS_ERR;
   }

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -85,6 +85,11 @@ void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict);
 /* Get the connection for a specific node by id, return NULL if this node is not in the pool */
 MRConn *MRConn_Get(MRConnManager *mgr, const char *id);
 
+/* Get the state string of the first connection for a specific node by id.
+ * Returns NULL if this node is not in the pool.
+ * Must be called from the uv event loop thread, as mgr->map is not thread-safe. */
+const char *MRConnManager_GetNodeState(MRConnManager *mgr, const char *id);
+
 int MRConn_SendCommand(MRConn *c, MRCommand *cmd, redisCallbackFn *fn, void *privdata);
 
 /* Add a node to the connection manager */

--- a/src/coord/rmr/io_runtime_ctx.c
+++ b/src/coord/rmr/io_runtime_ctx.c
@@ -59,9 +59,28 @@ static void rqAsyncCb(uv_async_t *async) {
 
 extern RedisModuleCtx *RSDummyContext;
 
+// Log which nodes in the topology are not connected.
+static void LogDisconnectedNodes(IORuntimeCtx *io_runtime_ctx) {
+  const MRClusterTopology *topo = io_runtime_ctx->topo;
+  if (!topo) return;
+  for (size_t i = 0; i < topo->numShards; i++) {
+    MRClusterNode *node = &topo->shards[i].node;
+    MRConn *conn = MRConn_Get(&io_runtime_ctx->conn_mgr, node->id);
+    if (!conn) {
+      const char *state = MRConnManager_GetNodeState(&io_runtime_ctx->conn_mgr, node->id);
+      RedisModule_Log(RSDummyContext, "warning",
+                      "IORuntime ID %zu: Node %s (%s:%d) not connected (state: %s)",
+                      io_runtime_ctx->queue->id,
+                      node->id, node->endpoint.host, node->endpoint.port,
+                      state ? state : "unknown");
+    }
+  }
+}
+
 static void topologyFailureCB(uv_timer_t *timer) {
   IORuntimeCtx *io_runtime_ctx = (IORuntimeCtx *)timer->data;
   RedisModule_Log(RSDummyContext, "warning", "IORuntime ID %zu: Topology validation failed: not all nodes connected", io_runtime_ctx->queue->id);
+  LogDisconnectedNodes(io_runtime_ctx);
   uv_timer_stop(&io_runtime_ctx->uv_runtime.topologyValidationTimer); // stop the validation timer
   // Mark the event loop thread as ready. This will allow any pending requests to be processed
   // (and fail, but it will unblock clients)


### PR DESCRIPTION
**Forward-port of #8621 (2.10 → master)**

**Current:** Topology validation failures log only "Topology validation failed: not all nodes connected" without details on which nodes failed or their connection states, making root cause analysis difficult.

**Change:** Add diagnostic logs that emit connection-related errors at warning level, including details about failed nodes during validation, MRConnManager_Add skip decisions, and connection/auth failure information.

**Outcome:** Improved observability for topology validation failures, enabling easier root cause analysis for connection issues.

**Fixes:** MOD-14306

**Differences from 2.10 PR:**
- `module.c` changes already present on master — no changes needed.
- `MRCluster_LogDisconnectedNodes` (cluster.c) → `LogDisconnectedNodes` (io_runtime_ctx.c) — adapted for master's per-thread `IORuntimeCtx` architecture (no global `MRCluster` singleton).
- `MRConn` is opaque on master (defined in .c), so `authFailCount` is added in conn.c rather than conn.h.
- `mastersOnly` filter not needed — master's `MRClusterShard` has a single node (no replicas in topology struct).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily additional logging and a new helper accessor, with minimal impact on connection behavior aside from log level/frequency adjustments during failures.
> 
> **Overview**
> Improves coordinator observability around topology validation and connection issues.
> 
> Topology validation failures now log *which* shard nodes are not connected, including their endpoint and current connection state (via new `MRConnManager_GetNodeState`). Connection/auth/TLS/connect failure paths have been promoted to `warning` logs and AUTH-send failures are rate-limited using a consecutive-failure counter, plus a `notice` log when a node’s address changes and the pool is reconnected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5412908fa0163998f6da13d8d3a0d8f9fb7369f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->