### PR TITLE
Add missing `SharedRsValue` helpers

### DIFF
--- a/src/redisearch_rs/value/src/lib.rs
+++ b/src/redisearch_rs/value/src/lib.rs
@@ -52,10 +52,6 @@ pub enum RsValue {
 }
 
 impl RsValue {
-    pub fn new_string(str: Vec<u8>) -> Self {
-        Self::String(RsString::from_vec(str))
-    }
-
     pub fn fully_dereferenced_ref(&self) -> &Self {
         match self {
             RsValue::Ref(ref_value) => ref_value.fully_dereferenced_ref(),

--- a/src/redisearch_rs/value/src/shared.rs
+++ b/src/redisearch_rs/value/src/shared.rs
@@ -15,7 +15,7 @@ use std::{
 
 use triomphe::Arc;
 
-use crate::RsValue;
+use crate::{Array, Map, RsString, RsValue, RsValueTrio};
 
 /// The total heap allocation size of the `triomphe::Arc` inner struct.
 /// Since that struct is inaccessible/hidden, the size is calculated manually,
@@ -132,12 +132,33 @@ impl SharedRsValue {
         }
     }
 
+    /// Create a new `SharedRsValue` of `RsValue::Number` type.
     pub fn new_num(num: f64) -> Self {
         Self::new(RsValue::Number(num))
     }
 
+    /// Create a new `SharedRsValue` of `RsValue::String` type.
     pub fn new_string(str: Vec<u8>) -> Self {
-        Self::new(RsValue::new_string(str))
+        Self::new(RsValue::String(RsString::from_vec(str)))
+    }
+
+    /// Create a new `SharedRsValue` of `RsValue::Array` type.
+    pub fn new_array(
+        values: impl IntoIterator<IntoIter: ExactSizeIterator, Item = SharedRsValue>,
+    ) -> Self {
+        Self::new(RsValue::Array(Array::new(values.into_iter().collect())))
+    }
+
+    /// Create a new `SharedRsValue` of `RsValue::Map` type.
+    pub fn new_map(
+        values: impl IntoIterator<IntoIter: ExactSizeIterator, Item = (SharedRsValue, SharedRsValue)>,
+    ) -> Self {
+        Self::new(RsValue::Map(Map::new(values.into_iter().collect())))
+    }
+
+    /// Create a new `SharedRsValue` of `RsValue::Trio` type.
+    pub fn new_trio(left: SharedRsValue, middle: SharedRsValue, right: SharedRsValue) -> Self {
+        Self::new(RsValue::Trio(RsValueTrio::new(left, middle, right)))
     }
 }
 

--- a/src/redisearch_rs/value/tests/integration/shared.rs
+++ b/src/redisearch_rs/value/tests/integration/shared.rs
@@ -18,15 +18,53 @@ fn null_static_holds_null() {
 }
 
 #[test]
+fn new_undefined() {
+    let v = SharedRsValue::new(RsValue::Undefined);
+    assert!(matches!(*v, RsValue::Undefined));
+}
+
+#[test]
 fn new_number() {
-    let v = SharedRsValue::new(RsValue::Number(42.0));
+    let v = SharedRsValue::new_num(42.0);
     assert!(matches!(*v, RsValue::Number(42.0)));
 }
 
 #[test]
-fn new_undefined() {
-    let v = SharedRsValue::new(RsValue::Undefined);
-    assert!(matches!(*v, RsValue::Undefined));
+fn new_string() {
+    let v = SharedRsValue::new_string(b"Hello".to_vec());
+    assert!(matches!(&*v, RsValue::String(s) if s.as_bytes() == b"Hello"));
+}
+
+#[test]
+fn new_array() {
+    let v = SharedRsValue::new_array([SharedRsValue::new_num(1.0), SharedRsValue::new_num(2.0)]);
+    assert!(matches!(&*v, RsValue::Array(a) if a.len() == 2
+        && matches!(*a[0], RsValue::Number(1.0))
+        && matches!(*a[1], RsValue::Number(2.0))));
+}
+
+#[test]
+fn new_map() {
+    let v = SharedRsValue::new_map([(
+        SharedRsValue::new_string(b"key".to_vec()),
+        SharedRsValue::new_num(42.0),
+    )]);
+    assert!(matches!(&*v, RsValue::Map(m) if m.len() == 1
+        && matches!(&*m[0].0, RsValue::String(s) if s.as_bytes() == b"key")
+        && matches!(*m[0].1, RsValue::Number(42.0))));
+}
+
+#[test]
+fn new_trio() {
+    let v = SharedRsValue::new_trio(
+        SharedRsValue::new_num(1.0),
+        SharedRsValue::new_num(2.0),
+        SharedRsValue::new_num(3.0),
+    );
+    assert!(matches!(&*v, RsValue::Trio(t)
+        if matches!(**t.left(), RsValue::Number(1.0))
+        && matches!(**t.middle(), RsValue::Number(2.0))
+        && matches!(**t.right(), RsValue::Number(3.0))));
 }
 
 #[test]


### PR DESCRIPTION
This adds missing helpers on `SharedRsValue` which were present on `RSValueFFI`.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API addition plus test updates; behavior remains the same aside from a minor helper removal, with minimal runtime risk.
> 
> **Overview**
> Adds new `SharedRsValue` helper constructors (`new_num`, `new_string`, `new_array`, `new_map`, `new_trio`) to mirror common `RsValue` variants, and removes the now-redundant `RsValue::new_string` helper.
> 
> Updates integration tests to exercise the new constructors and switches number creation to use `new_num`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71199a7a0dd84f7a29e8cd29e539de98e245fa79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->