### PR TITLE
Increase step timeout for coordinator tests to reduce failures on macOS 26

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -47,6 +47,9 @@ jobs:
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,fail-fast,sanitize' }}
       separate-coordinator-job: true
       rejson-branch: master
+      # Bump test timeout from 60 to 90 minutes to prevent spurious failures in the merge queue
+      # due to the slowness of macOS runners
+      test-timeout: 90
 
   pr-validation:
     needs:

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -31,6 +31,9 @@ on:
         type: boolean
         default: false
         description: "Run coordinator tests in a separate parallel job per platform"
+      test-timeout:
+        type: number
+        default: 60
 
   workflow_dispatch:
     inputs:
@@ -104,6 +107,9 @@ on:
         type: boolean
         default: false
         description: "Run coordinator tests in a separate parallel job per platform"
+      test-timeout:
+        type: number
+        default: 60
 
 jobs:
   generate-matrix:
@@ -141,3 +147,4 @@ jobs:
       coverage: ${{ matrix.job-type == 'coverage' }}
       san: ${{ matrix.job-type == 'sanitize' && 'address' || '' }}
       fail-fast: ${{ contains(inputs.options, 'fail-fast') || inputs.fail-fast == true }}
+      test-timeout: ${{ inputs.test-timeout }}


### PR DESCRIPTION
## Describe the changes in the pull request

Try to avoid failures like https://github.com/RediSearch/RediSearch/actions/runs/24437386576/job/71395386202 on macOS 26.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow changes that increase test step `timeout-minutes` and add a configurable `test-timeout` input; main impact is longer CI runtime if jobs hang.
> 
> **Overview**
> Increases merge-queue CI reliability on slower macOS runners by bumping the `flow-test` timeout from **60 to 90 minutes** for merge-group runs.
> 
> Makes `flow-test.yml` accept a new `test-timeout` input (default `60`) and forwards it through the matrix to `task-test.yml`, so all test steps use the configured `timeout-minutes` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2036f58b8197e1bc33e87abf5f18bdf504df25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->