### PR TITLE
skill: rust-benchmark to markdown

### DIFF
--- a/.skills/run-rust-benchmarks/SKILL.md
+++ b/.skills/run-rust-benchmarks/SKILL.md
@@ -26,6 +26,7 @@ Arguments provided: `$ARGUMENTS`
      ```
 2. **Run benchmarks only once.** If the output is too large or truncated, extract the timing data from the saved output file rather than re-running the benchmarks.
 3. Once the benchmarks are complete, generate a summary comparing the average run times between the Rust and C implementations.
+4. Ask the user: "Would you like a copyable markdown version for your PR description?" If yes, re-emit the summary table inside a fenced ` ```markdown ` code block so it can be pasted directly.
 
 ## Common Benchmark Commands
 


### PR DESCRIPTION
Small prompt to ease copying benchmarks report

I was a bit frustrated with claude skills not being markdown friendly, I ended up asking each time to output their response in a copyable fashion.

Or if anyone has a hint that makes this not useful? I guess we should be able to find the source of their output? But it doesn't seem very easily accessible, so that's a 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that tweaks the benchmark skill prompt; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the `.skills/run-rust-benchmarks/SKILL.md` instructions to ask users whether they want a **copyable markdown** version of the benchmark summary, and (if so) to re-emit the summary table inside a fenced ` ```markdown ` block for easy PR pasting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cacd3ae92ec10df57ccedd932588d5f03d2a11f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->