### PR TITLE
update redisbench-admin version to 0.12.4

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -80,7 +80,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.12
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Then install Python dependencies
           sudo apt install python3-pip -y
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.12
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
       - name: Compare benchmark results
         run: |
           redisbench-admin compare \

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.12.12
+redisbench_admin==0.12.14
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
The new redisbench-admin fixes a bug that allows to properly update db logs into s3 buckets on error helping on debugging issues

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to benchmark tooling and CI workflows; main risk is micro-benchmark runs/exports behaving differently due to upstream `redisbench-admin` changes.
> 
> **Overview**
> Updates the micro-benchmark tooling to use `redisbench-admin==0.12.14` (from `0.12.12`) across both GitHub Actions workflows and `tests/benchmarks/requirements.txt`, keeping CI and local benchmark dependencies in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d089562b981900ffb8cbcdc08c071816c0baab74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->