### PR TITLE
RSE perf - Accessors

### DIFF
--- a/src/redisearch_rs/buffer/tests/tests.rs
+++ b/src/redisearch_rs/buffer/tests/tests.rs
@@ -324,8 +324,8 @@ fn buffer_from_array<const N: usize>(a: [u8; N]) -> Buffer {
 /// Mock implementation of Buffer_Grow for tests
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
-pub extern "C" fn Buffer_Grow(buffer: *mut ffi::Buffer, extra_len: usize) -> usize {
-    // Safety: buffer is a valid pointer to a Buffer.
+pub unsafe extern "C" fn Buffer_Grow(buffer: *mut ffi::Buffer, extra_len: usize) -> usize {
+    // SAFETY: buffer is a valid pointer to a Buffer, guaranteed by the caller.
     let buffer = unsafe { &mut *buffer };
     let old_capacity = buffer.cap;
 
@@ -344,12 +344,12 @@ pub extern "C" fn Buffer_Grow(buffer: *mut ffi::Buffer, extra_len: usize) -> usi
 /// Mock implementation of BufferFree for tests
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
-pub extern "C" fn Buffer_Free(buffer: *mut ffi::Buffer) -> usize {
+pub unsafe extern "C" fn Buffer_Free(buffer: *mut ffi::Buffer) -> usize {
     if buffer.is_null() {
         return 0;
     }
 
-    // Safety: buffer is a valid pointer to a Buffer.
+    // SAFETY: buffer is a valid pointer to a Buffer, guaranteed by the caller.
     let buffer = unsafe { &mut *buffer };
 
     let layout = Layout::array::<c_char>(buffer.cap).unwrap();

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
@@ -33,7 +33,7 @@ prefix_with_name = true
 
 [export]
 include = ["RLookupKeyFlag", "RLookupOption"]
-exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "SchemaRule"]
+exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "SchemaRule", "RSSortingVector"]
 
 [export.rename]
 "OpaqueRLookup" = "RLookup"

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/cbindgen.toml
@@ -6,10 +6,36 @@ after_includes = """
 // Forward declaration of RSValue, which is only used as ptr in the sorting_vector module
 typedef struct RSValue RSValue;
 
-// Forward declaration of SortingVector, which is only used as ptr in the sorting_vector module
-typedef struct RSSortingVector RSSortingVector;
+/**
+ * `RSSortingVector` acts as a cache for sortable fields in a document.
+ *
+ * The struct is `#[repr(C)]` in Rust. `values` is an array of `len` RSValue
+ * pointers. Simple getters (length, element access) can read the fields
+ * directly without crossing the FFI boundary.
+ */
+typedef struct RSSortingVector {
+    size_t len;
+    RSValue **values;
+} RSSortingVector;
+
+/**
+ * Returns the element at `idx`. No bounds check.
+ */
+static inline RSValue *RSSortingVector_Get(const RSSortingVector *sv, size_t idx) {
+    return sv->values[idx];
+}
+
+/**
+ * Returns the number of elements.
+ */
+static inline size_t RSSortingVector_Length(const RSSortingVector *sv) {
+    return sv->len;
+}
 """
 
 [parse]
 parse_deps = true
 include = []
+
+[export]
+exclude = ["RSSortingVector"]

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
@@ -19,42 +19,9 @@ use value::RSValueFFI;
 
 pub const RS_SORTABLES_MAX: usize = 1024;
 
-/// Gets a RSValue from the sorting vector at the given index.
-///
-/// # Panics
-///
-/// Panics if the `idx` is out of bounds for the vector.
-///
-/// # Safety
-///
-/// 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
-///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_Get(
-    vec: *const RSSortingVector,
-    idx: size_t,
-) -> *mut ffi::RSValue {
-    // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.as_ref().expect("vec must not be null") };
-
-    vec[idx].as_ptr()
-}
-
-/// Returns the length of the sorting vector.
-///
-/// # Safety
-///
-/// 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
-///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_Length(vec: *const RSSortingVector) -> size_t {
-    // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.as_ref().expect("vec must not be null") };
-
-    vec.len() as size_t
-}
+// NOTE: RSSortingVector_Get and RSSortingVector_Length are now inline C functions
+// defined in the generated header (cbindgen.toml `after_includes`). They read
+// the `#[repr(C)]` struct fields directly, avoiding FFI function-call overhead.
 
 /// Returns the memory size of the sorting vector.
 ///

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -120,18 +120,6 @@ typedef struct IndexSpecCache IndexSpecCache;
 typedef struct RLookup RLookup;
 
 /**
- * [`RSSortingVector`] acts as a cache for sortable fields in a document.
- *
- * It has a constant length, determined upfront on creation. It can't be resized.
- * The [`RSSortingVector`] may contain values of different types, such as numbers, strings, or references to other values.
- * This depends on the fields in the source document.
- *
- * The fields in the sorting vector occur in the same order as they appeared in the document. Fields that are not sortable,
- * are not added at all to the sorting vector, i.e. the sorting vector does not contain null values for non-sortable fields.
- */
-typedef struct RSSortingVector RSSortingVector;
-
-/**
  * A type with size `N`.
  */
 typedef uint8_t Size_40[40];
@@ -765,7 +753,7 @@ RSValue *RLookupRow_Get(const struct RLookupKey *key, const struct RLookupRow *r
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-const struct RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRow *row);
+const RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRow *row);
 
 /**
  * Sets the sorting vector for the row.
@@ -778,7 +766,7 @@ const struct RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRo
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RLookupRow_SetSortingVector(struct RLookupRow *row,
-                                 const struct RSSortingVector *sv);
+                                 const RSSortingVector *sv);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/sorting_vector.h
+++ b/src/redisearch_rs/headers/sorting_vector.h
@@ -9,8 +9,31 @@
 // Forward declaration of RSValue, which is only used as ptr in the sorting_vector module
 typedef struct RSValue RSValue;
 
-// Forward declaration of SortingVector, which is only used as ptr in the sorting_vector module
-typedef struct RSSortingVector RSSortingVector;
+/**
+ * `RSSortingVector` acts as a cache for sortable fields in a document.
+ *
+ * The struct is `#[repr(C)]` in Rust. `values` is an array of `len` RSValue
+ * pointers. Simple getters (length, element access) can read the fields
+ * directly without crossing the FFI boundary.
+ */
+typedef struct RSSortingVector {
+    size_t len;
+    RSValue **values;
+} RSSortingVector;
+
+/**
+ * Returns the element at `idx`. No bounds check.
+ */
+static inline RSValue *RSSortingVector_Get(const RSSortingVector *sv, size_t idx) {
+    return sv->values[idx];
+}
+
+/**
+ * Returns the number of elements.
+ */
+static inline size_t RSSortingVector_Length(const RSSortingVector *sv) {
+    return sv->len;
+}
 
 
 #define RS_SORTABLES_MAX 1024
