### PR TITLE
[8.6] update redisbench-admin version to 0.12.15 (#9053)

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -78,7 +78,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.15
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -78,7 +78,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.9
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Then install Python dependencies
           sudo apt install python3-pip -y
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.9
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
       - name: Compare benchmark results
         run: |
           redisbench-admin compare \

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.12.9
+redisbench_admin==0.12.14
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
Backport #9053 to 8.6

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to CI benchmark tooling; main risk is workflow behavior changes due to the new `redisbench-admin` versions (including a minor version mismatch between runner and compare steps).
> 
> **Overview**
> Updates micro-benchmark CI to use newer `redisbench-admin` versions: the EC2 runner workflow installs `redisbench-admin==0.12.15`, while the compare workflow and `tests/benchmarks/requirements.txt` move to `0.12.14`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8547488547e04df0812d3bc0c61709f2a9af9c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->