### PR TITLE
[2.10] Reject Invalid Schema Options Combination - [MOD-14655]

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1353,7 +1353,7 @@ StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryEr
     }
   }
   if ((spec->flags & Index_WideSchema) && !(spec->flags & Index_StoreFieldFlags)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
+    QueryError_SetError(status, QUERY_EINVAL,
                         SPEC_SCHEMA_EXPANDABLE_STR " cannot be used with " SPEC_NOFIELDS_STR);
     goto failure;
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1352,6 +1352,11 @@ StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryEr
       goto failure;
     }
   }
+  if ((spec->flags & Index_WideSchema) && !(spec->flags & Index_StoreFieldFlags)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
+                        SPEC_SCHEMA_EXPANDABLE_STR " cannot be used with " SPEC_NOFIELDS_STR);
+    goto failure;
+  }
 
   if (timeout != -1) {
     spec->flags |= Index_Temporary;
@@ -2652,6 +2657,14 @@ void Indexes_ScanAndReindex() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
+static void IndexSpec_NormalizeStorageFlagsOnLoad(IndexFlags *flags) {
+  if ((*flags & Index_WideSchema) && !(*flags & Index_StoreFieldFlags)) {
+    *flags &= ~Index_WideSchema;
+    RedisModule_Log(RSDummyContext, "warning", "Ignoring %s because %s is set",
+                    SPEC_SCHEMA_EXPANDABLE_STR, SPEC_NOFIELDS_STR);
+  }
+}
+
 int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
                                        QueryError *status) {
   char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup_no_index);
@@ -2687,6 +2700,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     sp->flags |= Index_StoreFreqs;
   }
+  IndexSpec_NormalizeStorageFlagsOnLoad(&sp->flags);
 
   sp->numFields = LoadUnsigned_IOError(rdb, goto cleanup);
   sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));
@@ -2810,6 +2824,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     sp->flags |= Index_StoreFreqs;
   }
+  IndexSpec_NormalizeStorageFlagsOnLoad(&sp->flags);
 
   sp->numFields = RedisModule_LoadUnsigned(rdb);
   sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1310,6 +1310,15 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_TRUE(!(s->flags & Index_StoreTermOffsets));
   IndexSpec_RemoveFromGlobals(ref);
 
+  const char *args_invalid[] = {
+      "NOFIELDS", "MAXTEXTFIELDS", "SCHEMA", title, "TEXT",
+  };
+  QueryError_ClearError(&err);
+  ref = IndexSpec_ParseC(NULL, "idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
+  ASSERT_TRUE(QueryError_HasError(&err));
+  ASSERT_EQ(nullptr, StrongRef_Get(ref));
+  ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "MAXTEXTFIELDS cannot be used with NOFIELDS"));
+
   // User-reported bug
   const char *args3[] = {"SCHEMA", "ha", "NUMERIC", "hb", "TEXT", "WEIGHT", "1", "NOSTEM"};
   QueryError_ClearError(&err);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1314,7 +1314,7 @@ TEST_F(IndexTest, testIndexSpec) {
       "NOFIELDS", "MAXTEXTFIELDS", "SCHEMA", title, "TEXT",
   };
   QueryError_ClearError(&err);
-  ref = IndexSpec_ParseC(NULL, "idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
+  ref = IndexSpec_Parse("idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_EQ(nullptr, StrongRef_Get(ref));
   ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "MAXTEXTFIELDS cannot be used with NOFIELDS"));

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -196,6 +196,16 @@ def test_issue1932(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '1000000', '100000000000000000', 'SORTBY', '1', '@t').error() \
       .contains('LIMIT exceeds maximum of 2147483648')
 
+@skip(cluster=True)
+def test_MOD_14655(env:Env):
+  env.expect('FT.CREATE', 'idx', 'NOFIELDS', 'MAXTEXTFIELDS', 'SCHEMA', 't', 'TEXT').error() \
+      .contains('MAXTEXTFIELDS cannot be used with NOFIELDS')
+
+  # Previously, if the index was created successfully, the following HSET will cause a crash.
+  with env.getClusterConnectionIfNeeded() as conn:
+    conn.execute_command('HSET', 'doc1', 't', 'hello world')
+
+
 def test_issue1988(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')


### PR DESCRIPTION
# Description
Backport of #8941 to `2.10`.

## Describe the changes in the pull request

This fixes a crash caused by allowing the invalid `FT.CREATE` combination `NOFIELDS` + `MAXTEXTFIELDS`. That combination could produce unsupported text index storage flags and later crash during indexing when selecting the inverted-index encoder.

The fix rejects this combination at `FT.CREATE` time, and also hardens RDB loading by normalizing old persisted specs with that flag combination instead of failing startup. Regression tests were added for command parsing and RDB load behavior.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes index creation argument validation and RDB spec loading behavior, which could affect compatibility for edge-case existing indexes and startup migrations.
> 
> **Overview**
> **Release note:** Fixes a crash caused by allowing `FT.CREATE` with the invalid option combination `NOFIELDS` + `MAXTEXTFIELDS` (wide/expandable schema without stored field flags). The server now rejects this combination at index creation with a clear error, and **on RDB load** it automatically drops the incompatible `MAXTEXTFIELDS`/wide-schema flag combination (logging a warning) to keep older persisted indexes from crashing on startup.
> 
> Adds regression coverage in C++ and Python tests for the new validation and the previously crashing scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc711ff3608e4dfcabf20c9d6f773e0ef23e6c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->