### PR TITLE
Fix PR size label

### DIFF
--- a/.github/workflows/pr_label_size.yml
+++ b/.github/workflows/pr_label_size.yml
@@ -15,7 +15,7 @@ jobs:
           uses: actions/github-script@v7
           with:
             script: |
-              # This is a work-around until https://github.com/CodelyTV/pr-size-labeler/pull/97 is merged.
+              // This is a work-around until https://github.com/CodelyTV/pr-size-labeler/pull/97 is merged.
               const { data: labels } = await github.rest.issues.listLabelsOnIssue({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
When updating a PR, a new size label is sometimes added. But the old one stayed behind. Fix that.

This (below) shows that it works

<img width="422" height="109" alt="image" src="https://github.com/user-attachments/assets/506ec0b5-b319-42d8-8ec6-b5c0ba42a5d2" />

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts GitHub label management; main risk is mis-removing labels that share the `size:` prefix.
> 
> **Overview**
> Fixes PR size labeling so updates don’t leave multiple size labels behind.
> 
> The workflow now first removes any existing `size:*` labels via `actions/github-script` before running `codelytv/pr-size-labeler`, acting as a workaround for the upstream action’s current behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17a0ff175aaf5bbb7000413fecc5a02d4138a0d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->