### PR TITLE
[8.4] [MOD-14475] Fail queries with error when topology is incomplete (#8884)

### DIFF
--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -249,8 +249,11 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     }
     // Wait for all callbacks to complete
     pthread_mutex_lock(ctx->mutex);
-    // Wait until the IO thread has initialized numShards and all responses arrive.
-    while (!ctx->initialized || ctx->responseCount < ctx->numShards) {
+    // Wait until either:
+    // 1. Normal completion: IO thread initialized numShards and all responses arrived
+    // 2. Early failure: We got a response before initialization (e.g., connection validation failed)
+    //    In this case, responseCount > 0 but initialized is false - we should unblock.
+    while (ctx->responseCount == 0 || (ctx->initialized && ctx->responseCount < ctx->numShards)) {
         pthread_cond_wait(ctx->completionCond, ctx->mutex);
     }
     pthread_mutex_unlock(ctx->mutex);

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -45,14 +45,26 @@ int MRCluster_SendCommand(IORuntimeCtx *ioRuntime,
   return MRConn_SendCommand(conn, cmd, fn, privdata);
 }
 
-/* Multiplex a command to all coordinators, using a specific coordination strategy. Returns the
- * number of sent commands */
+/* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy.  Returns the
+ * number of sent commands.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
 int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime,
                            MRCommand *cmd,
                            redisCallbackFn *fn,
-                           void *privdata) {
+                           void *privdata,
+                           bool validateConnections) {
   struct MRClusterTopology *topo = ioRuntime->topo;
   uint32_t slotsInfoPos = cmd->slotsInfoArgIndex; // 0 if not set, which means slot info is not needed
+  // Pre-fanout connection validation
+  if (validateConnections) {
+    for (size_t i = 0; i < topo->numShards; i++) {
+      MRConn *conn = MRConn_Get(&ioRuntime->conn_mgr, topo->shards[i].node.id);
+      if (!conn) {
+        return 0;
+      }
+    }
+  }
+
   int ret = 0;
   for (size_t i = 0; i < topo->numShards; i++) {
     MRConn *conn = MRConn_Get(&ioRuntime->conn_mgr, topo->shards[i].node.id);

--- a/src/coord/rmr/cluster.h
+++ b/src/coord/rmr/cluster.h
@@ -31,9 +31,10 @@ typedef struct {
   size_t current_round_robin;
 } MRCluster;
 
-/* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy. The
- * return value is the number of nodes we managed to successfully send the command to */
-int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime, MRCommand *cmd, redisCallbackFn *fn, void *privdata);
+/* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy.  Returns the
+ * number of sent commands.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
+int MRCluster_FanoutCommand(IORuntimeCtx *ioRuntime, MRCommand *cmd, redisCallbackFn *fn, void *privdata, bool validateConnections);
 
 /* Send a command to its appropriate shard, selecting a node based on the coordination strategy.
  * Returns REDIS_OK on success, REDIS_ERR on failure. Notice that that send is asynchronous so even

--- a/src/coord/rmr/reply.c
+++ b/src/coord/rmr/reply.c
@@ -269,3 +269,14 @@ MRReply *MRReply_Clone(MRReply *src) {
   dst->len = src->len;
   return dst;
 }
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len) {
+  RS_ASSERT(msg && len > 0);
+  MRReply *reply = rm_calloc(1, sizeof(MRReply));
+  reply->type = MR_REPLY_ERROR;
+  reply->len = len;
+  reply->str = rm_strndup(msg, len);
+  return reply;
+}

--- a/src/coord/rmr/reply.h
+++ b/src/coord/rmr/reply.h
@@ -75,3 +75,7 @@ int RedisModule_ReplyKV_MRReply(RedisModule_Reply *reply, const char *key, MRRep
 // Currently implements a partial clone, only for the type and string types.
 // Support types - MR_REPLY_STRING, MR_REPLY_ERROR
 MRReply *MRReply_Clone(MRReply *src);
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -43,6 +43,8 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
+
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;
 
@@ -69,6 +71,10 @@ typedef struct MRCtx {
   RedisModuleBlockedClient *bc;
   MRCommand cmd;
   IORuntimeCtx *ioRuntime;
+
+  /* If true, the command should validate that all connections
+   are up before sending the command to the cluster */
+  bool validateConnections;
 
   /**
    * This is a reduce function inside the MRCtx.
@@ -103,6 +109,7 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   ret->bc = bc;
   RS_ASSERT(ctx || bc);
   ret->fn = NULL;
+  ret->validateConnections = false;
   ret->ioRuntime = MRCluster_GetIORuntimeCtx(cluster_g, MRCluster_AssignRoundRobinIORuntimeIdx(cluster_g));
   return ret;
 }
@@ -150,6 +157,14 @@ RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx) {
 
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn) {
   ctx->fn = fn;
+}
+
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections) {
+  ctx->validateConnections = validateConnections;
+}
+
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
+  return ctx->validateConnections;
 }
 
 static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
@@ -215,7 +230,7 @@ static void uvFanoutRequest(void *p) {
   MRCtx *mrctx = p;
   IORuntimeCtx *ioRuntime = mrctx->ioRuntime;
 
-  mrctx->numExpected = MRCluster_FanoutCommand(ioRuntime, &mrctx->cmd, fanoutCallback, mrctx);
+  mrctx->numExpected = MRCluster_FanoutCommand(ioRuntime, &mrctx->cmd, fanoutCallback, mrctx, MRCtx_GetValidateConnections(mrctx));
 
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->bc;
@@ -601,6 +616,22 @@ void iterStartCb(void *p) {
   IORuntimeCtx *io_runtime_ctx = it->ctx.ioRuntime;
   MRClusterShard *shards = io_runtime_ctx->topo->shards;
   size_t numShards = io_runtime_ctx->topo->numShards;
+
+  // Pre-fanout connection validation - check ALL connections before any setup.
+  // If validation fails, we return early with a single error (it->len stays 1).
+  for (size_t i = 0; i < numShards; i++) {
+    MRConn *conn = MRConn_Get(&io_runtime_ctx->conn_mgr, shards[i].node.id);
+    if (!conn) {
+      // At least one connection is not established - fail with a single error.
+      // it->len/pending/inProcess remain at their initial value of 1.
+      MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
+      it->ctx.cb(&it->cbxs[0], err);
+      rm_free(data);
+      return;
+    }
+  }
+
+  // All connections valid - proceed with full setup
   it->len = numShards;
   it->ctx.pending = numShards;
   it->ctx.inProcess = numShards; // Initially all commands are in process
@@ -629,15 +660,14 @@ void iterStartCb(void *p) {
   cmd->targetShardIdx = 0;
   MRCommand_SetSlotInfo(cmd, shards[0].slotRanges);
 
-  // This implies that every connection to each shard will work inside a single IO thread
-  for (size_t i = 0; i < it->len; i++) {
-    if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
-                              mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
+  // Send commands to all shards
+  for (size_t i = 0; i < numShards; i++) {
+    if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd, mrIteratorRedisCB, &it->cbxs[i]) ==
+        REDIS_ERR) {
       MRIteratorCallback_Done(&it->cbxs[i], 1);
     }
   }
 
-  // Clean up the data structure
   rm_free(data);
 }
 
@@ -691,7 +721,7 @@ void iterCursorMappingCb(void *p) {
   vsimOrSearch->mappings[0].targetShard = NULL; // transfer ownership
 
   // Send commands to all shards
-  for (size_t i = 0; i < it->len; i++) {
+  for (size_t i = 0; i < numShardsWithMapping; i++) {
     if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
                               mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
       MRIteratorCallback_Done(&it->cbxs[i], 1);
@@ -778,6 +808,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
       .privateDataInit = cbPrivateDataInit,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
+    .len = 1,
   };
   // Initialize the first command
   *ret->cbxs = (MRIteratorCallbackCtx){

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -624,6 +624,15 @@ void iterStartCb(void *p) {
     if (!conn) {
       // At least one connection is not established - fail with a single error.
       // it->len/pending/inProcess remain at their initial value of 1.
+      // Run privateDataInit so ShardResponseBarrier (used by FT.AGGREGATE
+      // WITHCOUNT) accepts the synthetic error notification; otherwise its
+      // numShards stays 0, Notify's bounds check short-circuits, and the real
+      // error gets replaced by a misleading timeout message in
+      // shardResponseBarrier_HandleTimeout.
+      void *privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
+      if (privateData && it->ctx.privateDataInit) {
+        it->ctx.privateDataInit(privateData, it);
+      }
       MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
       it->ctx.cb(&it->cbxs[0], err);
       rm_free(data);

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -94,6 +94,9 @@ void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn);
 /* Free the MapReduce context */
 void MRCtx_Free(struct MRCtx *ctx);
 
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx);
+
 /* Create a new MapReduce context with a given private data. In a redis module
  * this should be the RedisModuleCtx */
 struct MRCtx *MR_CreateCtx(struct RedisModuleCtx *ctx, struct RedisModuleBlockedClient *bc, void *privdata, int replyCap);

