### PR TITLE
initial imp

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -49,6 +49,8 @@ typedef struct {
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
 static int prepareExecutionPlan(AREQ *req, QueryError *status);
 static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+static int CursorReadTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Wrapper for AREQ_DecrRef to match BlockedClientFreePrivDataCB signature
 static void AREQ_DecrRefWrapper(void *privdata) {
@@ -1492,6 +1494,54 @@ static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int
   return REDISMODULE_OK;
 }
 
+static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  UNUSED(argv);
+  UNUSED(argc);
+
+  BlockedCursorNode *node = RedisModule_GetBlockedClientPrivateData(ctx);
+  if (!node || !node->privdata) {
+    RedisModule_Log(ctx, "warning", "CursorReadReplyCallback: no node or privdata");
+    RedisModule_ReplyWithError(ctx, "ERR Internal error: no request context");
+    return REDISMODULE_OK;
+  }
+
+  AREQ *req = (AREQ *)node->privdata;
+  if (!req->storedReplyState.hasStoredResults) {
+    if (QueryError_HasError(&req->storedReplyState.err)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->storedReplyState.err), 1,
+                                         !IsInternal(req));
+      QueryError_ReplyAndClear(ctx, &req->storedReplyState.err);
+    } else {
+      RedisModule_ReplyWithError(ctx, "ERR Internal error: no results stored");
+    }
+    return REDISMODULE_OK;
+  }
+
+  AREQ_ReplyWithStoredResults(ctx, req);
+  return REDISMODULE_OK;
+}
+
+static int CursorReadTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  UNUSED(argv);
+  UNUSED(argc);
+
+  BlockedCursorNode *node = RedisModule_GetBlockedClientPrivateData(ctx);
+  if (!node || !node->privdata) {
+    RedisModule_Log(ctx, "warning", "CursorReadTimeoutFailCallback: no node or privdata");
+    QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, true);
+    RedisModule_ReplyWithError(ctx, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
+    return REDISMODULE_OK;
+  }
+
+  AREQ *req = (AREQ *)node->privdata;
+  AREQ_SetTimedOut(req);
+  Cursors_Purge(GetGlobalCursor(node->cursorId), node->cursorId);
+
+  QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, !IsInternal(req));
+  RedisModule_ReplyWithError(ctx, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
+  return REDISMODULE_OK;
+}
+
 static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *status) {
   RedisSearchCtx *sctx = AREQ_SearchCtx(r);
   if (RunInThread()) {
@@ -1705,7 +1755,23 @@ static QueryProcessingCtx *prepareForCursorRead(Cursor *cursor, bool *hasLoader,
   return qctx;
 }
 
-static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool bg) {
+static bool shouldUseCursorReadReplyCallback(const Cursor *cursor) {
+  AREQ *req = cursor->execState;
+  return req &&
+         req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail &&
+         req->reqConfig.queryTimeoutMS > 0;
+}
+
+static void cursorReadCleanupTimedOut(Cursor *cursor) {
+  AREQ *req = cursor->execState;
+  if (req && req->storedReplyState.cursor == cursor) {
+    req->storedReplyState.cursor = NULL;
+  }
+  Cursor_Free(cursor);
+}
+
+static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool bg,
+                       bool useReplyCallback) {
 
   QueryError status = QueryError_Default();
 
@@ -1748,8 +1814,7 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
   }
 
   if (req) {
-    // Cursor reads don't use reply_callback, so clear the flag.
-    req->useReplyCallback = false;
+    req->useReplyCallback = useReplyCallback;
     RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
     runCursor(reply, cursor, count);
     RedisModule_EndReply(reply);
@@ -1765,12 +1830,28 @@ typedef struct {
   RedisModuleBlockedClient *bc;
   Cursor *cursor;
   size_t count;
+  bool useReplyCallback;
 } CursorReadCtx;
 
 static void cursorRead_ctx(CursorReadCtx *cr_ctx) {
+  AREQ *req = cr_ctx->cursor->execState;
+  if (cr_ctx->useReplyCallback && req && AREQ_TimedOut(req)) {
+    cursorReadCleanupTimedOut(cr_ctx->cursor);
+    RedisModule_BlockedClientMeasureTimeEnd(cr_ctx->bc);
+    void *privdata = RedisModule_BlockClientGetPrivateData(cr_ctx->bc);
+    RedisModule_UnblockClient(cr_ctx->bc, privdata);
+    rm_free(cr_ctx);
+    return;
+  }
+
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(cr_ctx->bc);
-  cursorRead(ctx, cr_ctx->cursor, cr_ctx->count, true);
+  cursorRead(ctx, cr_ctx->cursor, cr_ctx->count, true, cr_ctx->useReplyCallback);
   RedisModule_FreeThreadSafeContext(ctx);
+
+  if (cr_ctx->useReplyCallback && req && AREQ_TimedOut(req)) {
+    cursorReadCleanupTimedOut(cr_ctx->cursor);
+  }
+
   RedisModule_BlockedClientMeasureTimeEnd(cr_ctx->bc);
   void *privdata = RedisModule_BlockClientGetPrivateData(cr_ctx->bc);
   RedisModule_UnblockClient(cr_ctx->bc, privdata);
@@ -1811,13 +1892,27 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
   // We have to check that we are not blocked yet from elsewhere (e.g. coordinator)
   if (RunInThread() && !RedisModule_GetBlockedClientHandle(ctx)) {
+    BlockClientCtx blockClientCtx = {0};
+    bool useReplyCallback = shouldUseCursorReadReplyCallback(cursor);
+    if (useReplyCallback) {
+      AREQ *req = cursor->execState;
+      AREQ_IncrRef(req);
+      blockClientCtx.privdata = req;
+      blockClientCtx.replyCallback = CursorReadReplyCallback;
+      blockClientCtx.timeoutCallback = CursorReadTimeoutFailCallback;
+      blockClientCtx.freePrivData = AREQ_DecrRefWrapper;
+      blockClientCtx.timeoutMS = req->reqConfig.queryTimeoutMS;
+    }
+
     CursorReadCtx *cr_ctx = rm_new(CursorReadCtx);
-    cr_ctx->bc = BlockCursorClient(ctx, cursor, count, 0);
+    cr_ctx->bc = BlockCursorClient(ctx, cursor, count, &blockClientCtx);
     cr_ctx->cursor = cursor;
     cr_ctx->count = count;
-    workersThreadPool_AddWork((redisearch_thpool_proc)cursorRead_ctx, cr_ctx);
+    cr_ctx->useReplyCallback = useReplyCallback;
+    const int rc = workersThreadPool_AddWork((redisearch_thpool_proc)cursorRead_ctx, cr_ctx);
+    RS_ASSERT(rc == 0);
   } else {
-    cursorRead(ctx, cursor, count, false);
+    cursorRead(ctx, cursor, count, false, false);
   }
 
   return REDISMODULE_OK;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -29,6 +29,9 @@ static void FreeQueryNode(RedisModuleCtx* ctx, void *node) {
 
 static void FreeCursorNode(RedisModuleCtx* ctx, void *node) {
   BlockedCursorNode *cursorNode = node;
+  if (cursorNode->freePrivData && cursorNode->privdata) {
+    cursorNode->freePrivData(cursorNode->privdata);
+  }
   BlockedQueries_RemoveCursor(cursorNode);
   rm_free(cursorNode);
 }
@@ -56,15 +59,29 @@ RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, Stron
   return blockedClient;
 }
 
-RedisModuleBlockedClient *BlockCursorClient(RedisModuleCtx *ctx, Cursor *cursor, size_t count, int timeoutMS) {
+RedisModuleBlockedClient *BlockCursorClient(RedisModuleCtx *ctx, Cursor *cursor, size_t count,
+                                            BlockClientCtx *blockClientCtx) {
+  RS_ASSERT(blockClientCtx == NULL ||
+            blockClientCtx->timeoutMS == 0 ||
+            (blockClientCtx->timeoutCallback != NULL && blockClientCtx->replyCallback != NULL));
+
   BlockedQueries *blockedQueries = MainThread_GetBlockedQueries();
   RS_LOG_ASSERT(blockedQueries, "MainThread_InitBlockedQueries was not called, or function not called from main thread");
-  BlockedCursorNode *node = BlockedQueries_AddCursor(blockedQueries, cursor->spec_ref, cursor->id, &cursor->execState->ast, count);
+  QueryAST *ast = cursor->execState ? &cursor->execState->ast : NULL;
+  BlockedCursorNode *node = BlockedQueries_AddCursor(blockedQueries, cursor->spec_ref, cursor->id,
+                                                     ast, count,
+                                                     blockClientCtx ? blockClientCtx->privdata : NULL,
+                                                     blockClientCtx ? blockClientCtx->freePrivData : NULL);
   // Prepare context for the worker thread
   // Since we are still in the main thread, and we already validated the
   // spec's existence, it is safe to directly get the strong reference from the spec
   // found in buildRequest.
-  RedisModuleBlockedClient *blockedClient = RedisModule_BlockClient(ctx, NULL, NULL, FreeCursorNode, 0);
+  RedisModuleBlockedClient *blockedClient = RedisModule_BlockClient(
+      ctx,
+      blockClientCtx ? blockClientCtx->replyCallback : NULL,
+      blockClientCtx ? blockClientCtx->timeoutCallback : NULL,
+      FreeCursorNode,
+      blockClientCtx ? blockClientCtx->timeoutMS : 0);
   RedisModule_BlockClientSetPrivateData(blockedClient, node);
   // report block client start time
   RedisModule_BlockedClientMeasureTimeStart(blockedClient);

--- a/src/info/info_redis/block_client.h
+++ b/src/info/info_redis/block_client.h
@@ -35,7 +35,8 @@ typedef struct BlockClientCtx{
 } BlockClientCtx;
 
 RedisModuleBlockedClient* BlockQueryClientWithTimeout(RedisModuleCtx *ctx, StrongRef spec, BlockClientCtx *blockClientCtx);
-RedisModuleBlockedClient* BlockCursorClient(RedisModuleCtx *ctx, Cursor* cursor, size_t count, int timeoutMS);
+RedisModuleBlockedClient* BlockCursorClient(RedisModuleCtx *ctx, Cursor* cursor, size_t count,
+                                            BlockClientCtx *blockClientCtx);
 
 #ifdef __cplusplus
 }

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -58,27 +58,31 @@ BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* blockedQueries, Strong
   BlockedQueryNode* blockedQueryNode = rm_calloc(1, sizeof(BlockedQueryNode));
   blockedQueryNode->spec = StrongRef_Clone(spec);
   blockedQueryNode->start = time(NULL);
-  blockedQueryNode->query = QAST_DumpExplain(ast, StrongRef_Get(spec));
+  blockedQueryNode->query = ast ? QAST_DumpExplain(ast, StrongRef_Get(spec)) : NULL;
   blockedQueryNode->privdata = privdata;
   blockedQueryNode->freePrivData = freePrivData;
   dllist_prepend(&blockedQueries->queries, &blockedQueryNode->llnode);
   return blockedQueryNode;
 }
 
-BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, WeakRef spec, uint64_t cursorId, QueryAST* ast, size_t count) {
+BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, WeakRef spec, uint64_t cursorId,
+                                            QueryAST* ast, size_t count, void *privdata,
+                                            BlockedQueryNode_FreePrivData freePrivData) {
   BlockedCursorNode* blockedCursorNode = rm_calloc(1, sizeof(BlockedCursorNode));
   if (spec.rm) {
     // we don't want cursors to block index deletion, so we don't take a strong ref
     // not entirely sure we clean cursors on index drop, so better be safe than sorry
     blockedCursorNode->spec = WeakRef_Promote(spec);
     IndexSpec *sp = StrongRef_Get(blockedCursorNode->spec);
-    if (sp) {
+    if (sp && ast) {
       blockedCursorNode->query = QAST_DumpExplain(ast, sp);
     }
   }
   blockedCursorNode->cursorId = cursorId;
   blockedCursorNode->count = count;
   blockedCursorNode->start = time(NULL);
+  blockedCursorNode->privdata = privdata;
+  blockedCursorNode->freePrivData = freePrivData;
   dllist_prepend(&blockedQueries->cursors, &blockedCursorNode->llnode);
   return blockedCursorNode;
 }

--- a/src/info/info_redis/types/blocked_queries.h
+++ b/src/info/info_redis/types/blocked_queries.h
@@ -45,6 +45,8 @@ typedef struct {
   size_t count;       // cursor count
   time_t start;       // Time node was added into list
   char *query;        // The query that created the cursor
+  void *privdata;     // Non-owning. Must remain valid until UnblockClient is called.
+  BlockedQueryNode_FreePrivData freePrivData; // Optional callback to free privdata
 } BlockedCursorNode;
 
 /**
@@ -76,7 +78,9 @@ void BlockedQueries_Free(BlockedQueries*);
 
 BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* list, StrongRef spec, QueryAST* ast,
                                           void *privdata, BlockedQueryNode_FreePrivData freePrivData);
-BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* list, WeakRef spec, uint64_t cursorId, QueryAST* ast, size_t count);
+BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* list, WeakRef spec, uint64_t cursorId,
+                                            QueryAST* ast, size_t count, void *privdata,
+                                            BlockedQueryNode_FreePrivData freePrivData);
 void BlockedQueries_RemoveQuery(BlockedQueryNode* node);
 void BlockedQueries_RemoveCursor(BlockedCursorNode* node);
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -150,6 +150,21 @@ def wait_for_blocked_query_client(env, query, msg='Client for query not found', 
                 return client_id
             time.sleep(0.1)
 
+
+def wait_for_blocked_query_client_contains(env, cmd_substr,
+                                           msg='Client for blocked command not found',
+                                           timeout=30):
+    """Wait for a blocked client whose command contains the given substring."""
+    cmd_substr = cmd_substr.upper()
+    with TimeLimit(timeout, msg):
+        while True:
+            output = env.execute_command('CLIENT', 'LIST')
+            clients = parse_client_list(output)
+            for client in clients:
+                if cmd_substr in client.get('cmd', '').upper() and 'b' in client.get('flags', ''):
+                    return client['id']
+            time.sleep(0.1)
+
 class TestCoordinatorTimeout:
     """Tests for the blocked client timeout mechanism for the coordinator."""
 
@@ -578,8 +593,8 @@ class TestCoordinatorTimeout:
     def test_no_timeout_cursor(self):
         """
         Test that FAIL policy doesn't break cursor reads when there is no timeout.
-        This verifies that useReplyCallback is properly cleared for cursor reads,
-        since cursor reads use BlockCursorClient which has no reply_callback.
+        This verifies cursor pagination still works even when cursor reads use the
+        blocked-client timeout path.
         """
         env = self.env
 
@@ -604,6 +619,59 @@ class TestCoordinatorTimeout:
         env.assertEqual(total_results, self.n_docs,
                         message=f"Expected {self.n_docs} total results across all cursor reads")
 
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
+
+    def test_cursor_read_timeout_fail(self):
+        """Test FT.CURSOR READ timeout via the blocked-client timeout mechanism."""
+        env = self.env
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'fail').ok()
+
+        before_info = info_modules_to_dict(env)
+        base_err_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC])
+
+        res, cursor_id = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name',
+                                 'WITHCURSOR', 'COUNT', '10')
+        env.assertGreater(len(res), 0, message="Expected results in first chunk")
+        env.assertNotEqual(cursor_id, 0, message="Expected non-zero cursor ID for pagination")
+
+        initial_jobs_done = getWorkersThpoolStats(env)['totalJobsDone']
+        env.expect(debug_cmd(), 'WORKERS', 'pause').ok()
+
+        t_query = threading.Thread(
+            target=run_cmd_expect_timeout,
+            args=(env, ['FT.CURSOR', 'READ', 'idx', cursor_id]),
+            daemon=True
+        )
+        t_query.start()
+
+        blocked_client_id = wait_for_blocked_query_client_contains(
+            env, 'FT.CURSOR',
+            'Client for FT.CURSOR READ not found'
+        )
+
+        env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Cursor read thread should have finished")
+
+        env.expect(debug_cmd(), 'WORKERS', 'resume').ok()
+        wait_for_condition(
+            lambda: (getWorkersThpoolStats(env)['totalJobsDone'] > initial_jobs_done,
+                     {'totalJobsDone': getWorkersThpoolStats(env)['totalJobsDone']}),
+            'Timeout while waiting for worker to finish cursor read job'
+        )
+        env.expect(debug_cmd(), 'WORKERS', 'drain').ok()
+
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC],
+                        str(base_err_coord + 1),
+                        message="Coordinator timeout error should be +1 after FT.CURSOR READ timeout")
+        _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_ERROR_COORD_METRIC])
+
+        env.expect('FT.CURSOR', 'READ', 'idx', cursor_id).error().contains('Cursor not found')
         env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
 
     def test_shard_timeout_fail(self):
@@ -1636,8 +1704,8 @@ class TestShardTimeout:
     def test_no_timeout_cursor(self):
         """
         Test that FAIL policy doesn't break cursor reads when there is no timeout.
-        This verifies that useReplyCallback is properly cleared for cursor reads,
-        since cursor reads use BlockCursorClient which has no reply_callback.
+        This verifies cursor pagination still works even when cursor reads use the
+        blocked-client timeout path.
         """
         env = self.env
 
@@ -1662,6 +1730,59 @@ class TestShardTimeout:
         env.assertEqual(total_results, self.n_docs,
                         message=f"Expected {self.n_docs} total results across all cursor reads")
 
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
+
+    def test_cursor_read_timeout_fail(self):
+        """Test FT.CURSOR READ timeout via the blocked-client timeout mechanism."""
+        env = self.env
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'fail').ok()
+
+        before_info = info_modules_to_dict(env)
+        base_err_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC])
+
+        res, cursor_id = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name',
+                                 'WITHCURSOR', 'COUNT', '10')
+        env.assertGreater(len(res), 0, message="Expected results in first chunk")
+        env.assertNotEqual(cursor_id, 0, message="Expected non-zero cursor ID for pagination")
+
+        initial_jobs_done = getWorkersThpoolStats(env)['totalJobsDone']
+        env.expect(debug_cmd(), 'WORKERS', 'pause').ok()
+
+        t_query = threading.Thread(
+            target=run_cmd_expect_timeout,
+            args=(env, ['FT.CURSOR', 'READ', 'idx', cursor_id]),
+            daemon=True
+        )
+        t_query.start()
+
+        blocked_client_id = wait_for_blocked_query_client_contains(
+            env, 'FT.CURSOR',
+            'Client for FT.CURSOR READ not found'
+        )
+
+        env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Cursor read thread should have finished")
+
+        env.expect(debug_cmd(), 'WORKERS', 'resume').ok()
+        wait_for_condition(
+            lambda: (getWorkersThpoolStats(env)['totalJobsDone'] > initial_jobs_done,
+                     {'totalJobsDone': getWorkersThpoolStats(env)['totalJobsDone']}),
+            'Timeout while waiting for worker to finish cursor read job'
+        )
+        env.expect(debug_cmd(), 'WORKERS', 'drain').ok()
+
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC],
+                        str(base_err_coord + 1),
+                        message="Coordinator timeout error should be +1 after FT.CURSOR READ timeout")
+        _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_ERROR_COORD_METRIC])
+
+        env.expect('FT.CURSOR', 'READ', 'idx', cursor_id).error().contains('Cursor not found')
         env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
 
     def test_cursor_read_after_initial_timeout(self):


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threaded cursor execution, timeout handling, and lifetime/refcount management (`AREQ`/cursor purge), which are concurrency-sensitive and could regress cursor cleanup or error reporting if mismanaged.
> 
> **Overview**
> Adds blocked-client `replyCallback`/`timeoutCallback` support to `FT.CURSOR READ` when running with workers and `search-on-timeout=fail`, mirroring the existing reply-callback flow used by search/aggregate so timeouts return an error and the cursor is purged.
> 
> Extends blocked-cursor tracking (`BlockedCursorNode`, `BlockedQueries_AddCursor`, `BlockCursorClient`) to carry optional `privdata` plus a `freePrivData` hook (used for `AREQ` refcounting), and updates cleanup paths accordingly. Adds integration tests covering cursor pagination under FAIL policy and explicit cursor-read timeout/unblock behavior with metrics assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d832bb9a07cb274131891291d76136b13fee5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->