### PR TITLE
attempt to reproduce CI cargo nextest not found

### DIFF
--- a/.github/workflows/test-nextest-macos-cached.yml
+++ b/.github/workflows/test-nextest-macos-cached.yml
@@ -1,0 +1,21 @@
+name: Test cargo-nextest cache on macOS
+
+on:
+  pull_request:
+
+jobs:
+  test-nextest-macos:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/task-test.yml
+    secrets: inherit
+    with:
+      platform: macos-15
+      architecture: aarch64
+      redis-ref: unstable
+      test-config: ''
+      coordinator: false
+      standalone: false
+      unit-tests: true
+      rejson: false

--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -42,6 +42,8 @@ NEXTEST_ARGS=()
 if [[ "$OS_TYPE" = "Linux" ]] && [[ "$processor" =~ ^(x86_64|aarch64)$ ]]; then
     NEXTEST_ARGS+=(--target="${processor}-unknown-linux-musl")
 fi
+
+# TODO: check with force
 binstall "${NEXTEST_ARGS[@]}" cargo-nextest@0.9.130
 # Tool to aggressively unify the feature sets of our dependencies,
 # thus improving the cacheability of our builds


### PR DESCRIPTION
- closed, superseeded by https://github.com/RediSearch/RediSearch/pull/9036

- I had to resubmit https://github.com/RediSearch/RediSearch/pull/8692 5 times before it passed merge queue, due to [nextest not being found despite being found during install](https://github.com/RediSearch/RediSearch/actions/runs/24234741222/job/70755560582) it's time consuming so I looked a bit more in the problem:

## investigation strategy:
- reuse failing issue by forcing it from another task (it currently runs only on merge queue)
- once bug reproduced, apply a fix and verify.

## done (unsuccessful):
- first success (installing everything): https://github.com/RediSearch/RediSearch/actions/runs/24248991520/job/70802899165?pr=9004
	- ?? cargo-llvm struggling to install, installing from source, timeouting 5 times (+ 30 seconds)
		- source install eats 8 minutes
		- https://github.com/cargo-bins/cargo-binstall/issues/2045
			- fix would be to pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to impacted steps
	- ?? cargo-nextest same.
- second run, using cache, not updating path: https://github.com/RediSearch/RediSearch/actions/runs/24250375967/job/70807807788?pr=9004
	- nextest already installed :+1:
	- didn't fail :thinking:
- third try: https://github.com/RediSearch/RediSearch/actions/runs/24257987044/job/70834376872?pr=9004
	- still passing, the issue seems difficult to reproduce unfortunately.

## Next steps

- We could either:
  - retry blindly to reproduce, but maybe something else is needed to make this fail, so I'm not too fond of trying blindly again.
  - try to reproduce the environment rather than the full reproduction, by messing with the path, or adding logs to existing workflow, to confirm that our fix would work.
  - apply a "blind" fix, and monitor if we have that problem again.


## Recomended fix
- add path inconditionally in `install_rust_deps.sh`

```bash
if [[ -n "$GITHUB_PATH" ]]; then
    echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
fi
```

## Other possible fixes

- force install ; -> would mean repaying the price of downloading/installing from source
	- can be 5 minutes...
	
	
	

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that add a macOS test workflow and tweak Rust test dependency installation; impact is limited to build/test execution and caching behavior.
> 
> **Overview**
> Adds a new pull-request GitHub Actions workflow (`test-nextest-macos-cached.yml`) to run the existing `task-test.yml` flow on `macos-15`/`aarch64` (unit tests only) to exercise `cargo-nextest` caching on macOS.
> 
> Updates `.install/test_deps/install_rust_deps.sh` to install a pinned `cargo-nextest@0.9.130` via `cargo-binstall`, optionally adding a musl `--target` on supported Linux architectures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7611c576635083424a260fd1a233b54f900bf45c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->