--- a/src/module.c
+++ b/src/module.c
@@ -3824,6 +3824,8 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
 
   // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);
@@ -3858,6 +3860,7 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (mrctx) {
     if (MRCtx_GetNumReplied(mrctx) == 0) {
+      // Can happen in a topology error, before or after we sent the command to the cluster
       RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
     }
     searchRequestCtx_Free(MRCtx_GetPrivData(mrctx));
@@ -4346,6 +4349,8 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
   }
 
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -293,6 +293,10 @@ def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
     with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
         env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
 
+    # FT.AGGREGATE WITHCOUNT returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCOUNT hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT').error().contains('Could not send query to cluster')
+
     # FT.HYBRID returns an error (does not hang)
     with TimeLimit(5, f'FT.HYBRID hung ({scenario})'):
         env.expect('FT.HYBRID', 'idx',

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -236,3 +236,120 @@ def test_single_shard_optimization():
 
     # SpellCheck
     env.expect('FT.SPELLCHECK', 'idx', 'hell').equal([['TERM', 'hell', [['1', 'hello']]]])
+
+
+
+def _set_all_shards_unreachable(env: Env):
+    """Set topology so all shards point to unreachable addresses (port 9)."""
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', '127.0.0.1:9', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied
+    wait_for_condition(
+        lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _set_one_shard_unreachable(env: Env):
+    """Set topology so one shard is reachable and one points to an unreachable address."""
+    # Get the real shard address before we modify the topology
+    cluster_info = env.cmd('SEARCH.CLUSTERINFO')
+    # cluster_info[5] is the shards array, [0] is first shard, [7] is port, [5] is host
+    real_port = cluster_info[5][0][7]
+    real_host = cluster_info[5][0][5]
+
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', f'{real_host}:{real_port}', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied (check that any shard has port 9)
+    wait_for_condition(
+        lambda: (any(shard[7] == 9 for shard in env.cmd('SEARCH.CLUSTERINFO')[5]), {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
+    """Test that FT.SEARCH, FT.AGGREGATE, and FT.HYBRID all return an error."""
+    # FT.SEARCH returns an error (does not hang)
+    with TimeLimit(5, f'FT.SEARCH hung ({scenario})'):
+        env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE with cursor returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
+
+    # FT.HYBRID returns an error (does not hang)
+    with TimeLimit(5, f'FT.HYBRID hung ({scenario})'):
+        env.expect('FT.HYBRID', 'idx',
+                   'SEARCH', '*',
+                   'VSIM', '@v', '$BLOB',
+                   'PARAMS', '2', 'BLOB', 'abcdefgh'
+        ).error().contains('Could not send query to cluster')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_all_shards_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE, FT.HYBRID) return an error
+    when all shards are unreachable, rather than hanging indefinitely.
+
+    When MRCluster_SendCommand fails (REDIS_ERR) during the initial fanout, the error
+    must be routed through the user callback so that:
+    - FT.SEARCH: The reducer receives the error and returns it to the client
+    - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
+    - FT.HYBRID: The processCursorMappingCallback increments responseCount and signals
+      the condition variable, allowing ProcessHybridCursorMappings to unblock
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_all_shards_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'all shards unreachable')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_one_shard_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE, FT.HYBRID) return an error
+    when one shard is unreachable, rather than hanging indefinitely or returning partial results.
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_one_shard_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'one shard unreachable')

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -327,6 +327,9 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
 
+    # Enable unstable features so FT.AGGREGATE WITHCOUNT is accepted
+    enable_unstable_features(env)
+
     # Pause topology refresh so our invalid topology stays in effect
     env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
     # Set validation timeout to 1ms so we don't wait for unreachable shards
@@ -349,6 +352,9 @@ def test_queries_fail_on_one_shard_unreachable(env: Env):
     conn = getConnectionByEnv(env)
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Enable unstable features so FT.AGGREGATE WITHCOUNT is accepted
+    enable_unstable_features(env)
 
     # Pause topology refresh so our invalid topology stays in effect
     env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()


### PR DESCRIPTION
# Description

Backport of #8884 to `8.4`.

## Differences from the original PR

`8.4` predates the coordinator timeout / reducing-state / dispatch-time machinery that the original PR on master interleaves with the topology-validation change, so the backport keeps only the topology-validation pieces:

### `src/coord/rmr/cluster.c`
- Kept the new pre-fanout connection-validation loop in `MRCluster_FanoutCommand`.
- Dropped the `dispatchTimeArgIndex` / `MRCommand_SetDispatchTime` hunk — neither exists in 8.4.

### `src/coord/rmr/rmr.c`
- Kept only `MRCtx_SetValidateConnections` / `MRCtx_GetValidateConnections` from the PR's added helpers. Dropped `MRCtx_GetCommandProtocol`, `MRCtx_SetBlockedClient`, `MRCtx_SetTimedOut`, `MRCtx_IsTimedOut`, `MRCtx_TryClaimReducing`, `MRCtx_SignalReducerComplete`, `MRCtx_WaitForReducerComplete` — 8.4's `MRCtx` has no timeout/reducing fields.
- Kept 8.4's simple `if (!r)` branch in `fanoutCallback` (no `MRCtx_IsTimedOut` gate).
- Initialized `ret->validateConnections = false;` in `MR_CreateCtx` — 8.4 uses `rm_malloc`, so the field needs an explicit zero-init.

### `src/module.c`
- Inside `DistSearchUnblockClient`, kept the new informative comment above the existing `RedisModule_ReplyWithError("Could not send query to cluster")`.
- In the coordinator's FT.SEARCH dispatch path, kept 8.4's `SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));` structure and dropped the master-only block (`initQueryTimeout`, `rscParseRequest` on the main thread, `MR_CreateCtx` + `MRCtx_SetFreePrivDataCB(DistSearchMRCtxFreePrivData)` + `DistSearchBlockClientWithTimeout` + `MRCtx_SetBlockedClient` + `RedisModule_BlockClientSetPrivateData`). None of those symbols exist in 8.4.
- In 8.4 the FT.SEARCH `MRCtx` is created in `FlatSearchCommandHandler` and `DEBUG_FlatSearchCommandHandler` (same as 8.6), so added `MRCtx_SetValidateConnections(mrctx, true)` right after `MR_CreateCtx(0, bc, req, NumShards)` in both handlers.

All other files (`src/coord/rmr/cluster.h`, `src/coord/rmr/reply.c`/`.h`, `src/coord/rmr/rmr.h`, `src/coord/hybrid/hybrid_cursor_mappings.c`, `tests/pytests/test_coordinator.py`) merged cleanly without adjustments.

---

# Original PR description

**Summary**

When shards become unreachable, `FT.SEARCH` and `FT.AGGREGATE` silently ignore the connection issue, while `FT.HYBRID` hangs indefinitely. This PR adds pre-fanout connection validation to fail explicitly with a clear error message instead.

**Changes**

**Core Fix**
- **Topology validation**: Before sending commands to shards, validate that all connections are established. If any connection is invalid, return a synthetic error (`"Could not send query to cluster"`) via the callback instead of attempting to send commands that will fail or hang.

**Scope**
- Validates connections only on initial query fanout (`iterStartCb`, `MRCluster_FanoutCommand`)
- Does **not** validate on subsequent cursor reads

[MOD-14475]: https://redislabs.atlassian.net/browse/MOD-14475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fanout/iterator dispatch to pre-validate shard connections and synthesize errors, which affects distributed query behavior and error paths under cluster instability.
> 
> **Overview**
> **Release note:** Distributed query commands now *fail fast* with `Could not send query to cluster` when the coordinator detects missing/unreachable shard connections, instead of hanging (notably `FT.HYBRID`) or proceeding inconsistently.
> 
> This adds optional pre-fanout connection validation to coordinator dispatch (`MRCluster_FanoutCommand` and iterator startup), introduces `MRReply_CreateError` to inject a synthetic error reply, updates the hybrid cursor-mapping wait condition to unblock on early failures, and enables validation for `FT.SEARCH` dispatch. New coordinator tests cover all/one-shard-unreachable scenarios to ensure `FT.SEARCH`, `FT.AGGREGATE` (including `WITHCURSOR`/`WITHCOUNT`), and `FT.HYBRID` return an error promptly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533112ccd94034076c809c92d013e710308a8723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->