### PR TITLE
[MOD-14793] fix trimUnionIterator in DESC mode

### DIFF
--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -48,7 +48,7 @@ void trimUnionIterator(QueryIterator *iter, size_t offset, size_t limit, bool as
         curTotal += it->NumEstimated(it);
         if (curTotal > limit) {
           ui->num = i + 1;
-          memset(ui->its + ui->num, 0, ui->num_orig - ui->num);
+          memset(ui->its + ui->num, 0, (ui->num_orig - ui->num) * sizeof(*ui->its));
           break;
         }
       }
@@ -58,8 +58,8 @@ void trimUnionIterator(QueryIterator *iter, size_t offset, size_t limit, bool as
         curTotal += it->NumEstimated(it);
         if (curTotal > limit) {
           ui->num -= i;
-          memmove(ui->its, ui->its + i, ui->num);
-          memset(ui->its + ui->num, 0, ui->num_orig - ui->num);
+          memmove(ui->its, ui->its + i, ui->num * sizeof(*ui->its));
+          memset(ui->its + ui->num, 0, (ui->num_orig - ui->num) * sizeof(*ui->its));
           break;
         }
       }

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -32,7 +32,7 @@ static inline IteratorStatus UI_ReadUnsorted(QueryIterator *ctx) {
   return ITERATOR_EOF;
 }
 
-void trimUnionIterator(QueryIterator *iter, size_t offset, size_t limit, bool asc) {
+void trimUnionIterator(QueryIterator *iter, size_t limit, bool asc) {
   RS_LOG_ASSERT(iter->type == UNION_ITERATOR, "trim applies to union iterators only");
   UnionIterator *ui = (UnionIterator *)iter;
   if (ui->num_orig <= 2) { // nothing to trim
@@ -41,31 +41,27 @@ void trimUnionIterator(QueryIterator *iter, size_t offset, size_t limit, bool as
 
   size_t curTotal = 0;
   int i;
-  if (offset == 0) {
-    if (asc) {
-      for (i = 1; i < ui->num; ++i) {
-        QueryIterator *it = ui->its_orig[i];
-        curTotal += it->NumEstimated(it);
-        if (curTotal > limit) {
-          ui->num = i + 1;
-          memset(ui->its + ui->num, 0, (ui->num_orig - ui->num) * sizeof(*ui->its));
-          break;
-        }
-      }
-    } else {  //desc
-      for (i = ui->num - 2; i > 0; --i) {
-        QueryIterator *it = ui->its_orig[i];
-        curTotal += it->NumEstimated(it);
-        if (curTotal > limit) {
-          ui->num -= i;
-          memmove(ui->its, ui->its + i, ui->num * sizeof(*ui->its));
-          memset(ui->its + ui->num, 0, (ui->num_orig - ui->num) * sizeof(*ui->its));
-          break;
-        }
+  if (asc) {
+    for (i = 1; i < ui->num; ++i) {
+      QueryIterator *it = ui->its_orig[i];
+      curTotal += it->NumEstimated(it);
+      if (curTotal > limit) {
+        ui->num = i + 1;
+        memset(ui->its + ui->num, 0, (ui->num_orig - ui->num) * sizeof(*ui->its));
+        break;
       }
     }
-  } else {
-    UI_SyncIterList(ui);
+  } else {  //desc
+    for (i = ui->num - 2; i > 0; --i) {
+      QueryIterator *it = ui->its_orig[i];
+      curTotal += it->NumEstimated(it);
+      if (curTotal > limit) {
+        ui->num -= i;
+        memmove(ui->its, ui->its + i, ui->num * sizeof(*ui->its));
+        memset(ui->its + ui->num, 0, (ui->num_orig - ui->num) * sizeof(*ui->its));
+        break;
+      }
+    }
   }
   iter->Read = UI_ReadUnsorted;
 }
@@ -307,7 +303,7 @@ void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
       } else if (req->ast.root->type == QN_NUMERIC) {
         // trim the union numeric iterator to have the minimal number of ranges
         if (root->type == UNION_ITERATOR) {
-          trimUnionIterator(root, 0, opt->limit, opt->asc);
+          trimUnionIterator(root, opt->limit, opt->asc);
         }
       } else {
         req->rootiter = NewOptimizerIterator(opt, root, &req->ast.config);

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -551,6 +551,44 @@ def testAggregate(env):
             compare_optimized_to_not(env, ['ft.aggregate', 'idx', '*'], params, 'case 12')
         #input('stop')
 
+@skip(cluster=True)
+def testTrimUnionDesc(env):
+    """Cover the DESC branch of trimUnionIterator (query_optimizer.c lines 56-63).
+
+    The numeric tree needs >2 leaf nodes so that trimming is not skipped
+    (num_orig <= 2 early-return). With MINIMUM_RANGE_CARDINALITY=16 and
+    CARDINALITY_GROWTH_FACTOR=4, depth-1 nodes split at cardinality 64.
+    Using 500 unique values guarantees 4+ leaf nodes at depth 2.
+    """
+    conn = getConnectionByEnv(env)
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
+
+    # 500 docs with unique n values 0..499 → many numeric tree leaf nodes.
+    for i in range(500):
+        conn.execute_command('hset', i, 'n', i)
+
+    limits = [[0, 2], [0, 10], [0, 100]]
+    ranges = [[-1, 500], [0, 499], [50, 450], [100, 300]]
+    params = ['limit', 0, 0]
+
+    for lim in limits:
+        params[1] = lim[0]
+        params[2] = lim[1]
+        for rng in ranges:
+            numRange = '@n:[%d %d]' % (rng[0], rng[1])
+
+            # DESC: exercises lines 56-63
+            compare_optimized_to_not(
+                env, ['ft.search', 'idx', numRange, 'SORTBY', 'n', 'DESC'],
+                params, 'DESC ' + numRange)
+
+            # ASC: exercises lines 47-52 (already covered elsewhere, but
+            # validates the same data set)
+            compare_optimized_to_not(
+                env, ['ft.search', 'idx', numRange, 'SORTBY', 'n', 'ASC'],
+                params, 'ASC ' + numRange)
+
+
 @skip()  # TODO: solve flakiness (MOD-5257)
 def testCoordinator(env):
     # separate test which only has queries with sortby since otherwise the coordinator has random results


### PR DESCRIPTION
## Describe the changes in the pull request

  - Add `testTrimUnionDesc` to cover the DESC branch of `trimUnionIterator`, using 500 unique numeric values to ensure >2 tree
  leaf nodes                                                                                                                   
  - Fix `memmove`/`memset` calls in `trimUnionIterator` that used element counts instead of byte counts — the DESC path        
  returned wrong results on 64-bit systems                                                                                     
  - Remove unused `offset` parameter from `trimUnionIterator` (only call site hardcoded it to `0`, making the `offset != 0` branch dead code)   

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-optimizer iterator trimming logic used to limit numeric range unions during sorted queries; mistakes here can change result ordering/contents, though the change is small and now covered by a targeted regression test.
> 
> **Overview**
> Fixes `trimUnionIterator` so trimming a numeric `UNION_ITERATOR` for *DESC* sort uses correct byte sizes in `memmove`/`memset`, preventing incorrect results on 64-bit systems.
> 
> Simplifies the helper by removing the unused `offset` parameter and updates the only call site accordingly, and adds `testTrimUnionDesc` to exercise the DESC trimming path across multiple ranges/limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7732a8af715c942c1d1645ab0b92c5829f0f12ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->