### PR TITLE
query: fix clang -Wswitch warnings

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -141,6 +141,8 @@ void QueryNode_Free(QueryNode *n) {
     case QN_NULL:
     case QN_PHRASE:
       break;
+    case QN_MAX:
+      RS_ABORT("Invalid query node type");
   }
   rm_free(n);
 }
@@ -1509,6 +1511,8 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
       return NewEmptyIterator();
     case QN_MISSING:
       return Query_EvalMissingNode(q, n);
+    case QN_MAX:
+      RS_ABORT("Invalid query node type");
   }
 
   return NULL;
@@ -1662,6 +1666,8 @@ int QueryNode_EvalParams(dict *params, QueryNode *n, unsigned int dialectVersion
     case QN_MISSING:
       withChildren = 0;
       break;
+    case QN_MAX:
+      RS_ABORT("Invalid query node type");
   }
   // Handle children
   if (withChildren && res == REDISMODULE_OK) {
@@ -1797,6 +1803,8 @@ static int QueryNode_CheckIsValid(QueryNode *n, IndexSpec *spec, RSSearchOptions
     case QN_LEXRANGE:
     case QN_GEOMETRY:
       break;
+    case QN_MAX:
+      RS_ABORT("Invalid query node type");
   }
 
   // Handle children
@@ -2064,6 +2072,8 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
     case QN_MISSING:
       s = sdscatprintf(s, "ISMISSING{%s}", HiddenString_GetUnsafe(qs->miss.field->fieldName, NULL));
       break;
+    case QN_MAX:
+      RS_ABORT("Invalid query node type");
   }
 
   // print attributes if not the default


### PR DESCRIPTION
## Describe the changes in the pull request

Handling `QN_MAX` in switch to silent `-Wswitch` clang warnings.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds defensive `case QN_MAX` branches that abort on an impossible/sentinel enum value, without changing normal query parsing or execution behavior.
> 
> **Overview**
> Adds explicit `case QN_MAX` handling in `src/query.c` switch statements (freeing, evaluation, param resolution, validation, and AST dumping) to satisfy `-Wswitch` and **abort immediately** if the sentinel `QN_MAX` is ever encountered at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f13709dcd8b7e993c2a08f8f1a4b63f8799cbfe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->