### PR TITLE
MOD-14900: Skip Push When PR Is From Forked Repository

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -54,6 +54,7 @@ jobs:
           SAN: ${{ inputs.san }}
           RUNNER_ENV: ${{ inputs.runner-env }}
           RUN_ID: ${{ github.run_id }}
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           IMAGE_NAME="ghcr.io/redisearch/redisearch-ci"
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
@@ -66,6 +67,12 @@ jobs:
           echo "cache=$CACHE_REF" >> "$GITHUB_OUTPUT"
           echo "Using image tag: $IMAGE_TAG"
           echo "Using cache ref: $CACHE_REF"
+          if [[ "$IS_FORK_PR" == "true" ]]; then
+            echo "can_push=false" >> "$GITHUB_OUTPUT"
+            echo "Cross-repo PR detected. Skipping GHCR push."
+          else
+            echo "can_push=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -84,7 +91,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v7
         with:
-          push: true
+          push: ${{ steps.meta.outputs.can_push == 'true' }}
           context: .
           build-args: |
             BASE_IMAGE=${{ inputs.container }}
@@ -93,10 +100,15 @@ jobs:
             GITHUB_TOKEN=${{ github.token }}
           file: Dockerfile
           tags: ${{ steps.meta.outputs.image }}
-          cache-to: type=registry,ref=${{ steps.meta.outputs.cache }},mode=max,compression=zstd
+          cache-to: ${{ steps.meta.outputs.can_push == 'true' && format('type=registry,ref={0},mode=max,compression=zstd', steps.meta.outputs.cache) || '' }}
           cache-from: type=registry,ref=${{ steps.meta.outputs.cache }}
 
       - name: Mark build status
+        if: always()
         id: mark-status
         run: |
-          echo "succeeded=true" >> "$GITHUB_OUTPUT"
+          if [[ "${{ steps.meta.outputs.can_push }}" == "true" && "${{ steps.build-and-push.outcome }}" == "success" ]]; then
+            echo "succeeded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "succeeded=false" >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
Skip push when PR is from forked repository
Prevent push from failing due to insufficient permissions.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI build/push behavior and the `succeeded` output semantics, which can affect downstream jobs and caching performance.
> 
> **Overview**
> Prevents forked pull requests from failing the cached container build by detecting cross-repo PRs and **skipping GHCR image push and registry cache export** when `packages:write` isn’t usable.
> 
> Adds a `can_push` flag from the metadata step to gate `docker/build-push-action`’s `push` and `cache-to`, and updates the workflow output `succeeded` to only report success when a push was allowed and the build step succeeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb6656b00e4766fe2830ee55dd4d506879eb0bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->