### PR TITLE
[MOD-14864] improve query.c flow test coverage

### DIFF
--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -376,6 +376,7 @@ def test_issue_3124(env):
   res_not_exist2 = env.cmd('ft.search', 'idx_txt_suffix', '@t:ell*')
   env.assertEqual(res_not_exist1, res_not_exist2)
 
+@skip(cluster=True)
 def testTextSuffixTrieMaxPrefixExpansions():
     """Contains query on TEXT WITHSUFFIXTRIE field hits max prefix expansion limit."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -375,3 +375,25 @@ def test_issue_3124(env):
   res_not_exist1 = env.cmd('ft.search', 'idx_txt', '@t:ell*')
   res_not_exist2 = env.cmd('ft.search', 'idx_txt_suffix', '@t:ell*')
   env.assertEqual(res_not_exist1, res_not_exist2)
+
+def testTextSuffixTrieMaxPrefixExpansions():
+    """Contains query on TEXT WITHSUFFIXTRIE field hits max prefix expansion limit."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+
+    # Create many distinct values sharing a common substring
+    for i in range(20):
+        conn.execute_command('HSET', f'{{doc}}:{i}', 't', f'val{i}common')
+
+    # Set max expansions very low
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+    # Contains query (*common*) uses the suffix trie charIterCb path
+    res = env.cmd('FT.SEARCH', 'idx', '*common*', 'LIMIT', '0', '0')
+    env.assertContains('Max prefix expansions limit was reached', res['warning'])
+
+    # Restore default
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -347,3 +347,18 @@ def test_dialect_info():
 
   env.flush()
   check_info_module_results(env, [0,0,0,0])
+
+def test_dialect1_filter_on_nonexistent_field():
+    """FILTER on non-existent field in dialect 1 returns empty results (legacy behavior)."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 1')
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'num', 'NUMERIC').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'hello', 'num', '1')
+
+    # Numeric FILTER on field that doesn't exist in the schema → empty results (not an error)
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'FILTER', 'nonexistent', '0', '10', 'DIALECT', '1')
+    env.assertEqual(res[0], 0)
+
+    # GEOFILTER on field that doesn't exist → empty results (not an error)
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'nonexistent', '0', '0', '100', 'km', 'DIALECT', '1')
+    env.assertEqual(res[0], 0)

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -348,6 +348,7 @@ def test_dialect_info():
   env.flush()
   check_info_module_results(env, [0,0,0,0])
 
+@skip(cluster=True)
 def test_dialect1_filter_on_nonexistent_field():
     """FILTER on non-existent field in dialect 1 returns empty results (legacy behavior)."""
     env = Env(moduleArgs='DEFAULT_DIALECT 1')

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -357,8 +357,8 @@ def test_dialect1_filter_on_nonexistent_field():
 
     # Numeric FILTER on field that doesn't exist in the schema → empty results (not an error)
     res = env.cmd('FT.SEARCH', 'idx', '*', 'FILTER', 'nonexistent', '0', '10', 'DIALECT', '1')
-    env.assertEqual(res[0], 0)
+    env.assertEqual(res, [0])
 
     # GEOFILTER on field that doesn't exist → empty results (not an error)
     res = env.cmd('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'nonexistent', '0', '0', '100', 'km', 'DIALECT', '1')
-    env.assertEqual(res[0], 0)
+    env.assertEqual(res, [0])

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -111,7 +111,7 @@ def testFuzzyManyExpansions(env):
     # We expect at least 9 results (>8 to trigger the capacity doubling).
     # The exact count may vary depending on what the trie iterator yields,
     # but all 10 terms are within distance 1 of "bat".
-    env.assertGreaterEqual(res[0], 9)
+    env.assertGreaterEqual(res[0], 9, message=res)
 
 def testFuzzyMaxPrefixExpansionsWarning():
     """Verify that a fuzzy query triggers a max prefix expansions warning

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -93,6 +93,29 @@ def testFuzzyWithNumbersOnly(env):
         env.expect('ft.search', 'idx', '%%21345%%', 'DIALECT', dialect)\
             .equal([1, 'doc1', ['test', '12345']])
 
