### PR TITLE
Skip flaky test_barrier_waits_for_delayed_unbalanced_shard_resp2/resp3

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -307,11 +307,13 @@ def _test_barrier_waits_for_delayed_unbalanced_shard(protocol):
 
 @skip(cluster=False)
 def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
+    raise SkipTest("Flaky test, see https://github.com/RediSearch/RediSearch/actions/runs/24157298438")
     _test_barrier_waits_for_delayed_unbalanced_shard(2)
 
 
 @skip(cluster=False)
 def test_barrier_waits_for_delayed_unbalanced_shard_resp3():
+    raise SkipTest("Flaky test, see https://github.com/RediSearch/RediSearch/actions/runs/24157298438")
     _test_barrier_waits_for_delayed_unbalanced_shard(3)
 
 


### PR DESCRIPTION
## Description

Skip `test_aggregate_barrier:test_barrier_waits_for_delayed_unbalanced_shard_resp2` and `test_aggregate_barrier:test_barrier_waits_for_delayed_unbalanced_shard_resp3` — they are flaky on macOS (macos-15 aarch64) in OSS cluster mode, and also triggered an ASAN leak on the sanitize (x86_64) runner.

The tests fail with `SEARCH_TIMEOUT Timeout limit was reached` instead of the expected `ShardResponseBarrier: Timeout while waiting for first responses from all shards`.

### Failed nightly runs

- Apr 8 — macos-15 (aarch64), test failures: https://github.com/RediSearch/RediSearch/actions/runs/24157298438
- Apr 6 — sanitize (x86_64), ASAN leak detection: https://github.com/RediSearch/RediSearch/actions/runs/24049943203

---

## Release Notes

- [x] This PR does not require release notes
- [ ] This PR requires release notes

**Title:** N/A
**Content:** N/A

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author