### PR TITLE
Provide a GitHub token as a build secret to binstall in order to minimize rate-limiting 

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -89,6 +89,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ inputs.container }}
             SAN=${{ inputs.san }}
+          secrets: |
+            GITHUB_TOKEN=${{ github.token }}
           file: Dockerfile
           tags: ${{ steps.meta.outputs.image }}
           cache-to: type=registry,ref=${{ steps.meta.outputs.cache }},mode=max,compression=zstd

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,12 @@ COPY . .
 WORKDIR /project/.install
 # Install base dependencies, Rust toolchain, and optionally LLVM for sanitizer builds.
 RUN bash retry.sh bash -l -eo pipefail install_script.sh && \
-    bash retry.sh bash -l -eo pipefail test_deps/install_rust_deps.sh && \
     if [ "$SAN" = "address" ]; then bash retry.sh bash -l -eo pipefail install_llvm.sh; fi
+# Mount the GitHub token as a build secret so cargo-binstall benefits from
+# higher GitHub API rate limits when fetching prebuilt release artifacts.
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    if [ -f /run/secrets/GITHUB_TOKEN ]; then export GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN); fi && \
+    bash retry.sh bash -l -eo pipefail test_deps/install_rust_deps.sh
 WORKDIR /project
 # Expose newly-installed Rust and Python tools via PATH
 ENV PATH="/usr/local/llvm/bin:/root/.cargo/bin:/root/.local/bin:${PATH}"


### PR DESCRIPTION
## Describe the changes in the pull request

We see the occasional 403 in `cargo-binstall` logs when trying to fetch GitHub releases or determining the URL of a prebuilt artefact. Providing a GitHub token should minimize the number of failures and thus the amount of time we spend retrying/backing off.

Relevant upstream issue: https://github.com/cargo-bins/cargo-binstall/issues/2045

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a build secret to reduce GitHub API rate limiting; main risk is potential build failure if secret mounting behaves differently across runners/buildx versions.
> 
> **Overview**
> Improves the cached container build to **reduce `cargo-binstall` GitHub API rate-limiting** by passing `github.token` into the Docker build as a BuildKit secret.
> 
> Updates the `Dockerfile` to mount `GITHUB_TOKEN` during the Rust dependency install step and export it only for that `RUN`, keeping the token out of the final image layers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b928baabcdb5f97f2c1746dea3ff7ac2768338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->