### PR TITLE
fix: add --merge strategy to gh pr merge for branches without merge q…

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -150,7 +150,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
         run: |
           gh pr ready "$BRANCH" -R "$GITHUB_REPOSITORY"
-          gh pr merge "$BRANCH" -R "$GITHUB_REPOSITORY" --auto
+          gh pr merge "$BRANCH" -R "$GITHUB_REPOSITORY" --auto --merge
 
   generate-matrix:
     uses: ./.github/workflows/generate-matrix.yml


### PR DESCRIPTION
…ueue


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-flag change to the GitHub Actions release workflow that only affects how the auto-merge operation is performed for the version-bump PR.
> 
> **Overview**
> Ensures the release workflow merges the auto-generated version-bump PR using an explicit merge commit strategy by adding `--merge` to the `gh pr merge --auto` command in `event-release.yml`.
> 
> This avoids failures when merging on branches that don't support the default merge-queue behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d8d0ea1171e0e76e6fdb8982385f7245223686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->