### PR TITLE
[8.6] MOD-14554: Support Disk Optimized Not And Optional Iterators

### DIFF
--- a/src/iterators/not_iterator.c
+++ b/src/iterators/not_iterator.c
@@ -318,10 +318,15 @@ QueryIterator *NewNotIterator(QueryIterator *it, t_docId maxDocId, double weight
   }
   NotIterator *ni = rm_calloc(1, sizeof(*ni));
   ret = &ni->base;
-  bool optimized = q && q->sctx && q->sctx->spec && q->sctx->spec->rule && q->sctx->spec->rule->index_all;
-  optimized |= q && q->sctx && q->sctx->spec && q->sctx->spec->diskSpec;
+  QueryIterator *optimizedWildcardIterator = NULL;
+  if (q && q->sctx && q->sctx->spec && q->sctx->spec->rule && q->sctx->spec->rule->index_all) {
+    optimizedWildcardIterator = NewWildcardIterator_Optimized(q->sctx, weight);
+  } else if (q && q->sctx && q->sctx->spec && q->sctx->spec->diskSpec) {
+    optimizedWildcardIterator = NewWildcardIterator(q, weight);
+  }
+  bool optimized = optimizedWildcardIterator != NULL;
   if (optimized) {
-    ni->wcii = NewWildcardIterator_Optimized(q->sctx, weight);
+    ni->wcii = optimizedWildcardIterator;
   }
   ni->child = it;
   ni->maxDocId = maxDocId;          // Valid for the optimized case as well, since this is the maxDocId of the embedded wildcard iterator

--- a/src/iterators/optional_iterator.c
+++ b/src/iterators/optional_iterator.c
@@ -281,10 +281,15 @@ QueryIterator *NewOptionalIterator(QueryIterator *it, QueryEvalCtx *q, double we
     return ret;
   }
   OptionalIterator *oi = rm_calloc(1, sizeof(*oi));
-  bool optimized = q->sctx->spec->rule && q->sctx->spec->rule->index_all;
-  optimized |= q && q->sctx && q->sctx->spec && q->sctx->spec->diskSpec;
+  QueryIterator *optimizedWildcardIterator = NULL;
+  if (q->sctx->spec->rule && q->sctx->spec->rule->index_all) {
+    optimizedWildcardIterator = NewWildcardIterator_Optimized(q->sctx, 0);
+  } else if (q->sctx->spec->diskSpec) {
+    optimizedWildcardIterator = NewWildcardIterator(q, 0);
+  }
+  bool optimized = optimizedWildcardIterator != NULL;
   if (optimized) {
-    oi->wcii = NewWildcardIterator_Optimized(q->sctx, 0);
+    oi->wcii = optimizedWildcardIterator;
   }
   oi->child = it;
   oi->virt = NewVirtualResult(0, RS_FIELDMASK_ALL);


### PR DESCRIPTION
Backport of #8997 to `8.6`.

This was a manual backport because cherry-picking `fa04165a61256010b09b75c14ff6fce23ff060b7` failed on branch-diverged files.

### Cherry-pick conflicts encountered
- `src/iterators/optional_iterator.c` (content conflict)
- `src/redisearch_rs/rqe_iterators/src/not_reducer.rs` (modify/delete: deleted on `8.6`, modified in source commit)
- `src/redisearch_rs/rqe_iterators/src/wildcard.rs` (content conflict)

### How conflicts were resolved
- Applied equivalent behavior manually in the C constructors used on this branch:
  - `NewOptionalIterator`: use `NewWildcardIterator_Optimized(...)` only for `index_all`; use `NewWildcardIterator(...)` when `diskSpec` is present.
  - `NewNotIterator`: same routing logic as above.
- No Rust reducer files were restored on `8.6` since those conflicted files are not part of this branch line; behavior was mapped to the branch’s active C iterator construction path.

#### Main objects this PR modified
1. Iterators

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
