### PR TITLE
[8.6-rse] CI: Use Redis 8.6 branch instead of unstable for tests

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,7 +18,7 @@ jobs:
     # TODO: Revert to using the latest stable ref in redis
     runs-on: ubuntu-latest
     outputs:
-      tag: unstable
+      tag: '8.6'
     steps:
       - run: echo "Dummy step to set output"
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       platform: all
       architecture: all
-      redis-ref: unstable
+      redis-ref: '8.6'
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     # TODO: Revert when 8.4 is released
     runs-on: ubuntu-latest
     outputs:
-      tag: unstable
+      tag: '8.6'
     steps:
       - run: echo "Dummy step to set output"
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=unstable" >> $GITHUB_OUTPUT
+          echo "tag=8.6" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |


### PR DESCRIPTION
Change CI workflows to test against the Redis `8.6` branch instead of `unstable`.

Files changed:
- `event-pull_request.yml`: redis tag `unstable` → `8.6`
- `event-merge-to-queue.yml`: redis tag `unstable` → `8.6`
- `event-nightly.yml`: redis-ref `unstable` → `8.6`
- `flow-build-artifacts.yml`: redis tag `unstable` → `8.6`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it can alter CI results by switching the Redis version used in PR, merge-queue, nightly, and artifact build jobs.
> 
> **Overview**
> Updates GitHub Actions workflows to stop using Redis `unstable` in CI and instead pin tests/builds to the Redis `8.6` branch.
> 
> This change applies consistently across pull request, merge queue, nightly runs, and the artifact build workflow by updating the `redis-ref`/tag outputs used by downstream jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58f94726db84b1a61eaa5b807b6c6ee443a860c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->