### PR TITLE
[8.6-rse] ci: bump test-timeout from 60 to 120 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch to use when building RedisJSON for tests"
       test-timeout:
         type: number
-        default: 50
+        default: 120
       fail-fast:
         type: boolean
         default: false


### PR DESCRIPTION
# Description
Backport of #9093 to `8.6-rse`.

Bump the default `test-timeout` input in the `task-test.yml` CI workflow from 50 to 120 minutes.

This timeout applies to all test steps (C/C++ tests, Rust tests, flow tests, and MIRI tests).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the default `test-timeout` input for the `task-test.yml` GitHub Actions workflow, affecting CI execution time but not product code.
> 
> **Overview**
> Increases the default `test-timeout` input in `.github/workflows/task-test.yml` from `50` to `120` minutes, extending the timeout applied to all test steps that use `timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b089b7b64e06ba7f8083dd2e61f32c91c7471f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->