### PR TITLE
refactor: remove `UnsafeCell` from `RLookupKey`

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -9,7 +9,6 @@
 
 use std::{
     borrow::Cow,
-    cell::UnsafeCell,
     ffi::{CStr, c_char},
     mem,
     ops::{Deref, DerefMut},
@@ -172,7 +171,7 @@ pub struct RLookupKeyHeader<'a> {
     pub name_len: usize,
 
     /// Pointer to next field in the list
-    pub next: UnsafeCell<Option<NonNull<RLookupKey<'a>>>>,
+    pub next: Option<NonNull<RLookupKey<'a>>>,
 }
 
 // ===== impl RLookupKey =====
@@ -216,7 +215,7 @@ impl<'a> RLookupKey<'a> {
                 name: name.as_ptr(),
                 path: name.as_ptr(),
                 name_len: name.count_bytes(),
-                next: UnsafeCell::new(None),
+                next: None,
             },
             _name: name,
             _path: None,
@@ -316,9 +315,7 @@ impl<'a> RLookupKey<'a> {
     /// Return the next pointer in the linked list
     #[inline]
     pub(crate) fn next(&self) -> Option<NonNull<RLookupKey<'a>>> {
-        // Safety: RLookupKeys are created through `KeyList::push` and owned by the `List`. We
-        // can therefore assume this pointer is safe to dereference at this point.
-        unsafe { *self.next.get() }
+        self.next
     }
 
     /// Update the pointer to the next node
@@ -328,7 +325,7 @@ impl<'a> RLookupKey<'a> {
         next: Option<NonNull<RLookupKey<'a>>>,
     ) -> Option<NonNull<RLookupKey<'a>>> {
         let me = self.project();
-        mem::replace(me.header.next.get_mut(), next)
+        mem::replace(&mut me.header.next, next)
     }
 
     #[inline]


### PR DESCRIPTION
This change removes `UnsafeCell` from `RLookupKey`s next pointer. We didn't need the interior mutability anyways and `UnsafeCell` was causing the key to be invariant over the lifetime `'a`, a massive headache.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in linked-list pointer storage; behavior should be unchanged but touches pinned/FFI-adjacent data structures so mistakes could cause subtle list corruption or ABI issues.
> 
> **Overview**
> Removes `UnsafeCell`-based interior mutability from `RLookupKeyHeader.next`, storing the link directly as an `Option<NonNull<RLookupKey>>`.
> 
> Updates construction and linked-list helpers (`next()`/`set_next()`) to use normal mutable access, eliminating the associated `unsafe` dereference and avoiding lifetime invariance introduced by `UnsafeCell`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58681d0007245587f4dde5c42692244fc176e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->