### PR TITLE
CI: Enable LTO for build-artifacts

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -79,6 +79,7 @@ jobs:
     env:
       VERBOSE: 1 # For logging
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
+      LTO: ${{ needs.get-config.outputs.enable_lto }}
       # Build command
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
       GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
Final step for RS:
- Enable LTO for build-artifacts

Successful run (without upload step)
https://github.com/RediSearch/RediSearch/actions/runs/24401736608

Separate steps after this
- Enable for RSE
- Enable for Redis (parent repo)

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact build flags by propagating `enable_lto` into the build environment, which can affect binary output size/performance and potentially introduce build/link issues on some platforms.
> 
> **Overview**
> Build-artifacts CI now exports `LTO` from `task-get-config` into the `build` job environment, enabling platform-specific link-time optimization during artifact builds (based on `enable_lto`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9ac7ef40a1ec0366d5a3fe6506f8217a6ef581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->