### PR TITLE
Build iterators library as object

### DIFF
--- a/src/iterators/CMakeLists.txt
+++ b/src/iterators/CMakeLists.txt
@@ -2,5 +2,5 @@
 # This is a temporary requirement to allow us to benchmark the
 # Rust implementation of the iterators against the original C implementation.
 file(GLOB ITERATORS_SOURCES "*.c")
-add_library(iterators STATIC ${ITERATORS_SOURCES})
+add_library(iterators OBJECT ${ITERATORS_SOURCES})
 target_include_directories(iterators PRIVATE . ..)


### PR DESCRIPTION
`IntersectionIteratorReducer` was previously not called from Rust, and this broke in a downstream dependency, this PR is a fix attempt.

This will need comments fixes, polish and more analysis.

:warning: This didn't fix downstream issue, keeping open until resolution is known.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-system-only change that alters how the `iterators` C sources are packaged, which could affect downstream linking but does not change runtime logic.
> 
> **Overview**
> Switches the `iterators` CMake target from a `STATIC` library to an `OBJECT` library, changing how its `.c` sources are compiled and consumed by downstream targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644263cc77399efac7974f1fbb689ed514f3b4ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->