### PR TITLE
[8.6] MOD-14477: Add sync-point mechanism to control concurrent executions for debugging

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -907,9 +907,17 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
 
   // lock spec
   RedisSearchCtx_LockSpecRead(sctx);
+
   if (prepareExecutionPlan(req, &status) != REDISMODULE_OK) {
     goto error;
   }
+
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): pause after iterators are created and snapshot is established.
+  // For disk indexes, the lock is already released at this point.
+  // For RAM indexes, the lock is still held.
+  SyncPoint_Wait(SYNC_POINT_AFTER_ITERATOR_CREATE);
+#endif
 
   if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
     RedisModule_Reply _reply = RedisModule_NewReply(outctx), *reply = &_reply;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -22,6 +22,7 @@
 #include "query_error.h"
 #include "info/global_stats.h"
 #include "aggregate_debug.h"
+#include "debug_commands.h"
 #include "info/info_redis/block_client.h"
 #include "info/info_redis/threads/current_thread.h"
 #include "pipeline/pipeline.h"

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -57,6 +57,125 @@ bool QueryDebugCtx_HasDebugRP(void) {
   return globalDebugCtx.query.debugRP != NULL;
 }
 
+#ifdef ENABLE_ASSERT
+
+// ============================================================================
+// Named Sync Points Implementation
+// ============================================================================
+
+// Maximum number of named sync points that can be armed simultaneously
+#define SYNC_POINT_MAX_ARMED 16
+// Maximum length of a sync point name
+#define SYNC_POINT_NAME_MAX_LEN 64
+
+// State of a single sync point
+typedef struct SyncPointState {
+  char name[SYNC_POINT_NAME_MAX_LEN];   // Name of the sync point
+  atomic_bool armed;                    // Whether this sync point is armed (will block)
+  _Atomic uint32_t waiting;             // Number of threads currently waiting at this point
+} SyncPointState;
+
+// Container for all sync point states
+typedef struct SyncPointCtx {
+  SyncPointState points[SYNC_POINT_MAX_ARMED];   // Array of sync points
+  _Atomic uint32_t count;                        // Number of armed sync points
+} SyncPointCtx;
+
+static SyncPointCtx globalSyncPointCtx = {0};
+
+// Internal helper: find sync point by name
+static SyncPointState* SyncPoint_FindByName(const char *name) {
+  // Use acquire semantics to synchronize with the release fence in SyncPoint_Arm,
+  // ensuring we see fully initialized slots when iterating.
+  uint32_t count = atomic_load_explicit(&globalSyncPointCtx.count, memory_order_acquire);
+  for (uint32_t i = 0; i < count; i++) {
+    if (strcmp(globalSyncPointCtx.points[i].name, name) == 0) {
+      return &globalSyncPointCtx.points[i];
+    }
+  }
+  return NULL;
+}
+
+bool SyncPoint_Arm(const char *name) {
+  SyncPointState *existing = SyncPoint_FindByName(name);
+  if (existing) {
+    atomic_store(&existing->armed, true);
+    return true;
+  }
+  // Reserve a slot atomically. We use a simple counter since ARM is only called
+  // from the main thread (via FT.DEBUG command), so no concurrent ARMs occur.
+  uint32_t idx = atomic_load(&globalSyncPointCtx.count);
+  if (idx >= SYNC_POINT_MAX_ARMED) {
+    return false;
+  }
+  // Initialize the slot BEFORE making it visible to avoid data race:
+  // Other threads calling SyncPoint_FindByName iterate up to `count`,
+  // so we must fully initialize before incrementing count.
+  SyncPointState *sp = &globalSyncPointCtx.points[idx];
+  strncpy(sp->name, name, SYNC_POINT_NAME_MAX_LEN - 1);
+  sp->name[SYNC_POINT_NAME_MAX_LEN - 1] = '\0';
+  atomic_store(&sp->armed, true);
+  // Note: We intentionally do NOT reset sp->waiting here.
+  // The slot is either newly allocated (waiting is 0 from static init) or
+  // reused after ClearAll drained it to 0. Resetting it here would race with
+  // threads executing atomic_fetch_sub after exiting the spin-wait loop.
+
+  // Memory fence: ensure all writes above are visible before incrementing count
+  atomic_thread_fence(memory_order_release);
+  atomic_fetch_add(&globalSyncPointCtx.count, 1);
+  return true;
+}
+
+void SyncPoint_Signal(const char *name) {
+  SyncPointState *sp = SyncPoint_FindByName(name);
+  if (sp) atomic_store(&sp->armed, false);  // Disarm to release waiting thread
+}
+
+bool SyncPoint_IsWaiting(const char *name) {
+  SyncPointState *sp = SyncPoint_FindByName(name);
+  return sp ? (atomic_load(&sp->waiting) > 0) : false;
+}
+
+bool SyncPoint_IsArmed(const char *name) {
+  SyncPointState *sp = SyncPoint_FindByName(name);
+  return sp ? atomic_load(&sp->armed) : false;
+}
+
+void SyncPoint_ClearAll(void) {
+  uint32_t count = atomic_load(&globalSyncPointCtx.count);
+
+  // First, disarm all sync points to release waiting threads
+  for (uint32_t i = 0; i < count; i++) {
+    atomic_store(&globalSyncPointCtx.points[i].armed, false);
+  }
+
+  // Wait for all waiting threads to exit their spin-wait loops.
+  // This prevents a slot reuse race: if we reset count while a thread still
+  // holds a pointer to a slot, a subsequent Arm could reuse that slot and
+  // set armed=true, causing the old thread to get trapped waiting on the
+  // wrong sync point.
+  for (uint32_t i = 0; i < count; i++) {
+    while (atomic_load(&globalSyncPointCtx.points[i].waiting) > 0) {
+      usleep(1000);  // Brief sleep to avoid busy-waiting
+    }
+  }
+
+  // Now it's safe to reset count - no threads hold pointers to slots
+  atomic_store(&globalSyncPointCtx.count, 0);
+}
+
+void SyncPoint_Wait(const char *name) {
+  SyncPointState *sp = SyncPoint_FindByName(name);
+  if (!sp || !atomic_load(&sp->armed)) return;
+
+  atomic_fetch_add(&sp->waiting, 1);  // Increment waiting counter
+  while (atomic_load(&sp->armed)) {
+    usleep(1000);  // Spin-wait with 1ms sleep (matches existing pattern)
+  }
+  atomic_fetch_sub(&sp->waiting, 1);  // Decrement waiting counter
+}
+#endif
+
 void validateDebugMode(DebugCTX *debugCtx) {
   // Debug mode is enabled if any of its field is non-default
   // Should be called after each debug command that changes the debugCtx
@@ -2065,6 +2184,64 @@ DEBUG_COMMAND(printRPStream) {
   return REDISMODULE_OK;
 }
 
+#ifdef ENABLE_ASSERT
+// Subcommand constants for SYNC_POINT
+#define SYNC_POINT_SUBCMD_ARM        "ARM"
+#define SYNC_POINT_SUBCMD_SIGNAL     "SIGNAL"
+#define SYNC_POINT_SUBCMD_IS_WAITING "IS_WAITING"
+#define SYNC_POINT_SUBCMD_IS_ARMED   "IS_ARMED"
+#define SYNC_POINT_SUBCMD_CLEAR      "CLEAR"
+
+/**
+ * FT.DEBUG SYNC_POINT <subcommand> [point_name]
+ *
+ * Subcommands:
+ *   ARM <name>        - Enable a sync point (queries will pause when reaching it)
+ *   SIGNAL <name>     - Resume execution at a sync point
+ *   IS_WAITING <name> - Check if a query is paused at a sync point
+ *   IS_ARMED <name>   - Check if a sync point is armed
+ *   CLEAR             - Reset all sync points
+ */
+DEBUG_COMMAND(syncPoint) {
+  if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  // argc layout: FT.DEBUG SYNC_POINT <subcommand> [<point_name>]
+  // argv[0] = FT.DEBUG, argv[1] = SYNC_POINT, argv[2] = subcommand, argv[3] = point_name
+  if (argc < 3) return RedisModule_WrongArity(ctx);
+
+  const char *subOp = RedisModule_StringPtrLen(argv[2], NULL);
+
+  if (!strcmp(SYNC_POINT_SUBCMD_ARM, subOp)) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    const char *name = RedisModule_StringPtrLen(argv[3], NULL);
+    if (!SyncPoint_Arm(name)) {
+      return RedisModule_ReplyWithError(ctx, "ERR max sync points reached");
+    }
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+  }
+  if (!strcmp(SYNC_POINT_SUBCMD_SIGNAL, subOp)) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    const char *name = RedisModule_StringPtrLen(argv[3], NULL);
+    SyncPoint_Signal(name);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+  }
+  if (!strcmp(SYNC_POINT_SUBCMD_IS_WAITING, subOp)) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    const char *name = RedisModule_StringPtrLen(argv[3], NULL);
+    return RedisModule_ReplyWithBool(ctx, SyncPoint_IsWaiting(name));
+  }
+  if (!strcmp(SYNC_POINT_SUBCMD_IS_ARMED, subOp)) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    const char *name = RedisModule_StringPtrLen(argv[3], NULL);
+    return RedisModule_ReplyWithBool(ctx, SyncPoint_IsArmed(name));
+  }
+  if (!strcmp(SYNC_POINT_SUBCMD_CLEAR, subOp)) {
+    SyncPoint_ClearAll();
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+  }
+  return RedisModule_ReplyWithError(ctx, "Unknown SYNC_POINT subcommand. Valid: ARM, SIGNAL, IS_WAITING, IS_ARMED, CLEAR");
+}
+#endif
+
 /**
  * FT.DEBUG QUERY_CONTROLLER <command> [options]
  */
