### PR TITLE
[8.6-rse] MOD-13110: Implement foreground depletion for hybrid (#8534)

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -595,22 +595,22 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
     }
     // helper array to collect depleters so in async we can deplete them all at once before returning the cursors
     arrayof(ResultProcessor*) depleters = NULL;
-    if (backgroundDepletion) {
-      depleters = array_new(ResultProcessor *, req->nrequests);
-    }
+    depleters = array_new(ResultProcessor *, req->nrequests);
     arrayof(Cursor*) cursors = array_new(Cursor*, req->nrequests);
+    ResultProcessorType expectedDepleterType = backgroundDepletion ? RP_SAFE_DEPLETER : RP_DEPLETER;
     for (size_t i = 0; i < req->nrequests; i++) {
       AREQ *areq = req->requests[i];
-      ResultProcessor *rp = areq->pipeline.qctx.endProc;
-      if (IsProfile(req) && rp->type == RP_PROFILE) {
-        rp = rp->upstream;
+      ResultProcessor *depleter = areq->pipeline.qctx.endProc;
+      if (IsProfile(req) && depleter->type == RP_PROFILE) {
+        depleter = depleter->upstream;
       }
-      if (backgroundDepletion) {
-        if (rp->type != RP_SAFE_DEPLETER) {
-          break;
-        }
-        array_ensure_append_1(depleters, rp);
+      if (depleter->type != expectedDepleterType) {
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC,
+          "Unexpected depleter type: expected %s, got %s",
+          RPTypeToString(expectedDepleterType), RPTypeToString(depleter->type));
+        break;
       }
+      array_ensure_append_1(depleters, depleter);
       Cursor *cursor = Cursors_Reserve(getCursorList(false), areq->sctx->spec->own_ref, areq->cursorConfig.maxIdle, status);
       if (!cursor) {
         break;
@@ -624,27 +624,33 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
 
     if (array_len(cursors) != req->nrequests) {
       array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
-      if (depleters) {
-        array_free(depleters);
-      }
+      array_free(depleters);
       // verify error exists
       RS_ASSERT(QueryError_HasError(status));
       return REDISMODULE_ERR;
     }
 
+    int rc;
     if (backgroundDepletion) {
-      int rc = RPSafeDepleter_DepleteAll(depleters, status);
-      array_free(depleters);
-      if (rc != RS_RESULT_OK) {
-        array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
-        if (rc == RS_RESULT_ERROR) {
-          // Error was already set by RPSafeDepleter_DepleteAll
-          RS_ASSERT(QueryError_HasError(status));
+      rc = RPSafeDepleter_DepleteAll(depleters, status);
+    } else {
+      // Foreground depletion for WORKERS == 0
+      // Trigger synchronous depletion to read and buffer all results while the spec lock is held.
+      rc = RPDepleter_DepleteAll(depleters);
+    }
+
+    array_free(depleters);
+
+    if (rc != RS_RESULT_OK) {
+      array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
+      if (!QueryError_HasError(status)) {
+        if (rc == RS_RESULT_TIMEDOUT) {
+          QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_TIMED_OUT, "Depleting timed out");
         } else {
           QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to deplete set of results, rc=%d", rc);
         }
-        return REDISMODULE_ERR;
       }
+      return REDISMODULE_ERR;
     }
     replyWithCursors(replyCtx, cursors);
     array_free(cursors);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -79,11 +79,18 @@ int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelin
           RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
           ResultProcessor *depleter = RPSafeDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
           QITR_PushRP(qctx, depleter);
-          if (isProfile) {
-            // Wrap the depleter with a Profile RP to match the expected end processor type
-            ResultProcessor *profileRP = RPProfile_New(qctx->endProc, qctx);
-            QITR_PushRP(qctx, profileRP);
-          }
+        } else {
+          // Create a depleter processor for foreground depletion (WORKERS == 0)
+          // This depletes all results synchronously on the main thread while
+          // the spec lock is held, preventing crashes when the index is
+          // modified between cursor creation and first read.
+          ResultProcessor *depleter = RPDepleter_New();
+          QITR_PushRP(qctx, depleter);
+        }
+        if (isProfile) {
+          // Wrap the depleter with a Profile RP to match the expected end processor type
+          ResultProcessor *profileRP = RPProfile_New(qctx->endProc, qctx);
+          QITR_PushRP(qctx, profileRP);
         }
     }
     if (depleteInBackground) {
@@ -120,19 +127,21 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req) {
 int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params) {
     // Array to collect upstream from each individual request pipeline
     arrayof(ResultProcessor*) upstreams = array_new(ResultProcessor *, req->nrequests);
-    const ResultProcessorType expected = IsProfile(req) ? RP_PROFILE : RP_SAFE_LOADER;
     for (size_t i = 0; i < req->nrequests; i++) {
         AREQ *areq = req->requests[i];
-        if (IsProfile(req) && areq->pipeline.qctx.endProc->type != expected) {
+        // In profile mode, the end processor must be RP_PROFILE (which wraps the depleter)
+        if (IsProfile(req) && areq->pipeline.qctx.endProc->type != RP_PROFILE) {
             QueryError_SetWithoutUserDataFmt(
                 &req->tailPipelineError,
                 QUERY_ERROR_CODE_GENERIC,
                 "Expected %s processor at end of pipeline, found %s",
-                RPTypeToString(expected),
+                RPTypeToString(RP_PROFILE),
                 RPTypeToString(areq->pipeline.qctx.endProc->type));
             array_free(upstreams);
             return REDISMODULE_ERR;
         }
+        // In non-profile mode, the end processor is either RP_SAFE_DEPLETER (background)
+        // or RP_DEPLETER (foreground). Both implement the same Next interface.
         array_ensure_append_1(upstreams, areq->pipeline.qctx.endProc);
     }
 

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -130,13 +130,7 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
 
     return upstreamTime;
   }
-  double totalRPTime = rs_wall_clock_convert_ns_to_ms_d(RPProfile_GetClock(rp));
-
-  // For RP_SAFE_DEPLETER, use depletion time as the total time instead of
-  // RPProfile time because the actual work happens in the background thread
-  if (rp->upstream && rp->upstream->type == RP_SAFE_DEPLETER) {
-    totalRPTime = rs_wall_clock_convert_ns_to_ms_d(RPSafeDepleter_GetDepletionTime(rp->upstream));
-  }
+  double totalRPTime = rs_wall_clock_convert_ns_to_ms_d(RPProfile_GetTime(rp));
 
   if (printProfileClock) {
     double deltaTime = totalRPTime - upstreamTime;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1392,9 +1392,14 @@ ResultProcessor *RPProfile_New(ResultProcessor *rp, QueryProcessingCtx *qctx) {
   return &rpp->base;
 }
 
-rs_wall_clock_ns_t RPProfile_GetClock(ResultProcessor *rp) {
-  RPProfile *self = (RPProfile *)rp;
-  return self->profileTime;
+rs_wall_clock_ns_t RPProfile_GetTime(ResultProcessor *rp) {
+  if (rp->upstream && rp->upstream->type == RP_SAFE_DEPLETER) {
+    return RPSafeDepleter_GetDepletionTime(rp->upstream);
+  } else if (rp->upstream && rp->upstream->type == RP_DEPLETER) {
+    return RPDepleter_GetDepletionTime(rp->upstream);
+  } else {
+    return ((RPProfile *)rp)->profileTime;
+  }
 }
 
 uint64_t RPProfile_GetCount(ResultProcessor *rp) {
@@ -1689,8 +1694,8 @@ static void RPSafeDepleter_Free(ResultProcessor *base) {
  * Get the depletion time for RPSafeDepleter.
  * This is the time spent in the background thread depleting upstream results.
  */
-rs_wall_clock_ns_t RPSafeDepleter_GetDepletionTime(ResultProcessor *base) {
-  RPSafeDepleter *self = (RPSafeDepleter *)base;
+rs_wall_clock_ns_t RPSafeDepleter_GetDepletionTime(const ResultProcessor *base) {
+  const RPSafeDepleter *self = (const RPSafeDepleter *)base;
   return self->depletionTime;
 }
 
@@ -2646,6 +2651,7 @@ typedef struct {
   size_t cur_idx;                  // Current index for yielding results
   RPStatus last_rc;                // Last return code from upstream
   uint32_t depleted_results;       // Total number of results depleted
+  rs_wall_clock_ns_t depletionTime; // Time spent depleting upstream results
 } RPDepleter;
 
 /**
@@ -2657,6 +2663,10 @@ static void RPDepleter_Deplete(RPDepleter *self) {
   SearchResult *r = rm_calloc(1, sizeof(*r));
   *r = SearchResult_New();
 
+  // Track depletion time for profiling
+  rs_wall_clock start;
+  rs_wall_clock_init(&start);
+
   // Deplete all results from upstream
   while ((rc = self->base.upstream->Next(self->base.upstream, r)) == RS_RESULT_OK) {
     array_append(self->results, r);
@@ -2664,6 +2674,9 @@ static void RPDepleter_Deplete(RPDepleter *self) {
     *r = SearchResult_New();
     self->depleted_results++;
   }
+
+  // Record depletion time
+  self->depletionTime = rs_wall_clock_elapsed_ns(&start);
 
   SearchResult_Destroy(r);
   rm_free(r);
@@ -2719,9 +2732,6 @@ static void RPDepleter_Free(ResultProcessor *base) {
   rm_free(self);
 }
 
-/**
- * Constructs a new depleter processor that runs in the current thread.
- */
 ResultProcessor *RPDepleter_New() {
   RPDepleter *ret = rm_calloc(1, sizeof(*ret));
   ret->results = array_new(SearchResult*, 0);
@@ -2730,4 +2740,31 @@ ResultProcessor *RPDepleter_New() {
   ret->base.type = RP_DEPLETER;
   ret->depleted_results = 0;
   return &ret->base;
+}
+
+void RPDepleter_StartDepletion(ResultProcessor *base) {
+  RPDepleter *self = (RPDepleter *)base;
+
+  // Deplete all results from upstream
+  RPDepleter_Deplete(self);
+
+  // Switch to yield mode so subsequent Next() calls return buffered results
+  self->base.Next = RPDepleter_Next_Yield;
+}
+
+rs_wall_clock_ns_t RPDepleter_GetDepletionTime(const ResultProcessor *base) {
+  const RPDepleter *self = (const RPDepleter *)base;
+  return self->depletionTime;
+}
+
+int RPDepleter_DepleteAll(arrayof(ResultProcessor*) depleters) {
+  for (size_t i = 0; i < array_len(depleters); i++) {
+    RS_ASSERT(depleters[i]->type == RP_DEPLETER);
+    RPDepleter_StartDepletion(depleters[i]);
+    const RPDepleter *depleter = (const RPDepleter *)depleters[i];
+    if (depleter->last_rc != RS_RESULT_EOF) {
+      return depleter->last_rc;
+    }
+  }
+  return RS_RESULT_OK;
 }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -239,7 +239,7 @@ ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
  *******************************************************************************************************************/
 ResultProcessor *RPProfile_New(ResultProcessor *rp, QueryProcessingCtx *qctx);
 
-rs_wall_clock_ns_t RPProfile_GetClock(ResultProcessor *rp);
+rs_wall_clock_ns_t RPProfile_GetTime(ResultProcessor *rp);
 uint64_t RPProfile_GetCount(ResultProcessor *rp);
 void RPProfile_IncrementCount(ResultProcessor *rp);
 
@@ -290,12 +290,38 @@ ResultProcessor *RPSafeDepleter_New(StrongRef sync_ref, RedisSearchCtx *depletin
 * @param rp The RPSafeDepleter result processor
 * @return Time in nanoseconds spent depleting
 */
-rs_wall_clock_ns_t RPSafeDepleter_GetDepletionTime(ResultProcessor *rp);
+rs_wall_clock_ns_t RPSafeDepleter_GetDepletionTime(const ResultProcessor *rp);
 
 /**
 * Constructs a new depleter processor that runs in the current thread.
 */
 ResultProcessor *RPDepleter_New();
+
+
+/**
+* Consumes and buffers all upstream results without yielding any to the caller.
+* This is used for foreground depletion in WORKERS == 0 mode to pre-fill
+* the buffer while the spec lock is held.
+* @param base The depleter processor (must be RP_DEPLETER type)
+*/
+void RPDepleter_StartDepletion(ResultProcessor *depleter);
+
+/**
+* Get the depletion time for RPDepleter.
+* This is the time spent depleting upstream results synchronously.
+* @param depleter The depleter processor (must be RP_DEPLETER type)
+* @return The depletion time in nanoseconds
+*/
+rs_wall_clock_ns_t RPDepleter_GetDepletionTime(const ResultProcessor *depleter);
+
+/**
+ * Triggers depletion for all depleters in the array.
+ * Stops on first error and returns the error code.
+ * @param depleters Array of depleter processors (must be RP_DEPLETER type)
+ * @return RS_RESULT_OK if all depleters completed successfully,
+ *         or the error code from the first depleter that failed
+ */
+int RPDepleter_DepleteAll(arrayof(ResultProcessor*) depleters);
 
 /**
 * Starts the depletion for all the safe depleters in the array, waits until all finished depleting, and returns.

--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -1,6 +1,7 @@
 from common import *
 from dataclasses import dataclass
 from redis import Redis
+import redis
 import random
 import re
 import numpy as np
@@ -10,6 +11,10 @@ import os
 import signal
 import psutil
 import subprocess
+
+# Total number of hash slots in a Redis Cluster (CRC16(key) % 16384).
+# This is a fixed, protocol-level constant defined by the Redis Cluster specification.
+CLUSTER_SLOTS = 2**14
 
 # Random words for generating more diverse text content
 RANDOM_WORDS = [
@@ -177,7 +182,7 @@ class SlotRange:
     @staticmethod
     def from_str(s: str):
         start, end = map(int, s.split("-"))
-        assert 0 <= start <= end < 2**14
+        assert 0 <= start <= end < CLUSTER_SLOTS
         return SlotRange(start, end)
 
 @dataclass
@@ -375,7 +380,7 @@ def create_and_populate_index(env: Env, index_name: str, n_docs: int):
             text_content = f"document {i} content {' '.join(random_words)} data"
             tag_value = "even" if i % 2 == 0 else "odd"
             # force each document to a different slot
-            con.execute_command('HSET', f'doc-{i}:{{{i % 2**14}}}',
+            con.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',
                               'n', i,
                               'text', text_content,
                               'tag', tag_value,
@@ -437,7 +442,7 @@ def wait_for_migration_complete(env, dest_shard, source_shard, timeout=200, quer
 cluster_node_timeout = 60_000 # in milliseconds (1 minute)
 
 def import_slot_range_sanity_test(env: Env, query_type: str = 'FT.SEARCH'):
-    n_docs = 5 * 2**14
+    n_docs = 5 * CLUSTER_SLOTS
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1, shard2 = env.getConnection(1), env.getConnection(2)
@@ -479,7 +484,7 @@ def parallel_update_worker(env, n_docs, stop_event):
             # Update some unrelated fields that are not part of the query
             # We'll add a new field 'update_counter' and 'timestamp' that won't affect search results
             doc_id = random.randint(0, n_docs - 1)
-            key = f'doc-{doc_id}:{{{doc_id % 2**14}}}'
+            key = f'doc-{doc_id}:{{{doc_id % CLUSTER_SLOTS}}}'
 
             # Update fields that are not queried in the test
             con.execute_command('HSET', key,
@@ -497,7 +502,7 @@ def parallel_update_worker(env, n_docs, stop_event):
             time.sleep(0.1)
 
 def import_slot_range_test(env: Env, query_type: str = 'FT.SEARCH', parallel_updates: bool = False):
-    n_docs = 5 * 2**14
+    n_docs = 5 * CLUSTER_SLOTS
     create_and_populate_index(env, 'idx', n_docs)
 
     if query_type == 'FT.SEARCH':
@@ -586,9 +591,7 @@ def test_ft_aggregate_withcursor_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-#TODO: Enable once MOD-13110 is fixed
-#@skip(cluster=False, min_shards=2)
-@skip
+@skip(cluster=False, min_shards=2)
 def test_ft_hybrid_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.HYBRID')
@@ -629,9 +632,7 @@ def test_ft_aggregate_withcursor_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR', parallel_updates=True)
 
-#TODO: Enable once MOD-13110 is fixed
-#@skip(cluster=False, min_shards=2)
-@skip
+@skip(cluster=False, min_shards=2)
 def test_ft_hybrid_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.HYBRID', parallel_updates=True)
@@ -671,9 +672,7 @@ def test_ft_aggregate_withcursor_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-#TODO: Enable once MOD-13110 is fixed
-#@skip(cluster=False, min_shards=2)
-@skip
+@skip(cluster=False, min_shards=2)
 def test_ft_hybrid_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.HYBRID')
@@ -685,7 +684,7 @@ def test_ft_hybrid_import_slot_range_sanity_BG():
 
 def add_shard_and_migrate_test(env: Env, query_type: str = 'FT.SEARCH'):
     initial_shards_count = env.shardsCount
-    n_docs = 5 * 2**14
+    n_docs = 5 * CLUSTER_SLOTS
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1 = env.getConnection(1)
@@ -758,9 +757,7 @@ def test_add_shard_and_migrate_aggregate_withcursor_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-#TODO: Enable once MOD-13110 is fixed
-#@skip(cluster=False, min_shards=2)
-@skip
+@skip(cluster=False, min_shards=2)
 def test_add_shard_and_migrate_hybrid():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.HYBRID')
@@ -798,11 +795,11 @@ def info_modules_to_dict(conn):
 def _test_ft_cursors_trimmed_profile_warning(env: Env):
     run_command_on_all_shards(env, 'CONFIG', 'SET', 'search-_max-trim-delay-ms', 2500)
 
-    n_docs = 2**14
+    n_docs = CLUSTER_SLOTS
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1, shard2 = env.getConnection(1), env.getConnection(2)
-    query = ('_FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '@n:[1 999999]', 'LOAD', 1, 'n', 'WITHCURSOR', '_SLOTS_INFO', generate_slots(range(int(2**14/env.shardsCount) + 1, 2 * int(2**14/env.shardsCount) + 2)))
+    query = ('_FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '@n:[1 999999]', 'LOAD', 1, 'n', 'WITHCURSOR', '_SLOTS_INFO', generate_slots(range(int(CLUSTER_SLOTS/env.shardsCount) + 1, 2 * int(CLUSTER_SLOTS/env.shardsCount) + 2)))
     shard2.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
     _, cursor_id = shard2.execute_command(*query)
     wait_for_migration_complete(env, shard1, shard2)
@@ -813,7 +810,7 @@ def _test_ft_cursors_trimmed_profile_warning(env: Env):
 def _test_ft_cursors_trimmed(env: Env, protocol: int):
     for shard in env.getOSSMasterNodesConnectionList():
         shard.execute_command('CONFIG', 'SET', 'search-_max-trim-delay-ms', 2500)
-    n_docs = 2**14
+    n_docs = CLUSTER_SLOTS
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1, shard2 = env.getConnection(1), env.getConnection(2)
@@ -934,10 +931,10 @@ def test_migrate_no_indexes():
         shard.execute_command('CONFIG', 'SET', 'search-_min-trim-delay-ms', 1000000)
 
     # Add documents without creating any index
-    n_docs = 5 * 2**14
+    n_docs = 5 * CLUSTER_SLOTS
     with env.getClusterConnectionIfNeeded() as con:
         for i in range(n_docs):
-            con.execute_command('HSET', f'doc-{i}:{{{i % 2**14}}}',
+            con.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',
                               'n', i,
                               'text', f'document {i} content data',
                               'tag', 'even' if i % 2 == 0 else 'odd')
@@ -950,3 +947,208 @@ def test_migrate_no_indexes():
     migration_time = time.time() - start_time
     env.debugPrint(f"Migration time: {migration_time}")
     env.assertLess(migration_time, 300.0)
+
+# Constant value for _COORD_DISPATCH_TIME argument in internal commands
+ASM_COORD_DISPATCH_TIME = '1000000'  # 1ms in nanoseconds
+
+
+def _get_shard_slots_data(shard):
+    """Return (slots_set, slots_data) for the given shard connection.
+
+    Inspects ``CLUSTER NODES`` to find the "myself" entry, builds the full set
+    of hash slots owned by that shard, and returns both the set and the encoded
+    ``slots_data`` string expected by ``_SLOTS_INFO``.
+    """
+    shard_node = None
+    for line in shard.execute_command("cluster", "nodes").splitlines():
+        node = ClusterNode.from_str(line)
+        if "myself" in node.flags:
+            shard_node = node
+            break
+
+    slots = set()
+    for sr in shard_node.slots:
+        slots.update(range(sr.start, sr.end + 1))
+
+    return slots, generate_slots(slots)
+
+
+def _update_docs_removing_word(shard, n_docs, slots):
+    """Overwrite every doc whose slot is owned by *shard*, replacing its
+    description so that it no longer contains the word "shoes".
+
+    Keys that have already migrated away are silently skipped.
+    """
+    for i in range(n_docs):
+        slot = i % CLUSTER_SLOTS
+        if slot in slots:
+            try:
+                shard.execute_command('HSET', f'doc:{i}:{{{slot}}}',
+                                      'description', f'basketball sneakers product {i}')
+            except redis.exceptions.ResponseError as e:
+                if not (isinstance(e, (redis.exceptions.MovedError, redis.exceptions.AskError)) or
+                        str(e).startswith(('MOVED', 'ASK'))):
+                    raise
+
+
+def _write_memory_pressure_docs(shard, start, count, slots):
+    """Write *count* new documents (keys ``newdoc:<i>``) whose slots fall in
+    *slots*, using repetitive text to force memory reuse over previously freed
+    inverted-index blocks.
+
+    Keys whose slot is not owned by *shard* are skipped.
+    """
+    for i in range(start, start + count):
+        slot = i % CLUSTER_SLOTS
+        if slot in slots:
+            vector = np.array([float(i), float(i % 10)], dtype=np.float32)
+            try:
+                shard.execute_command('HSET', f'newdoc:{i}:{{{slot}}}',
+                                      'description', f'basketball sneakers product {i} ' * 10,
+                                      'embedding', vector.tobytes())
+            except redis.exceptions.ResponseError as e:
+                if not (isinstance(e, (redis.exceptions.MovedError, redis.exceptions.AskError)) or
+                        str(e).startswith(('MOVED', 'ASK'))):
+                    raise
+
+
+def _drain_cursor(shard, cursor_id, index):
+    """Read all pages of a cursor and return the list of ``__key`` values.
+
+    Repeatedly calls ``_FT.CURSOR READ`` until the server returns cursor id 0,
+    collecting every ``__key`` value found in each page.
+    """
+    keys = []
+    current_cursor = cursor_id
+    while current_cursor != 0:
+        cursor_response = shard.execute_command('_FT.CURSOR', 'READ', index, current_cursor)
+        results_array = cursor_response[0]
+        current_cursor = cursor_response[1]
+        for result in results_array[1:]:  # Skip the count at index 0
+            result_dict = dict(zip(result[::2], result[1::2]))
+            key = result_dict.get('__key')
+            if key is not None:
+                keys.append(key)
+    return keys
+
+@skip(cluster=False, min_shards=2)
+def test_hybrid_cursor_after_add_shard_migration():
+    """FT.HYBRID cursors access freed memory when slots are migrated to a new shard.
+
+    This test realistically reproduces the flaky failure seen in
+    test_add_shard_and_migrate_hybrid without artificially poisoning memory.
+
+    With WORKERS=0, _FT.HYBRID WITHCURSOR creates a cursor whose iterators are
+    not consumed (no background depletion). After migration, the inverted index
+    for the search term is emptied via document updates and freed via GC. When
+    the cursor is later read, the iterator references freed memory. In production
+    this is a use-after-free that can crash the server if the allocator reuses
+    those blocks; in this test the observable symptom is 0 results.
+
+    The sequence:
+    1. Create index, populate docs with "shoes" on shard1
+    2. Create _FT.HYBRID WITHCURSOR on shard1 searching for "shoes" (WORKERS=0)
+    3. Add a new shard and migrate a middle slot range from shard1 to new shard
+    4. Update ALL remaining docs on shard1: replace "shoes" with unrelated text
+    5. Force GC → "shoes" inverted index has 0 entries → GC frees ALL its blocks
+    6. Write new documents with different text to force memory reuse
+    7. Read cursor on shard1 → 15 buffered results (fixed) or 0 results (unfixed)
+
+    With the fix (foreground depletion via RPDepleter), step 2 buffers all results
+    before pausing the cursor, so step 7 serves from the buffer.
+    """
+    env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 0')
+
+    # Set short trim delays so trimming starts quickly after migration completes.
+    for shard in env.getOSSMasterNodesConnectionList():
+        shard.execute_command('CONFIG', 'SET', 'search-_min-trim-delay-ms', 50)
+        shard.execute_command('CONFIG', 'SET', 'search-_max-trim-delay-ms', 100)
+
+    n_docs = 500
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'description', 'TEXT',
+               'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
+    # Populate docs - they will be spread across both shards via cluster hashing
+    with env.getClusterConnectionIfNeeded() as con:
+        for i in range(n_docs):
+            vector = np.array([float(i), float(i % 10)], dtype=np.float32)
+            con.execute_command('HSET', f'doc:{i}:{{{i % CLUSTER_SLOTS}}}',
+                              'description', f'running shoes item {i}',
+                              'embedding', vector.tobytes())
+
+    shard1 = env.getConnection(1)
+
+    # Get shard1's slot ranges for _SLOTS_INFO
+    _, slots_data = _get_shard_slots_data(shard1)
+
+    # Step 1: Create hybrid cursor on shard1. With WORKERS=0, the iterators
+    # are not consumed — the cursor is paused before reading any results.
+    shard1.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
+    query_vec = np.array([0.0, 0.0], dtype=np.float32)
+    result = shard1.execute_command(
+        '_FT.HYBRID', 'idx', 'SEARCH', '@description:shoes',
+        'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '2', 'WINDOW', '15',
+        'WITHCURSOR', '_SLOTS_INFO', slots_data,
+        'PARAMS', '2', 'BLOB', query_vec.tobytes(),
+        '_COORD_DISPATCH_TIME', ASM_COORD_DISPATCH_TIME)
+
+    # Parse cursor IDs from result
+    if isinstance(result, list) and 'warnings' in result:
+        result = result[:result.index('warnings')]
+    result_dict = dict(zip(result[::2], result[1::2]))
+    search_cursor = result_dict.get('SEARCH', 0)
+    env.assertTrue(search_cursor != 0, message="Search cursor should be valid")
+
+    # Step 2: Add a new shard and migrate a middle slot range from shard1 to new shard
+    initial_shards_count = env.shardsCount
+    env.addShardToClusterIfExists()
+    new_shard = env.getConnection(shardId=initial_shards_count + 1)
+
+    # Also set trim delays on the new shard
+    new_shard.execute_command('CONFIG', 'SET', 'search-_min-trim-delay-ms', 50)
+    new_shard.execute_command('CONFIG', 'SET', 'search-_max-trim-delay-ms', 100)
+
+    task_id = import_middle_slot_range(new_shard, shard1)
+    with TimeLimit(200):
+        while not is_migration_complete(new_shard, task_id) or not is_migration_complete(shard1, task_id):
+            time.sleep(0.1)
+
+    # Step 3: Update ALL remaining docs on shard1 to remove "shoes" from their text.
+    # This causes the "shoes" inverted index to have 0 entries after GC, so GC
+    # will free ALL its blocks — not just the ones for migrated docs.
+    env.debugPrint("Updating remaining docs on shard1 to remove 'shoes' from text")
+    current_shard1_slots, _ = _get_shard_slots_data(shard1)
+    _update_docs_removing_word(shard1, n_docs, current_shard1_slots)
+
+    # Step 4: Wait for trimming, then force GC to free the now-empty "shoes" inverted index
+    env.debugPrint("Running GC to free empty 'shoes' inverted index blocks")
+    time.sleep(1)  # Allow trim timer to fire
+
+    for _ in range(5):
+        try:
+            shard1.execute_command('_FT.DEBUG', 'GC_FORCEINVOKE', 'idx')
+        except Exception:
+            pass
+        time.sleep(0.2)
+
+    # Step 5: Write new documents with different text to force memory reuse
+    # over the freed "shoes" inverted index blocks.
+    env.debugPrint("Writing new documents to force memory reuse")
+    _write_memory_pressure_docs(shard1, n_docs, 500, current_shard1_slots)
+
+    # Step 6: Read ALL results from the cursor on shard1.
+    # On unfixed code: the "shoes" inverted index has been freed, so the
+    # iterator reads invalid memory and returns 0 results.
+    # On fixed code: results were buffered before the cursor was paused,
+    # so cursor READ serves from the buffer regardless of index state.
+    all_results = _drain_cursor(shard1, search_cursor, 'idx')
+
+    env.debugPrint(f"Cursor returned {len(all_results)} results after add-shard migration")
+
+    env.assertEqual(len(all_results), 15,
+                    message=f"Expected cursor to return 15 results (WINDOW=15, buffered before "
+                            f"migration), but got {len(all_results)}. Without the fix "
+                            f"(foreground depletion), the cursor returns 0 results because "
+                            f"the inverted index memory was freed after migration + GC.")

--- a/tests/pytests/test_hybrid_profile.py
+++ b/tests/pytests/test_hybrid_profile.py
@@ -9,7 +9,8 @@ search_result_processors = [
     ['Type', 'Index', 'Results processed', ANY],
     ['Type', 'Scorer', 'Results processed', ANY],
     ['Type', 'Sorter', 'Results processed', ANY],
-    ['Type', 'Loader', 'Results processed', ANY]
+    ['Type', 'Loader', 'Results processed', ANY],
+    ['Type', 'Depleter', 'Results processed', ANY],
 ]
 
 search_result_processors_background_depletion = [
@@ -19,77 +20,199 @@ search_result_processors_background_depletion = [
     ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY, 'Results processed', ANY],
     ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
 ]
-# This is common for all test with `SEARCH hello`, no background depletion
-expected_shard_standalone_profile = [[
-    'SEARCH',
+def _make_shard_standalone_profile(search_rp, vsim_rp):
+    """Build a standalone shard profile for 'SEARCH hello' hybrid queries.
+
+    Args:
+        search_rp: the 'Result processors profile' list for the SEARCH subquery.
+        vsim_rp: the 'Result processors profile' list for the VSIM subquery.
+    """
+    return [[
+        'SEARCH',
+        [
+            'Warning',
+            ['None'],
+            'Iterators profile',
+            [
+                'Type', 'TEXT',
+                'Term', 'hello',
+                'Number of reading operations', 1,
+                'Estimated number of matches', 1
+            ],
+            'Result processors profile',
+            search_rp
+        ],
+        'VSIM',
+        [
+            'Warning',
+            ['None'],
+            'Iterators profile',
+            [
+                'Type', 'VECTOR',
+                'Number of reading operations', 4,
+                'Vector search mode', 'STANDARD_KNN'
+            ],
+            'Result processors profile',
+            vsim_rp
+        ]
+    ]]
+
+
+# This is common for all tests with `SEARCH hello`, no background depletion
+expected_shard_standalone_profile = _make_shard_standalone_profile(
+    search_result_processors,
     [
-        'Warning',
-        ['None'],
-        'Iterators profile',
+        ['Type', 'Index', 'Results processed', ANY],
+        ['Type', 'Metrics Applier', 'Results processed', ANY],
+        ['Type', 'Vector Normalizer', 'Results processed', ANY],
+        ['Type', 'Loader', 'Results processed', ANY],
+        ['Type', 'Depleter', 'Results processed', ANY]
+    ]
+)
+
+expected_shard_standalone_profile_background_depletion = _make_shard_standalone_profile(
+    search_result_processors_background_depletion,
+    [
+        ['Type', 'Index', 'Results processed', ANY],
+        ['Type', 'Metrics Applier', 'Results processed', ANY],
+        ['Type', 'Vector Normalizer', 'Results processed', ANY],
+        ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY, 'Results processed', ANY],
+        ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+    ]
+)
+
+# Shared iterator profile for shards searching for 'hello': either the shard
+# has no matching docs (EMPTY) or it has the "hello" term (TEXT).
+_HELLO_TEXT_VALID_VALUES = {
+    # Each shard can have different iterator profile, so we
+    # check that one of the following values is in the profile
+    'Valid Values':
+    [
+        ['Type', 'EMPTY', 'Number of reading operations', 0],
         [
             'Type', 'TEXT',
             'Term', 'hello',
             'Number of reading operations', 1,
             'Estimated number of matches', 1
-        ],
+        ]
+    ]
+}
+
+# Standard VSIM shard profile block reused across multiple test cases.
+# Exceptions are tests that add an extra Loader (e.g. LOAD * or GROUPBY).
+_VSIM_SHARD_CLUSTER_PROFILE = [
+    'Warning', ['None'],
+    'Internal cursor reads', 1,
+    'Iterators profile',
+    [
+        'Type', 'VECTOR',
+        'Number of reading operations', ANY,
+        'Vector search mode', 'STANDARD_KNN'
+    ],
+    'Result processors profile',
+    [
+        ['Type', 'Index', 'Results processed', ANY],
+        ['Type', 'Metrics Applier', 'Results processed', ANY],
+        ['Type', 'Scorer', 'Results processed', ANY],
+        ['Type', 'Vector Normalizer', 'Results processed', ANY],
+        ['Type', 'Loader', 'Results processed', ANY],
+        ['Type', 'Depleter', 'Results processed', ANY]
+    ]
+]
+
+# Full shard cluster profile for queries that match 'hello' with default
+# result processors (no extra Loader or GROUPBY).
+_SHARD_CLUSTER_PROFILE_HELLO = [
+    'Shard ID', ANY,
+    'SEARCH',
+    [
+        'Warning', ['None'],
+        'Internal cursor reads', 1,
+        'Iterators profile',
+        _HELLO_TEXT_VALID_VALUES,
         'Result processors profile',
         search_result_processors
     ],
     'VSIM',
-    [
-        'Warning',
-        ['None'],
-        'Iterators profile',
-        [
-            'Type', 'VECTOR',
-            'Number of reading operations', 4,
-            'Vector search mode', 'STANDARD_KNN'
-        ],
-        'Result processors profile',
-        [
-            ['Type', 'Index', 'Results processed', ANY],
-            ['Type', 'Metrics Applier', 'Results processed', ANY],
-            ['Type', 'Vector Normalizer', 'Results processed', ANY],
-            ['Type', 'Loader', 'Results processed', ANY]
-        ]
-    ]
-]]
+    _VSIM_SHARD_CLUSTER_PROFILE
+]
 
-expected_shard_standalone_profile_background_depletion = [[
-    'SEARCH',
-    [
-        'Warning',
-        ['None'],
-        'Iterators profile',
+def _make_extra_loader_shard_cluster_profile(iterators_profile):
+    """Build a shard cluster profile for tests with an extra Loader (LOAD * / GROUPBY).
+
+    Args:
+        iterators_profile: the SEARCH 'Iterators profile' value (e.g. _HELLO_TEXT_VALID_VALUES or ANY).
+    """
+    return [
+        'Shard ID', ANY,
+        'SEARCH',
         [
-            'Type', 'TEXT',
-            'Term', 'hello',
-            'Number of reading operations', 1,
-            'Estimated number of matches', 1
+            'Warning', ['None'],
+            'Internal cursor reads', 1,
+            'Iterators profile',
+            iterators_profile,
+            'Result processors profile',
+            [
+                ['Type', 'Index', 'Results processed', ANY],
+                ['Type', 'Scorer', 'Results processed', ANY],
+                ['Type', 'Sorter', 'Results processed', ANY],
+                ['Type', 'Loader', 'Results processed', ANY],
+                ['Type', 'Loader', 'Results processed', ANY],
+                ['Type', 'Depleter', 'Results processed', ANY]
+            ]
         ],
-        'Result processors profile',
-        search_result_processors_background_depletion
-    ],
-    'VSIM',
-    [
-        'Warning',
-        ['None'],
-        'Iterators profile',
+        'VSIM',
         [
-            'Type', 'VECTOR',
-            'Number of reading operations', 4,
-            'Vector search mode', 'STANDARD_KNN'
-        ],
-        'Result processors profile',
-        [
-            ['Type', 'Index', 'Results processed', ANY],
-            ['Type', 'Metrics Applier', 'Results processed', ANY],
-            ['Type', 'Vector Normalizer', 'Results processed', ANY],
-            ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY, 'Results processed', ANY],
-            ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+            'Warning', ['None'],
+            'Internal cursor reads', 1,
+            'Iterators profile',
+            [
+                'Type', 'VECTOR',
+                'Number of reading operations', ANY,
+                'Vector search mode', 'STANDARD_KNN'
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Index', 'Results processed', ANY],
+                ['Type', 'Metrics Applier', 'Results processed', ANY],
+                ['Type', 'Scorer', 'Results processed', ANY],
+                ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                ['Type', 'Loader', 'Results processed', ANY],
+                ['Type', 'Loader', 'Results processed', ANY],
+                ['Type', 'Depleter', 'Results processed', ANY]
+            ]
         ]
     ]
-]]
+
+
+def _make_coordinator_cluster_profile(n_search, result_processors):
+    """Build the coordinator cluster profile for a hybrid query.
+
+    Args:
+        n_search: the 'Results processed' count for the SEARCH network processor.
+        result_processors: the 'Result processors profile' list for the coordinator.
+    """
+    return [
+        'Shard ID', ANY,
+        'Warning', ['None'],
+        'Subqueries result processors profile',
+        [
+            'SEARCH',
+            [
+                ['Type', 'Network', 'Results processed', n_search],
+                ['Type', 'Sorter', 'Results processed', n_search],
+                ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+            ],
+            'VSIM',
+            [
+                ['Type', 'Network', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4],
+                ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+            ]
+        ],
+        'Result processors profile',
+        result_processors
+    ]
 
 
 query_and_profile = [
@@ -125,76 +248,13 @@ query_and_profile = [
             ]
         ],
         # expected_shard_cluster_profile
-        [
-            'Shard ID', ANY,
-            'SEARCH',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                {
-                    # Each shard can have different iterator profile, so we
-                    # check that one of the following values is in the profile
-                    'Valid Values':
-                    [
-                        ['Type', 'EMPTY', 'Number of reading operations', 0],
-                        [
-                            'Type', 'TEXT',
-                            'Term', 'hello',
-                            'Number of reading operations', 1,
-                            'Estimated number of matches', 1
-                        ]
-                    ]
-                },
-                'Result processors profile',
-                search_result_processors
-            ],
-            'VSIM',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                [
-                    'Type', 'VECTOR',
-                    'Number of reading operations', ANY,
-                    'Vector search mode', 'STANDARD_KNN'
-                ],
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Metrics Applier', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY]
-                ]
-            ]
-        ],
+        _SHARD_CLUSTER_PROFILE_HELLO,
         # expected_coordinator_cluster_profile
-        [
-            'Shard ID', ANY,
-            'Warning', ['None'],
-            'Subqueries result processors profile',
-            [
-                'SEARCH',
-                [
-                    ['Type', 'Network', 'Results processed', 1],
-                    ['Type', 'Sorter', 'Results processed', 1],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ],
-                'VSIM',
-                [
-                    ['Type', 'Network', 'Results processed', 4],
-                    ['Type', 'Sorter', 'Results processed', 4],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ]
-            ],
-            'Result processors profile',
-            [
-                ['Type', 'Hybrid Merger', 'Results processed', 4],
-                # Sorter is added by default, to sort by score.
-                ['Type', 'Sorter', 'Results processed', 4]
-            ]
-        ]
+        _make_coordinator_cluster_profile(1, [
+            ['Type', 'Hybrid Merger', 'Results processed', 4],
+            # Sorter is added by default, to sort by score.
+            ['Type', 'Sorter', 'Results processed', 4]
+        ])
     ),
     # Test: Hybrid query with LOAD * and NOSORT
     (
@@ -217,83 +277,12 @@ query_and_profile = [
             ]
         ],
         # expected_shard_cluster_profile
-        [
-            'Shard ID', ANY,
-            'SEARCH',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                 {
-                     # Each shard can have different iterator profile, so we
-                    # check that one of the following values is in the profile
-                    'Valid Values':
-                    [
-                        ['Type', 'EMPTY', 'Number of reading operations', 0],
-                        [
-                            'Type', 'TEXT',
-                            'Term', 'hello',
-                            'Number of reading operations', 1,
-                            'Estimated number of matches', 1
-                        ]
-                    ]
-                },
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Sorter', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                ]
-            ],
-            'VSIM',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                [
-                    'Type', 'VECTOR',
-                    'Number of reading operations', ANY,
-                    'Vector search mode', 'STANDARD_KNN'
-                ],
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Metrics Applier', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                    # Additional loader for LOAD *
-                    ['Type', 'Loader', 'Results processed', ANY]
-                ]
-            ]
-        ],
+        _make_extra_loader_shard_cluster_profile(_HELLO_TEXT_VALID_VALUES),
         # expected_coordinator_cluster_profile
-        [
-            'Shard ID', ANY,
-            'Warning', ['None'],
-            'Subqueries result processors profile',
-            [
-                'SEARCH',
-                [
-                    ['Type', 'Network', 'Results processed', 1],
-                    ['Type', 'Sorter', 'Results processed', 1],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ],
-                'VSIM',
-                [
-                    ['Type', 'Network', 'Results processed', 4],
-                    ['Type', 'Sorter', 'Results processed', 4],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ]
-            ],
-            'Result processors profile',
-            [
-                ['Type', 'Hybrid Merger', 'Results processed', 4]
-                # No sorter because of NOSORT
-            ]
-        ]
+        _make_coordinator_cluster_profile(1, [
+            ['Type', 'Hybrid Merger', 'Results processed', 4]
+            # No sorter because of NOSORT
+        ])
     ),
     # Test: Hybrid query with LIMIT
     (
@@ -318,75 +307,12 @@ query_and_profile = [
             ]
         ],
         # expected_shard_cluster_profile
-        [
-            'Shard ID', ANY,
-            'SEARCH',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                 {
-                     # Each shard can have different iterator profile, so we
-                    # check that one of the following values is in the profile
-                    'Valid Values':
-                    [
-                        ['Type', 'EMPTY', 'Number of reading operations', 0],
-                        [
-                            'Type', 'TEXT',
-                            'Term', 'hello',
-                            'Number of reading operations', 1,
-                            'Estimated number of matches', 1
-                        ]
-                    ]
-                },
-                'Result processors profile',
-                search_result_processors
-            ],
-            'VSIM',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                [
-                    'Type', 'VECTOR',
-                    'Number of reading operations', ANY,
-                    'Vector search mode', 'STANDARD_KNN'
-                ],
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Metrics Applier', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY]
-                ]
-            ]
-        ],
+        _SHARD_CLUSTER_PROFILE_HELLO,
         # expected_coordinator_cluster_profile
-        [
-            'Shard ID', ANY,
-            'Warning', ['None'],
-            'Subqueries result processors profile',
-            [
-                'SEARCH',
-                [
-                    ['Type', 'Network', 'Results processed', 1],
-                    ['Type', 'Sorter', 'Results processed', 1],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ],
-                'VSIM',
-                [
-                    ['Type', 'Network', 'Results processed', 4],
-                    ['Type', 'Sorter', 'Results processed', 4],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ]
-            ],
-            'Result processors profile',
-            [
-                ['Type', 'Hybrid Merger', 'Results processed', 4],
-                ['Type', 'Sorter', 'Results processed', 2]
-            ]
-        ]
+        _make_coordinator_cluster_profile(1, [
+            ['Type', 'Hybrid Merger', 'Results processed', 4],
+            ['Type', 'Sorter', 'Results processed', 2]
+        ])
     ),
     # Test: Hybrid query with GROUPBY
     (
@@ -413,70 +339,13 @@ query_and_profile = [
             ]
         ],
         # expected_shard_cluster_profile
-        [
-            'Shard ID', ANY,
-            'SEARCH',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                ANY,
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Sorter', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                ]
-            ],
-            'VSIM',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                [
-                    'Type', 'VECTOR',
-                    'Number of reading operations', ANY,
-                    'Vector search mode', 'STANDARD_KNN'
-                ],
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Metrics Applier', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                ]
-            ]
-        ],
+        _make_extra_loader_shard_cluster_profile(ANY),
         # expected_coordinator_cluster_profile
-        [
-            'Shard ID', ANY,
-            'Warning', ['None'],
-            'Subqueries result processors profile',
-            [
-                'SEARCH',
-                [
-                    ['Type', 'Network', 'Results processed', 1],
-                    ['Type', 'Sorter', 'Results processed', 1],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ],
-                'VSIM',
-                [
-                    ['Type', 'Network', 'Results processed', 4],
-                    ['Type', 'Sorter', 'Results processed', 4],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ]
-            ],
-            'Result processors profile',
-            [
-                ['Type', 'Hybrid Merger', 'Results processed', 4],
-                ['Type', 'Grouper', 'Results processed', 4],
-                ['Type', 'Sorter', 'Results processed', 4]
-            ]
-        ]
+        _make_coordinator_cluster_profile(1, [
+            ['Type', 'Hybrid Merger', 'Results processed', 4],
+            ['Type', 'Grouper', 'Results processed', 4],
+            ['Type', 'Sorter', 'Results processed', 4]
+        ])
     ),
     # Test: Hybrid query with wildcard query and fuzzy (without LIMITED)
     (
@@ -521,7 +390,8 @@ query_and_profile = [
                     ['Type', 'Index', 'Results processed', 2],
                     ['Type', 'Scorer', 'Results processed', 2],
                     ['Type', 'Sorter', 'Results processed', 2],
-                    ['Type', 'Loader', 'Results processed', 2]
+                    ['Type', 'Loader', 'Results processed', 2],
+                    ['Type', 'Depleter', 'Results processed', 2]
                 ]
             ],
             'VSIM',
@@ -535,7 +405,8 @@ query_and_profile = [
                     ['Type', 'Index', 'Results processed', 4],
                     ['Type', 'Metrics Applier', 'Results processed', 4],
                     ['Type', 'Vector Normalizer', 'Results processed', 4],
-                    ['Type', 'Loader', 'Results processed', 4]
+                    ['Type', 'Loader', 'Results processed', 4],
+                    ['Type', 'Depleter', 'Results processed', 4]
                 ]
             ]
         ]],
@@ -599,53 +470,17 @@ query_and_profile = [
                     ['Type', 'Scorer', 'Results processed', ANY],
                     ['Type', 'Sorter', 'Results processed', ANY],
                     ['Type', 'Loader', 'Results processed', ANY],
+                    ['Type', 'Depleter', 'Results processed', ANY]
                 ]
             ],
             'VSIM',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                [
-                    'Type', 'VECTOR',
-                    'Number of reading operations', ANY,
-                    'Vector search mode', 'STANDARD_KNN'
-                ],
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Metrics Applier', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                ]
-            ]
+            _VSIM_SHARD_CLUSTER_PROFILE
         ],
         # expected_coordinator_cluster_profile
-        [
-            'Shard ID', ANY,
-            'Warning', ['None'],
-            'Subqueries result processors profile',
-            [
-                'SEARCH',
-                [
-                    ['Type', 'Network', 'Results processed', 2],
-                    ['Type', 'Sorter', 'Results processed', 2],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ],
-                'VSIM',
-                [
-                    ['Type', 'Network', 'Results processed', 4],
-                    ['Type', 'Sorter', 'Results processed', 4],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY],
-                ]
-            ],
-            'Result processors profile',
-            [
-                ['Type', 'Hybrid Merger', 'Results processed', 4],
-                ['Type', 'Sorter', 'Results processed', 4]
-            ]
-        ]
+        _make_coordinator_cluster_profile(2, [
+            ['Type', 'Hybrid Merger', 'Results processed', 4],
+            ['Type', 'Sorter', 'Results processed', 4]
+        ])
     ),
     # Test: Hybrid query with wildcard query and fuzzy (LIMITED)
     (
@@ -684,7 +519,8 @@ query_and_profile = [
                     ['Type', 'Index', 'Results processed', 2],
                     ['Type', 'Scorer', 'Results processed', 2],
                     ['Type', 'Sorter', 'Results processed', 2],
-                    ['Type', 'Loader', 'Results processed', 2]
+                    ['Type', 'Loader', 'Results processed', 2],
+                    ['Type', 'Depleter', 'Results processed', 2]
                 ]
             ],
             'VSIM',
@@ -698,7 +534,8 @@ query_and_profile = [
                     ['Type', 'Index', 'Results processed', 4],
                     ['Type', 'Metrics Applier', 'Results processed', 4],
                     ['Type', 'Vector Normalizer', 'Results processed', 4],
-                    ['Type', 'Loader', 'Results processed', 4]
+                    ['Type', 'Loader', 'Results processed', 4],
+                    ['Type', 'Depleter', 'Results processed', 4]
                 ]
             ]
         ]],
@@ -755,53 +592,17 @@ query_and_profile = [
                     ['Type', 'Scorer', 'Results processed', ANY],
                     ['Type', 'Sorter', 'Results processed', ANY],
                     ['Type', 'Loader', 'Results processed', ANY],
+                    ['Type', 'Depleter', 'Results processed', ANY]
                 ]
             ],
             'VSIM',
-            [
-                'Warning', ['None'],
-                'Internal cursor reads', 1,
-                'Iterators profile',
-                [
-                    'Type', 'VECTOR',
-                    'Number of reading operations', ANY,
-                    'Vector search mode', 'STANDARD_KNN'
-                ],
-                'Result processors profile',
-                [
-                    ['Type', 'Index', 'Results processed', ANY],
-                    ['Type', 'Metrics Applier', 'Results processed', ANY],
-                    ['Type', 'Scorer', 'Results processed', ANY],
-                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
-                    ['Type', 'Loader', 'Results processed', ANY],
-                ]
-            ]
+            _VSIM_SHARD_CLUSTER_PROFILE
         ],
         # expected_coordinator_cluster_profile
-        [
-            'Shard ID', ANY,
-            'Warning', ['None'],
-            'Subqueries result processors profile',
-            [
-                'SEARCH',
-                [
-                    ['Type', 'Network', 'Results processed', 2],
-                    ['Type', 'Sorter', 'Results processed', 2],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
-                ],
-                'VSIM',
-                [
-                    ['Type', 'Network', 'Results processed', 4],
-                    ['Type', 'Sorter', 'Results processed', 4],
-                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY],
-                ]
-            ],
-            'Result processors profile',
-            [
-                ['Type', 'Hybrid Merger', 'Results processed', 4],
-                ['Type', 'Sorter', 'Results processed', 4]
-            ]
-        ]
+        _make_coordinator_cluster_profile(2, [
+            ['Type', 'Hybrid Merger', 'Results processed', 4],
+            ['Type', 'Sorter', 'Results processed', 4]
+        ])
     )
 ]
 
@@ -1049,4 +850,3 @@ def test_profile_errors():
         'VSIM', '@v', '$blob',
         'PARAMS', 2, 'blob', 'aaaaaaaa').error()\
             .contains('SEARCH_INDEX_NOT_FOUND Index not found: nonexistent_idx')
-


### PR DESCRIPTION
Backport #8534 to `8.6-rse`
(cherry picked from commit 99e6a374477ce8a12d88ca4e7bbd4590049d816b)

Conflicts solved:
- `HybridRequest_StartCursors()` doesn't contain changes done in [[MOD-14074] Shard-level FAIL timeout for FT.HYBRID](https://github.com/RediSearch/RediSearch/pull/8657)


#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

[MOD-14074]: https://redislabs.atlassian.net/browse/MOD-14074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes hybrid cursor execution and result processor plumbing in a concurrency- and memory-safety-sensitive path (cursor depletion under spec locks), which could impact correctness, timeouts, or performance across hybrid queries.
> 
> **Overview**
> Prevents `FT.HYBRID WITHCURSOR` from returning invalid/empty results in `WORKERS=0` by adding **foreground depletion**: pipelines now end with `RP_DEPLETER` and `HybridRequest_StartCursors()` synchronously drains all subquery depleters before returning cursors (with stricter depleter-type validation and clearer errors).
> 
> Updates profiling to report time spent in both background and foreground depletion via `RPProfile_GetTime()` (using `RPSafeDepleter`/`RPDepleter` depletion time), and adjusts hybrid merge pipeline expectations in profile mode.
> 
> Expands tests to cover the add-shard/slot-migration cursor regression (new targeted ASM repro) and updates hybrid profile expectations to include the new `Depleter` processor; also centralizes Redis Cluster slot constants in `test_asm.py` and re-enables previously skipped hybrid ASM tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f158b95e1abf8f93a8508ad9bed0bb23cfc635a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->