### PR TITLE
[8.4] Fix Rust

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1314,9 +1314,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
# Description
Backport of #9008 to `8.4`.

https://github.com/RediSearch/RediSearch/actions/runs/24284477166/job/70911498525#step:15:40

https://rustsec.org/advisories/RUSTSEC-2026-0097

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency bump; behavior should be unchanged aside from pulling in the patched `rand` version.
> 
> **Overview**
> Updates the Rust dependency lockfile for `redisearch_rs` to use **`rand` `0.9.3`** (from `0.9.2`), pulling in the latest patched crate version.
> 
> *User impact:* reduces exposure to known issues in the older `rand` release without requiring any code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4f31498b55e1cb611223b1acb1381aaf38a042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->