### PR TITLE
RSE perf - Combine Revert RLookup migration and Accessors

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1784,7 +1784,6 @@ dependencies = [
  "quote 1.0.44",
  "redis-module",
  "result_processor_ffi",
- "rlookup_ffi",
  "search_result_ffi",
  "slots_tracker_ffi",
  "sorting_vector_ffi",
@@ -2152,7 +2151,6 @@ dependencies = [
  "enumflags2",
  "ffi",
  "inverted_index",
- "rlookup",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/buffer/tests/tests.rs
+++ b/src/redisearch_rs/buffer/tests/tests.rs
@@ -324,8 +324,8 @@ fn buffer_from_array<const N: usize>(a: [u8; N]) -> Buffer {
 /// Mock implementation of Buffer_Grow for tests
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
-pub extern "C" fn Buffer_Grow(buffer: *mut ffi::Buffer, extra_len: usize) -> usize {
-    // Safety: buffer is a valid pointer to a Buffer.
+pub unsafe extern "C" fn Buffer_Grow(buffer: *mut ffi::Buffer, extra_len: usize) -> usize {
+    // SAFETY: buffer is a valid pointer to a Buffer, guaranteed by the caller.
     let buffer = unsafe { &mut *buffer };
     let old_capacity = buffer.cap;
 
@@ -344,12 +344,12 @@ pub extern "C" fn Buffer_Grow(buffer: *mut ffi::Buffer, extra_len: usize) -> usi
 /// Mock implementation of BufferFree for tests
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
-pub extern "C" fn Buffer_Free(buffer: *mut ffi::Buffer) -> usize {
+pub unsafe extern "C" fn Buffer_Free(buffer: *mut ffi::Buffer) -> usize {
     if buffer.is_null() {
         return 0;
     }
 
-    // Safety: buffer is a valid pointer to a Buffer.
+    // SAFETY: buffer is a valid pointer to a Buffer, guaranteed by the caller.
     let buffer = unsafe { &mut *buffer };
 
     let layout = Layout::array::<c_char>(buffer.cap).unwrap();

--- a/src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml
@@ -40,7 +40,6 @@ iterators_ffi = { path = "../iterators_ffi" }
 query_error_ffi = { path = "../query_error_ffi" }
 query_term_ffi = { path = "../query_term_ffi" }
 result_processor_ffi = { path = "../result_processor_ffi" }
-rlookup_ffi = { path = "../rlookup_ffi" }
 slots_tracker_ffi = { path = "../slots_tracker_ffi" }
 sorting_vector_ffi = { path = "../sorting_vector_ffi" }
 triemap_ffi = { path = "../triemap_ffi" }

--- a/src/redisearch_rs/c_entrypoint/redisearch_rs/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/redisearch_rs/src/lib.rs
@@ -26,7 +26,6 @@ pub use numeric_range_tree_ffi as numeric_range_tree;
 pub use query_error_ffi as query_error;
 pub use query_term_ffi as query_term;
 pub use result_processor_ffi as result_processor;
-pub use rlookup_ffi as rlookup;
 pub use search_result_ffi as search_result;
 pub use slots_tracker_ffi as slots_tracker;
 pub use sorting_vector_ffi as sorting_vector;

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
@@ -33,7 +33,7 @@ prefix_with_name = true
 
 [export]
 include = ["RLookupKeyFlag", "RLookupOption"]
-exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "SchemaRule"]
+exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "SchemaRule", "RSSortingVector"]
 
 [export.rename]
 "OpaqueRLookup" = "RLookup"

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
@@ -42,3 +42,7 @@ exclude = ["FieldSpec", "IndexSpec", "Option_Cow_CStr", "SchemaRule"]
 "RLookupKeyFlag" = "RLookup_F"
 "RLookupKeyHeader" = "RLookupKey"
 "RLookupOption" = "RLookup_Opt"
+
+[defines]
+# Remap this rust cfg to the C #define also set by CMake for debug builds.
+"debug_assertions" = "ENABLE_ASSERT"

--- a/src/redisearch_rs/c_entrypoint/search_result_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/search_result_ffi/cbindgen.toml
@@ -18,4 +18,4 @@ parse_deps = true
 include = ["rlookup", "search_result"]
 
 [export]
-exclude = ["Option_DocumentMetadata", "RLookupRow", "SearchResultFlags"]
+exclude = ["Option_DocumentMetadata", "SearchResultFlags"]

--- a/src/redisearch_rs/c_entrypoint/search_result_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/search_result_ffi/src/lib.rs
@@ -12,11 +12,6 @@ use std::{mem, ptr::NonNull};
 pub type SearchResult = search_result::SearchResult<'static>;
 
 /// Returns a newly created [`SearchResult`].
-//
-// The `SearchResult` type is technically not FFI-safe due to the `RLookupRow` type of its `_row_data` field.
-// However that type is in practice only exposed as an `OpaqueRLookupRow`, which _is_ FFI-safe.
-// Due to cbindgen limitations we need to put the `expect` attribute on the method itself, rather than on the return type.
-#[expect(improper_ctypes_definitions)]
 #[unsafe(no_mangle)]
 pub const extern "C" fn SearchResult_New() -> SearchResult {
     SearchResult::new()

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/cbindgen.toml
@@ -6,10 +6,36 @@ after_includes = """
 // Forward declaration of RSValue, which is only used as ptr in the sorting_vector module
 typedef struct RSValue RSValue;
 
-// Forward declaration of SortingVector, which is only used as ptr in the sorting_vector module
-typedef struct RSSortingVector RSSortingVector;
+/**
+ * `RSSortingVector` acts as a cache for sortable fields in a document.
+ *
+ * The struct is `#[repr(C)]` in Rust. `values` is an array of `len` RSValue
+ * pointers. Simple getters (length, element access) can read the fields
+ * directly without crossing the FFI boundary.
+ */
+typedef struct RSSortingVector {
+    size_t len;
+    RSValue **values;
+} RSSortingVector;
+
+/**
+ * Returns the element at `idx`. No bounds check.
+ */
+static inline RSValue *RSSortingVector_Get(const RSSortingVector *sv, size_t idx) {
+    return sv->values[idx];
+}
+
+/**
+ * Returns the number of elements.
+ */
+static inline size_t RSSortingVector_Length(const RSSortingVector *sv) {
+    return sv->len;
+}
 """
 
 [parse]
 parse_deps = true
 include = []
+
+[export]
+exclude = ["RSSortingVector"]

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
@@ -19,42 +19,9 @@ use value::RSValueFFI;
 
 pub const RS_SORTABLES_MAX: usize = 1024;
 
-/// Gets a RSValue from the sorting vector at the given index.
-///
-/// # Panics
-///
-/// Panics if the `idx` is out of bounds for the vector.
-///
-/// # Safety
-///
-/// 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
-///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_Get(
-    vec: *const RSSortingVector,
-    idx: size_t,
-) -> *mut ffi::RSValue {
-    // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.as_ref().expect("vec must not be null") };
-
-    vec[idx].as_ptr()
-}
-
-/// Returns the length of the sorting vector.
-///
-/// # Safety
-///
-/// 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
-///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSSortingVector_Length(vec: *const RSSortingVector) -> size_t {
-    // Safety: The caller must ensure that the pointer is valid (1.)
-    let vec = unsafe { vec.as_ref().expect("vec must not be null") };
-
-    vec.len() as size_t
-}
+// NOTE: RSSortingVector_Get and RSSortingVector_Length are now inline C functions
+// defined in the generated header (cbindgen.toml `after_includes`). They read
+// the `#[repr(C)]` struct fields directly, avoiding FFI function-call overhead.
 
 /// Returns the memory size of the sorting vector.
 ///

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -120,18 +120,6 @@ typedef struct IndexSpecCache IndexSpecCache;
 typedef struct RLookup RLookup;
 
 /**
- * [`RSSortingVector`] acts as a cache for sortable fields in a document.
- *
- * It has a constant length, determined upfront on creation. It can't be resized.
- * The [`RSSortingVector`] may contain values of different types, such as numbers, strings, or references to other values.
- * This depends on the fields in the source document.
- *
- * The fields in the sorting vector occur in the same order as they appeared in the document. Fields that are not sortable,
- * are not added at all to the sorting vector, i.e. the sorting vector does not contain null values for non-sortable fields.
- */
-typedef struct RSSortingVector RSSortingVector;
-
-/**
  * A type with size `N`.
  */
 typedef uint8_t Size_40[40];
@@ -765,7 +753,7 @@ RSValue *RLookupRow_Get(const struct RLookupKey *key, const struct RLookupRow *r
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-const struct RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRow *row);
+const RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRow *row);
 
 /**
  * Sets the sorting vector for the row.
@@ -778,7 +766,7 @@ const struct RSSortingVector *RLookupRow_GetSortingVector(const struct RLookupRo
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RLookupRow_SetSortingVector(struct RLookupRow *row,
-                                 const struct RSSortingVector *sv);
+                                 const RSSortingVector *sv);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/sorting_vector.h
+++ b/src/redisearch_rs/headers/sorting_vector.h
@@ -9,8 +9,31 @@
 // Forward declaration of RSValue, which is only used as ptr in the sorting_vector module
 typedef struct RSValue RSValue;
 
-// Forward declaration of SortingVector, which is only used as ptr in the sorting_vector module
-typedef struct RSSortingVector RSSortingVector;
+/**
+ * `RSSortingVector` acts as a cache for sortable fields in a document.
+ *
+ * The struct is `#[repr(C)]` in Rust. `values` is an array of `len` RSValue
+ * pointers. Simple getters (length, element access) can read the fields
+ * directly without crossing the FFI boundary.
+ */
+typedef struct RSSortingVector {
+    size_t len;
+    RSValue **values;
+} RSSortingVector;
+
+/**
+ * Returns the element at `idx`. No bounds check.
+ */
+static inline RSValue *RSSortingVector_Get(const RSSortingVector *sv, size_t idx) {
+    return sv->values[idx];
+}
+
+/**
+ * Returns the number of elements.
+ */
+static inline size_t RSSortingVector_Length(const RSSortingVector *sv) {
+    return sv->len;
+}
 
 
 #define RS_SORTABLES_MAX 1024
@@ -18,33 +41,6 @@ typedef struct RSSortingVector RSSortingVector;
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-/**
- * Gets a RSValue from the sorting vector at the given index.
- *
- * # Panics
- *
- * Panics if the `idx` is out of bounds for the vector.
- *
- * # Safety
- *
- * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-RSValue *RSSortingVector_Get(const RSSortingVector *vec,
-                             size_t idx);
-
-/**
- * Returns the length of the sorting vector.
- *
- * # Safety
- *
- * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-size_t RSSortingVector_Length(const RSSortingVector *vec);
 
 /**
  * Returns the memory size of the sorting vector.

--- a/src/redisearch_rs/inverted_index/tests/integration/controlled_cursor.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/controlled_cursor.rs
@@ -105,7 +105,7 @@ fn test_seek_and_overwrite() {
         let mut cursor = ControlledCursor::new(&mut buffer);
 
         // Write initial data
-        cursor.write(b"XXXXXXXXXX").expect("Write failed");
+        cursor.write_all(b"XXXXXXXXXX").expect("Write failed");
     }
     assert_eq!(&buffer[..], b"XXXXXXXXXX");
 
@@ -116,7 +116,7 @@ fn test_seek_and_overwrite() {
         cursor.seek(SeekFrom::Start(2)).expect("Seek failed");
 
         // Overwrite with new data
-        cursor.write(b"test").expect("Write failed");
+        cursor.write_all(b"test").expect("Write failed");
     }
 
     // Verify the overwrite

--- a/src/redisearch_rs/redis_mock/src/reply/mod.rs
+++ b/src/redisearch_rs/redis_mock/src/reply/mod.rs
@@ -21,6 +21,7 @@ pub use capture::capture_replies;
 pub use value::ReplyValue;
 
 #[cfg(test)]
+#[expect(clippy::approx_constant)] // 3.14 is an arbitrary test value, not an approximation of PI
 mod tests {
     use std::ffi::c_longlong;
 

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -209,7 +209,7 @@ impl<'a> RLookupRow<'a> {
             //   `if (ret != NULL && ret == RSValue_NullStatic()) ret = NULL;`
             self.sorting_vector()?
                 .get(key.svidx as usize)
-                .filter(|v| v.get_type() != ffi::RSValueType_RSValueType_Null)
+                .filter(|v| !v.is_null())
         } else {
             None
         }

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 [dependencies]
 ffi.workspace = true
 inverted_index.workspace = true
-rlookup.workspace = true
+
 enumflags2.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -11,8 +11,7 @@ pub mod bindings;
 
 use enumflags2::{BitFlags, bitflags};
 use inverted_index::RSIndexResult;
-use rlookup::RLookupRow;
-use std::ptr::NonNull;
+use std::ptr::{self, NonNull};
 
 use crate::bindings::DocumentMetadata;
 
@@ -54,7 +53,7 @@ pub struct SearchResult<'index> {
     _index_result: Option<&'index RSIndexResult<'index>>,
 
     // Row data. Use RLookup_* functions to access
-    _row_data: RLookupRow<'index>,
+    _row_data: ffi::RLookupRow,
 
     _flags: SearchResultFlags,
 }
@@ -63,7 +62,10 @@ impl Drop for SearchResult<'_> {
     fn drop(&mut self) {
         self.clear();
 
-        self._row_data.reset_dyn_values();
+        // Safety: we own (and therefore correctly initialized) the row data struct and have mutable access to it.
+        unsafe {
+            ffi::RLookupRow_Reset(ptr::from_mut(&mut self._row_data));
+        }
     }
 }
 
@@ -81,7 +83,11 @@ impl<'index> SearchResult<'index> {
             _score_explain: None,
             _document_metadata: None,
             _index_result: None,
-            _row_data: RLookupRow::new(),
+            _row_data: ffi::RLookupRow {
+                sv: ptr::null(),
+                dyn_: ptr::null_mut(),
+                ndyn: 0,
+            },
             _flags: SearchResultFlags::from_bits_truncate_c(0, BitFlags::CONST_TOKEN),
         }
     }
@@ -102,7 +108,10 @@ impl<'index> SearchResult<'index> {
 
         self._flags = SearchResultFlags::empty();
 
-        self._row_data.wipe();
+        // Safety: we own (and therefore correctly initialized) the row data struct and have mutable access to it.
+        unsafe {
+            ffi::RLookupRow_Wipe(ptr::from_mut(&mut self._row_data));
+        }
 
         // explicitly drop the DMD here to make clear we maintain the
         // same "drop order" as the old C implementation had.
@@ -181,12 +190,12 @@ impl<'index> SearchResult<'index> {
     }
 
     /// Returns an immutable reference to the [`RLookupRow`][ffi::RLookupRow] of this search result.
-    pub const fn row_data(&self) -> &RLookupRow<'index> {
+    pub const fn row_data(&self) -> &ffi::RLookupRow {
         &self._row_data
     }
 
     /// Returns a mutable reference to the [`RLookupRow`][ffi::RLookupRow] of this search result.
-    pub const fn row_data_mut(&mut self) -> &mut RLookupRow<'index> {
+    pub const fn row_data_mut(&mut self) -> &mut ffi::RLookupRow {
         &mut self._row_data
     }
 

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -38,45 +38,89 @@ impl std::error::Error for IndexOutOfBounds {}
 ///
 /// The fields in the sorting vector occur in the same order as they appeared in the document. Fields that are not sortable,
 /// are not added at all to the sorting vector, i.e. the sorting vector does not contain null values for non-sortable fields.
-#[derive(Debug, Clone)]
+///
+/// The struct uses `#[repr(C)]` to allow C code to directly access `len` and `values` without FFI
+/// function calls. This is critical for performance in the sort comparison hot path.
+#[repr(C)]
 pub struct RSSortingVector {
-    values: Box<[RSValueFFI]>,
+    /// Number of elements in the values array.
+    pub len: usize,
+    /// Pointer to a heap-allocated array of [`RSValueFFI`] elements.
+    ///
+    /// # Invariant
+    ///
+    /// When `len > 0`, `values` is a valid, non-null pointer to an allocation of exactly `len`
+    /// elements produced by `Vec::into_raw_parts`. When `len == 0`, `values` may be dangling
+    /// (from `Vec::new()`).
+    pub values: *mut RSValueFFI,
 }
+
+// SAFETY: The raw pointer `values` is an owned heap allocation that is never shared.
+// RSSortingVector has exclusive ownership of the allocation, similar to `Box<[RSValueFFI]>`.
+unsafe impl Send for RSSortingVector {}
+
+// SAFETY: RSSortingVector does not provide interior mutability through shared references.
+// All mutation requires `&mut self`.
+unsafe impl Sync for RSSortingVector {}
 
 impl RSSortingVector {
     /// Creates a new [`RSSortingVector`] with the given length.
     pub fn new(len: usize) -> Self {
-        Self {
-            values: vec![RSValueFFI::null_static(); len].into_boxed_slice(),
+        let vec = vec![RSValueFFI::null_static(); len];
+        let (values, actual_len, _cap) = vec.into_raw_parts();
+        debug_assert_eq!(actual_len, len);
+        Self { len, values }
+    }
+
+    /// Returns a shared slice over the values.
+    #[inline]
+    fn as_slice(&self) -> &[RSValueFFI] {
+        if self.len == 0 {
+            &[]
+        } else {
+            // SAFETY: `values` points to a valid allocation of `len` elements (struct invariant).
+            unsafe { std::slice::from_raw_parts(self.values, self.len) }
+        }
+    }
+
+    /// Returns a mutable slice over the values.
+    #[inline]
+    fn as_slice_mut(&mut self) -> &mut [RSValueFFI] {
+        if self.len == 0 {
+            &mut []
+        } else {
+            // SAFETY: `values` points to a valid allocation of `len` elements (struct invariant),
+            // and we have exclusive access via `&mut self`.
+            unsafe { std::slice::from_raw_parts_mut(self.values, self.len) }
         }
     }
 
     /// Returns an immutable reference to the value at index `index`,
     /// or `None` if the index is out-of-bounds for this sorting vector.
     pub fn get(&self, index: usize) -> Option<&RSValueFFI> {
-        self.values.get(index)
+        self.as_slice().get(index)
     }
 
     /// Returns an iterator over the values in the sorting vector.
     pub fn iter(&self) -> Iter<'_, RSValueFFI> {
-        self.values.iter()
+        self.as_slice().iter()
     }
 
     /// Returns a mutable iterator over the values in the sorting vector.
     pub fn iter_mut(&mut self) -> IterMut<'_, RSValueFFI> {
-        self.values.iter_mut()
+        self.as_slice_mut().iter_mut()
     }
 
     /// Set a number (double) at the given index
     pub fn try_insert_num(&mut self, idx: usize, num: f64) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_num(num);
         Ok(())
     }
 
     /// Set a string at the given index.
     pub fn try_insert_string(&mut self, idx: usize, str: Vec<u8>) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_string(str);
         Ok(())
     }
@@ -100,26 +144,26 @@ impl RSSortingVector {
         idx: usize,
         value: RSValueFFI,
     ) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = value;
         Ok(())
     }
 
     /// Set a null value at the given index
     pub fn try_insert_null(&mut self, idx: usize) -> Result<(), IndexOutOfBounds> {
-        let spot = self.values.get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::null_static();
         Ok(())
     }
 
     /// Get the len of the sorting vector.
     pub fn len(&self) -> usize {
-        self.values.len()
+        self.len
     }
 
     /// check if the sorting vector is empty.
     pub fn is_empty(&self) -> bool {
-        self.values.is_empty()
+        self.len == 0
     }
 
     /// approximate the memory size of the sorting vector.
@@ -127,10 +171,11 @@ impl RSSortingVector {
     /// The implementation by-passes references in the middle of the chain, so it only counts the size of the final value,
     /// as in C.
     pub fn get_memory_size(&self) -> usize {
-        let mut sz = self.values.len() * size_of::<RSValueFFI>();
+        let slice = self.as_slice();
+        let mut sz = slice.len() * size_of::<RSValueFFI>();
 
-        for idx in 0..self.values.len() {
-            if self.values[idx].is_null() {
+        for idx in 0..slice.len() {
+            if slice[idx].is_null() {
                 continue;
             }
 
@@ -138,7 +183,7 @@ impl RSSortingVector {
 
             // the original behavior would by-pass references in the middle of the chain
             // fixup in: MOD-10347
-            let value = self.values[idx].deep_deref();
+            let value = slice[idx].deep_deref();
 
             if value.get_type() == ffi::RSValueType_RSValueType_String {
                 sz += value.as_str_bytes().unwrap().len();
@@ -148,11 +193,40 @@ impl RSSortingVector {
     }
 }
 
+impl Clone for RSSortingVector {
+    fn clone(&self) -> Self {
+        // Clone each element (incrementing refcounts) and collect into a new Vec.
+        let cloned: Vec<RSValueFFI> = self.as_slice().iter().cloned().collect();
+        let (values, len, _cap) = cloned.into_raw_parts();
+        Self { len, values }
+    }
+}
+
+impl fmt::Debug for RSSortingVector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RSSortingVector")
+            .field("len", &self.len)
+            .field("values", &self.as_slice())
+            .finish()
+    }
+}
+
+impl Drop for RSSortingVector {
+    fn drop(&mut self) {
+        if self.len > 0 {
+            // SAFETY: `values` was allocated by `Vec::into_raw_parts` with exactly `len` elements
+            // and capacity equal to `len`. Reconstructing the Vec and dropping it frees the
+            // allocation and drops each `RSValueFFI` (decrementing refcounts).
+            let _ = unsafe { Vec::from_raw_parts(self.values, self.len, self.len) };
+        }
+    }
+}
+
 impl FromIterator<RSValueFFI> for RSSortingVector {
     fn from_iter<T: IntoIterator<Item = RSValueFFI>>(iter: T) -> Self {
-        Self {
-            values: iter.into_iter().collect(),
-        }
+        let vec: Vec<RSValueFFI> = iter.into_iter().collect();
+        let (values, len, _cap) = vec.into_raw_parts();
+        Self { len, values }
     }
 }
 
@@ -161,8 +235,18 @@ impl IntoIterator for RSSortingVector {
     type Item = RSValueFFI;
     type IntoIter = std::vec::IntoIter<RSValueFFI>;
     fn into_iter(self) -> Self::IntoIter {
-        // this does not use a new allocation
-        Vec::from(self.values).into_iter()
+        let len = self.len;
+        let values = self.values;
+        // Prevent Drop from running (which would free the same allocation).
+        std::mem::forget(self);
+
+        if len == 0 {
+            return Vec::new().into_iter();
+        }
+
+        // SAFETY: `values` was produced by `Vec::into_raw_parts` with capacity == len.
+        let vec = unsafe { Vec::from_raw_parts(values, len, len) };
+        vec.into_iter()
     }
 }
 
@@ -174,7 +258,7 @@ where
     type Output = <[RSValueFFI] as std::ops::Index<I>>::Output;
 
     fn index(&self, index: I) -> &Self::Output {
-        self.values.index(index)
+        self.as_slice().index(index)
     }
 }
 
@@ -184,6 +268,6 @@ where
     I: std::slice::SliceIndex<[RSValueFFI]>,
 {
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
-        self.values.index_mut(index)
+        self.as_slice_mut().index_mut(index)
     }
 }

--- a/src/redisearch_rs/sorting_vector/src/lib.rs
+++ b/src/redisearch_rs/sorting_vector/src/lib.rs
@@ -74,7 +74,7 @@ impl RSSortingVector {
 
     /// Returns a shared slice over the values.
     #[inline]
-    fn as_slice(&self) -> &[RSValueFFI] {
+    const fn as_slice(&self) -> &[RSValueFFI] {
         if self.len == 0 {
             &[]
         } else {
@@ -85,7 +85,7 @@ impl RSSortingVector {
 
     /// Returns a mutable slice over the values.
     #[inline]
-    fn as_slice_mut(&mut self) -> &mut [RSValueFFI] {
+    const fn as_slice_mut(&mut self) -> &mut [RSValueFFI] {
         if self.len == 0 {
             &mut []
         } else {
@@ -113,14 +113,20 @@ impl RSSortingVector {
 
     /// Set a number (double) at the given index
     pub fn try_insert_num(&mut self, idx: usize, num: f64) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_num(num);
         Ok(())
     }
 
     /// Set a string at the given index.
     pub fn try_insert_string(&mut self, idx: usize, str: Vec<u8>) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::new_string(str);
         Ok(())
     }
@@ -144,25 +150,31 @@ impl RSSortingVector {
         idx: usize,
         value: RSValueFFI,
     ) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = value;
         Ok(())
     }
 
     /// Set a null value at the given index
     pub fn try_insert_null(&mut self, idx: usize) -> Result<(), IndexOutOfBounds> {
-        let spot = self.as_slice_mut().get_mut(idx).ok_or(IndexOutOfBounds(()))?;
+        let spot = self
+            .as_slice_mut()
+            .get_mut(idx)
+            .ok_or(IndexOutOfBounds(()))?;
         *spot = RSValueFFI::null_static();
         Ok(())
     }
 
     /// Get the len of the sorting vector.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// check if the sorting vector is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 
@@ -172,10 +184,10 @@ impl RSSortingVector {
     /// as in C.
     pub fn get_memory_size(&self) -> usize {
         let slice = self.as_slice();
-        let mut sz = slice.len() * size_of::<RSValueFFI>();
+        let mut sz = size_of_val(slice);
 
-        for idx in 0..slice.len() {
-            if slice[idx].is_null() {
+        for item in slice {
+            if item.is_null() {
                 continue;
             }
 
@@ -183,7 +195,7 @@ impl RSSortingVector {
 
             // the original behavior would by-pass references in the middle of the chain
             // fixup in: MOD-10347
-            let value = slice[idx].deep_deref();
+            let value = item.deep_deref();
 
             if value.get_type() == ffi::RSValueType_RSValueType_String {
                 sz += value.as_str_bytes().unwrap().len();
@@ -196,7 +208,7 @@ impl RSSortingVector {
 impl Clone for RSSortingVector {
     fn clone(&self) -> Self {
         // Clone each element (incrementing refcounts) and collect into a new Vec.
-        let cloned: Vec<RSValueFFI> = self.as_slice().iter().cloned().collect();
+        let cloned: Vec<RSValueFFI> = self.as_slice().to_vec();
         let (values, len, _cap) = cloned.into_raw_parts();
         Self { len, values }
     }

--- a/src/redisearch_rs/thin_vec/src/lib.rs
+++ b/src/redisearch_rs/thin_vec/src/lib.rs
@@ -2145,13 +2145,13 @@ mod tests {
     #[test]
     fn test_data_ptr_alignment() {
         let v = ThinVec::<u16>::new();
-        assert!(v.data_raw() as usize % 2 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(2));
 
         let v = ThinVec::<u32>::new();
-        assert!(v.data_raw() as usize % 4 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(4));
 
         let v = ThinVec::<u64>::new();
-        assert!(v.data_raw() as usize % 8 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(8));
     }
 
     #[test]
@@ -2212,7 +2212,7 @@ mod tests {
         struct Align16(#[allow(dead_code)] u8);
 
         let v = ThinVec::<Align16>::new();
-        assert!(v.data_raw() as usize % 16 == 0);
+        assert!((v.data_raw() as usize).is_multiple_of(16));
     }
 
     #[test]

--- a/src/redisearch_rs/thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/thin_vec/tests/tests.rs
@@ -639,6 +639,7 @@ fn test_slice_out_of_bounds_2() {
 
 #[test]
 #[should_panic]
+#[expect(clippy::reversed_empty_ranges)]
 fn test_slice_out_of_bounds_3() {
     let x: SmallThinVec<i32> = small_thin_vec![1, 2, 3, 4, 5];
     let _ = &x[!0..4];
@@ -653,6 +654,7 @@ fn test_slice_out_of_bounds_4() {
 
 #[test]
 #[should_panic]
+#[expect(clippy::reversed_empty_ranges)]
 fn test_slice_out_of_bounds_5() {
     let x: SmallThinVec<i32> = small_thin_vec![1, 2, 3, 4, 5];
     let _ = &x[3..2];
@@ -802,6 +804,7 @@ fn test_reserve_exact() {
 #[test]
 fn test_set_len() {
     let mut vec: SmallThinVec<u32> = small_thin_vec![];
+    // SAFETY: Setting length to 0 on an empty vec is a no-op.
     unsafe {
         vec.set_len(0); // at one point this caused a crash
     }
@@ -813,6 +816,7 @@ fn test_set_len() {
 #[should_panic(expected = "invalid set_len(1) on empty ThinVec")]
 fn test_set_len_invalid() {
     let mut vec: SmallThinVec<u32> = small_thin_vec![];
+    // SAFETY: Intentionally invalid — this test verifies the debug assertion fires.
     unsafe {
         vec.set_len(1);
     }

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#include "rlookup.h"
+#include "module.h"
+#include "document.h"
+#include "rmutil/rm_assert.h"
+#include <util/arr.h>
+#include "doc_types.h"
+#include "value.h"
+#include "util/arr.h"
+
+typedef struct RLookupKey {
+  uint16_t _dstidx;
+  uint16_t _svidx;
+
+  uint32_t _flags;
+
+  const char *_path;
+  const char *_name;
+  size_t _name_len;
+
+  /** Pointer to next field in the list. */
+  struct RLookupKey *_next;
+} RLookupKey;
+
+/** The index into the array where the value resides  */
+inline uint16_t RLookupKey_GetDstIdx(const RLookupKey* key) {
+    return key->_dstidx;
+}
+
+/**
+ * If the source of this value points to a sort vector, then this is the
+ * index within the sort vector that the value is located
+ */
+inline uint16_t RLookupKey_GetSvIdx(const RLookupKey* key) {
+    return key->_svidx;
+}
+
+/** The name of this field. */
+inline const char * RLookupKey_GetName(const RLookupKey* key) {
+    return key->_name;
+}
+
+/** The path of this field. */
+inline const char * RLookupKey_GetPath(const RLookupKey* key) {
+    return key->_path;
+}
+
+/** The length of the name field in bytes. */
+inline size_t RLookupKey_GetNameLen(const RLookupKey* key) {
+    return key->_name_len;
+}
+
+/**
+ * Indicate the type and other attributes
+ * Can be F_SVSRC which means the target array is a sorting vector)
+ */
+inline uint32_t RLookupKey_GetFlags(const RLookupKey* key) {
+    return key->_flags;
+}
+
+static inline void RLookupKey_MergeFlags(RLookupKey* key, uint32_t flags) {
+    key->_flags |= flags;
+}
+
+void RLookupKey_SetPath(RLookupKey* key, const char * path) {
+    key->_path = path;
+}
+
+// Allocate a new RLookupKey and add it to the RLookup table.
+RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t name_len, uint32_t flags) {
+  RLookupKey *ret = rm_calloc(1, sizeof(*ret));
+
+  if (!lookup->_head) {
+    lookup->_head = lookup->_tail = ret;
+  } else {
+    lookup->_tail->_next = ret;
+    lookup->_tail = ret;
+  }
+
+  // Set the name of the key.
+  ret->_name = (flags & RLOOKUP_F_NAMEALLOC) ? rm_strndup(name, name_len) : name;
+  ret->_name_len = name_len;
+  ret->_path = ret->_name;
+  ret->_dstidx = lookup->_rowlen;
+  ret->_flags = flags & ~RLOOKUP_TRANSIENT_FLAGS;
+
+  // Increase the RLookup table row length. (all rows have the same length).
+  ++(lookup->_rowlen);
+
+  return ret;
+}
+
+// Allocate a new RLookupKey and add it to the RLookup table.
+static RLookupKey *overrideKey(RLookup *lk, RLookupKey *old, uint32_t flags) {
+  RLookupKey *new = rm_calloc(1, sizeof(*new));
+
+  /* Copy the old key to the new one */
+  new->_name = old->_name; // taking ownership of the name
+  new->_name_len = old->_name_len;
+  new->_path = new->_name; // keeping the initial default of path = name. Path resolution will happen later.
+  new->_dstidx = old->_dstidx;
+
+  /* Set the new flags */
+  new->_flags = flags & ~RLOOKUP_TRANSIENT_FLAGS;
+  // If the old key was allocated, we take ownership of the name.
+  new->_flags |= old->_flags & RLOOKUP_F_NAMEALLOC;
+
+  /* Make the old key inaccessible for new lookups */
+  if (old->_path == old->_name) {
+    // If the old key allocated the name and not the path, we take ownership of the allocation
+    old->_flags &= ~RLOOKUP_F_NAMEALLOC;
+  }
+  old->_name = NULL;
+  // 0 is a valid length if the user provided an empty string as a name.
+  // This is safe as whenever we compare key names, we first check that the length are equal.
+  old->_name_len = -1;
+  old->_flags |= RLOOKUP_F_HIDDEN; // Mark the old key as hidden so it won't be attempted to be returned
+
+  /* Add the new key to the lookup table */
+  new->_next = old->_next;
+  old->_next = new;
+  // If the old key was the tail, set the new key as the tail
+  if (lk->_tail == old) {
+    lk->_tail = new;
+  }
+
+  return new;
+}
+
+static void setKeyByFieldSpec(RLookupKey *key, const FieldSpec *fs) {
+  key->_flags |= RLOOKUP_F_DOCSRC | RLOOKUP_F_SCHEMASRC;
+  const char *path = HiddenString_GetUnsafe(fs->fieldPath, NULL);
+  key->_path = key->_flags & RLOOKUP_F_NAMEALLOC ? rm_strdup(path) : path;
+  if (FieldSpec_IsSortable(fs)) {
+    key->_flags |= RLOOKUP_F_SVSRC;
+    key->_svidx = fs->sortIdx;
+
+    if (FieldSpec_IsUnf(fs)) {
+      // If the field is sortable and not normalized (UNF), the available data in the
+      // sorting vector is the same as the data in the document.
+      key->_flags |= RLOOKUP_F_VALAVAILABLE;
+    }
+  }
+  if (FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
+    key->_flags |= RLOOKUP_F_NUMERIC;
+  }
+}
+
+static void RLookupKey_Cleanup(RLookupKey *k) {
+  if (k->_flags & RLOOKUP_F_NAMEALLOC) {
+    if (RLookupKey_GetName(k) != k->_path) {
+      rm_free((void *)k->_path);
+    }
+    rm_free((void *)k->_name);
+  }
+}
+
+void RLookupKey_Free(RLookupKey *k) {
+  RLookupKey_Cleanup(k);
+  rm_free(k);
+}
+
+const FieldSpec *RLookup_FindFieldInSpecCache(const RLookup *lookup, const char *name) {
+  const IndexSpecCache *cc = lookup->_spcache;
+  if (!cc) {
+    return NULL;
+  }
+
+  const FieldSpec *fs = NULL;
+  for (size_t ii = 0; ii < cc->nfields; ++ii) {
+    if (!HiddenString_CompareC(cc->fields[ii].fieldName, name, strlen(name))) {
+      fs = cc->fields + ii;
+      break;
+    }
+  }
+
+  return fs;
+}
+
+// Gets a key from the schema if the field is sortable (so its data is available), unless an RP upstream
+// has promised to load the entire document.
+static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t name_len, uint32_t flags) {
+  const FieldSpec *fs = RLookup_FindFieldInSpecCache(lookup, name);
+  // FIXME: LOAD ALL loads the key properties by their name, and we won't find their value by the field name
+  //        if the field has a different name (alias) than its path.
+  if(!fs || (!FieldSpec_IsSortable(fs) && !(lookup->_options & RLOOKUP_OPT_ALLLOADED))) {
+    return NULL;
+  }
+
+  RLookupKey *key = createNewKey(lookup, name, name_len, flags);
+  setKeyByFieldSpec(key, fs);
+  return key;
+}
+
+RLookupKey *RLookup_FindKey(RLookup *lookup, const char *name, size_t name_len) {
+  RLookupIteratorMut iter = RLookup_IterMut(lookup);
+  RLookupKey* key;
+
+  while (RLookupIteratorMut_Next(&iter, &key)) {
+    // match `name` to the name of the key
+    if (RLookupKey_GetNameLen(key) == name_len && !strncmp(RLookupKey_GetName(key), name, name_len)) {
+      return key;
+    }
+  }
+  return NULL;
+}
+
+/**
+ * Advances the iterator to the next key places a pointer to it into `key`.
+ *
+ * Returns `true` while there are more keys or `false` to indicate the
+ * last key ways returned and the caller should not call this function anymore.
+ */
+inline bool RLookupIterator_Next(RLookupIterator* iterator, const RLookupKey** key) {
+    const RLookupKey *current = iterator->current;
+    if (current == NULL) {
+        return false;
+    } else {
+        *key = current;
+        iterator->current = current->_next;
+
+        return true;
+    }
+}
+
+/**
+ * Advances the iterator to the next key places a pointer to it into `key`.
+ *
+ * Returns `true` while there are more keys or `false` to indicate the
+ * last key ways returned and the caller should not call this function anymore.
+ */
+inline bool RLookupIteratorMut_Next(RLookupIteratorMut* iterator, RLookupKey** key) {
+    RLookupKey *current = iterator->current;
+    if (current == NULL) {
+        return false;
+    } else {
+        *key = current;
+        iterator->current = current->_next;
+
+        return true;
+    }
+}
+
+/** Returns an immutable iterator over the keys in this RLookup */
+inline RLookupIterator RLookup_Iter(const RLookup* rlookup) {
+    RLookupIterator iter = { 0 };
+    iter.current = rlookup->_head;
+    return iter;
+}
+
+/** Returns an mutable iterator over the keys in this RLookup */
+inline RLookupIteratorMut RLookup_IterMut(const RLookup* rlookup) {
+    RLookupIteratorMut iter = { 0 };
+    iter.current = rlookup->_head;
+    return iter;
+}
+
+static RLookupKey *RLookup_GetKey_common(RLookup *lookup, const char *name, size_t name_len, const char *field_name, RLookupMode mode, uint32_t flags) {
+  // remove all flags that are not relevant to getting a key
+  flags &= RLOOKUP_GET_KEY_FLAGS;
+  // First, look for the key in the lookup table for an existing key with the same name
+  RLookupKey *key = RLookup_FindKey(lookup, name, name_len);
+  const FieldSpec *fs = NULL;
+
+  switch (mode) {
+  // 1. if the key is already loaded, or it has created by earlier RP for writing, return NULL (unless override was requested)
+  // 2. create a new key with the name of the field, and mark it as doc-source.
+  // 3. if the key is in the schema, mark it as schema-source and apply all the relevant flags according to the field spec.
+  // 4. if the key is "loaded" at this point (in schema, sortable and un-normalized), create the key but return NULL
+  //    (no need to load it from the document).
+  case RLOOKUP_M_LOAD:
+    // NOTICE: you should not call GetKey for loading if it's illegal to load the key at the given state.
+    // The responsibility of checking this is on the caller.
+    if (!key) {
+      key = createNewKey(lookup, name, name_len, flags);
+    } else if (((RLookupKey_GetFlags(key) & RLOOKUP_F_VALAVAILABLE) && !(RLookupKey_GetFlags(key) & RLOOKUP_F_ISLOADED)) &&
+                 !(flags & (RLOOKUP_F_OVERRIDE | RLOOKUP_F_FORCELOAD)) ||
+                (RLookupKey_GetFlags(key) & RLOOKUP_F_ISLOADED &&       !(flags &  RLOOKUP_F_OVERRIDE)) ||
+                (RLookupKey_GetFlags(key) & RLOOKUP_F_QUERYSRC &&       !(flags &  RLOOKUP_F_OVERRIDE))) {
+      // We found a key with the same name. We return NULL if:
+      // 1. The key has the origin data available (from the sorting vector, UNF) and the caller didn't
+      //    request to override or forced loading.
+      // 2. The key is already loaded (from the document) and the caller didn't request to override.
+      // 3. The key was created by the query (upstream) and the caller didn't request to override.
+
+      // If the caller wanted to mark this key as explicit return, mark it as such even if we don't return it.
+      RLookupKey_MergeFlags(key, flags & RLOOKUP_F_EXPLICITRETURN);
+      return NULL;
+    } else {
+      // overrides the key, and sets the new key according to the flags.
+      key = overrideKey(lookup, key, flags);
+    }
+
+    // At this point we know for sure that it is not marked as loaded.
+    fs = RLookup_FindFieldInSpecCache(lookup, field_name);
+    if (fs) {
+      setKeyByFieldSpec(key, fs);
+      if (RLookupKey_GetFlags(key) & RLOOKUP_F_VALAVAILABLE && !(flags & RLOOKUP_F_FORCELOAD)) {
+        // If the key is marked as "value available", it means that it is sortable and un-normalized.
+        // so we can use the sorting vector as the source, and we don't need to load it from the document.
+        return NULL;
+      }
+    } else {
+      // Field not found in the schema.
+      // We assume `field_name` is the path to load from in the document.
+      if (!(RLookupKey_GetFlags(key) & RLOOKUP_F_NAMEALLOC)) {
+        RLookupKey_SetPath(key, field_name);
+      } else if (name != field_name) {
+        RLookupKey_SetPath(key, rm_strdup(field_name));
+      } // else
+        // If the caller requested to allocate the name, and the name is the same as the path,
+        // it was already set to the same allocation for the name, so we don't need to do anything.
+    }
+    // Mark the key as loaded from the document (for the rest of the pipeline usage).
+    RLookupKey_MergeFlags(key, RLOOKUP_F_DOCSRC | RLOOKUP_F_ISLOADED);
+    return key;
+
+  // A. we found the key at the lookup table:
+  //    1. if we are in exclusive mode, return NULL
+  //    2. if we are in create mode, overwrite the key (remove schema related data, mark with new flags)
+  // B. we didn't find the key at the lookup table:
+  //    create a new key with the name and flags
+  case RLOOKUP_M_WRITE:
+    if (!key) {
+      key = createNewKey(lookup, name, name_len, flags);
+    } else if (!(flags & RLOOKUP_F_OVERRIDE)) {
+      return NULL;
+    } else {
+      // overrides the key, and sets the new key according to the flags.
+      key = overrideKey(lookup, key, flags);
+    }
+
+    RLookupKey_MergeFlags(key, RLOOKUP_F_QUERYSRC);
+    return key;
+
+  // Return the key if it exists in the lookup table, or if it exists in the schema as SORTABLE.
+  case RLOOKUP_M_READ:
+    if (!key) {
+      // If we didn't find the key at the lookup table, check if it exists in
+      // the schema as SORTABLE, and create only if so.
+      key = genKeyFromSpec(lookup, name, name_len, flags);
+    }
+
+    // If we didn't find the key in the schema (there is no schema) and unresolved is OK, create an unresolved key.
+    if (!key && (lookup->_options & RLOOKUP_OPT_ALLOWUNRESOLVED)) {
+      key = createNewKey(lookup, name, name_len, flags);
+      RLookupKey_MergeFlags(key, RLOOKUP_F_UNRESOLVED);
+    }
+    return key;
+  }
+
+  return NULL;
+}
+
+RLookupKey *RLookup_GetKey_Read(RLookup *lookup, const char *name, uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, RLOOKUP_M_READ, flags);
+}
+
+RLookupKey *RLookup_GetKey_ReadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, name_len, NULL, RLOOKUP_M_READ, flags);
+}
+
+RLookupKey *RLookup_GetKey_Write(RLookup *lookup, const char *name, uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, RLOOKUP_M_WRITE, flags);
+}
+
+RLookupKey *RLookup_GetKey_WriteEx(RLookup *lookup, const char *name, size_t name_len,
+                                   uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, name_len, NULL, RLOOKUP_M_WRITE, flags);
+}
+
+RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name,
+                                uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, strlen(name), field_name, RLOOKUP_M_LOAD, flags);
+}
+
+RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  const char *field_name, uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, name_len, field_name, RLOOKUP_M_LOAD, flags);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, bool *skipFieldIndex,
+                         size_t skipFieldIndex_len, uint32_t requiredFlags, uint32_t excludeFlags,
+                         SchemaRule *rule) {
+  RS_LOG_ASSERT(skipFieldIndex_len >= lookup->_rowlen, "'skipFieldIndex_len' should be at least equal to lookup len");
+
+  int i = 0;
+  size_t nfields = 0;
+  RLOOKUP_FOREACH(kk, lookup, {
+    if (RLookupKey_GetName(kk) == NULL) {
+        // Overridden key. Skip without incrementing the index
+        continue;
+    }
+    if (requiredFlags && !(RLookupKey_GetFlags(kk) & requiredFlags)) {
+        i +=1;
+        continue;
+    }
+    if (excludeFlags && (RLookupKey_GetFlags(kk) & excludeFlags)) {
+        i +=1;
+        continue;
+    }
+    const RSValue *v = RLookupRow_Get(kk, r);
+    if (!v) {
+        i +=1;
+        continue;
+    }
+    // on coordinator, we reach this code without sctx or rule,
+    // we trust the shards to not send those fields.
+    if (rule && ((rule->lang_field && strcmp(RLookupKey_GetName(kk), rule->lang_field) == 0) ||
+                    (rule->score_field && strcmp(RLookupKey_GetName(kk), rule->score_field) == 0) ||
+                    (rule->payload_field && strcmp(RLookupKey_GetName(kk), rule->payload_field) == 0))) {
+        i +=1;
+        continue;
+    }
+
+    skipFieldIndex[i] = true;
+    ++nfields;
+    i +=1;
+  });
+  RS_LOG_ASSERT(i == lookup->_rowlen, "'i' should be equal to lookup len");
+  return nfields;
+}
+
+void RLookup_SetCache(RLookup *lk, IndexSpecCache *spcache) {
+  lk->_spcache = spcache;
+}
+
+void RLookup_WriteOwnKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
+  // Find the pointer to write to ...
+  RSValue **vptr = array_ensure_at(&row->dyn, RLookupKey_GetDstIdx(key), RSValue *);
+  if (*vptr) {
+    RSValue_DecrRef(*vptr);
+    row->ndyn--;
+  }
+  *vptr = v;
+  row->ndyn++;
+}
+
+void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
+  RLookup_WriteOwnKey(key, row, RSValue_IncrRef(v));
+}
+
+void RLookup_WriteKeyByName(RLookup *lookup, const char *name, size_t len, RLookupRow *dst, RSValue *v) {
+  // Get the key first
+  RLookupKey *k = RLookup_FindKey(lookup, name, len);
+  if (!k) {
+    k = RLookup_GetKey_WriteEx(lookup, name, len, RLOOKUP_F_NAMEALLOC);
+  }
+  RLookup_WriteKey(k, dst, v);
+}
+
+void RLookupRow_WriteByNameOwned(RLookup *lookup, const char *name, size_t len, RLookupRow *row, RSValue *value) {
+  RLookup_WriteKeyByName(lookup, name, len, row, value);
+  RSValue_DecrRef(value);
+}
+
+void RLookupRow_Wipe(RLookupRow *r) {
+  for (size_t ii = 0; ii < array_len(r->dyn) && r->ndyn; ++ii) {
+    RSValue **vpp = r->dyn + ii;
+    if (*vpp) {
+      RSValue_DecrRef(*vpp);
+      *vpp = NULL;
+      r->ndyn--;
+    }
+  }
+  r->sv = NULL;
+}
+
+void RLookupRow_Reset(RLookupRow *r) {
+  RLookupRow_Wipe(r);
+  if (r->dyn) {
+    array_free(r->dyn);
+    r->dyn = NULL;
+  }
+  RS_LOG_ASSERT(r->ndyn == 0, "ndyn should be 0 after reset");
+}
+
+void RLookupRow_MoveFieldsFrom(const RLookup *lk, RLookupRow *src, RLookupRow *dst) {
+  RLookupIterator iter = RLookup_Iter(lk);
+  const RLookupKey* k;
+
+  while (RLookupIterator_Next(&iter, &k)) {
+    RSValue *vv = RLookupRow_Get(k, src);
+    if (vv) {
+      RLookup_WriteKey(k, dst, vv);
+    }
+  }
+
+  RLookupRow_Wipe(src);
+}
+
+void RLookup_Cleanup(RLookup *lk) {
+  RLookupKey *next, *cur = lk->_head;
+  while (cur) {
+    next = cur->_next;
+    RLookupKey_Free(cur);
+    cur = next;
+  }
+  IndexSpecCache_Decref(lk->_spcache);
+
+  lk->_head = lk->_tail = NULL;
+  memset(lk, 0, sizeof(*lk));
+}
+
+
+void RLookup_AddKeysFrom(const RLookup *src, RLookup *dest, uint32_t flags) {
+  RS_ASSERT(dest && src);
+  RS_ASSERT(dest != src);  // Prevent self-addition
+
+  // Iterate through all keys in source lookup
+  RLookupIterator iter = RLookup_Iter(src);
+  const RLookupKey* src_key;
+  while (RLookupIterator_Next(&iter, &src_key)) {
+    if (!RLookupKey_GetName(src_key)) {
+      // Skip overridden keys (they have name == NULL)
+      continue;
+    }
+
+    // Combine caller's control flags with source key's persistent properties
+    // Only preserve non-transient flags from source (F_SVSRC, F_HIDDEN, etc.)
+    // while respecting caller's control flags (F_OVERRIDE, F_FORCE_LOAD, etc.)
+    uint32_t combined_flags = flags | (RLookupKey_GetFlags(src_key) & ~RLOOKUP_TRANSIENT_FLAGS);
+    RLookupKey *dest_key = RLookup_GetKey_Write(dest, RLookupKey_GetName(src_key), combined_flags);
+  }
+}
+
+void RLookupRow_WriteFieldsFrom(const RLookupRow *srcRow, const RLookup *srcLookup,
+                               RLookupRow *destRow, RLookup *destLookup,
+                               bool createMissingKeys) {
+  RS_ASSERT(srcRow && srcLookup);
+  RS_ASSERT(destRow && destLookup);
+
+  // Iterate through all source keys
+  RLookupIterator iter = RLookup_Iter(srcLookup);
+  const RLookupKey* src_key;
+  while (RLookupIterator_Next(&iter, &src_key)) {
+    if (!RLookupKey_GetName(src_key)) {
+      // Skip overridden keys
+      continue;
+    }
+
+    // Get value from source row
+    RSValue *value = RLookupRow_Get(src_key, srcRow);
+    if (!value) {
+      // No data for this key in source row
+      continue;
+    }
+
+    // Find corresponding key in destination lookup
+    RLookupKey *dest_key = RLookup_FindKey(destLookup, RLookupKey_GetName(src_key), RLookupKey_GetNameLen(src_key));
+    if (!createMissingKeys) {
+      RS_ASSERT(dest_key != NULL);  // Assumption: all source keys exist in destination
+    } else if (!dest_key) {
+        // Key doesn't exist in destination - create it on demand.
+        // This can happen with LOAD * where keys are created dynamically.
+        // Inherit non-transient flags from source.
+        uint32_t flags = RLookupKey_GetFlags(src_key) & ~RLOOKUP_TRANSIENT_FLAGS;
+        dest_key = RLookup_GetKey_WriteEx(destLookup, RLookupKey_GetName(src_key), RLookupKey_GetNameLen(src_key), flags);
+    }
+    // Write fields to destination (increments refcount, shares ownership)
+    RLookup_WriteKey(dest_key, destRow, value);
+  }
+  // Caller is responsible for managing source row lifecycle
+}

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -17,11 +17,92 @@
 #include "sortable.h"
 #include "util/arr.h"
 
