### PR TITLE
[MOD-14143] Pass IndexSpec to Revalidate instead of storing the context in iterators

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -421,7 +421,7 @@ DEBUG_COMMAND(InvertedIndexSummary) {
   }
   GET_SEARCH_CTX(argv[2])
   invIdxName = RedisModule_StringPtrLen(argv[3], &len);
-  invidx = Redis_OpenInvertedIndex(sctx, invIdxName, len, 0, NULL);
+  invidx = Redis_OpenInvertedIndex(sctx->spec, invIdxName, len, 0, NULL);
   if (!invidx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;
@@ -473,7 +473,7 @@ DEBUG_COMMAND(DumpInvertedIndex) {
   }
   GET_SEARCH_CTX(argv[2])
   invIdxName = RedisModule_StringPtrLen(argv[3], &len);
-  invidx = Redis_OpenInvertedIndex(sctx, invIdxName, len, 0, NULL);
+  invidx = Redis_OpenInvertedIndex(sctx->spec, invIdxName, len, 0, NULL);
   if (!invidx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -24,7 +24,7 @@ void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
   while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, NULL, &dist)) {
     size_t termLen;
     char *term = runesToStr(rstr, slen, &termLen);
-    InvertedIndex *idx = Redis_OpenInvertedIndex(sctx, term, termLen, DONT_CREATE_INDEX, NULL);
+    InvertedIndex *idx = Redis_OpenInvertedIndex(sctx->spec, term, termLen, DONT_CREATE_INDEX, NULL);
     if (idx) {
       struct iovec iov = {.iov_base = (void *)term, termLen};
 
@@ -88,7 +88,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
 
   RedisSearchCtx_LockSpecWrite(sctx);
 
-  idx = Redis_OpenInvertedIndex(sctx, term, len, DONT_CREATE_INDEX, NULL);
+  idx = Redis_OpenInvertedIndex(sctx->spec, term, len, DONT_CREATE_INDEX, NULL);
 
   if (idx == NULL) {
     status = FGC_PARENT_ERROR;

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -119,7 +119,7 @@ std::size_t QIter_NumEstimated(const QueryIterator *ctx) {
 void QIter_Rewind(QueryIterator *ctx) {
   reinterpret_cast<CPPQueryIterator *>(ctx)->rewind();
 }
-ValidateStatus QIter_Revalidate(QueryIterator *ctx) {
+ValidateStatus QIter_Revalidate(QueryIterator *ctx, RedisSearchCtx *) {
   auto *qi = reinterpret_cast<CPPQueryIterator *>(ctx);
   qi->check_field_expiration_ =
       CPPQueryIterator::should_check_field_expiration(qi->sctx_, &qi->filterCtx_);

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -119,7 +119,7 @@ std::size_t QIter_NumEstimated(const QueryIterator *ctx) {
 void QIter_Rewind(QueryIterator *ctx) {
   reinterpret_cast<CPPQueryIterator *>(ctx)->rewind();
 }
-ValidateStatus QIter_Revalidate(QueryIterator *ctx, RedisSearchCtx *) {
+ValidateStatus QIter_Revalidate(QueryIterator *ctx, IndexSpec *) {
   auto *qi = reinterpret_cast<CPPQueryIterator *>(ctx);
   qi->check_field_expiration_ =
       CPPQueryIterator::should_check_field_expiration(qi->sctx_, &qi->filterCtx_);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -115,7 +115,7 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
       }
     } else {
       bool isNew;
-      InvertedIndex *invidx = Redis_OpenInvertedIndex(ctx, entry->term, entry->len, 1, &isNew);
+      InvertedIndex *invidx = Redis_OpenInvertedIndex(ctx->spec, entry->term, entry->len, 1, &isNew);
       if (isNew && strlen(entry->term) != 0) {
         IndexSpec_AddTerm(spec, entry->term, entry->len);
       }

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -572,9 +572,9 @@ static QueryIterator* HybridIteratorReducer(HybridIteratorParams *hParams) {
 // If we already have the results prepared, we are OK, and if not, we didn't execute the query yet so we are also OK.
 // Only if we have a child iterator, and it aborted, we need to abort the hybrid iterator.
 // If the child iterator is OK or MOVED, we are OK whether we have results prepared or not.
-static ValidateStatus HR_Revalidate(QueryIterator *ctx) {
+static ValidateStatus HR_Revalidate(QueryIterator *ctx, struct RedisSearchCtx *sctx) {
   HybridIterator *hr = (HybridIterator *)ctx;
-  if (hr->child && hr->child->Revalidate(hr->child) == VALIDATE_ABORTED) {
+  if (hr->child && hr->child->Revalidate(hr->child, sctx) == VALIDATE_ABORTED) {
     return VALIDATE_ABORTED;
   }
   hr->checkFieldExpiration = hr->sctx && hr->filterCtx.field.index != RS_INVALID_FIELD_INDEX &&

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -572,9 +572,9 @@ static QueryIterator* HybridIteratorReducer(HybridIteratorParams *hParams) {
 // If we already have the results prepared, we are OK, and if not, we didn't execute the query yet so we are also OK.
 // Only if we have a child iterator, and it aborted, we need to abort the hybrid iterator.
 // If the child iterator is OK or MOVED, we are OK whether we have results prepared or not.
-static ValidateStatus HR_Revalidate(QueryIterator *ctx, struct RedisSearchCtx *sctx) {
+static ValidateStatus HR_Revalidate(QueryIterator *ctx, struct IndexSpec *spec) {
   HybridIterator *hr = (HybridIterator *)ctx;
-  if (hr->child && hr->child->Revalidate(hr->child, sctx) == VALIDATE_ABORTED) {
+  if (hr->child && hr->child->Revalidate(hr->child, spec) == VALIDATE_ABORTED) {
     return VALIDATE_ABORTED;
   }
   hr->checkFieldExpiration = hr->sctx && hr->filterCtx.field.index != RS_INVALID_FIELD_INDEX &&

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -16,6 +16,7 @@
 #include "iterator_type.h"
 
 struct RLookupKey; // Forward declaration
+struct RedisSearchCtx; // Forward declaration
 
 typedef enum IteratorStatus {
   ITERATOR_OK,
@@ -75,11 +76,12 @@ typedef struct QueryIterator {
    * Called when the iterator is being revalidated after a concurrent index change.
    * The iterator should check if it is still valid.
    *
+   * @param sctx The search context, provided by the caller (result processor).
    * @return VALIDATE_OK if the iterator is still valid
    * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed (moved forward)
    * @return VALIDATE_ABORTED if the iterator is no longer valid
    */
-  ValidateStatus (*Revalidate)(struct QueryIterator *self);
+  ValidateStatus (*Revalidate)(struct QueryIterator *self, struct RedisSearchCtx *sctx);
 
   /* release the iterator's context and free everything needed */
   void (*Free)(struct QueryIterator *self);
@@ -93,7 +95,7 @@ typedef struct QueryIterator {
   QueryIterator* (*ProfileChildren)(struct QueryIterator *self);
 } QueryIterator;
 
-static inline ValidateStatus Default_Revalidate(struct QueryIterator *base) {
+static inline ValidateStatus Default_Revalidate(struct QueryIterator *base, struct RedisSearchCtx *sctx) {
   // Default implementation does nothing.
   return VALIDATE_OK;
 }

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -16,7 +16,6 @@
 #include "iterator_type.h"
 
 struct RLookupKey; // Forward declaration
-struct RedisSearchCtx; // Forward declaration
 
 typedef enum IteratorStatus {
   ITERATOR_OK,
@@ -76,12 +75,12 @@ typedef struct QueryIterator {
    * Called when the iterator is being revalidated after a concurrent index change.
    * The iterator should check if it is still valid.
    *
-   * @param sctx The search context, provided by the caller (result processor).
+   * @param spec The index spec, provided by the caller (result processor).
    * @return VALIDATE_OK if the iterator is still valid
    * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed (moved forward)
    * @return VALIDATE_ABORTED if the iterator is no longer valid
    */
-  ValidateStatus (*Revalidate)(struct QueryIterator *self, struct RedisSearchCtx *sctx);
+  ValidateStatus (*Revalidate)(struct QueryIterator *self, struct IndexSpec *spec);
 
   /* release the iterator's context and free everything needed */
   void (*Free)(struct QueryIterator *self);
@@ -95,7 +94,7 @@ typedef struct QueryIterator {
   QueryIterator* (*ProfileChildren)(struct QueryIterator *self);
 } QueryIterator;
 
-static inline ValidateStatus Default_Revalidate(struct QueryIterator *base, struct RedisSearchCtx *sctx) {
+static inline ValidateStatus Default_Revalidate(struct QueryIterator *base, struct IndexSpec *spec) {
   // Default implementation does nothing.
   return VALIDATE_OK;
 }

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -40,12 +40,12 @@ static size_t OPT_NumEstimated(const QueryIterator *self) {
 }
 
 // TODO: handle MOVED better
-static ValidateStatus OPT_Validate(QueryIterator *self) {
+static ValidateStatus OPT_Validate(QueryIterator *self, struct RedisSearchCtx *sctx) {
   OptimizerIterator *opt = (OptimizerIterator *)self;
-  if (opt->child->Revalidate(opt->child) != VALIDATE_OK) {
+  if (opt->child->Revalidate(opt->child, sctx) != VALIDATE_OK) {
     return VALIDATE_ABORTED;
   }
-  if (opt->numericIter->Revalidate(opt->numericIter) != VALIDATE_OK) {
+  if (opt->numericIter->Revalidate(opt->numericIter, sctx) != VALIDATE_OK) {
     return VALIDATE_ABORTED;
   }
   return VALIDATE_OK;

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -40,12 +40,12 @@ static size_t OPT_NumEstimated(const QueryIterator *self) {
 }
 
 // TODO: handle MOVED better
-static ValidateStatus OPT_Validate(QueryIterator *self, struct RedisSearchCtx *sctx) {
+static ValidateStatus OPT_Validate(QueryIterator *self, struct IndexSpec *spec) {
   OptimizerIterator *opt = (OptimizerIterator *)self;
-  if (opt->child->Revalidate(opt->child, sctx) != VALIDATE_OK) {
+  if (opt->child->Revalidate(opt->child, spec) != VALIDATE_OK) {
     return VALIDATE_ABORTED;
   }
-  if (opt->numericIter->Revalidate(opt->numericIter, sctx) != VALIDATE_OK) {
+  if (opt->numericIter->Revalidate(opt->numericIter, spec) != VALIDATE_OK) {
     return VALIDATE_ABORTED;
   }
   return VALIDATE_OK;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -161,27 +161,27 @@ void SearchCtx_Free(RedisSearchCtx *sctx) {
   rm_free(sctx);
 }
 
-static InvertedIndex *openIndexKeysDict(const RedisSearchCtx *ctx, CharBuf *termKey,
+static InvertedIndex *openIndexKeysDict(IndexSpec *spec, CharBuf *termKey,
                                         bool write, bool *outIsNew) {
-  InvertedIndex *idx = dictFetchValue(ctx->spec->keysDict, termKey);
+  InvertedIndex *idx = dictFetchValue(spec->keysDict, termKey);
   if (outIsNew) {
     *outIsNew = idx == NULL;
   }
   if (write && !idx) {
     size_t index_size;
-    idx = NewInvertedIndex(ctx->spec->flags, &index_size);
-    ctx->spec->stats.invertedSize += index_size;
-    dictAdd(ctx->spec->keysDict, termKey, idx);
+    idx = NewInvertedIndex(spec->flags, &index_size);
+    spec->stats.invertedSize += index_size;
+    dictAdd(spec->keysDict, termKey, idx);
   }
   return idx;
 }
 
-InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len, bool write, bool *outIsNew) {
+InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t len, bool write, bool *outIsNew) {
   CharBuf termKeyBuf = {
       .buf = (char *)term,
       .len = len,
   };
-  InvertedIndex *idx = openIndexKeysDict(ctx, &termKeyBuf, write, outIsNew);
+  InvertedIndex *idx = openIndexKeysDict(spec, &termKeyBuf, write, outIsNew);
   return idx;
 }
 
@@ -190,7 +190,7 @@ QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok
 
   CharBuf termKey = {.buf = tok->str, .len = tok->len};
 
-  InvertedIndex *idx = openIndexKeysDict(ctx, &termKey, false, NULL);
+  InvertedIndex *idx = openIndexKeysDict(ctx->spec, &termKey, false, NULL);
   if (!idx) {
     return NULL;
   }

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -26,7 +26,7 @@ extern "C" {
 QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
                                  t_fieldMask fieldMask, double weight);
 
-InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len,
+InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t len,
                                         bool write, bool *outIsNew);
 
 #define DONT_CREATE_INDEX false

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -45,7 +45,7 @@ impl MissingIterator<'_> {
         }
     }
 
-    pub(super) fn field_name(&self) -> (*const std::ffi::c_char, usize) {
+    pub(super) const fn field_name(&self) -> (*const std::ffi::c_char, usize) {
         match self {
             MissingIterator::Encoded(m) => m.field_name(),
             MissingIterator::Raw(m) => m.field_name(),
@@ -108,8 +108,9 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        dispatch!(self, revalidate)
+        dispatch!(self, revalidate, ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -106,11 +106,12 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        dispatch!(self, revalidate, ctx)
+        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+        unsafe { dispatch!(self, revalidate, ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -108,10 +108,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-        unsafe { dispatch!(self, revalidate, ctx) }
+        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+        unsafe { dispatch!(self, revalidate, spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -45,7 +45,7 @@ impl MissingIterator<'_> {
         }
     }
 
-    pub(super) const fn field_name(&self) -> (*const std::ffi::c_char, usize) {
+    pub(super) fn field_name(&self) -> (*const std::ffi::c_char, usize) {
         match self {
             MissingIterator::Encoded(m) => m.field_name(),
             MissingIterator::Raw(m) => m.field_name(),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -86,11 +86,12 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        self.iterator.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.iterator.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -88,10 +88,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.iterator.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.iterator.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -88,8 +88,9 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        self.iterator.revalidate()
+        self.iterator.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -103,8 +103,9 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        tag_it_dispatch!(self, revalidate)
+        tag_it_dispatch!(self, revalidate, ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -101,11 +101,12 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        tag_it_dispatch!(self, revalidate, ctx)
+        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+        unsafe { tag_it_dispatch!(self, revalidate, ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -103,10 +103,10 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-        unsafe { tag_it_dispatch!(self, revalidate, ctx) }
+        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+        unsafe { tag_it_dispatch!(self, revalidate, spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -99,13 +99,13 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            WildcardIterator::Encoded(w) => unsafe { w.revalidate(ctx) },
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            WildcardIterator::Raw(w) => unsafe { w.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            WildcardIterator::Encoded(w) => unsafe { w.revalidate(spec) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            WildcardIterator::Raw(w) => unsafe { w.revalidate(spec) },
         }
     }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -97,13 +97,15 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            WildcardIterator::Encoded(w) => w.revalidate(ctx),
-            WildcardIterator::Raw(w) => w.revalidate(ctx),
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            WildcardIterator::Encoded(w) => unsafe { w.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            WildcardIterator::Raw(w) => unsafe { w.revalidate(ctx) },
         }
     }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{fmt::Debug, ptr::NonNull};
+use std::fmt::Debug;
 
 use inverted_index::{
     RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
@@ -99,10 +99,11 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            WildcardIterator::Encoded(w) => w.revalidate(),
-            WildcardIterator::Raw(w) => w.revalidate(),
+            WildcardIterator::Encoded(w) => w.revalidate(ctx),
+            WildcardIterator::Raw(w) => w.revalidate(ctx),
         }
     }
 
@@ -152,18 +153,14 @@ pub unsafe extern "C" fn NewInvIndIterator_WildcardQuery(
     let ii_ref = unsafe { &*idx_ffi };
 
     debug_assert!(!sctx.is_null(), "sctx must not be null");
-    // SAFETY: 3. guarantees sctx is valid and non-null
-    let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
 
     // Create the appropriate wildcard iterator variant based on the encoding type
     let iterator = match ii_ref {
         inverted_index_ffi::InvertedIndex::DocIdsOnly(ii) => {
-            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
-            WildcardIterator::Encoded(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
+            WildcardIterator::Encoded(Wildcard::new(ii.reader(), weight))
         }
         inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
-            // SAFETY: 3. and 4. guarantee `sctx` and `sctx.spec` validity for the iterator's lifetime.
-            WildcardIterator::Raw(unsafe { Wildcard::new(ii.reader(), sctx, weight) })
+            WildcardIterator::Raw(Wildcard::new(ii.reader(), weight))
         }
         _ => panic!(
             "Wildcard iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -80,13 +80,15 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            Self::Not(it) => it.revalidate(ctx),
-            Self::NotOptimized(it) => it.revalidate(ctx),
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            Self::Not(it) => unsafe { it.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            Self::NotOptimized(it) => unsafe { it.revalidate(ctx) },
         }
     }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -82,10 +82,11 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            Self::Not(it) => it.revalidate(),
-            Self::NotOptimized(it) => it.revalidate(),
+            Self::Not(it) => it.revalidate(ctx),
+            Self::NotOptimized(it) => it.revalidate(ctx),
         }
     }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -82,13 +82,13 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            Self::Not(it) => unsafe { it.revalidate(ctx) },
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            Self::NotOptimized(it) => unsafe { it.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            Self::Not(it) => unsafe { it.revalidate(spec) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            Self::NotOptimized(it) => unsafe { it.revalidate(spec) },
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -259,14 +259,19 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         unsafe { callback(self.header.as_ptr()) };
     }
 
-    fn revalidate(&mut self) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
         let callback = unsafe { self.Revalidate.unwrap_unchecked() };
         // SAFETY:
         // - We have a unique handle over this iterator.
         // - The C code must guarantee, by constructor, that callbacks
         //   can be called on types that implement its C iterator API.
-        let status = unsafe { callback(self.header.as_ptr()) };
+        // - `ctx` is a valid `RedisSearchCtx` pointer, guaranteed by the
+        //   `revalidate` trait method contract.
+        let status = unsafe { callback(self.header.as_ptr(), ctx.as_ptr()) };
         #[expect(non_upper_case_globals)]
         let status = match status {
             ValidateStatus_VALIDATE_ABORTED => RQEValidateStatus::Aborted,

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -259,7 +259,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         unsafe { callback(self.header.as_ptr()) };
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<ffi::RedisSearchCtx>,
     ) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -261,7 +261,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
 
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<ffi::RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
         let callback = unsafe { self.Revalidate.unwrap_unchecked() };
@@ -269,9 +269,9 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         // - We have a unique handle over this iterator.
         // - The C code must guarantee, by constructor, that callbacks
         //   can be called on types that implement its C iterator API.
-        // - `ctx` is a valid `RedisSearchCtx` pointer, guaranteed by the
+        // - `spec` is a valid `IndexSpec` pointer, guaranteed by the
         //   `revalidate` trait method contract.
-        let status = unsafe { callback(self.header.as_ptr(), ctx.as_ptr()) };
+        let status = unsafe { callback(self.header.as_ptr(), spec.as_ptr()) };
         #[expect(non_upper_case_globals)]
         let status = match status {
             ValidateStatus_VALIDATE_ABORTED => RQEValidateStatus::Aborted,

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -58,7 +58,7 @@ impl<'index> RQEIterator<'index> for Empty {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -60,7 +60,7 @@ impl<'index> RQEIterator<'index> for Empty {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -58,7 +58,10 @@ impl<'index> RQEIterator<'index> for Empty {
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -243,7 +243,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -241,7 +241,10 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -241,7 +241,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 use ffi::{
     IteratorStatus, IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND,
     IteratorStatus_ITERATOR_OK, IteratorStatus_ITERATOR_TIMEOUT, QueryIterator, ValidateStatus,
@@ -279,12 +281,17 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
 
 extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
+    sctx: *mut ffi::RedisSearchCtx,
 ) -> ValidateStatus {
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
+    debug_assert!(!sctx.is_null());
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
     let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
-    match wrapper.inner.revalidate() {
+    // SAFETY: The caller guarantees `sctx` is a valid non-null pointer to a `RedisSearchCtx`
+    // while the read lock is held.
+    let ctx = unsafe { NonNull::new_unchecked(sctx) };
+    match wrapper.inner.revalidate(ctx) {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,
         Ok(RQEValidateStatus::Moved { current }) => {
             if let Some(result) = current {

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -291,7 +291,10 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     // SAFETY: The caller guarantees `sctx` is a valid non-null pointer to a `RedisSearchCtx`
     // while the read lock is held.
     let ctx = unsafe { NonNull::new_unchecked(sctx) };
-    match wrapper.inner.revalidate(ctx) {
+    // SAFETY: The caller guarantees `sctx` is a valid non-null pointer to a
+    // `RedisSearchCtx` while the read lock is held, satisfying the safety
+    // requirements of `RQEIterator::revalidate`.
+    match unsafe { wrapper.inner.revalidate(ctx) } {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,
         Ok(RQEValidateStatus::Moved { current }) => {
             if let Some(result) = current {

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -281,20 +281,19 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
 
 extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
-    sctx: *mut ffi::RedisSearchCtx,
+    spec: *mut ffi::IndexSpec,
 ) -> ValidateStatus {
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
-    debug_assert!(!sctx.is_null());
+    debug_assert!(!spec.is_null());
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
     let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
-    // SAFETY: The caller guarantees `sctx` is a valid non-null pointer to a `RedisSearchCtx`
-    // while the read lock is held.
-    let ctx = unsafe { NonNull::new_unchecked(sctx) };
-    // SAFETY: The caller guarantees `sctx` is a valid non-null pointer to a
-    // `RedisSearchCtx` while the read lock is held, satisfying the safety
-    // requirements of `RQEIterator::revalidate`.
-    match unsafe { wrapper.inner.revalidate(ctx) } {
+    // SAFETY: The caller guarantees `spec` is a valid, non-null pointer to an `IndexSpec`
+    // while the spec read lock is held.
+    let spec = unsafe { NonNull::new_unchecked(spec) };
+    // SAFETY: `spec` points to a valid `IndexSpec` while the spec read lock is held,
+    // satisfying the safety requirements of `RQEIterator::revalidate`.
+    match unsafe { wrapper.inner.revalidate(spec) } {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,
         Ok(RQEValidateStatus::Moved { current }) => {
             if let Some(result) = current {

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -517,15 +517,15 @@ where
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let mut any_child_moved = false;
         let mut max_child_doc_id: t_docId = 0;
         let mut moved_to_eof = false;
 
         for child in &mut self.children {
-            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-            match unsafe { child.revalidate(ctx) }? {
+            // SAFETY: Delegating to child with the same `spec` passed by our caller.
+            match unsafe { child.revalidate(spec) }? {
                 RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
                 RQEValidateStatus::Moved { current } => {
                     any_child_moved = true;

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -515,13 +515,16 @@ where
         self.is_eof
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let mut any_child_moved = false;
         let mut max_child_doc_id: t_docId = 0;
         let mut moved_to_eof = false;
 
         for child in &mut self.children {
-            match child.revalidate()? {
+            match child.revalidate(ctx)? {
                 RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
                 RQEValidateStatus::Moved { current } => {
                     any_child_moved = true;

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -515,7 +515,7 @@ where
         self.is_eof
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -524,7 +524,8 @@ where
         let mut moved_to_eof = false;
 
         for child in &mut self.children {
-            match child.revalidate(ctx)? {
+            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+            match unsafe { child.revalidate(ctx) }? {
                 RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
                 RQEValidateStatus::Moved { current } => {
                     any_child_moved = true;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -290,7 +290,7 @@ where
 
     unsafe fn revalidate(
         &mut self,
-        _ctx: NonNull<ffi::RedisSearchCtx>,
+        _spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if !self.reader.needs_revalidation() {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr::NonNull;
+
 use ffi::t_docId;
 use inverted_index::{IndexReader, RSIndexResult};
 
@@ -286,7 +288,10 @@ where
         self.at_eos
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        _ctx: NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if !self.reader.needs_revalidation() {
             return Ok(RQEValidateStatus::Ok);
         }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -288,7 +288,7 @@ where
         self.at_eos
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -222,7 +222,7 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -235,7 +235,8 @@ where
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.it.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -38,8 +38,12 @@ use super::InvIndIterator;
 /// * `C` - The expiration checker type.
 pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
     it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
-    context: NonNull<RedisSearchCtx>,
     field_index: t_fieldIndex,
+    /// Cached field name pointer and length, extracted from the spec at
+    /// construction time. The pointer remains valid for the iterator's
+    /// lifetime because pre-condition 3 of [`Missing::new`] requires
+    /// `context.spec` (and its fields) to remain valid for that long.
+    field_name: (*const std::ffi::c_char, usize),
 }
 
 impl<'index, E, C> Missing<'index, E, C>
@@ -57,7 +61,8 @@ where
     ///
     /// 1. `context` must point to a valid [`RedisSearchCtx`].
     /// 2. `context.spec` must be a non-null pointer to a valid `IndexSpec`.
-    /// 3. Both 1 and 2 must remain valid for the lifetime of the iterator.
+    /// 3. Both 1 and 2 must remain valid for the lifetime of the iterator
+    ///    (the cached field name pointer points into `spec.fields`).
     /// 4. `field_index` must be a valid index into `context.spec.fields`.
     /// 5. `context.spec.missingFieldDict` must be a non-null, valid dict pointer.
     /// 6. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
@@ -81,10 +86,33 @@ where
             .frequency(1)
             .build();
 
+        // Cache the field name at construction time so `field_name()` doesn't
+        // need the context later (it was removed from the struct).
+        // Pre-condition 3 guarantees the cached pointer remains valid.
+        // SAFETY: pre-conditions 1, 2, and 4 guarantee context, spec, and field_index validity.
+        let field_name = {
+            // SAFETY: pre-condition 1 guarantees `context` points to a valid `RedisSearchCtx`.
+            let sctx = unsafe { context.as_ref() };
+            // SAFETY: pre-condition 2 guarantees `spec` is non-null and valid.
+            let spec = unsafe { &*sctx.spec };
+            if spec.fields.is_null() {
+                (std::ptr::null(), 0)
+            } else {
+                // SAFETY: pre-condition 4 guarantees `field_index` is in bounds.
+                let field_ptr = unsafe { spec.fields.add(field_index as usize) };
+                // SAFETY: `field_ptr` is valid per the above bounds guarantee.
+                let field = unsafe { &*field_ptr };
+                let mut len = 0;
+                // SAFETY: `field.fieldName` is valid per spec field validity.
+                let name = unsafe { ffi::HiddenString_GetUnsafe(field.fieldName, &mut len) };
+                (name, len)
+            }
+        };
+
         Self {
             it: InvIndIterator::new(reader, result, expiration_checker),
-            context,
             field_index,
+            field_name,
         }
     }
 
@@ -94,10 +122,21 @@ where
     /// inverted index or replace it with a new allocation. In both cases the
     /// reader's pointer is stale and the iterator must
     /// [abort](RQEValidateStatus::Aborted).
-    fn should_abort(&self) -> bool {
-        // SAFETY: 1. and 3. guarantee `context` is valid for the iterator's lifetime.
-        let sctx_ref = unsafe { self.context.as_ref() };
-        // SAFETY: 2. and 3. guarantee `spec` is a valid, non-null pointer for the iterator's lifetime.
+    ///
+    /// # Safety
+    ///
+    /// 1. `context` must point to a valid [`RedisSearchCtx`].
+    /// 2. `context.spec` must be a non-null pointer to a valid `IndexSpec`.
+    /// 3. `self.field_index` must be a valid index into `context.spec.fields`.
+    /// 4. `context.spec.missingFieldDict` must be a non-null, valid dict pointer.
+    /// 5. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
+    ///    when non-null, must point to an opaque
+    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
+    ///    variant matches `E`.
+    unsafe fn should_abort(&self, context: NonNull<RedisSearchCtx>) -> bool {
+        // SAFETY: 1. guarantees `context` is valid.
+        let sctx_ref = unsafe { context.as_ref() };
+        // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
         let spec = unsafe { &*sctx_ref.spec };
 
         debug_assert!(
@@ -105,11 +144,11 @@ where
             "spec.missingFieldDict must be non-null",
         );
 
-        // SAFETY: 4. guarantees `field_index` is a valid index into `spec.fields`.
+        // SAFETY: 3. guarantees `field_index` is a valid index into `spec.fields`.
         let field_ptr = unsafe { spec.fields.offset(self.field_index as isize) };
         // SAFETY: the pointer is valid per the above.
         let field = unsafe { &*field_ptr };
-        // SAFETY: 5. guarantees the dict is valid.
+        // SAFETY: 4. guarantees the dict is non-null and valid.
         let missing_ii_ptr =
             unsafe { ffi::RS_dictFetchValue(spec.missingFieldDict, field.fieldName as *mut _) };
 
@@ -119,7 +158,7 @@ where
         }
 
         let missing_ii = missing_ii_ptr.cast::<inverted_index::opaque::InvertedIndex>();
-        // SAFETY: 6. guarantees the encoding variant matches E.
+        // SAFETY: 5. guarantees the encoding variant matches E.
         let ii = E::from_opaque(unsafe { &*missing_ii });
 
         !self.it.reader.points_to_ii(ii)
@@ -131,19 +170,8 @@ where
     }
 
     /// Get the field name tracked by this missing-field iterator.
-    pub fn field_name(&self) -> (*const std::ffi::c_char, usize) {
-        // SAFETY: the constructor guarantees `context` is valid for the iterator lifetime.
-        let sctx = unsafe { self.context.as_ref() };
-        // SAFETY: the constructor guarantees `spec` is non-null and valid.
-        let spec = unsafe { &*sctx.spec };
-        // SAFETY: the constructor guarantees `field_index` indexes `spec.fields`.
-        let field_ptr = unsafe { spec.fields.add(self.field_index as usize) };
-        // SAFETY: `field_ptr` was derived from a valid `spec.fields` base and an in-bounds index.
-        let field = unsafe { &*field_ptr };
-        let mut len = 0;
-        // SAFETY: `field.fieldName` belongs to the spec and remains valid while the spec lives.
-        let name = unsafe { ffi::HiddenString_GetUnsafe(field.fieldName, &mut len) };
-        (name, len)
+    pub const fn field_name(&self) -> (*const std::ffi::c_char, usize) {
+        self.field_name
     }
 }
 
@@ -192,12 +220,20 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        if self.should_abort() {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        // SAFETY: The caller (result processor) guarantees conditions 1-2
+        // of `should_abort` (`ctx` points to a valid `RedisSearchCtx` with a
+        // valid `spec`) while the spec read lock is held. Conditions 3-5
+        // (field_index validity, missingFieldDict, encoding match) are
+        // structural invariants guaranteed by the constructor's pre-conditions.
+        if unsafe { self.should_abort(ctx) } {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate()
+        self.it.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -43,8 +43,8 @@ pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChec
     it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
     field_index: t_fieldIndex,
     /// Owned copy of the field name, extracted from the spec at construction
-    /// time. Owning the string means the iterator no longer borrows into
-    /// `spec.fields`, so `context`/`spec` only need to be valid at
+    /// time. Owning the string means the iterator no longer borrows from
+    /// `spec.fields`, therefore `context`/`spec` only need to be valid at
     /// construction time (not for the iterator's entire lifetime).
     field_name: CString,
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -7,7 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ptr::NonNull;
+use std::{
+    ffi::{CString, c_char},
+    ptr::NonNull,
+};
 
 use ffi::{RedisSearchCtx, t_docId, t_fieldIndex};
 use inverted_index::{
@@ -39,11 +42,11 @@ use super::InvIndIterator;
 pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
     it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
     field_index: t_fieldIndex,
-    /// Cached field name pointer and length, extracted from the spec at
-    /// construction time. The pointer remains valid for the iterator's
-    /// lifetime because pre-condition 3 of [`Missing::new`] requires
-    /// `context.spec` (and its fields) to remain valid for that long.
-    field_name: (*const std::ffi::c_char, usize),
+    /// Owned copy of the field name, extracted from the spec at construction
+    /// time. Owning the string means the iterator no longer borrows into
+    /// `spec.fields`, so `context`/`spec` only need to be valid at
+    /// construction time (not for the iterator's entire lifetime).
+    field_name: CString,
 }
 
 impl<'index, E, C> Missing<'index, E, C>
@@ -61,11 +64,9 @@ where
     ///
     /// 1. `context` must point to a valid [`RedisSearchCtx`].
     /// 2. `context.spec` must be a non-null pointer to a valid `IndexSpec`.
-    /// 3. Both 1 and 2 must remain valid for the lifetime of the iterator
-    ///    (the cached field name pointer points into `spec.fields`).
-    /// 4. `field_index` must be a valid index into `context.spec.fields`.
-    /// 5. `context.spec.missingFieldDict` must be a non-null, valid dict pointer.
-    /// 6. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
+    /// 3. `field_index` must be a valid index into `context.spec.fields`.
+    /// 4. `context.spec.missingFieldDict` must be a non-null, valid dict pointer.
+    /// 5. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
     ///    when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
     ///    variant matches `E`.
@@ -86,26 +87,27 @@ where
             .frequency(1)
             .build();
 
-        // Cache the field name at construction time so `field_name()` doesn't
-        // need the context later (it was removed from the struct).
-        // Pre-condition 3 guarantees the cached pointer remains valid.
-        // SAFETY: pre-conditions 1, 2, and 4 guarantee context, spec, and field_index validity.
+        // Copy the field name into an owned CString so the iterator does not
+        // borrow into spec.fields beyond construction.
+        // SAFETY: pre-conditions 1, 2, and 3 guarantee context, spec, and field_index validity.
         let field_name = {
             // SAFETY: pre-condition 1 guarantees `context` points to a valid `RedisSearchCtx`.
             let sctx = unsafe { context.as_ref() };
             // SAFETY: pre-condition 2 guarantees `spec` is non-null and valid.
             let spec = unsafe { &*sctx.spec };
             if spec.fields.is_null() {
-                (std::ptr::null(), 0)
+                CString::default()
             } else {
-                // SAFETY: pre-condition 4 guarantees `field_index` is in bounds.
+                // SAFETY: pre-condition 3 guarantees `field_index` is in bounds.
                 let field_ptr = unsafe { spec.fields.add(field_index as usize) };
                 // SAFETY: `field_ptr` is valid per the above bounds guarantee.
                 let field = unsafe { &*field_ptr };
                 let mut len = 0;
                 // SAFETY: `field.fieldName` is valid per spec field validity.
                 let name = unsafe { ffi::HiddenString_GetUnsafe(field.fieldName, &mut len) };
-                (name, len)
+                // SAFETY: `name` points to `len` valid bytes (per HiddenString contract).
+                let bytes = unsafe { std::slice::from_raw_parts(name.cast::<u8>(), len) };
+                CString::new(bytes).expect("field name contains interior nul byte")
             }
         };
 
@@ -170,8 +172,8 @@ where
     }
 
     /// Get the field name tracked by this missing-field iterator.
-    pub const fn field_name(&self) -> (*const std::ffi::c_char, usize) {
-        self.field_name
+    pub fn field_name(&self) -> (*const c_char, usize) {
+        (self.field_name.as_ptr(), self.field_name.as_bytes().len())
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -127,30 +127,23 @@ where
     ///
     /// # Safety
     ///
-    /// 1. `context` must point to a valid [`RedisSearchCtx`].
-    /// 2. `context.spec` must be a non-null pointer to a valid `IndexSpec`.
-    /// 3. `self.field_index` must be a valid index into `context.spec.fields`.
-    /// 4. `context.spec.missingFieldDict` must be a non-null, valid dict pointer.
-    /// 5. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
+    /// 1. `self.field_index` must be a valid index into `spec.fields`.
+    /// 2. `spec.missingFieldDict` must be a non-null, valid dict pointer.
+    /// 3. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
     ///    when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    unsafe fn should_abort(&self, context: NonNull<RedisSearchCtx>) -> bool {
-        // SAFETY: 1. guarantees `context` is valid.
-        let sctx_ref = unsafe { context.as_ref() };
-        // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
-        let spec = unsafe { &*sctx_ref.spec };
-
+    unsafe fn should_abort(&self, spec: &ffi::IndexSpec) -> bool {
         debug_assert!(
             !spec.missingFieldDict.is_null(),
             "spec.missingFieldDict must be non-null",
         );
 
-        // SAFETY: 3. guarantees `field_index` is a valid index into `spec.fields`.
+        // SAFETY: 1. guarantees `field_index` is a valid index into `spec.fields`.
         let field_ptr = unsafe { spec.fields.offset(self.field_index as isize) };
         // SAFETY: the pointer is valid per the above.
         let field = unsafe { &*field_ptr };
-        // SAFETY: 4. guarantees the dict is non-null and valid.
+        // SAFETY: 2. guarantees the dict is non-null and valid.
         let missing_ii_ptr =
             unsafe { ffi::RS_dictFetchValue(spec.missingFieldDict, field.fieldName as *mut _) };
 
@@ -160,7 +153,7 @@ where
         }
 
         let missing_ii = missing_ii_ptr.cast::<inverted_index::opaque::InvertedIndex>();
-        // SAFETY: 5. guarantees the encoding variant matches E.
+        // SAFETY: 3. guarantees the encoding variant matches E.
         let ii = E::from_opaque(unsafe { &*missing_ii });
 
         !self.it.reader.points_to_ii(ii)
@@ -224,19 +217,21 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: The caller (result processor) guarantees conditions 1-2
-        // of `should_abort` (`ctx` points to a valid `RedisSearchCtx` with a
-        // valid `spec`) while the spec read lock is held. Conditions 3-5
-        // (field_index validity, missingFieldDict, encoding match) are
-        // structural invariants guaranteed by the constructor's pre-conditions.
-        if unsafe { self.should_abort(ctx) } {
+        // SAFETY: The caller guarantees `spec` points to a valid `IndexSpec`
+        // while the spec read lock is held.
+        let spec_ref = unsafe { spec.as_ref() };
+        // SAFETY: `spec_ref` satisfies `should_abort`'s safety requirements.
+        // Conditions 1-3 (field_index validity, missingFieldDict, encoding
+        // match) are structural invariants guaranteed by the constructor's
+        // pre-conditions.
+        if unsafe { self.should_abort(spec_ref) } {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.it.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.it.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -183,14 +183,14 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<ffi::RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.it.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.it.revalidate(spec) }
     }
 
     #[inline(always)]
@@ -509,15 +509,15 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<ffi::RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match self {
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            Self::Unfiltered(iter) => unsafe { iter.revalidate(ctx) },
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            Self::Filtered(iter) => unsafe { iter.revalidate(ctx) },
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            Self::Geo(iter) => unsafe { iter.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            Self::Unfiltered(iter) => unsafe { iter.revalidate(spec) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            Self::Filtered(iter) => unsafe { iter.revalidate(spec) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            Self::Geo(iter) => unsafe { iter.revalidate(spec) },
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -181,12 +181,15 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate()
+        self.it.revalidate(ctx)
     }
 
     #[inline(always)]
@@ -503,11 +506,14 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match self {
-            Self::Unfiltered(iter) => iter.revalidate(),
-            Self::Filtered(iter) => iter.revalidate(),
-            Self::Geo(iter) => iter.revalidate(),
+            Self::Unfiltered(iter) => iter.revalidate(ctx),
+            Self::Filtered(iter) => iter.revalidate(ctx),
+            Self::Geo(iter) => iter.revalidate(ctx),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -181,7 +181,7 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -189,7 +189,8 @@ where
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.it.revalidate(ctx) }
     }
 
     #[inline(always)]
@@ -506,14 +507,17 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match self {
-            Self::Unfiltered(iter) => iter.revalidate(ctx),
-            Self::Filtered(iter) => iter.revalidate(ctx),
-            Self::Geo(iter) => iter.revalidate(ctx),
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            Self::Unfiltered(iter) => unsafe { iter.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            Self::Filtered(iter) => unsafe { iter.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            Self::Geo(iter) => unsafe { iter.revalidate(ctx) },
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -218,12 +218,15 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate()
+        self.it.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -218,7 +218,7 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -226,7 +226,8 @@ where
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.it.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -220,14 +220,14 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.it.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.it.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -204,7 +204,7 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -215,7 +215,8 @@ where
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.it.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -31,7 +31,6 @@ use super::core::InvIndIterator;
 /// * `E` - The expiration checker type used to check for expired documents.
 pub struct Term<'index, R, E = crate::expiration_checker::NoOpChecker> {
     it: InvIndIterator<'index, R, E>,
-    context: NonNull<RedisSearchCtx>,
 }
 
 impl<'index, R, E> Term<'index, R, E>
@@ -57,7 +56,6 @@ where
     ///
     /// 1. `context` must point to a valid [`RedisSearchCtx`].
     /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
-    /// 3. Both 1 and 2 must remain valid for the lifetime of the iterator.
     pub unsafe fn new(
         reader: R,
         context: NonNull<RedisSearchCtx>,
@@ -82,7 +80,6 @@ where
             .build();
         Self {
             it: InvIndIterator::new(reader, result, expiration_checker),
-            context,
         }
     }
 
@@ -97,10 +94,15 @@ where
     /// replaced with a new allocation. If the index pointer returned by
     /// [`ffi::Redis_OpenInvertedIndex`] no longer matches the reader's
     /// stored index, the iterator must [abort](RQEValidateStatus::Aborted).
-    fn should_abort(&self) -> bool {
-        // SAFETY: 1. and 3. guarantee `context` is valid for the iterator's lifetime.
-        let sctx_ref = unsafe { self.context.as_ref() };
-        // SAFETY: 2. and 3. guarantee `spec` is a valid, non-null pointer for the iterator's lifetime.
+    ///
+    /// # Safety
+    ///
+    /// 1. `context` must point to a valid [`RedisSearchCtx`].
+    /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
+    unsafe fn should_abort(&self, context: NonNull<RedisSearchCtx>) -> bool {
+        // SAFETY: 1. guarantees `context` is valid.
+        let sctx_ref = unsafe { context.as_ref() };
+        // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
         let spec = unsafe { &*sctx_ref.spec };
 
         // Redis_OpenInvertedIndex() relies on keysDict to open the II.
@@ -121,11 +123,11 @@ where
             .as_bytes()
             .map_or(std::ptr::null(), |b| b.as_ptr().cast());
 
-        // SAFETY: `context` is a valid `RedisSearchCtx` (1.) and `str_ptr`
-        // is a valid byte slice of `term.len()` bytes.
+        // SAFETY: 1. guarantees `context` is a valid `RedisSearchCtx` and
+        // `str_ptr` is a valid byte slice of `term.len()` bytes.
         let idx = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                self.context.as_ptr(),
+                context.as_ptr(),
                 str_ptr,
                 term.len(),
                 false,
@@ -202,12 +204,18 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        if self.should_abort() {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        // SAFETY: The caller (result processor) guarantees conditions 1-2
+        // of `should_abort` (`ctx` points to a valid `RedisSearchCtx` with a
+        // valid `spec`) while the spec read lock is held.
+        if unsafe { self.should_abort(ctx) } {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate()
+        self.it.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -91,23 +91,18 @@ where
     /// Check if the iterator should abort revalidation.
     ///
     /// The term's inverted index may have been garbage-collected and
-    /// replaced with a new allocation. If the index pointer returned by
-    /// [`ffi::Redis_OpenInvertedIndex`] no longer matches the reader's
-    /// stored index, the iterator must [abort](RQEValidateStatus::Aborted).
+    /// replaced with a new allocation. If the index pointer looked up via
+    /// `spec.keysDict` no longer matches the reader's stored index, the
+    /// iterator must [abort](RQEValidateStatus::Aborted).
     ///
     /// # Safety
     ///
-    /// 1. `context` must point to a valid [`RedisSearchCtx`].
-    /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
-    unsafe fn should_abort(&self, context: NonNull<RedisSearchCtx>) -> bool {
-        // SAFETY: 1. guarantees `context` is valid.
-        let sctx_ref = unsafe { context.as_ref() };
-        // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
-        let spec = sctx_ref.spec;
-
+    /// The raw pointers inside `spec` (e.g. `keysDict`) must be valid and
+    /// dereferenceable for the duration of the call.
+    unsafe fn should_abort(&self, spec: &ffi::IndexSpec) -> bool {
         // Redis_OpenInvertedIndex() relies on keysDict to open the II.
         // It should always be set in production flows but some tests do not set up a full spec.
-        if unsafe { (*spec).keysDict.is_null() } {
+        if spec.keysDict.is_null() {
             return false;
         }
 
@@ -123,13 +118,19 @@ where
             .as_bytes()
             .map_or(std::ptr::null(), |b| b.as_ptr().cast());
 
-        // SAFETY: 2. guarantees `spec` is a valid `IndexSpec` and
+        // SAFETY: `spec` is a valid `IndexSpec` and
         // `str_ptr` is a valid byte slice of `term.len()` bytes.
         let idx = unsafe {
-            ffi::Redis_OpenInvertedIndex(spec, str_ptr, term.len(), false, std::ptr::null_mut())
+            ffi::Redis_OpenInvertedIndex(
+                spec as *const ffi::IndexSpec as *mut ffi::IndexSpec,
+                str_ptr,
+                term.len(),
+                false,
+                std::ptr::null_mut(),
+            )
         };
 
-        let Some(idx) = NonNull::new(idx) else {
+        let Some(idx) = NonNull::new(idx as *mut _) else {
             // The inverted index was collected entirely by GC.
             return true;
         };
@@ -200,17 +201,18 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: The caller (result processor) guarantees conditions 1-2
-        // of `should_abort` (`ctx` points to a valid `RedisSearchCtx` with a
-        // valid `spec`) while the spec read lock is held.
-        if unsafe { self.should_abort(ctx) } {
+        // SAFETY: The caller guarantees `spec` points to a valid `IndexSpec`
+        // while the spec read lock is held.
+        let spec_ref = unsafe { spec.as_ref() };
+        // SAFETY: `spec_ref` satisfies `should_abort`'s safety requirements.
+        if unsafe { self.should_abort(spec_ref) } {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.it.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.it.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -103,11 +103,11 @@ where
         // SAFETY: 1. guarantees `context` is valid.
         let sctx_ref = unsafe { context.as_ref() };
         // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
-        let spec = unsafe { &*sctx_ref.spec };
+        let spec = sctx_ref.spec;
 
         // Redis_OpenInvertedIndex() relies on keysDict to open the II.
         // It should always be set in production flows but some tests do not set up a full spec.
-        if spec.keysDict.is_null() {
+        if unsafe { (*spec).keysDict.is_null() } {
             return false;
         }
 
@@ -123,16 +123,10 @@ where
             .as_bytes()
             .map_or(std::ptr::null(), |b| b.as_ptr().cast());
 
-        // SAFETY: 1. guarantees `context` is a valid `RedisSearchCtx` and
+        // SAFETY: 2. guarantees `spec` is a valid `IndexSpec` and
         // `str_ptr` is a valid byte slice of `term.len()` bytes.
         let idx = unsafe {
-            ffi::Redis_OpenInvertedIndex(
-                context.as_ptr(),
-                str_ptr,
-                term.len(),
-                false,
-                std::ptr::null_mut(),
-            )
+            ffi::Redis_OpenInvertedIndex(spec, str_ptr, term.len(), false, std::ptr::null_mut())
         };
 
         let Some(idx) = NonNull::new(idx) else {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -37,7 +37,6 @@ use super::core::InvIndIterator;
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 pub struct Wildcard<'index, E: DecodedBy> {
     it: InvIndIterator<'index, IndexReaderCore<'index, E>>,
-    context: NonNull<RedisSearchCtx>,
 }
 
 impl<'index, E> Wildcard<'index, E>
@@ -49,20 +48,7 @@ where
     /// inverted index.
     ///
     /// `weight` is the score weight applied to every returned result.
-    ///
-    /// # Safety
-    ///
-    /// 1. `context` must point to a valid [`RedisSearchCtx`].
-    /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
-    /// 3. Both 1 and 2 must remain valid for the lifetime of the iterator.
-    /// 4. `context.spec.existingDocs`, when non-null, must point to an opaque
-    ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
-    ///    variant matches `E`.
-    pub unsafe fn new(
-        reader: IndexReaderCore<'index, E>,
-        context: NonNull<RedisSearchCtx>,
-        weight: f64,
-    ) -> Self {
+    pub fn new(reader: IndexReaderCore<'index, E>, weight: f64) -> Self {
         use ffi::RS_FIELDMASK_ALL;
 
         let result = RSIndexResult::build_virt()
@@ -74,7 +60,6 @@ where
         Self {
             // Wildcard iterator does not support expiration check
             it: InvIndIterator::new(reader, result, NoOpChecker),
-            context,
         }
     }
 
@@ -84,10 +69,18 @@ where
     /// collecting all documents) or replace it with a new allocation. In
     /// both cases the reader's pointer is stale and the iterator must
     /// [abort](RQEValidateStatus::Aborted).
-    fn should_abort(&self) -> bool {
-        // SAFETY: 1. and 3. guarantee `context` is valid for the iterator's lifetime.
-        let sctx_ref = unsafe { self.context.as_ref() };
-        // SAFETY: 2. and 3. guarantee `spec` is a valid, non-null pointer for the iterator's lifetime.
+    ///
+    /// # Safety
+    ///
+    /// 1. `context` must point to a valid [`RedisSearchCtx`].
+    /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
+    /// 3. `spec.existingDocs`, when non-null, must point to an opaque
+    ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
+    ///    variant matches `E`.
+    unsafe fn should_abort(&self, context: NonNull<RedisSearchCtx>) -> bool {
+        // SAFETY: 1. guarantees `context` is valid.
+        let sctx_ref = unsafe { context.as_ref() };
+        // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
         let spec = unsafe { &*sctx_ref.spec };
 
         let existing_docs = spec
@@ -98,9 +91,9 @@ where
             return true;
         }
 
-        // SAFETY: 4. guarantees `existingDocs` is valid when non-null, and we just checked it's not null.
+        // SAFETY: 3. guarantees `existingDocs` is valid when non-null, and we just checked it's not null.
         let existing_docs = unsafe { &*existing_docs };
-        // SAFETY: 4. guarantees the encoding variant matches E.
+        // SAFETY: 3. guarantees the encoding variant matches E.
         let ii = E::from_opaque(existing_docs);
 
         !self.it.reader.points_to_ii(ii)
@@ -156,12 +149,20 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        if self.should_abort() {
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        // SAFETY: The caller (result processor) guarantees conditions 1-2
+        // of `should_abort` (`ctx` points to a valid `RedisSearchCtx` with a
+        // valid `spec`) while the spec read lock is held. Condition 3
+        // (existingDocs encoding match) is a structural invariant: the
+        // encoding is determined at index creation and cannot change.
+        if unsafe { self.should_abort(ctx) } {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate()
+        self.it.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -149,7 +149,7 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -162,7 +162,8 @@ where
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        self.it.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.it.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -9,7 +9,7 @@
 
 use std::ptr::NonNull;
 
-use ffi::{RedisSearchCtx, t_docId};
+use ffi::t_docId;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
 };
@@ -72,17 +72,10 @@ where
     ///
     /// # Safety
     ///
-    /// 1. `context` must point to a valid [`RedisSearchCtx`].
-    /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
-    /// 3. `spec.existingDocs`, when non-null, must point to an opaque
+    /// 1. `spec.existingDocs`, when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    unsafe fn should_abort(&self, context: NonNull<RedisSearchCtx>) -> bool {
-        // SAFETY: 1. guarantees `context` is valid.
-        let sctx_ref = unsafe { context.as_ref() };
-        // SAFETY: 2. guarantees `spec` is a valid, non-null pointer.
-        let spec = unsafe { &*sctx_ref.spec };
-
+    unsafe fn should_abort(&self, spec: &ffi::IndexSpec) -> bool {
         let existing_docs = spec
             .existingDocs
             .cast::<inverted_index::opaque::InvertedIndex>();
@@ -91,9 +84,9 @@ where
             return true;
         }
 
-        // SAFETY: 3. guarantees `existingDocs` is valid when non-null, and we just checked it's not null.
+        // SAFETY: 1. guarantees `existingDocs` is valid when non-null, and we just checked it's not null.
         let existing_docs = unsafe { &*existing_docs };
-        // SAFETY: 3. guarantees the encoding variant matches E.
+        // SAFETY: 1. guarantees the encoding variant matches E.
         let ii = E::from_opaque(existing_docs);
 
         !self.it.reader.points_to_ii(ii)
@@ -151,19 +144,20 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: The caller (result processor) guarantees conditions 1-2
-        // of `should_abort` (`ctx` points to a valid `RedisSearchCtx` with a
-        // valid `spec`) while the spec read lock is held. Condition 3
-        // (existingDocs encoding match) is a structural invariant: the
+        // SAFETY: The caller guarantees `spec` points to a valid `IndexSpec`
+        // while the spec read lock is held.
+        let spec_ref = unsafe { spec.as_ref() };
+        // SAFETY: `spec_ref` satisfies `should_abort`'s safety requirements.
+        // The existingDocs encoding match is a structural invariant: the
         // encoding is determined at index creation and cannot change.
-        if unsafe { self.should_abort(ctx) } {
+        if unsafe { self.should_abort(spec_ref) } {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.it.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.it.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -136,10 +136,11 @@ pub trait RQEIterator<'index> {
     ///
     /// The iterator should check if it is still valid.
     ///
+    /// # Safety
     /// `ctx` must point to a valid [`RedisSearchCtx`] whose `spec` is a
     /// non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) for the duration of the call.
     /// The caller guarantees this while the spec read lock is held.
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
@@ -202,11 +203,12 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
         (**self).skip_to(doc_id)
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { (**self).revalidate(ctx) }
     }
 
     fn rewind(&mut self) {
@@ -259,11 +261,12 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
         (**self).skip_to(doc_id)
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { (**self).revalidate(ctx) }
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -7,8 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::t_docId;
-use std::sync::OnceLock;
+use std::{ptr::NonNull, sync::OnceLock};
+
+use ffi::{RedisSearchCtx, t_docId};
 use thiserror::Error;
 
 use ::inverted_index::{RSIndexResult, t_fieldMask};
@@ -134,7 +135,14 @@ pub trait RQEIterator<'index> {
     /// Called when the iterator is being revalidated after a concurrent index change.
     ///
     /// The iterator should check if it is still valid.
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
+    ///
+    /// `ctx` must point to a valid [`RedisSearchCtx`] whose `spec` is a
+    /// non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) for the duration of the call.
+    /// The caller guarantees this while the spec read lock is held.
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
 
     /// Rewind the iterator to the beginning and reset its properties.
     fn rewind(&mut self);
@@ -194,8 +202,11 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
         (**self).skip_to(doc_id)
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate()
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        (**self).revalidate(ctx)
     }
 
     fn rewind(&mut self) {
@@ -248,8 +259,11 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
         (**self).skip_to(doc_id)
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate()
+    fn revalidate(
+        &mut self,
+        ctx: NonNull<RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        (**self).revalidate(ctx)
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -139,7 +139,6 @@ pub trait RQEIterator<'index> {
     /// # Safety
     /// `ctx` must point to a valid [`RedisSearchCtx`] whose `spec` is a
     /// non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) for the duration of the call.
-    /// The caller guarantees this while the spec read lock is held.
     unsafe fn revalidate(
         &mut self,
         ctx: NonNull<RedisSearchCtx>,

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -9,7 +9,7 @@
 
 use std::{ptr::NonNull, sync::OnceLock};
 
-use ffi::{RedisSearchCtx, t_docId};
+use ffi::{IndexSpec, t_docId};
 use thiserror::Error;
 
 use ::inverted_index::{RSIndexResult, t_fieldMask};
@@ -137,11 +137,10 @@ pub trait RQEIterator<'index> {
     /// The iterator should check if it is still valid.
     ///
     /// # Safety
-    /// `ctx` must point to a valid [`RedisSearchCtx`] whose `spec` is a
-    /// non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) for the duration of the call.
+    /// `spec` must point to a valid [`IndexSpec`] for the duration of the call.
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
 
     /// Rewind the iterator to the beginning and reset its properties.
@@ -204,10 +203,10 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
 
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { (**self).revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { (**self).revalidate(spec) }
     }
 
     fn rewind(&mut self) {
@@ -262,10 +261,10 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
 
     unsafe fn revalidate(
         &mut self,
-        ctx: NonNull<RedisSearchCtx>,
+        spec: NonNull<IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { (**self).revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { (**self).revalidate(spec) }
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -117,10 +117,13 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match &mut self.0 {
-            MaybeEmptyOption::None(empty) => empty.revalidate(),
-            MaybeEmptyOption::Some(it) => it.revalidate(),
+            MaybeEmptyOption::None(empty) => empty.revalidate(ctx),
+            MaybeEmptyOption::Some(it) => it.revalidate(ctx),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -119,13 +119,13 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match &mut self.0 {
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            MaybeEmptyOption::None(empty) => unsafe { empty.revalidate(ctx) },
-            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-            MaybeEmptyOption::Some(it) => unsafe { it.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            MaybeEmptyOption::None(empty) => unsafe { empty.revalidate(spec) },
+            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+            MaybeEmptyOption::Some(it) => unsafe { it.revalidate(spec) },
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -117,13 +117,15 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match &mut self.0 {
-            MaybeEmptyOption::None(empty) => empty.revalidate(ctx),
-            MaybeEmptyOption::Some(it) => it.revalidate(ctx),
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            MaybeEmptyOption::None(empty) => unsafe { empty.revalidate(ctx) },
+            // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+            MaybeEmptyOption::Some(it) => unsafe { it.revalidate(ctx) },
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -185,11 +185,12 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.base.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.base.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -187,10 +187,10 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.base.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.base.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -185,8 +185,11 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.base.revalidate()
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        self.base.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -229,11 +229,11 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Get child status
-        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-        match unsafe { self.child.revalidate(ctx) }? {
+        // SAFETY: Delegating to child with the same `spec` passed by our caller.
+        match unsafe { self.child.revalidate(spec) }? {
             RQEValidateStatus::Aborted => {
                 self.child = MaybeEmpty::new_empty();
                 Ok(RQEValidateStatus::Ok)

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -227,9 +227,12 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Get child status
-        match self.child.revalidate()? {
+        match self.child.revalidate(ctx)? {
             RQEValidateStatus::Aborted => {
                 self.child = MaybeEmpty::new_empty();
                 Ok(RQEValidateStatus::Ok)

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -227,12 +227,13 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Get child status
-        match self.child.revalidate(ctx)? {
+        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+        match unsafe { self.child.revalidate(ctx) }? {
             RQEValidateStatus::Aborted => {
                 self.child = MaybeEmpty::new_empty();
                 Ok(RQEValidateStatus::Ok)

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -266,15 +266,18 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // 1. Revalidate the wildcard iterator first.
-        let wcii_status = self.wcii.revalidate()?;
+        let wcii_status = self.wcii.revalidate(ctx)?;
         if matches!(wcii_status, RQEValidateStatus::Aborted) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
         // 2. Revalidate the child iterator.
-        if matches!(self.child.revalidate()?, RQEValidateStatus::Aborted) {
+        if matches!(self.child.revalidate(ctx)?, RQEValidateStatus::Aborted) {
             // When child is aborted, NOT becomes "NOT nothing" = everything
             // from the wildcard iterator.
             self.child = MaybeEmpty::new_empty();

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -266,18 +266,24 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // 1. Revalidate the wildcard iterator first.
-        let wcii_status = self.wcii.revalidate(ctx)?;
+        // SAFETY: Delegating to children with the same `ctx` passed by our caller.
+        let wcii_status = unsafe { self.wcii.revalidate(ctx) }?;
         if matches!(wcii_status, RQEValidateStatus::Aborted) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
         // 2. Revalidate the child iterator.
-        if matches!(self.child.revalidate(ctx)?, RQEValidateStatus::Aborted) {
+        let child_aborted = matches!(
+            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+            unsafe { self.child.revalidate(ctx) }?,
+            RQEValidateStatus::Aborted
+        );
+        if child_aborted {
             // When child is aborted, NOT becomes "NOT nothing" = everything
             // from the wildcard iterator.
             self.child = MaybeEmpty::new_empty();

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -268,19 +268,19 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // 1. Revalidate the wildcard iterator first.
-        // SAFETY: Delegating to children with the same `ctx` passed by our caller.
-        let wcii_status = unsafe { self.wcii.revalidate(ctx) }?;
+        // SAFETY: Delegating to children with the same `spec` passed by our caller.
+        let wcii_status = unsafe { self.wcii.revalidate(spec) }?;
         if matches!(wcii_status, RQEValidateStatus::Aborted) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
         // 2. Revalidate the child iterator.
         let child_aborted = matches!(
-            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-            unsafe { self.child.revalidate(ctx) }?,
+            // SAFETY: Delegating to child with the same `spec` passed by our caller.
+            unsafe { self.child.revalidate(spec) }?,
             RQEValidateStatus::Aborted
         );
         if child_aborted {

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -225,14 +225,17 @@ where
         Ok(Some(SkipToOutcome::Found(&mut self.result)))
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let Some(ref mut child) = self.child else {
             return Ok(RQEValidateStatus::Ok);
         };
         let last_child_doc_id = child.last_doc_id();
 
         // Revalidate the child iterator
-        match child.revalidate()? {
+        match child.revalidate(ctx)? {
             // Abort: Handle child validation results (but continue processing)
             status @ (RQEValidateStatus::Aborted | RQEValidateStatus::Moved { .. }) => {
                 if matches!(status, RQEValidateStatus::Aborted) {

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -227,7 +227,7 @@ where
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let Some(ref mut child) = self.child else {
             return Ok(RQEValidateStatus::Ok);
@@ -235,8 +235,8 @@ where
         let last_child_doc_id = child.last_doc_id();
 
         // Revalidate the child iterator
-        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-        match unsafe { child.revalidate(ctx) }? {
+        // SAFETY: Delegating to child with the same `spec` passed by our caller.
+        match unsafe { child.revalidate(spec) }? {
             // Abort: Handle child validation results (but continue processing)
             status @ (RQEValidateStatus::Aborted | RQEValidateStatus::Moved { .. }) => {
                 if matches!(status, RQEValidateStatus::Aborted) {

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -225,7 +225,7 @@ where
         Ok(Some(SkipToOutcome::Found(&mut self.result)))
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -235,7 +235,8 @@ where
         let last_child_doc_id = child.last_doc_id();
 
         // Revalidate the child iterator
-        match child.revalidate(ctx)? {
+        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+        match unsafe { child.revalidate(ctx) }? {
             // Abort: Handle child validation results (but continue processing)
             status @ (RQEValidateStatus::Aborted | RQEValidateStatus::Moved { .. }) => {
                 if matches!(status, RQEValidateStatus::Aborted) {

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -245,7 +245,7 @@ where
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Simple enum to avoid holding a borrow through the match.
         enum ValidateOutcome {
@@ -254,8 +254,8 @@ where
         }
 
         // Step 1: Revalidate wcii. If it aborts or is at EOF, we can return immediately.
-        // SAFETY: Delegating to children with the same `ctx` passed by our caller.
-        let wcii_outcome = match unsafe { self.wcii.revalidate(ctx) }? {
+        // SAFETY: Delegating to children with the same `spec` passed by our caller.
+        let wcii_outcome = match unsafe { self.wcii.revalidate(spec) }? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { current: Some(_) } => ValidateOutcome::Moved,
             RQEValidateStatus::Moved { current: None } => {
@@ -273,8 +273,8 @@ where
 
         // Step 2: Revalidate child. If it aborts, replace with an empty iterator.
         // Abort is treated as Moved: child's state changed, so we must re-evaluate.
-        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-        let child_outcome = match unsafe { self.child.revalidate(ctx) }? {
+        // SAFETY: Delegating to child with the same `spec` passed by our caller.
+        let child_outcome = match unsafe { self.child.revalidate(spec) }? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { .. } => ValidateOutcome::Moved,
             RQEValidateStatus::Aborted => {

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -243,7 +243,7 @@ where
         }
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -254,7 +254,8 @@ where
         }
 
         // Step 1: Revalidate wcii. If it aborts or is at EOF, we can return immediately.
-        let wcii_outcome = match self.wcii.revalidate(ctx)? {
+        // SAFETY: Delegating to children with the same `ctx` passed by our caller.
+        let wcii_outcome = match unsafe { self.wcii.revalidate(ctx) }? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { current: Some(_) } => ValidateOutcome::Moved,
             RQEValidateStatus::Moved { current: None } => {
@@ -272,7 +273,8 @@ where
 
         // Step 2: Revalidate child. If it aborts, replace with an empty iterator.
         // Abort is treated as Moved: child's state changed, so we must re-evaluate.
-        let child_outcome = match self.child.revalidate(ctx)? {
+        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+        let child_outcome = match unsafe { self.child.revalidate(ctx) }? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { .. } => ValidateOutcome::Moved,
             RQEValidateStatus::Aborted => {

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -243,7 +243,10 @@ where
         }
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Simple enum to avoid holding a borrow through the match.
         enum ValidateOutcome {
             Ok,
@@ -251,7 +254,7 @@ where
         }
 
         // Step 1: Revalidate wcii. If it aborts or is at EOF, we can return immediately.
-        let wcii_outcome = match self.wcii.revalidate()? {
+        let wcii_outcome = match self.wcii.revalidate(ctx)? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { current: Some(_) } => ValidateOutcome::Moved,
             RQEValidateStatus::Moved { current: None } => {
@@ -269,7 +272,7 @@ where
 
         // Step 2: Revalidate child. If it aborts, replace with an empty iterator.
         // Abort is treated as Moved: child's state changed, so we must re-evaluate.
-        let child_outcome = match self.child.revalidate()? {
+        let child_outcome = match self.child.revalidate(ctx)? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { .. } => ValidateOutcome::Moved,
             RQEValidateStatus::Aborted => {

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -134,10 +134,10 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-        unsafe { self.child.revalidate(ctx) }
+        // SAFETY: Delegating to child with the same `spec` passed by our caller.
+        unsafe { self.child.revalidate(spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -132,8 +132,11 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
         self.child.at_eof()
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.child.revalidate()
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        self.child.revalidate(ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -132,11 +132,12 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
         self.child.at_eof()
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.child.revalidate(ctx)
+        // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+        unsafe { self.child.revalidate(ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -505,7 +505,10 @@ where
         self.is_eof
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Already at EOF - nothing to do
         if self.is_eof {
             return Ok(RQEValidateStatus::Ok);
@@ -519,7 +522,7 @@ where
         // We use index-based iteration because we need to remove elements while iterating.
         let mut i = 0;
         while i < self.children.len() {
-            match self.children[i].revalidate()? {
+            match self.children[i].revalidate(ctx)? {
                 RQEValidateStatus::Aborted => {
                     // Remove aborted child using swap_remove for O(1) removal.
                     // Order doesn't matter for union iteration.

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -507,7 +507,7 @@ where
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Already at EOF - nothing to do
         if self.is_eof {
@@ -522,8 +522,8 @@ where
         // We use index-based iteration because we need to remove elements while iterating.
         let mut i = 0;
         while i < self.children.len() {
-            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-            match unsafe { self.children[i].revalidate(ctx) }? {
+            // SAFETY: Delegating to child with the same `spec` passed by our caller.
+            match unsafe { self.children[i].revalidate(spec) }? {
                 RQEValidateStatus::Aborted => {
                     // Remove aborted child using swap_remove for O(1) removal.
                     // Order doesn't matter for union iteration.

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -505,7 +505,7 @@ where
         self.is_eof
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -522,7 +522,8 @@ where
         // We use index-based iteration because we need to remove elements while iterating.
         let mut i = 0;
         while i < self.children.len() {
-            match self.children[i].revalidate(ctx)? {
+            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+            match unsafe { self.children[i].revalidate(ctx) }? {
                 RQEValidateStatus::Aborted => {
                     // Remove aborted child using swap_remove for O(1) removal.
                     // Order doesn't matter for union iteration.

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -418,7 +418,10 @@ where
         self.is_eof
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.is_eof {
             return Ok(RQEValidateStatus::Ok);
         }
@@ -429,7 +432,7 @@ where
         // Index-based iteration: swap_remove may reorder elements.
         let mut i = 0;
         while i < self.children.len() {
-            match self.children[i].revalidate()? {
+            match self.children[i].revalidate(ctx)? {
                 RQEValidateStatus::Aborted => {
                     self.children.swap_remove(i);
                     any_change = true;

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -420,7 +420,7 @@ where
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.is_eof {
             return Ok(RQEValidateStatus::Ok);
@@ -432,8 +432,8 @@ where
         // Index-based iteration: swap_remove may reorder elements.
         let mut i = 0;
         while i < self.children.len() {
-            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
-            match unsafe { self.children[i].revalidate(ctx) }? {
+            // SAFETY: Delegating to child with the same `spec` passed by our caller.
+            match unsafe { self.children[i].revalidate(spec) }? {
                 RQEValidateStatus::Aborted => {
                     self.children.swap_remove(i);
                     any_change = true;

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -418,7 +418,7 @@ where
         self.is_eof
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -432,7 +432,8 @@ where
         // Index-based iteration: swap_remove may reorder elements.
         let mut i = 0;
         while i < self.children.len() {
-            match self.children[i].revalidate(ctx)? {
+            // SAFETY: Delegating to child with the same `ctx` passed by our caller.
+            match unsafe { self.children[i].revalidate(ctx) }? {
                 RQEValidateStatus::Aborted => {
                     self.children.swap_remove(i);
                     any_change = true;

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -166,8 +166,11 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        delegate_variant_ref_mut!(self, revalidate)
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        delegate_variant_ref_mut!(self, revalidate, ctx)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -168,10 +168,10 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-        unsafe { delegate_variant_ref_mut!(self, revalidate, ctx) }
+        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+        unsafe { delegate_variant_ref_mut!(self, revalidate, spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -166,11 +166,12 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        delegate_variant_ref_mut!(self, revalidate, ctx)
+        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+        unsafe { delegate_variant_ref_mut!(self, revalidate, ctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -266,7 +266,7 @@ where
     #[inline(always)]
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Trimmed unions run in a single, short-lived read path that does not
         // interleave with GC cycles, so revalidation should never be called.

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -264,7 +264,7 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -264,7 +264,10 @@ where
     }
 
     #[inline(always)]
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Trimmed unions run in a single, short-lived read path that does not
         // interleave with GC cycles, so revalidation should never be called.
         panic!(

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -97,7 +97,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -158,10 +158,10 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { (**self).revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { (**self).revalidate(spec) }
     }
 
     fn rewind(&mut self) {
@@ -265,10 +265,10 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-        unsafe { delegate_rqe_iterator!(self, revalidate, ctx) }
+        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+        unsafe { delegate_rqe_iterator!(self, revalidate, spec) }
     }
 
     #[inline(always)]
@@ -330,10 +330,10 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
-        unsafe { delegate_wildcard_iterator!(self, revalidate, ctx) }
+        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
+        unsafe { delegate_wildcard_iterator!(self, revalidate, spec) }
     }
 
     #[inline(always)]
@@ -541,10 +541,10 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
 
     unsafe fn revalidate(
         &mut self,
-        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
-        unsafe { self.0.revalidate(ctx) }
+        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
+        unsafe { self.0.revalidate(spec) }
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -95,7 +95,10 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
         self.result.doc_id >= self.top_id
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
 
@@ -153,8 +156,11 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
         (**self).skip_to(doc_id)
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate()
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        (**self).revalidate(ctx)
     }
 
     fn rewind(&mut self) {
@@ -256,8 +262,11 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
         delegate_rqe_iterator!(self, at_eof)
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        delegate_rqe_iterator!(self, revalidate)
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        delegate_rqe_iterator!(self, revalidate, ctx)
     }
 
     #[inline(always)]
@@ -317,8 +326,11 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
         delegate_wildcard_iterator!(self, at_eof)
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        delegate_wildcard_iterator!(self, revalidate)
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        delegate_wildcard_iterator!(self, revalidate, ctx)
     }
 
     #[inline(always)]
@@ -376,20 +388,12 @@ pub unsafe fn new_wildcard_iterator_optimized<'index>(
             // encoding (4).
             let ii_ref = unsafe { ii.as_ref() };
             let optimized = match ii_ref {
-                opaque::InvertedIndex::DocIdsOnly(ii) => {
-                    // SAFETY: All preconditions of `Wildcard::new` are
-                    // satisfied: `sctx` is valid (1), `sctx.spec` is valid (2),
-                    // both remain valid for `'index`, and the encoding matches.
-                    OptimizedWildcard::DocIdsOnly(unsafe {
-                        crate::inverted_index::Wildcard::new(ii.reader(), sctx, weight)
-                    })
-                }
-                opaque::InvertedIndex::RawDocIdsOnly(ii) => {
-                    // SAFETY: Same as the `DocIdsOnly` arm above.
-                    OptimizedWildcard::RawDocIdsOnly(unsafe {
-                        crate::inverted_index::Wildcard::new(ii.reader(), sctx, weight)
-                    })
-                }
+                opaque::InvertedIndex::DocIdsOnly(ii) => OptimizedWildcard::DocIdsOnly(
+                    crate::inverted_index::Wildcard::new(ii.reader(), weight),
+                ),
+                opaque::InvertedIndex::RawDocIdsOnly(ii) => OptimizedWildcard::RawDocIdsOnly(
+                    crate::inverted_index::Wildcard::new(ii.reader(), weight),
+                ),
                 _ => panic!("spec.existingDocs has the wrong inverted index type: {ii_ref:?}"),
             };
             NewWildcardIterator::Optimized(optimized)
@@ -532,8 +536,11 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
         self.0.skip_to(doc_id)
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.0.revalidate()
+    fn revalidate(
+        &mut self,
+        ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        self.0.revalidate(ctx)
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -95,7 +95,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
         self.result.doc_id >= self.top_id
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -156,11 +156,12 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
         (**self).skip_to(doc_id)
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { (**self).revalidate(ctx) }
     }
 
     fn rewind(&mut self) {
@@ -262,11 +263,12 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
         delegate_rqe_iterator!(self, at_eof)
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        delegate_rqe_iterator!(self, revalidate, ctx)
+        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+        unsafe { delegate_rqe_iterator!(self, revalidate, ctx) }
     }
 
     #[inline(always)]
@@ -326,11 +328,12 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
         delegate_wildcard_iterator!(self, at_eof)
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        delegate_wildcard_iterator!(self, revalidate, ctx)
+        // SAFETY: Delegating to variant with the same `ctx` passed by our caller.
+        unsafe { delegate_wildcard_iterator!(self, revalidate, ctx) }
     }
 
     #[inline(always)]
@@ -536,11 +539,12 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
         self.0.skip_to(doc_id)
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.0.revalidate(ctx)
+        // SAFETY: Delegating to inner iterator with the same `ctx` passed by our caller.
+        unsafe { self.0.revalidate(ctx) }
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -66,7 +66,7 @@ fn type_() {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let mut it = Empty::default();
     // SAFETY: test-only call with valid context
     assert_eq!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -68,8 +68,9 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let ctx = mock_ctx.sctx();
     let mut it = Empty::default();
+    // SAFETY: test-only call with valid context
     assert_eq!(
-        it.revalidate(ctx).expect("revalidate failed"),
+        unsafe { it.revalidate(ctx) }.expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -65,9 +65,11 @@ fn type_() {
 
 #[test]
 fn revalidate() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let mut it = Empty::default();
     assert_eq!(
-        it.revalidate().expect("revalidate failed"),
+        it.revalidate(ctx).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -231,9 +231,11 @@ fn rewind(#[case] case: &[u64]) {
 
 #[test]
 fn revalidate() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let mut it = IdListSorted::new(vec![1, 2, 3]);
     assert_eq!(
-        it.revalidate().expect("revalidate failed"),
+        it.revalidate(ctx).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -234,8 +234,9 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let ctx = mock_ctx.sctx();
     let mut it = IdListSorted::new(vec![1, 2, 3]);
+    // SAFETY: test-only call with valid context
     assert_eq!(
-        it.revalidate(ctx).expect("revalidate failed"),
+        unsafe { it.revalidate(ctx) }.expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -232,7 +232,7 @@ fn rewind(#[case] case: &[u64]) {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let mut it = IdListSorted::new(vec![1, 2, 3]);
     // SAFETY: test-only call with valid context
     assert_eq!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -555,7 +555,7 @@ fn many_children() {
 #[test]
 fn revalidate_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     // Create mock children with const generic arrays
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
@@ -599,7 +599,7 @@ fn revalidate_ok() {
 #[test]
 fn revalidate_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -634,7 +634,7 @@ fn revalidate_aborted() {
 #[test]
 fn revalidate_moved() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -680,7 +680,7 @@ fn revalidate_moved() {
 #[test]
 fn revalidate_mixed_results() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -716,7 +716,7 @@ fn revalidate_mixed_results() {
 #[test]
 fn revalidate_after_eof() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     // Pre-set children to return MOVE on revalidate
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
@@ -763,7 +763,7 @@ fn revalidate_after_eof() {
 #[test]
 fn revalidate_some_children_moved_to_eof() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     // Child 0 and 2 have normal data, child 1 is small (only 2 elements: [10, 20])
     // When we read doc 10 and then call Move, child 1 moves to 20 and the next Move
     // would go to EOF
@@ -932,7 +932,7 @@ fn overlapping_children_ids() {
 #[test]
 fn revalidate_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -970,7 +970,7 @@ fn revalidate_before_read() {
 #[test]
 fn revalidate_move_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -1092,7 +1092,7 @@ fn children_sorted_by_estimated() {
 #[test]
 fn revalidate_moved_skip_to_returns_none() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     // Set up children where:
     // - They share doc 10 (will read this first)
     // - After Move, child0 goes to doc 15, child1 goes to doc 18, child2 goes to doc 22

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -554,6 +554,8 @@ fn many_children() {
 /// Test: All children return VALIDATE_OK
 #[test]
 fn revalidate_ok() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     // Create mock children with const generic arrays
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
@@ -584,7 +586,7 @@ fn revalidate_ok() {
     assert_eq!(result.doc_id, 20);
 
     // Revalidate should return Ok
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
     // Should be able to continue reading
@@ -595,6 +597,8 @@ fn revalidate_ok() {
 /// Test: One child returns VALIDATE_ABORTED
 #[test]
 fn revalidate_aborted() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -620,13 +624,15 @@ fn revalidate_aborted() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Aborted since one child aborted
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
 
 /// Test: All children return VALIDATE_MOVED
 #[test]
 fn revalidate_moved() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -652,7 +658,7 @@ fn revalidate_moved() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
         "Expected Moved with current, got {:?}",
@@ -670,6 +676,8 @@ fn revalidate_moved() {
 /// Test: Mix of OK and MOVED results
 #[test]
 fn revalidate_mixed_results() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -695,7 +703,7 @@ fn revalidate_mixed_results() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved (if any child moved)
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
 }
@@ -703,6 +711,8 @@ fn revalidate_mixed_results() {
 /// Test: Revalidate after EOF - should return OK even if children moved
 #[test]
 fn revalidate_after_eof() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     // Pre-set children to return MOVE on revalidate
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
@@ -728,7 +738,7 @@ fn revalidate_after_eof() {
     assert!(ii.at_eof());
 
     // Revalidate should return OK when already at EOF
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate after EOF should return OK, got {:?}",
@@ -747,6 +757,8 @@ fn revalidate_after_eof() {
 /// one element left (20), so when Move is called during revalidate, it reaches EOF.
 #[test]
 fn revalidate_some_children_moved_to_eof() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     // Child 0 and 2 have normal data, child 1 is small (only 2 elements: [10, 20])
     // When we read doc 10 and then call Move, child 1 moves to 20 and the next Move
     // would go to EOF
@@ -777,7 +789,7 @@ fn revalidate_some_children_moved_to_eof() {
 
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved to EOF, got {:?}",
@@ -913,6 +925,8 @@ fn overlapping_children_ids() {
 /// Test: Revalidate immediately after construction (without reading first)
 #[test]
 fn revalidate_before_read() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -934,7 +948,7 @@ fn revalidate_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate before read should return Ok"
@@ -948,6 +962,8 @@ fn revalidate_before_read() {
 /// Test: Revalidate with Move before first read
 #[test]
 fn revalidate_move_before_read() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -969,7 +985,7 @@ fn revalidate_move_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read - children will move
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
     // the result depends on implementation. The iterator should
@@ -1067,6 +1083,8 @@ fn children_sorted_by_estimated() {
 /// The expected result is `RQEValidateStatus::Moved { current: None }`
 #[test]
 fn revalidate_moved_skip_to_returns_none() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     // Set up children where:
     // - They share doc 10 (will read this first)
     // - After Move, child0 goes to doc 15, child1 goes to doc 18, child2 goes to doc 22
@@ -1110,7 +1128,7 @@ fn revalidate_moved_skip_to_returns_none() {
     // skip_to(22) will fail because:
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
-    let status = ii.revalidate().expect("revalidate failed");
+    let status = ii.revalidate(ctx).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved {{ current: None }} when skip_to cannot find consensus, got {:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -586,7 +586,8 @@ fn revalidate_ok() {
     assert_eq!(result.doc_id, 20);
 
     // Revalidate should return Ok
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
     // Should be able to continue reading
@@ -624,7 +625,8 @@ fn revalidate_aborted() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Aborted since one child aborted
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
 
@@ -658,7 +660,8 @@ fn revalidate_moved() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
         "Expected Moved with current, got {:?}",
@@ -703,7 +706,8 @@ fn revalidate_mixed_results() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved (if any child moved)
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
 }
@@ -738,7 +742,8 @@ fn revalidate_after_eof() {
     assert!(ii.at_eof());
 
     // Revalidate should return OK when already at EOF
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate after EOF should return OK, got {:?}",
@@ -789,7 +794,8 @@ fn revalidate_some_children_moved_to_eof() {
 
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved to EOF, got {:?}",
@@ -948,7 +954,8 @@ fn revalidate_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate before read should return Ok"
@@ -985,7 +992,8 @@ fn revalidate_move_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read - children will move
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
     // the result depends on implementation. The iterator should
@@ -1128,7 +1136,8 @@ fn revalidate_moved_skip_to_returns_none() {
     // skip_to(22) will fail because:
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
-    let status = ii.revalidate(ctx).expect("revalidate failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved {{ current: None }} when skip_to cannot find consensus, got {:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -153,13 +153,15 @@ mod not_miri {
         let sctx = test.test.context.sctx;
 
         // Verify the iterator works normally and read at least one document
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -187,8 +189,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -216,8 +219,9 @@ mod not_miri {
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
         let sctx = test.test.context.sctx;
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -231,8 +235,9 @@ mod not_miri {
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -150,7 +150,7 @@ mod not_miri {
     fn missing_revalidate_after_index_disappears() {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
 
         // Verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
@@ -218,7 +218,7 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
         // SAFETY: test-only call with valid context
         assert_eq!(
             unsafe { it.revalidate(sctx) }.expect("revalidate failed"),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -150,15 +150,16 @@ mod not_miri {
     fn missing_revalidate_after_index_disappears() {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
+        let sctx = test.test.context.sctx;
 
         // Verify the iterator works normally and read at least one document
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -187,7 +188,7 @@ mod not_miri {
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -214,8 +215,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
+        let sctx = test.test.context.sctx;
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -230,7 +232,7 @@ mod not_miri {
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -407,8 +407,9 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(record.doc_id, 1);
 
     // Revalidate should succeed (not abort) even though there is no range tree.
+    // SAFETY: test-only call with valid context
     assert_eq!(
-        it.revalidate(mock_ctx.sctx()).expect("revalidate failed"),
+        unsafe { it.revalidate(mock_ctx.sctx()) }.expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }
@@ -647,8 +648,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            iters[0].revalidate(ctx.sctx()).expect("revalidate failed"),
+            unsafe { iters[0].revalidate(ctx.sctx()) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted,
         );
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -682,8 +684,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            iters[0].revalidate(ctx.sctx()).expect("revalidate failed"),
+            unsafe { iters[0].revalidate(ctx.sctx()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok,
         );
 
@@ -999,9 +1002,9 @@ mod not_miri {
 
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(test.test.context.sctx)
-                .expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1063,13 +1066,15 @@ mod not_miri {
         let sctx = test.test.context.sctx;
 
         // First, verify the iterator works normally and read at least one document
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1086,8 +1091,9 @@ mod not_miri {
         }
 
         // Now Revalidate should return Aborted because the revision IDs don't match
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -409,7 +409,7 @@ fn numeric_no_range_tree_revalidate() {
     // Revalidate should succeed (not abort) even though there is no range tree.
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(mock_ctx.sctx()) }.expect("revalidate failed"),
+        unsafe { it.revalidate(mock_ctx.spec()) }.expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }
@@ -650,7 +650,7 @@ mod from_tree {
 
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { iters[0].revalidate(ctx.sctx()) }.expect("revalidate failed"),
+            unsafe { iters[0].revalidate(ctx.spec()) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted,
         );
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -686,7 +686,7 @@ mod from_tree {
 
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { iters[0].revalidate(ctx.sctx()) }.expect("revalidate failed"),
+            unsafe { iters[0].revalidate(ctx.spec()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok,
         );
 
@@ -1004,7 +1004,7 @@ mod not_miri {
         // needs_revalidation is true, we should get Ok.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1063,7 +1063,7 @@ mod not_miri {
     fn numeric_revalidate_after_index_disappears() {
         let test = NumericRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
 
         // First, verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -393,6 +393,7 @@ fn numeric_reader_accessor() {
 /// Test `should_abort` returns false when no range tree is provided.
 #[test]
 fn numeric_no_range_tree_revalidate() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut ii =
         InvertedIndex::<inverted_index::numeric::Numeric>::new(IndexFlags_Index_StoreNumeric);
     let _ = ii.add_record(&RSIndexResult::build_numeric(1.0).doc_id(1).build());
@@ -407,7 +408,7 @@ fn numeric_no_range_tree_revalidate() {
 
     // Revalidate should succeed (not abort) even though there is no range tree.
     assert_eq!(
-        it.revalidate().expect("revalidate failed"),
+        it.revalidate(mock_ctx.sctx()).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }
@@ -647,7 +648,7 @@ mod from_tree {
         unsafe { (*tree_ptr).increment_revision() };
 
         assert_eq!(
-            iters[0].revalidate().expect("revalidate failed"),
+            iters[0].revalidate(ctx.sctx()).expect("revalidate failed"),
             RQEValidateStatus::Aborted,
         );
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -682,7 +683,7 @@ mod from_tree {
         unsafe { (*tree_ptr).increment_revision() };
 
         assert_eq!(
-            iters[0].revalidate().expect("revalidate failed"),
+            iters[0].revalidate(ctx.sctx()).expect("revalidate failed"),
             RQEValidateStatus::Ok,
         );
 
@@ -999,7 +1000,8 @@ mod not_miri {
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(test.test.context.sctx)
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1058,15 +1060,16 @@ mod not_miri {
     fn numeric_revalidate_after_index_disappears() {
         let test = NumericRevalidateTest::new(10);
         let mut it = test.create_iterator();
+        let sctx = test.test.context.sctx;
 
         // First, verify the iterator works normally and read at least one document
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1084,7 +1087,7 @@ mod not_miri {
 
         // Now Revalidate should return Aborted because the revision IDs don't match
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -177,15 +177,16 @@ mod not_miri {
     fn tag_revalidate_after_index_disappears() {
         let test = TagRevalidateTest::new(10);
         let mut it = test.create_iterator();
+        let sctx = test.test.context.sctx;
 
         // Verify the iterator works normally and read at least one document
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -217,7 +218,7 @@ mod not_miri {
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -246,8 +247,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
+        let sctx = test.test.context.sctx;
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -267,7 +269,7 @@ mod not_miri {
 
         // `should_abort` sees the tag value is missing and returns true.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -177,7 +177,7 @@ mod not_miri {
     fn tag_revalidate_after_index_disappears() {
         let test = TagRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
 
         // Verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
@@ -250,7 +250,7 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
         // SAFETY: test-only call with valid context
         assert_eq!(
             unsafe { it.revalidate(sctx) }.expect("revalidate failed"),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -180,13 +180,15 @@ mod not_miri {
         let sctx = test.test.context.sctx;
 
         // Verify the iterator works normally and read at least one document
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -217,8 +219,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -248,8 +251,9 @@ mod not_miri {
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
         let sctx = test.test.context.sctx;
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -268,8 +272,9 @@ mod not_miri {
         assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
 
         // `should_abort` sees the tag value is missing and returns true.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -357,13 +357,15 @@ mod not_miri {
         let sctx = test.test.context.sctx;
 
         // First, verify the iterator works normally and read at least one document
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -379,8 +381,9 @@ mod not_miri {
 
         it.swap_index(&mut dummy_ref);
 
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -424,9 +427,9 @@ mod not_miri {
         // Revalidation calls should_abort which looks up "gc_collected" in
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(test.test.context.sctx)
-                .expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -354,15 +354,16 @@ mod not_miri {
     fn term_revalidate_after_index_disappears() {
         let test = TermRevalidateTest::new(10);
         let mut it = test.create_iterator();
+        let sctx = test.test.context.sctx;
 
         // First, verify the iterator works normally and read at least one document
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -379,7 +380,7 @@ mod not_miri {
         it.swap_index(&mut dummy_ref);
 
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -424,7 +425,8 @@ mod not_miri {
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(test.test.context.sctx)
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -354,7 +354,7 @@ mod not_miri {
     fn term_revalidate_after_index_disappears() {
         let test = TermRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
 
         // First, verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
@@ -429,7 +429,7 @@ mod not_miri {
         // null, triggering the abort path.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -497,12 +497,12 @@ impl RevalidateTest {
         I: for<'iterator> RQEIterator<'index>,
     {
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(matches!(it.read(), Ok(Some(_))));
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -516,7 +516,7 @@ impl RevalidateTest {
         while let Some(_record) = it.read().expect("failed to read") {}
         assert!(it.at_eof());
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -573,7 +573,7 @@ impl RevalidateTest {
         I: for<'iterator> RQEIterator<'index>,
     {
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -601,14 +601,14 @@ impl RevalidateTest {
 
         // Nothing changed in the index so revalidate does nothing
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
         // Remove an element before the current iteration position.
         self.remove_document(ii, self.doc_ids[0]);
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -617,7 +617,7 @@ impl RevalidateTest {
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(self.context.sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -626,7 +626,7 @@ impl RevalidateTest {
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
-        let res = it.revalidate().expect("revalidate failed");
+        let res = it.revalidate(self.context.sctx).expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -660,7 +660,7 @@ impl RevalidateTest {
 
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
-        let res = it.revalidate().expect("revalidate failed");
+        let res = it.revalidate(self.context.sctx).expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -498,13 +498,13 @@ impl RevalidateTest {
     {
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(matches!(it.read(), Ok(Some(_))));
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -519,7 +519,7 @@ impl RevalidateTest {
         assert!(it.at_eof());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -577,7 +577,7 @@ impl RevalidateTest {
     {
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -606,7 +606,7 @@ impl RevalidateTest {
         // Nothing changed in the index so revalidate does nothing
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -614,7 +614,7 @@ impl RevalidateTest {
         self.remove_document(ii, self.doc_ids[0]);
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -624,7 +624,7 @@ impl RevalidateTest {
         self.remove_document(ii, self.doc_ids[4]);
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -634,7 +634,7 @@ impl RevalidateTest {
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
         // SAFETY: test-only call with valid context
-        let res = unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed");
+        let res = unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -669,7 +669,7 @@ impl RevalidateTest {
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
         // SAFETY: test-only call with valid context
-        let res = unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed");
+        let res = unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -496,13 +496,15 @@ impl RevalidateTest {
     where
         I: for<'iterator> RQEIterator<'index>,
     {
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(matches!(it.read(), Ok(Some(_))));
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -515,8 +517,9 @@ impl RevalidateTest {
         // Read all documents to reach EOF
         while let Some(_record) = it.read().expect("failed to read") {}
         assert!(it.at_eof());
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -572,8 +575,9 @@ impl RevalidateTest {
     ) where
         I: for<'iterator> RQEIterator<'index>,
     {
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -600,15 +604,17 @@ impl RevalidateTest {
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Nothing changed in the index so revalidate does nothing
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
         // Remove an element before the current iteration position.
         self.remove_document(ii, self.doc_ids[0]);
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -616,8 +622,9 @@ impl RevalidateTest {
 
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(self.context.sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -626,7 +633,8 @@ impl RevalidateTest {
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
-        let res = it.revalidate(self.context.sctx).expect("revalidate failed");
+        // SAFETY: test-only call with valid context
+        let res = unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -660,7 +668,8 @@ impl RevalidateTest {
 
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
-        let res = it.revalidate(self.context.sctx).expect("revalidate failed");
+        // SAFETY: test-only call with valid context
+        let res = unsafe { it.revalidate(self.context.sctx) }.expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -133,7 +133,7 @@ mod not_miri {
     fn wildcard_revalidate_after_index_disappears() {
         let test = WildcardRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
 
         // Verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
@@ -195,7 +195,7 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let sctx = test.test.context.sctx;
+        let sctx = test.test.context.spec;
         // SAFETY: test-only call with valid context
         assert_eq!(
             unsafe { it.revalidate(sctx) }.expect("revalidate failed"),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -14,7 +14,6 @@ use inverted_index::{RSIndexResult, doc_ids_only::DocIdsOnly};
 use rqe_iterators::{IteratorType, RQEIterator, inverted_index::Wildcard};
 
 use crate::inverted_index::utils::BaseTest;
-use rqe_iterators_test_utils::MockContext;
 
 pub struct WildcardBaseTest {
     test: BaseTest<DocIdsOnly>,
@@ -41,10 +40,7 @@ impl WildcardBaseTest {
     }
 
     pub(crate) fn create_iterator(&self) -> Wildcard<'_, DocIdsOnly> {
-        let reader = self.test.ii.reader();
-        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
-        // that outlives the returned iterator.
-        unsafe { Wildcard::new(reader, self.test.mock_ctx.sctx(), 1.0) }
+        Wildcard::new(self.test.ii.reader(), 1.0)
     }
 }
 
@@ -72,12 +68,8 @@ fn wildcard_skip_to() {
 #[test]
 fn wildcard_empty_index() {
     let ii = inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
-    let mock_ctx = MockContext::new(0, 0);
 
-    let reader = ii.reader();
-    // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
-    // that outlives the iterator.
-    let mut it = unsafe { Wildcard::new(reader, mock_ctx.sctx(), 1.0) };
+    let mut it = Wildcard::new(ii.reader(), 1.0);
 
     // Should immediately be at EOF
     assert!(it.read().expect("read failed").is_none());
@@ -119,7 +111,7 @@ mod not_miri {
             let ii = DocIdsOnly::from_opaque(self.test.context.wildcard_inverted_index());
             // SAFETY: `self.test.context` provides a valid `RedisSearchCtx` with a valid
             // `spec` and `existingDocs` that outlive the returned iterator.
-            unsafe { Wildcard::new(ii.reader(), self.test.context.sctx, 1.0) }
+            Wildcard::new(ii.reader(), 1.0)
         }
     }
 
@@ -141,15 +133,16 @@ mod not_miri {
     fn wildcard_revalidate_after_index_disappears() {
         let test = WildcardRevalidateTest::new(10);
         let mut it = test.create_iterator();
+        let sctx = test.test.context.sctx;
 
         // Verify the iterator works normally and read at least one document
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -168,7 +161,7 @@ mod not_miri {
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -199,8 +192,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
+        let sctx = test.test.context.sctx;
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -214,7 +208,7 @@ mod not_miri {
         }
 
         assert_eq!(
-            it.revalidate().expect("revalidate failed"),
+            it.revalidate(sctx).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -136,13 +136,15 @@ mod not_miri {
         let sctx = test.test.context.sctx;
 
         // Verify the iterator works normally and read at least one document
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -160,8 +162,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -193,8 +196,9 @@ mod not_miri {
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
         let sctx = test.test.context.sctx;
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -207,8 +211,9 @@ mod not_miri {
             (*spec).existingDocs = std::ptr::null_mut();
         }
 
+        // SAFETY: test-only call with valid context
         assert_eq!(
-            it.revalidate(sctx).expect("revalidate failed"),
+            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -53,7 +53,7 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
 
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -199,7 +199,7 @@ fn rewind_not_empty() {
 #[test]
 fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let mut it = MaybeEmpty::<Infinite>::new_empty();
     // SAFETY: test-only call with valid context
     assert_eq!(
@@ -211,7 +211,7 @@ fn revalidate_empty() {
 #[test]
 fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let mut it = MaybeEmpty::new(Infinite::default());
     // SAFETY: test-only call with valid context
     assert_eq!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -51,7 +51,10 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
         false
     }
 
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+    fn revalidate(
+        &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
 
@@ -195,14 +198,18 @@ fn rewind_not_empty() {
 
 #[test]
 fn revalidate_empty() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let mut it = MaybeEmpty::<Infinite>::new_empty();
-    assert_eq!(it.revalidate().unwrap(), RQEValidateStatus::Ok);
+    assert_eq!(it.revalidate(ctx).unwrap(), RQEValidateStatus::Ok);
 }
 
 #[test]
 fn revalidate_not_empty() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let mut it = MaybeEmpty::new(Infinite::default());
-    assert_eq!(it.revalidate().unwrap(), RQEValidateStatus::Ok);
+    assert_eq!(it.revalidate(ctx).unwrap(), RQEValidateStatus::Ok);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -51,7 +51,7 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
         false
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
@@ -201,7 +201,11 @@ fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let ctx = mock_ctx.sctx();
     let mut it = MaybeEmpty::<Infinite>::new_empty();
-    assert_eq!(it.revalidate(ctx).unwrap(), RQEValidateStatus::Ok);
+    // SAFETY: test-only call with valid context
+    assert_eq!(
+        unsafe { it.revalidate(ctx) }.unwrap(),
+        RQEValidateStatus::Ok
+    );
 }
 
 #[test]
@@ -209,7 +213,11 @@ fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let ctx = mock_ctx.sctx();
     let mut it = MaybeEmpty::new(Infinite::default());
-    assert_eq!(it.revalidate(ctx).unwrap(), RQEValidateStatus::Ok);
+    // SAFETY: test-only call with valid context
+    assert_eq!(
+        unsafe { it.revalidate(ctx) }.unwrap(),
+        RQEValidateStatus::Ok
+    );
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -281,9 +281,11 @@ mod metrics_tests {
 
 #[test]
 fn revalidate() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
-    assert_eq!(it.revalidate().unwrap(), RQEValidateStatus::Ok);
+    assert_eq!(it.revalidate(ctx).unwrap(), RQEValidateStatus::Ok);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -282,7 +282,7 @@ mod metrics_tests {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
     // SAFETY: test-only call with valid context

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -285,7 +285,11 @@ fn revalidate() {
     let ctx = mock_ctx.sctx();
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
-    assert_eq!(it.revalidate(ctx).unwrap(), RQEValidateStatus::Ok);
+    // SAFETY: test-only call with valid context
+    assert_eq!(
+        unsafe { it.revalidate(ctx) }.unwrap(),
+        RQEValidateStatus::Ok
+    );
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -309,10 +309,12 @@ fn rewind_resets_state() {
 // Child revalidate Ok: NOT still excludes the child's doc IDs.
 #[test]
 fn revalidate_child_ok_preserves_exclusions() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let status = it.revalidate().expect("revalidate() failed");
+    let status = it.revalidate(ctx).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -327,12 +329,14 @@ fn revalidate_child_ok_preserves_exclusions() {
 // Child revalidate Aborted: NOT degenerates to wildcard (empty child).
 #[test]
 fn revalidate_child_aborted_replaces_child_with_empty() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let status = it.revalidate().expect("revalidate() failed");
+    let status = it.revalidate(ctx).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -347,13 +351,15 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
 // Child revalidate Moved on fresh iterator: should not panic.
 #[test]
 fn revalidate_child_moved_on_fresh_iterator() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Move);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
-    let status = it.revalidate().expect("revalidate() failed");
+    let status = it.revalidate(ctx).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Iterator should still work correctly after revalidate
@@ -369,6 +375,8 @@ fn revalidate_child_moved_on_fresh_iterator() {
 // Child revalidate Moved after read: child ahead, should not panic.
 #[test]
 fn revalidate_child_moved_after_read_with_child_ahead() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child = Mock::new([5, 10]);
     let mut data = child.data();
     let mut it = Not::new(child, 15, 1.0, Duration::ZERO, true);
@@ -383,7 +391,7 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let status = it.revalidate().expect("revalidate() failed");
+    let status = it.revalidate(ctx).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly
@@ -400,6 +408,8 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
 // Child revalidate Moved after skip_to: child ahead, should not panic.
 #[test]
 fn revalidate_child_moved_after_skip_to_with_child_ahead() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child = Mock::new([8, 15]);
     let mut data = child.data();
     let mut it = Not::new(child, 20, 1.0, Duration::ZERO, true);
@@ -420,7 +430,7 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let status = it.revalidate().expect("revalidate() failed");
+    let status = it.revalidate(ctx).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -314,7 +314,8 @@ fn revalidate_child_ok_preserves_exclusions() {
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let status = it.revalidate(ctx).expect("revalidate() failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -336,7 +337,8 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let status = it.revalidate(ctx).expect("revalidate() failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -359,7 +361,8 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
-    let status = it.revalidate(ctx).expect("revalidate() failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Iterator should still work correctly after revalidate
@@ -391,7 +394,8 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let status = it.revalidate(ctx).expect("revalidate() failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly
@@ -430,7 +434,8 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let status = it.revalidate(ctx).expect("revalidate() failed");
+    // SAFETY: test-only call with valid context
+    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -310,7 +310,7 @@ fn rewind_resets_state() {
 #[test]
 fn revalidate_child_ok_preserves_exclusions() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
@@ -331,7 +331,7 @@ fn revalidate_child_ok_preserves_exclusions() {
 #[test]
 fn revalidate_child_aborted_replaces_child_with_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Abort);
@@ -354,7 +354,7 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
 #[test]
 fn revalidate_child_moved_on_fresh_iterator() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Move);
@@ -379,7 +379,7 @@ fn revalidate_child_moved_on_fresh_iterator() {
 #[test]
 fn revalidate_child_moved_after_read_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child = Mock::new([5, 10]);
     let mut data = child.data();
     let mut it = Not::new(child, 15, 1.0, Duration::ZERO, true);
@@ -413,7 +413,7 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
 #[test]
 fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child = Mock::new([8, 15]);
     let mut data = child.data();
     let mut it = Not::new(child, 20, 1.0, Duration::ZERO, true);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -600,7 +600,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -617,7 +618,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -633,7 +635,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -662,7 +665,8 @@ mod revalidate {
             (*spec).existingDocs = new_ii.cast();
         }
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: Restoring the original `existingDocs` pointer and dropping
@@ -689,7 +693,8 @@ mod revalidate {
         // GC doc_id=1 from the wildcard inverted index to trigger Moved.
         gc_document(&context, 1);
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -708,7 +713,8 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -726,7 +732,8 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -748,7 +755,8 @@ mod revalidate {
         // Since child is also at 10, read_inner should advance past it.
         gc_document(&context, 5);
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -778,7 +786,8 @@ mod revalidate {
         // GC the only document so wildcard becomes empty on revalidation.
         gc_document(&context, 1);
 
-        let status = it.revalidate(context.sctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -569,10 +569,7 @@ mod revalidate {
         crate::utils::MockData,
     ) {
         let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
-        // SAFETY: `context` provides a valid `RedisSearchCtx` + spec +
-        // existingDocs that outlive the returned iterator.
-        let wcii =
-            unsafe { rqe_iterators::inverted_index::Wildcard::new(ii.reader(), context.sctx, 1.0) };
+        let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
         let child = Mock::new(CHILD_IDS);
         let child_data = child.data();
         let it = NotOptimized::new(wcii, child, 100, 1.0, None);
@@ -603,7 +600,7 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -620,7 +617,7 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -636,7 +633,7 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -665,7 +662,7 @@ mod revalidate {
             (*spec).existingDocs = new_ii.cast();
         }
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: Restoring the original `existingDocs` pointer and dropping
@@ -692,7 +689,7 @@ mod revalidate {
         // GC doc_id=1 from the wildcard inverted index to trigger Moved.
         gc_document(&context, 1);
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -711,7 +708,7 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -729,7 +726,7 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -751,7 +748,7 @@ mod revalidate {
         // Since child is also at 10, read_inner should advance past it.
         gc_document(&context, 5);
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -768,10 +765,7 @@ mod revalidate {
             TestContext::wildcard([1].iter().copied()),
         );
         let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
-        // SAFETY: `context` provides a valid `RedisSearchCtx` + spec +
-        // existingDocs that outlive the returned iterator.
-        let wcii =
-            unsafe { rqe_iterators::inverted_index::Wildcard::new(ii.reader(), context.sctx, 1.0) };
+        let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
         let child = Mock::<1>::new([100]); // child won't match
         let mut child_data = child.data();
         child_data.set_revalidate_result(MockRevalidateResult::Ok);
@@ -784,7 +778,7 @@ mod revalidate {
         // GC the only document so wildcard becomes empty on revalidation.
         gc_document(&context, 1);
 
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(context.sctx).unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -601,7 +601,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -619,7 +619,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -636,7 +636,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -666,7 +666,7 @@ mod revalidate {
         }
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: Restoring the original `existingDocs` pointer and dropping
@@ -694,7 +694,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -714,7 +714,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -733,7 +733,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -756,7 +756,7 @@ mod revalidate {
         gc_document(&context, 5);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -787,7 +787,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.sctx) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec) }.unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -668,7 +668,7 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_ok() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_OK
@@ -702,7 +702,7 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_aborted() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_ABORTED
@@ -730,7 +730,7 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_moved() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_MOVED
@@ -768,7 +768,7 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_moved_virtual_result() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_MOVED
@@ -814,7 +814,7 @@ mod optional_iterator_revalidate_after_abort {
     #[test]
     fn test_revalidate_twice_after_abort() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -845,7 +845,7 @@ mod optional_iterator_revalidate_after_abort {
     #[test]
     fn test_skip_to_after_abort() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -878,7 +878,7 @@ mod optional_iterator_revalidate_after_abort {
     #[test]
     fn test_rewind_after_abort() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -980,7 +980,7 @@ mod optional_iterator_non_sequential_reads {
 
         unsafe fn revalidate(
             &mut self,
-            _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+            _spec: std::ptr::NonNull<ffi::IndexSpec>,
         ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
             Ok(RQEValidateStatus::Ok)
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -667,6 +667,8 @@ mod optional_iterator_revalidate_test {
 
     #[test]
     fn test_revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_OK
@@ -683,7 +685,7 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Revalidate should return VALIDATE_OK
-        let status = it.revalidate().expect("revalidate without error");
+        let status = it.revalidate(ctx).expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Verify child was revalidated
@@ -698,6 +700,8 @@ mod optional_iterator_revalidate_test {
 
     #[test]
     fn test_revalidate_aborted() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_ABORTED
@@ -710,7 +714,7 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
-        let status = it.revalidate().expect("revalidate without error");
+        let status = it.revalidate(ctx).expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
         // Should be able to continue reading (now all virtual hits)
@@ -723,6 +727,8 @@ mod optional_iterator_revalidate_test {
 
     #[test]
     fn test_revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_MOVED
@@ -744,7 +750,7 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Revalidate should handle child movement
-        let status = it.revalidate().expect("revalidate without error");
+        let status = it.revalidate(ctx).expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
 
@@ -758,6 +764,8 @@ mod optional_iterator_revalidate_test {
 
     #[test]
     fn test_revalidate_moved_virtual_result() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_MOVED
@@ -779,7 +787,7 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Since current result is virtual, revalidate should return OK
-        let status = it.revalidate().expect("revalidate without error");
+        let status = it.revalidate(ctx).expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should be able to continue reading
@@ -801,6 +809,8 @@ mod optional_iterator_revalidate_after_abort {
     /// `revalidate` should return `Ok` immediately.
     #[test]
     fn test_revalidate_twice_after_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -811,11 +821,11 @@ mod optional_iterator_revalidate_after_abort {
 
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(ctx).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
-        let status = it.revalidate().unwrap();
+        let status = it.revalidate(ctx).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -828,6 +838,8 @@ mod optional_iterator_revalidate_after_abort {
     /// When child is `None`, the skip_to falls through to the virtual result path.
     #[test]
     fn test_skip_to_after_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -838,7 +850,7 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let _ = it.revalidate().unwrap();
+        let _ = it.revalidate(ctx).unwrap();
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -858,6 +870,8 @@ mod optional_iterator_revalidate_after_abort {
     /// After child abort, rewind should work correctly with child=None.
     #[test]
     fn test_rewind_after_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -870,7 +884,7 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let _ = it.revalidate().unwrap();
+        let _ = it.revalidate(ctx).unwrap();
 
         // Rewind with child=None
         it.rewind();
@@ -958,6 +972,7 @@ mod optional_iterator_non_sequential_reads {
 
         fn revalidate(
             &mut self,
+            _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
         ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
             Ok(RQEValidateStatus::Ok)
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -685,7 +685,8 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Revalidate should return VALIDATE_OK
-        let status = it.revalidate(ctx).expect("revalidate without error");
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Verify child was revalidated
@@ -714,7 +715,8 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
-        let status = it.revalidate(ctx).expect("revalidate without error");
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
         // Should be able to continue reading (now all virtual hits)
@@ -750,7 +752,8 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Revalidate should handle child movement
-        let status = it.revalidate(ctx).expect("revalidate without error");
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
 
@@ -787,7 +790,8 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Since current result is virtual, revalidate should return OK
-        let status = it.revalidate(ctx).expect("revalidate without error");
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should be able to continue reading
@@ -821,11 +825,13 @@ mod optional_iterator_revalidate_after_abort {
 
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let status = it.revalidate(ctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
-        let status = it.revalidate(ctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -850,7 +856,8 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let _ = it.revalidate(ctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let _ = unsafe { it.revalidate(ctx) }.unwrap();
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -884,7 +891,8 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let _ = it.revalidate(ctx).unwrap();
+        // SAFETY: test-only call with valid context
+        let _ = unsafe { it.revalidate(ctx) }.unwrap();
 
         // Rewind with child=None
         it.rewind();
@@ -970,7 +978,7 @@ mod optional_iterator_non_sequential_reads {
             self.read_step >= N
         }
 
-        fn revalidate(
+        unsafe fn revalidate(
             &mut self,
             _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
         ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -636,7 +636,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
 
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -657,7 +657,7 @@ mod optional_optimized_iterator_revalidate_tests {
             assert_eq!(r.doc_id, 1);
 
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -685,7 +685,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -705,7 +705,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -727,7 +727,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         let status = unsafe { it.revalidate(ctx) }.expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
@@ -750,7 +750,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -779,7 +779,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -808,7 +808,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
@@ -841,7 +841,7 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
@@ -871,7 +871,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -905,7 +905,7 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         let status = unsafe { it.revalidate(ctx) }.expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
@@ -934,7 +934,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.sctx();
+        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
         match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -635,7 +635,8 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
             let _ = it.read().expect("read").expect("result");
 
-            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -655,7 +656,8 @@ mod optional_optimized_iterator_revalidate_tests {
             let r = it.read().expect("read").expect("result");
             assert_eq!(r.doc_id, 1);
 
-            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -682,7 +684,8 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -701,7 +704,8 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { it.revalidate(test_ctx.sctx) }.expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -724,7 +728,8 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        let status = it.revalidate(ctx).expect("revalidate");
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
 
@@ -746,7 +751,8 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        match it.revalidate(ctx).expect("revalidate") {
+        // SAFETY: test-only call with valid context
+        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, WEIGHT);
@@ -774,7 +780,8 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        match it.revalidate(ctx).expect("revalidate") {
+        // SAFETY: test-only call with valid context
+        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual result carries zero weight
@@ -802,7 +809,8 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        match it.revalidate(ctx).expect("revalidate") {
+        // SAFETY: test-only call with valid context
+        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -834,7 +842,8 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        match it.revalidate(ctx).expect("revalidate") {
+        // SAFETY: test-only call with valid context
+        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -863,7 +872,8 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        match it.revalidate(ctx).expect("revalidate") {
+        // SAFETY: test-only call with valid context
+        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual: child is gone
@@ -896,7 +906,8 @@ mod optional_optimized_iterator_revalidate_tests {
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        let status = it.revalidate(ctx).expect("revalidate");
+        // SAFETY: test-only call with valid context
+        let status = unsafe { it.revalidate(ctx) }.expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
         assert_eq!(wcii_data.revalidate_count(), 1);
@@ -924,7 +935,8 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let ctx = mock_ctx.sctx();
-        match it.revalidate(ctx).expect("revalidate") {
+        // SAFETY: test-only call with valid context
+        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -14,8 +14,6 @@ use rqe_iterators::{
     optional_optimized::OptionalOptimized,
 };
 
-use rqe_iterators_test_utils::MockContext;
-
 use crate::utils;
 
 /// An inverted index populated with all consecutive doc IDs 1..=`max_doc_id`,
@@ -29,7 +27,6 @@ use crate::utils;
 /// for those instead.
 struct WildcardIndex {
     ii: InvertedIndex<DocIdsOnly>,
-    mock_ctx: MockContext,
 }
 
 impl WildcardIndex {
@@ -43,14 +40,11 @@ impl WildcardIndex {
                 .build();
             ii.add_record(&record).unwrap();
         }
-        let mock_ctx = MockContext::new(max_doc_id, max_doc_id as usize);
-        Self { ii, mock_ctx }
+        Self { ii }
     }
 
     fn create_iterator(&self) -> Wildcard<'_, DocIdsOnly> {
-        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
-        // that outlives the returned iterator.
-        unsafe { Wildcard::new(self.ii.reader(), self.mock_ctx.sctx(), 0.) }
+        Wildcard::new(self.ii.reader(), 0.)
     }
 }
 
@@ -623,9 +617,7 @@ mod optional_optimized_iterator_revalidate_tests {
             utils::MockData,
         ) {
             let ii = DocIdsOnly::from_opaque(test_ctx.wildcard_inverted_index());
-            // SAFETY: `test_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
-            // and `existingDocs` that outlive the returned iterator.
-            let wcii = unsafe { Wildcard::new(ii.reader(), test_ctx.sctx, 0.) };
+            let wcii = Wildcard::new(ii.reader(), 0.);
             let child = utils::Mock::new(CHILD_DOCS);
             let data = child.data();
             let it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
@@ -643,7 +635,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
             let _ = it.read().expect("read").expect("result");
 
-            let status = it.revalidate().expect("revalidate");
+            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -663,7 +655,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let r = it.read().expect("read").expect("result");
             assert_eq!(r.doc_id, 1);
 
-            let status = it.revalidate().expect("revalidate");
+            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -690,7 +682,7 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let status = it.revalidate().expect("revalidate");
+            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -709,7 +701,7 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let status = it.revalidate().expect("revalidate");
+            let status = it.revalidate(test_ctx.sctx).expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -730,7 +722,9 @@ mod optional_optimized_iterator_revalidate_tests {
         let _ = it.read().expect("read").expect("result");
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let status = it.revalidate().expect("revalidate");
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        let status = it.revalidate(ctx).expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
 
@@ -750,7 +744,9 @@ mod optional_optimized_iterator_revalidate_tests {
         assert_eq!(r.doc_id, 5);
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
-        match it.revalidate().expect("revalidate") {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        match it.revalidate(ctx).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, WEIGHT);
@@ -776,7 +772,9 @@ mod optional_optimized_iterator_revalidate_tests {
         assert_eq!(r.doc_id, 5);
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
-        match it.revalidate().expect("revalidate") {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        match it.revalidate(ctx).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual result carries zero weight
@@ -802,7 +800,9 @@ mod optional_optimized_iterator_revalidate_tests {
         assert_eq!(r.doc_id, 5);
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
-        match it.revalidate().expect("revalidate") {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        match it.revalidate(ctx).expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -832,7 +832,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
-        match it.revalidate().expect("revalidate") {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        match it.revalidate(ctx).expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -859,7 +861,9 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
-        match it.revalidate().expect("revalidate") {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        match it.revalidate(ctx).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual: child is gone
@@ -890,7 +894,9 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
-        let status = it.revalidate().expect("revalidate");
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        let status = it.revalidate(ctx).expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
         assert_eq!(wcii_data.revalidate_count(), 1);
@@ -916,7 +922,9 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
-        match it.revalidate().expect("revalidate") {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let ctx = mock_ctx.sctx();
+        match it.revalidate(ctx).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -114,12 +114,8 @@ mod optional_reducer_tests {
             ii.add_record(&record).expect("failed to add record");
         }
 
-        // `MockContext` provides the `RedisSearchCtx` required by `InvIdxWildcard::new`.
-        let mock_ctx = MockContext::new(MAX_DOC_ID, 0);
         let reader = ii.reader();
-        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
-        // that outlives the iterator.
-        let mut child = unsafe { InvIdxWildcard::new(reader, mock_ctx.sctx(), INITIAL_WEIGHT) };
+        let mut child = InvIdxWildcard::new(reader, INITIAL_WEIGHT);
         assert_eq!(child.type_(), IteratorType::InvIdxWildcard);
 
         // Advance so `current()` is Some — the factory will apply `NEW_WEIGHT` to it.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -153,6 +153,8 @@ fn profile_rewind() {
 
 #[test]
 fn profile_revalidate() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let ctx = mock_ctx.sctx();
     let child = Wildcard::new(10, 1.0);
     let mut profile = Profile::new(child);
 
@@ -160,7 +162,7 @@ fn profile_revalidate() {
     let _ = profile.read(); // doc 2
 
     // Revalidate (Wildcard returns OK)
-    let status = profile.revalidate();
+    let status = profile.revalidate(ctx);
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -154,7 +154,7 @@ fn profile_rewind() {
 #[test]
 fn profile_revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.sctx();
+    let ctx = mock_ctx.spec();
     let child = Wildcard::new(10, 1.0);
     let mut profile = Profile::new(child);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -162,7 +162,8 @@ fn profile_revalidate() {
     let _ = profile.read(); // doc 2
 
     // Revalidate (Wildcard returns OK)
-    let status = profile.revalidate(ctx);
+    // SAFETY: test-only call with valid context
+    let status = unsafe { profile.revalidate(ctx) };
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -528,7 +528,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 15);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -559,7 +559,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
@@ -591,7 +591,7 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -624,7 +624,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
@@ -655,7 +655,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
@@ -694,7 +694,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 20);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -730,7 +730,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
@@ -762,7 +762,7 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -818,7 +818,7 @@ macro_rules! union_common_tests {
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { quick_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -848,7 +848,7 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let ctx = mock_ctx.sctx();
+                let ctx = mock_ctx.spec();
                 // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
                 assert!(matches!(
@@ -877,7 +877,7 @@ macro_rules! union_common_tests {
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let ctx = mock_ctx.sctx();
+                let ctx = mock_ctx.spec();
                 // SAFETY: test-only call with valid context
             let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
@@ -909,7 +909,7 @@ macro_rules! union_common_tests {
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { quick_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(
@@ -941,7 +941,7 @@ macro_rules! union_common_tests {
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let _status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
 
@@ -986,7 +986,7 @@ macro_rules! union_common_tests {
 
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
             assert!(
@@ -1033,7 +1033,7 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.sctx();
+            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
             let status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
             assert!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -529,7 +529,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -559,7 +560,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -590,7 +592,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -622,7 +625,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -652,7 +656,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -690,7 +695,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -725,7 +731,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -756,7 +763,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -811,7 +819,8 @@ macro_rules! union_common_tests {
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = quick_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { quick_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -840,7 +849,8 @@ macro_rules! union_common_tests {
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
                 let ctx = mock_ctx.sctx();
-                let status = union_iter.revalidate(ctx).expect("revalidate failed");
+                // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -868,7 +878,8 @@ macro_rules! union_common_tests {
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
                 let ctx = mock_ctx.sctx();
-                let status = union_iter.revalidate(ctx).expect("revalidate failed");
+                // SAFETY: test-only call with valid context
+            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -899,7 +910,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = quick_iter.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { quick_iter.revalidate(ctx) }.expect("revalidate failed");
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -930,7 +942,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let _status = union.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let _status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -974,7 +987,8 @@ macro_rules! union_common_tests {
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -1020,7 +1034,8 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let ctx = mock_ctx.sctx();
-            let status = union.revalidate(ctx).expect("revalidate failed");
+            // SAFETY: test-only call with valid context
+            let status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -527,7 +527,9 @@ macro_rules! union_common_tests {
             let result = union_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 15);
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -555,7 +557,9 @@ macro_rules! union_common_tests {
             let result = union_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 10);
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -584,7 +588,9 @@ macro_rules! union_common_tests {
             while union_iter.read().expect("read failed").is_some() {}
             assert!(union_iter.at_eof());
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -614,7 +620,9 @@ macro_rules! union_common_tests {
             let result = union_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 10);
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -642,7 +650,9 @@ macro_rules! union_common_tests {
             let result = union_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 10);
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -678,7 +688,9 @@ macro_rules! union_common_tests {
             let result = union_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 20);
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -711,7 +723,9 @@ macro_rules! union_common_tests {
             let result = union_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 10);
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -740,7 +754,9 @@ macro_rules! union_common_tests {
             while union_iter.read().expect("read failed").is_some() {}
             assert!(union_iter.at_eof());
 
-            let status = union_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union_iter.revalidate(ctx).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -793,7 +809,9 @@ macro_rules! union_common_tests {
             }
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
-            let status = quick_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = quick_iter.revalidate(ctx).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -820,7 +838,9 @@ macro_rules! union_common_tests {
 
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
-                let status = union_iter.revalidate().expect("revalidate failed");
+                let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+                let ctx = mock_ctx.sctx();
+                let status = union_iter.revalidate(ctx).expect("revalidate failed");
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -846,7 +866,9 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
-                let status = union_iter.revalidate().expect("revalidate failed");
+                let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+                let ctx = mock_ctx.sctx();
+                let status = union_iter.revalidate(ctx).expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -875,7 +897,9 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
-            let status = quick_iter.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = quick_iter.revalidate(ctx).expect("revalidate failed");
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -904,7 +928,9 @@ macro_rules! union_common_tests {
 
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
-            let _status = union.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let _status = union.revalidate(ctx).expect("revalidate failed");
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -946,7 +972,9 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             // Revalidate — nothing moved, nothing aborted.
-            let status = union.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union.revalidate(ctx).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -990,7 +1018,9 @@ macro_rules! union_common_tests {
             //   child1.last_doc_id() = 50  <  100 = union.last_doc_id()
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
-            let status = union.revalidate().expect("revalidate failed");
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let ctx = mock_ctx.sctx();
+            let status = union.revalidate(ctx).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -284,7 +284,8 @@ fn revalidate_panics() {
     let mut union = UnionTrimmed::new(children, usize::MAX, true);
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let _ = union.revalidate(mock_ctx.sctx());
+    // SAFETY: test-only call with valid context
+    let _ = unsafe { union.revalidate(mock_ctx.sctx()) };
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -285,7 +285,7 @@ fn revalidate_panics() {
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     // SAFETY: test-only call with valid context
-    let _ = unsafe { union.revalidate(mock_ctx.sctx()) };
+    let _ = unsafe { union.revalidate(mock_ctx.spec()) };
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -283,7 +283,8 @@ fn revalidate_panics() {
     let (children, _data) = create_mock_3([1], [2], [3]);
     let mut union = UnionTrimmed::new(children, usize::MAX, true);
 
-    let _ = union.revalidate();
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let _ = union.revalidate(mock_ctx.sctx());
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -385,7 +385,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
         }))
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
@@ -553,7 +553,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
         }))
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -387,7 +387,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
 
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();
@@ -555,7 +555,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
 
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -387,6 +387,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
 
     fn revalidate(
         &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();
@@ -554,6 +555,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
 
     fn revalidate(
         &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -75,7 +75,7 @@ impl RQEIterator<'static> for FieldMaskMock {
         }
     }
 
-    fn revalidate(
+    unsafe fn revalidate(
         &mut self,
         _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'static>, RQEIteratorError> {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -77,6 +77,7 @@ impl RQEIterator<'static> for FieldMaskMock {
 
     fn revalidate(
         &mut self,
+        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'static>, RQEIteratorError> {
         Ok(rqe_iterators::RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -77,7 +77,7 @@ impl RQEIterator<'static> for FieldMaskMock {
 
     unsafe fn revalidate(
         &mut self,
-        _ctx: std::ptr::NonNull<ffi::RedisSearchCtx>,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'static>, RQEIteratorError> {
         Ok(rqe_iterators::RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
@@ -9,14 +9,12 @@
 
 use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
 use inverted_index::{InvertedIndex, RSIndexResult, doc_ids_only::DocIdsOnly};
-use rqe_iterators_test_utils::MockContext;
 
-/// Holds an [`InvertedIndex`] and a [`MockContext`] so a
+/// Holds an [`InvertedIndex`] so a
 /// [`Wildcard`](rqe_iterators::inverted_index::Wildcard) iterator can be
-/// created from them.
+/// created from it.
 pub(crate) struct WildcardHelper {
     ii: InvertedIndex<DocIdsOnly>,
-    mock_ctx: MockContext,
 }
 
 impl WildcardHelper {
@@ -27,8 +25,7 @@ impl WildcardHelper {
             let record = RSIndexResult::build_virt().doc_id(doc_id).build();
             ii.add_record(&record).expect("failed to add record");
         }
-        let mock_ctx = MockContext::new(0, 0);
-        Self { ii, mock_ctx }
+        Self { ii }
     }
 
     /// Create a [`Wildcard`](rqe_iterators::inverted_index::Wildcard)
@@ -36,9 +33,6 @@ impl WildcardHelper {
     pub(crate) fn create_wildcard(
         &self,
     ) -> rqe_iterators::inverted_index::Wildcard<'_, DocIdsOnly> {
-        let reader = self.ii.reader();
-        // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid
-        // `spec` that outlives the returned iterator.
-        unsafe { rqe_iterators::inverted_index::Wildcard::new(reader, self.mock_ctx.sctx(), 1.0) }
+        rqe_iterators::inverted_index::Wildcard::new(self.ii.reader(), 1.0)
     }
 }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/wildcard.rs
@@ -64,9 +64,7 @@ impl WildcardBencher {
         group.bench_function("Rust", |b| {
             let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
             b.iter(|| {
-                // SAFETY: `context` provides a valid `RedisSearchCtx` with a valid
-                // `spec` that outlives the iterator.
-                let mut it = unsafe { Wildcard::new(ii.reader(), context.sctx, 1.0) };
+                let mut it = Wildcard::new(ii.reader(), 1.0);
                 while let Ok(Some(current)) = it.read() {
                     black_box(current);
                 }
@@ -82,9 +80,7 @@ impl WildcardBencher {
         group.bench_function("Rust", |b| {
             let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
             b.iter(|| {
-                // SAFETY: `context` provides a valid `RedisSearchCtx` with a valid
-                // `spec` that outlives the iterator.
-                let mut it = unsafe { Wildcard::new(ii.reader(), context.sctx, 1.0) };
+                let mut it = Wildcard::new(ii.reader(), 1.0);
                 while let Ok(Some(outcome)) = it.skip_to(it.last_doc_id() + SKIP_TO_STEP) {
                     match outcome {
                         SkipToOutcome::Found(current) | SkipToOutcome::NotFound(current) => {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -169,8 +169,8 @@ impl QueryIterator {
     }
 
     #[inline(always)]
-    pub fn revalidate(&self, sctx: *mut ffi::RedisSearchCtx) -> ValidateStatus {
-        unsafe { (*self.0).Revalidate.unwrap()(self.0, sctx) }
+    pub fn revalidate(&self, spec: *mut ffi::IndexSpec) -> ValidateStatus {
+        unsafe { (*self.0).Revalidate.unwrap()(self.0, spec) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -169,8 +169,8 @@ impl QueryIterator {
     }
 
     #[inline(always)]
-    pub fn revalidate(&self) -> ValidateStatus {
-        unsafe { (*self.0).Revalidate.unwrap()(self.0) }
+    pub fn revalidate(&self, sctx: *mut ffi::RedisSearchCtx) -> ValidateStatus {
+        unsafe { (*self.0).Revalidate.unwrap()(self.0, sctx) }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -124,6 +124,11 @@ impl MockContext {
         NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
     }
 
+    /// Get the index spec pointer from the [`MockContext`].
+    pub const fn spec(&self) -> NonNull<ffi::IndexSpec> {
+        NonNull::new(self.spec).expect("IndexSpec should not be null")
+    }
+
     /// Get the query evaluation context from the [`MockContext`].
     pub const fn qctx(&self) -> NonNull<ffi::QueryEvalCtx> {
         NonNull::new(self.qctx).expect("QueryEvalCtx should not be null")

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -261,7 +261,7 @@ impl TestContext {
         let mut is_new = false;
         let inverted_index = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                sctx.as_ptr(),
+                spec.as_ptr(),
                 term.as_ptr(),
                 term.as_bytes().len(),
                 true, // write mode

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -233,7 +233,7 @@ static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
 
   RedisSearchCtx_LockSpecRead(sctx);
 
-  ValidateStatus rc = it->Revalidate(it);
+  ValidateStatus rc = it->Revalidate(it, sctx);
 
   if (rc == VALIDATE_ABORTED) {
     self->iterator->Free(self->iterator);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -233,7 +233,7 @@ static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
 
   RedisSearchCtx_LockSpecRead(sctx);
 
-  ValidateStatus rc = it->Revalidate(it, sctx);
+  ValidateStatus rc = it->Revalidate(it, sctx->spec);
 
   if (rc == VALIDATE_ABORTED) {
     self->iterator->Free(self->iterator);

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -87,7 +87,7 @@ void RS_SuggestionsFree(RS_Suggestions *s) {
  */
 static double SpellCheck_GetScore(SpellCheckCtx *scCtx, char *suggestion, size_t len,
                                   t_fieldMask fieldMask) {
-  InvertedIndex *invidx = Redis_OpenInvertedIndex(scCtx->sctx, suggestion, len, 0, NULL);
+  InvertedIndex *invidx = Redis_OpenInvertedIndex(scCtx->sctx->spec, suggestion, len, 0, NULL);
   double retVal = 0;
   IndexDecoderCtx ctx = {.field_mask_tag = IndexDecoderCtx_FieldMask, .field_mask = fieldMask};
   IndexReader *reader = NULL;

--- a/tests/cpptests/iterator_util.cpp
+++ b/tests/cpptests/iterator_util.cpp
@@ -24,6 +24,6 @@ void MockIterator_Rewind(QueryIterator *base) {
 void MockIterator_Free(QueryIterator *base) {
     delete reinterpret_cast<MockIterator *>(base);
 }
-ValidateStatus MockIterator_Revalidate(QueryIterator *base) {
+ValidateStatus MockIterator_Revalidate(QueryIterator *base, RedisSearchCtx *) {
     return reinterpret_cast<MockIterator *>(base)->Revalidate();
 }

--- a/tests/cpptests/iterator_util.cpp
+++ b/tests/cpptests/iterator_util.cpp
@@ -24,6 +24,6 @@ void MockIterator_Rewind(QueryIterator *base) {
 void MockIterator_Free(QueryIterator *base) {
     delete reinterpret_cast<MockIterator *>(base);
 }
-ValidateStatus MockIterator_Revalidate(QueryIterator *base, RedisSearchCtx *) {
+ValidateStatus MockIterator_Revalidate(QueryIterator *base, IndexSpec *) {
     return reinterpret_cast<MockIterator *>(base)->Revalidate();
 }

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -24,7 +24,7 @@ extern "C" {
     size_t MockIterator_NumEstimated(const QueryIterator *base);
     void MockIterator_Rewind(QueryIterator *base);
     void MockIterator_Free(QueryIterator *base);
-    ValidateStatus MockIterator_Revalidate(QueryIterator *base, RedisSearchCtx *);
+    ValidateStatus MockIterator_Revalidate(QueryIterator *base, IndexSpec *);
 }
 
 class MockIterator {

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -24,7 +24,7 @@ extern "C" {
     size_t MockIterator_NumEstimated(const QueryIterator *base);
     void MockIterator_Rewind(QueryIterator *base);
     void MockIterator_Free(QueryIterator *base);
-    ValidateStatus MockIterator_Revalidate(QueryIterator *base);
+    ValidateStatus MockIterator_Revalidate(QueryIterator *base, RedisSearchCtx *);
 }
 
 class MockIterator {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -705,7 +705,7 @@ TEST_F(IndexTest, testHybridVector) {
     ASSERT_EQ(hybridIt->lastDocId, expected_id);
   }
   ASSERT_EQ(hybridIt->lastDocId, max_id - step*((k/2)-1));
-  ASSERT_EQ(hybridIt->Revalidate(hybridIt), VALIDATE_OK);
+  ASSERT_EQ(hybridIt->Revalidate(hybridIt, &mockQctx.sctx), VALIDATE_OK);
 
   // Rerun in AD_HOC BF mode.
   hybridIt->Rewind(hybridIt);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -705,7 +705,7 @@ TEST_F(IndexTest, testHybridVector) {
     ASSERT_EQ(hybridIt->lastDocId, expected_id);
   }
   ASSERT_EQ(hybridIt->lastDocId, max_id - step*((k/2)-1));
-  ASSERT_EQ(hybridIt->Revalidate(hybridIt, &mockQctx.sctx), VALIDATE_OK);
+  ASSERT_EQ(hybridIt->Revalidate(hybridIt, mockQctx.sctx.spec), VALIDATE_OK);
 
   // Rerun in AD_HOC BF mode.
   hybridIt->Rewind(hybridIt);


### PR DESCRIPTION
Change the Revalidate API to accept a `IndexSpec*` parameter from the caller (result processor), rather than requiring each iterator to store a context pointer for its entire lifetime.

This relaxes the safety requirements on `Term`, `Missing`, and `inverted_index::Wildcard iterators`: their constructors no longer require that context and context.spec remain valid for the iterator's lifetime. Instead, the spec only needs to be valid at the point of the `Revalidate` call, which is trivially guaranteed by the result processor holding the spec read lock.

Also modified `Redis_OpenInvertedIndex` in the same way so it can be used inside `Revalidate`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide API signature change across C/C++/Rust iterator boundaries; incorrect spec pointer/locking or missed call-site updates could cause subtle revalidation bugs or unsafe FFI misuse.
> 
> **Overview**
> Refactors iterator revalidation so `QueryIterator::Revalidate` is called as `Revalidate(it, spec)` (with the spec provided by the result processor under a spec read lock) instead of relying on iterators storing a long-lived search context.
> 
> Aligns inverted-index access with this model by changing `Redis_OpenInvertedIndex` to take an `IndexSpec*` (updating all callers in debug commands, GC, indexer, spellcheck, and reader open paths). The Rust iterator layer and C<->Rust interop are updated accordingly (revalidate becomes `unsafe` and receives `NonNull<IndexSpec>`), and iterators like term/missing/wildcard drop stored context usage by using the passed spec or owning needed data; integration tests/benchers are updated to pass a mock spec pointer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4460b883dd12a6e5d1bd5b0df04599c49dab4f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->