### PR TITLE
[8.4] update redisbench-admin version to 0.12.14 (#9053)

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -78,7 +78,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.6
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Then install Python dependencies
           sudo apt install python3-pip -y
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.6
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
       - name: Compare benchmark results
         run: |
           redisbench-admin compare \

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.12.6
+redisbench_admin==0.12.14
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
Backport #9053 to 8.4

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `redisbench-admin` tooling version used by CI micro-benchmark workflows and benchmark requirements, without changing product/runtime code paths.
> 
> **Overview**
> **Release note:** Updates the micro-benchmark CI tooling to `redisbench-admin` `0.12.14` (from `0.12.6`) in both the benchmark workflows and `tests/benchmarks/requirements.txt`, ensuring benchmark runs and comparisons use the newer tool version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78593b256b0a303fb72db2336853a7f568a4d22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->