### PR TITLE
fix Daily CI report handling, missing inputs

### DIFF
--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -63,19 +63,6 @@ jobs:
         run: |
           python scripts/collect_nightly_results.py --date "${{ steps.date.outputs.date }}"
 
-      - name: Handle collect failure
-        if: steps.collect.outcome == 'failure'
-        uses: slackapi/slack-github-action@v2
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "repository": "${{ github.repository }}",
-              "header": "❌ CI Report Generation Failed - ${{ steps.date.outputs.date }}",
-              "error": "The collect_nightly_results.py script failed. Check workflow logs for details."
-            }
-
       - name: Read summary file
         id: summary
         run: |
@@ -107,7 +94,7 @@ jobs:
           fi
 
       - name: Send reports to Slack
-        if: steps.summary.outputs.summary_exists == 'true' || steps.failure_report.outputs.failure_exists == 'true'
+        if: always()
         uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
@@ -115,9 +102,10 @@ jobs:
           payload: |
             {
               "repository": "${{ github.repository }}",
-              "header": "📊 Daily CI Report - ${{ steps.date.outputs.date }}",
-              "summary_report": ${{ steps.summary.outputs.summary_exists == 'true' && steps.summary.outputs.summary_content || '"(No summary available)"' }},
-              "failure_report": ${{ steps.failure_report.outputs.failure_exists == 'true' && steps.failure_report.outputs.failure_content || '"(No failures)"' }}
+              "header": "${{ steps.collect.outcome == 'failure' && format('❌ CI Report Generation Failed - {0}', steps.date.outputs.date) || format('📊 Daily CI Report - {0}', steps.date.outputs.date) }}",
+              "summary_report": ${{ steps.summary.outputs.summary_exists == 'true' && steps.summary.outputs.summary_content || '""' }},
+              "failure_report": ${{ steps.failure_report.outputs.failure_exists == 'true' && steps.failure_report.outputs.failure_content || '""' }},
+              "error": "${{ steps.collect.outcome == 'failure' && 'The collect_nightly_results.py script failed. Check workflow logs for details.' || '' }}"
             }
 
       - name: Upload artifacts


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to Slack notification conditions and payload formatting; low risk aside from potentially noisier Slack posts or empty report fields.
> 
> **Overview**
> Daily CI report workflow now **always posts to Slack**, even when report files are missing, and consolidates failure handling into the main Slack message.
> 
> The Slack payload is updated to dynamically switch the header (success vs. collection failure), include an `error` field when `collect_nightly_results.py` fails, and send empty-string content instead of placeholder "(No …)" text for missing summary/failure reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baab741cbaec9800ab41d4a7240e7ffa27c1c9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->