### PR TITLE
Skip flaky test_with_tls_and_non_tls_ports (RED-176581)

### DIFF
--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4572,8 +4572,10 @@ def test_with_tls():
 
     common_with_auth(env)
 
-# TODO: enable macos+san once https://redislabs.atlassian.net/browse/RED-176581 is fixed
-@skip(cluster=False, macos=True, asan=True)
+# Skipped due to RED-176581: cluster fails to recover after `CONFIG SET tls-cluster no`
+# with dual TLS. The cluster bus connections get permanently stuck with "Connection refused".
+# Re-enable once RED-176581 is resolved.
+@skip()
 def test_with_tls_and_non_tls_ports():
     """Tests that the coordinator-shard connections are using the correct
     protocol (TLS vs. non-TLS) according to the redis `tls-cluster` configuration."""


### PR DESCRIPTION
## Summary

Skip `test_with_tls_and_non_tls_ports` entirely until [RED-176581](https://redislabs.atlassian.net/browse/RED-176581) is resolved.

## Problem

This test is flaky due to a Redis server bug where the cluster fails to recover after `CONFIG SET tls-cluster no` with dual TLS enabled. The cluster bus connections get permanently stuck with "Connection refused" across all nodes, causing `waitCluster()` to time out.

The test was previously skipped only on macOS and ASAN, but the failure also reproduces on Linux coverage builds against Redis unstable (e.g., [this CI run](https://github.com/RediSearch/RediSearch/actions/runs/24391402396/attempts/1?pr=8983)).

### Related tickets
- [RED-176581](https://redislabs.atlassian.net/browse/RED-176581) — "Cluster fail after setting tls-cluster to no"
- [MOD-9216](https://redislabs.atlassian.net/browse/MOD-9216) — "Fix flaky TLS test in RLTest"

## Changes

- Changed `@skip(cluster=False, macos=True, asan=True)` → `@skip()` (unconditional skip)
- Updated the comment to reference RED-176581 and explain the root cause

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[RED-176581]: https://redislabs.atlassian.net/browse/RED-176581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RED-176581]: https://redislabs.atlassian.net/browse/RED-176581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-9216]: https://redislabs.atlassian.net/browse/MOD-9216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