### PR TITLE
[MOD-14828] test: add sleep to avoid epoch collision

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -712,10 +712,10 @@ def add_shard_and_migrate_test(env: Env, query_type: str = 'FT.SEARCH'):
 
     # Add a new shard
     env.addShardToClusterIfExists()
+    time.sleep(5)
     new_shard = env.getConnection(shardId=initial_shards_count+1)
     # ...and migrate slots from shard 1 to the new shard
     wait_for_migration_complete(env, new_shard, shard1, query_during_migration={'query': query, 'shards': shards, 'expected': expected, 'query_type': query_type})
-
     # Expect new shard to have the index schema
     env.assertEqual(new_shard.execute_command('FT._LIST'), ['idx'])
 
@@ -754,7 +754,6 @@ def test_add_shard_and_migrate_aggregate_withcursor():
 
 @skip(cluster=False, min_shards=2, asan=True)
 def test_add_shard_and_migrate_aggregate_withcursor_BG():
-    raise SkipTest("Flaky test, see MOD-14828")
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
@@ -1107,6 +1106,7 @@ def test_hybrid_cursor_after_add_shard_migration():
     # Step 2: Add a new shard and migrate a middle slot range from shard1 to new shard
     initial_shards_count = env.shardsCount
     env.addShardToClusterIfExists()
+    time.sleep(5)
     new_shard = env.getConnection(shardId=initial_shards_count + 1)
 
     # Also set trim delays on the new shard


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add a small delay and re-enable one previously skipped test; main risk is increased CI time or renewed flakiness.
> 
> **Overview**
> Adds a short `time.sleep(5)` after `env.addShardToClusterIfExists()` in the add-shard migration test helpers to give the cluster time to stabilize before connecting to the new shard and starting slot migration.
> 
> Removes the explicit `SkipTest` from `test_add_shard_and_migrate_aggregate_withcursor_BG`, effectively re-enabling that background/ASAN variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84f7d5e6994913beacff81b117bba81e1531d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->