### PR TITLE
[MOD-13606] Enable LTO for Rocky Linux 9 x86_64

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -197,7 +197,7 @@ jobs:
                       'container': 'rockylinux:9',
                       'setup_script': 'dnf update -y && dnf install -y git',
                       'name': 'Rocky Linux 9 x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'rockylinux:9',


### PR DESCRIPTION
Enable LTO for Rocky Linux 9 x86_64.
(My previous comment was wrong, a new binary was _not_ needed.)

Test run
https://github.com/RediSearch/RediSearch/actions/runs/23703667439

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8bd84e2bd881dbc1fdac7c9b2dae2d5bd170b3ca. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->