### PR TITLE
[8.6-rse] refactor the way we handle redis-ref

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,15 +15,10 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert to using the latest stable ref in redis
-    runs-on: ubuntu-latest
-    outputs:
-      tag: '8.6'
-    steps:
-      - run: echo "Dummy step to set output"
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
 
   lint:
     permissions:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -36,7 +36,7 @@ jobs:
 
 
   notify-failure:
-    needs: [test-all-platforms, micro-benchmarks]
+    needs: [get-latest-redis-tag, test-all-platforms, micro-benchmarks]
     if: failure()
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -10,7 +10,14 @@ on:
 # TODO: Use RedisJSON's `master` branch when testing on nightly
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
+
   test-all-platforms:
+    needs: [get-latest-redis-tag]
     permissions:
       contents: read
       packages: write
@@ -19,7 +26,7 @@ jobs:
     with:
       platform: all
       architecture: all
-      redis-ref: '8.6'
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,15 +12,10 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert when 8.4 is released
-    runs-on: ubuntu-latest
-    outputs:
-      tag: '8.6'
-    steps:
-      - run: echo "Dummy step to set output"
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
 
   check-what-changed:
     uses: ./.github/workflows/task-check-changes.yml

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -48,12 +48,19 @@ on:
         default: false
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.6'
+
   setup:
+    needs: [get-latest-redis-tag]
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -61,12 +68,6 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=8.6" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -68,9 +68,9 @@ on:
         type: string
         default: QUICK=1
       redis-ref:
-        description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
+        description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "8.6"'
         type: string
-        default: unstable
+        default: "8.6"
       rejson-branch:
         type: string
         default: master


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only changes, but they alter how the Redis version is resolved and add a GitHub API dependency; failures or tag selection issues could break CI runs or test against an unintended Redis patch.
> 
> **Overview**
> CI now derives `redis-ref` from `task-get-latest-tag.yml` (filtered to the `8.6` release line) rather than hardcoding `8.6` in multiple workflows.
> 
> This wires the new `get-latest-redis-tag` job into PR, merge-queue, nightly, and artifact build flows, propagating the resolved tag via `needs.*.outputs.tag`, and updates `flow-test.yml`’s `workflow_dispatch` default `redis-ref` from `unstable` to `8.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 710b5e6ff776d85bc5cb37daf704b51cbceafde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->