### PR TITLE
CI: Fix script injection vulnerabilities in workflows

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -117,7 +117,7 @@ jobs:
         if: steps.benchmark-filter.outputs.skip != 'true'
         env:
           REJSON_BRANCH: ${{ inputs.rejson_branch }}
-        run: REJSON_BRANCH=$REJSON_BRANCH ./tests/deps/setup_rejson.sh
+        run: ./tests/deps/setup_rejson.sh
 
       - name: Run CI benchmarks on aws for envs ${{ inputs.allowed_envs }}
         if: steps.benchmark-filter.outputs.skip != 'true'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -115,7 +115,9 @@ jobs:
           terraform_wrapper: false
       - name: Prepare ReJSON Module
         if: steps.benchmark-filter.outputs.skip != 'true'
-        run: REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh
+        env:
+          REJSON_BRANCH: ${{ inputs.rejson_branch }}
+        run: REJSON_BRANCH=$REJSON_BRANCH ./tests/deps/setup_rejson.sh
 
       - name: Run CI benchmarks on aws for envs ${{ inputs.allowed_envs }}
         if: steps.benchmark-filter.outputs.skip != 'true'
@@ -136,20 +138,25 @@ jobs:
           BENCHMARK_RUNNER_GROUP_M_ID: ${{ inputs.benchmark_runner_group_member_id }}
           BENCHMARK_RUNNER_GROUP_TOTAL: ${{ inputs.benchmark_runner_group_total }}
           SEARCH_MEMORY_ENABLED: 1
+          MODULE_PATH: ${{ inputs.module_path }}
+          REJSON_MODULE_PATH: ${{ inputs.rejson_module_path }}
+          TRIGGERING_ENV: ${{ inputs.triggering_env }}
+          ALLOWED_ENVS: ${{ inputs.allowed_envs }}
+          ALLOWED_SETUPS: ${{ inputs.allowed_setups }}
         run: redisbench-admin run-remote
-              --module_path ../../${{ inputs.module_path }}
+              --module_path ../../$MODULE_PATH
               --required-module search
               --github_actor ${{ github.triggering_actor }}
               --github_repo ${{ github.event.repository.name }}
               --github_org ${{ github.repository_owner }}
-              --module_path ../../${{ inputs.rejson_module_path }}
+              --module_path ../../$REJSON_MODULE_PATH
               --required-module ReJSON
               --github_sha ${{ github.sha }}
               --github_branch ${{ github.head_ref || github.ref_name }}
               --upload_results_s3
-              --triggering_env ${{ inputs.triggering_env }}
-              --allowed-envs ${{ inputs.allowed_envs }}
-              --allowed-setups ${{ inputs.allowed_setups }}
+              --triggering_env $TRIGGERING_ENV
+              --allowed-envs $ALLOWED_ENVS
+              --allowed-setups $ALLOWED_SETUPS
               --push_results_redistimeseries
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}
               --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }}

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -94,11 +94,16 @@ jobs:
           fi
       - name: Validate Reference
         shell: python