@@ -2288,6 +2465,14 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                */
                                {NULL, NULL}};
 
+#ifdef ENABLE_ASSERT
+// Debug commands only available with ENABLE_ASSERT (debug/test builds)
+// Add new assert-only commands to this array instead of hard-coding #ifdef blocks
+static DebugCommandType assertOnlyCommands[] = {
+    {"SYNC_POINT", syncPoint},
+    {NULL, NULL}};
+#endif
+
 int DebugHelpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
   size_t len = 0;
@@ -2299,6 +2484,12 @@ int DebugHelpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_ReplyWithCString(ctx, coordCommandsNames[i]);
     ++len;
   }
+#ifdef ENABLE_ASSERT
+  for (DebugCommandType *c = &assertOnlyCommands[0]; c->name != NULL; c++) {
+    RedisModule_ReplyWithCString(ctx, c->name);
+    ++len;
+  }
+#endif
   RedisModule_ReplySetArrayLength(ctx, len);
   return REDISMODULE_OK;
 }
@@ -2310,6 +2501,14 @@ int RegisterDebugCommands(RedisModuleCommand *debugCommand) {
               RS_DEBUG_FLAGS);
     if (rc != REDISMODULE_OK) return rc;
   }
+#ifdef ENABLE_ASSERT
+  for (DebugCommandType *c = &assertOnlyCommands[0]; c->name != NULL; c++) {
+    int rc = RedisModule_CreateSubcommand(debugCommand, c->name, c->callback,
+              IsEnterprise() ? "readonly " CMD_PROXY_FILTERED : "readonly",
+              RS_DEBUG_FLAGS);
+    if (rc != REDISMODULE_OK) return rc;
+  }
+#endif
   return RedisModule_CreateSubcommand(debugCommand, "HELP", DebugHelpCommand,
           IsEnterprise() ? "readonly " CMD_PROXY_FILTERED : "readonly",
           RS_DEBUG_FLAGS);

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -9,8 +9,9 @@
 #pragma once
 
 #include "redismodule.h"
