### PR TITLE
[MOD-14917] Update tests so they don't rely on children order of the union iterator

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -489,6 +489,35 @@ def to_dict(res):
 def to_list(input_dict: dict):
     return [item for pair in input_dict.items() for item in pair]
 
+def sort_profile_children(profile):
+    """Recursively sort 'Child iterators' lists in profile output so that
+    assertions do not depend on union child ordering.
+
+    Works with both RESP2 (flat key-value lists) and RESP3 (dicts).
+    Children are sorted by their string representation to give a stable order.
+    """
+    if isinstance(profile, dict):
+        for key, val in profile.items():
+            if key == 'Child iterators' and isinstance(val, list):
+                for child in val:
+                    sort_profile_children(child)
+                val.sort(key=lambda c: str(c))
+            else:
+                sort_profile_children(val)
+    elif isinstance(profile, list):
+        # RESP2 flat key-value format: [..., 'Child iterators', [...], ...]
+        i = 0
+        while i < len(profile):
+            if profile[i] == 'Child iterators' and i + 1 < len(profile) and isinstance(profile[i + 1], list):
+                children = profile[i + 1]
+                for child in children:
+                    sort_profile_children(child)
+                children.sort(key=lambda c: str(c))
+                i += 2
+            else:
+                sort_profile_children(profile[i])
+                i += 1
+
 def get_redis_memory_in_mb(env):
     return float(env.cmd('info', 'memory')['used_memory'])/0x100000
 

--- a/tests/pytests/test_hybrid_profile.py
+++ b/tests/pytests/test_hybrid_profile.py
@@ -655,7 +655,10 @@ def test_profile_standalone():
     for query, expected_shard_profile, _, expected_coordinator_profile, _, _ in query_and_profile:
         actual_res = env.execute_command(*query)
         _verify_profile_structure(env, env.protocol, actual_res)
-        env.assertEqual(actual_res[8][1], expected_shard_profile,
+        actual_shard = actual_res[8][1]
+        sort_profile_children(actual_shard)
+        sort_profile_children(expected_shard_profile)
+        env.assertEqual(actual_shard, expected_shard_profile,
                         message=f'query: {query}')
         env.assertEqual(actual_res[8][3], expected_coordinator_profile,
                         message=f'query: {query}')

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -126,7 +126,11 @@ def testOptimizer(env):
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo @n:[10 20]', *params)
     env.assertEqual(res[0], [10, '10', '12', '14', '16', '18', '20', '110', '112', '114', '116'])
     actual_profiler = to_dict(res[1][1][0])
-    env.assertEqual(actual_profiler['Iterators profile'], profiler['Iterators profile'])
+    actual_iters = actual_profiler['Iterators profile']
+    expected_iters = profiler['Iterators profile']
+    sort_profile_children(actual_iters)
+    sort_profile_children(expected_iters)
+    env.assertEqual(actual_iters, expected_iters)
     env.assertEqual(actual_profiler['Result processors profile'], profiler['Result processors profile'])
 
     ### (3) TAG and range with sort ###

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -37,7 +37,10 @@ def testProfileSearch(env):
   expected_res = ['Type', 'UNION', 'Query type', 'UNION', 'Number of reading operations', 2, 'Child iterators', [
                     ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
                     ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
-  env.assertEqual(actual_res[1][1][0][3], expected_res)
+  actual_union = actual_res[1][1][0][3]
+  sort_profile_children(actual_union)
+  sort_profile_children(expected_res)
+  env.assertEqual(actual_union, expected_res)
 
   # test INTERSECT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello world', 'nocontent')
@@ -207,9 +210,14 @@ def testProfileNumeric(env):
                     ['Type', 'NUMERIC', 'Term', '32.7 - 45.4', 'Number of reading operations', 1280, 'Estimated number of matches', 1280],
                     ['Type', 'NUMERIC', 'Term', '45.5 - 49.1', 'Number of reading operations', 370, 'Estimated number of matches', 370],
                     ['Type', 'NUMERIC', 'Term', '49.2 - 50', 'Number of reading operations', 90, 'Estimated number of matches', 90]]]]
+  sort_profile_children(expected_res)
   # [1] (Profile data) -> [1] (`Shards` value) -> [0] (single shard/standalone) -> [2:4] (Iterators profile - key+value)
