### PR TITLE
Remove unimplemented function declarations from header files

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -291,8 +291,6 @@ int RSConfig_SetOption(RSConfig *config, RSConfigOptions *options, const char *n
 
 sds RSConfig_GetInfoString(const RSConfig *config);
 
-void RSConfig_AddToInfo(RedisModuleInfoCtx *ctx);
-
 void UpgradeDeprecatedMTConfigs();
 
 char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);

--- a/src/document.h
+++ b/src/document.h
@@ -212,7 +212,6 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, QueryError
 int Document_LoadAllFields(Document *doc, RedisModuleCtx *ctx);
 
 void Document_LoadPairwiseArgs(Document *doc, RedisModuleString **args, size_t nargs);
-void Document_LoadHSetParams(Document *d, const AddDocumentOptions *opts);
 
 /**
  * Free any copied data within the document. anyCtx is any non-NULL
@@ -376,9 +375,6 @@ size_t DocumentField_GetArrayValueCStrTotalLen(const DocumentField *df);
 
 // Document add functions:
 int RSAddDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int RSAddHashCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int RSSafeAddHashCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-
 int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocumentOptions *opts,
                    QueryError *status);
 

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -35,7 +35,6 @@ typedef struct LegacyNumericFilter {
 NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int inclusiveMax,
                                 bool asc, const FieldSpec *fs);
 LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status);
-int NumericFilter_EvalParams(dict *params, QueryNode *node, QueryError *status);
 void NumericFilter_Free(NumericFilter *nf);
 void LegacyNumericFilter_Free(LegacyNumericFilter *nf);
 

--- a/src/query_internal.h
+++ b/src/query_internal.h
@@ -74,7 +74,6 @@ QueryNode *NewGeometryNode_FromWkt_WithParams(struct QueryParseCtx *q, const cha
 QueryNode *NewGeofilterNode(QueryParam *p);
 QueryNode *NewVectorNode_WithParams(struct QueryParseCtx *q, VectorQueryType type, QueryToken *value, QueryToken *vec);
 QueryNode *NewTagNode(const FieldSpec *fs);
-QueryNode *NewVerbatimNode_WithParams(QueryParseCtx *q, QueryToken *qt);
 QueryNode *NewWildcardNode_WithParams(QueryParseCtx *q, QueryToken *qt);
 QueryNode *NewMissingNode(const FieldSpec *fs);
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -642,10 +642,8 @@ void IndexSpec_Free(IndexSpec *spec);
 void IndexSpec_AddTerm(IndexSpec *sp, const char *term, size_t len);
 
 IndexSpec *NewIndexSpec(const HiddenString *name);
-int IndexSpec_AddField(IndexSpec *sp, FieldSpec *fs);
 IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryError *status);
 void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp, int contextFlags);
-void IndexSpec_Digest(RedisModuleDigest *digest, void *value);
 int IndexSpec_RegisterType(RedisModuleCtx *ctx);
 // int IndexSpec_UpdateWithHash(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);
 void IndexSpec_ClearAliases(StrongRef ref);

--- a/src/stemmer.h
+++ b/src/stemmer.h
@@ -38,9 +38,6 @@ Stemmer *NewStemmer(StemmerType type, RSLanguage language);
 
 int ResetStemmer(Stemmer *stemmer, StemmerType type, RSLanguage language);
 
-/* Get a stemmer expander instance for registering it */
-void RegisterStemmerExpander();
-
 /* Snoball Stemmer wrapper implementation */
 const char *__sbstemmer_Stem(void *ctx, const char *word, size_t len, size_t *outlen);
 void __sbstemmer_Free(Stemmer *s);

--- a/src/synonym_map.h
+++ b/src/synonym_map.h
@@ -92,15 +92,6 @@ TermData* SynonymMap_GetIdsBySynonym(SynonymMap* smap, const char* synonym, size
 TermData** SynonymMap_DumpAllTerms(SynonymMap* smap, size_t* size);
 
 /**
- * Return an str representation of the given id
- * id - the id
- * buff - buffer to put the str representation
- * len - the buff len
- * return the size of the str written to buff
- */
-size_t SynonymMap_IdToStr(uint32_t id, char* buff, size_t len);
-
-/**
  * Return a read only copy of the given smap.
  * The read only copy is used in indexing to allow thread safe access to the synonym data structure
  * The read only copy is manage with ref count. The smap contains a reference to its read only copy


### PR DESCRIPTION
Those are not implemented anywhere.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low behavioral risk since code paths aren’t changing, but it is an ABI/API surface change that could break downstream compilation if anyone included and referenced these removed declarations.
> 
> **Overview**
> Removes several **stale/unimplemented** function declarations from public headers (`config.h`, `document.h`, `numeric_filter.h`, `query_internal.h`, `spec.h`, `stemmer.h`, `synonym_map.h`), including old document-add/hash helpers, numeric filter param evaluation, verbatim query node creation, spec digest/field-add hooks, and synonym/stemmer utilities.
> 
> This is a cleanup that reduces exposed surface area and prevents consumers from relying on APIs that have no backing implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45af2b57864fbaf5b51321fee5cc8763be62b607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->