### PR TITLE
union_iterator: add profile accessors

### DIFF
--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -543,3 +543,24 @@ QueryIterator *NewUnionIterator(QueryIterator **its, int num, bool quickExit,
   UI_SyncIterList(ui);
   return ret;
 }
+
+QueryNodeType GetUnionIteratorQueryNodeType(const QueryIterator *base) {
+  const UnionIterator *ui = (const UnionIterator *)base;
+  return ui->type;
+}
+
+const char *GetUnionIteratorQueryString(const QueryIterator *base) {
+  const UnionIterator *ui = (const UnionIterator *)base;
+  return ui->q_str;
+}
+
+size_t GetUnionIteratorNumChildren(const QueryIterator *base) {
+  const UnionIterator *ui = (const UnionIterator *)base;
+  return ui->num_orig;
+}
+
+QueryIterator *GetUnionIteratorChild(const QueryIterator *base, size_t index) {
+  const UnionIterator *ui = (const UnionIterator *)base;
+  RS_ASSERT(index < ui->num_orig);
+  return ui->its_orig[index];
+}

--- a/src/iterators/union_iterator.h
+++ b/src/iterators/union_iterator.h
@@ -53,6 +53,12 @@ QueryIterator *NewUnionIterator(QueryIterator **its, int num, bool quickExit, do
 // Sync state according to `its_orig` and `num_orig` (exposed for profile iterator injection)
 void UI_SyncIterList(UnionIterator *ui);
 
+// Accessor functions for UnionIterator fields (used by profile code to avoid direct struct access)
+QueryNodeType GetUnionIteratorQueryNodeType(const QueryIterator *base);
+const char *GetUnionIteratorQueryString(const QueryIterator *base);
+size_t GetUnionIteratorNumChildren(const QueryIterator *base);
+QueryIterator *GetUnionIteratorChild(const QueryIterator *base, size_t index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -365,8 +365,8 @@ void Profile_PrintDefault(RedisModule_Reply *reply, void *ctx) {
                                                   PrintProfileConfig *config)
 
 PRINT_PROFILE_FUNC(printUnionIt) {
-  const UnionIterator *ui = (const UnionIterator *)root;
-  int printFull = !limited  || (ui->type & QN_UNION);
+  QueryNodeType nodeType = GetUnionIteratorQueryNodeType(root);
+  int printFull = !limited || (nodeType & QN_UNION);
 
   RedisModule_Reply_Map(reply);
 
@@ -374,7 +374,7 @@ PRINT_PROFILE_FUNC(printUnionIt) {
 
   RedisModule_Reply_SimpleString(reply, "Query type");
   char *unionTypeStr;
-  switch (ui->type) {
+  switch (nodeType) {
   case QN_GEO : unionTypeStr = "GEO"; break;
   case QN_TAG : unionTypeStr = "TAG"; break;
   case QN_UNION : unionTypeStr = "UNION"; break;
@@ -388,13 +388,14 @@ PRINT_PROFILE_FUNC(printUnionIt) {
     RS_ABORT_ALWAYS("Invalid type for union");
   // LCOV_EXCL_STOP
   }
-  if (!ui->q_str) {
+  const char *q_str = GetUnionIteratorQueryString(root);
+  if (!q_str) {
     RedisModule_Reply_SimpleString(reply, unionTypeStr);
   } else {
-    const char *qstr = ui->q_str;
+    const char *qstr = q_str;
     if (isUnsafeForSimpleString(qstr)) qstr = escapeSimpleString(qstr);
     RedisModule_Reply_SimpleStringf(reply, "%s - %s", unionTypeStr, qstr);
-    if (qstr != ui->q_str) rm_free((char*)qstr);
+    if (qstr != q_str) rm_free((char*)qstr);
   }
 
   if (config->printProfileClock) {
@@ -403,15 +404,16 @@ PRINT_PROFILE_FUNC(printUnionIt) {
 
   printProfileCounters(counters);
 
+  size_t num_children = GetUnionIteratorNumChildren(root);
   RedisModule_Reply_SimpleString(reply, "Child iterators");
   if (printFull) {
     RedisModule_Reply_Array(reply);
-      for (int i = 0; i < ui->num_orig; i++) {
-        printIteratorProfile(reply, ui->its_orig[i], 0, 0, depth + 1, limited, config);
+      for (size_t i = 0; i < num_children; i++) {
+        printIteratorProfile(reply, GetUnionIteratorChild(root, i), 0, 0, depth + 1, limited, config);
       }
     RedisModule_Reply_ArrayEnd(reply);
   } else {
-    RedisModule_Reply_SimpleStringf(reply, "The number of iterators in the union is %d", ui->num_orig);
+    RedisModule_Reply_SimpleStringf(reply, "The number of iterators in the union is %zu", num_children);
   }
 
   RedisModule_Reply_MapEnd(reply);


### PR DESCRIPTION
Use accessors instead of direct access to the struct. Will ease transition to the Rust version.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how profiling reads `UnionIterator` metadata/children without altering iterator execution logic. Main risk is minor profiling output regressions (e.g., formatting/child enumeration) if accessors diverge from struct semantics.
> 
> **Overview**
> Updates iterator profiling to stop directly casting and reading `UnionIterator` internals.
> 
> Adds `UnionIterator` accessor APIs (`GetUnionIteratorQueryNodeType`, `GetUnionIteratorQueryString`, `GetUnionIteratorNumChildren`, `GetUnionIteratorChild`) and rewires `printUnionIt` in `profile.c` to use them, including switching child counts/loops to `size_t` (and `%zu`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2727c42f83e58674f84a52fb92caf9a0694e7a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->