### PR TITLE
add logs to update disk path

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -212,11 +212,19 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
       uint64_t oldDocId = 0;
       DocIdMeta_Get(ctx->redisCtx, cur->doc->docKey, spec->specId, &oldDocId);
 
+      RedisModule_Log(RSDummyContext, "debug",
+        "Disk update: key='%.*s', oldDocId=%lu, score=%f, flags=%u",
+        (int)len, key, (unsigned long)oldDocId, cur->doc->score, cur->docFlags);
+
       // Put the document and get a new doc-id, and remove the old id->dmd entry
       // if it existed.
       t_docId docId = SearchDisk_PutDocument(spec->diskSpec, key, len,
         cur->doc->score, cur->docFlags, cur->fwIdx->maxTermFreq,
         cur->fwIdx->totalFreq, &oldLen, cur->doc->docExpirationTime, oldDocId);
+
+      RedisModule_Log(RSDummyContext, "debug",
+        "Disk update: key='%.*s', newDocId=%lu, oldLen=%u",
+        (int)len, key, (unsigned long)docId, oldLen);
 
       bool failure = docId == 0;
 
@@ -227,6 +235,9 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
         RS_ASSERT(spec->stats.scoring.totalDocsLen >= oldLen);
         spec->stats.scoring.totalDocsLen -= oldLen;
         updated = docId != 0; // If docId is 0, the document was not added
+        RedisModule_Log(RSDummyContext, "debug",
+          "Disk update: key='%.*s', old document deleted (oldLen=%u), updated=%d",
+          (int)len, key, oldLen, updated);
       }
 
       if (!failure) {
@@ -238,9 +249,16 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
         if (failure) {
           uint32_t docLen = 0;
           SearchDisk_DeleteDocumentById(spec->diskSpec, docId, &docLen);
+          RedisModule_Log(RSDummyContext, "warning",
+            "Disk update: key='%.*s', failed to set DocIdMeta for newDocId=%lu, rolled back",
+            (int)len, key, (unsigned long)docId);
         } else {
           spec->stats.scoring.totalDocsLen += cur->fwIdx->totalFreq;
           ++spec->stats.scoring.numDocuments;
+          RedisModule_Log(RSDummyContext, "debug",
+            "Disk update: key='%.*s', successfully indexed newDocId=%lu, numDocs=%zu, totalDocsLen=%zu",
+            (int)len, key, (unsigned long)docId,
+            spec->stats.scoring.numDocuments, spec->stats.scoring.totalDocsLen);
         }
       }
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no functional behavior modifications beyond extra runtime log output and minor performance overhead in the disk update path.
> 
> **Overview**
> Improves observability of the disk indexing update path by adding `RedisModule_Log` statements around `SearchDisk_PutDocument` and `DocIdMeta_Set` in `doAssignIds`.
> 
> The new logs emit old/new `docId`, document key, score/flags, old document deletion, and a warning when `DocIdMeta_Set` fails and the newly written document is rolled back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa9c774c3178c25ed21dc5f3eb30b72c57be65a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->