### PR TITLE
Fix Profile Print on Missing Value - [MOD-10560]

### DIFF
--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -28,6 +28,17 @@ typedef struct {
 void printIteratorProfile(RedisModule_Reply *reply, const QueryIterator *root, const ProfileCounters *counters,
                           double cpuTime, int depth, int limited, PrintProfileConfig *config);
 
+static void printInvIdxIteratorCounters(RedisModule_Reply *reply, const QueryIterator *root,
+                                        const ProfileCounters *counters, double cpuTime,
+                                        PrintProfileConfig *config) {
+  if (config->printProfileClock) {
+    printProfileTime(cpuTime);
+  }
+
+  printProfileCounters(counters);
+  RedisModule_ReplyKV_LongLong(reply, "Estimated number of matches", root->NumEstimated(root));
+}
+
 void printInvIdxIt(RedisModule_Reply *reply, const QueryIterator *root, const ProfileCounters *counters, double cpuTime, PrintProfileConfig *config) {
   IndexFlags readerFlags = InvIndIterator_GetReaderFlags(root);
 
@@ -63,14 +74,19 @@ void printInvIdxIt(RedisModule_Reply *reply, const QueryIterator *root, const Pr
     RedisModule_ReplyKV_StringBuffer(reply, "Term", term_str, term_len);
   }
 
-  // print counter and clock
-  if (config->printProfileClock) {
-    printProfileTime(cpuTime);
-  }
+  printInvIdxIteratorCounters(reply, root, counters, cpuTime, config);
+  RedisModule_Reply_MapEnd(reply);
+}
 
-  printProfileCounters(counters);
-  RedisModule_ReplyKV_LongLong(reply, "Estimated number of matches", root->NumEstimated(root));
+void printInvIdxMissingIt(RedisModule_Reply *reply, const QueryIterator *root, const ProfileCounters *counters, double cpuTime, PrintProfileConfig *config) {
+  RedisModule_Reply_Map(reply);
+  printProfileType("MISSING");
 
+  size_t field_len = 0;
+  const char *field_name = InvIndMissingIterator_GetFieldName(root, &field_len);
+  RedisModule_ReplyKV_StringBuffer(reply, "Field", field_name, field_len);
+
+  printInvIdxIteratorCounters(reply, root, counters, cpuTime, config);
   RedisModule_Reply_MapEnd(reply);
 }
 
@@ -552,10 +568,9 @@ void printIteratorProfile(RedisModule_Reply *reply, const QueryIterator *root, c
     // Reader
     case INV_IDX_NUMERIC_ITERATOR:
     case INV_IDX_TERM_ITERATOR:
-    case INV_IDX_WILDCARD_ITERATOR:
-    case INV_IDX_MISSING_ITERATOR:
     case INV_IDX_TAG_ITERATOR:
                                             { printInvIdxIt(reply, root, counters, cpuTime, config);                                break; }
+    case INV_IDX_MISSING_ITERATOR:          { printInvIdxMissingIt(reply, root, counters, cpuTime, config);                         break; }
     // Multi values
     case UNION_ITERATOR:                    { printUnionIt(reply, root, counters, cpuTime, depth, limited, config);                 break; }
     case INTERSECT_ITERATOR:                { printIntersectIt(reply, root, counters, cpuTime, depth, limited, config);             break; }
@@ -564,6 +579,7 @@ void printIteratorProfile(RedisModule_Reply *reply, const QueryIterator *root, c
     case NOT_ITERATOR_OPTIMIZED:            { printNotIt(reply, root, counters, cpuTime, depth, limited, config);                   break; }
     case OPTIONAL_ITERATOR: // fallthrough
     case OPTIONAL_OPTIMIZED_ITERATOR:       { printOptionalIt(reply, root, counters, cpuTime, depth, limited, config);              break; }
+    case INV_IDX_WILDCARD_ITERATOR: // fallthrough
     case WILDCARD_ITERATOR:                 { printWildcardIt(reply, root, counters, cpuTime, depth, limited, config);              break; }
     case EMPTY_ITERATOR:                    { printEmptyIt(reply, root, counters, cpuTime, depth, limited, config);                 break; }
     case ID_LIST_SORTED_ITERATOR:           { printIdListSortedIt(reply, root, counters, cpuTime, depth, limited, config);          break; }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -44,6 +44,13 @@ impl MissingIterator<'_> {
             MissingIterator::Raw(m) => m.reader().flags(),
         }
     }
+
+    pub(super) fn field_name(&self) -> (*const std::ffi::c_char, usize) {
+        match self {
+            MissingIterator::Encoded(m) => m.field_name(),
+            MissingIterator::Raw(m) => m.field_name(),
+        }
+    }
 }
 
 /// Macro to dispatch RQEIterator methods across all [`MissingIterator`] variants.
