### PR TITLE
perf: Avoid runtime checks for properties in the safety contract

### DIFF
--- a/src/redisearch_rs/c_entrypoint/c_ffi_utils/src/opaque.rs
+++ b/src/redisearch_rs/c_entrypoint/c_ffi_utils/src/opaque.rs
@@ -73,6 +73,13 @@ macro_rules! opaque {
                 unsafe { opaque.cast::<Self>().as_ref() }
             }
 
+            pub unsafe fn from_opaque_ptr_unchecked<'__lt>(
+                opaque: *const $opaque_ty,
+            ) -> &'__lt Self {
+                // Safety: see trait's safety requirement.
+                unsafe { &*opaque.cast::<Self>() }
+            }
+
             pub unsafe fn from_opaque_mut_ptr<'__lt>(
                 opaque: *mut $opaque_ty,
             ) -> Option<&'__lt mut Self> {

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -329,15 +329,16 @@ pub unsafe extern "C-unwind" fn RLookupRow_WriteFieldsFrom<'a>(
 pub unsafe extern "C" fn RLookupRow_Get(
     key: *const RLookupKey,
     row: *const OpaqueRLookupRow,
-) -> Option<NonNull<RsValue>> {
+) -> *mut RsValue {
     // Safety: ensured by caller (1.)
-    let key = unsafe { key.as_ref().unwrap() };
+    let key = unsafe { &*key };
 
     // Safety: ensured by caller (2.)
-    let row = unsafe { RLookupRow::from_opaque_ptr(row).unwrap() };
+    let row = unsafe { RLookupRow::from_opaque_ptr_unchecked(row) };
 
     row.get(key)
-        .map(|x| NonNull::new(x.as_ptr().cast_mut()).unwrap())
+        .map(|x| x.as_ptr().cast_mut())
+        .unwrap_or(std::ptr::null_mut())
 }
 
 /// Returns the sorting vector for the row, or null if none exists.


### PR DESCRIPTION
## Describe the changes in the pull request

Minimize runtime overhead.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces defensive pointer validation in unsafe FFI paths by switching to unchecked dereferencing; if callers violate the documented non-null/valid pointer contract, this can now trigger immediate UB instead of returning `NULL`/panicking.
> 
> **Overview**
> Optimizes the FFI boundary by removing runtime null/validity checks when converting opaque pointers.
> 
> Adds `from_opaque_ptr_unchecked` to the `opaque!` macro and updates `RLookupRow_Get` to use unchecked dereferencing and return a raw `*mut RsValue` (returning `NULL` when missing), avoiding `Option`/`NonNull` wrapping overhead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcc71ab9ac7e3596c82d3b13038a664619d1c085. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->