### PR TITLE
[MOD-14488] not iterator: add Rust micro benchmarks for optimized version

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
@@ -61,6 +61,11 @@ fn benchmark_union(c: &mut Criterion) {
     bencher.bench(c);
 }
 
+fn benchmark_not_optimized_iterator(c: &mut Criterion) {
+    let bencher = benchers::not_optimized::Bencher::default();
+    bencher.bench(c);
+}
+
 fn benchmark_inverted_index_numeric(c: &mut Criterion) {
     let bencher = benchers::inverted_index::NumericBencher::default();
     bencher.bench(c);
@@ -163,6 +168,7 @@ criterion_group!(
     benchmark_id_list,
     benchmark_metric,
     benchmark_not_iterator,
+    benchmark_not_optimized_iterator,
     benchmark_wildcard,
     benchmark_intersection,
     benchmark_optional,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/mod.rs
@@ -13,6 +13,7 @@ pub mod intersection;
 pub mod inverted_index;
 pub mod metric;
 pub mod not;
+pub mod not_optimized;
 pub mod optional;
 pub mod union;
 pub mod wildcard;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Benchmark NOT iterator (optimized version).
+
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
+use rqe_iterators::{
+    RQEIterator, empty::Empty, id_list::IdListSorted, not_optimized::NotOptimized,
+    wildcard::new_wildcard_iterator_optimized,
+};
+use rqe_iterators_test_utils::TestContext;
+
+use crate::ffi::{IteratorStatus_ITERATOR_OK, QueryIterator};
+
+pub struct Bencher {
+    context_all: TestContext,
+    context_sparse: TestContext,
+}
+
+impl Default for Bencher {
+    fn default() -> Self {
+        let context_all = TestContext::wildcard(1..Self::MAX_DOC_ID);
+        let context_sparse = TestContext::wildcard((1..Self::MAX_DOC_ID).step_by(100));
+        // SAFETY: no iterators have been created from these contexts yet.
+        // We set index_all=true so the wildcard iterator returns all doc IDs up to MAX_DOC_ID
+        // rather than consulting existingDocs.
+        unsafe {
+            context_all.set_index_all(true);
+            context_sparse.set_index_all(true);
+        }
+
+        Self {
+            context_all,
+            context_sparse,
+        }
+    }
+}
+
+impl Bencher {
+    const MEASUREMENT_TIME: Duration = Duration::from_millis(500);
+    const WARMUP_TIME: Duration = Duration::from_millis(200);
+
+    const WEIGHT: f64 = 1.0;
+    const MAX_DOC_ID: u64 = 1_000_000;
+    /// Step size for sparse child data (every 200th doc).
+    const SPARSE_STEP: usize = 200;
+    /// Step size for skip_to() calls.
+    const SKIP_TO_STEP: u64 = 100;
+
+    fn benchmark_group<'a>(
+        &self,
+        c: &'a mut Criterion,
+        label: &str,
+    ) -> BenchmarkGroup<'a, WallTime> {
+        let mut group = c.benchmark_group(label);
+        group.measurement_time(Self::MEASUREMENT_TIME);
+        group.warm_up_time(Self::WARMUP_TIME);
+        group
+    }
+
+    /// Dense child data: 99% of docs (all except every 100th doc).
+    fn dense_child() -> Vec<u64> {
+        (1..Self::MAX_DOC_ID).filter(|x| x % 100 != 0).collect()
+    }
+
+    /// Sparse child data: every 200th doc (half the sparse wildcard).
+    fn sparse_child() -> Vec<u64> {
+        (1..Self::MAX_DOC_ID).step_by(Self::SPARSE_STEP).collect()
+    }
+
+    pub fn bench(&self, c: &mut Criterion) {
+        self.read_empty_child(c);
+        self.read_dense_child(c);
+        self.read_sparse_wc(c);
+        self.skip_to_empty_child(c);
+        self.skip_to_sparse_child(c);
+        self.skip_to_dense_child(c);
+    }
+
+    /// Benchmark NOT-optimized with empty child (all wildcard docs returned).
+    fn read_empty_child(&self, c: &mut Criterion) {
+        let context = &self.context_all;
+        let mut group = self.benchmark_group(c, "Iterator - NotOptimized - Read Empty Child");
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
+                    NotOptimized::new(wc, Empty, Self::MAX_DOC_ID, Self::WEIGHT, None)
+                },
+                |it| {
+                    while let Ok(Some(current)) = it.read() {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe {
+                        QueryIterator::new_wildcard_optimized(context.sctx, Self::WEIGHT)
+                    };
+                    let child = QueryIterator::new_empty();
+                    QueryIterator::new_not_optimized(child, wc, Self::MAX_DOC_ID, Self::WEIGHT)
+                },
+                |it| {
+                    while it.read() == IteratorStatus_ITERATOR_OK {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark NOT-optimized with dense child (few docs returned).
+    fn read_dense_child(&self, c: &mut Criterion) {
+        let context = &self.context_all;
+        let mut group = self.benchmark_group(c, "Iterator - NotOptimized - Read Dense Child");
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
+                    NotOptimized::new(
+                        wc,
+                        IdListSorted::new(Self::dense_child()),
+                        Self::MAX_DOC_ID,
+                        Self::WEIGHT,
+                        None,
+                    )
+                },
+                |it| {
+                    while let Ok(Some(current)) = it.read() {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe {
+                        QueryIterator::new_wildcard_optimized(context.sctx, Self::WEIGHT)
+                    };
+                    let child = QueryIterator::new_id_list(Self::dense_child());
+                    QueryIterator::new_not_optimized(child, wc, Self::MAX_DOC_ID, Self::WEIGHT)
+                },
+                |it| {
+                    while it.read() == IteratorStatus_ITERATOR_OK {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark NOT-optimized with sparse wildcard (only 1% of docs exist).
+    fn read_sparse_wc(&self, c: &mut Criterion) {
+        let context = &self.context_sparse;
+        let mut group = self.benchmark_group(c, "Iterator - NotOptimized - Read Sparse WC");
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
+                    NotOptimized::new(
+                        wc,
+                        IdListSorted::new(Self::sparse_child()),
+                        Self::MAX_DOC_ID,
+                        Self::WEIGHT,
+                        None,
+                    )
+                },
+                |it| {
+                    while let Ok(Some(current)) = it.read() {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe {
+                        QueryIterator::new_wildcard_optimized(context.sctx, Self::WEIGHT)
+                    };
+                    let child = QueryIterator::new_id_list(Self::sparse_child());
+                    QueryIterator::new_not_optimized(child, wc, Self::MAX_DOC_ID, Self::WEIGHT)
+                },
+                |it| {
+                    while it.read() == IteratorStatus_ITERATOR_OK {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark NOT-optimized SkipTo with empty child.
+    fn skip_to_empty_child(&self, c: &mut Criterion) {
+        let context = &self.context_all;
+        let mut group = self.benchmark_group(c, "Iterator - NotOptimized - SkipTo Empty Child");
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
+                    NotOptimized::new(wc, Empty, Self::MAX_DOC_ID, Self::WEIGHT, None)
+                },
+                |it| {
+                    while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                    {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe {
+                        QueryIterator::new_wildcard_optimized(context.sctx, Self::WEIGHT)
+                    };
+                    let child = QueryIterator::new_empty();
+                    QueryIterator::new_not_optimized(child, wc, Self::MAX_DOC_ID, Self::WEIGHT)
+                },
+                |it| {
+                    while it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                        == IteratorStatus_ITERATOR_OK
+                    {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark NOT-optimized SkipTo with sparse child.
+    fn skip_to_sparse_child(&self, c: &mut Criterion) {
+        let context = &self.context_all;
+        let mut group = self.benchmark_group(c, "Iterator - NotOptimized - SkipTo Sparse Child");
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
+                    NotOptimized::new(
+                        wc,
+                        IdListSorted::new(Self::sparse_child()),
+                        Self::MAX_DOC_ID,
+                        Self::WEIGHT,
+                        None,
+                    )
+                },
+                |it| {
+                    while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                    {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe {
+                        QueryIterator::new_wildcard_optimized(context.sctx, Self::WEIGHT)
+                    };
+                    let child = QueryIterator::new_id_list(Self::sparse_child());
+                    QueryIterator::new_not_optimized(child, wc, Self::MAX_DOC_ID, Self::WEIGHT)
+                },
+                |it| {
+                    while it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                        == IteratorStatus_ITERATOR_OK
+                    {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark NOT-optimized SkipTo with dense child.
+    fn skip_to_dense_child(&self, c: &mut Criterion) {
+        let context = &self.context_all;
+        let mut group = self.benchmark_group(c, "Iterator - NotOptimized - SkipTo Dense Child");
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
+                    NotOptimized::new(
+                        wc,
+                        IdListSorted::new(Self::dense_child()),
+                        Self::MAX_DOC_ID,
+                        Self::WEIGHT,
+                        None,
+                    )
+                },
+                |it| {
+                    while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                    {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || {
+                    // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
+                    let wc = unsafe {
+                        QueryIterator::new_wildcard_optimized(context.sctx, Self::WEIGHT)
+                    };
+                    let child = QueryIterator::new_id_list(Self::dense_child());
+                    QueryIterator::new_not_optimized(child, wc, Self::MAX_DOC_ID, Self::WEIGHT)
+                },
+                |it| {
+                    while it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                        == IteratorStatus_ITERATOR_OK
+                    {
+                        black_box(it.current());
+                    }
+                    it.free();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+}

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -13,10 +13,12 @@ pub use ffi::{
     IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_OK,
     RedisModule_Alloc, RedisModule_Free, ValidateStatus, t_docId,
 };
-use inverted_index::RSIndexResult;
-use inverted_index::RSQueryTerm;
+use inverted_index::{RSIndexResult, RSQueryTerm};
 use iterators_ffi::intersection::NewIntersectionIterator;
-use std::{ffi::c_void, ptr};
+use std::{
+    ffi::c_void,
+    ptr::{self, NonNull},
+};
 
 /// Simple wrapper around the C `QueryIterator` type.
 /// All methods are inlined to avoid the overhead when benchmarking.
@@ -88,6 +90,47 @@ impl QueryIterator {
                 field::FieldMaskOrIndex::Mask(ffi::RS_FIELDMASK_ALL),
                 term,
                 1.0,
+            )
+        })
+    }
+
+    /// Create an optimized wildcard iterator from a search context.
+    ///
+    /// # Safety
+    ///
+    /// `sctx` must satisfy the preconditions of `NewWildcardIterator_Optimized`:
+    /// valid `RedisSearchCtx` with `spec.rule.index_all == true` and a valid
+    /// `spec.existingDocs` inverted index.
+    #[inline(always)]
+    pub unsafe fn new_wildcard_optimized(sctx: NonNull<ffi::RedisSearchCtx>, weight: f64) -> Self {
+        // SAFETY: Caller guarantees the preconditions of `NewWildcardIterator_Optimized`.
+        Self(unsafe {
+            iterators_ffi::wildcard::NewWildcardIterator_Optimized(sctx.as_ptr(), weight)
+        })
+    }
+
+    /// Create an optimized NOT iterator with the given child and wildcard iterators.
+    /// Uses `_New_NotIterator_With_WildCardIterator` which is the C benchmark constructor.
+    #[inline(always)]
+    pub fn new_not_optimized(child: Self, wc: Self, max_doc_id: u64, weight: f64) -> Self {
+        let timeout = ffi::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // REDISEARCH_UNINITIALIZED (-1 as u32) to skip timeout checks.
+        let timeout_counter = u32::MAX;
+
+        // SAFETY: `child.0` and `wc.0` are valid QueryIterator pointers created by
+        // the C API. Ownership of both is transferred to the new NOT iterator.
+        // `timeout` and `timeout_counter` are stack values with no pointer invariants.
+        Self(unsafe {
+            ffi::_New_NotIterator_With_WildCardIterator(
+                child.0,
+                wc.0,
+                max_doc_id,
+                weight,
+                timeout,
+                timeout_counter,
             )
         })
     }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -714,6 +714,21 @@ impl TestContext {
         tree.node_mut(index).range_mut().unwrap().entries_mut()
     }
 
+    /// Set [`SchemaRule::index_all`](ffi::SchemaRule::index_all).
+    ///
+    /// # Safety
+    ///
+    /// Must not be called while any iterator created from this context is
+    /// still alive, as it mutates the spec's rule through a raw pointer.
+    pub unsafe fn set_index_all(&self, value: bool) {
+        // SAFETY: Caller guarantees no iterators from this context are alive,
+        // so the write does not race. The spec and rule pointers are valid
+        // because they were created during TestContext construction.
+        unsafe {
+            (*(*self.spec.as_ptr()).rule).index_all = value;
+        }
+    }
+
     /// Initialize the TTL table if not already initialized.
     fn verify_ttl_init(&mut self) {
         // SAFETY: self.spec is a valid pointer created via IndexSpec_ParseC.


### PR DESCRIPTION
  | Benchmark | Rust | C | Rust speedup |                                                                                      
  |---|---|---|---|                                     
  | Read Empty Child | 2.78 ms | 4.32 ms | 1.55x |                                                                             
  | Read Dense Child | 3.25 ms | 4.28 ms | 1.32x |                                                                             
  | Read Sparse WC | 40.2 µs | 42.7 µs | 1.06x |                                                                               
  | SkipTo Empty Child | 424.7 µs | 441.3 µs | 1.04x |  
  | SkipTo Sparse Child | 446.2 µs | 464.6 µs | 1.04x |                                                                        
  | SkipTo Dense Child | 472.0 µs | 515.9 µs | 1.09x |  

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to benchmarking/test utilities, though they add new `unsafe` FFI helpers (`set_index_all`, `new_wildcard_optimized`) that rely on strict lifetime/ownership assumptions.
> 
> **Overview**
> Adds a new Criterion benchmark suite for the Rust `NotOptimized` iterator and registers it in `benches/iterators.rs`, comparing Rust vs C performance for both `read()` and `skip_to()` across empty, dense, and sparse child/wildcard scenarios.
> 
> To support these benches, extends the C `QueryIterator` wrapper with constructors for `NewWildcardIterator_Optimized` and the C benchmark-only optimized NOT constructor (`_New_NotIterator_With_WildCardIterator`), and adds `TestContext::set_index_all()` to flip `spec.rule.index_all` for wildcard-based setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed259c5647ab0989ca819350207dbb91999273bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->