### PR TITLE
MOD-14732: Skip flaky test_add_shard_and_migrate_hybrid_BG and increase CI test timeout to 60 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch to use when building RedisJSON for tests"
       test-timeout:
         type: number
-        default: 50
+        default: 60
       fail-fast:
         type: boolean
         default: false

--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -764,6 +764,8 @@ def test_add_shard_and_migrate_hybrid():
 
 @skip(cluster=False, min_shards=2)
 def test_add_shard_and_migrate_hybrid_BG():
+    # TODO: MOD-14732 - Skipped due to flaky crash (SIGSEGV) during hybrid cursor migration.
+    raise SkipTest()
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.HYBRID')
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Skip flaky test** `test_asm:test_add_shard_and_migrate_hybrid_BG` — this test is flaky due to a SIGSEGV crash during hybrid cursor migration. To be fixed in [MOD-14732](https://redislabs.atlassian.net/browse/MOD-14732).

2. **Increase CI test timeout from 50 to 60 minutes** — run https://github.com/RediSearch/RediSearch/actions/runs/24192377018 got timeout at 50 minutes.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

[MOD-14732]: https://redislabs.atlassian.net/browse/MOD-14732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI timeout configuration and skipping a single known-flaky pytest, with no production code impact. The main downside is reduced coverage for the skipped hybrid background migration scenario until the underlying crash is fixed.
> 
> **Overview**
> Increases the shared GitHub Actions `test-timeout` input from **50 → 60 minutes** to reduce CI timeouts on longer test runs.
> 
> Skips `test_add_shard_and_migrate_hybrid_BG` in `tests/pytests/test_asm.py` by raising `SkipTest()` due to a flaky SIGSEGV during hybrid cursor migration (tracked as `MOD-14732`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7425dc0aae9b4fa533d676b6e205399585356e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->