### PR TITLE
[8.6] MOD-14135: Fix Memory leak in FT.HYBRID while FT.DROPINDEX runs in background (#9005)

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -23,6 +23,7 @@
 #include "dist_profile.h"
 #include "shard_window_ratio.h"
 #include "config.h"
+#include "debug_commands.h"
 
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
@@ -787,10 +788,15 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
         return;
     }
 
+#ifdef ENABLE_ASSERT
+    SyncPoint_Wait(SYNC_POINT_BEFORE_DIST_HYBRID_PROMOTE);
+#endif
+
     // Check if the index still exists, and promote the ref accordingly
     StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
     IndexSpec *sp = StrongRef_Get(strong_ref);
     if (!sp) {
+        SearchCtx_Free(sctx);
         QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
         DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, NULL, reply, &status);
         return;

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -68,8 +68,9 @@ bool QueryDebugCtx_HasDebugRP(void);
 
 // Predefined sync point names for query execution
 // These correspond to specific locations in the query execution path
-#define SYNC_POINT_AFTER_ITERATOR_CREATE  "AfterIteratorCreate"
-#define SYNC_POINT_BEFORE_FIRST_READ      "BeforeFirstRead"
+#define SYNC_POINT_AFTER_ITERATOR_CREATE       "AfterIteratorCreate"
+#define SYNC_POINT_BEFORE_FIRST_READ           "BeforeFirstRead"
+#define SYNC_POINT_BEFORE_DIST_HYBRID_PROMOTE  "BeforeDistHybridPromote"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -1,0 +1,66 @@
+from common import *
+import threading
+
+
+@skip(cluster=False)
+@require_enable_assert
+def test_dist_hybrid_index_drop_after_sctx_allocation(env):
+    """MOD-14135: SearchCtx must be freed when index is dropped between
+    sctx allocation and IndexSpecRef_Promote in RSExecDistHybrid.
+    Leak detection relies on valgrind/sanitizers in CI."""
+    set_workers(env, 1)
+
+    dim = 2
+    conn = getConnectionByEnv(env)
+
+    env.expect(
+        'FT.CREATE', 'idx', 'SCHEMA',
+        'name', 'TEXT',
+        'embedding', 'VECTOR', 'FLAT', '6',
+        'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2'
+    ).ok()
+
+    query_vec = np.array([0.0] * dim, dtype=np.float32).tobytes()
+    doc_vec = np.array([1.0] * dim, dtype=np.float32).tobytes()
+    conn.execute_command('HSET', 'doc1', 'name', 'hello', 'embedding', doc_vec)
+
+    sync_point = 'BeforeDistHybridPromote'
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
+
+    error_holder = []
+    def run_hybrid_query(conn, errors):
+        try:
+            conn.execute_command(
+                'FT.HYBRID', 'idx',
+                'SEARCH', '*',
+                'VSIM', '@embedding', '$BLOB',
+                'PARAMS', '2', 'BLOB', query_vec
+            )
+        except Exception as e:
+            errors.append(e)
+
+    query_conn = env.getConnection()
+    query_thread = threading.Thread(
+        target=run_hybrid_query,
+        args=(query_conn, error_holder),
+        daemon=True
+    )
+    query_thread.start()
+
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+        f'Timeout waiting for {sync_point} sync point'
+    )
+
+    env.expect('FT.DROPINDEX', 'idx').ok()
+
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point)
+
+    query_thread.join(timeout=10)
+    env.assertFalse(query_thread.is_alive(), message='Query thread is still blocked after signal')
+
+    env.assertEqual(len(error_holder), 1, message='Expected query to fail with an error')
+    error_msg = str(error_holder[0])
+    env.assertTrue(error_msg.startswith('SEARCH_INDEX_DROPPED_BG'),
+                   message=f'Expected error to start with SEARCH_INDEX_DROPPED_BG, got: {error_msg}')

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -62,5 +62,5 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
 
     env.assertEqual(len(error_holder), 1, message='Expected query to fail with an error')
     error_msg = str(error_holder[0])
-    env.assertTrue(error_msg.startswith('SEARCH_INDEX_DROPPED_BG'),
-                   message=f'Expected error to start with SEARCH_INDEX_DROPPED_BG, got: {error_msg}')
+    env.assertEqual(error_msg, 'The index was dropped before the query could be executed',
+                   message=f'Expected error: `The index was dropped before the query could be executed`, got: {error_msg}')


### PR DESCRIPTION
## Description
Backport of #9005 to `8.6`.

Fix memory leak by freeing `SearchCtx` in `RSExecDistHybrid` on error

(cherry picked from commit d141b6398d4a87b0164a1ac424b2ce06d0fa99f9)

Changes:
- Since `8.6` doesn't have the error codes prefixes, the test assertion was updated.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Fixed a memory leak in FT.HYBRID that occurred when FT.DROPINDEX ran concurrently, causing the search context to not be properly freed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted cleanup in an error path plus an `ENABLE_ASSERT`-gated sync point and regression test; main query execution logic is unchanged.
> 
> **Overview**
> Prevents a memory leak in distributed `FT.HYBRID` when `FT.DROPINDEX` races the coordinator between `SearchCtx` allocation and index ref promotion by explicitly freeing the `SearchCtx` on the dropped-index error path.
> 
> Adds an `ENABLE_ASSERT` sync point (`BeforeDistHybridPromote`) and a new pytest that drops the index at that exact point to validate the query fails cleanly without leaking memory (verified via CI sanitizers/valgrind).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a00df7ccbd37d44e3808ffc8df9d3806084adb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->