### PR TITLE
Optimize SharedRsValue::Deref: remove redundant is_null_static branch

### DIFF
--- a/src/redisearch_rs/value/src/shared.rs
+++ b/src/redisearch_rs/value/src/shared.rs
@@ -123,13 +123,10 @@ impl Deref for SharedRsValue {
     type Target = RsValue;
 
     fn deref(&self) -> &Self::Target {
-        if self.is_null_static() {
-            &NULL_VALUE
-        } else {
-            // SAFETY: `self.ptr` was obtained from `Arc::into_raw` and the
-            // `Arc` is kept alive for the lifetime of `self`.
-            unsafe { &*self.ptr }
-        }
+        // SAFETY: `self.ptr` is either `&NULL_VALUE` (static) or was obtained
+        // from `Arc::into_raw` and the `Arc` is kept alive for the lifetime of
+        // `self`. Both cases produce a valid pointer.
+        unsafe { &*self.ptr }
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

There is no need to branch.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unsafe pointer dereferencing in `SharedRsValue::deref`, which is widely used and could cause UB if the pointer invariants are ever violated, though the change is small and intended to be behavior-preserving.
> 
> **Overview**
> Removes the `is_null_static()` conditional in `SharedRsValue::deref`, always returning `&*self.ptr` and updating the safety comment to treat both the static `NULL_VALUE` sentinel and `Arc::into_raw` pointers uniformly.
> 
> This is a small micro-optimization/cleanup that should be behavior-preserving but slightly increases reliance on the raw-pointer invariant being upheld everywhere `SharedRsValue` is constructed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f9f07b6a38b409e2aa56c7d27e9f7161ceaa780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->