### PR TITLE
RSE perf - RLookupRow_CmpByFields

### DIFF
--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
@@ -33,7 +33,7 @@ prefix_with_name = true
 
 [export]
 include = ["RLookupKeyFlag", "RLookupOption"]
-exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "SchemaRule"]
+exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "RSValue_Cmp", "SchemaRule"]
 
 [export.rename]
 "OpaqueRLookup" = "RLookup"

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -11,12 +11,17 @@ use ffi::RSValue;
 use libc::size_t;
 use rlookup::{OpaqueRLookupRow, RLookup, RLookupKey, RLookupRow};
 use std::{
-    ffi::{CStr, c_char},
+    ffi::{CStr, c_char, c_int, c_void},
     mem::{self, ManuallyDrop},
     ptr::{self, NonNull},
     slice,
 };
 use value::RSValueFFI;
+
+// C-implemented value comparison — the value layer hasn't been fully ported to Rust yet.
+unsafe extern "C" {
+    fn RSValue_Cmp(v1: *const RSValue, v2: *const RSValue, qerr: *mut c_void) -> c_int;
+}
 
 /// Returns a newly created [`RLookupRow`].
 #[unsafe(no_mangle)]
@@ -372,4 +377,76 @@ pub unsafe extern "C" fn RLookupRow_SetSortingVector(
     let sv = unsafe { sv.as_ref() };
 
     row.set_sorting_vector(sv);
+}
+
+/// Maximum number of sort fields, mirroring `SORTASCMAP_MAXFIELDS` in C.
+const SORTASCMAP_MAXFIELDS: usize = 8;
+
+/// Compare two [`RLookupRow`]s by a set of sort keys.
+///
+/// Returns `-1` if `row1 < row2`, `0` if all keys are equal (caller should
+/// use docId tiebreak), or `1` if `row1 > row2`.
+///
+/// This batches all per-key lookups and value comparisons into a single FFI
+/// call, avoiding repeated FFI boundary crossings in the hot sort path.
+///
+/// # Safety
+///
+/// 1. `keys` must be a [valid] pointer to an array of at least `nkeys` [valid]
+///    pointers to [`RLookupKey`]s.
+/// 2. `nkeys` must not exceed `SORTASCMAP_MAXFIELDS` (8).
+/// 3. `row1` must be a [valid], non-null pointer to an [`RLookupRow`].
+/// 4. `row2` must be a [valid], non-null pointer to an [`RLookupRow`].
+/// 5. `qerr`, when non-null, must be a [valid], writable pointer to a
+///    `QueryError`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RLookupRow_CmpByFields(
+    keys: *const *const RLookupKey,
+    nkeys: usize,
+    row1: *const OpaqueRLookupRow,
+    row2: *const OpaqueRLookupRow,
+    ascend_map: u64,
+    qerr: *mut c_void,
+) -> c_int {
+    // Safety: ensured by caller (3.)
+    let row1 = unsafe { RLookupRow::from_opaque_ptr(row1).unwrap() };
+
+    // Safety: ensured by caller (4.)
+    let row2 = unsafe { RLookupRow::from_opaque_ptr(row2).unwrap() };
+
+    let nkeys = nkeys.min(SORTASCMAP_MAXFIELDS);
+
+    // Safety: ensured by caller (1.)
+    let keys = unsafe { slice::from_raw_parts(keys, nkeys) };
+
+    for (i, &key_ptr) in keys.iter().enumerate() {
+        // Safety: ensured by caller (1.) — each element is a valid RLookupKey pointer
+        let key = unsafe { key_ptr.as_ref().unwrap() };
+
+        let v1 = row1.get(key);
+        let v2 = row2.get(key);
+
+        let ascending = (ascend_map & (1u64 << i)) != 0;
+
+        match (v1, v2) {
+            // If at least one has no sort key, it gets high value regardless of asc/desc
+            (Some(_), None) => return 1,
+            (None, Some(_)) => return -1,
+            (None, None) => continue,
+            (Some(v1), Some(v2)) => {
+                // Safety: RSValueFFI holds valid RSValue pointers, and qerr is
+                // either null or valid per caller (5.)
+                let rc = unsafe { RSValue_Cmp(v1.as_ptr(), v2.as_ptr(), qerr) };
+
+                if rc != 0 {
+                    return if ascending { -rc } else { rc };
+                }
+            }
+        }
+    }
+
+    // All keys equal — caller handles docId tiebreak
+    0
 }

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -780,6 +780,34 @@ const struct RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRo
 void RLookupRow_SetSortingVector(struct RLookupRow *row,
                                  const struct RSSortingVector *sv);
 
