### PR TITLE
[MOD-14708] CI: Add Ubuntu Resolute with LTO

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -7,6 +7,7 @@ on:
         type: choice
         options:
           - all
+          - ubuntu:resolute
           - ubuntu:noble
           - ubuntu:jammy
           - ubuntu:focal

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -38,6 +38,7 @@ on:
         type: choice
         options:
           - all
+          - ubuntu:resolute
           - ubuntu:noble
           - ubuntu:jammy
           - ubuntu:focal

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -51,6 +51,8 @@ jobs:
 
           # All available platform/architecture combinations
           all_combinations = [
+              ('ubuntu:resolute', 'x86_64'),
+              ('ubuntu:resolute', 'aarch64'),
               ('ubuntu:noble', 'x86_64'),
               ('ubuntu:noble', 'aarch64'),
               ('ubuntu:jammy', 'x86_64'),

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -141,7 +141,7 @@ jobs:
                       'container': 'ubuntu:resolute',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Resolute x86_64',
-                      'enable_lto': '0'
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'ubuntu:resolute',

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -136,6 +136,20 @@ jobs:
                       'name': 'Ubuntu Latest ARM64'
                   }
               },
+              "ubuntu:resolute": {
+                  "x86_64": {
+                      'container': 'ubuntu:resolute',
+                      'setup_script': 'apt update && apt install -y git',
+                      'name': 'Ubuntu Resolute x86_64',
+                      'enable_lto': '0'
+                  },
+                  "aarch64": {
+                      'container': 'ubuntu:resolute',
+                      'setup_script': 'apt update && apt install -y git',
+                      'name': 'Ubuntu Resolute ARM64',
+                      'enable_lto': '1'
+                  }
+              },
               "ubuntu:noble": {
                   "x86_64": {
                       'container': 'ubuntu:noble',

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -132,8 +132,6 @@ install_llvm() {
             # apt.llvm.org may not support this distro version yet; fall back to tarball.
             echo ">>> apt.llvm.org failed — falling back to official tarball"
             rm -f /tmp/llvm.sh
-            # The tarball's lld is dynamically linked against libxml2.
-            apt_get_cmd "$MODE" install -y --no-install-recommends libxml2
             install_from_tarball
         fi
         ;;

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -117,22 +117,30 @@ install_llvm() {
 
     case "$distro" in
 
-    # ----- Debian / Ubuntu (apt.llvm.org, tarball fallback) -------------------
+    # ----- Debian / Ubuntu (native apt → apt.llvm.org → tarball) --------------
     ubuntu|debian)
-        echo ">>> Using apt.llvm.org"
         source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
         apt_get_cmd "$MODE" update -qq
-        apt_get_cmd "$MODE" install -y --no-install-recommends \
-            lsb-release wget software-properties-common gnupg ca-certificates
-        wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-        chmod +x /tmp/llvm.sh
-        if $MODE /tmp/llvm.sh "$LLVM_VER"; then
-            rm -f /tmp/llvm.sh
+
+        # 1) Try native distro packages first (e.g. Ubuntu 26.04 ships clang-21).
+        if apt_get_cmd "$MODE" install -y --no-install-recommends \
+                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "libclang-${LLVM_VER}-dev" 2>/dev/null; then
+            echo ">>> Installed clang-${LLVM_VER} from native apt repos"
         else
-            # apt.llvm.org may not support this distro version yet; fall back to tarball.
-            echo ">>> apt.llvm.org failed — falling back to official tarball"
-            rm -f /tmp/llvm.sh
-            install_from_tarball
+            # 2) Fall back to apt.llvm.org third-party repo.
+            echo ">>> Native packages not available — trying apt.llvm.org"
+            apt_get_cmd "$MODE" install -y --no-install-recommends \
+                lsb-release wget software-properties-common gnupg ca-certificates
+            wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+            chmod +x /tmp/llvm.sh
+            if $MODE /tmp/llvm.sh "$LLVM_VER"; then
+                rm -f /tmp/llvm.sh
+            else
+                # 3) Last resort: official pre-built tarball.
+                echo ">>> apt.llvm.org failed — falling back to official tarball"
+                rm -f /tmp/llvm.sh
+                install_from_tarball
+            fi
         fi
         ;;
 

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -132,6 +132,8 @@ install_llvm() {
             # apt.llvm.org may not support this distro version yet; fall back to tarball.
             echo ">>> apt.llvm.org failed — falling back to official tarball"
             rm -f /tmp/llvm.sh
+            # The tarball's lld is dynamically linked against libxml2.
+            apt_get_cmd "$MODE" install -y --no-install-recommends libxml2
             install_from_tarball
         fi
         ;;

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -117,7 +117,7 @@ install_llvm() {
 
     case "$distro" in
 
-    # ----- Debian / Ubuntu (apt.llvm.org) ------------------------------------
+    # ----- Debian / Ubuntu (apt.llvm.org, tarball fallback) -------------------
     ubuntu|debian)
         echo ">>> Using apt.llvm.org"
         source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
@@ -126,8 +126,14 @@ install_llvm() {
             lsb-release wget software-properties-common gnupg ca-certificates
         wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
         chmod +x /tmp/llvm.sh
-        $MODE /tmp/llvm.sh "$LLVM_VER"
-        rm -f /tmp/llvm.sh
+        if $MODE /tmp/llvm.sh "$LLVM_VER"; then
+            rm -f /tmp/llvm.sh
+        else
+            # apt.llvm.org may not support this distro version yet; fall back to tarball.
+            echo ">>> apt.llvm.org failed — falling back to official tarball"
+            rm -f /tmp/llvm.sh
+            install_from_tarball
+        fi
         ;;
 
     # ----- Alpine Linux (apk) ------------------------------------------------

--- a/.install/ubuntu_26.04.sh
+++ b/.install/ubuntu_26.04.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+export DEBIAN_FRONTEND=noninteractive
+MODE=$1 # whether to install using sudo or not
+source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
+
+apt_get_cmd "$MODE" update -qq
+apt_get_cmd "$MODE" install -yqq git wget build-essential lcov openssl libssl-dev \
+    unzip rsync clang curl libclang-dev gdb libcrypt-dev
+
+# We need Python headers to build psutil@5.x.y from
+# source, since it only started providing wheels for aarch64
+# in version 6.w.z.
+if [ "$(uname -m)" = "aarch64" ]; then
+    apt_get_cmd "$MODE" install -y python3-dev
+fi
+
+# Need clang for LTO
+source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE

--- a/.install/ubuntu_26.04.sh
+++ b/.install/ubuntu_26.04.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
 
 apt_get_cmd "$MODE" update -qq
 apt_get_cmd "$MODE" install -yqq git wget build-essential lcov openssl libssl-dev \
-    unzip rsync clang curl libclang-dev gdb libcrypt-dev libxml2-16
+    unzip rsync clang curl libclang-dev gdb libcrypt-dev
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/.install/ubuntu_26.04.sh
+++ b/.install/ubuntu_26.04.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
 
 apt_get_cmd "$MODE" update -qq
 apt_get_cmd "$MODE" install -yqq git wget build-essential lcov openssl libssl-dev \
-    unzip rsync clang curl libclang-dev gdb libcrypt-dev
+    unzip rsync clang curl libclang-dev gdb libcrypt-dev libxml2-16
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,11 @@ set(LIBUV_BUILD_TESTS OFF CACHE BOOL "Build libuv tests" FORCE)
 set(LIBUV_BUILD_BENCH OFF CACHE BOOL "Build libuv benchmarks" FORCE)
 set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build shared libuv library" FORCE)
 add_subdirectory(${root}/deps/libuv ${CMAKE_CURRENT_BINARY_DIR}/libuv)
+# libuv has const-correctness issues that trigger -Werror=discarded-qualifiers on gcc 16+.
+# Mirror the gcc guard from the top-level CMakeLists.txt.
+if(HAS_DISCARDED_QUALIFIERS)
+    target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=discarded-qualifiers>)
+endif()
 
 option(VECSIM_BUILD_TESTS "Build vecsim tests" OFF)
 add_subdirectory(${root}/deps/VectorSimilarity ${CMAKE_CURRENT_BINARY_DIR}/VectorSimilarity)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,10 +37,14 @@ set(LIBUV_BUILD_TESTS OFF CACHE BOOL "Build libuv tests" FORCE)
 set(LIBUV_BUILD_BENCH OFF CACHE BOOL "Build libuv benchmarks" FORCE)
 set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build shared libuv library" FORCE)
 add_subdirectory(${root}/deps/libuv ${CMAKE_CURRENT_BINARY_DIR}/libuv)
-# libuv has const-correctness issues that trigger -Werror=discarded-qualifiers on gcc 16+.
-# Mirror the gcc guard from the top-level CMakeLists.txt.
+# libuv has const-correctness issues that trigger warnings-as-errors on newer compilers.
+# gcc 16+: -Werror=discarded-qualifiers; clang 21+: -Werror=incompatible-pointer-types-discards-qualifiers.
+# Mirror the compiler guards from the top-level CMakeLists.txt.
 if(HAS_DISCARDED_QUALIFIERS)
     target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=discarded-qualifiers>)
+endif()
+if(HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
+    target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types-discards-qualifiers>)
 endif()
 
 option(VECSIM_BUILD_TESTS "Build vecsim tests" OFF)


### PR DESCRIPTION
Add Ubuntu Resolute with LTO

Successful run
https://github.com/RediSearch/RediSearch/actions/runs/24143484513

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the CI/build matrix and changes LLVM installation behavior on Debian/Ubuntu, which can affect toolchain consistency and build reliability across Linux runners.
> 
> **Overview**
> Adds **Ubuntu `ubuntu:resolute`** as a first-class CI target (build artifacts + tests) by extending workflow dispatch options, the generated platform/arch matrix (including `x86_64` and `aarch64`), and per-platform config with `enable_lto=1`.
> 
> Updates LLVM installation on Debian/Ubuntu to prefer *native* `clang/lld` packages, fall back to `apt.llvm.org`, and finally to the official LLVM tarball if needed. Also adjusts `src/CMakeLists.txt` to suppress new compiler warnings-as-errors for `libuv` on newer GCC/Clang toolchains, and adds a new `.install/ubuntu_26.04.sh` bootstrap script for Ubuntu 26.04 environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2703cd8c81433283b9ceddf8ea40c1c7a15938ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->