-#include "rlookup_rs.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef enum {
+  RLOOKUP_C_STR = 0,
+  RLOOKUP_C_INT = 1,
+  RLOOKUP_C_DBL = 2,
+  RLOOKUP_C_BOOL = 3
+} RLookupCoerceType;
+
+/**
+ * RLookup Key
+ *
+ * A lookup key is a structure which contains an array index at which the
+ * data may be reliably located. This avoids needless string comparisons by
+ * using quick objects rather than "dynamic" string comparison mechanisms.
+ *
+ * The basic workflow is that users of a given key (i.e. "foo") are expected
+ * to first create the key by use of RLookup_GetKey(). This will provide
+ * the consumer with an opaque object that is the slot of "foo". Once the
+ * key is provided, it may then be use to both read and write the key.
+ *
+ * Using a pre-defined key also allows the query to maintain a central registry
+ * of used names. If a user makes a typo in a query, this registry will easily
+ * detect that the name was not used previously.
+ *
+ * Note that the same name can be registered twice, in which case it will simply
+ * increment the reference to the same key.
+ *
+ * There are two arrays which are accessed to check for the key. Their use is
+ * mutually exclusive per-key, though multiple keys may exist which can access
+ * either one or the other array. The first array is the "sorting vector" for
+ * a given document. The F_SVSRC flag is set on keys which are expected to be
+ * found within the sorting vector.
+ *
+ * The second array is a "dynamic" array within a given result's row data.
+ * This is used for data generated on the fly, or for data not stored within
+ * the sorting vector.
+ */
+typedef struct RLookupKey RLookupKey;
+
+/** The index into the array where the value resides  */
+uint16_t RLookupKey_GetDstIdx(const RLookupKey* key);
+
+/**
+ * If the source of this value points to a sort vector, then this is the
+ * index within the sort vector that the value is located
+ */
+uint16_t RLookupKey_GetSvIdx(const RLookupKey* key);
+
+/** The name of this field. */
+const char * RLookupKey_GetName(const RLookupKey* key);
+
+/** The path of this field. */
+const char * RLookupKey_GetPath(const RLookupKey* key);
+
+/** The length of the name field in bytes. */
+size_t RLookupKey_GetNameLen(const RLookupKey* key);
+
+/**
+ * Indicate the type and other attributes
+ * Can be F_SVSRC which means the target array is a sorting vector)
+ */
+uint32_t RLookupKey_GetFlags(const RLookupKey* key);
+
+typedef struct RLookup {
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_Iter or RLookup_IterMut INSTEAD! */
+  RLookupKey *_head;
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_Iter or RLookup_IterMut INSTEAD! */
+  RLookupKey *_tail;
+
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_GetRowLen INSTEAD! */
+  uint32_t _rowlen;
+
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_EnableOptions or RLookup_DisableOptions INSTEAD! */
+  uint32_t _options;
+
+  // If present, then GetKey will consult this list if the value is not found in
+  // the existing list of keys.
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_HasIndexSpecCache INSTEAD! */
+  IndexSpecCache *_spcache;
+} RLookup;
+
+/** Returns a new RLookup struct. Will forward the call to Rust once RLookup is migrated. */
+static inline RLookup RLookup_New(void) { return (RLookup){0}; }
 
 #define RLOOKUP_FOREACH(key, rlookup, block) \
     RLookupIterator iter = RLookup_Iter(rlookup); \
