### PR TITLE
Add debug prints for flaky timeout test

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -10,6 +10,43 @@ ON_TIMEOUT_CONFIG = 'search-on-timeout'
 def run_cmd_expect_timeout(env, query_args):
     env.expect(*query_args).error().contains(TIMEOUT_ERROR)
 
+
+def debug_print_hybrid_clients(env, label=""):
+    """Debug helper: Print clients with HYBRID commands from coordinator and all shards.
+
+    Filters and prints only clients whose last command contains 'HYBRID' (FT.HYBRID or _FT.HYBRID).
+    """
+    prefix = f"[{label}] " if label else ""
+
+    # Check coordinator
+    try:
+        conn = getConnectionByEnv(env)
+        output = conn.execute_command('CLIENT', 'LIST')
+        clients = parse_client_list(output)
+        hybrid_clients = [c for c in clients if 'HYBRID' in c.get('cmd', '').upper()]
+        if hybrid_clients:
+            env.debugPrint(f"{prefix}Coordinator HYBRID clients:", force=True)
+            for c in hybrid_clients:
+                env.debugPrint(f"  id={c.get('id')} cmd={c.get('cmd')} flags={c.get('flags')}", force=True)
+        else:
+            env.debugPrint(f"{prefix}Coordinator: No HYBRID clients found", force=True)
+    except Exception as e:
+        env.debugPrint(f"{prefix}Coordinator CLIENT LIST error: {e}", force=True)
+
+    # Check all shards
+    for shardId in range(1, env.shardsCount + 1):
+        try:
+            shard_conn = env.getConnection(shardId)
+            output = shard_conn.execute_command('CLIENT', 'LIST')
+            clients = parse_client_list(output)
+            hybrid_clients = [c for c in clients if 'HYBRID' in c.get('cmd', '').upper()]
+            if hybrid_clients:
+                env.debugPrint(f"{prefix}Shard {shardId} HYBRID clients:", force=True)
+                for c in hybrid_clients:
+                    env.debugPrint(f"  id={c.get('id')} cmd={c.get('cmd')} flags={c.get('flags')}", force=True)
+        except Exception as e:
+            env.debugPrint(f"{prefix}Shard {shardId} CLIENT LIST error: {e}", force=True)
+
 def pid_cmd(conn):
     """Get the process ID of a Redis connection."""
     return conn.execute_command('info', 'server')['process_id']
@@ -146,6 +183,10 @@ class TestCoordinatorTimeout:
             'PARAMS', '2', 'BLOB', query_vec
         ).noError()
         self.hybrid_query_vec = query_vec
+
+    def tearDown(self):
+        """Teardown: Print debug info about any remaining HYBRID clients."""
+        debug_print_hybrid_clients(self.env, "TestCoordinatorTimeout teardown")
 
     def _test_fail_timeout_impl(self, query_args):
         env = self.env


### PR DESCRIPTION
## Description

Add debug helper function and teardown hook to print any remaining HYBRID clients after each test in `TestCoordinatorTimeout`.

This will help diagnose flaky timeout test failures by showing if there are any leftover HYBRID commands in coordinator or shard connections when tests complete.

### Changes
- Added `debug_print_hybrid_clients()` helper function to print clients with HYBRID commands from coordinator and all shards
- Added `tearDown()` method to `TestCoordinatorTimeout` class to call the debug helper after each test

### Mark if applicable
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

### Release Notes
- [ ] This PR requires release notes
- [X] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds extra logging in teardown; low functional risk beyond potentially noisier CI output.
> 
> **Overview**
> Adds a new `debug_print_hybrid_clients()` helper in `test_blocked_client_timeout.py` to dump `CLIENT LIST` entries whose last command contains `HYBRID` across the coordinator and all shards.
> 
> Hooks this helper into `TestCoordinatorTimeout` via a new `tearDown()` so each test prints any leftover HYBRID clients after completion to help diagnose flaky timeout failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe37687950131d51e54801fe7c328056e00e9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->