### PR TITLE
[8.4][MOD-14649] fix stack smashing error on coord tests (#9045)

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -172,8 +172,6 @@ TEST_F(IORuntimeCtxCommonTest, Schedule) {
 }
 
 TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
-  GTEST_SKIP() << "Temporarily skipping ScheduleTopology.";
-
   // Reset the signal before starting
   lastAppliedCapShards.store(0, std::memory_order_relaxed);
 
@@ -195,7 +193,12 @@ TEST_F(IORuntimeCtxCommonTest, ScheduleTopology) {
     return lastAppliedCapShards.load(std::memory_order_acquire) == 4097;
   });
   ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, lastAppliedCapShards=" << lastAppliedCapShards.load();
-  // We don't need to free newTopo here as it's handled by testTopoCallback
+
+  // Wait for the testCallback to complete before `counter` goes out of scope.
+  // Otherwise the event loop thread may write to a dangling stack address,
+  // corrupting the stack canary and triggering "stack smashing detected".
+  success = RS::WaitForCondition([&]() { return counter >= 1; });
+  ASSERT_TRUE(success) << "Timeout waiting for scheduled callback to complete";
 }
 
 TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
@@ -219,6 +222,12 @@ TEST_F(IORuntimeCtxCommonTest, MultipleTopologyUpdates) {
     return lastAppliedCapShards.load(std::memory_order_acquire) == 4101;
   });
   ASSERT_TRUE(success) << "Timeout waiting for topology to be applied, lastAppliedCapShards=" << lastAppliedCapShards.load();
+
+  // Wait for the testCallbacks to complete before `counter` goes out of scope.
+  // Otherwise the event loop thread may write to a dangling stack address,
+  // corrupting the stack canary and triggering "stack smashing detected".
+  success = RS::WaitForCondition([&]() { return counter >= 2; });
+  ASSERT_TRUE(success) << "Timeout waiting for scheduled callbacks to complete";
 }
 
 TEST_F(IORuntimeCtxCommonTest, ClearPendingTopo) {


### PR DESCRIPTION
Backport #9045 to 8.4
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to C++ coord tests. Main risk is potential test flakiness/timeouts due to added waits on async callback completion.
> 
> **Overview**
> Re-enables `ScheduleTopology` and hardens the IO runtime context topology tests against a use-after-scope bug that could trigger "stack smashing detected".
> 
> After waiting for the topology-apply signal, the tests now also wait for scheduled `testCallback` executions to complete (via `RS::WaitForCondition`) before returning, ensuring the event loop thread doesn’t write to a dangling `counter` stack address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e02c319b1273ce52401b73d4882ec52b06bdac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->