### PR TITLE
Move numeric filter constructor + destructor to Rust

### DIFF
--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -97,27 +97,8 @@ LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFil
   return nf;
 }
 
-void NumericFilter_Free(NumericFilter *nf) {
-  rm_free(nf);
-}
-
 void LegacyNumericFilter_Free(LegacyNumericFilter *nf) {
   HiddenString_Free(nf->field, false);
   rm_free(nf);
 }
 
-NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int inclusiveMax,
-                                bool asc, const FieldSpec *fs) {
-  NumericFilter *f = rm_malloc(sizeof(NumericFilter));
-
-  f->min = min;
-  f->max = max;
-  f->fieldSpec = fs;
-  f->maxInclusive = inclusiveMax;
-  f->minInclusive = inclusiveMin;
-  f->geoFilter = NULL;
-  f->ascending = asc;
-  f->offset = 0;
-  f->limit = 0;
-  return f;
-}

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -32,10 +32,7 @@ typedef struct LegacyNumericFilter {
   HiddenString *field;    // the numeric field name
 } LegacyNumericFilter;
 
-NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int inclusiveMax,
-                                bool asc, const FieldSpec *fs);
 LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status);
-void NumericFilter_Free(NumericFilter *nf);
 void LegacyNumericFilter_Free(LegacyNumericFilter *nf);
 
 int parseDoubleRange(const char *s, bool *inclusive, double *target, int isMin,

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2775,6 +2775,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "cbindgen",
+ "ffi",
  "field",
  "inverted_index",
  "workspace_hack",

--- a/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
@@ -19,6 +19,7 @@ cbindgen.workspace = true
 build_utils = { path = "../../build_utils" }
 
 [dependencies]
+ffi.workspace = true
 field.workspace = true
 inverted_index.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -9,7 +9,10 @@
 
 //! This module contains pure Rust types that we want to expose to C code.
 
-use std::{ffi::c_char, mem, ptr};
+use std::{
+    ffi::{c_char, c_int},
+    mem, ptr,
+};
 
 use inverted_index::{
     NumericFilter, RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSQueryTerm,
@@ -53,6 +56,50 @@ pub unsafe extern "C" fn NumericFilter_Match(filter: *const NumericFilter, value
     let filter = unsafe { &*filter };
 
     filter.value_in_range(value)
+}
+
+/// Allocate a new numeric filter. The filter should be freed using [`NumericFilter_Free`].
+///
+/// # Safety
+///
+/// - `fs` must be a valid `FieldSpec` pointer or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NewNumericFilter(
+    min: f64,
+    max: f64,
+    inclusive_min: c_int,
+    inclusive_max: c_int,
+    asc: bool,
+    fs: *const ffi::FieldSpec,
+) -> *mut NumericFilter {
+    Box::into_raw(Box::new(NumericFilter {
+        min,
+        max,
+        field_spec: fs,
+        min_inclusive: inclusive_min != 0,
+        max_inclusive: inclusive_max != 0,
+        geo_filter: ptr::null(),
+        ascending: asc,
+        offset: 0,
+        limit: 0,
+    }))
+}
+
+/// Free a numeric filter created with [`NewNumericFilter`].
+///
+/// No-op if `nf` is NULL.
+///
+/// # Safety
+///
+/// - `nf` must have been created by [`NewNumericFilter`], or be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NumericFilter_Free(nf: *mut NumericFilter) {
+    if nf.is_null() {
+        return;
+    }
+
+    // SAFETY: caller ensures `nf` was created by `NewNumericFilter`.
+    drop(unsafe { Box::from_raw(nf) });
 }
 
 /// Allocate a new intersect result with a given capacity and weight. This result should be freed

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -601,6 +601,31 @@ bool NumericFilter_IsNumeric(const struct NumericFilter *filter);
 bool NumericFilter_Match(const struct NumericFilter *filter, double value);
 
 /**
+ * Allocate a new numeric filter. The filter should be freed using [`NumericFilter_Free`].
+ *
+ * # Safety
+ *
+ * - `fs` must be a valid `FieldSpec` pointer or NULL.
+ */
+struct NumericFilter *NewNumericFilter(double min,
+                                       double max,
+                                       int inclusive_min,
+                                       int inclusive_max,
+                                       bool asc,
+                                       const FieldSpec *fs);
+
+/**
+ * Free a numeric filter created with [`NewNumericFilter`].
+ *
+ * No-op if `nf` is NULL.
+ *
+ * # Safety
+ *
+ * - `nf` must have been created by [`NewNumericFilter`], or be NULL.
+ */
+void NumericFilter_Free(struct NumericFilter *nf);
+
+/**
  * Allocate a new intersect result with a given capacity and weight. This result should be freed
  * using [`IndexResult_Free`].
  */


### PR DESCRIPTION
In https://github.com/RediSearch/RediSearch/pull/9085#discussion_r3086973878 I was wondering how to create a NumericFilter ; turns out it's built from a lot of different places, as we're starting to build it from Rust, I figured it's time to move the constructor to Rust.

We still have to return a pointer in all cases as it's stored like that.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-language allocation/free semantics for `NumericFilter`, so mismatched ownership or ABI expectations could cause leaks or crashes if any call sites violate the new FFI contract.
> 
> **Overview**
> Moves `NumericFilter` lifecycle management from C to Rust: removes the C implementations/declarations of `NewNumericFilter` and `NumericFilter_Free` and reintroduces them as Rust `extern "C"` functions that allocate/free via `Box`.
> 
> Updates the generated C header (`types_rs.h`) and the `types_ffi` crate dependencies (`ffi` workspace + lockfile) to expose the new APIs, while leaving legacy numeric filter parsing/freeing (`LegacyNumericFilter_*`) in C unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48d07b37928cc521df3a7ffa05bfdb79286e6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->