### PR TITLE
[8.2] Fix Profile Print on Missing Value - [MOD-10560]

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -15,7 +15,12 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
   IndexReader *ir = root->ctx;
 
   RedisModule_Reply_Map(reply);
-  if (ir->idx->flags == Index_DocIdsOnly) {
+  if (ir->filterCtx.predicate == FIELD_EXPIRATION_MISSING) {
+    printProfileType("MISSING");
+    size_t fieldLen = 0;
+    const char *fieldName = HiddenString_GetUnsafe(ir->sctx->spec->fields[ir->filterCtx.field.value.index].fieldName, &fieldLen);
+    RedisModule_ReplyKV_StringBuffer(reply, "Field", fieldName, fieldLen);
+  } else if (ir->idx->flags == Index_DocIdsOnly) {
     if (ir->record->data.term.term != NULL) {
       printProfileType("TAG");
       REPLY_KVSTR_SAFE("Term", ir->record->data.term.term->str);

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -289,12 +289,12 @@ def testProfileMissingFieldQuery(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '2'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '1'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
-                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1]])
 
 @skip(cluster=True)
 def testProfileVector(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -279,6 +279,24 @@ def testProfileTag(env):
   env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2])
 
 @skip(cluster=True)
+def testProfileMissingFieldQuery(env):
+  conn = getConnectionByEnv(env)
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text', 'INDEXMISSING')
+  conn.execute_command('hset', '1', 't', 'hello')
+  conn.execute_command('hset', '2', 'other', 'value')
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
+  env.assertEqual(actual_res[0], [1, '2'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1])
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  env.assertEqual(actual_res[0], [1, '1'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+
+@skip(cluster=True)
 def testProfileVector(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')


### PR DESCRIPTION
## Describe the changes in the pull request

`8.2` variant of #9051 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only `FT.PROFILE` iterator printing for missing-field predicates and adds coverage; no query execution or index mutation logic is modified.
> 
> **Overview**
> Fixes `FT.PROFILE` iterator output for `ismissing(@field)` queries by detecting `FIELD_EXPIRATION_MISSING` readers and printing a dedicated `Type: MISSING` entry including the missing field name.
> 
> Adds a regression test covering both `ismissing(@t)` and `-ismissing(@t)` to ensure the profile output includes the expected `MISSING` iterator (and nesting under `NOT`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f0f9d3f894a6a871c25e202eff0db99b8293cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->