### PR TITLE
[8.4] ci: bump test-timeout from 60 to 120 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch to use when building RedisJSON for tests"
       test-timeout:
         type: number
-        default: 50
+        default: 120
       fail-fast:
         type: boolean
         default: false


### PR DESCRIPTION
# Description
Backport of #9093 to `8.4`.

Bump the default `test-timeout` input in the `task-test.yml` CI workflow from 50 to 120 minutes.

This timeout applies to all test steps (C/C++ tests, Rust tests, flow tests, and MIRI tests).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just increases the allowed runtime for existing test steps, with no impact on product code or runtime behavior.
> 
> **Overview**
> Increases the default `test-timeout` input in `.github/workflows/task-test.yml` from 50 to 120 minutes, giving C/C++, Rust, flow, and MIRI test steps more time to complete and reducing CI failures due to timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f517d4ed3f8b1f27acf1b136d01d38b6a29ba98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->