+  def sort_and_return(x):
+    res = x[1][1][0][2:4]
+    sort_profile_children(res)
+    return res
   env.expect('ft.profile', 'idx', 'search', 'query', '@n:[0,100]', 'nocontent').apply(
-    lambda x: x[1][1][0][2:4]).equal(expected_res)
+    sort_and_return).equal(expected_res)
 
 @skip(cluster=True)
 def testProfileNegativeNumeric():
@@ -242,6 +250,9 @@ def testProfileNegativeNumeric():
       range_dict = {"min":float(res_range[0]), "max": float(res_range[1])}
       env.assertEqual(range_dict['max'], range_dict['min'] + child['Estimated number of matches'] - 1, message=f"{title}: range_max should equal range_min + (range_size - 1)")
       return range_dict
+
+    # Sort children by their min range value so assertions don't depend on iteration order
+    child_iter_list.sort(key=lambda c: float(c['Term'].split(" - ")[0]))
 
     # The first child iterator should contain the min val
     range_dict = extract_child_range(child_iter_list[0])

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -722,6 +722,8 @@ def test_profile_child_itrerators_array():
       },
     }
     if not env.isCluster():  # on cluster, lack of crash is enough
+        sort_profile_children(res)
+        sort_profile_children(exp)
         env.assertEqual(res, exp)
 
     # test INTERSECT

--- a/tests/pytests/test_summarize.py
+++ b/tests/pytests/test_summarize.py
@@ -69,12 +69,13 @@ def testPrefixExpansion(env):
                   'HIGHLIGHT', 'FIELDS', 1, 'txt', 'TAGS', '<b>', '</b>',
                   'SUMMARIZE', 'FIELDS', 1, 'txt', 'LEN', 20)
 
-    # Prefix expansion uses "early exit" strategy, so the term highlighted won't necessarily be the
-    # best term
-    possibilities = [[1, 'gen1', ['txt', 'is] one, and they have all one language; and this they <b>begin</b> to do: and now nothing will be restrained from them, which... ']],
-                     [1, 'gen1', ['txt', 'First Book of Moses, called Genesis {1:1} In the <b>beginning</b> God created the heaven and the earth. {1:2} And the earth... the mighty hunter before the LORD. {10:10} And the <b>beginning</b> of his kingdom was Babel, and Erech, and Accad, and Calneh... is] one, and they have all one language; and this they <b>begin</b> to do: and now nothing will be restrained from them, which... ']],
-                     [1, 'gen1', ['txt', '49:3} Reuben, thou [art] my firstborn, my might, and the <b>beginning of</b> my strength, the excellency of dignity, and the excellency... ']]]
-    env.assertContains(res, possibilities)
+    # Prefix expansion uses "early exit" strategy, so the highlighted term
+    # depends on iterator ordering.
+    # Just verify we got one result for 'gen1' with a highlighted begi* match.
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], 'gen1')
+    env.assertEqual(res[2][0], 'txt')
+    env.assertContains('<b>begin', res[2][1])
 
 def testSummarizationMultiField(env):
     p1 = "Redis is an open-source in-memory database project implementing a networked, in-memory key-value store with optional durability. Redis supports different kinds of abstract data structures, such as strings, lists, maps, sets, sorted sets, hyperloglogs, bitmaps and spatial indexes. The project is mainly developed by Salvatore Sanfilippo and is currently sponsored by Redis Labs.[4] Redis Labs creates and maintains the official Redis Enterprise Pack."


### PR DESCRIPTION
## Describe the changes in the pull request

The Rust union iterators do not preserve children ordering with `SUMMARIZE + HIGHLIGHT` and when printing profile debug output.
The order is not relevant there so update tests so they don't enforce a specific order.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Python tests and only relax ordering-sensitive assertions to reduce flakiness from non-deterministic UNION child ordering.
> 
> **Overview**
> Updates profile-related tests to **stop depending on UNION child ordering**.
> 
> Adds `sort_profile_children()` (handles both RESP2 and RESP3 shapes) and uses it to sort `Child iterators` before comparing expected vs actual profiles in several `FT.PROFILE` tests.
> 
> Relaxes `SUMMARIZE`+`HIGHLIGHT` prefix-expansion assertions to check for a highlighted `begi*` match rather than an exact snippet, avoiding failures caused by iterator ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b0c6ce1d71748d207329fc6c9ef100bddcac10a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->