-#include  <stdbool.h>
+#include <stdbool.h>
 #include <stdatomic.h>
+#include <stdint.h>
 #include "result_processor.h"
 
 #define RS_DEBUG_FLAGS 0, 0, 0
@@ -58,6 +59,36 @@ void QueryDebugCtx_SetPause(bool pause);
 ResultProcessor* QueryDebugCtx_GetDebugRP(void);
 void QueryDebugCtx_SetDebugRP(ResultProcessor* debugRP);
 bool QueryDebugCtx_HasDebugRP(void);
+
+#ifdef ENABLE_ASSERT
+
+// ============================================================================
+// Named Sync Points for deterministic concurrency testing
+// ============================================================================
+
+// Predefined sync point names for query execution
+// These correspond to specific locations in the query execution path
+#define SYNC_POINT_AFTER_ITERATOR_CREATE  "AfterIteratorCreate"
+#define SYNC_POINT_BEFORE_FIRST_READ      "BeforeFirstRead"
+
+// SyncPoint API function declarations
+// Arm a sync point - subsequent calls to SyncPoint_Wait will block
+// Returns true on success, false if max sync points reached
+// NOTE: Not thread-safe. Must only be called from the main thread.
+bool SyncPoint_Arm(const char *name);
+// Signal a waiting thread at the named sync point to continue (also disarms it)
+void SyncPoint_Signal(const char *name);
+// Check if a thread is waiting at the named sync point
+bool SyncPoint_IsWaiting(const char *name);
+// Check if a sync point is armed
+bool SyncPoint_IsArmed(const char *name);
+// Clear all sync points
+void SyncPoint_ClearAll(void);
+// Called from code paths to potentially wait at a sync point
+// If the named point is armed, blocks until signaled
+void SyncPoint_Wait(const char *name);
+
+#endif  // ENABLE_ASSERT
 
 // Yield counter functions
 void IncrementLoadYieldCounter(void);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -51,6 +51,10 @@ typedef struct {
   uint32_t timeoutLimiter;                      // counter to limit number of calls to TimedOut_WithCounter()
   uint32_t keySpaceVersion;                     // version of the Keyspace slot ranges used for filtering
   const RedisModuleSlotRangeArray *querySlots;  // Query slots info, may be used for filtering
+
+#ifdef ENABLE_ASSERT
+  bool firstRead;  // Debug only: tracks if this is the first read for sync point testing
+#endif
 } RPQueryIterator;
 
 
