### PR TITLE
MOD-14525 Add test coverage for SORTBY before GROUPBY and double GROUPBY profiles

### DIFF
--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -828,6 +828,15 @@ def _test_profile(protocol):
            [('Index', 1041), ('Grouper', 25)]],
            [('Network', 75), ('Grouper', 25), ('Grouper', 1)]]),
 
+        # NOTE: The following WITHOUTCOUNT counterparts are intentionally
+        # missing because they currently fail with "Success (not an error)":
+        # - WITHOUTCOUNT + SORTBY -> GROUPBY (no MAX) — counterpart of
+        #   WITHCOUNT + SORTBY -> GROUPBY (no MAX)
+        # - WITHOUTCOUNT + GROUPBY -> SORTBY -> GROUPBY (mixed pipeline) —
+        #   counterpart of WITHCOUNT + GROUPBY -> SORTBY -> GROUPBY
+        # SORTBY without MAX combined with GROUPBY under WITHOUTCOUNT triggers
+        # a bug. The WITHCOUNT variants and SORTBY+MAX variants work correctly.
+
     ]
 
     for (query, standalone, cluster) in queries_and_profiles:

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -586,6 +586,27 @@ def _test_profile(protocol):
            [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
            [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)]]),
 
+        # WITHCOUNT + GROUPBY -> GROUPBY (re-grouping)
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT',
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'GROUPBY', 1, '@cnt', 'REDUCE', 'COUNT', 0, 'AS', 'num_brands'],
+         [('Index', 3100), ('Grouper', 25), ('Grouper', 1)],
+         [[[('Index', 1027), ('Grouper', 25)],
+           [('Index', 1032), ('Grouper', 25)],
+           [('Index', 1041), ('Grouper', 25)]],
+           [('Network', 75), ('Grouper', 25), ('Grouper', 1)]]),
+
+        # WITHCOUNT + GROUPBY -> SORTBY -> GROUPBY (mixed pipeline)
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT',
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'SORTBY', 2, '@cnt', 'DESC',
+          'GROUPBY', 1, '@cnt', 'REDUCE', 'COUNT', 0, 'AS', 'num_brands'],
+         [('Index', 3100), ('Grouper', 25), ('Sorter', 10), ('Grouper', 1)],
+         [[[('Index', 1027), ('Grouper', 25)],
+           [('Index', 1032), ('Grouper', 25)],
+           [('Index', 1041), ('Grouper', 25)]],
+           [('Network', 75), ('Grouper', 25), ('Sorter', 10), ('Grouper', 1)]]),
+
         # ----------------------------------------------------------------------
         # WITHOUTCOUNT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT'],
@@ -781,6 +802,16 @@ def _test_profile(protocol):
            [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
            [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
            [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)]]),
+
+        # WITHOUTCOUNT + GROUPBY -> GROUPBY (re-grouping)
+        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT',
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'GROUPBY', 1, '@cnt', 'REDUCE', 'COUNT', 0, 'AS', 'num_brands'],
+         [('Index', 3100), ('Grouper', 25), ('Grouper', 1)],
+         [[[('Index', 1027), ('Grouper', 25)],
+           [('Index', 1032), ('Grouper', 25)],
+           [('Index', 1041), ('Grouper', 25)]],
+           [('Network', 75), ('Grouper', 25), ('Grouper', 1)]]),
 
     ]
 

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -776,7 +776,7 @@ def _test_profile(protocol):
           'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
           'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
           'FILTER', '@cnt > 5'],
-         [('Index', 3100), ('Loader', 199), ('Pager/Limiter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)],
+         [('Index', 199), ('Loader', 199), ('Pager/Limiter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)],
          [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
            [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
            [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -828,14 +828,22 @@ def _test_profile(protocol):
            [('Index', 1041), ('Grouper', 25)]],
            [('Network', 75), ('Grouper', 25), ('Grouper', 1)]]),
 
-        # NOTE: The following WITHOUTCOUNT counterparts are intentionally
-        # missing because they currently fail with "Success (not an error)":
-        # - WITHOUTCOUNT + SORTBY -> GROUPBY (no MAX) — counterpart of
-        #   WITHCOUNT + SORTBY -> GROUPBY (no MAX)
-        # - WITHOUTCOUNT + GROUPBY -> SORTBY -> GROUPBY (mixed pipeline) —
-        #   counterpart of WITHCOUNT + GROUPBY -> SORTBY -> GROUPBY
-        # SORTBY without MAX combined with GROUPBY under WITHOUTCOUNT triggers
-        # a bug. The WITHCOUNT variants and SORTBY+MAX variants work correctly.
+        # MOD-14849: WITHOUTCOUNT + SORTBY (no MAX) + GROUPBY returns
+        # "Success (not an error)". Uncomment when MOD-14849 is fixed.
+        #
+        # # WITHOUTCOUNT + SORTBY -> GROUPBY
+        # (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 1, '@title',
+        #   'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
+        #  [<TBD standalone profile>],
+        #  [<TBD cluster profile>]),
+        #
+        # # WITHOUTCOUNT + GROUPBY -> SORTBY -> GROUPBY (mixed pipeline)
+        # (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT',
+        #   'GROUPBY', 1, '@category', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+        #   'SORTBY', 2, '@cnt', 'DESC',
+        #   'GROUPBY', 1, '@cnt', 'REDUCE', 'COUNT', 0, 'AS', 'num_categories'],
+        #  [<TBD standalone profile>],
+        #  [<TBD cluster profile>]),
 
     ]
 

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -443,6 +443,14 @@ def _test_profile(protocol):
          [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
          [('Network', 150), ('Sorter', 50)]]),
 
+        # WITHCOUNT + SORTBY + MAX
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 1, '@title', 'MAX', 50],
+         [('Index', 3100), ('Sorter', 50)],
+         [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
+           [('Network', 150), ('Sorter', 50)]]),
+
         # WITHCOUNT + LOAD
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@title'],
          [('Index', 3100), ('Loader', 3100), ('Depleter', 3100)],