+def testFuzzyMaxPrefixExpansionsWarning():
+    """Verify that a fuzzy query triggers a max prefix expansions warning
+    when the number of fuzzy matches exceeds MAXPREFIXEXPANSIONS."""
+    env = Env(protocol=3)
+    conn = getConnectionByEnv(env)
+
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+
+    # Create terms that are all within Levenshtein distance 1 of "ab":
+    # aa, ab, ac, ..., az  (26 terms, all distance <= 1 from "ab")
+    for c in 'abcdefghijklmnopqrstuvwxyz':
+        conn.execute_command('HSET', f'doc_a{c}', 't', f'a{c}')
+
+    # Set max prefix expansions to 1 so the fuzzy expansion is sure to exceed it
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+    # Fuzzy query: %ab% should try to expand to all terms within distance 1
+    res = env.cmd('FT.SEARCH', 'idx', '%ab%')
+    env.assertContains('Max prefix expansions limit was reached', res['warning'])
+
+    # Restore default
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
+
 @skip()
 def testTagFuzzy(env):
     # TODO: fuzzy on tag is broken?

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -93,6 +93,26 @@ def testFuzzyWithNumbersOnly(env):
         env.expect('ft.search', 'idx', '%%21345%%', 'DIALECT', dialect)\
             .equal([1, 'doc1', ['test', '12345']])
 
+def testFuzzyManyExpansions(env):
+    """Verify that a fuzzy query works correctly when matching more than 8
+    terms, which triggers the internal iterator array capacity doubling in
+    addTerm (initial capacity is 8)."""
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+
+    # Create 10 distinct 3-letter terms that are all within Levenshtein
+    # distance 1 of "bat": substitute the first character.
+    terms = ['bat', 'cat', 'dat', 'eat', 'fat', 'gat', 'hat', 'mat', 'pat', 'rat']
+    for i, term in enumerate(terms):
+        conn.execute_command('HSET', f'doc{i}', 't', term)
+
+    # Fuzzy search with distance 1: %bat% should match all of the above
+    res = env.cmd('ft.search', 'idx', '%bat%', 'LIMIT', '0', '0')
+    # We expect at least 9 results (>8 to trigger the capacity doubling).
+    # The exact count may vary depending on what the trie iterator yields,
+    # but all 10 terms are within distance 1 of "bat".
+    env.assertGreaterEqual(res[0], 9)
+
 def testFuzzyMaxPrefixExpansionsWarning():
     """Verify that a fuzzy query triggers a max prefix expansions warning
     when the number of fuzzy matches exceeds MAXPREFIXEXPANSIONS."""

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -93,6 +93,7 @@ def testFuzzyWithNumbersOnly(env):
         env.expect('ft.search', 'idx', '%%21345%%', 'DIALECT', dialect)\
             .equal([1, 'doc1', ['test', '12345']])
 
+@skip(cluster=True)
 def testFuzzyManyExpansions(env):
     """Verify that a fuzzy query works correctly when matching more than 8
     terms, which triggers the internal iterator array capacity doubling in
@@ -113,6 +114,7 @@ def testFuzzyManyExpansions(env):
     # but all 10 terms are within distance 1 of "bat".
     env.assertGreaterEqual(res[0], 9, message=res)
 
+@skip(cluster=True)
 def testFuzzyMaxPrefixExpansionsWarning():
     """Verify that a fuzzy query triggers a max prefix expansions warning
     when the number of fuzzy matches exceeds MAXPREFIXEXPANSIONS."""

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -98,7 +98,7 @@ def testFuzzyManyExpansions(env):
     terms, which triggers the internal iterator array capacity doubling in
     addTerm (initial capacity is 8)."""
     conn = getConnectionByEnv(env)
-    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 
     # Create 10 distinct 3-letter terms that are all within Levenshtein
     # distance 1 of "bat": substitute the first character.
@@ -119,7 +119,7 @@ def testFuzzyMaxPrefixExpansionsWarning():
     env = Env(protocol=3)
     conn = getConnectionByEnv(env)
 
