### PR TITLE
[8.6] ci: bump test-timeout from 60 to 120 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch to use when building RedisJSON for tests"
       test-timeout:
         type: number
-        default: 50
+        default: 120
       fail-fast:
         type: boolean
         default: false


### PR DESCRIPTION
# Description
Backport of #9093 to `8.6`.

Bump the default `test-timeout` input in the `task-test.yml` CI workflow from 50 to 120 minutes.

This timeout applies to all test steps (C/C++ tests, Rust tests, flow tests, and MIRI tests).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes CI workflow configuration by allowing tests to run longer before timing out.
> 
> **Overview**
> **Release note:** CI test jobs now default to a longer timeout (`test-timeout` increased from 50 to 120 minutes in `.github/workflows/task-test.yml`), reducing spurious failures on slower/loaded runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1dc56813c0710f03cb86a972d8fa3df58d790d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->