### PR TITLE
[8.4] Fix Profile Print on Missing Value - [MOD-10560]

### DIFF
--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -34,7 +34,14 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
   InvIndIterator *it = (InvIndIterator *)root;
 
   RedisModule_Reply_Map(reply);
-  if (IndexReader_Flags(it->reader) == Index_DocIdsOnly) {
+  if (it->isWildcard) {
+    printProfileType("WILDCARD");
+  } else if (it->filterCtx.predicate == FIELD_EXPIRATION_MISSING) {
+    printProfileType("MISSING");
+    size_t fieldLen = 0;
+    const char *fieldName = HiddenString_GetUnsafe(it->sctx->spec->fields[it->filterCtx.field.value.index].fieldName, &fieldLen);
+    RedisModule_ReplyKV_StringBuffer(reply, "Field", fieldName, fieldLen);
+  } else if (IndexReader_Flags(it->reader) == Index_DocIdsOnly) {
     RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
     if (term != NULL) {
       printProfileType("TAG");

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -276,6 +276,24 @@ def testProfileTag(env):
   env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2])
 
 @skip(cluster=True)
+def testProfileMissingFieldQuery(env):
+  conn = getConnectionByEnv(env)
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text', 'INDEXMISSING')
+  conn.execute_command('hset', '1', 't', 'hello')
+  conn.execute_command('hset', '2', 'other', 'value')
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
+  env.assertEqual(actual_res[0], [1, '2'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1])
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  env.assertEqual(actual_res[0], [1, '1'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+
+@skip(cluster=True)
 def testProfileVector(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
@@ -1305,4 +1323,3 @@ def testCoordinatorQueueTimeInProfile():
   env.assertGreaterEqual(coord_queue_time, pause_duration_ms * 0.8,  # Allow 20% tolerance
     message=f"Coordinator queue time ({coord_queue_time}ms) should capture queue wait. "
             f"Expected >= {pause_duration_ms * 0.8}ms. Full result: {result}")
-

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -286,12 +286,12 @@ def testProfileMissingFieldQuery(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '2'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '1'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
-                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1]])
 
 @skip(cluster=True)
 def testProfileVector(env):


### PR DESCRIPTION
## Describe the changes in the pull request

`8.4` variant of #9051 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `FT.PROFILE` iterator output formatting and adds targeted tests; query execution behavior is unchanged.
> 
> **Overview**
> `FT.PROFILE` now prints a distinct iterator type for missing-field queries (`Type: MISSING`) and includes the relevant field name, instead of misclassifying the iterator based on index reader flags.
> 
> Adds regression tests covering `ismissing(@field)` and its negation to validate the new profile output structure (including `NOT` wrapping a `MISSING` child iterator).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5dcb067373b0c5efec2e84831193987a9f17d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->