### PR TITLE
Fix CVE - Upgrade setuptools

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -2,4 +2,4 @@ redisbench_admin==0.12.9
 numpy>=2.0.0
 pandas
 requests
-setuptools<75.0.0  # Required for pkg_resources compatibility with redisbench-admin
+setuptools>=78.1.1


### PR DESCRIPTION
Fix CVE
https://github.com/RediSearch/RediSearch/security/dependabot/8
by upgrading `setuptools`.

As per this commit
https://github.com/redis-performance/redisbench-admin/commit/ee120f0ac9346adae08d3e57beaf295cf0175732
the `pkg_resources` issue previously mentioned would appear to have been already solved.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to the `tests/benchmarks` environment; potential risk is only if the newer `setuptools` causes install/build issues in that test setup.
> 
> **Overview**
> Upgrades `tests/benchmarks/requirements.txt` to replace the previous `setuptools<75.0.0` pin with `setuptools>=78.1.1`, aligning benchmark dependencies with the updated `redisbench_admin`/`pkg_resources` compatibility and addressing the referenced CVE.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a402c9bf669726dab55ecb715cd488f9d6192ca5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->