### PR TITLE
Fix cargo-nextest installation script

### DIFF
--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -26,23 +26,68 @@ rustup toolchain install $NIGHTLY_VERSION \
 export BINSTALL_VERSION="1.17.7"
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/4c4aeb61ee54318eba5737b7c07aa509a2ed6d32/install-from-binstall-release.sh | bash
 
-# Wrapper around `cargo binstall` that auto-confirms (-y), respects
-# the lockfile (--locked), and tries prebuilt binaries first, falling
-# back to compiling from source (--strategies).
+# Pick a preferred prebuilt target. On Linux x86_64/aarch64 we prefer
+# the musl prebuilt so the binary is statically linked against musl and
+# works across a wide range of glibc versions (the default host-target
+# prebuilt is dynamically linked against system glibc, which causes
+# issues on older systems). Empty on other platforms.
+PREFERRED_TARGET=""
+if [[ "$OS_TYPE" = "Linux" ]] && [[ "$processor" =~ ^(x86_64|aarch64)$ ]]; then
+    PREFERRED_TARGET="${processor}-unknown-linux-musl"
+fi
+
+# Wrapper around `cargo binstall` that auto-confirms (-y) and respects
+# the lockfile (--locked).
+#
+# First tries the $PREFERRED_TARGET prebuilt (when set, e.g. musl on
+# Linux for glibc independence). If that fails, falls back to installing
+# for the host target — by default trying a host-target prebuilt and
+# then compiling from source with the host toolchain. Without the
+# host-target fallback we'd fail on hosts that don't have the musl
+# cross-toolchain installed when the musl prebuilt is unavailable.
+#
+# Options (consumed by the wrapper, not forwarded to cargo-binstall):
+#   --no-host-prebuilt   Don't accept a host-target prebuilt in the
+#                        fallback. Use this for tools where the musl
+#                        prebuilt was chosen for glibc compatibility and
+#                        a glibc-linked host prebuilt would defeat the
+#                        purpose — fall back directly to a source build
+#                        with the host toolchain.
 binstall() {
-    cargo binstall "$@" -y --locked --strategies="crate-meta-data,compile"
+    local allow_host_prebuilt=1
+    if [[ "$1" == "--no-host-prebuilt" ]]; then
+        allow_host_prebuilt=0
+        shift
+    fi
+
+    if [[ -n "$PREFERRED_TARGET" ]]; then
+        if cargo binstall "$@" -y --locked --force \
+                --target="$PREFERRED_TARGET" \
+                --strategies=crate-meta-data; then
+            return 0
+        fi
+        echo "Prebuilt $PREFERRED_TARGET artifact unavailable for $*; falling back to host target" >&2
+    fi
+
+    # --no-host-prebuilt only matters when a preferred target was set:
+    # it guards against falling back to a (glibc-linked) host prebuilt
+    # after the preferred (musl) prebuilt failed. On platforms where no
+    # preferred target applies (e.g. macOS), there's no such concern and
+    # a host-target prebuilt is perfectly fine.
+    local strategies="crate-meta-data,compile"
+    if (( ! allow_host_prebuilt )) && [[ -n "$PREFERRED_TARGET" ]]; then
+        strategies="compile"
+    fi
+    cargo binstall "$@" -y --locked --force --strategies="$strategies"
 }
 
 # Tool required to compute test coverage for Rust code
 binstall cargo-llvm-cov@0.8.4
-# Our preferred test runner, instead of the default `cargo test`
-# Use musl targets on Linux for maximum compatibility across glibc versions
-# (default builds dynamically against system glibc which causes issues on older systems)
-NEXTEST_ARGS=()
-if [[ "$OS_TYPE" = "Linux" ]] && [[ "$processor" =~ ^(x86_64|aarch64)$ ]]; then
-    NEXTEST_ARGS+=(--target="${processor}-unknown-linux-musl")
-fi
-binstall "${NEXTEST_ARGS[@]}" cargo-nextest@0.9.130
+# Our preferred test runner, instead of the default `cargo test`.
+# The musl prebuilt is chosen for glibc independence; a host-target
+# prebuilt would be glibc-linked and defeat the purpose, so on fallback
+# we go straight to a source build with the host toolchain.
+binstall --no-host-prebuilt cargo-nextest@0.9.130
 # Tool to aggressively unify the feature sets of our dependencies,
 # thus improving the cacheability of our builds
 # See https://docs.rs/cargo-hakari/latest/cargo_hakari/about/


### PR DESCRIPTION
## Describe the changes in the pull request

Make sure we don't try to build from source using the `...-musl` toolchain, since it won't be installed.
Use `--force` to ensure `cargo-binstall` doesn't skip installation because it _thinks_ the tool is available (based on its own cache) even though it's not in the `.cargo` bin folder.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes dependency installation behavior in CI/dev environments; a mis-detected target or fallback strategy could break tool installs on some platforms.
> 
> **Overview**
> Updates `.install/test_deps/install_rust_deps.sh` to prefer installing musl prebuilt artifacts on Linux (`x86_64`/`aarch64`) for better glibc compatibility, instead of passing musl targets through to all installs.
> 
> Refactors the `binstall` wrapper to first attempt a preferred `--target` prebuilt, then fall back to host-target installation, and adds `--no-host-prebuilt` to force a source-build fallback when a glibc-linked host prebuilt would defeat the musl-compatibility goal (used for `cargo-nextest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f719b03ca3f4876d947b192e4f3f6d4c33725266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->