### PR TITLE
set commit hash as redis tag

### DIFF
--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -75,7 +75,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
         type: string
-        default: unstable
+        default: 3cd464263b03b425ffae2e23db24df3dc9346871
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -135,7 +135,7 @@ jobs:
 
   common-flow:
     needs: [get-config, build-image, start-runner]
-    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref || 'unstable' }}
+    name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.redis-ref || '3cd464263b03b425ffae2e23db24df3dc9346871' }}
     # Run if get-config succeeded and at least one test type is enabled
     if: |
       !cancelled() &&
@@ -370,7 +370,7 @@ jobs:
           COV_LABEL: ${{ inputs.coverage && 'coverage test' || '' }}
           PLATFORM: ${{ needs.get-config.outputs.container || needs.get-config.outputs.env }}
           ARCH: ${{ runner.arch }}
-          REDIS_VERSION: ${{ inputs.redis-ref || 'unstable' }}
+          REDIS_VERSION: ${{ inputs.redis-ref || '3cd464263b03b425ffae2e23db24df3dc9346871' }}
         run:
           | # Invalid characters include: Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?
           UNIQUE_ID="$RANDOM$RANDOM"


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that pins the default Redis version used in CI; main risk is accidentally locking tests to an unintended Redis commit.
> 
> **Overview**
> CI test workflows now default `redis-ref` to a specific Redis commit (`3cd464263b03b425ffae2e23db24df3dc9346871`) rather than `unstable`.
> 
> This updates `flow-test.yml` dispatch defaults and adjusts `task-test.yml` job naming and artifact naming fallbacks so runs consistently display and label the pinned Redis ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b7cd7ab5a3c9df1d5f74fde1912b090304c58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->