### PR TITLE
Update benchmark documentation in developer.md

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -265,22 +265,22 @@ To start the external redis-server instance:
 
 #### Full-Text Search Benchmark (FTSB)
 
-Ensure you have Full-Text Search Benchmark (FTSB) installed. See installation instructions here: https://github.com/RediSearch/ftsb
+Install Full-Text Search Benchmark (FTSB) as per the instructions on https://github.com/RediSearch/ftsb
 
 Make sure you have the `ftsb_redisearch` binary available in your `$PATH`.
 
 #### memtier_benchmark
 
-Also ensure you have `memtier_benchmark` installed. See installation instructions here: https://github.com/redis/memtier_benchmark
+Install `memtier_benchmark` as per the instructions on https://github.com/redis/memtier_benchmark
+
+Make sure you have the `memtier_benchmark` binary available in your `$PATH`.
 
 #### Python packages
 
 Install necessary python packages:
 
-NOTE: You will need to have your python virtual env activated. See steps for 'Python Tests'.
-
 ```sh
-pip3 install -r ./tests/benchmarks/requirements.txt
+uv pip install -r ./tests/benchmarks/requirements.txt
 ```
 
 ### Run benchmarks
@@ -288,7 +288,7 @@ pip3 install -r ./tests/benchmarks/requirements.txt
 To run a specific benchmark, use the following command:
 
 ```sh
-redisbench-admin run-local \
+uv redisbench-admin run-local \
     --module_path $(find $(pwd)/bin -name "redisearch.so" | head -1) \
     --required-module search \
     --allowed-setups oss-standalone \
@@ -300,18 +300,20 @@ Replace `<benchmark>` in the `--test` argument with the desired benchmark file. 
 
 #### Profiling benchmarks with Samply
 
-Install samply as per the instructions on https://github.com/mstange/samply
+Install `samply` as per the instructions on https://github.com/mstange/samply
 
-In one termimal panel run:
+Make sure you have the `samply` binary available in your `$PATH`.
+
+In one terminal panel run:
 
 ```sh
-samply record redis-server --module-path $(find $(pwd)/bin -name "redisearch.so" | head -1)
+samply record redis-server --loadmodule $(find $(pwd)/bin -name "redisearch.so" | head -1)
 ```
 
 In the other terminal panel run:
 
 ```sh
-redisbench-admin run-local \
+uv redisbench-admin run-local \
     --skip-redis-spin True \
     --required-module search \
     --allowed-setups oss-standalone \

--- a/developer.md
+++ b/developer.md
@@ -277,6 +277,8 @@ Also ensure you have `memtier_benchmark` installed. See installation instruction
 
 Install necessary python packages:
 
+NOTE: You will need to have your python virtual env activated. See steps for 'Python Tests'.
+
 ```sh
 pip3 install -r ./tests/benchmarks/requirements.txt
 ```
@@ -291,13 +293,31 @@ redisbench-admin run-local \
     --required-module search \
     --allowed-setups oss-standalone \
     --allowed-envs oss-standalone \
-    --skip-redis-spin True \
     --test tests/benchmarks/<benchmark>.yml
 ```
 
 Replace `<benchmark>` in the `--test` argument with the desired benchmark file. Look in `tests/benchmarks` for all available benchmarks.
 
-Use `--skip-redis-spin True` to skip spinning up a Redis instance.
+#### Profiling benchmarks with Samply
+
+Install samply as per the instructions on https://github.com/mstange/samply
+
+In one termimal panel run:
+
+```sh
+samply record redis-server --module-path $(find $(pwd)/bin -name "redisearch.so" | head -1)
+```
+
+In the other terminal panel run:
+
+```sh
+redisbench-admin run-local \
+    --skip-redis-spin True \
+    --required-module search \
+    --allowed-setups oss-standalone \
+    --allowed-envs oss-standalone \
+    --test tests/benchmarks/<benchmark>.yml
+```
 
 ## Supported Platforms
 


### PR DESCRIPTION
The documentation was missing info on profiling and had one bug in the `redisbench-admin` invocation.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no production code or runtime behavior changes.
> 
> **Overview**
> Refreshes `developer.md` benchmarking instructions by clarifying FTSB/memtier installation expectations (including PATH requirements) and switching commands to use `uv` (for `pip` installs and `redisbench-admin`).
> 
> Fixes the sample `redisbench-admin run-local` invocation by removing the misplaced `--skip-redis-spin` flag from the main benchmark command, and adds a new section showing how to profile benchmarks using `samply` with a manually launched `redis-server` plus `--skip-redis-spin True`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657055798074091858f7e4336bae533b2216f072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->