### PR TITLE
MOD-14828: Skip flaky test_add_shard_and_migrate_aggregate_withcursor_BG

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -754,6 +754,7 @@ def test_add_shard_and_migrate_aggregate_withcursor():
 
 @skip(cluster=False, min_shards=2, asan=True)
 def test_add_shard_and_migrate_aggregate_withcursor_BG():
+    raise SkipTest("Flaky test, see MOD-14828")
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
 


### PR DESCRIPTION
## Description

Skip `test_asm:test_add_shard_and_migrate_aggregate_withcursor_BG` — flaky on macOS 26 (aarch64) in OSS cluster mode.

Same pattern as MOD-14732 (`test_add_shard_and_migrate_hybrid_BG`): Redis slot migration times out with `Write pause timeout during slot handoff: destination did not take ownership within 10000 ms`.

### Failed nightly run

- Apr 13, 2026 — macos-26 (aarch64), Redis unstable: https://github.com/RediSearch/RediSearch/actions/runs/24329959739

### Jira

- https://redislabs.atlassian.net/browse/MOD-14828
- Related: https://redislabs.atlassian.net/browse/MOD-14732

---

## Release Notes

- [x] This PR does not require release notes
- [ ] This PR requires release notes

**Title:** N/A
**Content:** N/A

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only disables a single flaky pytest case and does not change production code paths.
> 
> **Overview**
> Marks `test_add_shard_and_migrate_aggregate_withcursor_BG` as skipped by unconditionally raising `SkipTest` (referencing `MOD-14828`), preventing intermittent failures in the background/ASAN cluster run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fe8c28505389e890ff6ebbf32537f508620d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->