### PR TITLE
[8.6] fix: add codespell skip paths without ./ prefix

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c
+skip = .git,./deps/*,deps/*,*.csv,./srcutil/*,srcutil/*,./bin/*,bin/*,./sbin/*,sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt
 


### PR DESCRIPTION
The spellcheck CI runs codespell on file paths from `git diff`, which outputs paths without the `./` prefix (e.g. `deps/snowball/...`). The skip patterns in `.codespellrc` used `./deps/*`, `./srcutil/*`, `./bin/*`, `./sbin/*` which didn't match these paths.

Add both variants (with and without `./` prefix) to ensure skipping works regardless of how paths are passed to codespell.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only change affecting spellcheck exclusions, with no runtime or production impact.
> 
> **Overview**
> **Improves `codespell` CI reliability** by expanding `.codespellrc` `skip` patterns to match excluded directories both with and without the `./` prefix (e.g., `deps/*` in addition to `./deps/*`). This prevents unintended spellcheck failures when file paths come from `git diff` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0beaba068cebb0e95d699e03d252249f34b012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->