### PR TITLE
Beng union flat original indices

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -112,15 +112,15 @@ where
 
     /// Returns a shared reference to the child originally at insertion index `idx`.
     ///
-    /// Scans the children to find the one whose `original_index` matches,
-    /// so this is O(n) — intended for profile display, not hot-path iteration.
-    pub fn child_at(&self, idx: usize) -> &I {
-        let pos = self
-            .children
+    /// Returns `None` if the child was permanently removed (e.g. aborted during
+    /// revalidation). Scans the children to find the one whose `original_index`
+    /// matches, so this is O(n) — intended for profile display, not hot-path
+    /// iteration.
+    pub fn child_at(&self, idx: usize) -> Option<&I> {
+        self.children
             .iter()
-            .position(|c| c.original_index == idx)
-            .expect("child_at: original index not found");
-        &self.children[pos].inner
+            .find(|c| c.original_index == idx)
+            .map(|c| &c.inner)
     }
 
     /// Advances all active children whose `last_doc_id` equals `current_id` and finds the

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -14,6 +14,33 @@ use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
+/// A child iterator paired with its original insertion index.
+///
+/// Tracks where the child was in the original `children` vector so that
+/// we can restore the original order. 
+pub(crate) struct IndexedChild<I> {
+    /// Position of this child in the original `children` vector passed to
+    /// [`UnionFlat::new`].
+    pub(crate) original_index: usize,
+    /// The underlying child iterator.
+    pub(crate) inner: I,
+}
+
+impl<I> std::ops::Deref for IndexedChild<I> {
+    type Target = I;
+    #[inline(always)]
+    fn deref(&self) -> &I {
+        &self.inner
+    }
+}
+
+impl<I> std::ops::DerefMut for IndexedChild<I> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut I {
+        &mut self.inner
+    }
+}
+
 /// Yields documents appearing in ANY child iterator using a flat array scan.
 ///
 /// Unlike [`crate::Intersection`] which requires documents to appear in ALL children,
@@ -34,7 +61,7 @@ use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, Skip
 pub struct UnionFlat<'index, I, const QUICK_EXIT: bool> {
     /// Child iterators. Active children are in `children[..num_active]`,
     /// exhausted children are moved to the end and not removed so we can rewind the iterator.
-    children: Vec<I>,
+    children: Vec<IndexedChild<I>>,
     /// Number of active (non-EOF) children. Only `children[..num_active]` are scanned.
     num_active: usize,
     /// Sum of all children's estimated counts (upper bound).
