### PR TITLE
[8.6] Resolve `PARAMS` in `FT.SPELLCHECK` command - [MOD-10596]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.dSYM
 /bin/
 /site/
-/venv*/
+/*venv*/
 /srcutil/lemon
 /src/query_parser/lemon
 /.vscode/

--- a/src/module.c
+++ b/src/module.c
@@ -35,6 +35,7 @@
 #include "cursor.h"
 #include "debug_commands.h"
 #include "spell_check.h"
+#include "query_param.h"
 #include "dictionary.h"
 #include "suggest.h"
 #include "numeric_index.h"
@@ -327,9 +328,25 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   const char **includeDict = NULL, **excludeDict = NULL;
   RSSearchOptions opts = {0};
   QueryAST qast = {0};
-  int rc = QAST_Parse(&qast, sctx, &opts, rawQuery, len, dialect, &status);
 
-  if (rc != REDISMODULE_OK) {
+  // Parse PARAMS if present
+  int paramsArgIndex = RMUtil_ArgExists("PARAMS", argv, argc, argvOffset);
+  if (paramsArgIndex > 0) {
+    ArgsCursor ac;
+    ArgsCursor_InitRString(&ac, argv + paramsArgIndex + 1, argc - paramsArgIndex - 1);
+    if (parseParams(&opts.params, &ac, &status) != REDISMODULE_OK) {
+      RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
+      goto end;
+    }
+  }
+
+  if (QAST_Parse(&qast, sctx, &opts, rawQuery, len, dialect, &status) != REDISMODULE_OK) {
+    RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
+    goto end;
+  }
+
+  // Evaluate parameters in the parsed query AST
+  if (QAST_EvalParams(&qast, &opts, dialect, &status) != REDISMODULE_OK) {
     RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
     goto end;
   }
@@ -389,6 +406,9 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 end:
   QueryError_ClearError(&status);
+  if (opts.params) {
+    Param_DictFree(opts.params);
+  }
   if (includeDict != NULL) {
     array_free(includeDict);
   }

--- a/src/query.c
+++ b/src/query.c
@@ -1594,8 +1594,7 @@ int QAST_Expand(QueryAST *q, const char *expander, RSSearchOptions *opts, RedisS
 int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, unsigned int dialectVersion, QueryError *status) {
   if (!q || !q->root || q->numParams == 0)
     return REDISMODULE_OK;
-  QueryNode_EvalParams(opts->params, q->root, dialectVersion, status);
-  return REDISMODULE_OK;
+  return QueryNode_EvalParams(opts->params, q->root, dialectVersion, status);
 }
 
 int QueryNode_EvalParams(dict *params, QueryNode *n, unsigned int dialectVersion, QueryError *status) {

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -199,7 +199,7 @@ def test_spell_check_with_params(env:Env):
     compare_lists(env, res1, res2)
 
     # Missing PARAMS: $a in dialect 3 without PARAMS should error, not crash
-    env.expect('ft.spellcheck', 'idx', '$a', 'DIALECT', '3').error().contains('Parameter not found `a`')
+    env.expect('ft.spellcheck', 'idx', '$a', 'DIALECT', '3').error().contains('No such parameter `a`')
 
     # Cover the PARAMS parsing error path
     env.expect('ft.spellcheck', 'idx', '$a', 'PARAMS', '3', 'a', 'b', 'c', 'DIALECT', '2').error().contains('Parameters must be specified in PARAM VALUE pairs')

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -176,3 +176,35 @@ def testSpellCheckIssue437(env):
                'Tooni toque kerfuffle', 'TERMS',
                'EXCLUDE', 'slang', 'TERMS',
                'INCLUDE', 'slang').equal([['TERM', 'tooni', [['0', 'toonie']]]])
+
+def test_spell_check_with_params(env:Env):
+    """Test FT.SPELLCHECK with PARAMS support (MOD-10596).
+    Covers parameterized queries in dialect 2 and 3, missing params error,
+    and fuzzy params."""
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc4', 'name', 'hello', 'body', 'help')
+
+    # Dialect 2: parameterized query should match non-parameterized baseline
+    res1 = env.cmd('ft.spellcheck', 'idx', 'name', 'DIALECT', '2')
+    res2 = env.cmd('ft.spellcheck', 'idx', '$query', 'PARAMS', '2', 'query', 'name', 'DIALECT', '2')
+    compare_lists(env, res1, res2)
+
+    # Dialect 3: the exact scenario that causes the crash
+    res1 = env.cmd('ft.spellcheck', 'idx', 'name', 'DIALECT', '3')
+    res2 = env.cmd('ft.spellcheck', 'idx', '$query', 'PARAMS', '2', 'query', 'name', 'DIALECT', '3')
+    compare_lists(env, res1, res2)
+
+    # Missing PARAMS: $a in dialect 3 without PARAMS should error, not crash
+    env.expect('ft.spellcheck', 'idx', '$a', 'DIALECT', '3').error().contains('Parameter not found `a`')
+
+    # Cover the PARAMS parsing error path
+    env.expect('ft.spellcheck', 'idx', '$a', 'PARAMS', '3', 'a', 'b', 'c', 'DIALECT', '2').error().contains('Parameters must be specified in PARAM VALUE pairs')
+
+    # Fuzzy params
+    res1 = env.cmd('ft.spellcheck', 'idx', '%hell%', 'DIALECT', '2')
+    res2 = env.cmd('ft.spellcheck', 'idx', '%$tok%', 'PARAMS', '2', 'tok', 'hell', 'DIALECT', '2')
+    compare_lists(env, res1, res2)


### PR DESCRIPTION
# Description
Backport of #8901 to `8.6`.

## Describe the changes in the pull request

Fix a bug where attributes/parameters in the `FT.SPELLCHECK` command could be left unresolved, leading to an invalid read.
Adding missing support for `PARAMS` in `FT.SPELLCHECK`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query parsing/parameter evaluation and error propagation for `FT.SPELLCHECK`, which can affect request validation and failure modes across dialects; behavior is covered by new regression tests but impacts a core query path.
> 
> **Overview**
> `FT.SPELLCHECK` now supports `PARAMS`: the command parses provided param pairs into `RSSearchOptions`, resolves them against the parsed query via `QAST_EvalParams`, and frees the param dict on exit.
> 
> `QAST_EvalParams` is updated to propagate errors from `QueryNode_EvalParams` instead of always returning success, and new pytests cover dialect 2/3 parameterized spellcheck, missing/invalid `PARAMS` errors, and fuzzy param substitution. `.gitignore` is tweaked to ignore venv directories via `/*venv*/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f554056ac64ca7528a22c7f7e04884aa014d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->