### PR TITLE
MOD-14826 MOD-14725: Fix flaky SVS tests — non-blocking debugInfo + drain workers + increase timeout

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -886,7 +886,9 @@ def test_hybrid_query_with_text_vamana():
     create_vector_index(env, dim, datatype=data_type, alg='SVS-VAMANA', additional_schema_args=['t', 'TEXT'])
 
     load_vectors_with_texts_into_redis(conn, DEFAULT_FIELD_NAME, dim, index_size, data_type)
+    start_time = time.time()
     wait_for_background_indexing(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.debugPrint("wait_for_background_indexing took {} seconds".format(time.time() - start_time), force=True)
     index_size = get_tiered_backend_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)['INDEX_SIZE']
     env.debugPrint(f"svs index size: {index_size}", force=True)
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -877,7 +877,6 @@ def test_memory_info():
 # The heuristic is implemented in VectorSimilarity library in SVSIndex::preferAdHocSearch.
 # The test scenarios below demonstrate each heuristic path with detailed explanations.
 def test_hybrid_query_with_text_vamana():
-    raise SkipTest("Flaky test, see MOD-14826")
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000 WORKERS 8')
     conn = getConnectionByEnv(env)

--- a/tests/pytests/vecsim_utils.py
+++ b/tests/pytests/vecsim_utils.py
@@ -90,7 +90,7 @@ def wait_for_background_indexing(env, index_name, field_name, message=''):
     index_state = f"iter: {iter}, index_sizes: {index_sizes}, flat_index_sizes: {flat_index_sizes}, backend_index_sizes: {backend_index_sizes}, is_trained: {is_trained}"
 
     try:
-        with TimeLimit(120):
+        with TimeLimit(250):
             while not all(is_trained):
                 # 'BACKGROUND_INDEXING' == 0 means training is done
                 for i, con in enumerate(env.getOSSMasterNodesConnectionList()):
@@ -103,6 +103,10 @@ def wait_for_background_indexing(env, index_name, field_name, message=''):
                 time.sleep(0.1)
                 iter += 1
                 index_state = f"iter: {iter}, index_sizes: {index_sizes}, flat_index_sizes: {flat_index_sizes}, backend_index_sizes: {backend_index_sizes}, is_trained: {is_trained}"
+            # Drain workers to ensure all background job cleanup (including job object
+            # deallocation from tracked memory) has completed before returning.
+            for con in env.getOSSMasterNodesConnectionList():
+                con.execute_command(debug_cmd(), 'WORKERS', 'DRAIN')
         for id, con in enumerate(env.getOSSMasterNodesConnectionList()):
             index_size = get_tiered_debug_info(con, index_name, field_name)['INDEX_SIZE']
             env.assertGreater(get_tiered_backend_debug_info(con, index_name, field_name)['INDEX_SIZE'], 0, message=f"wait_for_background_indexing: shard: {id}, index size: {index_size}" + message)


### PR DESCRIPTION
**Current:** Two SVS-related tests are flaky on macOS x86_64:
1. `test_hybrid_query_with_text_vamana` (MOD-14826) — times out in OSS cluster mode because SVS training takes a long time on slow macOS x86_64 CI runners, exceeding the 120s timeout in `wait_for_background_indexing`.
2. `test_vecsim_svs:test_gc` (MOD-14725) — memory assertion fails because `wait_for_background_indexing` returns as soon as `BACKGROUND_INDEXING == 0`, but background job cleanup (`delete_job`) runs *after* the mutex is released. This race means ~304 bytes of tracked memory from job objects may be freed between the "before" and "after" memory measurements.

**Change:** This PR applies fixes on two levels:

*RediSearch (this PR):*
- **Increase `wait_for_background_indexing` timeout** from 120s to 250s to accommodate slow macOS x86_64 CI runners where SVS training can take 40–85s per shard (MOD-14826).
- **Drain workers after background indexing completes** — call `DEBUG WORKERS DRAIN` on all shards after the `BACKGROUND_INDEXING == 0` loop exits. This ensures all async job cleanup (including job object deallocation from tracked memory) finishes before tests proceed, closing the race window that caused the memory assertion failure (MOD-14725).
- **Re-enable `test_hybrid_query_with_text_vamana`** — remove the `SkipTest` added by skip PR (#9023).

*VectorSimilarity (via [RedisAI/VectorSimilarity#931](https://github.com/RedisAI/VectorSimilarity/pull/931)):*
- Replace `std::lock_guard` with `std::unique_lock` using `try_to_lock` in `TieredSVSIndex::debugInfo()`. If the mutex is held (training in progress), report `indexUpdateScheduled = true` instead of blocking. This is an observability improvement — it prevents `debugInfo()` from stalling the caller for the full training duration, so status polling returns immediately rather than hanging on the socket.

**Outcome:** Both flaky tests are fixed. The timeout is generous enough for slow CI machines, memory measurements are stable because workers are fully drained before assertions run, and `debugInfo()` no longer blocks during training.

#### Which additional issues this PR fixes
1. MOD-14826 — `test_hybrid_query_with_text_vamana` flaky timeout on macOS x86_64
2. MOD-14725 — `test_vecsim_svs:test_gc` flaky memory assertion on macOS x86_64

#### Main objects this PR modified
1. `deps/VectorSimilarity` — bumped submodule to include `try_to_lock` fix in `debugInfo()`
2. `tests/pytests/vecsim_utils.py` — increased timeout, added `WORKERS DRAIN` after background indexing
3. `tests/pytests/test_vecsim.py` — removed `SkipTest` for `test_hybrid_query_with_text_vamana`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes



If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that increase wait time and add worker draining; main risk is longer CI runtime or hiding real performance regressions behind a larger timeout.
> 
> **Overview**
> Re-enables the previously skipped `test_hybrid_query_with_text_vamana` and adds simple timing debug output around `wait_for_background_indexing` to help diagnose slow SVS training.
> 
> Stabilizes SVS-related tests by extending `wait_for_background_indexing`’s timeout from **120s to 250s** and draining async workers (`DEBUG WORKERS DRAIN`) after background indexing completes to avoid post-training cleanup races (notably affecting memory assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c6f8cdf87c81b38929b705f972ce2ef50da016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->