### PR TITLE
Cache Redis build in task-test workflow

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -1,0 +1,119 @@
+name: Build Redis (cached)
+description: |
+  Build and install Redis once per (resolved Redis SHA, platform, arch, sanitizer,
+  coverage) tuple, restoring from the GitHub Actions cache when available.
+
+  Redis is installed under a workspace-relative prefix and that directory is
+  cached. After the action completes, `redis-server` is on PATH for subsequent
+  steps and the REDIS_SERVER env var points at the binary explicitly.
+
+inputs:
+  ref:
+    description: "Redis git ref to build (e.g. 'unstable', '7.2.3', or a 40-char SHA)"
+    required: true
+  san:
+    description: "Sanitizer (empty or 'address')"
+    required: false
+    default: ""
+  coverage:
+    description: "Build with coverage instrumentation ('true' or 'false')"
+    required: false
+    default: "false"
+  build_tls:
+    description: "Build Redis with TLS support ('true' or 'false')"
+    required: false
+    default: "true"
+  cache_platform_id:
+    description: "Opaque identifier for the binary-compatible platform (container image or runner env)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Redis SHA
+      id: resolve
+      shell: bash
+      env:
+        REDIS_REF: ${{ inputs.ref }}
+      run: |
+        if [[ "$REDIS_REF" =~ ^[0-9a-f]{40}$ ]]; then
+          SHA="$REDIS_REF"
+        else
+          SHA=$(git ls-remote https://github.com/redis/redis.git "$REDIS_REF" \
+                | awk 'NR==1 {print $1}')
+        fi
+        if [[ -z "$SHA" ]]; then
+          echo "Failed to resolve Redis ref '$REDIS_REF' to a commit SHA" >&2
+          exit 1
+        fi
+        echo "Resolved $REDIS_REF -> $SHA"
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+        echo "prefix=$GITHUB_WORKSPACE/redis-install" >> "$GITHUB_OUTPUT"
+
+    - name: Compute cache key
+      id: key
+      shell: bash
+      env:
+        SHA: ${{ steps.resolve.outputs.sha }}
+        PLATFORM_ID: ${{ inputs.cache_platform_id }}
+        ARCH: ${{ runner.arch }}
+        SAN: ${{ inputs.san }}
+        COV: ${{ inputs.coverage }}
+        TLS: ${{ inputs.build_tls }}
+      run: |
+        SAN_LABEL="${SAN:-none}"
+        # Sanitize platform id for use in a cache key.
+        PLATFORM_SAFE=$(echo "$PLATFORM_ID" | sed 's#[^A-Za-z0-9_.-]#-#g')
+        KEY="redis-${SHA}-${PLATFORM_SAFE}-${ARCH}-san_${SAN_LABEL}-cov_${COV}-tls_${TLS}"
+        echo "key=$KEY" >> "$GITHUB_OUTPUT"
+        echo "Cache key: $KEY"
+
+    - name: Restore cached Redis
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.resolve.outputs.prefix }}
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Get Redis (cache miss)
+      if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+      uses: ./.github/actions/get-redis
+      with:
+        # Check out the resolved SHA, not the original (possibly moving) ref,
+        # so the built binary always matches the cache key.
+        ref: ${{ steps.resolve.outputs.sha }}
+        path: redis
+
+    - name: Build Redis (cache miss)
+      if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+      shell: bash
+      working-directory: redis
+      env:
+        PREFIX: ${{ steps.resolve.outputs.prefix }}
+        SAN: ${{ inputs.san }}
+        COVERAGE: ${{ inputs.coverage }}
+        BUILD_TLS: ${{ inputs.build_tls }}
+      run: |
+        EXTRA=()
+        if [[ "$BUILD_TLS" == "true" ]]; then
+          EXTRA+=("BUILD_TLS=yes")
+        fi
+        if [[ "$COVERAGE" == "true" ]]; then
+          EXTRA+=("REDIS_CFLAGS=-DCOVERAGE_TEST")
+        fi
+        make PREFIX="$PREFIX" install "${EXTRA[@]}" SANITIZER="$SAN"
+
+    - name: Save Redis to cache
+      if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.resolve.outputs.prefix }}
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Expose Redis on PATH
+      shell: bash
+      env:
+        PREFIX: ${{ steps.resolve.outputs.prefix }}
+      run: |
+        echo "$PREFIX/bin" >> "$GITHUB_PATH"
+        echo "REDIS_SERVER=$PREFIX/bin/redis-server" >> "$GITHUB_ENV"

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -154,15 +154,12 @@ jobs:
         with:
           command: uv pip install -q -r .install/build_package_requirements.txt
 