@@ -55,6 +82,14 @@ where
     pub fn new(children: Vec<I>) -> Self {
         let num_estimated: usize = children.iter().map(|c| c.num_estimated()).sum();
         let num_children = children.len();
+        let children: Vec<IndexedChild<I>> = children
+            .into_iter()
+            .enumerate()
+            .map(|(i, inner)| IndexedChild {
+                original_index: i,
+                inner,
+            })
+            .collect();
 
         if children.is_empty() {
             return Self {
@@ -407,7 +442,10 @@ where
     }
 
     fn rewind(&mut self) {
-        // Reset num_active to include all children again
+        // Restore children to their original insertion order so that the
+        self.children
+            .sort_unstable_by_key(|c| c.original_index);
+
         self.num_active = self.children.len();
         self.is_eof = self.children.is_empty();
         self.result.reset_aggregate();
@@ -538,7 +576,10 @@ impl<'index, const QUICK_EXIT: bool> crate::interop::ProfileChildren<'index>
             children: self
                 .children
                 .into_iter()
-                .map(crate::c2rust::CRQEIterator::into_profiled)
+                .map(|c| IndexedChild {
+                    original_index: c.original_index,
+                    inner: c.inner.into_profiled(),
+                })
                 .collect(),
             num_active: self.num_active,
             num_estimated: self.num_estimated,

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -110,6 +110,19 @@ where
         }
     }
 
+    /// Returns a shared reference to the child originally at insertion index `idx`.
+    ///
+    /// Scans the children to find the one whose `original_index` matches,
+    /// so this is O(n) — intended for profile display, not hot-path iteration.
+    pub fn child_at(&self, idx: usize) -> &I {
+        let pos = self
+            .children
+            .iter()
+            .position(|c| c.original_index == idx)
+            .expect("child_at: original index not found");
+        &self.children[pos].inner
+    }
+
     /// Advances all active children whose `last_doc_id` equals `current_id` and finds the
     /// minimum doc_id in a single pass.
     ///

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -442,7 +442,7 @@ where
     }
 
     fn rewind(&mut self) {
-        // Restore children to their original insertion order so that the
+        // Restore children to their original insertion order.
         self.children
             .sort_unstable_by_key(|c| c.original_index);
 

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -17,7 +17,7 @@ use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, Skip
 /// A child iterator paired with its original insertion index.
 ///
 /// Tracks where the child was in the original `children` vector so that
-/// we can restore the original order. 
+/// we can restore the original order.
 pub(crate) struct IndexedChild<I> {
     /// Position of this child in the original `children` vector passed to
     /// [`UnionFlat::new`].
@@ -443,8 +443,7 @@ where
 
     fn rewind(&mut self) {
         // Restore children to their original insertion order.
-        self.children
-            .sort_unstable_by_key(|c| c.original_index);
+        self.children.sort_unstable_by_key(|c| c.original_index);
 
         self.num_active = self.children.len();
         self.is_eof = self.children.is_empty();

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -73,8 +73,10 @@ where
     }
 
     /// Returns a shared reference to the child originally at insertion index `idx`.
-    pub fn child_at(&self, idx: usize) -> &I {
-        &self.children[idx]
+    ///(if any child was removed, there is no guarantee that the same child will be at this position).
+    /// Returns `None` if the child is out of range.
+    pub fn child_at(&self, idx: usize) -> Option<&I> {
+        self.children.get(idx)
     }
 
     /// Rebuilds the heap from scratch based on current child positions.

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -72,6 +72,11 @@ where
         }
     }
 
+    /// Returns a shared reference to the child originally at insertion index `idx`.
+    pub fn child_at(&self, idx: usize) -> &I {
+        &self.children[idx]
+    }
+
     /// Rebuilds the heap from scratch based on current child positions.
     /// Used after revalidation when children may have moved arbitrarily.
     fn rebuild_heap(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -189,7 +189,9 @@ macro_rules! union_common_tests {
 
             // Record the pointer (address) of each child before any reads.
             let ptrs_before: Vec<*const dyn RQEIterator<'static>> = (0..3)
-                .map(|i| union_iter.child_at(i) as *const dyn RQEIterator<'static>)
+                .map(|i| {
+                    union_iter.child_at(i).unwrap() as *const dyn RQEIterator<'static>
+                })
                 .collect();
 
             while union_iter.read().expect("read failed").is_some() {}
@@ -198,8 +200,8 @@ macro_rules! union_common_tests {
             // Rewind and verify child_at returns the same child objects.
             union_iter.rewind();
             for i in 0..3 {
-                let ptr_after =
-                    union_iter.child_at(i) as *const dyn RQEIterator<'static>;
+                let ptr_after = union_iter.child_at(i).unwrap()
+                    as *const dyn RQEIterator<'static>;
                 assert!(
                     std::ptr::addr_eq(ptrs_before[i], ptr_after),
                     "child_at({i}) should return the same child after rewind"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -178,6 +178,35 @@ macro_rules! union_common_tests {
             }
         }
 
+        #[test]
+        #[cfg_attr(miri, ignore)] // Calls RSYieldableMetric_Concat FFI in push_borrowed
+        fn rewind_restores_original_order_after_exhaustion() {
+            // Child 0: [1]         — exhausts first
+            // Child 1: [1, 5]      — exhausts second
+            // Child 2: [1, 5, 10]  — exhausts last
+            let (children, _data) = create_mock_3([1], [1, 5], [1, 5, 10]);
+            let mut union_iter = Union::new(children);
+
+            // Record the pointer (address) of each child before any reads.
+            let ptrs_before: Vec<*const dyn RQEIterator<'static>> = (0..3)
+                .map(|i| union_iter.child_at(i) as *const dyn RQEIterator<'static>)
+                .collect();
+
+            while union_iter.read().expect("read failed").is_some() {}
+            assert!(union_iter.at_eof());
+
+            // Rewind and verify child_at returns the same child objects.
+            union_iter.rewind();
+            for i in 0..3 {
+                let ptr_after =
+                    union_iter.child_at(i) as *const dyn RQEIterator<'static>;
+                assert!(
+                    std::ptr::addr_eq(ptrs_before[i], ptr_after),
+                    "child_at({i}) should return the same child after rewind"
+                );
+            }
+        }
+
         // =============================================================================
         // Edge case tests
         // =============================================================================


### PR DESCRIPTION

## Describe the changes in the pull request

change the union flat to be aware of the original children order


#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `UnionFlat`’s internal child storage and `rewind()` behavior (adds sorting by original insertion index), which could affect iteration/profiling expectations and adds minor overhead; core union semantics are intended to remain unchanged but touches query-iterator internals.
> 
> **Overview**
> **`UnionFlat` now tracks each child’s original insertion index** by wrapping children in `IndexedChild`, enabling stable lookup and order restoration even after swap-removing exhausted children.
> 
> `UnionFlat::rewind()` now re-sorts children back to insertion order, and a new `child_at()` API returns the child by original index (O(n)). `UnionHeap` gains a simple `child_at()` accessor for parity, and integration tests add coverage ensuring rewind restores original child identity/order after full exhaustion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ab6f44368143522b6564f08dcec8888c508f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->