### PR TITLE
[8.6-rse] [MOD-14475] Fail queries with error when topology is incomplete (#8884)

### DIFF
--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -255,8 +255,11 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     }
     // Wait for all callbacks to complete
     pthread_mutex_lock(ctx->mutex);
-    // Wait until the IO thread has initialized numShards and all responses arrive.
-    while (!ctx->initialized || ctx->responseCount < ctx->numShards) {
+    // Wait until either:
+    // 1. Normal completion: IO thread initialized numShards and all responses arrived
+    // 2. Early failure: We got a response before initialization (e.g., connection validation failed)
+    //    In this case, responseCount > 0 but initialized is false - we should unblock.
+    while (ctx->responseCount == 0 || (ctx->initialized && ctx->responseCount < ctx->numShards)) {
         pthread_cond_wait(ctx->completionCond, ctx->mutex);
     }
     pthread_mutex_unlock(ctx->mutex);

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -45,12 +45,14 @@ int MRCluster_SendCommand(IORuntimeCtx *ioRuntime,
   return MRConn_SendCommand(conn, cmd, fn, privdata);
 }
 
-/* Multiplex a command to all coordinators, using a specific coordination strategy. Returns the
- * number of sent commands */
+/* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy.  Returns the
+ * number of sent commands.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
 int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime,
                            MRCommand *cmd,
                            redisCallbackFn *fn,
-                           void *privdata) {
+                           void *privdata,
+                           bool validateConnections) {
   struct MRClusterTopology *topo = ioRuntime->topo;
   uint32_t slotsInfoPos = cmd->slotsInfoArgIndex; // 0 if not set, which means slot info is not needed
   uint32_t dispatchTimePos = cmd->dispatchTimeArgIndex; // 0 if not set, which means dispatch time is not needed
@@ -58,6 +60,17 @@ int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime,
     // Update dispatch time for this command
     MRCommand_SetDispatchTime(cmd);
   }
+
+  // Pre-fanout connection validation
+  if (validateConnections) {
+    for (size_t i = 0; i < topo->numShards; i++) {
+      MRConn *conn = MRConn_Get(&ioRuntime->conn_mgr, topo->shards[i].node.id);
+      if (!conn) {
+        return 0;
+      }
+    }
+  }
+
   int ret = 0;
   for (size_t i = 0; i < topo->numShards; i++) {
     MRConn *conn = MRConn_Get(&ioRuntime->conn_mgr, topo->shards[i].node.id);

--- a/src/coord/rmr/cluster.h
+++ b/src/coord/rmr/cluster.h
@@ -31,9 +31,10 @@ typedef struct {
   size_t current_round_robin;
 } MRCluster;
 
-/* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy. The
- * return value is the number of nodes we managed to successfully send the command to */
-int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime, MRCommand *cmd, redisCallbackFn *fn, void *privdata);
+/* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy.  Returns the
+ * number of sent commands.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
+int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime, MRCommand *cmd, redisCallbackFn *fn, void *privdata, bool validateConnections);
 
 /* Send a command to its appropriate shard, selecting a node based on the coordination strategy.
  * Returns REDIS_OK on success, REDIS_ERR on failure. Notice that that send is asynchronous so even

--- a/src/coord/rmr/reply.c
+++ b/src/coord/rmr/reply.c
@@ -269,3 +269,14 @@ MRReply *MRReply_Clone(MRReply *src) {
   dst->len = src->len;
   return dst;
 }
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len) {
+  RS_ASSERT(msg && len > 0);
+  MRReply *reply = rm_calloc(1, sizeof(MRReply));
+  reply->type = MR_REPLY_ERROR;
+  reply->len = len;
+  reply->str = rm_strndup(msg, len);
+  return reply;
+}

--- a/src/coord/rmr/reply.h
+++ b/src/coord/rmr/reply.h
@@ -75,3 +75,7 @@ int RedisModule_ReplyKV_MRReply(RedisModule_Reply *reply, const char *key, MRRep
 // Currently implements a partial clone, only for the type and string types.
 // Support types - MR_REPLY_STRING, MR_REPLY_ERROR
 MRReply *MRReply_Clone(MRReply *src);
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -46,6 +46,8 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
+
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;
 
@@ -73,6 +75,10 @@ typedef struct MRCtx {
   MRCommand cmd;
   IORuntimeCtx *ioRuntime;
   QueryError status;
+
+  /* If true, the command should validate that all connections
+   are up before sending the command to the cluster */
+  bool validateConnections;
 
   /**
    * This is a reduce function inside the MRCtx.
@@ -201,6 +207,14 @@ bool MRCtx_TryClaimReducing(struct MRCtx *ctx) {
   return atomic_compare_exchange_strong(&ctx->reducing, &expected, true);
 }
 
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections) {
+  ctx->validateConnections = validateConnections;
+}
+
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
+  return ctx->validateConnections;
+}
+
 void MRCtx_SignalReducerComplete(struct MRCtx *ctx) {
   pthread_mutex_lock(&ctx->reducingLock);
   ctx->reducerDone = true;
@@ -243,8 +257,9 @@ static int unblockHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   MRCtx *ctx = privdata;
 
-  // Check if timed out - discard reply.
-  // Currently, timeout checks are relevant only for Coordinator FT.SEARCH fanouts.
+  // Check if timed out or incomplete fanout - discard reply.
+  // Timeout checks are relevant only for Coordinator FT.SEARCH fanouts.
+  // Incomplete fanout means not all shards were reached during the fanout send loop.
   bool timedOut = MRCtx_IsTimedOut(ctx);
   if (timedOut) {
     if (r) {
@@ -286,7 +301,7 @@ static void uvFanoutRequest(void *p) {
   MRCtx *mrctx = p;
   IORuntimeCtx *ioRuntime = mrctx->ioRuntime;
 
-  mrctx->numExpected = MRCluster_FanoutCommand(ioRuntime, &mrctx->cmd, fanoutCallback, mrctx);
+  mrctx->numExpected = MRCluster_FanoutCommand(ioRuntime, &mrctx->cmd, fanoutCallback, mrctx, MRCtx_GetValidateConnections(mrctx));
 
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->bc;
@@ -682,6 +697,22 @@ void iterStartCb(void *p) {
   IORuntimeCtx *io_runtime_ctx = it->ctx.ioRuntime;
   MRClusterShard *shards = io_runtime_ctx->topo->shards;
   size_t numShards = io_runtime_ctx->topo->numShards;
+
+  // Pre-fanout connection validation - check ALL connections before any setup.
+  // If validation fails, we return early with a single error (it->len stays 1).
+  for (size_t i = 0; i < numShards; i++) {
+    MRConn *conn = MRConn_Get(&io_runtime_ctx->conn_mgr, shards[i].node.id);
+    if (!conn) {
+      // At least one connection is not established - fail with a single error.
+      // it->len/pending/inProcess remain at their initial value of 1.
+      MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
+      it->ctx.cb(&it->cbxs[0], err);
+      rm_free(data);
+      return;
+    }
+  }
+
+  // All connections valid - proceed with full setup
   it->len = numShards;
   it->ctx.pending = numShards;
   it->ctx.inProcess = numShards; // Initially all commands are in process
@@ -714,15 +745,14 @@ void iterStartCb(void *p) {
   cmd->targetShardIdx = 0;
   MRCommand_SetSlotInfo(cmd, shards[0].slotRanges);
 
-  // This implies that every connection to each shard will work inside a single IO thread
-  for (size_t i = 0; i < it->len; i++) {
-    if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
-                              mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
+  // Send commands to all shards
+  for (size_t i = 0; i < numShards; i++) {
+    if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd, mrIteratorRedisCB, &it->cbxs[i]) ==
+        REDIS_ERR) {
       MRIteratorCallback_Done(&it->cbxs[i], 1);
     }
   }
 
-  // Clean up the data structure
   rm_free(data);
 }
 
@@ -778,7 +808,7 @@ void iterCursorMappingCb(void *p) {
   vsimOrSearch->mappings[0].targetShard = NULL; // transfer ownership
 
   // Send commands to all shards
-  for (size_t i = 0; i < it->len; i++) {
+  for (size_t i = 0; i < numShardsWithMapping; i++) {
     if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
                               mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
       MRIteratorCallback_Done(&it->cbxs[i], 1);
@@ -865,6 +895,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
       .privateDataInit = cbPrivateDataInit,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
+    .len = 1,
   };
   // Initialize the first command
   *ret->cbxs = (MRIteratorCallbackCtx){

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -705,6 +705,15 @@ void iterStartCb(void *p) {
     if (!conn) {
       // At least one connection is not established - fail with a single error.
       // it->len/pending/inProcess remain at their initial value of 1.
+      // Run privateDataInit so ShardResponseBarrier (used by FT.AGGREGATE
+      // WITHCOUNT) accepts the synthetic error notification; otherwise its
+      // numShards stays 0, Notify's bounds check short-circuits, and the real
+      // error gets replaced by a misleading timeout message in
+      // shardResponseBarrier_HandleTimeout.
+      void *privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
+      if (privateData && it->ctx.privateDataInit) {
+        it->ctx.privateDataInit(privateData, it);
+      }
       MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
       it->ctx.cb(&it->cbxs[0], err);
       rm_free(data);

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -107,6 +107,9 @@ void MRCtx_WaitForReducerComplete(struct MRCtx *ctx);
 /* Free the MapReduce context */
 void MRCtx_Free(struct MRCtx *ctx);
 
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx);
+
 /* Create a new MapReduce context with a given private data. In a redis module
  * this should be the RedisModuleCtx */
 struct MRCtx *MR_CreateCtx(struct RedisModuleCtx *ctx, struct RedisModuleBlockedClient *bc, void *privdata, int replyCap);

