### PR TITLE
[8.2] Reject Invalid Schema Options Combination - [MOD-14655]

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1575,6 +1575,11 @@ StrongRef IndexSpec_Parse(const HiddenString *name, const char **argv, int argc,
       goto failure;
     }
   }
+  if ((spec->flags & Index_WideSchema) && !(spec->flags & Index_StoreFieldFlags)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
+                        SPEC_SCHEMA_EXPANDABLE_STR " cannot be used with " SPEC_NOFIELDS_STR);
+    goto failure;
+  }
 
   if (timeout != -1) {
     spec->flags |= Index_Temporary;
@@ -2991,6 +2996,14 @@ void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp) {
   }
 }
 
+static void IndexSpec_NormalizeStorageFlagsOnLoad(IndexFlags *flags) {
+  if ((*flags & Index_WideSchema) && !(*flags & Index_StoreFieldFlags)) {
+    *flags &= ~Index_WideSchema;
+    RedisModule_Log(RSDummyContext, "warning", "Ignoring %s because %s is set",
+                    SPEC_SCHEMA_EXPANDABLE_STR, SPEC_NOFIELDS_STR);
+  }
+}
+
 IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status) {
   char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup_no_index);
   size_t len = strlen(rawName);
@@ -3007,6 +3020,8 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     flags |= Index_StoreFreqs;
   }
+  IndexSpec_NormalizeStorageFlagsOnLoad(&flags);
+
   int16_t numFields = LoadUnsigned_IOError(rdb, goto cleanup);
 
   initializeIndexSpec(sp, specName, flags, numFields);
@@ -3143,6 +3158,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     sp->flags |= Index_StoreFreqs;
   }
+  IndexSpec_NormalizeStorageFlagsOnLoad(&sp->flags);
 
   sp->numFields = RedisModule_LoadUnsigned(rdb);
   sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));

--- a/src/spec.c
+++ b/src/spec.c
@@ -1576,7 +1576,7 @@ StrongRef IndexSpec_Parse(const HiddenString *name, const char **argv, int argc,
     }
   }
   if ((spec->flags & Index_WideSchema) && !(spec->flags & Index_StoreFieldFlags)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
+    QueryError_SetError(status, QUERY_EINVAL,
                         SPEC_SCHEMA_EXPANDABLE_STR " cannot be used with " SPEC_NOFIELDS_STR);
     goto failure;
   }

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1300,6 +1300,15 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_TRUE(!(s->flags & Index_StoreTermOffsets));
   IndexSpec_RemoveFromGlobals(ref, false);
 
+  const char *args_invalid[] = {
+      "NOFIELDS", "MAXTEXTFIELDS", "SCHEMA", title, "TEXT",
+  };
+  QueryError_ClearError(&err);
+  ref = IndexSpec_ParseC(NULL, "idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
+  ASSERT_TRUE(QueryError_HasError(&err));
+  ASSERT_EQ(nullptr, StrongRef_Get(ref));
+  ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "MAXTEXTFIELDS cannot be used with NOFIELDS"));
+
   // User-reported bug
   const char *args3[] = {"SCHEMA", "ha", "NUMERIC", "hb", "TEXT", "WEIGHT", "1", "NOSTEM"};
   QueryError_ClearError(&err);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1304,7 +1304,7 @@ TEST_F(IndexTest, testIndexSpec) {
       "NOFIELDS", "MAXTEXTFIELDS", "SCHEMA", title, "TEXT",
   };
   QueryError_ClearError(&err);
-  ref = IndexSpec_ParseC(NULL, "idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
+  ref = IndexSpec_ParseC("idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_EQ(nullptr, StrongRef_Get(ref));
   ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "MAXTEXTFIELDS cannot be used with NOFIELDS"));

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -216,6 +216,49 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
     }
 }
 
+TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
+
+    const char *args[] = {"NOFIELDS", "SCHEMA", "title", "TEXT"};
+    QueryError err = QueryError_Default();
+
+    StrongRef original_spec_ref = IndexSpec_ParseC(NULL, "test_rdb_invalid_idx", args, sizeof(args) / sizeof(const char *), &err);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+
+    IndexSpec *spec = (IndexSpec *)StrongRef_Get(original_spec_ref);
+    ASSERT_TRUE(spec != nullptr);
+    std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> specPtr(spec, [](IndexSpec *spec) {
+        StrongRef_Release(spec->own_ref);
+    });
+
+    // Make sure Index_StoreFieldFlags is not set, and turn on Index_WideSchema which is invalid without it, to simulate an invalid RDB state that we want to normalize on load
+    ASSERT_FALSE(spec->flags & Index_StoreFieldFlags) << "Original IndexSpec should not have storage flags set";
+    uint64_t flags = spec->flags;
+    flags |= Index_WideSchema;
+    spec->flags = (IndexFlags)flags;
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    IndexSpec_RdbSave(io, spec, 0);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    io->read_pos = 0;
+
+    QueryError status = QueryError_Default();
+    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, false, &status);
+    ASSERT_NE(nullptr, loadedSpec);
+    std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {
+        StrongRef_Release(spec->own_ref);
+    });
+    // We expect no error, and the invalid storage flags to be normalized (i.e., Index_WideSchema should be turned off because Index_StoreFieldFlags is not set)
+    EXPECT_FALSE(QueryError_HasError(&status)) << QueryError_GetUserError(&status);
+    EXPECT_FALSE(loadedSpec->flags & Index_WideSchema);
+    EXPECT_FALSE(loadedSpec->flags & Index_StoreFieldFlags);
+}
+
 TEST_F(RdbMockTest, testDuplicateIndexRdbLoad) {
     // Create an index with a single text field
     const char *args[] = {"ON", "HASH", "SCHEMA", "title", "TEXT"};

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -247,7 +247,7 @@ TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
 
     io->read_pos = 0;
 
-    QueryError status = QueryError_Default();
+    QueryError status = {QUERY_OK};
     IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, &status);
     ASSERT_NE(nullptr, loadedSpec);
     std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -219,9 +219,9 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
 TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
 
     const char *args[] = {"NOFIELDS", "SCHEMA", "title", "TEXT"};
-    QueryError err = QueryError_Default();
+    QueryError err = {QUERY_OK};
 
-    StrongRef original_spec_ref = IndexSpec_ParseC(NULL, "test_rdb_invalid_idx", args, sizeof(args) / sizeof(const char *), &err);
+    StrongRef original_spec_ref = IndexSpec_ParseC("test_rdb_invalid_idx", args, sizeof(args) / sizeof(const char *), &err);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
 
     IndexSpec *spec = (IndexSpec *)StrongRef_Get(original_spec_ref);
@@ -242,13 +242,13 @@ TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
     });
     ASSERT_TRUE(io != nullptr);
 
-    IndexSpec_RdbSave(io, spec, 0);
+    IndexSpec_RdbSave(io, spec);
     EXPECT_EQ(0, RMCK_IsIOError(io));
 
     io->read_pos = 0;
 
     QueryError status = QueryError_Default();
-    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, false, &status);
+    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, &status);
     ASSERT_NE(nullptr, loadedSpec);
     std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {
         StrongRef_Release(spec->own_ref);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -196,6 +196,16 @@ def test_issue1932(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '1000000', '100000000000000000', 'SORTBY', '1', '@t').error() \
       .contains('LIMIT exceeds maximum of 2147483648')
 
+@skip(cluster=True)
+def test_MOD_14655(env:Env):
+  env.expect('FT.CREATE', 'idx', 'NOFIELDS', 'MAXTEXTFIELDS', 'SCHEMA', 't', 'TEXT').error() \
+      .contains('MAXTEXTFIELDS cannot be used with NOFIELDS')
+
+  # Previously, if the index was created successfully, the following HSET will cause a crash.
+  with env.getClusterConnectionIfNeeded() as conn:
+    conn.execute_command('HSET', 'doc1', 't', 'hello world')
+
+
 def test_issue1988(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')


### PR DESCRIPTION
# Description
Backport of #8941 to `8.2`.

## Describe the changes in the pull request

This fixes a crash caused by allowing the invalid `FT.CREATE` combination `NOFIELDS` + `MAXTEXTFIELDS`. That combination could produce unsupported text index storage flags and later crash during indexing when selecting the inverted-index encoder.

The fix rejects this combination at `FT.CREATE` time, and also hardens RDB loading by normalizing old persisted specs with that flag combination instead of failing startup. Regression tests were added for command parsing and RDB load behavior.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens `FT.CREATE` validation and changes how persisted index flags are interpreted on load; could affect users relying on previously-accepted (but invalid) option combinations or legacy RDBs with inconsistent flags.
> 
> **Overview**
> Prevents a crash by rejecting the invalid `FT.CREATE` option combination `NOFIELDS` + `MAXTEXTFIELDS` (wide/expandable schema without stored field flags), returning a clear error instead of creating a broken index.
> 
> Hardens startup by normalizing legacy/persisted specs during RDB load: if an index has `MAXTEXTFIELDS` set while `NOFIELDS` is also set, the loader now drops the wide-schema flag and logs a warning. Adds regression tests covering the command error and the RDB-load normalization path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65c4a1db9d417aaf0e6ea6dc3076b1f5937d9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->