### PR TITLE
[MOD-14709] CI - Remove Node 20 fallback

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -1,7 +1,6 @@
 name: Configure AWS Credentials
 description: |
   Configures AWS credentials using either IAM role (OIDC) or access keys.
-  Handles both node20-supported and legacy platforms.
 
 inputs:
   use_role:
@@ -19,109 +18,23 @@ inputs:
   aws_region:
     description: "AWS region"
     required: true
-  node20_supported:
-    description: "Whether node20 is supported on this platform"
-    required: true
 
 runs:
   using: composite
   steps:
-    # Role-based auth with node20
-    - name: Configure AWS Credentials Using Role (node20)
-      if: ${{ inputs.use_role == 'true' && inputs.node20_supported == 'true' }}
+    # Role-based auth
+    - name: Configure AWS Credentials Using Role
+      if: ${{ inputs.use_role == 'true' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role_to_assume }}
         aws-region: ${{ inputs.aws_region }}
 
-    # Role-based auth without node20 (manual OIDC)
-    - name: Configure AWS Credentials Using Role (legacy)
-      if: ${{ inputs.use_role == 'true' && inputs.node20_supported != 'true' }}
-      shell: bash
-      env:
-        ROLE_ARN: ${{ inputs.role_to_assume }}
-        AWS_REGION: ${{ inputs.aws_region }}
-      run: |
-        if ! command -v jq &> /dev/null; then
-          echo "Error: jq is not installed."
-          exit 1
-        fi
-
-        echo "Requesting GitHub OIDC token..."
-        OIDC_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value // empty') || {
-          echo "Failed to get OIDC token from GitHub"
-          exit 1
-        }
-
-        if [ -z "$OIDC_TOKEN" ]; then
-          echo "Failed to get OIDC token from GitHub"
-          exit 1
-        fi
-
-        echo "Assuming AWS role using OIDC..."
-        CREDS_JSON=$(aws sts assume-role-with-web-identity \
-          --role-arn "$ROLE_ARN" \
-          --role-session-name "GitHubActions" \
-          --web-identity-token "$OIDC_TOKEN" \
-          --region "$AWS_REGION") || {
-          echo "Failed to assume AWS role using OIDC"
-          exit 1
-        }
-
-        AWS_ACCESS_KEY_ID=$(echo "$CREDS_JSON" | jq -r '.Credentials.AccessKeyId')
-        AWS_SECRET_ACCESS_KEY=$(echo "$CREDS_JSON" | jq -r '.Credentials.SecretAccessKey')
-        AWS_SESSION_TOKEN=$(echo "$CREDS_JSON" | jq -r '.Credentials.SessionToken')
-
-        if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_SESSION_TOKEN" ]; then
-          echo "Failed to parse AWS credentials from assume-role response"
-          exit 1
-        fi
-
-        echo "::add-mask::$AWS_ACCESS_KEY_ID"
-        echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
-        echo "::add-mask::$AWS_SESSION_TOKEN"
-
-        {
-          echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
-          echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
-          echo "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
-          echo "AWS_REGION=$AWS_REGION"
-        } >> "$GITHUB_ENV"
-
-        echo "AWS credentials configured successfully using OIDC."
-
-    # Key-based auth with node20
-    - name: Configure AWS Credentials Using Keys (node20)
-      if: ${{ inputs.use_role != 'true' && inputs.node20_supported == 'true' }}
+    # Key-based auth
+    - name: Configure AWS Credentials Using Keys
+      if: ${{ inputs.use_role != 'true' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
         aws-region: ${{ inputs.aws_region }}
-
-    # Key-based auth without node20
-    - name: Configure AWS Credentials Using Keys (legacy)
-      if: ${{ inputs.use_role != 'true' && inputs.node20_supported != 'true' }}
-      shell: bash
-      env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
-        AWS_REGION: ${{ inputs.aws_region }}
-      run: |
-        if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_REGION" ]; then
-          echo "Missing AWS credentials or region configuration."
-          exit 1
-        fi
-
-        echo "::add-mask::$AWS_ACCESS_KEY_ID"
-        echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
-
-        {
-          echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
-          echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
-          echo "AWS_REGION=$AWS_REGION"
-        } >> "$GITHUB_ENV"
-
-        echo "AWS credentials configured successfully using access keys."
-

--- a/.github/actions/get-redis/action.yml
+++ b/.github/actions/get-redis/action.yml
@@ -1,14 +1,9 @@
 name: Get Redis
-description: |
-  Checkout Redis repository. Uses actions/checkout for node20-supported platforms,
-  falls back to manual git clone for legacy platforms.
+description: Checkout Redis repository.
 
 inputs:
   ref:
     description: "Redis git ref to checkout"
-    required: true
-  node20_supported:
-    description: "Whether node20 is supported on this platform"
     required: true
   path:
     description: "Path to checkout Redis into"
@@ -18,28 +13,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get Redis (node20)
-      if: ${{ inputs.node20_supported == 'true' }}
+    - name: Get Redis
       uses: actions/checkout@v4
       with:
         repository: redis/redis
         ref: ${{ inputs.ref }}
         path: ${{ inputs.path }}
-
-    - name: Get Redis (legacy)
-      if: ${{ inputs.node20_supported != 'true' }}
-      shell: bash
-      env:
-        REDIS_REF: ${{ inputs.ref }}
-        DEST_DIR: ${{ inputs.path }}
-      run: |
-        REPO_URL="https://github.com/redis/redis.git"
-
-        # Clone the repository
-        git clone "$REPO_URL" "$DEST_DIR"
-        cd "$DEST_DIR"
-
-        # Checkout the requested ref
-        git fetch origin "$REDIS_REF"
-        git checkout "$REDIS_REF"
-

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -127,21 +127,12 @@ jobs:
         if: needs.get-config.outputs.post_setup_script
         run: ${{ needs.get-config.outputs.post_setup_script }}
 
-      - name: checkout (node20)
-        if: needs.get-config.outputs.node20_supported == 'true'
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: ${{ env.REF }}
-      - name: checkout (legacy)
-        # Manual checkout path for platforms where Node 20-based actions are unavailable.
-        if: needs.get-config.outputs.node20_supported != 'true'
-        run: |
-          echo "No legacy checkout platforms remaining"
-          exit 1
       - name: Setup sccache
-        # sccache-action is a JavaScript action requiring Node.js 20+
-        if: needs.get-config.outputs.node20_supported == 'true'
         uses: ./.github/actions/setup-sccache
       - name: Setup
         if: needs.build-image.outputs.succeeded != 'true'
@@ -168,7 +159,6 @@ jobs:
         uses: ./.github/actions/get-redis
         with:
           ref: ${{ inputs.redis-ref }}
-          node20_supported: ${{ needs.get-config.outputs.node20_supported }}
 
       - name: Build Redis
         working-directory: redis
@@ -181,7 +171,6 @@ jobs:
         run: ${{ env.BUILD_CMD }} && make pack
 
       - name: Show sccache stats
-        if: needs.get-config.outputs.node20_supported == 'true'
         run: ${SCCACHE_PATH:-sccache} --show-stats
 
       - name: Validate glibc version
@@ -197,7 +186,6 @@ jobs:
           aws_access_key_id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
           aws_region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
-          node20_supported: ${{ needs.get-config.outputs.node20_supported }}
       - name: Set Version identifier
         id: set-versions
         env:

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -36,9 +36,6 @@ on:
       ec2_instance_type:
         description: "EC2 instance type for self-hosted runners"
         value: ${{ jobs.get-config.outputs.ec2_instance_type }}
-      node20_supported:
-        description: "Whether node20 is supported on this platform"
-        value: ${{ jobs.get-config.outputs.node20_supported }}
       install_mode:
         description: "Installation mode (sudo for non-container, empty for container)"
         value: ${{ jobs.get-config.outputs.install_mode }}
@@ -57,7 +54,6 @@ jobs:
       name: ${{ steps.get-config.outputs.name }}
       ec2_image_id: ${{ steps.get-config.outputs.ec2_image_id }}
       ec2_instance_type: ${{ steps.get-config.outputs.ec2_instance_type }}
-      node20_supported: ${{ steps.get-config.outputs.node20_supported }}
       install_mode: ${{ steps.get-config.outputs.install_mode }}
       enable_lto: ${{ steps.get-config.outputs.enable_lto }}
     steps:
@@ -95,13 +91,9 @@ jobs:
               'name': '',
               'ec2_image_id': '',
               'ec2_instance_type': '',
-              'node20_supported': 'true',  # Most platforms support node20
               'install_mode': '',  # Empty for containers, 'sudo' for non-containers
               'enable_lto': '0'  # Whether LTO is enabled for this platform
           }
-
-          # Platforms that don't support node20
-          node20_unsupported_platforms = []
 
           # Platform configurations
           platform_configs = {
@@ -345,10 +337,6 @@ jobs:
               print(f"Error: Unsupported platform '{platform}'")
               sys.exit(1)
 
-          # Determine node20 support based on platform
-          if platform in node20_unsupported_platforms:
-              config['node20_supported'] = 'false'
-
           # Determine install mode: 'sudo' for non-container builds, empty for containers
           if not config['container']:
               config['install_mode'] = 'sudo'
@@ -365,6 +353,5 @@ jobs:
               f.write(f'name={config["name"]}\n')
               f.write(f'ec2_image_id={config["ec2_image_id"]}\n')
               f.write(f'ec2_instance_type={config["ec2_instance_type"]}\n')
-              f.write(f'node20_supported={config["node20_supported"]}\n')
               f.write(f'install_mode={config["install_mode"]}\n')
               f.write(f'enable_lto={config["enable_lto"]}\n')

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -234,20 +234,10 @@ jobs:
           ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/ghc || true
           ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
-      - name: Full checkout (node20)
-        if: needs.get-config.outputs.node20_supported == 'true'
+      - name: Full checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Full checkout (legacy)
-        # Manual checkout path for platforms where Node 20-based actions are unavailable.
-        if: needs.get-config.outputs.node20_supported != 'true'
-        env:
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_REPO: ${{ github.repository }}
-        run: |
-          echo "No legacy checkout platforms remaining"
-          exit 1
       - name: Print CPU information
         env:
           RUNNER_ARCH: ${{ runner.arch }}
@@ -271,8 +261,6 @@ jobs:
           echo "Runner Architecture: $RUNNER_ARCH"
           echo "========================"
       - name: Setup sccache
-        # sccache-action is a JavaScript action requiring Node.js 20+
-        if: needs.get-config.outputs.node20_supported == 'true'
         uses: ./.github/actions/setup-sccache
       - name: Setup
         if: needs.build-image.outputs.succeeded != 'true'
@@ -283,7 +271,6 @@ jobs:
 
       # Cache Rust packages
       - uses: Swatinem/rust-cache@v2
-        if: needs.get-config.outputs.node20_supported == 'true'
         with:
           prefix-key: "v2-rust"
           key: ${{ inputs.platform }}-${{ inputs.architecture }}-${{ inputs.san }}-${{ inputs.coverage && 'cov' || '' }}
@@ -334,7 +321,6 @@ jobs:
         uses: ./.github/actions/get-redis
         with:
           ref: ${{ inputs.redis-ref }}
-          node20_supported: ${{ needs.get-config.outputs.node20_supported }}
 
       - name: Build Redis
         working-directory: redis
@@ -444,7 +430,6 @@ jobs:
         run: make rust-tests
 
       - name: Show sccache stats
-        if: needs.get-config.outputs.node20_supported == 'true'
         run: ${SCCACHE_PATH:-sccache} --show-stats
 
       - name: Check test logs folder size
@@ -501,18 +486,16 @@ jobs:
           fi
           echo "=========================="
 
-      # Using version 4 if node20 is supported, since it is MUCH faster (15m vs 25s)
-      - name: Upload Artifacts (node20)
-        # Upload artifacts only if node20 is supported and tests failed (including sanitizer failures)
+      - name: Upload Artifacts
+        # Upload artifacts if tests failed (including sanitizer failures)
         if: >
-          needs.get-config.outputs.node20_supported == 'true' &&
-          (failure() || (
+          failure() || (
             (steps.rust_unit_tests_miri.outcome == 'failure') ||
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure' ||
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
-          ))
+          )
         uses: actions/upload-artifact@v4
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
@@ -522,19 +505,6 @@ jobs:
             bin/**/redisearch.so.debug
 
           if-no-files-found: ignore
-      # If node20 is not supported, we can only use version 3.
-      # Here we only upload the artifacts if the tests had failed, since it is very slow
-      - name: Upload Artifacts (node20 not supported) (temporarily disabled)
-        if: >
-          needs.get-config.outputs.node20_supported != 'true' &&
-          (failure() || (
-            (steps.rust_unit_tests_miri.outcome == 'failure') ||
-            steps.rust_unit_tests.outcome == 'failure' ||
-            steps.c_unit_tests.outcome == 'failure' ||
-            steps.standalone_tests.outcome == 'failure' ||
-            steps.coordinator_tests.outcome == 'failure'
-          ))
-        run: echo "Currently not available..."
 
       - name: Fail flow if tests failed
         # due to continue-on-error, we need to check failure() explicitly for step to run


### PR DESCRIPTION
Amazon Linux 2 was the only platform that didn't support Node.js 20. With it removed, node20_supported is always true, making all legacy checkout, upload, and AWS credential fallback code dead.

Remove the node20_supported output, guards, and legacy steps from task-test, task-build-artifacts, get-redis, and configure-aws-credentials.

~Stacks on top of https://github.com/RediSearch/RediSearch/pull/9015.~

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes conditional/legacy CI steps and outputs, which simplifies pipelines but could break builds/uploads on any remaining runners that lack Node 20 support or relied on the manual fallback logic.
> 
> **Overview**
> Simplifies CI workflows and composite actions by **removing the `node20_supported` flag entirely** and deleting all associated legacy fallbacks.
> 
> `configure-aws-credentials` and `get-redis` now always use the standard `aws-actions/configure-aws-credentials@v4` and `actions/checkout@v4` paths, and `task-test`/`task-build-artifacts` drop conditional checkouts, artifact upload gating, and other Node20 guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ac9d5b64df383041c3322109ee13e25ff65ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->