### PR TITLE
[MOD-14700] Enable LTO for x86_64 platforms

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -191,7 +191,7 @@ jobs:
                       'container': 'ubuntu:jammy',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Jammy x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'ubuntu:jammy',
@@ -205,7 +205,7 @@ jobs:
                       'container': 'ubuntu:focal',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Focal x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'ubuntu:focal',
@@ -309,7 +309,7 @@ jobs:
                       'container': 'gcc:11-bullseye',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Debian Bullseye x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'gcc:11-bullseye',
@@ -323,7 +323,7 @@ jobs:
                       'container': 'gcc:12-bookworm',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Debian Bookworm x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'gcc:12-bookworm',
@@ -351,7 +351,7 @@ jobs:
                       'container': 'amazonlinux:2023',
                       'setup_script': 'dnf install -y tar gzip git',
                       'name': 'Amazon Linux 2023 x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'amazonlinux:2023',
@@ -365,7 +365,7 @@ jobs:
                       'container': 'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                       'setup_script': 'tdnf install -y --noplugins --skipsignature tar gzip git ca-certificates',
                       'name': 'Mariner 2 x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'mcr.microsoft.com/cbl-mariner/base/core:2.0',
@@ -379,7 +379,7 @@ jobs:
                       'container': 'mcr.microsoft.com/azurelinux/base/core:3.0',
                       'setup_script': 'tdnf install -y --noplugins tar git ca-certificates',
                       'name': 'Azure Linux 3 x86_64',
-                      'enable_lto': '0' #  We need a new SVS binary from Intel for this.
+                      'enable_lto': '1'
                   },
                   "aarch64": {
                       'container': 'mcr.microsoft.com/azurelinux/base/core:3.0',


### PR DESCRIPTION
Enable LTO for x86_64 platforms, thanks to new SVS binaries from Intel (via VecSim dep).

Successful run
https://github.com/RediSearch/RediSearch/actions/runs/24310171915

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a107a8fe761f09fbb932c200b4dbdd32442f4bc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->