### PR TITLE
[8.2] [MOD-14475] Fail queries with error when topology is incomplete

### DIFF
--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -191,9 +191,15 @@ int MRCluster_CheckConnections(MRCluster *cl, bool mastersOnly) {
 }
 
 /* Multiplex a command to all coordinators, using a specific coordination strategy. Returns the
- * number of sent commands */
+ * number of sent commands.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
 int MRCluster_FanoutCommand(MRCluster *cl, bool mastersOnly, MRCommand *cmd,
-                            redisCallbackFn *fn, void *privdata) {
+                            redisCallbackFn *fn, void *privdata, bool validateConnections) {
+  // Pre-fanout connection validation
+  if (validateConnections && MRCluster_CheckConnections(cl, mastersOnly) != REDIS_OK) {
+    return 0;
+  }
+
   int ret = 0;
   for (size_t i = 0; i < cl->topo->numShards; i++) {
     MRClusterShard *sh = &cl->topo->shards[i];

--- a/src/coord/rmr/cluster.h
+++ b/src/coord/rmr/cluster.h
@@ -73,9 +73,10 @@ typedef struct {
 int MRCluster_CheckConnections(MRCluster *cl, bool mastersOnly);
 
 /* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy. The
- * return value is the number of nodes we managed to successfully send the command to */
+ * return value is the number of nodes we managed to successfully send the command to.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
 int MRCluster_FanoutCommand(MRCluster *cl, bool mastersOnly, MRCommand *cmd, redisCallbackFn *fn,
-                            void *privdata);
+                            void *privdata, bool validateConnections);
 
 /* Get a connected connection according to the cluster, strategy and command.
  * Returns NULL if no fitting connection exists at the moment */

--- a/src/coord/rmr/reply.c
+++ b/src/coord/rmr/reply.c
@@ -255,3 +255,14 @@ void MRReply_ArrayToMap(MRReply *reply) {
   if (reply->type != MR_REPLY_ARRAY) return;
   reply->type = MR_REPLY_MAP;
 }
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len) {
+  RS_ASSERT(msg && len > 0);
+  MRReply *reply = rm_calloc(1, sizeof(MRReply));
+  reply->type = MR_REPLY_ERROR;
+  reply->len = len;
+  reply->str = rm_strndup(msg, len);
+  return reply;
+}

--- a/src/coord/rmr/reply.h
+++ b/src/coord/rmr/reply.h
@@ -70,3 +70,7 @@ int MRReply_ToDouble(MRReply *reply, double *d);
 
 int MR_ReplyWithMRReply(RedisModule_Reply *reply, MRReply *rep);
 int RedisModule_ReplyKV_MRReply(RedisModule_Reply *reply, const char *key, MRReply *rep);
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -593,6 +593,16 @@ void iterStartCb(void *p) {
   if (MRCluster_CheckConnections(cluster_g, true) != REDIS_OK) {
     // At least one connection is not established - fail with a single error.
     // it->len/pending/inProcess remain at their initial value of 1.
+    // Set targetShard to 0 (default is INVALID_SHARD=-1) and run privateDataInit
+    // so ShardResponseBarrier (used by FT.AGGREGATE WITHCOUNT) accepts the
+    // synthetic error notification; otherwise its numShards stays 0, Notify's
+    // bounds check short-circuits, and the real error gets replaced by a
+    // misleading timeout message in shardResponseBarrier_HandleTimeout.
+    it->cbxs[0].cmd.targetShard = 0;
+    void *privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
+    if (privateData && it->ctx.privateDataInit) {
+      it->ctx.privateDataInit(privateData, it);
+    }
     MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
     it->ctx.cb(&it->cbxs[0], err);
     return;

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -36,6 +36,8 @@
 #define REFCOUNT_DECR_MSG(caller, refcount) \
   RS_DEBUG_LOG_FMT("%s: decreased refCount to == %d", caller, refcount);
 
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
+
 /* Currently a single cluster is supported */
 static MRCluster *cluster_g = NULL;
 static MRWorkQueue *rq_g = NULL;
@@ -56,6 +58,10 @@ typedef struct MRCtx {
   RedisModuleBlockedClient *bc;
   bool mastersOnly;
   MRCommand cmd;
+
+  /* If true, the command should validate that all connections
+   are up before sending the command to the cluster */
+  bool validateConnections;
 
   /**
    * This is a reduce function inside the MRCtx.
@@ -88,7 +94,7 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   ret->bc = bc;
   RS_ASSERT(ctx || bc);
   ret->fn = NULL;
-
+  ret->validateConnections = false;
   return ret;
 }
 
@@ -131,6 +137,14 @@ RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx) {
 
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn) {
   ctx->fn = fn;
+}
+
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections) {
+  ctx->validateConnections = validateConnections;
+}
+
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
+  return ctx->validateConnections;
 }
 
 static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
@@ -227,7 +241,8 @@ static void uvFanoutRequest(void *p) {
   MRCtx *mrctx = p;
 
   mrctx->numExpected =
-      MRCluster_FanoutCommand(cluster_g, mrctx->mastersOnly, &mrctx->cmd, fanoutCallback, mrctx);
+      MRCluster_FanoutCommand(cluster_g, mrctx->mastersOnly, &mrctx->cmd, fanoutCallback, mrctx,
+                              MRCtx_GetValidateConnections(mrctx));
 
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->bc;
@@ -573,6 +588,16 @@ void *MRIteratorCallback_GetPrivateData(MRIteratorCallbackCtx *ctx) {
 void iterStartCb(void *p) {
   MRIterator *it = p;
 
+  // Pre-fanout connection validation - check ALL connections before any setup.
+  // If validation fails, we return early with a single error (it->len stays 1).
+  if (MRCluster_CheckConnections(cluster_g, true) != REDIS_OK) {
+    // At least one connection is not established - fail with a single error.
+    // it->len/pending/inProcess remain at their initial value of 1.
+    MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
+    it->ctx.cb(&it->cbxs[0], err);
+    return;
+  }
+
   size_t len = cluster_g->topo->numShards;
   it->len = len;
   it->ctx.pending = len;
@@ -678,6 +703,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
       .privateDataInit = cbPrivateDataInit,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
+    .len = 1,
   };
   // Initialize the first command
   *ret->cbxs = (MRIteratorCallbackCtx){

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -73,6 +73,9 @@ void MR_requestCompleted();
 /* Free the MapReduce context */
 void MRCtx_Free(struct MRCtx *ctx);
 
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx);
+
 /* Create a new MapReduce context with a given private data. In a redis module
  * this should be the RedisModuleCtx */
 struct MRCtx *MR_CreateCtx(struct RedisModuleCtx *ctx, struct RedisModuleBlockedClient *bc, void *privdata, int replyCap);

--- a/src/module.c
+++ b/src/module.c
@@ -3517,6 +3517,8 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
 
   // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);
@@ -3551,6 +3553,7 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (mrctx) {
     if (MRCtx_GetNumReplied(mrctx) == 0) {
+      // Can happen in a topology error, before or after we sent the command to the cluster
       RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
     }
     searchRequestCtx_Free(MRCtx_GetPrivData(mrctx));
@@ -4011,6 +4014,8 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
   }
 
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -306,6 +306,10 @@ def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
     with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
         env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
 
+    # FT.AGGREGATE WITHCOUNT returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCOUNT hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT').error().contains('Could not send query to cluster')
+
 
 @skip(cluster=False, min_shards=2)
 def test_queries_fail_on_all_shards_unreachable(env: Env):

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -234,3 +234,110 @@ def test_single_shard_optimization():
 
     # SpellCheck
     env.expect('FT.SPELLCHECK', 'idx', 'hell').equal([['TERM', 'hell', [['1', 'hello']]]])
+
+
+
+def _set_all_shards_unreachable(env: Env):
+    """Set topology so all shards point to unreachable addresses (port 9)."""
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', '127.0.0.1:9', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied
+    wait_for_condition(
+        lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _set_one_shard_unreachable(env: Env):
+    """Set topology so one shard is reachable and one points to an unreachable address."""
+    # Get the real shard address before we modify the topology
+    cluster_info = env.cmd('SEARCH.CLUSTERINFO')
+    # cluster_info[5] is the shards array, [0] is first shard, [7] is port, [5] is host
+    real_port = cluster_info[5][0][7]
+    real_host = cluster_info[5][0][5]
+
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', f'{real_host}:{real_port}', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied (check that any shard has port 9)
+    wait_for_condition(
+        lambda: (any(shard[7] == 9 for shard in env.cmd('SEARCH.CLUSTERINFO')[5]), {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
+    """Test that FT.SEARCH and FT.AGGREGATE all return an error."""
+    # FT.SEARCH returns an error (does not hang)
+    with TimeLimit(5, f'FT.SEARCH hung ({scenario})'):
+        env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE with cursor returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_all_shards_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE) return an error
+    when all shards are unreachable, rather than hanging indefinitely.
+
+    When MRCluster_SendCommand fails (REDIS_ERR) during the initial fanout, the error
+    must be routed through the user callback so that:
+    - FT.SEARCH: The reducer receives the error and returns it to the client
+    - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_all_shards_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'all shards unreachable')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_one_shard_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE) return an error
+    when one shard is unreachable, rather than hanging indefinitely or returning partial results.
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_one_shard_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'one shard unreachable')

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -237,6 +237,21 @@ def test_single_shard_optimization():
 
 
 
+def _cluster_info_shards(env: Env):
+    """Return the list of shard sub-arrays from SEARCH.CLUSTERINFO (RESP2).
+
+    On this branch the reply is a flat array:
+      ['num_partitions', N, 'cluster_type', X, 'hash_func', H, 'num_slots', S,
+       'slots', [startSlot, endSlot, [id, host, port, role], ...], ...]
+    Shards are flattened at the root, starting after the 'slots' marker.
+    Each shard is [startSlot, endSlot, node_array, ...]; each node_array is
+    [id, host, port, role].
+    """
+    info = env.cmd('SEARCH.CLUSTERINFO')
+    slots_idx = info.index('slots')
+    return info[slots_idx + 1:]
+
+
 def _set_all_shards_unreachable(env: Env):
     """Set topology so all shards point to unreachable addresses (port 9)."""
     env.expect('SEARCH.CLUSTERSET',
@@ -247,20 +262,20 @@ def _set_all_shards_unreachable(env: Env):
                'SHARD', '2', 'SLOTRANGE', '8192', '16383',
                'ADDR', '127.0.0.1:9', 'MASTER'
     ).ok()
-    # Wait for the new topology to be applied
+    # Wait for the new topology to be applied (first shard's first node on port 9)
     wait_for_condition(
-        lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+        lambda: (_cluster_info_shards(env)[0][2][2] == 9, {}),
         'Failed waiting for topology to be applied'
     )
 
 
 def _set_one_shard_unreachable(env: Env):
     """Set topology so one shard is reachable and one points to an unreachable address."""
-    # Get the real shard address before we modify the topology
-    cluster_info = env.cmd('SEARCH.CLUSTERINFO')
-    # cluster_info[5] is the shards array, [0] is first shard, [7] is port, [5] is host
-    real_port = cluster_info[5][0][7]
-    real_host = cluster_info[5][0][5]
+    # Get the real shard address before we modify the topology.
+    # Each shard is [startSlot, endSlot, [id, host, port, role], ...].
+    first_shard = _cluster_info_shards(env)[0]
+    real_host = first_shard[2][1]
+    real_port = first_shard[2][2]
 
     env.expect('SEARCH.CLUSTERSET',
                'MYID', '1',
@@ -270,9 +285,9 @@ def _set_one_shard_unreachable(env: Env):
                'SHARD', '2', 'SLOTRANGE', '8192', '16383',
                'ADDR', '127.0.0.1:9', 'MASTER'
     ).ok()
-    # Wait for the new topology to be applied (check that any shard has port 9)
+    # Wait for the new topology to be applied (any shard's first node on port 9)
     wait_for_condition(
-        lambda: (any(shard[7] == 9 for shard in env.cmd('SEARCH.CLUSTERINFO')[5]), {}),
+        lambda: (any(shard[2][2] == 9 for shard in _cluster_info_shards(env)), {}),
         'Failed waiting for topology to be applied'
     )
 

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -330,6 +330,9 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
 
+    # Enable unstable features so FT.AGGREGATE WITHCOUNT is accepted
+    enable_unstable_features(env)
+
     # Pause topology refresh so our invalid topology stays in effect
     env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
     # Set validation timeout to 1ms so we don't wait for unreachable shards
@@ -352,6 +355,9 @@ def test_queries_fail_on_one_shard_unreachable(env: Env):
     conn = getConnectionByEnv(env)
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Enable unstable features so FT.AGGREGATE WITHCOUNT is accepted
+    enable_unstable_features(env)
 
     # Pause topology refresh so our invalid topology stays in effect
     env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()


### PR DESCRIPTION
# Description

Backport of #8884 to `8.2`.

## Differences from the original PR

`8.2` is architecturally much older than `master`, and it also predates `FT.HYBRID`, the `IORuntime` refactor, and the coordinator timeout / reducing-state / dispatch-time machinery that the original PR on master interleaves with the topology-validation change. The cherry-pick was applied from the already-resolved `8.4` backport (architecturally closer to `8.2` than `master`) and reshaped to keep only the topology-validation pieces:

### `src/coord/hybrid/hybrid_cursor_mappings.c`
- Modify/delete conflict — `FT.HYBRID` does not exist in `8.2` at all. Deleted the file; it isn't in `8.2`'s tree.

### `src/coord/rmr/cluster.c` / `cluster.h`
- `8.2`'s `MRCluster_FanoutCommand` has a different signature (no `IORuntimeCtx`, no `slotsInfoArgIndex`, no dispatch-time): `(MRCluster *cl, bool mastersOnly, MRCommand *cmd, redisCallbackFn *fn, void *privdata)`. Kept that signature and appended `bool validateConnections`.
- The pre-fanout connection-validation inside `MRCluster_FanoutCommand` reuses the existing `MRCluster_CheckConnections(cl, mastersOnly)` helper that `8.2` already provides, instead of a hand-rolled per-shard `MRConn_Get` loop.
- Dropped the `dispatchTimeArgIndex` / `MRCommand_SetDispatchTime` hunk — neither exists in `8.2`.


## Correctness of the `MRCluster_CheckConnections` translation

The original `8.4`-style per-shard loop (used in the master PR) walks `shards[i].node.id` — the single node per shard — and calls `MRConn_Get` on each. On `8.4` this is fine because `cluster_topology.h` states *"we keep a single node per shard"*: each `MRClusterShard` holds one `.node` (the master).

`8.2` still has the older shard shape with a `.nodes[]` array (master plus possible replicas, distinguished by the `MRNode_Master` flag). The equivalent fast-check there is the pre-existing `MRCluster_CheckConnections(cl, mastersOnly)`:

```c
for (size_t i = 0; i < cl->topo->numShards; i++) {
  MRClusterShard *sh = &cl->topo->shards[i];
  for (size_t j = 0; j < sh->numNodes; j++) {
    if (mastersOnly && !(sh->nodes[j].flags & MRNode_Master)) continue;
    if (!MRConn_Get(&cl->mgr, sh->nodes[j].id)) return REDIS_ERR;
  }
}
```

With `mastersOnly=true` this visits exactly one node per shard — the master — and applies the same `MRConn_Get(...)` primitive used by `8.4`'s loop, failing fast if any master is not connected.

**Why `mastersOnly=true` is the correct filter on `8.2`:**
- `iterStartCb` dispatches with `MRCluster_SendCommand(cluster_g, true, ...)`. Inside, `MRCluster_GetConn` → `_MRClusterShard_SelectNode(sh, true)` → `MRConn_Get(&cl->mgr, node->id)` resolves to the same per-shard master connection that `MRCluster_CheckConnections(cluster_g, true)` validates up-front. The pre-check validates exactly the nodes the dispatch will target.
- `uvFanoutRequest` / `MRCluster_FanoutCommand` takes `bool mastersOnly` from `mrctx->mastersOnly`, and the added `validateConnections` check inside it calls `MRCluster_CheckConnections(cl, mastersOnly)` — the filter follows the fanout strategy, so it validates precisely the nodes the fanout will hit (for FT.SEARCH via `DistSearch` this is `true`).

**Edge case parity:** if the topology is malformed and a shard has no matching masters, `MRCluster_CheckConnections`'s inner loop runs zero times for that shard and returns `REDIS_OK`. `8.4`'s per-shard loop does not hit this case because `shards[i].node` always exists by construction, but in either branch if dispatch subsequently fails the existing fallback (`MRCluster_SendCommand` returning `REDIS_ERR` → `MRIteratorCallback_Done(&it->cbxs[i], 1)`) handles it. No behavioral regression risk.

### `src/coord/rmr/reply.c` / `reply.h`
- Kept only the new `MRReply_CreateError`. Dropped `MRReply_Clone` — unrelated to this backport and not used by it.

### `src/coord/rmr/rmr.c`
- Added `#define CLUSTER_QUERY_ERROR "Could not send query to cluster"`.
- Kept only `MRCtx_SetValidateConnections` / `MRCtx_GetValidateConnections` from the PR's added helpers. Dropped `MRCtx_GetCommandProtocol`, `MRCtx_SetBlockedClient`, `MRCtx_SetTimedOut`, `MRCtx_IsTimedOut`, `MRCtx_TryClaimReducing`, `MRCtx_SignalReducerComplete`, `MRCtx_WaitForReducerComplete` — `8.2`'s `MRCtx` has no timeout/reducing fields.
- Added the `validateConnections` field to `MRCtx` and initialized `ret->validateConnections = false;` in `MR_CreateCtx` (`8.2` uses `rm_malloc`, so the field must be zeroed manually). Dropped the `ret->ioRuntime = MRCluster_GetIORuntimeCtx(...)` init — `8.2` uses the `cluster_g` global; there is no `ioRuntime` on `MRCtx`.
- Kept `8.2`'s simple `if (!r)` branch in `fanoutCallback` (no `MRCtx_IsTimedOut` gate).
- `uvFanoutRequest`: kept `8.2`'s signature `MRCluster_FanoutCommand(cluster_g, mrctx->mastersOnly, &mrctx->cmd, fanoutCallback, mrctx, ...)` and just appended `MRCtx_GetValidateConnections(mrctx)`.
- `iterStartCb`: `8.2`'s version receives `MRIterator *` directly (no `IteratorData` wrapper, no `ioRuntime`, no `slotRanges`, simpler `cmd->targetSlot = shards[i].startSlot` / `cmd->targetShard = i` pattern). Added the pre-fanout validation at the top using `8.2`'s API: `if (MRCluster_CheckConnections(cluster_g, true) != REDIS_OK) { ... it->ctx.cb(&it->cbxs[0], err); return; }`. The initial `it->len/pending/inProcess == 1` values set by `MR_IterateWithPrivateData` make the early-error path work the same way it does on master / 8.4.
- Dropped the entire `iterCursorMappingCb` function from the PR — it's FT.HYBRID-only.
- Kept `8.2`'s dispatch loop `MRCluster_SendCommand(cluster_g, true, &it->cbxs[i].cmd, ...)`.

### `src/module.c`
- Kept the PR's comment update in `DistSearchUnblockClient` ("Can happen in a topology error, before or after we sent the command to the cluster").
- In `8.2` the FT.SEARCH `MRCtx` is created in `FlatSearchCommandHandler` and `DEBUG_FlatSearchCommandHandler` (same as 8.6 / 8.4), so added `MRCtx_SetValidateConnections(mrctx, true)` right after `MR_CreateCtx(0, bc, req, NumShards)` in both handlers.
- Did not pull in the master-only restructure (`initQueryTimeout`, `rscParseRequest` on the main thread, `DistSearchMRCtxFreePrivData`, `DistSearchBlockClientWithTimeout`, `MRCtx_SetFreePrivDataCB`, `MRCtx_SetBlockedClient` main-thread wiring, etc.) — none of those symbols exist in `8.2`.

### `tests/pytests/test_coordinator.py`
- Dropped the `FT.HYBRID` assertion inside `_test_all_queries_fail_on_unreachable_shard` and the `FT.HYBRID` mentions in the two new tests' docstrings — `8.2` has no `FT.HYBRID` command.
- Kept `FT.SEARCH`, `FT.AGGREGATE`, and `FT.AGGREGATE WITHCURSOR` coverage for both the "all shards unreachable" and "one shard unreachable" regression tests. The test harness primitives (`SEARCH.CLUSTERSET`, `SEARCH.CLUSTERINFO`, `PAUSE_TOPOLOGY_UPDATER`, `TOPOLOGY_VALIDATION_TIMEOUT`, `debug_cmd()`, `config_cmd()`, `wait_for_condition`, `TimeLimit`) are all already present in `8.2`.

The rest of the files — `src/coord/rmr/rmr.h` (two new declarations) — merged cleanly without adjustments.

---

# Original PR description

**Summary**

When shards become unreachable, `FT.SEARCH` and `FT.AGGREGATE` silently ignore the connection issue, while `FT.HYBRID` hangs indefinitely. This PR adds pre-fanout connection validation to fail explicitly with a clear error message instead.

**Changes**

**Core Fix**
- **Topology validation**: Before sending commands to shards, validate that all connections are established. If any connection is invalid, return a synthetic error (`"Could not send query to cluster"`) via the callback instead of attempting to send commands that will fail or hang.

**Scope**
- Validates connections only on initial query fanout (`iterStartCb`, `MRCluster_FanoutCommand`)
- Does **not** validate on subsequent cursor reads

[MOD-14475]: https://redislabs.atlassian.net/browse/MOD-14475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator fanout/iterator dispatch and error reply creation, which can affect cluster query availability and error propagation paths. Changes are scoped to pre-send validation and covered by new cluster regression tests.
> 
> **Overview**
> **Release note:** In cluster mode, `FT.SEARCH`/`FT.AGGREGATE` now *fail fast* with `"Could not send query to cluster"` when the topology is incomplete or shards are unreachable, instead of hanging or returning partial results.
> 
> This adds an optional pre-fanout connection validation (`MRCluster_FanoutCommand(..., validateConnections)` plus `MRCtx` wiring) and an early error path in iterator startup using a new helper `MRReply_CreateError`. New pytests cover both “all shards unreachable” and “one shard unreachable” scenarios (including cursor/`WITHCOUNT`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2441254c3aa959fd29fbd2031508555c96251f96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->