@@ -30,23 +111,10 @@ extern "C" {
         block \
     }
 
-/**
- * Advances the iterator to the next key places a pointer to it into `key`.
- *
- * Returns `true` while there are more keys or `false` to indicate the
- * last key ways returned and the caller should not call this function anymore.
- */
-static inline bool RLookupIterator_Next(RLookupIterator* iterator, const RLookupKey** key) {
-    const RLookupKey *current = iterator->current;
-    if (current == NULL) {
-        return false;
-    } else {
-        *key = current;
-        iterator->current = current->next;
-
-        return true;
-    }
-}
+/** An iterator over the keys in an `RLookup` returning immutable pointers. */
+typedef struct RLookupIterator {
+    const struct RLookupKey *current;
+} RLookupIterator;
 
 /**
  * Advances the iterator to the next key places a pointer to it into `key`.
@@ -54,53 +122,361 @@ static inline bool RLookupIterator_Next(RLookupIterator* iterator, const RLookup
  * Returns `true` while there are more keys or `false` to indicate the
  * last key ways returned and the caller should not call this function anymore.
  */
-static inline bool RLookupIteratorMut_Next(RLookupIteratorMut* iterator, RLookupKey** key) {
-    RLookupKey *current = iterator->current;
-    if (current == NULL) {
-        return false;
-    } else {
-        *key = current;
-        iterator->current = current->next;
+bool RLookupIterator_Next(RLookupIterator* iterator, const RLookupKey** key);
 
-        return true;
+/** A iterator over the keys in an `RLookup` returning mutable pointers. */
+typedef struct RLookupIteratorMut {
+    struct RLookupKey *current;
+} RLookupIteratorMut;
+
+/**
+ * Advances the iterator to the next key places a pointer to it into `key`.
+ *
+ * Returns `true` while there are more keys or `false` to indicate the
+ * last key ways returned and the caller should not call this function anymore.
+ */
+bool RLookupIteratorMut_Next(RLookupIteratorMut* iterator, RLookupKey** key);
+
+/** Returns an immutable iterator over the keys in this RLookup */
+RLookupIterator RLookup_Iter(const RLookup* rlookup);
+
+/** Returns an mutable iterator over the keys in this RLookup */
+RLookupIteratorMut RLookup_IterMut(const RLookup* rlookup);
+
+/**
+ * Returns the length of the data row.
+ * This is not necessarily the number of lookup keys
+ */
+static inline uint32_t RLookup_GetRowLen(const RLookup* rlookup) {
+    return rlookup->_rowlen;
+}
+
+/**
+ * Enables the given set of RLookup options.
+ */
+static inline void RLookup_EnableOptions(RLookup* rlookup, uint32_t options) {
+    rlookup->_options |= options;
+}
+
+/**
+ * Disables the given set of RLookup options.
+ */
+static inline void RLookup_DisableOptions(RLookup* rlookup, uint32_t options) {
+    rlookup->_options &= ~options;
+}
+
+/** Returns `true` if this RLookup has an associated IndexSpecCache. */
+static inline bool RLookup_HasIndexSpecCache(const RLookup* rlookup) {
+    return rlookup->_spcache != NULL;
+}
+
+// If the key cannot be found, do not mark it as an error, but create it and
+// mark it as F_UNRESOLVED
+#define RLOOKUP_OPT_ALLOWUNRESOLVED 0x01
+
+// If a loader was added to load the entire document, this flag will allow
+// later calls to GetKey in read mode to create a key (from the schema) even if it is not sortable
+#define RLOOKUP_OPT_ALLLOADED 0x02
+
+/**
+ * Row data for a lookup key. This abstracts the question of "where" the
+ * data comes from.
+ */
+typedef struct {
+  /** Sorting vector attached to document */
+  const RSSortingVector *sv;
+
+  /** Dynamic values obtained from prior processing */
+  RSValue **dyn;
+
+  /**
+   * How many values actually exist in dyn. Note that this
+   * is not the length of the array!
+   */
+  size_t ndyn;
+} RLookupRow;
+
+/** Returns a new RLookupRow struct. Will forward the call to Rust once RLookupRow is migrated. */
+static inline RLookupRow RLookupRow_New(void) { return (RLookupRow){0}; }
+
+static inline const RSSortingVector* RLookupRow_GetSortingVector(const RLookupRow* row) {return row->sv;}
+static inline void RLookupRow_SetSortingVector(RLookupRow* row, const RSSortingVector* sv) {row->sv = sv;}
+
+typedef enum {
+  RLOOKUP_M_READ,   // Get key for reading (create only if in schema and sortable)
+  RLOOKUP_M_WRITE,  // Get key for writing
+  RLOOKUP_M_LOAD,   // Load key from redis keyspace (include known information on the key, fail if already loaded)
+} RLookupMode;
+
+#define RLOOKUP_F_NOFLAGS 0x0 // No special flags to pass.
+
+/**
+ * This field is (or assumed to be) part of the document itself.
+ * This is a basic flag for a loaded key.
+ */
+#define RLOOKUP_F_DOCSRC 0x01
+
+/**
+ * This field is part of the index schema.
+ */
+#define RLOOKUP_F_SCHEMASRC 0x02
+
+/** Check the sorting table, if necessary, for the index of the key. */
+#define RLOOKUP_F_SVSRC 0x04
+
+/**
+ * This key was created by the query itself (not in the document)
+ */
+#define RLOOKUP_F_QUERYSRC 0x08
+
+/** Copy the key string via strdup. `name` may be freed */
+#define RLOOKUP_F_NAMEALLOC 0x10
+
+/**
+ * If the key is already present, then overwrite it (relevant only for LOAD or WRITE modes)
+ */
+#define RLOOKUP_F_OVERRIDE 0x20
+
+/**
+ * Request that the key is returned for loading even if it is already loaded.
+ */
+#define RLOOKUP_F_FORCELOAD 0x40
+
+/**
+ * This key is unresolved. Its source needs to be derived from elsewhere
+ */
+#define RLOOKUP_F_UNRESOLVED 0x80
+
+/**
+ * This field is hidden within the document and is only used as a transient
+ * field for another consumer. Don't output this field.
+ */
+#define RLOOKUP_F_HIDDEN 0x100
+
+/**
+ * The opposite of F_HIDDEN. This field is specified as an explicit return in
+ * the RETURN list, so ensure that this gets emitted. Only set if
+ * explicitReturn is true in the aggregation request.
+ */
+#define RLOOKUP_F_EXPLICITRETURN 0x200
+
+/**
+ * This key's value is already available in the RLookup table,
+ * if it was opened for read but the field is sortable and not normalized,
+ * so the data should be exactly the same as in the doc.
+ */
+#define RLOOKUP_F_VALAVAILABLE 0x400
+
+/**
+ * This key's value was loaded (by a loader) from the document itself.
+ */
+#define RLOOKUP_F_ISLOADED 0x800
+
+/**
+ * This key type is numeric
+ */
+#define RLOOKUP_F_NUMERIC 0x1000
+
+// Flags that are allowed to be passed to GetKey
+#define RLOOKUP_GET_KEY_FLAGS (RLOOKUP_F_NAMEALLOC | RLOOKUP_F_OVERRIDE | RLOOKUP_F_HIDDEN | RLOOKUP_F_EXPLICITRETURN | \
+                               RLOOKUP_F_FORCELOAD)
+// Flags do not persist to the key, they are just options to GetKey()
+#define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OVERRIDE | RLOOKUP_F_FORCELOAD)
+
+/**
+ * Get a RLookup key for a given name.
+ *
+ * 1. On READ mode, a key is returned only if it's already in the lookup table (available from the
+ * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
+ * if the lookup table accepts unresolved keys.
+ */
+RLookupKey *RLookup_GetKey_Read(RLookup *lookup, const char *name, uint32_t flags);
+RLookupKey *RLookup_GetKey_ReadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  uint32_t flags);
+/**
+ * Get a RLookup key for a given name.
+ *
+ * 2. On WRITE mode, a key is created and returned only if it's NOT in the lookup table, unless the
+ * override flag is set.
+ */
+RLookupKey *RLookup_GetKey_Write(RLookup *lookup, const char *name, uint32_t flags);
+RLookupKey *RLookup_GetKey_WriteEx(RLookup *lookup, const char *name, size_t name_len,
+                                   uint32_t flags);
+/**
+ * Get a RLookup key for a given name.
+ *
+ * 3. On LOAD mode, a key is created and returned only if it's NOT in the lookup table (unless the
+ * override flag is set), and it is not already loaded. It will override an existing key if it was
+ * created for read out of a sortable field, and the field was normalized. A sortable un-normalized
+ * field counts as loaded.
+ */
+RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name,
+                                uint32_t flags);
+RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  const char *field_name, uint32_t flags);
+
+/**
+ * Get the amount of visible fields is the RLookup
+ */
+size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, bool *skipFieldIndex,
+                         size_t skipFieldIndex_len, uint32_t requiredFlags, uint32_t excludeFlags,
+                         SchemaRule *rule);
+
+/**
+ * Get a value from the lookup.
+ */
+
+/**
+ * Write a value to a lookup table. Key must already be registered, and not
+ * refer to a read-only (SVSRC) key.
+ *
+ * The value written will have its refcount incremented
+ */
+void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *value);
+
+/**
+ * Exactly like RLookup_WriteKey, but does not increment the refcount, allowing
+ * idioms such as RLookup_WriteKey(..., RSValue_NewNumber(10)); which would otherwise cause
+ * a leak.
+ */
+void RLookup_WriteOwnKey(const RLookupKey *key, RLookupRow *row, RSValue *value);
+
+/**
+ * Move data from the source row to the destination row. The source row is cleared.
+ * @param lk lookup common to both rows
+ * @param src the source row
+ * @param dst the destination row
+ */
+void RLookupRow_MoveFieldsFrom(const RLookup *lk, RLookupRow *src, RLookupRow *dst);
+
+/**
+ * Write a value by-name to the lookup table. This is useful for 'dynamic' keys
+ * for which it is not necessary to use the boilerplate of getting an explicit
+ * key.
+ *
+ * The reference count of the value will be incremented.
+ */
+void RLookup_WriteKeyByName(RLookup *lookup, const char *name, size_t len, RLookupRow *row, RSValue *value);
+
+/**
+ * Like WriteKeyByName, but consumes a refcount
+ */
+void RLookupRow_WriteByNameOwned(RLookup *lookup, const char *name, size_t len, RLookupRow *row, RSValue *value);
+
+/** Get a value from the row, provided the key.
+ *
+ * This does not actually "search" for the key, but simply performs array
+ * lookups!
+ *
+ * @param lookup The lookup table containing the lookup table data
+ * @param key the key that contains the index
+ * @param row the row data which contains the value
+ * @return the value if found, NULL otherwise.
+ */
+static inline RSValue *RLookupRow_Get(const RLookupKey *key, const RLookupRow *row) {
+
+  RSValue *ret = NULL;
+  if (row->dyn && array_len(row->dyn) > RLookupKey_GetDstIdx(key)) {
+    ret = row->dyn[RLookupKey_GetDstIdx(key)];
+  }
+  if (!ret) {
+    if (RLookupKey_GetFlags(key) & RLOOKUP_F_SVSRC) {
+      const RSSortingVector* sv = RLookupRow_GetSortingVector(row);
+      if (sv && RSSortingVector_Length(sv) > RLookupKey_GetSvIdx(key)) {
+        ret = RSSortingVector_Get(sv, RLookupKey_GetSvIdx(key));
+        if (ret != NULL && ret == RSValue_NullStatic()) {
+          ret = NULL;
+        }
+      }
     }
-}
-
-/** The index into the array where the value resides  */
-static inline uint16_t RLookupKey_GetDstIdx(const RLookupKey* key) {
-    return key->dstidx;
+  }
+  return ret;
 }
 
 /**
- * If the source of this value points to a sort vector, then this is the
- * index within the sort vector that the value is located
+ * Wipes the row, retaining its memory but decrefing any included values.
+ * This does not free all the memory consumed by the row, but simply resets
+ * the row data (preserving any caches) so that it may be refilled.
  */
