### PR TITLE
Disk iterator Rust mocks + use for optional

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -18,7 +18,7 @@ use rqe_iterators::{
 };
 use rqe_iterators_test_utils::MockContext;
 
-use crate::utils::Mock;
+use crate::utils::{MOCK_DISK_WILDCARD_TOP_ID, Mock, init_enterprise_iterators};
 
 mod optional_reducer_tests {
     use super::*;
@@ -175,6 +175,52 @@ mod optional_reducer_tests {
         );
     }
 
+    /// Regular case — disk index: child is a plain [`Mock`] iterator and
+    /// `spec.diskSpec` is non-null, so the factory calls
+    /// `new_wildcard_iterator_on_disk` and wraps the child in an
+    /// [`OptionalOptimized`].
+    ///
+    /// We confirm the disk path was taken by checking `num_estimated()` on the
+    /// result — [`OptionalOptimized`] delegates it to its inner wildcard, and
+    /// [`MockEnterpriseIterators`](crate::utils::MockEnterpriseIterators) uses
+    /// [`MOCK_DISK_WILDCARD_TOP_ID`] as the sentinel `top_id`.
+    #[test]
+    fn regular_disk_index_child_wrapped_in_optional_optimized_via_disk_wildcard() {
+        const MAX_DOC_ID: ffi::t_docId = 100;
+        const WEIGHT: f64 = 1.5;
+        const DOCS: [ffi::t_docId; 3] = [10, 20, 30];
+
+        // Ensure the global enterprise-iterator registry is populated.
+        init_enterprise_iterators();
+
+        let ctx = MockContext::new(MAX_DOC_ID, 0);
+        // Point `spec.diskSpec` at a local storage cell — its value is ignored
+        // by the mock; all that matters is that the pointer is non-null.
+        let mut disk_spec_storage: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
+        // SAFETY: no iterator from `ctx` is alive at this point, and
+        // `disk_spec_storage` outlives all iterators created below.
+        unsafe { ctx.set_disk_spec(&mut disk_spec_storage) };
+
+        let child = Mock::new(DOCS);
+
+        // SAFETY: `ctx` provides a valid `QueryEvalCtx`; `spec.diskSpec` is
+        // non-null so `new_wildcard_iterator_on_disk` is called;
+        // `SEARCH_ENTERPRISE_ITERATORS` is initialized above.
+        let result = unsafe { new_optional_iterator(child, WEIGHT, ctx.qctx(), MAX_DOC_ID) };
+
+        let NewOptionalIterator::OptionalOptimized(it) = result else {
+            panic!("expected OptionalOptimized for disk-index path, got a different variant");
+        };
+        // `OptionalOptimized::num_estimated` delegates to the inner wildcard.
+        // The mock returns a `Wildcard` with `MOCK_DISK_WILDCARD_TOP_ID` as its
+        // `top_id`, so this assertion confirms the disk path was taken.
+        assert_eq!(
+            it.num_estimated(),
+            MOCK_DISK_WILDCARD_TOP_ID as usize,
+            "inner wildcard must come from the mock disk enterprise iterator"
+        );
+    }
+
     /// Regular case — optimized index: child is a plain [`Mock`] iterator and
     /// `rule.index_all` is true, so the factory wraps it in an
     /// [`OptionalOptimized`] backed by an empty wildcard (because
