### PR TITLE
[MOD-14649] fix stack smashing error on coord tests

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -172,8 +172,6 @@ TEST_F(IORuntimeCtxCommonTest, Schedule) {
 }
 
 TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
-  GTEST_SKIP() << "Temporarily skipping ScheduleTopology.";
-
   // Reset the signal before starting
   lastAppliedCapShards.store(0, std::memory_order_relaxed);
 
@@ -196,7 +194,11 @@ TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
   });
   ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, lastAppliedCapShards=" << lastAppliedCapShards.load();
 
-  // We don't need to free newTopo here as it's handled by testTopoCallback
+  // Wait for the testCallback to complete before `counter` goes out of scope.
+  // Otherwise the event loop thread may write to a dangling stack address,
+  // corrupting the stack canary and triggering "stack smashing detected".
+  success = RS::WaitForCondition([&]() { return counter >= 1; });
+  ASSERT_TRUE(success) << "Timeout waiting for scheduled callback to complete";
 }
 
 TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
@@ -218,6 +220,12 @@ TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
     return lastAppliedCapShards.load(std::memory_order_acquire) == 4101;
   });
   ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, lastAppliedCapShards=" << lastAppliedCapShards.load();
+
+  // Wait for the testCallbacks to complete before `counter` goes out of scope.
+  // Otherwise the event loop thread may write to a dangling stack address,
+  // corrupting the stack canary and triggering "stack smashing detected".
+  success = RS::WaitForCondition([&]() { return counter >= 2; });
+  ASSERT_TRUE(success) << "Timeout waiting for scheduled callbacks to complete";
 }
 
 TEST_F(IORuntimeCtxCommonTest, ClearPendingTopo) {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `ScheduleTopology` and `MultipleTopologyUpdates` C++ coord tests schedule async callbacks (`testCallback`) that write to a stack-local `counter` variable. The tests wait for topology to be applied but do not wait for the scheduled callbacks to complete. When the test body returns, the event loop thread may still write to the now-freed stack address, corrupting the stack canary and triggering `*** stack smashing detected ***`.
2. **Change**: Both tests now explicitly wait (via `RS::WaitForCondition`) for the scheduled `testCallback` invocations to complete before returning, ensuring `counter` is still alive when the event loop thread writes to it. The `ScheduleTopology` test is also re-enabled (removed `GTEST_SKIP`).
3. **Outcome**: Eliminates the stack smashing crash in `MultipleTopologyUpdates` and prevents the same issue in `ScheduleTopology`.

#### Main objects this PR modified
1. `tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
