### PR TITLE
Fix operator precedence bug in artifact upload conditions

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -515,13 +515,13 @@ jobs:
         # Upload artifacts only if node20 is supported and tests failed (including sanitizer failures)
         if: >
           needs.get-config.outputs.node20_supported == 'true' &&
-          failure() || (
+          (failure() || (
             (steps.rust_unit_tests_miri.outcome == 'failure') ||
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure' ||
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
-          )
+          ))
         uses: actions/upload-artifact@v4
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
@@ -536,13 +536,13 @@ jobs:
       - name: Upload Artifacts (node20 not supported) (temporarily disabled)
         if: >
           needs.get-config.outputs.node20_supported != 'true' &&
-          failure() || (
+          (failure() || (
             (steps.rust_unit_tests_miri.outcome == 'failure') ||
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure' ||
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
-          )
+          ))
         run: echo "Currently not available..."
 
       - name: Fail flow if tests failed


### PR DESCRIPTION
Fix operator precedence in the `if` conditions of both "Upload Artifacts" steps in `task-test.yml`.

This bug was introduced in #7600 (Compile Rust with ASAN when SAN flag is on). The original code had correct parenthesization, but when the miri failure checks were added, the parentheses were restructured incorrectly.

Due to `&&` binding tighter than `||`, the expression:
```yaml
node20_supported == 'true' && failure() || (steps... == 'failure')
```
evaluates as:
```
(node20_supported == 'true' && failure()) || (steps... == 'failure')
```
This means artifact upload could trigger regardless of `node20_supported` whenever any individual step outcome is `'failure'`.

Fixed by wrapping `failure() || (...)` in parentheses so `node20_supported` gates the entire condition:
```yaml
node20_supported == 'true' && (failure() || (steps... == 'failure'))
```

Applies to both the node20 and non-node20 upload steps.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tightens `if` conditions so artifact uploads are properly gated by `node20_supported`; main risk is slightly changing when logs are uploaded on failures.
> 
> **Overview**
> Fixes a boolean precedence bug in `.github/workflows/task-test.yml` where the artifact-upload steps could run even when `node20_supported` didn’t match.
> 
> Both "Upload Artifacts" `if:` expressions are re-parenthesized so `needs.get-config.outputs.node20_supported` gates the entire failure check (`failure()` or any individual test step outcome), preventing unintended artifact uploads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1143be18f397dc6afbba7798e16c50a6c63d2fc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->