### PR TITLE
[8.6-rse] fix: add codespell skip paths without ./ prefix

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py,tests/ctests/test_trie.c
+skip = .git,./deps/*,deps/*,*.csv,./srcutil/*,srcutil/*,./bin/*,bin/*,./sbin/*,sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py,tests/ctests/test_trie.c
 
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt


### PR DESCRIPTION
The spellcheck CI runs codespell on file paths from `git diff`, which outputs paths without the `./` prefix (e.g. `deps/snowball/...`). The skip patterns in `.codespellrc` used `./deps/*`, `./srcutil/*`, `./bin/*`, `./sbin/*` which didn't match these paths.

Add both variants (with and without `./` prefix) to ensure skipping works regardless of how paths are passed to codespell.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects which paths codespell ignores in CI.
> 
> **Overview**
> Updates `.codespell/.codespellrc` to **duplicate key skip globs without the `./` prefix** (e.g. `deps/*`, `srcutil/*`, `bin/*`, `sbin/*`) so codespell reliably ignores those directories regardless of how file paths are provided (such as from `git diff`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f28844e3a905d80c2dee9e77bd04ef144765617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->