### PR TITLE
CI: Pin Redis to specific commit for tests

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,7 +18,7 @@ jobs:
     # TODO: Revert to using the latest stable ref in redis
     runs-on: ubuntu-latest
     outputs:
-      tag: unstable
+      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
     steps:
       - run: echo "Dummy step to set output"
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       platform: all
       architecture: all
-      redis-ref: unstable
+      redis-ref: 3cd464263b03b425ffae2e23db24df3dc9346871
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     # TODO: Revert when 8.4 is released
     runs-on: ubuntu-latest
     outputs:
-      tag: unstable
+      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
     steps:
       - run: echo "Dummy step to set output"
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=unstable" >> $GITHUB_OUTPUT
+          echo "tag=3cd464263b03b425ffae2e23db24df3dc9346871" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |


### PR DESCRIPTION
Pin CI workflows to use Redis commit `3cd464263b03b425ffae2e23db24df3dc9346871` instead of `unstable`.

Files changed:
- `event-pull_request.yml`: redis tag `unstable` → `3cd464263b03b425ffae2e23db24df3dc9346871`
- `event-merge-to-queue.yml`: redis tag `unstable` → `3cd464263b03b425ffae2e23db24df3dc9346871`
- `event-nightly.yml`: redis-ref `unstable` → `3cd464263b03b425ffae2e23db24df3dc9346871`
- `flow-build-artifacts.yml`: redis tag `unstable` → `3cd464263b03b425ffae2e23db24df3dc9346871`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that makes Redis version deterministic, though it may change test/build outcomes compared to tracking `unstable`.
> 
> **Overview**
> Pins all CI workflows that previously used Redis `unstable` to a specific Redis commit (`3cd464263b03b425ffae2e23db24df3dc9346871`) for pull requests, merge-queue validation, nightly runs, and artifact builds, improving reproducibility across runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c075de0ac01a0cbc510c4b1fc1b049e2b2814281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->