### PR TITLE
MOD-14918 [8.6] CI: Use Redis 8.6 branch instead of unstable for tests

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,7 +18,7 @@ jobs:
     # TODO: Revert to using the latest stable ref in redis when 8.6 is released
     runs-on: ubuntu-latest
     outputs:
-      tag: unstable
+      tag: '8.6'
     steps:
       - run: echo "Dummy step to set output"
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,15 +15,10 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert to using the latest stable ref in redis when 8.6 is released
-    runs-on: ubuntu-latest
-    outputs:
-      tag: '8.6'
-    steps:
-      - run: echo "Dummy step to set output"
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
 
   lint:
     permissions:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -36,7 +36,7 @@ jobs:
 
 
   notify-failure:
-    needs: [test-all-platforms, micro-benchmarks]
+    needs: [get-latest-redis-tag, test-all-platforms, micro-benchmarks]
     if: failure()
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       platform: all
       architecture: all
-      redis-ref: unstable
+      redis-ref: '8.6'
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -10,7 +10,14 @@ on:
 # TODO: Use RedisJSON's `master` branch when testing on nightly
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
+
   test-all-platforms:
+    needs: [get-latest-redis-tag]
     permissions:
       contents: read
       packages: write
@@ -19,7 +26,7 @@ jobs:
     with:
       platform: all
       architecture: all
-      redis-ref: '8.6'
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,15 +12,10 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert when 8.6 is released
-    runs-on: ubuntu-latest
-    outputs:
-      tag: '8.6'
-    steps:
-      - run: echo "Dummy step to set output"
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
 
   check-what-changed:
     uses: ./.github/workflows/task-check-changes.yml

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     # TODO: Revert when 8.6 is released
     runs-on: ubuntu-latest
     outputs:
-      tag: unstable
+      tag: '8.6'
     steps:
       - run: echo "Dummy step to set output"
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -48,12 +48,19 @@ on:
         default: false
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
+
   setup:
+    needs: [get-latest-redis-tag]
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -61,12 +68,6 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=8.6" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=unstable" >> $GITHUB_OUTPUT
+          echo "tag=8.6" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -68,9 +68,9 @@ on:
         type: string
         default: QUICK=1
       redis-ref:
-        description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
+        description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "8.6"'
         type: string
-        default: unstable
+        default: "8.6"
       rejson-branch:
         type: string
         default: master


### PR DESCRIPTION
Change CI workflows to test against the Redis `8.6` branch instead of `unstable`.

Files changed:
- `event-pull_request.yml`: redis tag `unstable` → `8.6`
- `event-merge-to-queue.yml`: redis tag `unstable` → `8.6`
- `event-nightly.yml`: redis-ref `unstable` → `8.6`
- `flow-build-artifacts.yml`: redis tag `unstable` → `8.6`

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes
---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI configuration, but it alters the Redis version under test and adds a dependency on GitHub Releases tag resolution, which could cause unexpected CI failures if tags or API calls misbehave.
> 
> **Overview**
> CI now runs PR, merge-queue, nightly, and artifact-build workflows against the latest `redis/redis` release matching the `8.6` prefix (via `task-get-latest-tag.yml`) instead of the hardcoded `unstable` ref.
> 
> The reusable `flow-test.yml` manual-dispatch default for `redis-ref` is updated to `8.6`, aligning ad-hoc runs with the new baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a311640fd670db7a30e13dbc8deeb625e20de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->