### PR TITLE
[2.10] Fix Profile Print on Missing Value - [MOD-10560]

### DIFF
--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1083,6 +1083,7 @@ static void IndexReader_Init(const IndexSpec *sp, IndexReader *ret, InvertedInde
   ret->decoderCtx = decoderCtx;
   ret->isValidP = NULL;
   ret->sp = sp;
+  ret->profileCtx = (typeof(ret->profileCtx)){0};
   IR_SetAtEnd(ret, 0);
 }
 
@@ -1118,11 +1119,14 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
   return NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
 }
 
-IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp) {
+IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp, uint16_t fieldIndex) {
   IndexDecoderCtx dctx = {.wideMask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
   IndexDecoderProcs decoder = InvertedIndex_GetDecoder(idx->flags);
   RSIndexResult *record = NewVirtualResult(0, RS_FIELDMASK_ALL);
-  return NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
+  IndexReader *ir = NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
+  ir->profileCtx.missing.isMissing = true;
+  ir->profileCtx.missing.fieldIndex = fieldIndex;
+  return ir;
 }
 
 void IR_Free(IndexReader *ir) {

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -162,6 +162,10 @@ typedef struct IndexReader {
       double rangeMin;
       double rangeMax;
     } numeric;
+    struct {
+      bool isMissing;
+      uint16_t fieldIndex;
+    } missing;
   } profileCtx;
 
   /* The decoder's filtering context. It may be a number or a pointer. The number is used for
@@ -231,7 +235,7 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
                                 RSQueryTerm *term, double weight);
 
 /* Create a new index reader on an inverted index of "missing values". */
-IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp);
+IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp, uint16_t fieldIndex);
 
 void IR_Abort(void *ctx);
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -14,7 +14,11 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
 
   RedisModule_Reply_Map(reply);
 
-  if (ir->idx->flags == Index_DocIdsOnly) {
+  if (ir->idx->flags == Index_DocIdsOnly && ir->profileCtx.missing.isMissing) {
+    printProfileType("MISSING");
+    RedisModule_ReplyKV_SimpleString(reply, "Field",
+                                     ir->sp->fields[ir->profileCtx.missing.fieldIndex].name);
+  } else if (ir->idx->flags == Index_DocIdsOnly) {
     printProfileType("TAG");
     REPLY_KVSTR_SAFE("Term", ir->record->term.term->str);
   } else if (ir->idx->flags & Index_StoreNumeric) {

--- a/src/query.c
+++ b/src/query.c
@@ -1522,7 +1522,7 @@ static IndexIterator *Query_EvalMissingNode(QueryEvalCtx *q, QueryNode *qn) {
   }
 
   // Create a reader for the missing values InvertedIndex.
-  IndexReader *ir = NewMissingIndexReader(missingII, q->sctx->spec);
+  IndexReader *ir = NewMissingIndexReader(missingII, q->sctx->spec, fs->index);
 
   return NewReadIterator(ir);
 }

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -297,12 +297,12 @@ def testProfileMissingFieldQuery(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '2'])
-  env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+  env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1]])
 
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '1'])
-  env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
-                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]]])
+  env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1]]])
 
 @skip(cluster=True)
 def testProfileVector(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -287,6 +287,24 @@ def testProfileTag(env):
   env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2]])
 
 @skip(cluster=True)
+def testProfileMissingFieldQuery(env):
+  conn = getConnectionByEnv(env)
+  env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text', 'INDEXMISSING')
+  conn.execute_command('hset', '1', 't', 'hello')
+  conn.execute_command('hset', '2', 'other', 'value')
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
+  env.assertEqual(actual_res[0], [1, '2'])
+  env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  env.assertEqual(actual_res[0], [1, '1'])
+  env.assertEqual(actual_res[1][5], ['Iterators profile', ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]]])
+
+@skip(cluster=True)
 def testProfileVector(env):
   conn = getConnectionByEnv(env)
   env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')


### PR DESCRIPTION
## Describe the changes in the pull request

`2.10` variant of #9051 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to profiling metadata/plumbing and add test coverage; query execution and index decoding logic are otherwise unchanged.
> 
> **Overview**
> **Release note:** `FT.PROFILE` now correctly reports `ismissing(@field)` iterators as type `MISSING` (including the field name) instead of being printed as a `TAG` iterator.
> 
> Internally, `IndexReader` now carries a small profiling context for missing-field readers (initialized to zero), `NewMissingIndexReader` accepts/persists the field index, and `printReadIt` uses that metadata when rendering the iterator profile. A new pytest validates profile output for `ismissing` and `-ismissing` queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a7f49c38a85592b958935ab7d29cf7bad9d49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->