@@ -578,17 +586,6 @@ def _test_profile(protocol):
            [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
            [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)]]),
 
-        # WITHCOUNT + LOAD -> SORTBY + MAX -> GROUPBY + REDUCE SUM -> APPLY
-        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@price',
-          'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
-          'GROUPBY', 1, '@brand', 'REDUCE', 'SUM', 1, '@price', 'AS', 'total',
-          'APPLY', '@total * 2', 'AS', 'doubled'],
-         [('Index', 3100), ('Loader', 3100), ('Sorter', 200), ('Grouper', 25), ('Projector - Operator *', 25)],
-         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
-           [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
-           [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
-           [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Projector - Operator *', 25)]]),
-
         # ----------------------------------------------------------------------
         # WITHOUTCOUNT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT'],
@@ -653,6 +650,14 @@ def _test_profile(protocol):
 
         # WITHOUTCOUNT + SORTBY + LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 1, '@title', 'LIMIT', 0, 50],
+         [('Index', 3100), ('Sorter', 50)],
+         [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
+           [('Network', 150), ('Sorter', 50)]]),
+
+        # WITHOUTCOUNT + SORTBY + MAX
+        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 1, '@title', 'MAX', 50],
          [('Index', 3100), ('Sorter', 50)],
          [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
            [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
@@ -777,16 +782,6 @@ def _test_profile(protocol):
            [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
            [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)]]),
 
-        # WITHOUTCOUNT + LOAD -> SORTBY + MAX -> GROUPBY + REDUCE SUM -> APPLY
-        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LOAD', 1, '@price',
-          'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
-          'GROUPBY', 1, '@brand', 'REDUCE', 'SUM', 1, '@price', 'AS', 'total',
-          'APPLY', '@total * 2', 'AS', 'doubled'],
-         [('Index', 3100), ('Loader', 199), ('Pager/Limiter', 200), ('Grouper', 25), ('Projector - Operator *', 25)],
-         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
-           [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
-           [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
-           [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Projector - Operator *', 25)]]),
     ]
 
     for (query, standalone, cluster) in queries_and_profiles:

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -777,10 +777,10 @@ def _test_profile(protocol):
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 1, '@title', 'MAX', 50,
           'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
          [('Index', 49), ('Pager/Limiter', 50), ('Grouper', 25)],
-         [[[('Index', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Pager/Limiter', 50)],
-           [('Index', 49), ('Pager/Limiter', 50)]],
-           [('Network', 150), ('Grouper', 25)]]),
+         [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
+           [('Network', 150), ('Sorter', 50), ('Grouper', 25)]]),
 
         # WITHOUTCOUNT + SORTBY + MAX -> GROUPBY + REDUCE -> SORTBY -> LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 2, '@price', 'DESC', 'MAX', 100,

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -207,6 +207,10 @@ def _test_withcount(protocol):
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'GROUPBY', 1, '@brand', 'SORTBY', 1, '@brand', 'LIMIT', 0, 11], 25, 11),
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'GROUPBY', 1, '@brand', 'SORTBY', 1, '@brand', 'LIMIT', 0, 50], 25, 25),
 
+        # WITHCOUNT + SORTBY + MAX -> GROUPBY (high-cardinality — fan-in reduction)
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 1, '@title', 'MAX', 50,
+          'GROUPBY', 1, '@price', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'], 50, 50),
+
         # WITHCOUNT + ADDSCORES
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'ADDSCORES'], docs, docs),
 
@@ -564,6 +568,17 @@ def _test_profile(protocol):
            [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
            [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
            [('Network', 150), ('Sorter', 50), ('Grouper', 25)]]),
