### PR TITLE
RED-182188: Omit bots from reviewers list

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -137,12 +137,17 @@ jobs:
           ISSUES_SHIFT_ASSIGNEE: ${{ vars.ISSUES_SHIFT_ASSIGNEE }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
+          # Omit GITHUB_ACTOR from reviewers if it is a bot account
+          REVIEWERS="$TEAM_LEADERS,$ISSUES_SHIFT_ASSIGNEE"
+          if [[ "$GITHUB_ACTOR" != *"[bot]" ]]; then
+            REVIEWERS="$REVIEWERS,$GITHUB_ACTOR"
+          fi
           gh pr create \
             --title    "Bump version from $CUR_VERSION to $NEXT_VERSION" \
             --body     "This PR was automatically created by the release workflow of $RELEASE_TAG." \
             --head     "$BRANCH" \
             --base     "$RELEASE_BRANCH" \
-            --reviewer "$TEAM_LEADERS,$ISSUES_SHIFT_ASSIGNEE,$GITHUB_ACTOR" \
+            --reviewer "$REVIEWERS" \
             --draft
 
       - name: Trigger CI


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: There is no filter for who is included in the reviewers list
2. Change: Filtering out [bot] users from the list
3. Outcome: Allows the event-release to complete when tag was created by a bot. 

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only changes how reviewers are computed for the auto-created version bump PR; main risk is unintentionally omitting a human reviewer if the actor string matches the bot pattern.
> 
> **Overview**
> Updates the `event-release.yml` workflow to **skip adding `github.actor` as a PR reviewer when the actor is a bot** (matches `*[bot]`). This prevents the auto-generated version bump PR (`gh pr create`) from failing when a release tag is created by a bot account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da249d4cd7d9a5991177d2c3b63d6d9739a6471d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->