### PR TITLE
Use triomphe::Arc rather than std's Arc

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2736,6 +2736,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "types_ffi"
 version = "0.0.1"
 dependencies = [
@@ -2858,6 +2868,7 @@ dependencies = [
  "redis_mock",
  "redisearch_rs",
  "thiserror",
+ "triomphe",
  "workspace_hack",
 ]
 
@@ -3319,6 +3330,7 @@ dependencies = [
  "serde",
  "serde_core",
  "serde_json",
+ "stable_deref_trait",
  "syn 1.0.109",
  "syn 2.0.117",
  "thiserror",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -165,6 +165,7 @@ syn = "2"
 # need "unstable" for the "default_log_filter" attribute allowing to override the default level (info).
 test-log = { version = "0.2", features = ["trace", "unstable"] }
 thiserror = "2.0.18"
+triomphe = "0.1.2"
 toml = "0.9"
 tracing = "0.1.44"
 tracing-core = "0.1"

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -13,6 +13,7 @@ libc.workspace = true
 query_error.workspace = true
 workspace_hack.workspace = true
 thiserror.workspace = true
+triomphe.workspace = true
 
 [dev-dependencies]
 redisearch_rs = { workspace = true, features = ["mock_allocator"] }

--- a/src/redisearch_rs/value/src/shared.rs
+++ b/src/redisearch_rs/value/src/shared.rs
@@ -11,8 +11,9 @@ use std::{
     mem::{self, ManuallyDrop},
     ops::Deref,
     ptr,
-    sync::Arc,
 };
+
+use triomphe::Arc;
 
 use crate::RsValue;
 

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -39,6 +39,7 @@ semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_core = { version = "1", features = ["alloc"] }
 serde_json = { version = "1", features = ["unbounded_depth"] }
+stable_deref_trait = { version = "1", default-features = false, features = ["alloc"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 thiserror = { version = "2" }
 toml = { version = "0.9" }
@@ -70,6 +71,7 @@ semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_core = { version = "1", features = ["alloc"] }
 serde_json = { version = "1", features = ["unbounded_depth"] }
+stable_deref_trait = { version = "1", default-features = false, features = ["alloc"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "full", "visit-mut"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 thiserror = { version = "2" }


### PR DESCRIPTION
## Describe the changes in the pull request

Reduce overhead by 8 bytes, since it only tracks the strong count.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `SharedRsValue`’s reference-counted ownership used across FFI boundaries; while the API is Arc-compatible, any behavioral differences in `triomphe::Arc` refcounting/raw pointer conversions could cause leaks or UB if assumptions don’t hold.
> 
> **Overview**
> Replaces `std::sync::Arc` with `triomphe::Arc` for `value::SharedRsValue`’s heap-backed `RsValue` sharing, aiming to reduce per-allocation overhead by using a strong-count-only `Arc`.
> 
> Updates workspace and `value` crate dependencies to include `triomphe` (and its `stable_deref_trait` transitive requirement), and refreshes `Cargo.lock`/`workspace_hack` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31c4937cc7be0cdb990503d6dc3ab75124763c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->