### PR TITLE
[MOD-14679] RsValue: Remove nul-terminator support

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -89,14 +89,19 @@ static void reeval_key(RedisModule_Reply *reply, const RSValue *key) {
         // tell it's a double and not just a numeric string value
         rskey = RedisModule_CreateStringPrintf(outctx, "#%.17g", RSValue_Number_Get(key));
         break;
-      case RSValueType_String:
+      case RSValueType_String: {
         // Serialize string - by prepending "$" to it
-        rskey = RedisModule_CreateStringPrintf(outctx, "$%s", RSValue_String_Get(key, NULL));
+        uint32_t len;
+        const char *str = RSValue_String_Get(key, &len);
+        rskey = RedisModule_CreateStringPrintf(outctx, "$%.*s", (int)len, str);
         break;
-      case RSValueType_RedisString:
-        rskey = RedisModule_CreateStringPrintf(outctx, "$%s",
-          RedisModule_StringPtrLen(RSValue_RedisString_Get(key), NULL));
+      }
+      case RSValueType_RedisString: {
+        size_t len;
+        const char *str = RedisModule_StringPtrLen(RSValue_RedisString_Get(key), &len);
+        rskey = RedisModule_CreateStringPrintf(outctx, "$%.*s", (int)len, str);
         break;
+      }
       case RSValueType_Null:
       case RSValueType_Undef:
       case RSValueType_Array:

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -564,7 +564,7 @@ void RPEvaluator_Reply(RedisModule_Reply *reply, const char *title, const Result
       if (RSValue_IsString(v)) {
         size_t len;
         const char *ptr = RSValue_StringPtrLen(v, &len);
-        RedisModule_Reply_SimpleStringf(reply, "%s - Literal %s", typeStr, ptr);
+        RedisModule_Reply_SimpleStringf(reply, "%s - Literal %.*s", typeStr, (int)len, ptr);
       } else if (RSValue_IsNumber(v)) {
         char buf[32];
         RSValue_NumToString(v, buf, sizeof(buf));

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -286,7 +286,8 @@ static int parseTime(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result
   VALIDATE_ARG_ISSTRING("parsetime", argv, 1);
 
   // strptime requires nul-terminated inputs; stage terminated copies of both args.
-  size_t vallen, fmtlen;
+  size_t vallen;
+  size_t fmtlen;
   const char *val_src = RSValue_StringPtrLen(argv[0], &vallen);
   const char *fmt_src = RSValue_StringPtrLen(argv[1], &fmtlen);
   char *val = rm_malloc(vallen + 1);

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -20,6 +20,8 @@
 // TIME(property, [fmt_string])
 static int timeFormat(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result) {
   const char *fmt = ISOFMT;
+  // Owns a nul-terminated copy of an argv-provided fmt; NULL when we use the default.
+  char *fmt_buf = NULL;
   char timebuf[1024];  // Should be enough for any human time string
   double n = 0.0;
   time_t tt = 0;
@@ -29,8 +31,13 @@ static int timeFormat(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *resul
 
   if (argc == 2) {
     VALIDATE_ARG_TYPE("time", argv, 1, RSValueType_String);
-    // The returned `fmt` string is nul-terminated so is safe to use in `strftime`.
-    fmt = RSValue_StringPtrLen(argv[1], NULL);
+    // strftime requires a nul-terminated format string; stage a terminated copy.
+    size_t fmtlen;
+    const char *fmt_src = RSValue_StringPtrLen(argv[1], &fmtlen);
+    fmt_buf = rm_malloc(fmtlen + 1);
+    memcpy(fmt_buf, fmt_src, fmtlen);
+    fmt_buf[fmtlen] = '\0';
+    fmt = fmt_buf;
   }
   // Get the format
   // value is not a number
@@ -56,11 +63,13 @@ static int timeFormat(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *resul
   // the value ref counter will not release it
   RS_ASSERT(rv <= UINT32_MAX);
   RSValue_SetConstString(result, buf, rv);
+  rm_free(fmt_buf);
   return EXPR_EVAL_OK;
 err:
   // on runtime error (bad formatting, etc) we just set the result to null
 
   RSValue_MakeReference(result, RSValue_NullStatic());
+  rm_free(fmt_buf);
   return EXPR_EVAL_OK;
 }
 
@@ -269,8 +278,6 @@ err:
 }
 
 static int parseTime(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result) {
-  const char *val;
-  const char *fmt;
   struct tm tm = {0};
   char *rc;
   time_t rv;
@@ -278,12 +285,20 @@ static int parseTime(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result
   VALIDATE_ARG_ISSTRING("parsetime", argv, 0);
   VALIDATE_ARG_ISSTRING("parsetime", argv, 1);
 
+  // strptime requires nul-terminated inputs; stage terminated copies of both args.
   size_t vallen, fmtlen;
-  // TODO: copy string over to nul-terminated string before passing to `strptime`.
-  val = RSValue_StringPtrLen(argv[0], &vallen);
-  fmt = RSValue_StringPtrLen(argv[1], &fmtlen);
+  const char *val_src = RSValue_StringPtrLen(argv[0], &vallen);
+  const char *fmt_src = RSValue_StringPtrLen(argv[1], &fmtlen);
+  char *val = rm_malloc(vallen + 1);
+  memcpy(val, val_src, vallen);
+  val[vallen] = '\0';
+  char *fmt = rm_malloc(fmtlen + 1);
+  memcpy(fmt, fmt_src, fmtlen);
+  fmt[fmtlen] = '\0';
 
   rc = strptime(val, fmt, &tm);
+  rm_free(val);
+  rm_free(fmt);
   if (rc == NULL) {
     goto err;
   }

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -29,6 +29,7 @@ static int timeFormat(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *resul
 
   if (argc == 2) {
     VALIDATE_ARG_TYPE("time", argv, 1, RSValueType_String);
+    // The returned `fmt` string is nul-terminated so is safe to use in `strftime`.
     fmt = RSValue_StringPtrLen(argv[1], NULL);
   }
   // Get the format
@@ -277,8 +278,10 @@ static int parseTime(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result
   VALIDATE_ARG_ISSTRING("parsetime", argv, 0);
   VALIDATE_ARG_ISSTRING("parsetime", argv, 1);
 
-  val = RSValue_StringPtrLen(argv[0], NULL);
-  fmt = RSValue_StringPtrLen(argv[1], NULL);
+  size_t vallen, fmtlen;
+  // TODO: copy string over to nul-terminated string before passing to `strptime`.
+  val = RSValue_StringPtrLen(argv[0], &vallen);
+  fmt = RSValue_StringPtrLen(argv[1], &fmtlen);
 
   rc = strptime(val, fmt, &tm);
   if (rc == NULL) {

--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -384,9 +384,12 @@ static int stringfunc_contains(ExprEval *ctx, RSValue **argv, size_t argc, RSVal
   size_t num;
   if (p_pref_size > 0) {
     num = 0;
-    while ((p_str = strstr(p_str, p_pref)) != NULL) {
+    const char *end = p_str + p_str_size;
+    while (p_str < end) {
+      char *found = memmem(p_str, end - p_str, p_pref, p_pref_size);
+      if (!found) break;
       num++;
-      p_str++;
+      p_str = found + 1;
     }
   } else {
     num = p_str_size + 1;

--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -123,7 +123,7 @@ int func_to_number(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result) 
     size_t sz = 0;
     const char *p = RSValue_StringPtrLen(argv[0], &sz);
     QueryError_SetWithUserDataFmt(ctx->err, QUERY_ERROR_CODE_PARSE_ARGS,
-                                  "to_number: cannot convert string", " '%s'", p);
+                                  "to_number: cannot convert string", " '%.*s'", (int)sz, p);
     return EXPR_EVAL_ERR;
   }
 
@@ -266,13 +266,13 @@ error:
   return EXPR_EVAL_ERR;
 }
 
-static char *str_trim(char *s, size_t sl, const char *cset, size_t *outlen) {
+static char *str_trim(char *s, size_t sl, const char *cset, size_t csetlen, size_t *outlen) {
   char *start, *end, *sp, *ep;
 
   sp = start = s;
   ep = end = s + sl - 1;
-  while (sp <= end && strchr(cset, *sp)) sp++;
-  while (ep > sp && strchr(cset, *ep)) ep--;
+  while (sp <= end && memchr(cset, *sp, csetlen)) sp++;
+  while (ep > sp && memchr(cset, *ep, csetlen)) ep--;
   *outlen = (sp > ep) ? 0 : ((ep - sp) + 1);
 
   return sp;
@@ -280,14 +280,16 @@ static char *str_trim(char *s, size_t sl, const char *cset, size_t *outlen) {
 static int stringfunc_split(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result) {
   VALIDATE_ARG_ISSTRING("split", argv, 0);
   const char *sep = ",";
+  size_t seplen = 1;
   const char *strp = " ";
+  size_t strplen = 1;
   if (argc >= 2) {
     VALIDATE_ARG_ISSTRING("split", argv, 1);
-    sep = RSValue_StringPtrLen(argv[1], NULL);
+    sep = RSValue_StringPtrLen(argv[1], &seplen);
   }
   if (argc == 3) {
     VALIDATE_ARG_ISSTRING("split", argv, 2);
-    strp = RSValue_StringPtrLen(argv[2], NULL);
+    strp = RSValue_StringPtrLen(argv[2], &strplen);
   }
 
   size_t len;
@@ -300,13 +302,20 @@ static int stringfunc_split(ExprEval *ctx, RSValue **argv, size_t argc, RSValue 
   // extract at most 1024 values
   RSValue *tmp[1024];
   while (l < 1024 && tok < ep) {
-    next = strpbrk(tok, sep);
+    // Find the next occurrence of any separator character within bounds
+    next = NULL;
+    for (char *p = tok; p < ep; p++) {
+      if (memchr(sep, *p, seplen)) {
+        next = p;
+        break;
+      }
+    }
     size_t sl = next ? (next - tok) : ep - tok;
 
     if (sl > 0) {
       size_t outlen;
       // trim the strip set
-      char *s = str_trim(tok, sl, strp, &outlen);
+      char *s = str_trim(tok, sl, strp, strplen, &outlen);
       if (outlen) {
         RS_ASSERT(outlen <= UINT32_MAX);
         tmp[l++] = RSValue_NewCopiedString(s, outlen);
@@ -352,10 +361,11 @@ static int stringfunc_startswith(ExprEval *ctx, RSValue **argv, size_t argc, RSV
   RSValue *str = RSValue_Dereference(argv[0]);
   RSValue *pref = RSValue_Dereference(argv[1]);
 
-  const char *p_str = RSValue_StringPtrLen(str, NULL);
+  size_t str_len;
+  const char *p_str = RSValue_StringPtrLen(str, &str_len);
   size_t n;
   const char *p_pref = RSValue_StringPtrLen(pref, &n);
-  RSValue_SetNumber(result, strncmp(p_pref, p_str, n) == 0);
+  RSValue_SetNumber(result, str_len >= n && memcmp(p_pref, p_str, n) == 0);
   return EXPR_EVAL_OK;
 }
 

--- a/src/redisearch_rs/value/src/rs_string.rs
+++ b/src/redisearch_rs/value/src/rs_string.rs
@@ -13,13 +13,6 @@ use std::fmt;
 
 /// An [`RsString`] is meant to store string data with support for rust allocated data, C
 /// allocated data or borrowed data, and support for a max length of `u32::MAX`.
-/// It can contain binary data and is always nul-terminated.
-///
-/// # Invariants
-///
-/// - `ptr` points to valid data of `len+1` size.
-/// - a nul-terminator is always present in memory at `ptr+len`
-/// - The size determined by `len` excludes the nul-terminator.
 pub struct RsString {
     ptr: *const c_char,
     len: u32,
@@ -40,9 +33,10 @@ enum RsStringKind {
 }
 
 impl RsString {
-    /// Create an [`RsString`] from a `Vec<u8>`. The length must not be more than
-    /// `u32::MAX` for compatibility with existing C code using `RSValue` functionality.
-    /// A nul-terminator is automatically added by this constructor for compatibility.
+    /// Create an [`RsString`] from any owned byte container that can convert into a
+    /// `Vec<u8>` (e.g. `Vec<u8>`, `String`, `Box<[u8]>`, `&[u8]`, `&str`). The length
+    /// must not be more than `u32::MAX` for compatibility with existing C code using
+    /// `RSValue` functionality.
     ///
     /// # Panic
     ///
@@ -65,11 +59,9 @@ impl RsString {
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a [valid], non-null pointer to a buffer of `len+1` bytes
+    /// 1. `ptr` must be a [valid], non-null pointer to a buffer of at least `len` bytes
     ///    allocated by `RedisModule_Alloc`.
-    /// 2. A nul-terminator is expected in memory at `ptr+len`.
-    /// 3. The size determined by `len` excludes the nul-terminator.
-    /// 4. `ptr` **must not** be used or freed after this function is called, as this function
+    /// 2. `ptr` **must not** be used or freed after this function is called, as this function
     ///    takes ownership of the allocation.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
@@ -87,10 +79,8 @@ impl RsString {
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
-    /// 2. A nul-terminator is expected in memory at `ptr+len`.
-    /// 3. The size determined by `len` excludes the nul-terminator.
-    /// 4. The string pointed to by `ptr`/`len+1` must stay valid for as long as
+    /// 1. `ptr` must be a [valid], non-null pointer to a buffer of at least `len` bytes.
+    /// 2. The string pointed to by `ptr`/`len` must stay valid for as long as
     ///    this [`RsString`] is exists.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
@@ -111,7 +101,7 @@ impl RsString {
 
     /// Gets the string pointed to by `ptr`/`len` as a byte slice.
     pub const fn as_bytes(&self) -> &[u8] {
-        // Safety: `self.ptr` points to valid memory of `self.len` bytes per our invariant.
+        // Safety: `self.ptr` points to valid memory of `self.len` bytes.
         unsafe { std::slice::from_raw_parts(self.ptr.cast(), self.len as usize) }
     }
 }
@@ -124,7 +114,7 @@ impl Drop for RsString {
                     self.ptr.cast_mut().cast::<u8>(),
                     self.len as usize,
                 );
-                // Safety: Boxed slice was created in `Self::from_vec` which has `len + 1` bytes.
+                // Safety: Boxed slice was created in `Self::from_bytes` which has `len` bytes.
                 drop(unsafe { Box::from_raw(slice) });
             }
             RsStringKind::RedisModuleAlloc => {

--- a/src/redisearch_rs/value/src/rs_string.rs
+++ b/src/redisearch_rs/value/src/rs_string.rs
@@ -47,11 +47,10 @@ impl RsString {
     /// # Panic
     ///
     /// Panics when the size is larger than `u32::MAX`.
-    pub fn from_vec(mut vec: Vec<u8>) -> Self {
+    pub fn from_vec(vec: Vec<u8>) -> Self {
         let len = vec.len();
         assert!(len <= u32::MAX as usize);
 
-        vec.push(b'\0');
         let ptr = Box::into_raw(vec.into_boxed_slice());
 
         Self {
@@ -123,7 +122,7 @@ impl Drop for RsString {
             RsStringKind::RustGlobalAlloc => {
                 let slice = std::ptr::slice_from_raw_parts_mut(
                     self.ptr.cast_mut().cast::<u8>(),
-                    (self.len as usize) + 1,
+                    self.len as usize,
                 );
                 // Safety: Boxed slice was created in `Self::from_vec` which has `len + 1` bytes.
                 drop(unsafe { Box::from_raw(slice) });

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2108,11 +2108,19 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   const char *keyPtr = dmd ? dmd->keyPtr : NULL;
   // Coordinator case - no dmd - use docKey in rlookup
   const bool fallbackToLookup = !keyPtr && self->docKey;
-  size_t keyLen = 0;
+  // `hybridResults` uses the generic string dict callbacks (strlen/strcmp/strdup), so the
+  // key must be nul-terminated. RSValue_StringPtrLen returns a (ptr, len) buffer that is
+  // not guaranteed to be nul-terminated, so we stage a terminated copy for the dict calls.
+  char *keyBuf = NULL;
   if (fallbackToLookup) {
     RSValue *docKeyValue = RLookupRow_Get(self->docKey, SearchResult_GetRowData(r));
     if (docKeyValue != NULL) {
-      keyPtr = RSValue_StringPtrLen(docKeyValue, &keyLen);
+      size_t keyLen = 0;
+      const char *ptr = RSValue_StringPtrLen(docKeyValue, &keyLen);
+      keyBuf = rm_malloc(keyLen + 1);
+      memcpy(keyBuf, ptr, keyLen);
+      keyBuf[keyLen] = '\0';
+      keyPtr = keyBuf;
     }
   }
   if (!keyPtr) {
@@ -2127,6 +2135,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
     hybridResult = HybridSearchResult_New(self->numUpstreams);
     dictAdd(self->hybridResults, (void*)keyPtr, hybridResult);
   }
+  rm_free(keyBuf);
 
    SearchResult_SetScore(r, score);
    HybridSearchResult_StoreResult(hybridResult, r, upstreamIndex);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2108,10 +2108,11 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   const char *keyPtr = dmd ? dmd->keyPtr : NULL;
   // Coordinator case - no dmd - use docKey in rlookup
   const bool fallbackToLookup = !keyPtr && self->docKey;
+  size_t keyLen = 0;
   if (fallbackToLookup) {
     RSValue *docKeyValue = RLookupRow_Get(self->docKey, SearchResult_GetRowData(r));
     if (docKeyValue != NULL) {
-      keyPtr = RSValue_StringPtrLen(docKeyValue, NULL);
+      keyPtr = RSValue_StringPtrLen(docKeyValue, &keyLen);
     }
   }
   if (!keyPtr) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2117,10 +2117,12 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
     if (docKeyValue != NULL) {
       size_t keyLen = 0;
       const char *ptr = RSValue_StringPtrLen(docKeyValue, &keyLen);
-      keyBuf = rm_malloc(keyLen + 1);
-      memcpy(keyBuf, ptr, keyLen);
-      keyBuf[keyLen] = '\0';
-      keyPtr = keyBuf;
+      if (ptr != NULL) {
+        keyBuf = rm_malloc(keyLen + 1);
+        memcpy(keyBuf, ptr, keyLen);
+        keyBuf[keyLen] = '\0';
+        keyPtr = keyBuf;
+      }
     }
   }
   if (!keyPtr) {

--- a/src/rs_geo.c
+++ b/src/rs_geo.c
@@ -116,7 +116,8 @@ int parseGeo(const char *c, size_t len, double *lon, double *lat, QueryError *st
     return REDISMODULE_ERR;
   }
   char str[len + 1];
-  memcpy(str, c, len + 1);
+  memcpy(str, c, len);
+  str[len] = '\0';
   char *pos = strpbrk(str, " ,");
   if (!pos) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid geo string");

--- a/src/spec.c
+++ b/src/spec.c
@@ -3995,13 +3995,14 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
 #if defined(_DEBUG) && 0
   RLookupKey *k = RLookup_GetKey_LoadEx(&r->lk, UNDERSCORE_KEY, strlen(UNDERSCORE_KEY), UNDERSCORE_KEY, RLOOKUP_F_NOFLAGS);
   RSValue *v = RLookup_GetItem(k, &r->row);
-  const char *x = RSValue_StringPtrLen(v, NULL);
-  RedisModule_Log(RSDummyContext, "notice", "Indexes_FindMatchingSchemaRules: x=%s", x);
+  size_t xlen;
+  const char *x = RSValue_StringPtrLen(v, &xlen);
+  RedisModule_Log(RSDummyContext, "notice", "Indexes_FindMatchingSchemaRules: x=%.*s", (int)xlen, x);
   const char *f = "name";
   k = RLookup_GetKey_ReadEx(&r->lk, f, strlen(f), RLOOKUP_F_NOFLAGS);
   if (k) {
     v = RLookup_GetItem(k, &r->row);
-    x = RSValue_StringPtrLen(v, NULL);
+    x = RSValue_StringPtrLen(v, &xlen);
   }
 #endif  // _DEBUG
 


### PR DESCRIPTION
Remove nul-terminator support in `from_vec` in `RsString`.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level string/memory handling across query execution and string/date functions; bugs here could cause incorrect parsing/serialization or memory issues, though changes are localized and generally make behavior safer.
> 
> **Overview**
> Removes the implicit nul-terminator contract from Rust `RsString::from_vec` (and its drop logic), so `RsValue` strings are treated as `(ptr,len)` byte buffers rather than C-strings.
> 
> Updates multiple C call sites that previously assumed nul-termination to be length-safe: reply/log formatting now uses `%.*s`, string functions (`split`, `startswith`, `contains`, `to_number`) operate within explicit bounds (replacing `strpbrk`/`strstr`/`strchr` with bounded scans), and `timefmt`/`parsetime`/`hybridResults`/`parseGeo` stage temporary terminated copies only where required by libc or Redis dict callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea332dfd6d9e905ed040e93b8984e0f4eeff36eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->