+
+        # SORTBY+MAX before GROUPBY on high-cardinality field — demonstrates fan-in reduction.
+        # Without SORTBY+MAX, GROUPBY @price sends ~1000 groups per shard (Network ~3100).
+        # With SORTBY MAX 50, each shard sends only 50 sorted docs (Network 150) — a ~20x reduction.
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 1, '@title', 'MAX', 50,
+          'GROUPBY', 1, '@price', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
+         [('Index', 3100), ('Sorter', 50), ('Loader', 50), ('Grouper', 50)],
+         [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
+           [('Network', 150), ('Sorter', 50), ('Grouper', 50)]]),
 
         # WITHCOUNT + SORTBY + MAX -> GROUPBY + REDUCE -> SORTBY -> LIMIT
         (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 2, '@price', 'DESC', 'MAX', 100,

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -539,6 +539,56 @@ def _test_profile(protocol):
            [('Index', 1041), ('Loader', 1041), ('Filter - Predicate <', 68), ('Depleter', 49), ('Pager/Limiter', 50)]],
            [('Network', 150), ('Depleter', 49), ('Pager/Limiter', 50)]]),
 
+        # WITHCOUNT + SORTBY -> GROUPBY
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 1, '@title',
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
+         [('Index', 3100), ('Sorter', 10), ('Grouper', 7)],
+         [[[('Index', 1027), ('Sorter', 10), ('Loader', 10)],
+           [('Index', 1032), ('Sorter', 10), ('Loader', 10)],
+           [('Index', 1041), ('Sorter', 10), ('Loader', 10)]],
+           [('Network', 30), ('Sorter', 10), ('Grouper', 7)]]),
+
+        # WITHCOUNT + SORTBY + MAX -> GROUPBY
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 1, '@title', 'MAX', 50,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
+         [('Index', 3100), ('Sorter', 50), ('Grouper', 25)],
+         [[[('Index', 1027), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1032), ('Sorter', 50), ('Loader', 50)],
+           [('Index', 1041), ('Sorter', 50), ('Loader', 50)]],
+           [('Network', 150), ('Sorter', 50), ('Grouper', 25)]]),
+
+        # WITHCOUNT + SORTBY + MAX -> GROUPBY + REDUCE -> SORTBY -> LIMIT
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'SORTBY', 2, '@price', 'DESC', 'MAX', 100,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'SORTBY', 2, '@cnt', 'DESC', 'LIMIT', 0, 10],
+         [('Index', 3100), ('Loader', 3100), ('Sorter', 100), ('Grouper', 25), ('Sorter', 10)],
+         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 100), ('Loader', 100)],
+           [('Index', 1032), ('Loader', 1032), ('Sorter', 100), ('Loader', 100)],
+           [('Index', 1041), ('Loader', 1041), ('Sorter', 100), ('Loader', 100)]],
+           [('Network', 300), ('Sorter', 100), ('Grouper', 25), ('Sorter', 10)]]),
+
+        # WITHCOUNT + LOAD -> SORTBY + MAX -> GROUPBY + REDUCE -> FILTER
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@price',
+          'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'FILTER', '@cnt > 5'],
+         [('Index', 3100), ('Loader', 3100), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)],
+         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
+           [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)]]),
+
+        # WITHCOUNT + LOAD -> SORTBY + MAX -> GROUPBY + REDUCE SUM -> APPLY
+        (['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@price',
+          'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'SUM', 1, '@price', 'AS', 'total',
+          'APPLY', '@total * 2', 'AS', 'doubled'],
+         [('Index', 3100), ('Loader', 3100), ('Sorter', 200), ('Grouper', 25), ('Projector - Operator *', 25)],
+         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
+           [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Projector - Operator *', 25)]]),
+
         # ----------------------------------------------------------------------
         # WITHOUTCOUNT
         (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT'],
@@ -696,6 +746,47 @@ def _test_profile(protocol):
            [('Index', 49), ('Loader', 49), ('Filter - Predicate <', 49), ('Pager/Limiter', 50)],
            [('Index', 49), ('Loader', 49), ('Filter - Predicate <', 49), ('Pager/Limiter', 50)]],
            [('Network', 49), ('Pager/Limiter', 50)]]),
