### PR TITLE
[MOD-13606] Add explanations for non-LTO platforms

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -154,7 +154,8 @@ jobs:
                   "x86_64": {
                       'container': 'ubuntu:jammy',
                       'setup_script': 'apt update && apt install -y git',
-                      'name': 'Ubuntu Jammy x86_64'
+                      'name': 'Ubuntu Jammy x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'ubuntu:jammy',
@@ -167,7 +168,8 @@ jobs:
                   "x86_64": {
                       'container': 'ubuntu:focal',
                       'setup_script': 'apt update && apt install -y git',
-                      'name': 'Ubuntu Focal x86_64'
+                      'name': 'Ubuntu Focal x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'ubuntu:focal',
@@ -180,19 +182,22 @@ jobs:
                   "x86_64": {
                       'container': 'rockylinux:8',
                       'setup_script': 'dnf update -y && dnf install -y git',
-                      'name': 'Rocky Linux 8 x86_64'
+                      'name': 'Rocky Linux 8 x86_64',
+                      'enable_lto': '0' #  Shipped glibc is too old.
                   },
                   "aarch64": {
                       'container': 'rockylinux:8',
                       'setup_script': 'dnf update -y && dnf install -y git',
-                      'name': 'Rocky Linux 8 ARM64'
+                      'name': 'Rocky Linux 8 ARM64',
+                      'enable_lto': '0' #  Shipped glibc is too old.
                   }
               },
               "rockylinux:9": {
                   "x86_64": {
                       'container': 'rockylinux:9',
                       'setup_script': 'dnf update -y && dnf install -y git',
-                      'name': 'Rocky Linux 9 x86_64'
+                      'name': 'Rocky Linux 9 x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'rockylinux:9',
@@ -204,12 +209,14 @@ jobs:
                   "x86_64": {
                       'container': 'amazonlinux:2',
                       'setup_script': 'yum install -y tar gzip git',
-                      'name': 'Amazon Linux 2 x86_64'
+                      'name': 'Amazon Linux 2 x86_64',
+                      'enable_lto': '0' #  Shipped glibc is too old.
                   },
                   "aarch64": {
                       'container': 'amazonlinux:2',
                       'setup_script': 'yum install -y tar gzip git',
-                      'name': 'Amazon Linux 2 ARM64'
+                      'name': 'Amazon Linux 2 ARM64',
+                      'enable_lto': '0' #  Shipped glibc is too old.
                   }
               },
               "alpine:3.22": {
@@ -232,7 +239,8 @@ jobs:
                   "x86_64": {
                       'container': 'gcc:11-bullseye',
                       'setup_script': 'apt update && apt install -y git',
-                      'name': 'Debian Bullseye x86_64'
+                      'name': 'Debian Bullseye x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'gcc:11-bullseye',
@@ -245,7 +253,8 @@ jobs:
                   "x86_64": {
                       'container': 'gcc:12-bookworm',
                       'setup_script': 'apt update && apt install -y git',
-                      'name': 'Debian Bookworm x86_64'
+                      'name': 'Debian Bookworm x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'gcc:12-bookworm',
@@ -258,7 +267,8 @@ jobs:
                   "x86_64": {
                       'container': 'amazonlinux:2023',
                       'setup_script': 'dnf install -y tar gzip git',
-                      'name': 'Amazon Linux 2023 x86_64'
+                      'name': 'Amazon Linux 2023 x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'amazonlinux:2023',
@@ -271,7 +281,8 @@ jobs:
                   "x86_64": {
                       'container': 'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                       'setup_script': 'tdnf install -y --noplugins --skipsignature tar gzip git ca-certificates',
-                      'name': 'Mariner 2 x86_64'
+                      'name': 'Mariner 2 x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'mcr.microsoft.com/cbl-mariner/base/core:2.0',
@@ -284,7 +295,8 @@ jobs:
                   "x86_64": {
                       'container': 'mcr.microsoft.com/azurelinux/base/core:3.0',
                       'setup_script': 'tdnf install -y --noplugins tar git ca-certificates',
-                      'name': 'Azure Linux 3 x86_64'
+                      'name': 'Azure Linux 3 x86_64',
+                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
                   },
                   "aarch64": {
                       'container': 'mcr.microsoft.com/azurelinux/base/core:3.0',


### PR DESCRIPTION
Add explanations for non-LTO platforms

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a GitHub Actions configuration map to explicitly set `enable_lto: '0'` with explanatory comments for certain OS/arch combinations, without changing build logic outside CI config selection.
> 
> **Overview**
> Clarifies CI platform configuration in `.github/workflows/task-get-config.yml` by explicitly adding `enable_lto: '0'` to several non-LTO targets (e.g., `ubuntu:jammy/focal` x86_64, `rockylinux:8/9`, `amazonlinux:2/2023`, `debian:bullseye/bookworm`, `mariner:2`, `azurelinux:3`).
> 
> Each newly-disabled entry includes a short inline reason (e.g., *glibc too old* or *awaiting updated Intel SVS binary*), making LTO support expectations per platform explicit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0e2cf6fc29e605896a8f4fffe0c4f11c6ec247d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->