### PR TITLE
[8.2] ci: bump test-timeout from 60 to 120 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch to use when building RedisJSON for tests"
       test-timeout:
         type: number
-        default: 50
+        default: 120
       fail-fast:
         type: boolean
         default: false


### PR DESCRIPTION
# Description
Backport of #9093 to `8.2`.

Bump the default `test-timeout` input in the `task-test.yml` CI workflow from 50 to 120 minutes.

This timeout applies to all test steps (C/C++ tests, Rust tests, flow tests, and MIRI tests).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just extends the allowed runtime for test steps. Main impact is potentially longer CI runs before timing out if tests hang.
> 
> **Overview**
> Extends the default `test-timeout` for the reusable `task-test.yml` GitHub Actions workflow from 50 to 120 minutes, reducing flaky CI failures caused by long-running test suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbdebbb89f0359faaa6d5686ed850a56783c895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->