### PR TITLE
ci: bump test-timeout from 60 to 120 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch to use when building RedisJSON for tests"
       test-timeout:
         type: number
-        default: 60
+        default: 120
       fail-fast:
         type: boolean
         default: false


### PR DESCRIPTION
Bump the default `test-timeout` input in the `task-test.yml` CI workflow from 60 to 120 minutes.

This timeout applies to all test steps (C/C++ tests, Rust tests, flow tests, and MIRI tests).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just increases the allowed runtime for test steps; main impact is potentially longer CI runs before failing when jobs hang.
> 
> **Overview**
> Increases the default `test-timeout` input in `.github/workflows/task-test.yml` from 60 to 120 minutes, extending `timeout-minutes` for all workflow test steps that reference `inputs.test-timeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c4527adff4befcbd06c73514e0bb163d89cc36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->