-    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 
     # Create terms that are all within Levenshtein distance 1 of "ab":
     # aa, ab, ac, ..., az  (26 terms, all distance <= 1 from "ab")

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -594,6 +594,7 @@ def testMissingGC():
     env.cmd(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx')
     env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')
 
+@skip(cluster=True)
 def testMissingWithParams():
     """Tests that ismissing() works correctly in a parameterized query.
     This exercises QueryNode_EvalParams traversal of QN_MISSING nodes."""

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -593,3 +593,30 @@ def testMissingGC():
     # Reschedule the gc - add a job to the queue
     env.cmd(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx')
     env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')
+
+def testMissingWithParams():
+    """Tests that ismissing() works correctly in a parameterized query.
+    This exercises QueryNode_EvalParams traversal of QN_MISSING nodes."""
+
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT', 'INDEXMISSING').ok()
+    waitForIndex(env, 'idx')
+
+    conn.execute_command('HSET', 'has_t', 't', 'hello')
+    conn.execute_command('HSET', 'no_t', 'other', 'world')
+
+    # Parameterized query combined with ismissing - triggers
+    # QueryNode_EvalParams on a QN_MISSING node (withChildren=0 path)
+    res = env.cmd('FT.SEARCH', 'idx', '@t:$val | ismissing(@t)',
+                  'NOCONTENT', 'SORTBY', 't', 'ASC',
+                  'PARAMS', '2', 'val', 'hello')
+    env.assertEqual(res[0], 2)
+
+    # Parameterized query with only ismissing in an intersection
+    res = env.cmd('FT.SEARCH', 'idx', '@t:$val ismissing(@t)',
+                  'NOCONTENT',
+                  'PARAMS', '2', 'val', 'hello')
+    env.assertEqual(res[0], 0)

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -603,7 +603,6 @@ def testMissingWithParams():
 
     env.expect('FT.CREATE', 'idx', 'SCHEMA',
                't', 'TEXT', 'INDEXMISSING').ok()
-    waitForIndex(env, 'idx')
 
     conn.execute_command('HSET', 'has_t', 't', 'hello')
     conn.execute_command('HSET', 'no_t', 'other', 'world')

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -612,10 +612,10 @@ def testMissingWithParams():
     res = env.cmd('FT.SEARCH', 'idx', '@t:$val | ismissing(@t)',
                   'NOCONTENT', 'SORTBY', 't', 'ASC',
                   'PARAMS', '2', 'val', 'hello')
-    env.assertEqual(res[0], 2)
+    env.assertEqual(res, [2, 'has_t', 'no_t'])
 
     # Parameterized query with only ismissing in an intersection
     res = env.cmd('FT.SEARCH', 'idx', '@t:$val ismissing(@t)',
                   'NOCONTENT',
                   'PARAMS', '2', 'val', 'hello')
-    env.assertEqual(res[0], 0)
+    env.assertEqual(res, [0])

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -804,3 +804,34 @@ INTERSECT {
     env.expect('FT.EXPLAIN', 'idx', '@text:foo bar @tag:{baz}', 'VERBATIM').equal(expected)
     env.expect('FT.EXPLAIN', 'idx', '(@text:foo bar) @tag:{baz}', 'VERBATIM').equal(expected)
     env.expect('FT.EXPLAIN', 'idx', '@tag:{baz} (@text:foo bar)', 'VERBATIM').equal(expected)
+
+def test_invalid_query_attributes():
+    """Test that invalid query attribute values produce proper errors."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    waitForIndex(env, 'idx')
+
+    # Invalid $slop value (not a number)
+    env.expect('FT.SEARCH', 'idx', 'hello=>{$slop: abc}').error() \
+        .contains('Invalid value')
+
+    # Invalid $slop value (below minimum of -1)
+    env.expect('FT.SEARCH', 'idx', 'hello=>{$slop: -2}').error() \
+        .contains('Invalid value')
+
+    # Invalid $inorder value (not a boolean)
+    env.expect('FT.SEARCH', 'idx', 'hello=>{$inorder: abc}').error() \
+        .contains('Invalid value')
+
+    # Invalid $weight value (not a number)
+    env.expect('FT.SEARCH', 'idx', 'hello=>{$weight: abc}').error() \
+        .contains('Invalid value')
+
+    # Invalid $weight value (negative)
+    env.expect('FT.SEARCH', 'idx', 'hello=>{$weight: -1}').error() \
+        .contains('Invalid value')
+
+    # Unrecognized attribute name
+    env.expect('FT.SEARCH', 'idx', 'hello=>{$bogus: 42}').error() \
+        .contains('Invalid attribute')

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -805,6 +805,7 @@ INTERSECT {
     env.expect('FT.EXPLAIN', 'idx', '(@text:foo bar) @tag:{baz}', 'VERBATIM').equal(expected)
     env.expect('FT.EXPLAIN', 'idx', '@tag:{baz} (@text:foo bar)', 'VERBATIM').equal(expected)
 
+@skip(cluster=True)
 def test_invalid_query_attributes():
     """Test that invalid query attribute values produce proper errors."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
@@ -834,6 +835,7 @@ def test_invalid_query_attributes():
     env.expect('FT.SEARCH', 'idx', 'hello=>{$bogus: 42}').error() \
         .contains('Invalid attribute')
 
+@skip(cluster=True)
 def test_explain_with_inkeys():
     """FT.EXPLAIN with INKEYS renders IDS node in the explain output."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -835,3 +835,14 @@ def test_invalid_query_attributes():
     # Unrecognized attribute name
     env.expect('FT.SEARCH', 'idx', 'hello=>{$bogus: 42}').error() \
         .contains('Invalid attribute')
+
+def test_explain_with_inkeys():
+    """FT.EXPLAIN with INKEYS renders IDS node in the explain output."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'hello')
+    conn.execute_command('HSET', 'doc2', 't', 'world')
+
+    res = env.cmd('FT.EXPLAIN', 'idx', 'hello', 'INKEYS', '2', 'doc1', 'doc2')
+    env.assertContains('IDS', res)

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -808,9 +808,7 @@ INTERSECT {
 def test_invalid_query_attributes():
     """Test that invalid query attribute values produce proper errors."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
-    conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-    waitForIndex(env, 'idx')
 
     # Invalid $slop value (not a number)
     env.expect('FT.SEARCH', 'idx', 'hello=>{$slop: abc}').error() \

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -806,9 +806,8 @@ INTERSECT {
     env.expect('FT.EXPLAIN', 'idx', '@tag:{baz} (@text:foo bar)', 'VERBATIM').equal(expected)
 
 @skip(cluster=True)
-def test_invalid_query_attributes():
+def test_invalid_query_attributes(env):
     """Test that invalid query attribute values produce proper errors."""
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 
     # Invalid $slop value (not a number)
@@ -836,9 +835,8 @@ def test_invalid_query_attributes():
         .contains('Invalid attribute')
 
 @skip(cluster=True)
-def test_explain_with_inkeys():
+def test_explain_with_inkeys(env):
     """FT.EXPLAIN with INKEYS renders IDS node in the explain output."""
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
     conn.execute_command('HSET', 'doc1', 't', 'hello')

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -1005,3 +1005,91 @@ def testTagUNF():
     res = env.cmd('FT.AGGREGATE', 'idx_unf', '*', 'GROUPBY', '1', '@tag',
                   'REDUCE', 'COUNT', '0')
     env.assertEqual(res[0], 3)
+
+def testTagWildcardWithSuffixTrieNoMatch():
+    """Tag wildcard on WITHSUFFIXTRIE field with no matching terms returns
+    empty results (covers suffix trie NULL return path)."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'tag', 'TAG', 'WITHSUFFIXTRIE').ok()
+
+    conn.execute_command('HSET', '{doc}:1', 'tag', 'apple')
+    conn.execute_command('HSET', '{doc}:2', 'tag', 'banana')
+    conn.execute_command('HSET', '{doc}:3', 'tag', 'cherry')
+
+    # Wildcard with a long fixed prefix that the suffix trie can process
+    # but finds no matches — triggers the NULL return path
+    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'xyznonexistent*'}", 'NOCONTENT')
+    env.assertEqual(res[0], 0)
+
+def testTagSuffixMaxExpansionsWithSuffixTrie():
+    """Tag suffix query on WITHSUFFIXTRIE field hits max prefix expansion
+    limit when there are more matching terms than allowed (covers the suffix
+    trie branch of Query_EvalTagPrefixNode)."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'tag', 'TAG', 'WITHSUFFIXTRIE').ok()
+
+    # Create many distinct tag values sharing a common suffix
+    for i in range(20):
+        conn.execute_command('HSET', f'{{doc}}:{i}', 'tag', f'val{i}common')
+
+    # Set max expansions very low
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+    # Suffix query (*common) uses the suffix trie path and should trigger
+    # max expansion warning
+    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*common}', 'LIMIT', '0', '0')
+    env.assertContains('Max prefix expansions limit was reached', res['warning'])
+
+    # Restore default
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
+
+def testTagWildcardMaxExpansionsWithSuffixTrie():
+    """Tag wildcard on WITHSUFFIXTRIE field hits max prefix expansion limit."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'tag', 'TAG', 'WITHSUFFIXTRIE').ok()
+
+    # Create many distinct tag values
+    for i in range(20):
+        conn.execute_command('HSET', f'{{doc}}:{i}', 'tag', f'val{i}end')
+
+    # Set max expansions very low
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+    # Wildcard query that uses suffix trie and exceeds max expansions
+    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'val*end'}", 'LIMIT', '0', '0')
+    env.assertContains('Max prefix expansions limit was reached', res['warning'])
+
+    # Restore default
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
+
+def testTagWildcardMaxExpansionsBruteForce():
+    """Tag wildcard without suffix trie (brute-force) hits max prefix
+    expansion limit."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
+    conn = getConnectionByEnv(env)
+
+    # No WITHSUFFIXTRIE - forces brute-force wildcard path
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
+
+    # Create many distinct tag values
+    for i in range(20):
+        conn.execute_command('HSET', f'{{doc}}:{i}', 'tag', f'val{i}end')
+
+    # Set max expansions very low
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+    # Wildcard query through brute-force path
+    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'val*end'}", 'LIMIT', '0', '0')
+    env.assertContains('Max prefix expansions limit was reached', res['warning'])
+
+    # Restore default
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -1026,6 +1026,7 @@ def testTagUNF():
                   'REDUCE', 'COUNT', '0')
     env.assertEqual(res[0], 3)
 
+@skip(cluster=True)
 def testTagWildcardWithSuffixTrieNoMatch():
     """Tag wildcard on WITHSUFFIXTRIE field with no matching terms returns
     empty results (covers suffix trie NULL return path)."""
@@ -1044,6 +1045,7 @@ def testTagWildcardWithSuffixTrieNoMatch():
     res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'xyznonexistent*'}", 'NOCONTENT')
     env.assertEqual(res, [0])
 
+@skip(cluster=True)
 def testTagSuffixMaxExpansionsWithSuffixTrie():
     """Tag suffix query on WITHSUFFIXTRIE field hits max prefix expansion
     limit when there are more matching terms than allowed (covers the suffix
@@ -1069,6 +1071,7 @@ def testTagSuffixMaxExpansionsWithSuffixTrie():
     # Restore default
     run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
 
+@skip(cluster=True)
 def testTagWildcardMaxExpansionsWithSuffixTrie():
     """Tag wildcard on WITHSUFFIXTRIE field hits max prefix expansion limit."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
@@ -1091,6 +1094,7 @@ def testTagWildcardMaxExpansionsWithSuffixTrie():
     # Restore default
     run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
 
+@skip(cluster=True)
 def testTagWildcardMaxExpansionsBruteForce():
     """Tag wildcard without suffix trie (brute-force) hits max prefix
     expansion limit."""

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -92,11 +92,11 @@ def testTagPrefixTooShort(env):
         waitForIndex(env, 'idx')
         # 2-char prefix works (meets default MINPREFIX=2)
         res = env.cmd('ft.search', 'idx', '@tags:{al*}', 'nocontent')
-        env.assertEqual(res[0], 1)
+        env.assertEqual(res, [1, 'doc1'])
 
         # 1-char prefix returns nothing (below MINPREFIX)
         res = env.cmd('ft.search', 'idx', '@tags:{a*}', 'nocontent')
-        env.assertEqual(res[0], 0)
+        env.assertEqual(res, [0])
 
 def testTagFieldCase(env):
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
@@ -1042,7 +1042,7 @@ def testTagWildcardWithSuffixTrieNoMatch():
     # Wildcard with a long fixed prefix that the suffix trie can process
     # but finds no matches — triggers the NULL return path
     res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'xyznonexistent*'}", 'NOCONTENT')
-    env.assertEqual(res[0], 0)
+    env.assertEqual(res, [0])
 
 def testTagSuffixMaxExpansionsWithSuffixTrie():
     """Tag suffix query on WITHSUFFIXTRIE field hits max prefix expansion

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -78,6 +78,26 @@ def testTagPrefix(env):
             res = env.cmd('ft.search', 'idx', q)
             env.assertEqual(res[0], 1)
 
+@skip(cluster=True)
+def testTagPrefixTooShort(env):
+    """A single-char tag prefix is rejected when MINPREFIX (default 2) is not met."""
+    env.expect(
+        'ft.create', 'idx', 'ON', 'HASH',
+        'schema', 'tags', 'tag', 'separator', ',').ok()
+
+    env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
+               'tags', 'alpha,beta,gamma').ok()
+
+    for _ in env.reloadingIterator():
+        waitForIndex(env, 'idx')
+        # 2-char prefix works (meets default MINPREFIX=2)
+        res = env.cmd('ft.search', 'idx', '@tags:{al*}', 'nocontent')
+        env.assertEqual(res[0], 1)
+
+        # 1-char prefix returns nothing (below MINPREFIX)
+        res = env.cmd('ft.search', 'idx', '@tags:{a*}', 'nocontent')
+        env.assertEqual(res[0], 0)
+
 def testTagFieldCase(env):
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
     env.expect(

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -85,8 +85,8 @@ def testTagPrefixTooShort(env):
         'ft.create', 'idx', 'ON', 'HASH',
         'schema', 'tags', 'tag', 'separator', ',').ok()
 
-    env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
-               'tags', 'alpha,beta,gamma').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc1', 'tags', 'alpha,beta,gamma')
 
     for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -718,6 +718,12 @@ def test_search_errors():
     env.expect('FT.SEARCH', 'idx', 'hello=>[KNN 2 @v $b AS score]=>{$yield_distance_as:__v_score;}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('Distance field was specified twice for vector query: score and __v_score')
     env.expect('FT.SEARCH', 'idx', 'hello=>[KNN 2 @v $b AS score]=>{$yield_distance_as:score;}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('Distance field was specified twice for vector query: score and score')
 
+    # Invalid shard_k_ratio via query attribute syntax.
+    env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]=>{$shard_k_ratio: invalid;}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('Invalid shard k ratio value')
+
+    # Unrecognized vector attribute via query attribute syntax.
+    env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]=>{$bogus_vec_param: 42;}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('Invalid attribute')
+
     # Invalid range queries
     env.expect('FT.SEARCH', 'idx', '@v:[vector_range 0.1 $b]', 'PARAMS', '2', 'b', 'abcdefg').error().contains('Error parsing vector similarity query: query vector blob size (7) does not match index\'s expected size (8).')
     env.expect('FT.SEARCH', 'idx', '@v:[vector_range 0.1 $b]', 'PARAMS', '2', 'b', 'abcdefghi').error().contains('Error parsing vector similarity query: query vector blob size (9) does not match index\'s expected size (8).')

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -406,3 +406,18 @@ def testMOD7453():
     # the text wildcard doesn't match the result correctly.
     res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'*a*?'} | @text:w'*a*?'")
     env.assertEqual(res, [1, 'doc1', ['tag', 'ba*cl', 'text', 'ba*cl']])
