### PR TITLE
Build RediSearch once in the benchmark flow

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -37,6 +37,10 @@ on:
       benchmark_runner_group_total:
         type: number
         default: 1
+      binary_artifact_name:
+        type: string
+        required: true
+        description: "Name of the artifact (uploaded by flow-build-benchmark-binary.yml) containing the prebuilt redisearch.so"
 
 jobs:
   benchmark-steps:
@@ -48,8 +52,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Compute effective benchmark filter
         id: benchmark-filter
         working-directory: tests/benchmarks
@@ -88,20 +90,20 @@ jobs:
       - name: Setup tests dependencies
         if: steps.benchmark-filter.outputs.skip != 'true'
         run: .install/test_deps/common_installations.sh sudo
-      - name: Install Boost
+      - name: Download prebuilt redisearch.so
         if: steps.benchmark-filter.outputs.skip != 'true'
-        working-directory: .install
-        run: ./install_boost.sh
-
-      - name: Setup sccache
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.binary_artifact_name }}
+          # Place the .so where `inputs.module_path` expects it, e.g.
+          # bin/linux-x64-release/search-community/redisearch.so
+          path: ${{ inputs.profile_env == 1 && 'bin/linux-x64-release-profile/search-community' || 'bin/linux-x64-release/search-community' }}
+      - name: Make redisearch.so executable
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: ./.github/actions/setup-sccache
-      - name: Build RediSearch
-        if: steps.benchmark-filter.outputs.skip != 'true'
-        run: make build ${{ inputs.profile_env == 1 && 'PROFILE' || ''}}
-      - name: Show sccache stats
-        if: steps.benchmark-filter.outputs.skip != 'true'
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        env:
+          MODULE_PATH: ${{ inputs.module_path }}
+        run: chmod +x "../../${MODULE_PATH}"
+        working-directory: tests/benchmarks
       - name: Install Python dependencies
         if: steps.benchmark-filter.outputs.skip != 'true'
         run: |

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -46,8 +46,25 @@ on:
         description: "if true, will notify failure on slack"
 
 jobs:
+  # Build RediSearch ONCE here. Every benchmark job below downloads the
+  # resulting redisearch.so as an artifact instead of rebuilding it.
+  build-redisearch:
+    uses: ./.github/workflows/flow-build-benchmark-binary.yml
+    with:
+      profile_env: 0
+      artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+
+  # Profile build is only needed when profiler benchmarks are enabled.
+  build-redisearch-profile:
+    if: ${{ inputs.profiler }}
+    uses: ./.github/workflows/flow-build-benchmark-binary.yml
+    with:
+      profile_env: 1
+      artifact_name: redisearch-bin-profile-${{ github.run_id }}-${{ github.run_attempt }}
+
   benchmark-search-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -61,10 +78,12 @@ jobs:
       allowed_setups: oss-standalone
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-standalone-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
     if: false # ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -78,9 +97,11 @@ jobs:
       allowed_setups: oss-standalone-threads-6
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-vecsim-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -94,9 +115,11 @@ jobs:
       allowed_setups: oss-standalone
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-vecsim-oss-standalone-threads-6:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -110,9 +133,11 @@ jobs:
       allowed_setups: oss-standalone-threads-6
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-02-primaries:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-02-primaries' }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -126,9 +151,11 @@ jobs:
       allowed_setups: oss-cluster-02-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-04-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries') }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -142,10 +169,12 @@ jobs:
       allowed_setups: oss-cluster-04-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-04-primaries-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
     if: false # if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries-threads-6' }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -159,9 +188,11 @@ jobs:
       allowed_setups: oss-cluster-04-primaries-threads-6
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-08-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-08-primaries') }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -175,9 +206,11 @@ jobs:
       allowed_setups: oss-cluster-08-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8:
     if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' }}
+    needs: build-redisearch
     uses: ./.github/workflows/benchmark-flow.yml
     secrets: inherit
     with:
