### PR TITLE
Fix Rust CVE

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1585,7 +1585,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bitflags 2.11.0",
  "num-traits 0.2.19",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1610,7 +1610,7 @@ dependencies = [
  "criterion",
  "proptest",
  "proptest-derive",
- "rand 0.9.2",
+ "rand 0.9.3",
  "workspace_hack",
 ]
 
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2082,7 +2082,7 @@ dependencies = [
  "iterators_ffi",
  "itertools 0.14.0",
  "query_term",
- "rand 0.9.2",
+ "rand 0.9.3",
  "redis_mock",
  "redisearch_rs",
  "rqe_iterators",
@@ -3341,7 +3341,7 @@ dependencies = [
  "ppv-lite86",
  "proc-macro2",
  "quote 1.0.44",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
  "redis-module",


### PR DESCRIPTION
https://github.com/RediSearch/RediSearch/actions/runs/24284477166/job/70911498525#step:15:40

https://rustsec.org/advisories/RUSTSEC-2026-0097

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the resolved Rust dependency `rand` from `0.9.2` to `0.9.3` in `Cargo.lock` to address a security advisory; no functional code changes are included.
> 
> **Overview**
> Updates the Rust dependency resolution in `src/redisearch_rs/Cargo.lock`, bumping `rand` from `0.9.2` to `0.9.3` (and adjusting dependent entries like `proptest` consumers) to remediate **RUSTSEC-2026-0097**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eff84441cd1aacb28fb46ea9c31d08b1c35bb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->