### PR TITLE
[8.6] Fix Rust

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1419,9 +1419,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
# Description
Backport of #9008 to `8.6`.

https://github.com/RediSearch/RediSearch/actions/runs/24284477166/job/70911498525#step:15:40

https://rustsec.org/advisories/RUSTSEC-2026-0097

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change updating `rand` in `Cargo.lock`; runtime impact is unlikely but builds may pull a new crate revision.
> 
> **Overview**
> Updates the Rust dependency lockfile to use `rand` `0.9.3` (from `0.9.2`), pulling in the latest patch release for consumers of the `redisearch_rs` crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553c771ea29c1ae596a29c3edc5d2649f1dfd41d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->