+
+def testWildcardOnFieldWithoutSuffixTrie():
+    """Wildcard query on a TEXT field without WITHSUFFIXTRIE errors when spec has a suffix trie."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    # t1 has WITHSUFFIXTRIE, t2 does not
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't1', 'TEXT', 'WITHSUFFIXTRIE',
+               't2', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc1', 't1', 'hello', 't2', 'world')
+
+    # Wildcard on t2 should error: spec->suffix exists (from t1) but t2 is not in suffixMask
+    env.expect('FT.SEARCH', 'idx', "@t2:w'hel*o'").error() \
+        .contains('WITHSUFFIXTRIE')

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -407,6 +407,7 @@ def testMOD7453():
     res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'*a*?'} | @text:w'*a*?'")
     env.assertEqual(res, [1, 'doc1', ['tag', 'ba*cl', 'text', 'ba*cl']])
 
+@skip(cluster=True)
 def testWildcardOnFieldWithoutSuffixTrie():
     """Wildcard query on a TEXT field without WITHSUFFIXTRIE errors when spec has a suffix trie."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')


### PR DESCRIPTION
Filling gaps in `query.c` flow test coverage by adding new python tests.

Improve codecov reported coverage by 1.55%.

All those have been generated using my new `check-flow-coverage` skill: https://github.com/RediSearch/RediSearch/pull/9126

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage for edge-case warnings/errors without modifying production logic.
> 
> **Overview**
> Improves regression/flow coverage by adding **new standalone-only Python tests** for query parsing and iterator edge cases.
> 
> The new tests cover: `WITHSUFFIXTRIE` TEXT/TAG contains/suffix/wildcard behavior when `MAXPREFIXEXPANSIONS` is exceeded (warning paths and NULL/no-match paths), fuzzy expansion behavior (including iterator capacity growth and max-expansion warnings), `ismissing()` correctness inside parameterized queries, and dialect-1 legacy behavior where `FILTER`/`GEOFILTER` on non-schema fields returns empty results.
> 
> It also adds parser/validation coverage for invalid query attribute values (including vector query attributes like invalid `shard_k_ratio`/unknown attributes), ensures `FT.EXPLAIN` renders `IDS` when using `INKEYS`, and validates tag prefix results when below default `MINPREFIX`, plus an error case for wildcard queries against a TEXT field lacking `WITHSUFFIXTRIE` in a mixed schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d8fc9b5888703d586313c50cad2cad271abaa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->