### PR TITLE
CI - Remove pr-size-labeler workaround

### DIFF
--- a/.github/workflows/pr_label_size.yml
+++ b/.github/workflows/pr_label_size.yml
@@ -7,30 +7,9 @@ jobs:
       permissions:
         pull-requests: write
         contents: read
-        issues: write
       runs-on: ubuntu-latest
       name: Label the PR size
       steps:
-        - name: Remove existing size labels
-          uses: actions/github-script@v7
-          with:
-            script: |
-              // This is a work-around until https://github.com/CodelyTV/pr-size-labeler/pull/97 is merged.
-              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-              });
-              for (const label of labels) {
-                if (label.name.startsWith('size:')) {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.payload.pull_request.number,
-                    name: label.name,
-                  });
-                }
-              }
         - uses: codelytv/pr-size-labeler@v1
           with:
             xs_label: 'size:XS'


### PR DESCRIPTION
`pr-size-labeler` was updated, and the current workaround is no longer necessary.

Working well
<img width="545" height="46" alt="image" src="https://github.com/user-attachments/assets/c225fbc2-147d-48dc-b8c8-d35a0d24b4d9" />

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the proximity/relevancy logic used by the Rust `Intersection` iterator by routing it through a new C implementation via FFI, which can affect query matching semantics and has memory/FFI edge cases; CI workflow changes are low risk.
> 
> **Overview**
> **CI cleanup:** removes `macos-14` from build/test matrices and deletes the associated macOS 14 linker workaround (brew `llvm@17` setup + `ld64.lld` flags). Simplifies the PR size labeling workflow by dropping the manual “remove existing `size:` labels” workaround and reducing required permissions.
> 
> **Query/proximity logic change:** deletes the Rust `index_result` proximity module and its Rust integration tests, adds a new C API `IndexResult_IsWithinRange` (ordered/unordered slop checking using `RSIndexResult_IterateOffsets`), and updates the Rust `Intersection` iterator to call this C function (including capping `max_slop` to `i32::MAX`). Adds a corresponding C++ unit test (`testDistance`) to cover proximity and merged-offset iteration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da3be58f3cfe0d65d21b7ea175acbea604f6d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->