+
+        # WITHOUTCOUNT + SORTBY + MAX -> GROUPBY
+        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 1, '@title', 'MAX', 50,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt'],
+         [('Index', 49), ('Pager/Limiter', 50), ('Grouper', 25)],
+         [[[('Index', 49), ('Pager/Limiter', 50)],
+           [('Index', 49), ('Pager/Limiter', 50)],
+           [('Index', 49), ('Pager/Limiter', 50)]],
+           [('Network', 150), ('Grouper', 25)]]),
+
+        # WITHOUTCOUNT + SORTBY + MAX -> GROUPBY + REDUCE -> SORTBY -> LIMIT
+        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'SORTBY', 2, '@price', 'DESC', 'MAX', 100,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'SORTBY', 2, '@cnt', 'DESC', 'LIMIT', 0, 10],
+         [('Index', 3100), ('Loader', 3100), ('Sorter', 100), ('Grouper', 25), ('Sorter', 10)],
+         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 100), ('Loader', 100)],
+           [('Index', 1032), ('Loader', 1032), ('Sorter', 100), ('Loader', 100)],
+           [('Index', 1041), ('Loader', 1041), ('Sorter', 100), ('Loader', 100)]],
+           [('Network', 300), ('Sorter', 100), ('Grouper', 25), ('Sorter', 10)]]),
+
+        # WITHOUTCOUNT + LOAD -> SORTBY + MAX -> GROUPBY + REDUCE -> FILTER
+        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LOAD', 1, '@price',
+          'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'COUNT', 0, 'AS', 'cnt',
+          'FILTER', '@cnt > 5'],
+         [('Index', 3100), ('Loader', 199), ('Pager/Limiter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)],
+         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
+           [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Filter - Predicate >', 25)]]),
+
+        # WITHOUTCOUNT + LOAD -> SORTBY + MAX -> GROUPBY + REDUCE SUM -> APPLY
+        (['FT.AGGREGATE', 'idx', '*', 'WITHOUTCOUNT', 'LOAD', 1, '@price',
+          'SORTBY', 2, '@price', 'DESC', 'MAX', 200,
+          'GROUPBY', 1, '@brand', 'REDUCE', 'SUM', 1, '@price', 'AS', 'total',
+          'APPLY', '@total * 2', 'AS', 'doubled'],
+         [('Index', 3100), ('Loader', 199), ('Pager/Limiter', 200), ('Grouper', 25), ('Projector - Operator *', 25)],
+         [[[('Index', 1027), ('Loader', 1027), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1032), ('Loader', 1032), ('Sorter', 200), ('Loader', 200)],
+           [('Index', 1041), ('Loader', 1041), ('Sorter', 200), ('Loader', 200)]],
+           [('Network', 600), ('Sorter', 200), ('Grouper', 25), ('Projector - Operator *', 25)]]),
     ]
 
     for (query, standalone, cluster) in queries_and_profiles:


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `_test_profile()` function in `test_aggregate_count.py` has FT.PROFILE coverage for GROUPBY→SORTBY pipelines, standalone SORTBY, LOAD, FILTER, and ADDSCORES — but zero coverage for SORTBY *before* GROUPBY, standalone SORTBY+MAX, or double GROUPBY pipelines.

2. **Change**: Add 12 new FT.PROFILE test entries covering:
   - **SORTBY+MAX** standalone baseline (WITHCOUNT + WITHOUTCOUNT)
   - **SORTBY→GROUPBY** (WITHCOUNT only — WITHOUTCOUNT crashes, pre-existing bug)
   - **SORTBY+MAX→GROUPBY** (WITHCOUNT + WITHOUTCOUNT)
   - **SORTBY+MAX→GROUPBY→SORTBY→LIMIT** — the LTK query pattern (WITHCOUNT + WITHOUTCOUNT)
   - **LOAD→SORTBY+MAX→GROUPBY→FILTER** (WITHCOUNT + WITHOUTCOUNT)
   - **GROUPBY→GROUPBY** double grouper (WITHCOUNT + WITHOUTCOUNT)
   - **GROUPBY→SORTBY→GROUPBY** mixed pipeline (WITHCOUNT only)

3. **Outcome**: Solid FT.PROFILE test coverage for SORTBY-before-GROUPBY and double-GROUPBY aggregate pipelines, verifying RP chain types and result counts at every stage for both standalone and cluster (3-shard) modes.

#### Main objects this PR modified
1. `tests/pytests/test_aggregate_count.py`

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Test-only changes, but they add many new `FT.PROFILE` expectations that are sensitive to planner/profile output and may be brittle across engine changes or cluster/RESP variations.
> 
> **Overview**
> Adds new `FT.AGGREGATE`/`FT.PROFILE` test cases in `test_aggregate_count.py` to validate result counts and result-processor chains for **`SORTBY` (with/without `MAX`) occurring before `GROUPBY`**, including a high-cardinality "fan-in reduction" scenario.
> 
> Extends coverage to more complex pipelines such as `SORTBY+MAX -> GROUPBY -> SORTBY -> LIMIT`, `LOAD -> SORTBY+MAX -> GROUPBY -> FILTER`, and **double-`GROUPBY` (re-grouping)**; also documents a known `WITHOUTCOUNT + SORTBY (no MAX) + GROUPBY` issue via disabled/placeholder cases (MOD-14849).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843580819a51313ce688cc8e39f6bdb494856c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->