### PR TITLE
improve profile.c flow test coverage

### DIFF
--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -135,9 +135,10 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
         printProfileGILTime(rs_wall_clock_convert_ns_to_ms_d(rp->rpGILTime));
         break;
 
-      default:
+      default: // LCOV_EXCL_START — defensive: all valid RPType values are handled above
         RS_ABORT("RPType error");
         break;
+      // LCOV_EXCL_STOP
     }
 
     return upstreamTime;

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -451,6 +451,34 @@ def testProfileVector(env):
   env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES_TO_ADHOC_BF')
 
 @skip(cluster=True)
+def testProfileHybridRangeMetricSortedByScore(env):
+  """Hybrid RANGE query with YIELD_SCORE_AS creates a METRIC SORTED BY SCORE iterator."""
+  conn = getConnectionByEnv(env)
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',
+             'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2', 't', 'TEXT').ok()
+  query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+  conn.execute_command('hset', '1', 'v', np.array([1.0, 0.0], dtype=np.float32).tobytes(), 't', 'hello')
+  conn.execute_command('hset', '2', 'v', np.array([0.0, 1.0], dtype=np.float32).tobytes(), 't', 'hello')
+  conn.execute_command('hset', '3', 'v', np.array([10.0, 10.0], dtype=np.float32).tobytes(), 't', 'hello')
+
+  # Hybrid RANGE query without FILTER yields BY_SCORE order + yields_metric=true
+  # This produces a METRIC_SORTED_BY_SCORE iterator
+  actual_res = conn.execute_command('FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+                                    'SEARCH', 'hello',
+                                    'VSIM', '@v', '$BLOB',
+                                    'RANGE', '2', 'RADIUS', '5',
+                                    'YIELD_SCORE_AS', 'dist',
+                                    'PARAMS', '2', 'BLOB', query_vector)
+  # RESP2: profile data is at actual_res[-1] = ['Shards', [shard_profiles], 'Coordinator', [...]]
+  # shard_profiles[0] = ['SEARCH', [...], 'VSIM', [...]]
+  shard_profile = to_dict(actual_res[-1][1][0])
+  vsim_profile = to_dict(shard_profile['VSIM'])
+  env.assertEqual(vsim_profile['Iterators profile'][0], 'Type', message=vsim_profile)
+  env.assertEqual(vsim_profile['Iterators profile'][1], 'METRIC SORTED BY SCORE - VECTOR DISTANCE', message=vsim_profile)
+
+@skip(cluster=True)
 def testResultProcessorCounter(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -275,6 +275,36 @@ def testProfileTag(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@t:{foo}', 'nocontent')
   env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2])
 
+  # tag union profile (multi-value tag query creates a UNION with TAG query type)
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@t:{foo|bar}', 'nocontent')
+  expected_res = ['Type', 'UNION', 'Query type', 'TAG', 'Number of reading operations', 2,
+                  'Child iterators', [
+                    ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2],
+                    ['Type', 'TAG', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
+
+@skip(cluster=True)
+def testProfileGeo(env):
+  """GEO query profile: a large-radius GEO query creates a UNION with GEO query type."""
+  conn = getConnectionByEnv(env)
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 'g', 'GEO')
+  # Add enough geo points to force multiple numeric tree nodes, creating a UNION
+  for i in range(10000):
+    lon = (i % 360) - 180
+    lat = (i % 180) - 90
+    conn.execute_command('hset', i, 'g', f'{lon},{lat}')
+  waitForIndex(env, 'idx')
+
+  # geo profile - large radius GEO query creates a UNION with GEO query type
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@g:[0 0 20000 km]', 'nocontent', 'limit', '0', '0')
+  profile_data = actual_res[1][1][0][3]
+  env.assertEqual(profile_data[0], 'Type', message=profile_data)
+  env.assertEqual(profile_data[1], 'UNION', message=profile_data)
+  env.assertEqual(profile_data[2], 'Query type', message=profile_data)
+  env.assertContains('GEO', profile_data[3])
+
 @skip(cluster=True)
 def testProfileMissingFieldQuery(env):
   conn = getConnectionByEnv(env)


### PR DESCRIPTION
Improving `profile.c` coverage before porting more of it to Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions plus a coverage annotation; no functional behavior changes beyond how coverage tools treat an unreachable abort branch.
> 
> **Overview**
> Improves `FT.PROFILE` coverage by adding new iterator-profile assertions for **multi-value TAG queries** (expected `UNION` with `Query type` = `TAG`) and for **large-radius GEO queries** that fan out into a `UNION` iterator.
> 
> Adds a hybrid RANGE profiling test ensuring `YIELD_SCORE_AS` produces a `METRIC SORTED BY SCORE - VECTOR DISTANCE` iterator in the `VSIM` sub-profile. Separately annotates the `profile.c` result-processor `default` switch arm with `LCOV_EXCL_*` to exclude a defensive abort branch from coverage metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeca92744728350db15a29d25a8d540170c8384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->