+        env:
+          INPUT_ARCHITECTURE: ${{ inputs.architecture }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          GIT_REF_NAME: ${{ github.ref_name }}
         run: |
+          import os
           from re import fullmatch
-          ref = '${{ github.ref_name }}'
+          ref = os.environ['GIT_REF_NAME']
           if bool(fullmatch(r'[0-9]+\.[0-9]+', ref)) or ref == 'master': # e.g. 2.8, 2.10, master
-            if '${{ inputs.architecture }}' != 'all' or '${{ inputs.platform }}' != 'all':
+            if os.environ['INPUT_ARCHITECTURE'] != 'all' or os.environ['INPUT_PLATFORM'] != 'all':
               print("::error title=Invalid Request::"
                     "You can only build all configurations for master or a release branch")
               exit(1)

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats
       - name: Collect results
+        env:
+          INPUT_ARCHITECTURE: ${{ inputs.architecture }}
         run: |
           # Determine OS name
           OS_NAME=$(uname | tr '[:upper:]' '[:lower:]')
@@ -152,7 +154,7 @@ jobs:
               --results-format google.benchmark \
               --benchmark-result-file "$file" \
               --triggering_env redisearch-micro-benchmarks \
-              --architecture ${{ inputs.architecture }}
+              --architecture $INPUT_ARCHITECTURE
           done
 
   stop-runner:

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Set matrix
         id: set-matrix
+        env:
+          INPUT_ARCHITECTURE: ${{ inputs.architecture }}
         run: |
           # Define the full matrix as a JSON string
           FULL_MATRIX='
@@ -47,12 +49,12 @@ jobs:
           '
 
           # Filter the matrix based on architecture
-          if [ "${{ inputs.architecture }}" = "all" ]; then
+          if [ "$INPUT_ARCHITECTURE" = "all" ]; then
             # Use the full matrix
             FILTERED_MATRIX="$FULL_MATRIX"
           else
             # Filter to only the selected architecture
-            FILTERED_MATRIX=$(echo "$FULL_MATRIX" | jq -c '{include: [.include[] | select(.architecture | contains("${{ inputs.architecture }}"))]}')
+            FILTERED_MATRIX=$(echo "$FULL_MATRIX" | jq -c "{include: [.include[] | select(.architecture | contains(\"$INPUT_ARCHITECTURE\"))]}")
           fi
 
           # Use multiline output delimiter syntax for GitHub Actions

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Generate filtered matrix
         id: generate-matrix
         shell: python
+        env:
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_ARCHITECTURE: ${{ inputs.architecture }}
         run: |
           import json
           import os
@@ -89,8 +92,8 @@ jobs:
               ('intel', 'x86_64'),  # Self-hosted EC2 runner
           ]
 
-          platform_filter = "${{ inputs.platform }}"
-          architecture_filter = "${{ inputs.architecture }}"
+          platform_filter = os.environ["INPUT_PLATFORM"]
+          architecture_filter = os.environ["INPUT_ARCHITECTURE"]
           include_coverage = "${{ inputs.include-coverage }}" == "true"
           include_sanitize = "${{ inputs.include-sanitize }}" == "true"
           separate_coordinator = "${{ inputs.separate-coordinator-job }}" == "true"

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -230,13 +230,16 @@ jobs:
           node20_supported: ${{ needs.get-config.outputs.node20_supported }}
       - name: Set Version identifier
         id: set-versions
+        env:
+          INPUT_VERSION_SUFFIX: ${{ inputs.version-suffix }}
+          INPUT_BETA_VERSION: ${{ inputs.beta-version }}
         run: |
-          VERSION_SUFFIX="${{ inputs.version-suffix }}"
+          VERSION_SUFFIX="$INPUT_VERSION_SUFFIX"
           echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_OUTPUT
           # Use the pre-generated beta version if provided (master branch builds)
           # Otherwise generate regular version from version.h (non-master branch builds)
-          if [[ -n "${{ inputs.beta-version }}" ]]; then
-            BETA_VERSION="${{ inputs.beta-version }}"
+          if [[ -n "$INPUT_BETA_VERSION" ]]; then
+            BETA_VERSION="$INPUT_BETA_VERSION"
             echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
             echo "Using pre-generated beta version: $BETA_VERSION"
           else

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -64,13 +64,16 @@ jobs:
       - name: Get configuration for platform and architecture
         id: get-config
         shell: python
+        env:
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_ARCHITECTURE: ${{ inputs.architecture }}
         run: |
           import json
           import os
           import sys
 
-          platform = "${{ inputs.platform }}"
-          architecture = "${{ inputs.architecture }}"
+          platform = os.environ["INPUT_PLATFORM"]
+          architecture = os.environ["INPUT_ARCHITECTURE"]
           print(f"Getting configuration for platform: {platform}, architecture: {architecture}")
 
           # Default environment per architecture

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -34,6 +34,8 @@ jobs:
         id: latest
         if: ${{ !inputs.prefix }}
         # Get the `tag_name` of the latest release (latest patch of latest minor of latest major)
