### PR TITLE
fix potential compilation issue

### DIFF
--- a/src/buffer/CMakeLists.txt
+++ b/src/buffer/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Build the `buffer` module as a standalone static library
-# This is a temporary requirement to allow us to benchmark the
-# Rust implementation of the encoders/decoders against the original C implementation.
+# Build the `buffer` module as an object library for inclusion in libredisearch_all.a
+# This is required because the main CMakeLists.txt uses $<TARGET_OBJECTS:buffer>
 file(GLOB BUFFER_SOURCES "buffer.c")
-add_library(buffer STATIC ${BUFFER_SOURCES})
+add_library(buffer OBJECT ${BUFFER_SOURCES})
 target_include_directories(buffer PRIVATE . ..)

--- a/src/index_result/CMakeLists.txt
+++ b/src/index_result/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Build the `index_result` module as an object library for inclusion in libredisearch_all.a
+# This is required because the main CMakeLists.txt uses $<TARGET_OBJECTS:index_result>
 file(GLOB SOURCES "index_result.c")
-add_library(index_result STATIC ${SOURCES})
+add_library(index_result OBJECT ${SOURCES})
 target_include_directories(index_result PRIVATE . ..)

--- a/src/iterators/CMakeLists.txt
+++ b/src/iterators/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Build the `iterators` module as a standalone static library
-# This is a temporary requirement to allow us to benchmark the
-# Rust implementation of the iterators against the original C implementation.
+# Build the `iterators` module as an object library for inclusion in libredisearch_all.a
+# This is required because the main CMakeLists.txt uses $<TARGET_OBJECTS:iterators>
 file(GLOB ITERATORS_SOURCES "*.c")
-add_library(iterators STATIC ${ITERATORS_SOURCES})
+add_library(iterators OBJECT ${ITERATORS_SOURCES})
 target_include_directories(iterators PRIVATE . ..)

--- a/src/value/CMakeLists.txt
+++ b/src/value/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Build the `value` module as an object library for inclusion in libredisearch_all.a
+# This is required because the main CMakeLists.txt uses $<TARGET_OBJECTS:value>
 file(GLOB SOURCES "value.c")
-add_library(value STATIC ${SOURCES})
+add_library(value OBJECT ${SOURCES})
 target_include_directories(value PRIVATE . ..)

--- a/src/wildcard/CMakeLists.txt
+++ b/src/wildcard/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Build the `wildcard` module as a standalone static library
-# This is a temporary requirement to allow us to benchmark the
-# Rust implementation of the triemap against the original C implementation.
+# Build the `wildcard` module as an object library for inclusion in libredisearch_all.a
+# This is required because the main CMakeLists.txt uses $<TARGET_OBJECTS:wildcard>
 file(GLOB ARR_SOURCES "wildcard.c")
-add_library(wildcard STATIC ${ARR_SOURCES})
+add_library(wildcard OBJECT ${ARR_SOURCES})
 target_include_directories(wildcard PRIVATE . ..)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CMake target types, but could affect build/link behavior for consumers expecting standalone static archives.
> 
> **Overview**
> Aligns several src submodules with the top-level build by switching `buffer`, `iterators`, `wildcard`, `index_result`, and `value` from `STATIC` libraries to `OBJECT` libraries so they can be included via `$<TARGET_OBJECTS:...>` when producing the unified `libredisearch_all.a`/final artifacts.
> 
> Removes outdated benchmarking-focused comments and replaces them with notes explaining the object-library requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f07b2eed4a865145724f3a8ee0a133ae19e85a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->