@@ -185,9 +218,11 @@ jobs:
       benchmark_filter: ${{ inputs.benchmark_filter }}
       allowed_envs: oss-cluster
       allowed_setups: oss-cluster-08-primaries-250gb-threads-8
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-16-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-16-primaries') }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -201,9 +236,11 @@ jobs:
       allowed_setups: oss-cluster-16-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-20-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-20-primaries') }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -217,9 +254,11 @@ jobs:
       allowed_setups: oss-cluster-20-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-cluster-24-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-24-primaries') }}
+    needs: build-redisearch
     strategy:
       fail-fast: false
       matrix:
@@ -233,9 +272,11 @@ jobs:
       allowed_setups: oss-cluster-24-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-standalone-profiler:
     if: ${{ inputs.profiler && (inputs.allowed_setup == '' || inputs.allowed_setup == 'standalone') }}
+    needs: build-redisearch-profile
     strategy:
       fail-fast: false
       matrix:
@@ -253,9 +294,11 @@ jobs:
       allowed_setups: oss-standalone
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-profile-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-vecsim-oss-standalone-profiler:
     if: ${{ inputs.profiler && (inputs.allowed_setup == '' || inputs.allowed_setup == 'standalone') }}
+    needs: build-redisearch-profile
     strategy:
       fail-fast: false
       matrix:
@@ -273,6 +316,7 @@ jobs:
       allowed_setups: oss-standalone
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-profile-${{ github.run_id }}-${{ github.run_attempt }}
 
   notify-failure:
     needs:

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -1,0 +1,55 @@
+name: Build RediSearch Binary for Benchmarks
+
+# Builds RediSearch once and uploads the resulting redisearch.so as an artifact
+# so that downstream benchmark jobs can download it instead of rebuilding.
+
+on:
+  workflow_call:
+    inputs:
+      profile_env:
+        type: number
+        default: 0
+        description: "If 1, build with PROFILE=1 (output under bin/linux-x64-release-profile)"
+      artifact_name:
+        type: string
+        required: true
+        description: "Name of the artifact to upload the built redisearch.so under"
+
+jobs:
+  build:
+    name: "Build RediSearch${{ inputs.profile_env == 1 && ' (profile)' || '' }}"
+    # Must match the runner used by benchmark-flow.yml so the binary is ABI-compatible
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    env:
+      BUILD_DIR: ${{ inputs.profile_env == 1 && 'bin/linux-x64-release-profile/search-community' || 'bin/linux-x64-release/search-community' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup specific
+        working-directory: .install
+        run: ./install_script.sh sudo
+      - name: Setup tests dependencies
+        run: .install/test_deps/common_installations.sh sudo
+      - name: Install Boost
+        working-directory: .install
+        run: ./install_boost.sh
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+      - name: Build RediSearch
+        run: make build ${{ inputs.profile_env == 1 && 'PROFILE' || '' }}
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+      - name: Upload redisearch.so artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: |
+            ${{ env.BUILD_DIR }}/redisearch.so
+            ${{ env.BUILD_DIR }}/redisearch.so.debug
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## Describe the changes in the pull request

Build RediSearch once for benchmarks, rather than N times.
Bonus side-effect: we get to store the .so file as an artefact, thus allowing devs to download it easily if needed (e.g. to look at the generated assembly for x86_64 if they have an aarch64 dev laptop).

Tested here: https://github.com/RediSearch/RediSearch/actions/runs/24464735220

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark CI orchestration to depend on a shared build artifact; misconfigured artifact names/paths or missing executable bit could cause benchmark runs to fail across all setups.
> 
> **Overview**
> Benchmarks now **build `redisearch.so` once per workflow run** and reuse it across all benchmark jobs by downloading a prebuilt artifact, instead of rebuilding in each job.
> 
> Adds a reusable workflow `flow-build-benchmark-binary.yml` that builds (optionally `PROFILE`) and uploads `redisearch.so`/`.debug` as a short-lived artifact, wires `benchmark-runner.yml` jobs to `needs` this build (and a profile build when `inputs.profiler` is enabled), and updates `benchmark-flow.yml` to require `binary_artifact_name`, download the artifact into the expected `bin/...` location, and `chmod +x` the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0773ebc1e4540318b8e5883a3a4bcb4f743e817c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->