@@ -183,4 +190,28 @@ pub unsafe extern "C" fn NewInvIndIterator_MissingQuery(
     };
 
     RQEIteratorWrapper::boxed_new(iterator)
+}
+
+/// Gets the field name used by a missing-field inverted index iterator.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
+/// 2. `it` must have type [`IteratorType::InvIdxMissing`].
+/// 3. `out_len` must be a valid writable pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn InvIndMissingIterator_GetFieldName(
+    it: *const ffi::QueryIterator,
+    out_len: *mut usize,
+) -> *const std::ffi::c_char {
+    debug_assert!(!it.is_null(), "it must not be null");
+    debug_assert!(!out_len.is_null(), "out_len must not be null");
+
+    // SAFETY: 1. and 2. guarantee the iterator is a valid missing iterator wrapper.
+    let wrapper =
+        unsafe { RQEIteratorWrapper::<MissingIterator<'static>>::ref_from_header_ptr(it.cast()) };
+    let (field_name, field_name_len) = wrapper.inner.field_name();
+    // SAFETY: 3. guarantees `out_len` is valid and writable.
+    unsafe { *out_len = field_name_len };
+    field_name
 }

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -205,6 +205,17 @@ QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx,
                                               t_fieldIndex field_index);
 
 /**
+ * Gets the field name used by a missing-field inverted index iterator.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
+ * 2. `it` must have type [`IteratorType::InvIdxMissing`].
+ * 3. `out_len` must be a valid writable pointer.
+ */
+const char *InvIndMissingIterator_GetFieldName(const QueryIterator *it, size_t *out_len);
+
+/**
  * Creates a new numeric inverted index iterator for querying numeric fields.
  *
  * # Parameters

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -137,7 +137,9 @@ where
         // SAFETY: the constructor guarantees `spec` is non-null and valid.
         let spec = unsafe { &*sctx.spec };
         // SAFETY: the constructor guarantees `field_index` indexes `spec.fields`.
-        let field = unsafe { &*spec.fields.add(self.field_index as usize) };
+        let field_ptr = unsafe { spec.fields.add(self.field_index as usize) };
+        // SAFETY: `field_ptr` was derived from a valid `spec.fields` base and an in-bounds index.
+        let field = unsafe { &*field_ptr };
         let mut len = 0;
         // SAFETY: `field.fieldName` belongs to the spec and remains valid while the spec lives.
         let name = unsafe { ffi::HiddenString_GetUnsafe(field.fieldName, &mut len) };

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -129,6 +129,20 @@ where
     pub const fn reader(&self) -> &IndexReaderCore<'index, E> {
         &self.it.reader
     }
+
+    /// Get the field name tracked by this missing-field iterator.
+    pub fn field_name(&self) -> (*const std::ffi::c_char, usize) {
+        // SAFETY: the constructor guarantees `context` is valid for the iterator lifetime.
+        let sctx = unsafe { self.context.as_ref() };
+        // SAFETY: the constructor guarantees `spec` is non-null and valid.
+        let spec = unsafe { &*sctx.spec };
+        // SAFETY: the constructor guarantees `field_index` indexes `spec.fields`.
+        let field = unsafe { &*spec.fields.add(self.field_index as usize) };
+        let mut len = 0;
+        // SAFETY: `field.fieldName` belongs to the spec and remains valid while the spec lives.
+        let name = unsafe { ffi::HiddenString_GetUnsafe(field.fieldName, &mut len) };
+        (name, len)
+    }
 }
 
 impl<'index, E, C> RQEIterator<'index> for Missing<'index, E, C>

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -90,6 +90,7 @@ mod not_miri {
     use crate::inverted_index::utils::{RevalidateIndexType, RevalidateTest};
     use inverted_index::opaque::OpaqueEncoding;
     use rqe_iterators::RQEValidateStatus;
+    use std::ffi::CStr;
 
     struct MissingRevalidateTest {
         test: RevalidateTest,
@@ -247,5 +248,18 @@ mod not_miri {
         let reader = it.reader();
         let ii = DocIdsOnly::from_opaque(test.test.context.missing_inverted_index());
         assert!(reader.points_to_ii(ii));
+    }
+
+    #[test]
+    fn missing_field_name() {
+        let test = MissingRevalidateTest::new(10);
+        let it = test.create_iterator();
+
+        let (field_name, field_name_len) = it.field_name();
+        // SAFETY: `field_name()` returns a valid pointer to the field name stored in the live spec.
+        let field_name = unsafe { CStr::from_ptr(field_name) };
+
+        assert_eq!(field_name.to_bytes().len(), field_name_len);
+        assert_eq!(field_name.to_bytes(), b"text_field");
     }
 }

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -284,7 +284,7 @@ def testProfileMissingFieldQuery(env):
   conn.execute_command('hset', '1', 't', 'hello')
   conn.execute_command('hset', '2', 'other', 'value')
 
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent')
   env.assertEqual(actual_res[0], [1, '2'])
   env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
@@ -292,6 +292,11 @@ def testProfileMissingFieldQuery(env):
   env.assertEqual(actual_res[0], [1, '1'])
   env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
                                             ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1]])
+
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'true')
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent')
+  env.assertEqual(actual_res[0], [1, '2'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Time', ANY, 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
 @skip(cluster=True)
 def testProfileVector(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -296,7 +296,7 @@ def testProfileMissingFieldQuery(env):
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'true')
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent')
   env.assertEqual(actual_res[0], [1, '2'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Time', ANY, 'Number of reading operations', 1, 'Estimated number of matches', 1])
+  env.assertEqual(actual_res[1][1][0][11], ['Type', 'MISSING', 'Field', 't', 'Time', ANY, 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
 @skip(cluster=True)
 def testProfileVector(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -286,12 +286,12 @@ def testProfileMissingFieldQuery(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
   env.assertEqual(actual_res[0], [1, '2'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
   env.assertEqual(actual_res[0], [1, '1'])
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
-                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 1, 'Estimated number of matches', 1]])
 
 @skip(cluster=True)
 def testProfileVector(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -276,6 +276,24 @@ def testProfileTag(env):
   env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2])
 
 @skip(cluster=True)
+def testProfileMissingFieldQuery(env):
+  conn = getConnectionByEnv(env)
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text', 'INDEXMISSING')
+  conn.execute_command('hset', '1', 't', 'hello')
+  conn.execute_command('hset', '2', 'other', 'value')
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'ismissing(@t)', 'nocontent', 'DIALECT', 2)
+  env.assertEqual(actual_res[0], [1, '2'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1])
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-ismissing(@t)', 'nocontent')
+  env.assertEqual(actual_res[0], [1, '1'])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'NOT', 'Number of reading operations', 2, 'Child iterator',
+                                            ['Type', 'MISSING', 'Field', 't', 'Number of reading operations', 2, 'Estimated number of matches', 1]])
+
+@skip(cluster=True)
 def testProfileVector(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
@@ -1498,4 +1516,3 @@ def testCoordinatorQueueTimeInProfile():
   env.assertGreaterEqual(coord_queue_time, pause_duration_ms * 0.8,  # Allow 20% tolerance
     message=f"Coordinator queue time ({coord_queue_time}ms) should capture queue wait. "
             f"Expected >= {pause_duration_ms * 0.8}ms. Full result: {result}")
-


### PR DESCRIPTION
## Describe the changes in the pull request

Fix for `master` and `8.6-rse`.
For the other versions:
1. `8.6` - #9047
2. `8.4` - #9048
3. `8.2` - #9049 
4. `2.10` - #9050 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iterator profiling output and adds a new C↔Rust FFI accessor for missing-field iterators; mistakes could cause incorrect profile replies or unsafe pointer/len issues, but scope is limited and covered by new tests.
> 
> **Overview**
> Fixes `FT.PROFILE` output for `ismissing(@field)` queries by introducing a dedicated `MISSING` iterator profile entry that includes the **field name** and reuses shared counter/time printing.
> 
> Adds a new C↔Rust FFI accessor (`InvIndMissingIterator_GetFieldName`) to retrieve the missing iterator’s tracked field name, plus Rust/unit and Python integration tests to validate both non-verbose and verbose (time-included) profile formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed7726bd22794b629027bfb2e3c74c80cb0eaa8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->