### PR TITLE
[8.6] MOD-14826 MOD-14725: Fix flaky SVS tests — non-blocking debugInfo + drain workers + increase timeout (#9058)

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -881,7 +881,9 @@ def test_hybrid_query_with_text_vamana():
     create_vector_index(env, dim, datatype=data_type, alg='SVS-VAMANA', additional_schema_args=['t', 'TEXT'])
 
     load_vectors_with_texts_into_redis(conn, DEFAULT_FIELD_NAME, dim, index_size, data_type)
+    start_time = time.time()
     wait_for_background_indexing(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.debugPrint("wait_for_background_indexing took {} seconds".format(time.time() - start_time), force=True)
     index_size = get_tiered_backend_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)['INDEX_SIZE']
     env.debugPrint(f"svs index size: {index_size}", force=True)
 

--- a/tests/pytests/vecsim_utils.py
+++ b/tests/pytests/vecsim_utils.py
@@ -90,7 +90,7 @@ def wait_for_background_indexing(env, index_name, field_name, message=''):
     index_state = f"iter: {iter}, index_sizes: {index_sizes}, flat_index_sizes: {flat_index_sizes}, backend_index_sizes: {backend_index_sizes}, is_trained: {is_trained}"
 
     try:
-        with TimeLimit(120):
+        with TimeLimit(250):
             while not all(is_trained):
                 # 'BACKGROUND_INDEXING' == 0 means training is done
                 for i, con in enumerate(env.getOSSMasterNodesConnectionList()):
@@ -103,6 +103,10 @@ def wait_for_background_indexing(env, index_name, field_name, message=''):
                 time.sleep(0.1)
                 iter += 1
                 index_state = f"iter: {iter}, index_sizes: {index_sizes}, flat_index_sizes: {flat_index_sizes}, backend_index_sizes: {backend_index_sizes}, is_trained: {is_trained}"
+            # Drain workers to ensure all background job cleanup (including job object
+            # deallocation from tracked memory) has completed before returning.
+            for con in env.getOSSMasterNodesConnectionList():
+                con.execute_command(debug_cmd(), 'WORKERS', 'DRAIN')
         for id, con in enumerate(env.getOSSMasterNodesConnectionList()):
             index_size = get_tiered_debug_info(con, index_name, field_name)['INDEX_SIZE']
             env.assertGreater(get_tiered_backend_debug_info(con, index_name, field_name)['INDEX_SIZE'], 0, message=f"wait_for_background_indexing: shard: {id}, index size: {index_size}" + message)


### PR DESCRIPTION
backport #9058 to 8.6


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to pytest utilities/tests (timeouts, worker draining, extra debug logging) with no production code impact.
> 
> **Overview**
> Improves reliability of SVS-VAMANA hybrid VecSim tests by increasing the background-indexing wait timeout and draining workers after training so async job cleanup finishes before assertions.
> 
> Adds timing debug output around `wait_for_background_indexing` in `test_hybrid_query_with_text_vamana` to make slow/flaky CI runs easier to diagnose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7220b0303cb5907b246549c4e170159b3d5d1975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->