### PR TITLE
CI: Remove unnecessary DEBIAN_FRONTEND

### DIFF
--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -2,7 +2,6 @@
 ARCH=$(uname -m)
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
-export DEBIAN_FRONTEND=noninteractive
 
 $MODE yum update -y
 $MODE yum install -y which

--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
-export DEBIAN_FRONTEND=noninteractive
 
 $MODE dnf update -y
 $MODE dnf install -y gcc gcc-c++ gdb gzip git libstdc++-static make openssl openssl-devel rsync tar unzip wget which xz

--- a/.install/common_base_linux_mariner_2.0.sh
+++ b/.install/common_base_linux_mariner_2.0.sh
@@ -3,7 +3,6 @@
 # Don't attempt to change the name of this file.
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
-export DEBIAN_FRONTEND=noninteractive
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip xz rsync \
                          openssl-devel openssl which gzip gdb curl binutils
 

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
-export DEBIAN_FRONTEND=noninteractive
 
 $MODE tdnf install -yq build-essential ca-certificates gdb git libxcrypt-devel openssl-devel rsync tar unzip wget which xz
 

--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
-export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 
 $MODE dnf install -y gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ make wget git --nobest --skip-broken --allowerasing


### PR DESCRIPTION
As noticed here https://github.com/RediSearch/RediSearch/pull/8973#discussion_r3056367423
we set `DEBIAN_FRONTEND` in far too many places.

Successful run
https://github.com/RediSearch/RediSearch/actions/runs/24187733261

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a no-op environment variable from yum/dnf/tdnf-based install scripts and should not affect package installation behavior.
> 
> **Overview**
> Removes `export DEBIAN_FRONTEND=noninteractive` from the Amazon Linux, Mariner, Azure Linux, and Rocky Linux CI provisioning scripts, since it is Debian/apt-specific and unnecessary on these platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3b8b41f525fa9eb98b5ccb0cce1d63dcbae7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->