@@ -197,9 +243,16 @@ mod optional_reducer_tests {
         // wildcard side of the `OptionalOptimized`.
         let result = unsafe { new_optional_iterator(child, WEIGHT, ctx.qctx(), MAX_DOC_ID) };
 
-        assert!(
-            matches!(result, NewOptionalIterator::OptionalOptimized(_)),
-            "expected OptionalOptimized, got a different variant"
+        let NewOptionalIterator::OptionalOptimized(it) = result else {
+            panic!("expected OptionalOptimized, got a different variant");
+        };
+        // `diskSpec` is null, so the disk path is not taken.
+        // The inner wildcard is an `EmptyWildcard` (because `existingDocs` is
+        // also null), which reports `num_estimated() == 0`.
+        assert_eq!(
+            it.num_estimated(),
+            0,
+            "inner wildcard must be EmptyWildcard, not the disk wildcard"
         );
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A mock implementation of [`SearchEnterpriseIterators`] for use in integration tests.
+//!
+//! The real disk iterator is part of the closed-source enterprise codebase and is not
+//! available in this repository. This mock stands in for it, allowing the open-source
+//! test suite to exercise code paths that depend on [`SEARCH_ENTERPRISE_ITERATORS`]
+//! without requiring the actual enterprise implementation.
+
+use rqe_iterators::{
+    RQEIterator, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators, wildcard::Wildcard,
+};
+
+/// The `top_id` used by the wildcard returned from
+/// [`MockEnterpriseIterators::new_wildcard_on_disk`].
+///
+/// Tests that exercise the disk-wildcard path can call `num_estimated()` on the
+/// resulting iterator and compare against this sentinel to confirm the disk path
+/// was taken.
+pub(crate) const MOCK_DISK_WILDCARD_TOP_ID: ffi::t_docId = 53596;
+
+/// Minimal [`SearchEnterpriseIterators`] stub for tests that exercise the
+/// disk-index code paths.
+///
+/// `new_wildcard_on_disk` returns a [`Wildcard`] with [`MOCK_DISK_WILDCARD_TOP_ID`]
+/// as its `top_id`, so callers which delegates `num_estimated` to their inner wildcard
+/// can observe through it that the disk path was taken.
+pub(crate) struct MockEnterpriseIterators;
+
+impl SearchEnterpriseIterators for MockEnterpriseIterators {
+    fn new_wildcard_on_disk<'index>(
+        &self,
+        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        weight: f64,
+    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+        Ok(Box::new(Wildcard::new(MOCK_DISK_WILDCARD_TOP_ID, weight)))
+    }
+
+    fn new_term_on_disk<'index>(
+        &self,
+        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        _query_term: Box<query_term::RSQueryTerm>,
+        _field_mask: inverted_index::t_fieldMask,
+        _weight: f64,
+    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("MockEnterpriseIterators::new_term_on_disk not used in these tests")
+    }
+
+    fn new_tag_on_disk<'index>(
+        &self,
+        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        _token: &ffi::RSToken,
+        _field_index: ffi::t_fieldIndex,
+        _weight: f64,
+    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("MockEnterpriseIterators::new_tag_on_disk not used in these tests")
+    }
+}
+
+/// Initialize [`SEARCH_ENTERPRISE_ITERATORS`] with [`MockEnterpriseIterators`]
+/// if it has not been set yet.
+///
+/// Safe to call from multiple tests in the same binary: subsequent calls are
+/// no-ops (the `OnceLock` keeps the first value).
+pub(crate) fn init_enterprise_iterators() {
+    SEARCH_ENTERPRISE_ITERATORS.get_or_init(|| Box::new(MockEnterpriseIterators));
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -7,8 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+mod mock_enterprise_iterators;
 mod mock_iterator;
 mod wildcard_helper;
+pub(crate) use mock_enterprise_iterators::{MOCK_DISK_WILDCARD_TOP_ID, init_enterprise_iterators};
 pub(crate) use mock_iterator::{Mock, MockData, MockIteratorError, MockRevalidateResult, MockVec};
 pub(crate) use wildcard_helper::WildcardHelper;
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -141,6 +141,23 @@ impl MockContext {
         unsafe { (*self.rule).index_all = value };
     }
 
+    /// Set [`IndexSpec::diskSpec`] to point to the given disk index spec.
+    ///
+    /// Pass `std::ptr::null_mut()` to clear the field (making the spec appear
+    /// to have no disk index).
+    ///
+    /// # Safety
+    ///
+    /// 1. Must not be called while any iterator created from this context is
+    ///    still alive, as it mutates the spec through a raw pointer.
+    /// 2. `disk_spec`, when non-null, must remain valid for as long as
+    ///    iterators created from this context are alive.
+    pub unsafe fn set_disk_spec(&self, disk_spec: *mut ffi::RedisSearchDiskIndexSpec) {
+        // SAFETY: Caller guarantees no iterators from this context are alive (1),
+        // so the write does not race.
+        unsafe { (*self.spec).diskSpec = disk_spec };
+    }
+
     /// Get a zeroed [`TagIndex`](ffi::TagIndex) pointer for basic (non-revalidation) tests.
     pub const fn tag_index(&self) -> NonNull<ffi::TagIndex> {
         NonNull::new(self.tag_index).expect("TagIndex should not be null")


### PR DESCRIPTION
- based on https://github.com/RediSearch/RediSearch/pull/8751
- see last commit e83eab39622581d850313a09cad05c9745ae7d58

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test code and test utilities, adding coverage for the disk-index optional path. The only caution is new unsafe pointer mutation in `MockContext`, but it’s limited to controlled test usage.
> 
> **Overview**
> Adds an open-source test stub for enterprise on-disk iterators by introducing `MockEnterpriseIterators` and an `init_enterprise_iterators()` helper that initializes `SEARCH_ENTERPRISE_ITERATORS`.
> 
> Extends the `optional_reducer` integration tests to exercise the **disk index** branch (non-null `spec.diskSpec`) and assert the factory returns `OptionalOptimized` backed by the disk wildcard via a sentinel `MOCK_DISK_WILDCARD_TOP_ID`; also tightens the existing optimized-index test to assert it does *not* use the disk path.
> 
> Updates `MockContext` with an unsafe `set_disk_spec()` so tests can toggle the `IndexSpec::diskSpec` pointer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37d9d56baf848bbfdaf8318f6b5380cf4c1de20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->