### PR TITLE
MOD-14826: Skip flaky test_hybrid_query_with_text_vamana

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -877,6 +877,7 @@ def test_memory_info():
 # The heuristic is implemented in VectorSimilarity library in SVSIndex::preferAdHocSearch.
 # The test scenarios below demonstrate each heuristic path with detailed explanations.
 def test_hybrid_query_with_text_vamana():
+    raise SkipTest("Flaky test, see MOD-14826")
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000 WORKERS 8')
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
## Description

Skip `test_vecsim:test_hybrid_query_with_text_vamana` — it is flaky on macOS platforms (both macos-26 and macos-15) in OSS cluster mode.

### Failed nightly runs

- Apr 12 — macos-26 (x86_64) and macos-15 (x86_64): https://github.com/RediSearch/RediSearch/actions/runs/24315789392

---

## Release Notes

- [x] This PR does not require release notes
- [ ] This PR requires release notes

**Title:** N/A
**Content:** N/A

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only disables a single flaky pytest by unconditionally raising `SkipTest`, with no production code changes.
> 
> **Overview**
> Marks `test_hybrid_query_with_text_vamana` as **skipped** by adding an unconditional `raise SkipTest("Flaky test, see MOD-14826")`, disabling this SVS-VAMANA hybrid-mode heuristic test to avoid flaky CI failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65193ff414e08829b1c254eb6e7cfca9706c24d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->