### PR TITLE
[MOD-14828] test: add sleep to avoid epoch collision (#9033)

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -721,7 +721,6 @@ def add_shard_and_migrate_test(env: Env, query_type: str = 'FT.SEARCH'):
     new_shard = env.getConnection(shardId=initial_shards_count+1)
     # ...and migrate slots from shard 1 to the new shard
     wait_for_migration_complete(env, new_shard, shard1, query_during_migration={'query': query, 'shards': shards, 'expected': expected, 'query_type': query_type})
-
     # Expect new shard to have the index schema
     env.assertEqual(new_shard.execute_command('FT._LIST'), ['idx'])
 


### PR DESCRIPTION
add tests to avoid epoch collision

(cherry picked from commit 962a57cd450c029e26600cb069fe30d3cca2822d)


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds/uses a short delay to reduce cluster timing flakiness; no production logic is affected.
> 
> **Overview**
> Reduces flakiness in the atomic slot migration test by waiting briefly after adding a new shard before starting slot migration, avoiding transient cluster `config_epoch`/stabilization timing issues.
> 
> User impact: more reliable CI signal for shard-add + migration scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7a41cdbf74696beac39a71c1d5d496d828f011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->