### PR TITLE
[8.6] Reject Invalid Schema Options Combination - [MOD-14655]

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1689,6 +1689,11 @@ StrongRef IndexSpec_Parse(const HiddenString *name, const char **argv, int argc,
     QueryError_SetError(status, QUERY_ERROR_CODE_FLEX_UNSUPPORTED_FT_CREATE_ARGUMENT, "Only HASH is supported as index data type for Flex indexes");
     goto failure;
   }
+  if ((spec->flags & Index_WideSchema) && !(spec->flags & Index_StoreFieldFlags)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
+                        SPEC_SCHEMA_EXPANDABLE_STR " cannot be used with " SPEC_NOFIELDS_STR);
+    goto failure;
+  }
 
   if (timeout != -1) {
     spec->flags |= Index_Temporary;
@@ -3141,6 +3146,14 @@ void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp) {
   }
 }
 
+static void IndexSpec_NormalizeStorageFlagsOnLoad(IndexFlags *flags) {
+  if ((*flags & Index_WideSchema) && !(*flags & Index_StoreFieldFlags)) {
+    *flags &= ~Index_WideSchema;
+    RedisModule_Log(RSDummyContext, "warning", "Ignoring %s because %s is set",
+                    SPEC_SCHEMA_EXPANDABLE_STR, SPEC_NOFIELDS_STR);
+  }
+}
+
 IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status) {
   char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup_no_index);
   size_t len = strlen(rawName);
@@ -3157,6 +3170,8 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     flags |= Index_StoreFreqs;
   }
+  IndexSpec_NormalizeStorageFlagsOnLoad(&flags);
+
   int16_t numFields = LoadUnsigned_IOError(rdb, goto cleanup);
 
   initializeIndexSpec(sp, specName, flags, numFields);
@@ -3327,6 +3342,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     sp->flags |= Index_StoreFreqs;
   }
+  IndexSpec_NormalizeStorageFlagsOnLoad(&sp->flags);
 
   sp->numFields = RedisModule_LoadUnsigned(rdb);
   sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1121,6 +1121,15 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_TRUE(!(s->flags & Index_StoreTermOffsets));
   IndexSpec_RemoveFromGlobals(ref, false);
 
+  const char *args_invalid[] = {
+      "NOFIELDS", "MAXTEXTFIELDS", "SCHEMA", title, "TEXT",
+  };
+  QueryError_ClearError(&err);
+  ref = IndexSpec_ParseC(NULL, "idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
+  ASSERT_TRUE(QueryError_HasError(&err));
+  ASSERT_EQ(nullptr, StrongRef_Get(ref));
+  ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "MAXTEXTFIELDS cannot be used with NOFIELDS"));
+
   // User-reported bug
   const char *args3[] = {"SCHEMA", "ha", "NUMERIC", "hb", "TEXT", "WEIGHT", "1", "NOSTEM"};
   QueryError_ClearError(&err);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1125,7 +1125,7 @@ TEST_F(IndexTest, testIndexSpec) {
       "NOFIELDS", "MAXTEXTFIELDS", "SCHEMA", title, "TEXT",
   };
   QueryError_ClearError(&err);
-  ref = IndexSpec_ParseC(NULL, "idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
+  ref = IndexSpec_ParseC("idx", args_invalid, sizeof(args_invalid) / sizeof(args_invalid[0]), &err);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_EQ(nullptr, StrongRef_Get(ref));
   ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "MAXTEXTFIELDS cannot be used with NOFIELDS"));

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -216,6 +216,49 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
     }
 }
 
+TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
+
+    const char *args[] = {"NOFIELDS", "SCHEMA", "title", "TEXT"};
+    QueryError err = QueryError_Default();
+
+    StrongRef original_spec_ref = IndexSpec_ParseC(NULL, "test_rdb_invalid_idx", args, sizeof(args) / sizeof(const char *), &err);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+
+    IndexSpec *spec = (IndexSpec *)StrongRef_Get(original_spec_ref);
+    ASSERT_TRUE(spec != nullptr);
+    std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> specPtr(spec, [](IndexSpec *spec) {
+        StrongRef_Release(spec->own_ref);
+    });
+
+    // Make sure Index_StoreFieldFlags is not set, and turn on Index_WideSchema which is invalid without it, to simulate an invalid RDB state that we want to normalize on load
+    ASSERT_FALSE(spec->flags & Index_StoreFieldFlags) << "Original IndexSpec should not have storage flags set";
+    uint64_t flags = spec->flags;
+    flags |= Index_WideSchema;
+    spec->flags = (IndexFlags)flags;
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    IndexSpec_RdbSave(io, spec, 0);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    io->read_pos = 0;
+
+    QueryError status = QueryError_Default();
+    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, false, &status);
+    ASSERT_NE(nullptr, loadedSpec);
+    std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {
+        StrongRef_Release(spec->own_ref);
+    });
+    // We expect no error, and the invalid storage flags to be normalized (i.e., Index_WideSchema should be turned off because Index_StoreFieldFlags is not set)
+    EXPECT_FALSE(QueryError_HasError(&status)) << QueryError_GetUserError(&status);
+    EXPECT_FALSE(loadedSpec->flags & Index_WideSchema);
+    EXPECT_FALSE(loadedSpec->flags & Index_StoreFieldFlags);
+}
+
 TEST_F(RdbMockTest, testIndexSpecStringSerialize) {
 
     // Create an IndexSpec

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -221,7 +221,7 @@ TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
     const char *args[] = {"NOFIELDS", "SCHEMA", "title", "TEXT"};
     QueryError err = QueryError_Default();
 
-    StrongRef original_spec_ref = IndexSpec_ParseC(NULL, "test_rdb_invalid_idx", args, sizeof(args) / sizeof(const char *), &err);
+    StrongRef original_spec_ref = IndexSpec_ParseC("test_rdb_invalid_idx", args, sizeof(args) / sizeof(const char *), &err);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
 
     IndexSpec *spec = (IndexSpec *)StrongRef_Get(original_spec_ref);
@@ -242,13 +242,13 @@ TEST_F(RdbMockTest, testIndexSpecRdbLoadNormalizesInvalidStorageFlags) {
     });
     ASSERT_TRUE(io != nullptr);
 
-    IndexSpec_RdbSave(io, spec, 0);
+    IndexSpec_RdbSave(io, spec);
     EXPECT_EQ(0, RMCK_IsIOError(io));
 
     io->read_pos = 0;
 
     QueryError status = QueryError_Default();
-    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, false, &status);
+    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, &status);
     ASSERT_NE(nullptr, loadedSpec);
     std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {
         StrongRef_Release(spec->own_ref);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -192,6 +192,16 @@ def test_issue1932(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '1000000', '100000000000000000', 'SORTBY', '1', '@t').error() \
       .contains('LIMIT exceeds maximum of 2147483648')
 
+@skip(cluster=True)
+def test_MOD_14655(env:Env):
+  env.expect('FT.CREATE', 'idx', 'NOFIELDS', 'MAXTEXTFIELDS', 'SCHEMA', 't', 'TEXT').error() \
+      .contains('MAXTEXTFIELDS cannot be used with NOFIELDS')
+
+  # Previously, if the index was created successfully, the following HSET will cause a crash.
+  with env.getClusterConnectionIfNeeded() as conn:
+    conn.execute_command('HSET', 'doc1', 't', 'hello world')
+
+
 def test_issue1988(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')


### PR DESCRIPTION
# Description
Backport of #8941 to `8.6`.

## Describe the changes in the pull request

This fixes a crash caused by allowing the invalid `FT.CREATE` combination `NOFIELDS` + `MAXTEXTFIELDS`. That combination could produce unsupported text index storage flags and later crash during indexing when selecting the inverted-index encoder.

The fix rejects this combination at `FT.CREATE` time, and also hardens RDB loading by normalizing old persisted specs with that flag combination instead of failing startup. Regression tests were added for command parsing and RDB load behavior.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches index creation validation and RDB load normalization; mistakes could reject previously accepted inputs or change behavior when loading existing persisted indexes.
> 
> **Overview**
> Prevents creating indexes with the invalid `FT.CREATE NOFIELDS MAXTEXTFIELDS` option combination (now returns an error), avoiding a crash later during indexing.
> 
> Hardens upgrades/startup by normalizing persisted specs that contain the same invalid storage-flag combination on RDB load (logs a warning and drops `MAXTEXTFIELDS`/`Index_WideSchema` instead of failing). Regression tests were added for both command parsing and RDB load behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42784b5c30a1892ab0919c367bb11372ce3b123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->