+/**
+ * Compare two [`RLookupRow`]s by a set of sort keys.
+ *
+ * Returns `-1` if `row1 < row2`, `0` if all keys are equal (caller should
+ * use docId tiebreak), or `1` if `row1 > row2`.
+ *
+ * This batches all per-key lookups and value comparisons into a single FFI
+ * call, avoiding repeated FFI boundary crossings in the hot sort path.
+ *
+ * # Safety
+ *
+ * 1. `keys` must be a [valid] pointer to an array of at least `nkeys` [valid]
+ *    pointers to [`RLookupKey`]s.
+ * 2. `nkeys` must not exceed `SORTASCMAP_MAXFIELDS` (8).
+ * 3. `row1` must be a [valid], non-null pointer to an [`RLookupRow`].
+ * 4. `row2` must be a [valid], non-null pointer to an [`RLookupRow`].
+ * 5. `qerr`, when non-null, must be a [valid], writable pointer to a
+ *    `QueryError`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+int RLookupRow_CmpByFields(const struct RLookupKey *const *keys,
+                           uintptr_t nkeys,
+                           const struct RLookupRow *row1,
+                           const struct RLookupRow *row2,
+                           uint64_t ascend_map,
+                           void *qerr);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -14,6 +14,11 @@ use std::{
 };
 
 use icu_casemap::CaseMapper;
+use icu_casemap::CaseMapperBorrowed;
+
+thread_local! {
+    static CASE_MAPPER: CaseMapperBorrowed<'static> = const { CaseMapper::new() };
+}
 use value::RSValueFFI;
 
 /// IndexOutOfBounds error can be returned by [`RSSortingVector::try_insert_num`] and the other `try_insert_*` methods.
@@ -87,9 +92,7 @@ impl RSSortingVector {
         idx: usize,
         str: impl AsRef<str>,
     ) -> Result<(), IndexOutOfBounds> {
-        let casemapper = CaseMapper::new();
-
-        let normalized = casemapper.fold_string(str.as_ref()).into_owned();
+        let normalized = CASE_MAPPER.with(|cm| cm.fold_string(str.as_ref()).into_owned());
 
         self.try_insert_string(idx, normalized.into_bytes())
     }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -724,35 +724,24 @@ static inline int cmpByScore(const void *e1, const void *e2, const void *udata) 
 static int cmpByFields(const void *e1, const void *e2, const void *udata) {
   const RPSorter *self = udata;
   const SearchResult *h1 = e1, *h2 = e2;
-  int ascending = 0;
 
   QueryError *qerr = NULL;
   if (self && self->base.parent && self->base.parent->err) {
     qerr = self->base.parent->err;
   }
 
-  for (size_t i = 0; i < self->fieldcmp.nkeys && i < SORTASCMAP_MAXFIELDS; i++) {
-    const RSValue *v1 = RLookupRow_Get(self->fieldcmp.keys[i], SearchResult_GetRowData(h1));
-    const RSValue *v2 = RLookupRow_Get(self->fieldcmp.keys[i], SearchResult_GetRowData(h2));
-    // take the ascending bit for this property from the ascending bitmap
-    ascending = SORTASCMAP_GETASC(self->fieldcmp.ascendMap, i);
-    if (!v1 || !v2) {
-      // If at least one of these has no sort key, it gets high value regardless of asc/desc
-      if (v1) {
-        return 1;
-      } else if (v2) {
-        return -1;
-      } else {
-        // Both have no sort key, so they are equal. Continue to next sort key
-        continue;
-      }
-    }
+  int rc = RLookupRow_CmpByFields(
+    self->fieldcmp.keys, self->fieldcmp.nkeys,
+    SearchResult_GetRowData(h1), SearchResult_GetRowData(h2),
+    self->fieldcmp.ascendMap, qerr);
 
-    int rc = RSValue_Cmp(v1, v2, qerr);
-    if (rc != 0) return ascending ? -rc : rc;
-  }
+  if (rc != 0) return rc;
 
-  int rc = SearchResult_GetDocId(h1) < SearchResult_GetDocId(h2) ? -1 : 1;
+  // Tiebreak by docId, using the last key's ascending bit
+  int ascending = self->fieldcmp.nkeys > 0
+    ? SORTASCMAP_GETASC(self->fieldcmp.ascendMap, self->fieldcmp.nkeys - 1)
+    : 0;
+  rc = SearchResult_GetDocId(h1) < SearchResult_GetDocId(h2) ? -1 : 1;
   return ascending ? -rc : rc;
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sort comparator used in the result heap and introduces a new cross-language FFI entrypoint; incorrect comparison semantics or error propagation could affect query result ordering and stability in a hot path.
> 
> **Overview**
> Moves per-field sort comparison for search results into a new Rust FFI helper `RLookupRow_CmpByFields`, replacing the C loop in `cmpByFields` to reduce repeated lookups/FFI crossings and leaving docId as a C-side tiebreak.
> 
> Optimizes string normalization in `sorting_vector` by reusing a thread-local ICU case mapper instead of constructing a new `CaseMapper` per call, and updates cbindgen config/header generation to expose the new comparison API while excluding the imported `RSValue_Cmp` symbol.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48793c59787c8a8fde336c541123cbbe8a3adefa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->