-static inline uint16_t RLookupKey_GetSvIdx(const RLookupKey* key) {
-    return key->svidx;
-}
-
-/** The name of this field. */
-static inline const char * RLookupKey_GetName(const RLookupKey* key) {
-    return key->name;
-}
-
-/** The path of this field. */
-static inline const char * RLookupKey_GetPath(const RLookupKey* key) {
-    return key->path;
-}
-
-/** The length of the name field in bytes. */
-static inline size_t RLookupKey_GetNameLen(const RLookupKey* key) {
-    return key->name_len;
-}
+void RLookupRow_Wipe(RLookupRow *row);
 
 /**
- * Indicate the type and other attributes
- * Can be F_SVSRC which means the target array is a sorting vector
+ * Frees all the memory consumed by the row. Implies Wipe(). This should be used
+ * when the row object will no longer be used.
  */
-static inline uint32_t RLookupKey_GetFlags(const RLookupKey* key) {
-    return key->flags;
-}
+void RLookupRow_Reset(RLookupRow *row);
+
+/**
+ * Sets the `IndexSpecCache` of the lookup. If cache is provided, then it will be used as an
+ * alternate source for lookups whose fields are absent
+ */
+void RLookup_SetCache(RLookup *l, IndexSpecCache *cache);
+
+/**
+ * Releases any resources created by this lookup object. Note that if there are
+ * lookup keys created with RLOOKUP_F_NOINCREF, those keys will no longer be
+ * valid after this call!
+ */
+void RLookup_Cleanup(RLookup *l);
+
+/**
+ * Frees an individual RLookupKey, cleaning up its allocated strings
+ */
+void RLookupKey_Free(RLookupKey *k);
+
+/**
+ * Find a key in the lookup table by name. Returns NULL if not found.
+ */
+RLookupKey *RLookup_FindKey(RLookup *lookup, const char *name, size_t name_len);
+
+/**
+ * Allocate a new RLookupKey and add it to the RLookup table.
+ */
+RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t name_len, uint32_t flags);
+
+/**
+ * Set the path of a RLookupKey.
+ */
+void RLookupKey_SetPath(RLookupKey *key, const char *path);
+
+
+/**
+ * Search an index field by its name in the lookup table spec cache.
+ */
+const FieldSpec *RLookup_FindFieldInSpecCache(const RLookup *lookup, const char *name);
+
+/**
+ * Add non-overridden keys from source lookup into destination lookup (overridden keys are skipped).
+ * For each key in src, check if it already exists in dest by name.
+ * If doesn't exists, create new key in dest.
+ * Handle existing keys based on flags (skip with RLOOKUP_F_NOFLAGS, override with RLOOKUP_F_OVERRIDE).
+ *
+ * Flag handling:
+ * - Preserves persistent source key properties (F_SVSRC, F_HIDDEN, F_EXPLICITRETURN, etc.)
+ * - Filters out transient flags from source keys (F_OVERRIDE, F_FORCE_LOAD)
+ * - Respects caller's control flags for behavior (F_OVERRIDE, F_FORCE_LOAD, etc.)
+ * - Targat flags = caller_flags | (source_flags & ~RLOOKUP_TRANSIENT_FLAGS)
+ */
+void RLookup_AddKeysFrom(const RLookup *src, RLookup *dest, uint32_t flags);
+
+/**
+ * Write field data from source row to destination row with different schemas.
+ * Iterate through source lookup keys, find corresponding keys in destination by name,
+ * and write it to destination row using RLookup_WriteOwnKey().
+ *
+ * @param srcRow        Source row containing the data
+ * @param srcLookup     Source lookup containing the schema of the source row
+ * @param destRow       Destination row to write data to
+ * @param destLookup    Destination lookup containing the schema of the
+ *                      destination row
+ * @param createMissingKeys
+ *                      If true, creates keys in destination that don't exist
+ *                      (LOAD * behavior).
+ *                      If false, skips keys that don't exist in destination.
+ */
+void RLookupRow_WriteFieldsFrom(const RLookupRow *srcRow, const RLookup *srcLookup,
+                               RLookupRow *destRow, RLookup *destLookup,
+                               bool createMissingKeys);
 
 #ifdef __cplusplus
 }

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -15,13 +15,6 @@
 #include "value.h"
 #include "util/arr.h"
 
