### PR TITLE
CI: Enable LTO for benchmarks

### DIFF
--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
       - name: Build RediSearch
-        run: make build ${{ inputs.profile_env == 1 && 'PROFILE' || '' }}
+        run: make build LTO=1 ${{ inputs.profile_env == 1 && 'PROFILE' || '' }}
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats
       - name: Upload redisearch.so artifact

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Run Micro Benchmark
         env:
           ARCH: ${{ inputs.architecture }}
+          LTO: 1
         timeout-minutes: 300
         run: |
           export HOME=/home/ubuntu

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
       - name: Build RediSearch
-        run: make build
+        run: make build LTO=1
       - name: Download Latest Baseline Artifact from master
         id: get-artifact
         if: github.event_name == 'pull_request'


### PR DESCRIPTION


#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that toggle build flags for benchmarks; main risk is altered benchmark comparability and longer CI build times due to LTO.
> 
> **Overview**
> Benchmark CI builds now enable link-time optimization by default. The benchmark binary build workflow and the Rust micro-benchmark workflow invoke `make build LTO=1`, and the micro-benchmarks runner exports `LTO=1` so `make micro-benchmarks` uses the LTO build path for benchmark runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7e440c5fe5362a224791746bb619e45295e483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->