### PR TITLE
RED-186133 Support Boost versions older than 1.88 for SHA1 digest

### DIFF
--- a/src/util/hash/hash.cpp
+++ b/src/util/hash/hash.cpp
@@ -8,12 +8,28 @@
 */
 
 #include "hash.h"
+#include <boost/version.hpp>
 #include <boost/uuid/detail/sha1.hpp>
 
 void Sha1_Compute(const char *value, size_t len, Sha1* output) {
   boost::uuids::detail::sha1 sha1;
   sha1.process_bytes(value, len);
+#if BOOST_VERSION >= 108800
+  // Boost 1.88+: digest_type is unsigned char[20], stored as big-endian bytes.
   sha1.get_digest(output->hash);
+#else
+  // Boost < 1.88: digest_type is unsigned int[5] (host-endian words).
+  // Convert each 32-bit word to big-endian bytes to match the layout
+  // expected by Sha1_FormatIntoBuffer.
+  boost::uuids::detail::sha1::digest_type digest;
+  sha1.get_digest(digest);
+  for (int i = 0; i < 5; i++) {
+    output->hash[i*4]   = static_cast<unsigned char>((digest[i] >> 24) & 0xFF);
+    output->hash[i*4+1] = static_cast<unsigned char>((digest[i] >> 16) & 0xFF);
+    output->hash[i*4+2] = static_cast<unsigned char>((digest[i] >> 8)  & 0xFF);
+    output->hash[i*4+3] = static_cast<unsigned char>( digest[i]        & 0xFF);
+  }
+#endif
 }
 
 void Sha1_FormatIntoBuffer(const Sha1 *sha1, char *buffer) {


### PR DESCRIPTION
Boost 1.88 changed sha1::digest_type from unsigned int[5] to unsigned char[20] and now stores the digest as big-endian bytes via store_big_u32(). The current code calls get_digest(output->hash) which compiles only when digest_type matches unsigned char[20] (Boost >= 1.88).

Add compile-time detection of BOOST_VERSION so that builds against older system Boost (e.g. 1.85-1.87 on Fedora 43) use the unsigned int[5] digest_type with an explicit big-endian conversion, while Boost 1.88+ continues to use the direct call.

Made-with: Cursor


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SHA1 digest generation used for derived identifiers; a conversion bug could change generated hashes across versions. The change is small and compile-time gated by `BOOST_VERSION`.
> 
> **Overview**
> Improves compatibility with system Boost versions prior to 1.88 by updating `Sha1_Compute` to handle the older `sha1::digest_type` representation and explicitly convert it to the byte layout expected by the formatter.
> 
> User impact: builds on distros shipping Boost 1.85–1.87 now compile successfully while preserving the same SHA1 string output format as Boost 1.88+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e37e958005fdc63b16ad5845ebf050aee40988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->