@@ -113,6 +117,14 @@ static int rpQueryItNext(ResultProcessor *base, SearchResult *res) {
       goto validate_current;
     }
   }
+
+#ifdef ENABLE_ASSERT
+  // Make sure MT is enabled and `workers > 0` - deadlock otherwise.
+  if (self->firstRead) {
+    self->firstRead = false;
+    SyncPoint_Wait(SYNC_POINT_BEFORE_FIRST_READ);
+  }
+#endif
 
   // Read from the root filter until we have a valid result
   while (1) {
@@ -189,6 +201,9 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
   ret->base.Free = rpQueryItFree;
   ret->sctx = sctx;
   ret->base.type = RP_INDEX;
+#ifdef ENABLE_ASSERT
+  ret->firstRead = true;
+#endif
   return &ret->base;
 }
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -292,10 +292,17 @@ def getWorkersThpoolStats(env):
 def getWorkersThpoolNumThreads(env):
     return env.cmd(debug_cmd(), "WORKERS", "n_threads")
 
+def set_workers(env, workers):
+    """Set the worker thread count and verify that the change took effect."""
+    verify_command_OK_on_all_shards(env, config_cmd(), 'SET', 'WORKERS', workers)
+    env.assertEqual(getWorkersThpoolNumThreadsFromAllShards(env), [workers] * env.shardsCount)
 
 def getWorkersThpoolStatsFromShard(shard_conn):
     return to_dict(shard_conn.execute_command(debug_cmd(), "WORKERS", "stats"))
 
+
+def getWorkersThpoolNumThreadsFromAllShards(env):
+    return [shard_conn.execute_command(debug_cmd(), "WORKERS", "n_threads") for shard_conn in env.getOSSMasterNodesConnectionList()]
 
 def skipOnExistingEnv(env):
     if 'existing' in env.env:
@@ -964,6 +971,40 @@ def allShards_setPauseRPResume(env, start_shard=1):
         result = env.getConnection(shardId).execute_command(debug_cmd(), 'QUERY_CONTROLLER', 'SET_PAUSE_RP_RESUME')
         results.append(result)
     return results