+        env:
+          INPUT_REPO: ${{ inputs.repo }}
         run: |
           TAG=$(curl -sL --retry-all-errors \
                       --retry ${{ env.RETRY_COUNT }} \
@@ -41,7 +43,7 @@ jobs:
                       -H "Accept: application/vnd.github+json" \
                       -H "X-GitHub-Api-Version: 2022-11-28" \
                       -H "authorization: Bearer ${{ github.token }}" \
-                      https://api.github.com/repos/${{ inputs.repo }}/releases/latest | \
+                      "https://api.github.com/repos/${INPUT_REPO}/releases/latest" | \
                 jq -e -r '.tag_name') && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Get Latest Release Tag with Prefix
@@ -49,6 +51,9 @@ jobs:
         if: ${{ inputs.prefix }}
         # Get the `tag_name` of the latest release with prefix:
         # Get 30 latest releases (by date), filter by prefix, sort by version, get the last one
+        env:
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_PREFIX: ${{ inputs.prefix }}
         run: |
           TAG=$(curl -sL --retry-all-errors \
                       --retry ${{ env.RETRY_COUNT }} \
@@ -56,8 +61,8 @@ jobs:
                       -H "Accept: application/vnd.github+json" \
                       -H "X-GitHub-Api-Version: 2022-11-28" \
                       -H "authorization: Bearer ${{ github.token }}" \
-                      https://api.github.com/repos/${{ inputs.repo }}/releases?per_page=${{ env.NUM_RELEASES }} | \
-                jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
+                      "https://api.github.com/repos/${INPUT_REPO}/releases?per_page=${{ env.NUM_RELEASES }}" | \
+                jq -e -r ".[].tag_name | select(startswith(\"$INPUT_PREFIX\"))" | \
                 sort -V | tail -1) && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -356,10 +356,12 @@ jobs:
 
       - name: Build Redis
         working-directory: redis
+        env:
+          SAN: ${{ inputs.san }}
         run:  ${{ needs.get-config.outputs.install_mode }} make install
               BUILD_TLS=yes
               ${{ inputs.coverage && 'REDIS_CFLAGS=-DCOVERAGE_TEST' || '' }}
-              SANITIZER=${{ inputs.san }}
+              SANITIZER=$SAN
 
       - name: Set Artifact Names
         # Artifact names have to be unique, so we base them on the environment.
@@ -428,7 +430,8 @@ jobs:
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
-        run: make pytest ${{ inputs.test-config }}
+          TEST_CONFIG: ${{ inputs.test-config }}
+        run: make pytest $TEST_CONFIG
 
       - name: Flow tests (coordinator)
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
@@ -443,7 +446,8 @@ jobs:
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
-        run: make pytest ${{ inputs.test-config }}
+          TEST_CONFIG: ${{ inputs.test-config }}
+        run: make pytest $TEST_CONFIG
 
       - name: Rust tests (MIRI)
         if: inputs.san == 'address' && inputs.unit-tests


### PR DESCRIPTION
A ton of warnings here
https://github.com/RediSearch/RediSearch/security/code-scanning

Move ${{ inputs.* }} expressions from run: blocks to env: blocks, referencing them as shell variables instead. Prevents potential command injection via workflow inputs.

Fixes 24 SonarCloud alerts (githubactions:S7630) across 9 files.

Successful run
https://github.com/RediSearch/RediSearch/actions/runs/24403252626

Only running benchmarks to make sure nothing broke. This PR does not affect performance.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are limited to CI/workflow plumbing but affect many critical pipelines; miswired env var names or quoting could break builds/tests/benchmarks despite no product code changes.
> 
> **Overview**
> Updates several GitHub Actions workflows to **prevent potential command injection via workflow inputs** by moving `${{ inputs.* }}` usage out of `run:` bodies and into `env:` variables, then referencing them as shell/Python environment variables.
> 
> This touches benchmark, artifact build, micro-benchmark, matrix generation, tag fetching, and test workflows, changing how parameters like module paths, architecture/platform filters, version suffixes, and test configs are passed to scripts/commands without changing the intended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ac121a15c82611263b049c6f468ab6134babc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->