### PR TITLE
union: add timeout/error propagation tests for flat and heap variants

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -21,10 +21,12 @@
 macro_rules! union_common_tests {
     ($UnionFull:ident, $UnionQuick:ident) => {
         use crate::utils::{
-            Mock, MockRevalidateResult, MockVec, create_mock_1, create_mock_2, create_mock_3,
-            create_union_children,
+            Mock, MockIteratorError, MockRevalidateResult, MockVec, create_mock_1, create_mock_2,
+            create_mock_3, create_union_children,
         };
-        use rqe_iterators::{IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome};
+        use rqe_iterators::{
+            IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+        };
         use crate::utils::FieldMaskMock;
 
         type Union<I> = $UnionFull<'static, I>;
@@ -1437,6 +1439,161 @@ macro_rules! union_common_tests {
             let r = union.read().unwrap().unwrap();
             assert_eq!(r.doc_id, 30);
             assert_eq!(r.field_mask, 0x2, "doc 30: only child1 → mask must be 0x2");
+        }
+
+        // =====================================================================
+        // Timeout / error propagation tests
+        // =====================================================================
+
+        /// Helper: create 3 mock iterators and set the child at
+        /// `timeout_idx` to return a timeout error at EOF.
+        fn make_timeout_children(
+            timeout_idx: usize,
+        ) -> Vec<Box<dyn RQEIterator<'static>>> {
+            let mocks = [
+                Mock::new([10, 20, 30, 40, 50]),
+                Mock::new([10, 20, 30, 40, 50]),
+                Mock::new([10, 20, 30, 40, 50]),
+            ];
+            mocks[timeout_idx]
+                .data()
+                .set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
+            mocks.into_iter().map(|m| Box::new(m) as _).collect()
+        }
+
+        /// Read until we get a non-Ok result and assert it is a timeout.
+        fn assert_read_eventually_times_out<'a>(
+            union: &mut impl RQEIterator<'a>,
+        ) {
+            loop {
+                match union.read() {
+                    Ok(Some(_)) => continue,
+                    Err(RQEIteratorError::TimedOut) => return,
+                    Ok(None) => panic!("expected timeout error, got EOF"),
+                    Err(e) => panic!("expected timeout error, got {e:?}"),
+                }
+            }
+        }
+
+        /// Skip forward until we get a non-Ok result and assert it is a timeout.
+        fn assert_skip_to_eventually_times_out<'a>(
+            union: &mut impl RQEIterator<'a>,
+        ) {
+            let mut next = 1;
+            loop {
+                match union.skip_to(next) {
+                    Ok(Some(SkipToOutcome::Found(_) | SkipToOutcome::NotFound(_))) => {
+                        next = union.last_doc_id() + 1;
+                    }
+                    Err(RQEIteratorError::TimedOut) => return,
+                    Ok(None) => panic!("expected timeout error, got EOF"),
+                    Err(e) => panic!("expected timeout error, got {e:?}"),
+                }
+            }
+        }
+
+        // -- Full mode: read propagates timeout ---------------------
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn read_full_propagates_timeout_first_child() {
+            let children = make_timeout_children(0);
+            let mut union = $UnionFull::new(children);
+            assert_read_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn read_full_propagates_timeout_mid_child() {
+            let children = make_timeout_children(1);
+            let mut union = $UnionFull::new(children);
+            assert_read_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn read_full_propagates_timeout_last_child() {
+            let children = make_timeout_children(2);
+            let mut union = $UnionFull::new(children);
+            assert_read_eventually_times_out(&mut union);
+        }
+
+        // -- Quick mode: read propagates timeout --------------------
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn read_quick_propagates_timeout_first_child() {
+            let children = make_timeout_children(0);
+            let mut union = $UnionQuick::new(children);
+            assert_read_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn read_quick_propagates_timeout_mid_child() {
+            let children = make_timeout_children(1);
+            let mut union = $UnionQuick::new(children);
+            assert_read_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn read_quick_propagates_timeout_last_child() {
+            let children = make_timeout_children(2);
+            let mut union = $UnionQuick::new(children);
+            assert_read_eventually_times_out(&mut union);
+        }
+
+        // -- Full mode: skip_to propagates timeout ------------------
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn skip_to_full_propagates_timeout_first_child() {
+            let children = make_timeout_children(0);
+            let mut union = $UnionFull::new(children);
+            assert_skip_to_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn skip_to_full_propagates_timeout_mid_child() {
+            let children = make_timeout_children(1);
+            let mut union = $UnionFull::new(children);
+            assert_skip_to_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn skip_to_full_propagates_timeout_last_child() {
+            let children = make_timeout_children(2);
+            let mut union = $UnionFull::new(children);
+            assert_skip_to_eventually_times_out(&mut union);
+        }
+
+        // -- Quick mode: skip_to propagates timeout -----------------
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn skip_to_quick_propagates_timeout_first_child() {
+            let children = make_timeout_children(0);
+            let mut union = $UnionQuick::new(children);
+            assert_skip_to_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn skip_to_quick_propagates_timeout_mid_child() {
+            let children = make_timeout_children(1);
+            let mut union = $UnionQuick::new(children);
+            assert_skip_to_eventually_times_out(&mut union);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn skip_to_quick_propagates_timeout_last_child() {
+            let children = make_timeout_children(2);
+            let mut union = $UnionQuick::new(children);
+            assert_skip_to_eventually_times_out(&mut union);
         }
 
     };


### PR DESCRIPTION
## Describe the changes in the pull request 

Test timeout for Rust union iterators. Re-implement timeout tests from `test_cpp_iterator_union.cpp`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new integration tests only, exercising timeout error propagation paths for union iterators; no production logic changes.
> 
> **Overview**
> **Adds timeout/error propagation coverage for union iterators.** The shared `union_common_tests!` suite now includes helpers and 12 new tests that force one child iterator to time out at EOF and assert `RQEIteratorError::TimedOut` is surfaced by both `read()` and `skip_to()` across *Full* and *Quick* union variants.
> 
> Also updates imports to use `MockIteratorError`/`RQEIteratorError` needed for the new assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531a3d4213e9a983ac0cf0392ba8c621b30b7496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->