### PR TITLE
Fix Test Filtering

### DIFF
--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -41,7 +41,7 @@ def testExpireIndex(env):
             # `assertContains` expects (expected_substring, actual_string)
             env.assertContains('SEARCH_INDEX_NOT_FOUND Index not found', str(e))
 
-@skip(cluster=True, redis_less_than="7.2")
+@skip(cluster=True, redis_less_than="7.4")
 def test_MOD_14800_persist_clears_expiration_metadata(env: Env):
     # Regression for MOD-14800:
     # Verify that persisting a hash key or an indexed hash field clears the


### PR DESCRIPTION
## Describe the changes in the pull request

Minimal Redis version should be `7.4`, when `HEXPIRE` and `HPERSIST` were introduced

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts version gating; risk is limited to skipping the regression test on Redis 7.2/7.3 where it cannot run reliably due to missing `HPEXPIRE`/`HPERSIST`.
> 
> **Overview**
> Updates the `test_MOD_14800_persist_clears_expiration_metadata` skip filter to require Redis `7.4+` (was `7.2+`), aligning the regression test with the Redis version where `HEXPIRE`/`HPERSIST` are available so CI doesn’t attempt to run it on unsupported versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638af91d71579f5b2ca60e4c610484157f8ff213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->