-      # Get Redis
-      - name: Get Redis
-        uses: ./.github/actions/get-redis
+      - name: Build Redis (cached)
+        uses: ./.github/actions/build-redis
         with:
           ref: ${{ inputs.redis-ref }}
-
-      - name: Build Redis
-        working-directory: redis
-        run: ${{ needs.get-config.outputs.install_mode }} make install
+          build_tls: 'false'
+          cache_platform_id: ${{ needs.get-config.outputs.container || needs.get-config.outputs.env }}
 
       # Build & Pack
       - name: Build and Pack RediSearch OSS

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -317,19 +317,13 @@ jobs:
           echo "CXX=$(dirname $CLANG_BIN)/clang++-$CLANG_VERSION" >> $GITHUB_ENV
           echo "LD=$CLANG_BIN" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-$CLANG_VERSION/bin/llvm-symbolizer" >> $GITHUB_ENV
-      - name: Get Redis
-        uses: ./.github/actions/get-redis
+      - name: Build Redis (cached)
+        uses: ./.github/actions/build-redis
         with:
           ref: ${{ inputs.redis-ref }}
-
-      - name: Build Redis
-        working-directory: redis
-        env:
-          SAN: ${{ inputs.san }}
-        run:  ${{ needs.get-config.outputs.install_mode }} make install
-              BUILD_TLS=yes
-              ${{ inputs.coverage && 'REDIS_CFLAGS=-DCOVERAGE_TEST' || '' }}
-              SANITIZER=$SAN
+          san: ${{ inputs.san }}
+          coverage: ${{ inputs.coverage }}
+          cache_platform_id: ${{ needs.get-config.outputs.container || needs.get-config.outputs.env }}
 
       - name: Set Artifact Names
         # Artifact names have to be unique, so we base them on the environment.


### PR DESCRIPTION
## Describe the changes in the pull request

Extract the Get Redis + Build Redis steps into a reusable composite action that caches the install dir keyed by the resolved Redis SHA, platform, architecture, sanitizer, and coverage flags. Subsequent runs with the same inputs restore the binary from the GitHub Actions cache instead of rebuilding from source.

The legacy (non-node20) path on amazonlinux:2 falls back to the previous uncached make install behaviour.

Cache in action:
<img width="3014" height="884" alt="image" src="https://github.com/user-attachments/assets/25dafe72-3d35-4b5d-84ad-2737aae8a9f1" />


#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change, but it alters how Redis binaries are fetched/built and introduces cache-keying logic; mis-keying or env differences could cause stale/incorrect binaries or new workflow failures.
> 
> **Overview**
> Adds a new composite action `build-redis` that resolves the requested Redis ref to an immutable SHA, builds Redis into a workspace-local prefix, and caches/restores that install directory keyed by SHA + platform/arch + sanitizer/coverage/TLS flags; it also exports `redis-server` on `PATH` and sets `REDIS_SERVER`.
> 
> Updates `task-test.yml` and `task-build-artifacts.yml` to replace the previous `get-redis` + manual `make install` steps with the cached action (passing through sanitizer/coverage settings and disabling TLS for artifact builds), reducing repeat build time across runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db983fb4ae2bc3466460f212b9f8b78c4d45abf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->