@@ -18,33 +41,6 @@ typedef struct RSSortingVector RSSortingVector;
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-/**
- * Gets a RSValue from the sorting vector at the given index.
- *
- * # Panics
- *
- * Panics if the `idx` is out of bounds for the vector.
- *
- * # Safety
- *
- * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-RSValue *RSSortingVector_Get(const RSSortingVector *vec,
-                             size_t idx);
-
-/**
- * Returns the length of the sorting vector.
- *
- * # Safety
- *
- * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-size_t RSSortingVector_Length(const RSSortingVector *vec);
 
 /**
  * Returns the memory size of the sorting vector.

--- a/src/redisearch_rs/inverted_index/tests/integration/controlled_cursor.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/controlled_cursor.rs
@@ -105,7 +105,7 @@ fn test_seek_and_overwrite() {
         let mut cursor = ControlledCursor::new(&mut buffer);
 
         // Write initial data
-        cursor.write(b"XXXXXXXXXX").expect("Write failed");
+        cursor.write_all(b"XXXXXXXXXX").expect("Write failed");
     }
     assert_eq!(&buffer[..], b"XXXXXXXXXX");
 
@@ -116,7 +116,7 @@ fn test_seek_and_overwrite() {
         cursor.seek(SeekFrom::Start(2)).expect("Seek failed");
 
         // Overwrite with new data
-        cursor.write(b"test").expect("Write failed");
+        cursor.write_all(b"test").expect("Write failed");
     }
 
     // Verify the overwrite

--- a/src/redisearch_rs/redis_mock/src/reply/mod.rs
+++ b/src/redisearch_rs/redis_mock/src/reply/mod.rs
@@ -21,6 +21,7 @@ pub use capture::capture_replies;
 pub use value::ReplyValue;
 
 #[cfg(test)]
+#[expect(clippy::approx_constant)] // 3.14 is an arbitrary test value, not an approximation of PI
 mod tests {
     use std::ffi::c_longlong;
 

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -209,7 +209,7 @@ impl<'a> RLookupRow<'a> {
             //   `if (ret != NULL && ret == RSValue_NullStatic()) ret = NULL;`
             self.sorting_vector()?
                 .get(key.svidx as usize)
-                .filter(|v| v.get_type() != ffi::RSValueType_RSValueType_Null)
+                .filter(|v| !v.is_null())
         } else {
             None
         }

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -38,45 +38,89 @@ impl std::error::Error for IndexOutOfBounds {}
 ///
 /// The fields in the sorting vector occur in the same order as they appeared in the document. Fields that are not sortable,
 /// are not added at all to the sorting vector, i.e. the sorting vector does not contain null values for non-sortable fields.
-#[derive(Debug, Clone)]
+///
+/// The struct uses `#[repr(C)]` to allow C code to directly access `len` and `values` without FFI
+/// function calls. This is critical for performance in the sort comparison hot path.
+#[repr(C)]
 pub struct RSSortingVector {
-    values: Box<[RSValueFFI]>,
+    /// Number of elements in the values array.
+    pub len: usize,
+    /// Pointer to a heap-allocated array of [`RSValueFFI`] elements.
+    ///
+    /// # Invariant
+    ///
+    /// When `len > 0`, `values` is a valid, non-null pointer to an allocation of exactly `len`
+    /// elements produced by `Vec::into_raw_parts`. When `len == 0`, `values` may be dangling
+    /// (from `Vec::new()`).
+    pub values: *mut RSValueFFI,
 }
+
+// SAFETY: The raw pointer `values` is an owned heap allocation that is never shared.
+// RSSortingVector has exclusive ownership of the allocation, similar to `Box<[RSValueFFI]>`.
+unsafe impl Send for RSSortingVector {}
+
+// SAFETY: RSSortingVector does not provide interior mutability through shared references.
+// All mutation requires `&mut self`.
+unsafe impl Sync for RSSortingVector {}
 
 impl RSSortingVector {
     /// Creates a new [`RSSortingVector`] with the given length.
     pub fn new(len: usize) -> Self {
-        Self {
-            values: vec![RSValueFFI::null_static(); len].into_boxed_slice(),
+        let vec = vec![RSValueFFI::null_static(); len];
+        let (values, actual_len, _cap) = vec.into_raw_parts();
+        debug_assert_eq!(actual_len, len);
+        Self { len, values }
+    }
+
+    /// Returns a shared slice over the values.
+    #[inline]
+    fn as_slice(&self) -> &[RSValueFFI] {
+        if self.len == 0 {
+            &[]
+        } else {
+            // SAFETY: `values` points to a valid allocation of `len` elements (struct invariant).
+            unsafe { std::slice::from_raw_parts(self.values, self.len) }
+        }
+    }
+
+    /// Returns a mutable slice over the values.
+    #[inline]
+    fn as_slice_mut(&mut self) -> &mut [RSValueFFI] {
+        if self.len == 0 {
+            &mut []
+        } else {
+            // SAFETY: `values` points to a valid allocation of `len` elements (struct invariant),
+            // and we have exclusive access via `&mut self`.
+            unsafe { std::slice::from_raw_parts_mut(self.values, self.len) }
         }
     }
 
     /// Returns an immutable reference to the value at index `index`,
     /// or `None` if the index is out-of-bounds for this sorting vector.
     pub fn get(&self, index: usize) -> Option<&RSValueFFI> {
-        self.values.get(index)
+        self.as_slice().get(index)
     }
 
     /// Returns an iterator over the values in the sorting vector.
     pub fn iter(&self) -> Iter<'_, RSValueFFI> {
-        self.values.iter()
+        self.as_slice().iter()
     }
 
     /// Returns a mutable iterator over the values in the sorting vector.
     pub fn iter_mut(&mut self) -> IterMut<'_, RSValueFFI> {
-        self.values.iter_mut()
+        self.as_slice_mut().iter_mut()
     }
 
     /// Set a number (double) at the given index
     pub fn try_insert_num(&mut self, idx: usize, num: f64) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_num(num);
         Ok(())
     }
 
     /// Set a string at the given index.
     pub fn try_insert_string(&mut self, idx: usize, str: Vec<u8>) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_string(str);
         Ok(())
     }
@@ -100,26 +144,26 @@ impl RSSortingVector {
         idx: usize,
         value: RSValueFFI,
     ) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = value;
         Ok(())
     }
 
     /// Set a null value at the given index
     pub fn try_insert_null(&mut self, idx: usize) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::null_static();
         Ok(())
     }
 
     /// Get the len of the sorting vector.
     pub fn len(&self) -> usize {
-        self.values.len()
+        self.len
     }
 
     /// check if the sorting vector is empty.
     pub fn is_empty(&self) -> bool {
-        self.values.is_empty()
+        self.len == 0
     }
 
     /// approximate the memory size of the sorting vector.
@@ -127,10 +171,11 @@ impl RSSortingVector {
     /// The implementation by-passes references in the middle of the chain, so it only counts the size of the final value,
     /// as in C.
     pub fn get_memory_size(&self) -> usize {
-        let mut sz = self.values.len() * size_of::<RSValueFFI>();
+        let slice = self.as_slice();
+        let mut sz = slice.len() * size_of::<RSValueFFI>();
 
-        for idx in 0..self.values.len() {
-            if self.values[idx].is_null() {
+        for idx in 0..slice.len() {
+            if slice[idx].is_null() {
                 continue;
             }
 
@@ -138,7 +183,7 @@ impl RSSortingVector {
 
             // the original behavior would by-pass references in the middle of the chain
             // fixup in: MOD-10347
-            let value = self.values[idx].deep_deref();
+            let value = slice[idx].deep_deref();
 
             if value.get_type() == ffi::RSValueType_RSValueType_String {
                 sz += value.as_str_bytes().unwrap().len();
@@ -148,11 +193,40 @@ impl RSSortingVector {
     }
 }
 
+impl Clone for RSSortingVector {
+    fn clone(&self) -> Self {
+        // Clone each element (incrementing refcounts) and collect into a new Vec.
+        let cloned: Vec<RSValueFFI> = self.as_slice().iter().cloned().collect();
+        let (values, len, _cap) = cloned.into_raw_parts();
+        Self { len, values }
+    }
+}
+
+impl fmt::Debug for RSSortingVector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RSSortingVector")
+            .field("len", &self.len)
+            .field("values", &self.as_slice())
+            .finish()
+    }
+}
+
+impl Drop for RSSortingVector {
+    fn drop(&mut self) {
+        if self.len > 0 {
+            // SAFETY: `values` was allocated by `Vec::into_raw_parts` with exactly `len` elements
+            // and capacity equal to `len`. Reconstructing the Vec and dropping it frees the
+            // allocation and drops each `RSValueFFI` (decrementing refcounts).
+            let _ = unsafe { Vec::from_raw_parts(self.values, self.len, self.len) };
+        }
+    }
+}
+
 impl FromIterator<RSValueFFI> for RSSortingVector {
     fn from_iter<T: IntoIterator<Item = RSValueFFI>>(iter: T) -> Self {
-        Self {
-            values: iter.into_iter().collect(),
-        }
+        let vec: Vec<RSValueFFI> = iter.into_iter().collect();
+        let (values, len, _cap) = vec.into_raw_parts();
+        Self { len, values }
     }
 }
 
@@ -161,8 +235,18 @@ impl IntoIterator for RSSortingVector {
     type Item = RSValueFFI;
     type IntoIter = std::vec::IntoIter<RSValueFFI>;
     fn into_iter(self) -> Self::IntoIter {
-        // this does not use a new allocation
-        Vec::from(self.values).into_iter()
+        let len = self.len;
+        let values = self.values;
+        // Prevent Drop from running (which would free the same allocation).
+        std::mem::forget(self);
+
+        if len == 0 {
+            return Vec::new().into_iter();
+        }
+
+        // SAFETY: `values` was produced by `Vec::into_raw_parts` with capacity == len.
+        let vec = unsafe { Vec::from_raw_parts(values, len, len) };
+        vec.into_iter()
     }
 }
 
@@ -174,7 +258,7 @@ where
     type Output = <[RSValueFFI] as std::ops::Index<I>>::Output;
 
     fn index(&self, index: I) -> &Self::Output {
-        self.values.index(index)
+        self.as_slice().index(index)
     }
 }
 
@@ -184,6 +268,6 @@ where
     I: std::slice::SliceIndex<[RSValueFFI]>,
 {
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
-        self.values.index_mut(index)
+        self.as_slice_mut().index_mut(index)
     }
 }

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -74,7 +74,7 @@ impl RSSortingVector {
 
     /// Returns a shared slice over the values.
     #[inline]
-    fn as_slice(&self) -> &[RSValueFFI] {
+    const fn as_slice(&self) -> &[RSValueFFI] {
         if self.len == 0 {
             &[]
         } else {
@@ -85,7 +85,7 @@ impl RSSortingVector {
 
     /// Returns a mutable slice over the values.
     #[inline]
-    fn as_slice_mut(&mut self) -> &mut [RSValueFFI] {
+    const fn as_slice_mut(&mut self) -> &mut [RSValueFFI] {
         if self.len == 0 {
             &mut []
         } else {
@@ -113,14 +113,20 @@ impl RSSortingVector {
 
     /// Set a number (double) at the given index
     pub fn try_insert_num(&mut self, idx: usize, num: f64) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_num(num);
         Ok(())
     }
 
     /// Set a string at the given index.
     pub fn try_insert_string(&mut self, idx: usize, str: Vec<u8>) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_string(str);
         Ok(())
     }
@@ -144,25 +150,31 @@ impl RSSortingVector {
         idx: usize,
         value: RSValueFFI,
     ) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = value;
         Ok(())
     }
 
     /// Set a null value at the given index
     pub fn try_insert_null(&mut self, idx: usize) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::null_static();
         Ok(())
     }
 
     /// Get the len of the sorting vector.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// check if the sorting vector is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 
@@ -172,10 +184,10 @@ impl RSSortingVector {
     /// as in C.
     pub fn get_memory_size(&self) -> usize {
         let slice = self.as_slice();
-        let mut sz = slice.len() * size_of::<RSValueFFI>();
+        let mut sz = size_of_val(slice);
 
-        for idx in 0..slice.len() {
-            if slice[idx].is_null() {
+        for item in slice {
+            if item.is_null() {
                 continue;
             }
 
@@ -183,7 +195,7 @@ impl RSSortingVector {
 
             // the original behavior would by-pass references in the middle of the chain
             // fixup in: MOD-10347
-            let value = slice[idx].deep_deref();
+            let value = item.deep_deref();
 
             if value.get_type() == ffi::RSValueType_RSValueType_String {
                 sz += value.as_str_bytes().unwrap().len();
@@ -196,7 +208,7 @@ impl RSSortingVector {
 impl Clone for RSSortingVector {
     fn clone(&self) -> Self {
         // Clone each element (incrementing refcounts) and collect into a new Vec.
-        let cloned: Vec<RSValueFFI> = self.as_slice().iter().cloned().collect();
+        let cloned: Vec<RSValueFFI> = self.as_slice().to_vec();
         let (values, len, _cap) = cloned.into_raw_parts();
         Self { len, values }
     }

--- a/src/redisearch_rs/thin_vec/src/lib.rs
+++ b/src/redisearch_rs/thin_vec/src/lib.rs
@@ -2145,13 +2145,13 @@ mod tests {
     #[test]
     fn test_data_ptr_alignment() {
         let v = ThinVec::<u16>::new();
-        assert!(v.data_raw() as usize % 2 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(2));
 
         let v = ThinVec::<u32>::new();
-        assert!(v.data_raw() as usize % 4 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(4));
 
         let v = ThinVec::<u64>::new();
-        assert!(v.data_raw() as usize % 8 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(8));
     }
 
     #[test]
@@ -2212,7 +2212,7 @@ mod tests {
         struct Align16(#[allow(dead_code)] u8);
 
         let v = ThinVec::<Align16>::new();
-        assert!(v.data_raw() as usize % 16 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(16));
     }
 
     #[test]

--- a/src/redisearch_rs/thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/thin_vec/tests/tests.rs
@@ -639,6 +639,7 @@ fn test_slice_out_of_bounds_2() {
 
 #[test]
 #[should_panic]
+#[expect(clippy::reversed_empty_ranges)]
 fn test_slice_out_of_bounds_3() {
     let x: SmallThinVec<i32> = small_thin_vec![1, 2, 3, 4, 5];
     let _ = &x[!0..4];
@@ -653,6 +654,7 @@ fn test_slice_out_of_bounds_4() {
 
 #[test]
 #[should_panic]
+#[expect(clippy::reversed_empty_ranges)]
 fn test_slice_out_of_bounds_5() {
     let x: SmallThinVec<i32> = small_thin_vec![1, 2, 3, 4, 5];
     let _ = &x[3..2];
@@ -802,6 +804,7 @@ fn test_reserve_exact() {
 #[test]
 fn test_set_len() {
     let mut vec: SmallThinVec<u32> = small_thin_vec![];
+    // SAFETY: Setting length to 0 on an empty vec is a no-op.
     unsafe {
         vec.set_len(0); // at one point this caused a crash
     }
@@ -813,6 +816,7 @@ fn test_set_len() {
 #[should_panic(expected = "invalid set_len(1) on empty ThinVec")]
 fn test_set_len_invalid() {
     let mut vec: SmallThinVec<u32> = small_thin_vec![];
+    // SAFETY: Intentionally invalid — this test verifies the debug assertion fires.
     unsafe {
         vec.set_len(1);
     }


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Rust/C FFI boundaries by changing `RSSortingVector`’s public layout and moving accessors into inline C, which risks ABI/ownership bugs if any consumer assumes the old opaque type or mismatches allocation/freeing semantics.
> 
> **Overview**
> **Speeds up sortable-field access in the C hot path** by making `RSSortingVector` a concrete `#[repr(C)]` struct with exposed `len` and `values` pointer, enabling direct field reads from C.
> 
> The Rust FFI functions `RSSortingVector_Get`/`RSSortingVector_Length` are removed and replaced with `static inline` C helpers emitted into `sorting_vector.h`; the generated headers and cbindgen configs are updated accordingly (including excluding `RSSortingVector` from `rlookup_rs.h` generation and adjusting `RLookupRow_*SortingVector` signatures).
> 
> Internally, `RSSortingVector` storage is refactored from `Box<[RSValueFFI]>` to a raw pointer + explicit `Clone`/`Drop`/`IntoIterator` handling to preserve correct refcounting while avoiding FFI call overhead; `RLookupRow::get` also switches to `RSValueFFI::is_null()` for filtering SV null sentinels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9508375ea3b3ba540e8abb95ab6df158f5646280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->