+
+def isEnableAssertEnabled(env):
+    """
+    Check if ENABLE_ASSERT is enabled in the build.
+    Returns True if ENABLE_ASSERT commands are available, False otherwise.
+    """
+    try:
+        env.cmd(debug_cmd(), 'QUERY_CONTROLLER', 'GET_IS_COORD_REDUCE_PAUSED')
+        return True
+    except Exception:
+        return False
+
+def skipIfNoEnableAssert(env):
+    """
+    Skip the current test if ENABLE_ASSERT is not enabled in the build.
+    Call this at the beginning of tests that require ENABLE_ASSERT functionality.
+    """
+    if not isEnableAssertEnabled(env):
+        env.debugPrint("Skipping test: ENABLE_ASSERT is not enabled", force=True)
+        env.skip()
+
+def require_enable_assert(f):
+    """
+    Decorator to skip tests if ENABLE_ASSERT is not enabled in the build.
+    Usage: @require_enable_assert
+    """
+    @wraps(f)
+    def wrapper(env, *args, **kwargs):
+        if not isEnableAssertEnabled(env):
+            env.debugPrint(f"Skipping {f.__name__}: ENABLE_ASSERT is not enabled", force=True)
+            env.skip()
+            return
+        return f(env, *args, **kwargs)
+    return wrapper
 
 class vecsimMockTimeoutContext:
     """Context manager for enabling/disabling VECSIM mock timeout on all shards"""

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -978,7 +978,7 @@ def isEnableAssertEnabled(env):
     Returns True if ENABLE_ASSERT commands are available, False otherwise.
     """
     try:
-        env.cmd(debug_cmd(), 'QUERY_CONTROLLER', 'GET_IS_COORD_REDUCE_PAUSED')
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
         return True
     except Exception:
         return False

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -13,7 +13,6 @@ class TestDebugCommands(object):
                         'age', 'NUMERIC', 'SORTABLE',
                         't', 'TAG', 'SORTABLE',
                         'v', 'VECTOR', 'HNSW', 6, 'DIM', 2, 'DISTANCE_METRIC', 'L2', 'TYPE', 'float32').ok()
-        waitForIndex(self.env, 'idx')
         self.env.expect('HSET', 'doc1', 'name', 'meir', 'age', '34', 't', 'test').equal(3)
         self.env.cmd('SET', 'foo', 'bar')
 
@@ -78,6 +77,9 @@ class TestDebugCommands(object):
         ]
         coord_help_list = ['SHARD_CONNECTION_STATES', 'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY']
         help_list.extend(coord_help_list)
+        # SYNC_POINT is only available in ENABLE_ASSERT builds
+        if isEnableAssertEnabled(self.env):
+            help_list.append('SYNC_POINT')
 
         self.env.expect(debug_cmd(), 'help').equal(help_list)
 
@@ -610,7 +612,6 @@ class TestQueryDebugCommands(object):
         conn = getConnectionByEnv(self.env)
 
         self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
-        waitForIndex(self.env, 'idx')
         self.num_docs = 1500 * self.env.shardsCount
         for i in range(self.num_docs):
             conn.execute_command('HSET', f'doc{i}' ,'n', i)
@@ -1543,14 +1544,11 @@ def test_max_doc_id(env):
     for i in range(10):
         env.cmd('HSET', f'doc{i}', 't', f"hello{i}")
 
-    waitForIndex(env, 'idx')
-
     # The max doc id is now 10
     env.expect(debug_cmd(), 'GET_MAX_DOC_ID', 'idx').equal(10)
 
     # Delete some documents
     env.cmd('DEL', 'doc5', 'doc7')
-    waitForIndex(env, 'idx')
 
     # Max doc id should still be 10 (doesn't decrease on deletion)
     env.expect(debug_cmd(), 'GET_MAX_DOC_ID', 'idx').equal(10)
@@ -1558,8 +1556,6 @@ def test_max_doc_id(env):
     # Add more documents
     for i in range(10, 15):
         env.cmd('HSET', f'doc{i}', 't', f"hello{i}")
-
-    waitForIndex(env, 'idx')
 
     # Max doc id should now be 15
     env.expect(debug_cmd(), 'GET_MAX_DOC_ID', 'idx').equal(15)
@@ -1585,8 +1581,6 @@ def test_dump_deleted_ids(env):
     for i in range(10):
         env.cmd('HSET', f'doc{i}', 't', f"hello{i}")
 
-    waitForIndex(env, 'idx')
-
     # Still no deleted IDs
     env.expect(debug_cmd(), 'DUMP_DELETED_IDS', 'idx').equal([])
 
@@ -1601,3 +1595,217 @@ def test_dump_deleted_ids(env):
 
     # Test error handling - non-existent index
     env.expect(debug_cmd(), 'DUMP_DELETED_IDS', 'nonexistent').error().contains('Can not create a search ctx')
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_basic_commands(env):
+    """Verify the basic SYNC_POINT command lifecycle and error handling."""
+    sync_point = 'BeforeFirstRead'
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(False)
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point).equal(False)
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(True)
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point).equal(False)
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(False)
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(False)
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point).equal(False)
+
+    env.expect(debug_cmd(), 'SYNC_POINT').error().contains('wrong number of arguments')
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM').error().contains('wrong number of arguments')
+    env.expect(debug_cmd(), 'SYNC_POINT', 'UNKNOWN', sync_point).error() \
+        .contains('Unknown SYNC_POINT subcommand')
+
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_max_armed_limit(env):
+    """Verify that the sync point registry enforces its fixed capacity."""
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+    for i in range(16):
+        env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', f'point-{i}').ok()
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'point-overflow').error() \
+        .contains('max sync points reached')
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'point-after-clear').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', 'point-after-clear').equal(True)
+
+
+def _run_sync_point_query(conn, result_holder, error_holder, *query):
+    try:
+        result_holder.append(conn.execute_command(*query))
+    except Exception as e:
+        error_holder.append(e)
+
+
+def _assert_sync_point_query_blocks_and_resumes(env, sync_point, release_cmd, *query):
+    """Run a query in the background, wait for the sync point, then release it."""
+    conn = env.getConnection()
+    result_holder = []
+    error_holder = []
+    query_thread = threading.Thread(
+        target=_run_sync_point_query,
+        args=(conn, result_holder, error_holder, *query),
+        daemon=True
+    )
+    query_thread.start()
+
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+        f'Timeout waiting for {sync_point} sync point')
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(True)
+    env.expect(*release_cmd).ok()
+
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 0, {}),
+        f'Timeout waiting for {sync_point} sync point to resume')
+
+    query_thread.join(timeout=10)
+    env.assertFalse(query_thread.is_alive(), message='Query thread is still blocked after release')
+    env.assertEqual(len(error_holder), 0, message=str(error_holder[0]) if error_holder else None)
+    env.assertEqual(result_holder[0], [1, 'doc1', ['t', 'hello']])
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(False)
+
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_before_first_read_blocks_and_resumes(env):
+    """Verify that BeforeFirstRead blocks query execution until explicitly signaled."""
+    set_workers(env, 1)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('HSET', 'doc1', 't', 'hello').equal(1)
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'BeforeFirstRead').ok()
+    _assert_sync_point_query_blocks_and_resumes(
+        env,
+        'BeforeFirstRead',
+        (debug_cmd(), 'SYNC_POINT', 'SIGNAL', 'BeforeFirstRead'),
+        'FT.SEARCH', 'idx', '*'
+    )
+
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_after_iterator_create_blocks_and_resumes(env):
+    """Verify that AfterIteratorCreate blocks query execution until explicitly signaled."""
+    set_workers(env, 1)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('HSET', 'doc1', 't', 'hello').equal(1)
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'AfterIteratorCreate').ok()
+    _assert_sync_point_query_blocks_and_resumes(
+        env,
+        'AfterIteratorCreate',
+        (debug_cmd(), 'SYNC_POINT', 'SIGNAL', 'AfterIteratorCreate'),
+        'FT.SEARCH', 'idx', '*'
+    )
+
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_duplicate_arm_does_not_consume_extra_slot(env):
+    """Verify that re-arming the same named sync point is idempotent for capacity."""
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+    for _ in range(32):
+        env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'point-0').ok()
+
+    for i in range(1, 16):
+        env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', f'point-{i}').ok()
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'point-overflow').error() \
+        .contains('max sync points reached')
+
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_clear_releases_waiting_query(env):
+    """Verify that CLEAR disarms sync points and releases any blocked query."""
+    set_workers(env, 1)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('HSET', 'doc1', 't', 'hello').equal(1)
+
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', 'BeforeFirstRead').ok()
+    _assert_sync_point_query_blocks_and_resumes(
+        env,
+        'BeforeFirstRead',
+        (debug_cmd(), 'SYNC_POINT', 'CLEAR'),
+        'FT.SEARCH', 'idx', '*'
+    )
+
+
+@skip(cluster=True)
+@require_enable_assert
+def test_sync_point_multiple_queries_waiting(env):
+    """Verify that multiple queries can wait at the same sync point simultaneously."""
+    set_workers(env, 2)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('HSET', 'doc1', 't', 'hello').equal(1)
+    env.expect('HSET', 'doc2', 't', 'world').equal(1)
+
+    sync_point = 'BeforeFirstRead'
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+    # Start two queries in parallel
+    conn1 = env.getConnection()
+    conn2 = env.getConnection()
+    results1, errors1 = [], []
+    results2, errors2 = [], []
+
+    thread1 = threading.Thread(
+        target=_run_sync_point_query,
+        args=(conn1, results1, errors1, 'FT.SEARCH', 'idx', '*'),
+        daemon=True
+    )
+    thread2 = threading.Thread(
+        target=_run_sync_point_query,
+        args=(conn2, results2, errors2, 'FT.SEARCH', 'idx', '*'),
+        daemon=True
+    )
+
+    thread1.start()
+    thread2.start()
+
+    # Wait for both queries to reach the sync point
+    # The waiting counter should report 2 (true for IS_WAITING)
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+        'Timeout waiting for first query to reach sync point')
+
+    # Give the second query time to also reach the sync point
+    time.sleep(0.1)
+
+    # Signal to release both queries
+    env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+
+    # Wait for both queries to complete
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+
+    env.assertFalse(thread1.is_alive(), message='Query thread 1 is still blocked after release')
+    env.assertFalse(thread2.is_alive(), message='Query thread 2 is still blocked after release')
+    env.assertEqual(len(errors1), 0, message=str(errors1[0]) if errors1 else None)
+    env.assertEqual(len(errors2), 0, message=str(errors2[0]) if errors2 else None)
+
+    # Both queries should have returned results (2 docs each)
+    env.assertEqual(results1[0][0], 2)
+    env.assertEqual(results2[0][0], 2)
+
+    # Sync point should no longer be armed and no queries should be waiting
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_ARMED', sync_point).equal(False)
+    env.expect(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point).equal(False)


### PR DESCRIPTION
Backport #8680 to `8.6`

(cherry picked from commit 06209b434399b5e1b12ef35c378d2a9320661cb9)

- In `common.py` were included functions required by the tests that were created in PR #8236 :
   `isEnableAssertEnabled()`, `skipIfNoEnableAssert()`, and `require_enable_assert()`
- `isEnableAssertEnabled()` was modified to use   `env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')` because `QUERY_CONTROLLER GET_IS_COORD_REDUCE_PAUSED`  debug command doesn't exist in this branch.
   

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated behind `ENABLE_ASSERT` and primarily add test/debug-only control points; production builds should be unaffected aside from minimal compile-time wiring.
> 
> **Overview**
> Adds a debug-only *sync point* mechanism (via `FT.DEBUG SYNC_POINT`) to deterministically pause and resume concurrent query execution for debugging and concurrency testing.
> 
> When built with `ENABLE_ASSERT`, query execution now optionally blocks at two predefined points (`AfterIteratorCreate` and `BeforeFirstRead`), with new pytests and helpers to arm/signal/clear sync points and verify blocking behavior and capacity limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c56a8473061c4550668a1ed2fa4ccbed110c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->