--- a/src/module.c
+++ b/src/module.c
@@ -4089,7 +4089,7 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
     }
 
     if (MRCtx_GetNumReplied(mrctx) == 0) {
-      // Can happen in a topology error
+      // Can happen in a topology error, before or after we sent the command to the cluster
       RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
       return REDISMODULE_OK;
     }
@@ -4364,6 +4364,8 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Create MRCtx on main thread with searchRequestCtx as privdata.
   // NumShards is used as a hint for reply capacity - unsafe read is fine.
   struct MRCtx *mrctx = MR_CreateCtx(ctx, NULL, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   // Block client - MRCtx is set as privdata so timeout callback can access it
   RedisModuleBlockedClient* bc = DistSearchBlockClientWithTimeout(ctx, queryTimeoutMS);

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -283,3 +283,120 @@ def test_single_shard_optimization():
 
     # SpellCheck
     env.expect('FT.SPELLCHECK', 'idx', 'hell').equal([['TERM', 'hell', [['1', 'hello']]]])
+
+
+
+def _set_all_shards_unreachable(env: Env):
+    """Set topology so all shards point to unreachable addresses (port 9)."""
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', '127.0.0.1:9', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied
+    wait_for_condition(
+        lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _set_one_shard_unreachable(env: Env):
+    """Set topology so one shard is reachable and one points to an unreachable address."""
+    # Get the real shard address before we modify the topology
+    cluster_info = env.cmd('SEARCH.CLUSTERINFO')
+    # cluster_info[5] is the shards array, [0] is first shard, [7] is port, [5] is host
+    real_port = cluster_info[5][0][7]
+    real_host = cluster_info[5][0][5]
+
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', f'{real_host}:{real_port}', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied (check that any shard has port 9)
+    wait_for_condition(
+        lambda: (any(shard[7] == 9 for shard in env.cmd('SEARCH.CLUSTERINFO')[5]), {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
+    """Test that FT.SEARCH, FT.AGGREGATE, and FT.HYBRID all return an error."""
+    # FT.SEARCH returns an error (does not hang)
+    with TimeLimit(5, f'FT.SEARCH hung ({scenario})'):
+        env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE with cursor returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
+
+    # FT.HYBRID returns an error (does not hang)
+    with TimeLimit(5, f'FT.HYBRID hung ({scenario})'):
+        env.expect('FT.HYBRID', 'idx',
+                   'SEARCH', '*',
+                   'VSIM', '@v', '$BLOB',
+                   'PARAMS', '2', 'BLOB', 'abcdefgh'
+        ).error().contains('Could not send query to cluster')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_all_shards_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE, FT.HYBRID) return an error
+    when all shards are unreachable, rather than hanging indefinitely.
+
+    When MRCluster_SendCommand fails (REDIS_ERR) during the initial fanout, the error
+    must be routed through the user callback so that:
+    - FT.SEARCH: The reducer receives the error and returns it to the client
+    - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
+    - FT.HYBRID: The processCursorMappingCallback increments responseCount and signals
+      the condition variable, allowing ProcessHybridCursorMappings to unblock
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_all_shards_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'all shards unreachable')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_one_shard_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE, FT.HYBRID) return an error
+    when one shard is unreachable, rather than hanging indefinitely or returning partial results.
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_one_shard_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'one shard unreachable')

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -340,6 +340,10 @@ def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
     with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
         env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
 
+    # FT.AGGREGATE WITHCOUNT returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCOUNT hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT').error().contains('Could not send query to cluster')
+
     # FT.HYBRID returns an error (does not hang)
     with TimeLimit(5, f'FT.HYBRID hung ({scenario})'):
         env.expect('FT.HYBRID', 'idx',


### PR DESCRIPTION
# Description

Backport of #8884 to `8.6-rse`.

## Differences from the original PR

`8.6-rse` already contains the coordinator timeout / reducing-state machinery that the original PR builds on, so the backport is almost a verbatim apply. The only adjustments were:

### `src/coord/rmr/rmr.h`
- Kept the 8.6-rse `MRCtx_Free` forward-declaration (which sits at the same spot where the PR adds its new declarations on master). Added the two new declarations from the PR (`MRCtx_SetValidateConnections` / `MRCtx_GetValidateConnections`) right next to it.

### `src/module.c`
- Kept the PR's `MRCtx_SetValidateConnections(mrctx, true)` call in `DistSearchCommandImp`. Dropped the adjacent `MRCtx_SetFreePrivDataCB(mrctx, DistSearchMRCtxFreePrivData)` line from the incoming change — neither `MRCtx_SetFreePrivDataCB` nor `DistSearchMRCtxFreePrivData` exists in 8.6-rse (they belong to unrelated master-only work).

All other files (`src/coord/rmr/cluster.c`/`.h`, `src/coord/rmr/reply.c`/`.h`, `src/coord/rmr/rmr.c`, `src/coord/hybrid/hybrid_cursor_mappings.c`, `tests/pytests/test_coordinator.py`) merged cleanly without adjustments. `MR_CreateCtx` in 8.6-rse already uses `rm_calloc`, so `validateConnections` is zero-initialized without an explicit assignment.

---

# Original PR description

**Summary**

When shards become unreachable, `FT.SEARCH` and `FT.AGGREGATE` silently ignore the connection issue, while `FT.HYBRID` hangs indefinitely. This PR adds pre-fanout connection validation to fail explicitly with a clear error message instead.

**Changes**

**Core Fix**
- **Topology validation**: Before sending commands to shards, validate that all connections are established. If any connection is invalid, return a synthetic error (`"Could not send query to cluster"`) via the callback instead of attempting to send commands that will fail or hang.

**Scope**
- Validates connections only on initial query fanout (`iterStartCb`, `MRCluster_FanoutCommand`)
- Does **not** validate on subsequent cursor reads

[MOD-14475]: https://redislabs.atlassian.net/browse/MOD-14475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the coordinator fanout/iterator startup behavior to validate shard connections and return a synthetic error instead of hanging or returning partial results, which can affect query error handling paths across `FT.SEARCH`/`FT.AGGREGATE`/`FT.HYBRID`. Risk is moderated by added integration tests covering unreachable-shard scenarios.
> 
> **Overview**
> Ensures coordinator queries fail fast with a clear error when the cluster topology is incomplete/unreachable, instead of silently dropping shard failures or hanging (notably for `FT.HYBRID`).
> 
> This adds optional **pre-fanout connection validation** to `MRCluster_FanoutCommand` and propagates a `validateConnections` flag through `MRCtx`, enabling it for coordinator `FT.SEARCH`. Iterator startup (`iterStartCb`) now validates all shard connections up-front and, on failure, invokes the user callback with a synthetic `MR_REPLY_ERROR` (via new `MRReply_CreateError`) to unblock reducers/barriers.
> 
> Hybrid cursor-mapping wait logic is updated to also unblock on early failure-before-initialization, and new pytests assert `FT.SEARCH`/`FT.AGGREGATE` (including cursor variants)/`FT.HYBRID` return `"Could not send query to cluster"` quickly when one or all shards are unreachable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7146c265feba086ce2f19e9032e89bbae9bc02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->