-typedef enum {
-  RLOOKUP_C_STR = 0,
-  RLOOKUP_C_INT = 1,
-  RLOOKUP_C_DBL = 2,
-  RLOOKUP_C_BOOL = 3
-} RLookupCoerceType;
-
 static RSValue *hvalToValue(const RedisModuleString *src, RLookupCoerceType type) {
   if (type == RLOOKUP_C_BOOL || type == RLOOKUP_C_INT) {
     long long ll;
@@ -206,22 +199,6 @@ done:
   return rc;
 }
 
-/**
- * Find a key in the lookup table by name. Returns NULL if not found.
- */
-static RLookupKey *RLookup_FindKey(RLookup *lookup, const char *name, size_t name_len) {
-  RLookupIteratorMut iter = RLookup_IterMut(lookup);
-  RLookupKey* key;
-
-  while (RLookupIteratorMut_Next(&iter, &key)) {
-    // match `name` to the name of the key
-    if (RLookupKey_GetNameLen(key) == name_len && !strncmp(RLookupKey_GetName(key), name, name_len)) {
-      return key;
-    }
-  }
-  return NULL;
-}
-
 typedef struct {
   RLookup *it;
   RLookupRow *dst;
@@ -352,5 +329,37 @@ int RLookup_LoadDocumentIndividual(RLookup *it, RLookupRow *dst, RLookupLoadOpti
 
   rv = loadIndividualKeys(it, dst, options);
 
+  return rv;
+}
+
+int RLookup_LoadRuleFields(RedisSearchCtx *sctx, RLookup *it, RLookupRow *dst, IndexSpec *spec, const char *keyptr, QueryError *status) {
+  SchemaRule *rule = spec->rule;
+
+  // create rlookupkeys
+  int nkeys = array_len(rule->filter_fields);
+  RLookupKey **keys = rm_malloc(nkeys * sizeof(*keys));
+  for (int i = 0; i < nkeys; ++i) {
+    int idx = rule->filter_fields_index[i];
+    if (idx == -1) {
+      keys[i] = createNewKey(it, rule->filter_fields[i], strlen(rule->filter_fields[i]), RLOOKUP_F_NOFLAGS);
+      continue;
+    }
+    FieldSpec *fs = spec->fields + idx;
+    size_t length = 0;
+    const char *name = HiddenString_GetUnsafe(fs->fieldName, &length);
+    keys[i] = createNewKey(it, name, length, RLOOKUP_F_NOFLAGS);
+    RLookupKey_SetPath(keys[i], HiddenString_GetUnsafe(fs->fieldPath, NULL));
+  }
+
+  // load
+  RLookupLoadOptions opt = {.keys = (const RLookupKey **)keys,
+                            .nkeys = nkeys,
+                            .sctx = sctx,
+                            .keyPtr = keyptr,
+                            .type = rule->type,
+                            .status = status,
+                            .forceLoad = 1 };
+  int rv = loadIndividualKeys(it, dst, &opt);
+  rm_free(keys);
   return rv;
 }

--- a/src/rlookup_load_document.h
+++ b/src/rlookup_load_document.h
@@ -55,6 +55,9 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
 int RLookup_LoadDocumentAll(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *options);
 int RLookup_LoadDocumentIndividual(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *options);
 
+int RLookup_LoadRuleFields(RedisSearchCtx *sctx, RLookup *it, RLookupRow *dst,
+                           IndexSpec *sp, const char *keyptr, QueryError *status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -13,7 +13,6 @@
 #include "spec.h"
 #include "common.h"
 #include "module.h"
-#include "rlookup.h"
 
 #include <vector>
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core result lookup/data movement code and FFI boundaries (new C `rlookup` implementation, `RSSortingVector` layout/access changes), which could introduce memory-safety or behavioral regressions. Changes are localized but impact hot-path query execution and field loading.
> 
> **Overview**
> Reverts `rlookup` back to a C implementation (`rlookup.c`/`rlookup.h`), removing the dependency on the Rust `rlookup_ffi` entrypoint and moving helpers like `RLookup_FindKey`/coercion types out of `rlookup_load_document.c`.
> 
> Updates the sorting-vector FFI to expose `RSSortingVector` as a concrete `#[repr(C)]` struct and replaces `RSSortingVector_Get`/`RSSortingVector_Length` exported functions with inline C accessors in `sorting_vector.h` for lower overhead.
> 
> Adjusts Rust-side integration accordingly: `search_result` drops its `rlookup` dependency and stores row data as `ffi::RLookupRow` with cleanup via `ffi::RLookupRow_Wipe/Reset`; `RLookupRow` null-sentinel handling is simplified to `!v.is_null()`. Includes minor test/lint cleanups (unsafe FFI mocks, `write_all`, clippy expects) and header generation tweaks (cbindgen excludes/defines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da9d027a48e231c8e38f0d46b942897e295f45a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->