### PR TITLE
[2.10] [MOD-14475] Fail queries with error when topology is incomplete (#8884)

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1890,6 +1890,8 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol, RedisMo
 
   // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);
@@ -1920,6 +1922,7 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (mrctx) {
     if (MRCtx_GetNumReplied(mrctx) == 0) {
+      // Can happen in a topology error, before or after we sent the command to the cluster
       RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
     }
     searchRequestCtx_Free(MRCtx_GetPrivData(mrctx));
@@ -2262,6 +2265,8 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
   }
 
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+  // FT.SEARCH coordinator should validate connections before sending the command to the cluster
+  MRCtx_SetValidateConnections(mrctx, true);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);

--- a/coord/src/rmr/cluster.c
+++ b/coord/src/rmr/cluster.c
@@ -212,9 +212,15 @@ void MRCluster_LogDisconnectedNodes(MRCluster *cl, bool mastersOnly) {
 }
 
 /* Multiplex a command to all coordinators, using a specific coordination strategy. Returns the
- * number of sent commands */
+ * number of sent commands.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
 int MRCluster_FanoutCommand(MRCluster *cl, bool mastersOnly, MRCommand *cmd,
-                            redisCallbackFn *fn, void *privdata) {
+                            redisCallbackFn *fn, void *privdata, bool validateConnections) {
+  // Pre-fanout connection validation
+  if (validateConnections && MRCluster_CheckConnections(cl, mastersOnly) != REDIS_OK) {
+    return 0;
+  }
+
   int ret = 0;
   for (size_t i = 0; i < cl->topo->numShards; i++) {
     MRClusterShard *sh = &cl->topo->shards[i];

--- a/coord/src/rmr/cluster.h
+++ b/coord/src/rmr/cluster.h
@@ -70,9 +70,10 @@ int MRCluster_CheckConnections(MRCluster *cl, bool mastersOnly);
 void MRCluster_LogDisconnectedNodes(MRCluster *cl, bool mastersOnly);
 
 /* Multiplex a non-sharding command to all coordinators, using a specific coordination strategy. The
- * return value is the number of nodes we managed to successfully send the command to */
+ * return value is the number of nodes we managed to successfully send the command to.
+ * If validateConnections is true, the function will validate that all connections are up before sending the command */
 int MRCluster_FanoutCommand(MRCluster *cl, bool mastersOnly, MRCommand *cmd, redisCallbackFn *fn,
-                            void *privdata);
+                            void *privdata, bool validateConnections);
 
 /* Get a connected connection according to the cluster, strategy and command.
  * Returns NULL if no fitting connection exists at the moment */

--- a/coord/src/rmr/reply.c
+++ b/coord/src/rmr/reply.c
@@ -235,3 +235,14 @@ void MRReply_ArrayToMap(MRReply *reply) {
   if (reply->type != MR_REPLY_ARRAY) return;
   reply->type = MR_REPLY_MAP;
 }
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len) {
+  RS_ASSERT(msg && len > 0);
+  MRReply *reply = rm_calloc(1, sizeof(MRReply));
+  reply->type = MR_REPLY_ERROR;
+  reply->len = len;
+  reply->str = rm_strndup(msg, len);
+  return reply;
+}

--- a/coord/src/rmr/reply.h
+++ b/coord/src/rmr/reply.h
@@ -64,3 +64,7 @@ int MRReply_ToDouble(MRReply *reply, double *d);
 
 int MR_ReplyWithMRReply(RedisModule_Reply *reply, MRReply *rep);
 int RedisModule_ReplyKV_MRReply(RedisModule_Reply *reply, const char *key, MRReply *rep);
+
+// Create a new error reply with the given message.
+// `msg` must be non-NULL and `len` must be greater than 0.
+MRReply *MRReply_CreateError(const char *msg, size_t len);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -34,6 +34,8 @@
 #define REFCOUNT_DECR_MSG(caller, refcount) \
   RS_DEBUG_LOG_FMT("%s: decreased refCount to == %d", caller, refcount);
 
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
+
 /* Currently a single cluster is supported */
 static MRCluster *cluster_g = NULL;
 static MRWorkQueue *rq_g = NULL;
@@ -54,6 +56,10 @@ typedef struct MRCtx {
   RedisModuleBlockedClient *bc;
   bool mastersOnly;
   MRCommand cmd;
+
+  /* If true, the command should validate that all connections
+   are up before sending the command to the cluster */
+  bool validateConnections;
 
   /**
    * This is a reduce function inside the MRCtx.
@@ -86,7 +92,7 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   ret->bc = bc;
   RS_ASSERT(ctx || bc);
   ret->fn = NULL;
-
+  ret->validateConnections = false;
   return ret;
 }
 
@@ -129,6 +135,14 @@ RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx) {
 
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn) {
   ctx->fn = fn;
+}
+
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections) {
+  ctx->validateConnections = validateConnections;
+}
+
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
+  return ctx->validateConnections;
 }
 
 static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
@@ -211,7 +225,8 @@ static void uvFanoutRequest(void *p) {
   MRCtx *mrctx = p;
 
   mrctx->numExpected =
-      MRCluster_FanoutCommand(cluster_g, mrctx->mastersOnly, &mrctx->cmd, fanoutCallback, mrctx);
+      MRCluster_FanoutCommand(cluster_g, mrctx->mastersOnly, &mrctx->cmd, fanoutCallback, mrctx,
+                              MRCtx_GetValidateConnections(mrctx));
 
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->bc;
@@ -547,6 +562,16 @@ void *MRIteratorCallback_GetPrivateData(MRIteratorCallbackCtx *ctx) {
 void iterStartCb(void *p) {
   MRIterator *it = p;
 
+  // Pre-fanout connection validation - check ALL connections before any setup.
+  // If validation fails, we return early with a single error (it->len stays 1).
+  if (MRCluster_CheckConnections(cluster_g, true) != REDIS_OK) {
+    // At least one connection is not established - fail with a single error.
+    // it->len/pending/inProcess remain at their initial value of 1.
+    MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
+    it->ctx.cb(&it->cbxs[0], err);
+    return;
+  }
+
   size_t len = cluster_g->topo->numShards;
   it->len = len;
   it->ctx.pending = len;
@@ -652,6 +677,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
       .privateDataInit = cbPrivateDataInit,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
+    .len = 1,
   };
   // Initialize the first command
   *ret->cbxs = (MRIteratorCallbackCtx){

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -567,6 +567,16 @@ void iterStartCb(void *p) {
   if (MRCluster_CheckConnections(cluster_g, true) != REDIS_OK) {
     // At least one connection is not established - fail with a single error.
     // it->len/pending/inProcess remain at their initial value of 1.
+    // Set targetShard to 0 (default is INVALID_SHARD=-1) and run privateDataInit
+    // so ShardResponseBarrier (used by FT.AGGREGATE WITHCOUNT) accepts the
+    // synthetic error notification; otherwise its numShards stays 0, Notify's
+    // bounds check short-circuits, and the real error gets replaced by a
+    // misleading timeout message in shardResponseBarrier_HandleTimeout.
+    it->cbxs[0].cmd.targetShard = 0;
+    void *privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
+    if (privateData && it->ctx.privateDataInit) {
+      it->ctx.privateDataInit(privateData, it);
+    }
     MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
     it->ctx.cb(&it->cbxs[0], err);
     return;

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -67,6 +67,9 @@ void MR_requestCompleted();
 /* Free the MapReduce context */
 void MRCtx_Free(struct MRCtx *ctx);
 
+void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
+bool MRCtx_GetValidateConnections(struct MRCtx *ctx);
+
 /* Create a new MapReduce context with a given private data. In a redis module
  * this should be the RedisModuleCtx */
 struct MRCtx *MR_CreateCtx(struct RedisModuleCtx *ctx, struct RedisModuleBlockedClient *bc, void *privdata, int replyCap);

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -298,6 +298,9 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
 
+    # Enable unstable features so FT.AGGREGATE WITHCOUNT is accepted
+    enable_unstable_features(env)
+
     # Pause topology refresh so our invalid topology stays in effect
     env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
     # Set validation timeout to 1ms so we don't wait for unreachable shards
@@ -320,6 +323,9 @@ def test_queries_fail_on_one_shard_unreachable(env: Env):
     conn = getConnectionByEnv(env)
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Enable unstable features so FT.AGGREGATE WITHCOUNT is accepted
+    enable_unstable_features(env)
 
     # Pause topology refresh so our invalid topology stays in effect
     env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -203,3 +203,109 @@ def test_mod_6287(env):
     # Send another command to make sure that the coordinator is healthy
     res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', '0', str(n_docs))
     env.assertEqual(len(res)-1, n_docs)
+
+
+def _set_all_shards_unreachable(env: Env):
+    """Set topology so all shards point to unreachable addresses (port 9)."""
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', '127.0.0.1:9', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied
+    wait_for_condition(
+        lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _set_one_shard_unreachable(env: Env):
+    """Set topology so one shard is reachable and one points to an unreachable address."""
+    # Get the real shard address before we modify the topology
+    cluster_info = env.cmd('SEARCH.CLUSTERINFO')
+    # cluster_info[5] is the shards array, [0] is first shard, [7] is port, [5] is host
+    real_port = cluster_info[5][0][7]
+    real_host = cluster_info[5][0][5]
+
+    env.expect('SEARCH.CLUSTERSET',
+               'MYID', '1',
+               'RANGES', '2',
+               'SHARD', '1', 'SLOTRANGE', '0', '8191',
+               'ADDR', f'{real_host}:{real_port}', 'MASTER',
+               'SHARD', '2', 'SLOTRANGE', '8192', '16383',
+               'ADDR', '127.0.0.1:9', 'MASTER'
+    ).ok()
+    # Wait for the new topology to be applied (check that any shard has port 9)
+    wait_for_condition(
+        lambda: (any(shard[7] == 9 for shard in env.cmd('SEARCH.CLUSTERINFO')[5]), {}),
+        'Failed waiting for topology to be applied'
+    )
+
+
+def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
+    """Test that FT.SEARCH and FT.AGGREGATE all return an error."""
+    # FT.SEARCH returns an error (does not hang)
+    with TimeLimit(5, f'FT.SEARCH hung ({scenario})'):
+        env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*').error().contains('Could not send query to cluster')
+
+    # FT.AGGREGATE with cursor returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_all_shards_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE) return an error
+    when all shards are unreachable, rather than hanging indefinitely.
+
+    When MRCluster_SendCommand fails (REDIS_ERR) during the initial fanout, the error
+    must be routed through the user callback so that:
+    - FT.SEARCH: The reducer receives the error and returns it to the client
+    - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_all_shards_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'all shards unreachable')
+
+
+@skip(cluster=False, min_shards=2)
+def test_queries_fail_on_one_shard_unreachable(env: Env):
+    """Test that all query commands (FT.SEARCH, FT.AGGREGATE) return an error
+    when one shard is unreachable, rather than hanging indefinitely or returning partial results.
+    """
+    # Create an index and add data before breaking topology
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+               'DISTANCE_METRIC', 'L2').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}', 'v', 'abcdefgh')
+
+    # Pause topology refresh so our invalid topology stays in effect
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    # Set validation timeout to 1ms so we don't wait for unreachable shards
+    env.expect(config_cmd(), 'SET', 'TOPOLOGY_VALIDATION_TIMEOUT', '1').ok()
+
+    _set_one_shard_unreachable(env)
+    _test_all_queries_fail_on_unreachable_shard(env, 'one shard unreachable')

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -274,6 +274,10 @@ def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
     with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
         env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
 
+    # FT.AGGREGATE WITHCOUNT returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCOUNT hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT').error().contains('Could not send query to cluster')
+
 
 @skip(cluster=False, min_shards=2)
 def test_queries_fail_on_all_shards_unreachable(env: Env):

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -205,6 +205,21 @@ def test_mod_6287(env):
     env.assertEqual(len(res)-1, n_docs)
 
 
+def _cluster_info_shards(env: Env):
+    """Return the list of shard sub-arrays from SEARCH.CLUSTERINFO (RESP2).
+
+    On this branch the reply is a flat array:
+      ['num_partitions', N, 'cluster_type', X, 'hash_func', H, 'num_slots', S,
+       'slots', [startSlot, endSlot, [id, host, port, role], ...], ...]
+    Shards are flattened at the root, starting after the 'slots' marker.
+    Each shard is [startSlot, endSlot, node_array, ...]; each node_array is
+    [id, host, port, role].
+    """
+    info = env.cmd('SEARCH.CLUSTERINFO')
+    slots_idx = info.index('slots')
+    return info[slots_idx + 1:]
+
+
 def _set_all_shards_unreachable(env: Env):
     """Set topology so all shards point to unreachable addresses (port 9)."""
     env.expect('SEARCH.CLUSTERSET',
@@ -215,20 +230,20 @@ def _set_all_shards_unreachable(env: Env):
                'SHARD', '2', 'SLOTRANGE', '8192', '16383',
                'ADDR', '127.0.0.1:9', 'MASTER'
     ).ok()
-    # Wait for the new topology to be applied
+    # Wait for the new topology to be applied (first shard's first node on port 9)
     wait_for_condition(
-        lambda: (env.cmd('SEARCH.CLUSTERINFO')[5][0][7] == 9, {}),
+        lambda: (_cluster_info_shards(env)[0][2][2] == 9, {}),
         'Failed waiting for topology to be applied'
     )
 
 
 def _set_one_shard_unreachable(env: Env):
     """Set topology so one shard is reachable and one points to an unreachable address."""
-    # Get the real shard address before we modify the topology
-    cluster_info = env.cmd('SEARCH.CLUSTERINFO')
-    # cluster_info[5] is the shards array, [0] is first shard, [7] is port, [5] is host
-    real_port = cluster_info[5][0][7]
-    real_host = cluster_info[5][0][5]
+    # Get the real shard address before we modify the topology.
+    # Each shard is [startSlot, endSlot, [id, host, port, role], ...].
+    first_shard = _cluster_info_shards(env)[0]
+    real_host = first_shard[2][1]
+    real_port = first_shard[2][2]
 
     env.expect('SEARCH.CLUSTERSET',
                'MYID', '1',
@@ -238,9 +253,9 @@ def _set_one_shard_unreachable(env: Env):
                'SHARD', '2', 'SLOTRANGE', '8192', '16383',
                'ADDR', '127.0.0.1:9', 'MASTER'
     ).ok()
-    # Wait for the new topology to be applied (check that any shard has port 9)
+    # Wait for the new topology to be applied (any shard's first node on port 9)
     wait_for_condition(
-        lambda: (any(shard[7] == 9 for shard in env.cmd('SEARCH.CLUSTERINFO')[5]), {}),
+        lambda: (any(shard[2][2] == 9 for shard in _cluster_info_shards(env)), {}),
         'Failed waiting for topology to be applied'
     )
 


### PR DESCRIPTION
# Description

Backport of #8884 to `2.10`.

## Differences from the original PR

`2.10` predates both the `FT.HYBRID` feature, the `IORuntime` refactor, and the coordinator timeout / reducing-state / dispatch-time machinery that the original PR on master interleaves with the topology-validation change. It also keeps the coordinator sources at the older top-level `coord/src/` location instead of `src/coord/`. The backport was applied from the already-resolved `8.2` backport (architecturally identical at the relevant call sites) with a path rewrite and one small test-file fixup:

### Path relocation
- `src/coord/rmr/{cluster,reply,rmr}.{c,h}` → `coord/src/rmr/{cluster,reply,rmr}.{c,h}`
- `src/module.c` (coord entry points) → `coord/src/module.c`

### `src/coord/hybrid/hybrid_cursor_mappings.c`
- Dropped entirely — `FT.HYBRID` does not exist in `2.10` (no `coord/src/hybrid/` directory).

### `coord/src/rmr/cluster.c` / `cluster.h`
- Kept `2.10`'s `MRCluster_FanoutCommand` signature `(MRCluster *cl, bool mastersOnly, MRCommand *cmd, redisCallbackFn *fn, void *privdata)` and appended `bool validateConnections`.
- Pre-fanout connection-validation inside `MRCluster_FanoutCommand` reuses the existing `MRCluster_CheckConnections(cl, mastersOnly)` helper already present in `2.10`.
- Dropped the `dispatchTimeArgIndex` / `MRCommand_SetDispatchTime` hunk — neither exists in `2.10`.

### `coord/src/rmr/reply.c` / `reply.h`
- Kept only the new `MRReply_CreateError`. Dropped `MRReply_Clone` — unrelated to this backport and not used by it.

### `coord/src/rmr/rmr.c`
- Added `#define CLUSTER_QUERY_ERROR "Could not send query to cluster"`.
- Kept only `MRCtx_SetValidateConnections` / `MRCtx_GetValidateConnections` from the PR's added helpers. Dropped `MRCtx_GetCommandProtocol`, `MRCtx_SetBlockedClient`, `MRCtx_SetTimedOut`, `MRCtx_IsTimedOut`, `MRCtx_TryClaimReducing`, `MRCtx_SignalReducerComplete`, `MRCtx_WaitForReducerComplete` — `2.10`'s `MRCtx` has no timeout/reducing fields.
- Added the `validateConnections` field to `MRCtx` and initialized `ret->validateConnections = false;` in `MR_CreateCtx` (`2.10` uses `rm_malloc`, so the field must be zeroed manually). Dropped the `ret->ioRuntime = MRCluster_GetIORuntimeCtx(...)` init — `2.10` uses the `cluster_g` global; there is no `ioRuntime` on `MRCtx`.
- Kept `2.10`'s simple `if (!r)` branch in `fanoutCallback` (no `MRCtx_IsTimedOut` gate).
- `uvFanoutRequest`: kept `2.10`'s signature `MRCluster_FanoutCommand(cluster_g, mrctx->mastersOnly, &mrctx->cmd, fanoutCallback, mrctx, ...)` and just appended `MRCtx_GetValidateConnections(mrctx)`.
- `iterStartCb`: `2.10`'s version receives `MRIterator *` directly (no `IteratorData` wrapper, no `ioRuntime`, no `slotRanges`, simpler `cmd->targetSlot = shards[i].startSlot` / `cmd->targetShard = i` pattern). Added the pre-fanout validation at the top using `2.10`'s API: `if (MRCluster_CheckConnections(cluster_g, true) != REDIS_OK) { ... it->ctx.cb(&it->cbxs[0], err); return; }`. The initial `it->len/pending/inProcess == 1` values set by `MR_IterateWithPrivateData` make the early-error path work the same way it does on master / 8.4.
- Dropped the entire `iterCursorMappingCb` function from the PR — it's FT.HYBRID-only.
- Kept `2.10`'s dispatch loop `MRCluster_SendCommand(cluster_g, true, &it->cbxs[i].cmd, ...)`.

### `coord/src/module.c`
- Kept the PR's comment update in `DistSearchUnblockClient` ("Can happen in a topology error, before or after we sent the command to the cluster").
- In `2.10` the FT.SEARCH `MRCtx` is created in `FlatSearchCommandHandler` and `DEBUG_FlatSearchCommandHandler` (same as 8.2 / 8.4 / 8.6), so added `MRCtx_SetValidateConnections(mrctx, true)` right after `MR_CreateCtx(0, bc, req, NumShards)` in both handlers.
- Did not pull in the master-only restructure (`initQueryTimeout`, `rscParseRequest` on the main thread, `DistSearchMRCtxFreePrivData`, `DistSearchBlockClientWithTimeout`, `MRCtx_SetFreePrivDataCB`, `MRCtx_SetBlockedClient` main-thread wiring, etc.) — none of those symbols exist in `2.10`.

### `tests/pytests/test_coordinator.py`
- The 8.2 patch anchored its additions after `test_single_shard_optimization`, which is present in 8.2 but does not exist in `2.10`. The 3-way fallback pulled `test_single_shard_optimization` in as an addition; resolved by dropping it (unrelated to this backport) and appending only the two new regression tests and their three helpers:
  - `_set_all_shards_unreachable`, `_set_one_shard_unreachable`, `_test_all_queries_fail_on_unreachable_shard`
  - `test_queries_fail_on_all_shards_unreachable`, `test_queries_fail_on_one_shard_unreachable`
- Kept `FT.SEARCH`, `FT.AGGREGATE`, and `FT.AGGREGATE WITHCURSOR` coverage for both the "all shards unreachable" and "one shard unreachable" regression tests. No `FT.HYBRID` assertion (same as the 8.2 backport). The test harness primitives (`TimeLimit`, `wait_for_condition`, `getConnectionByEnv`, `debug_cmd()`, `config_cmd()`, `SEARCH.CLUSTERSET`, `SEARCH.CLUSTERINFO`, `PAUSE_TOPOLOGY_UPDATER`, `TOPOLOGY_VALIDATION_TIMEOUT`) are all already present in `2.10`.

The rest of the files — `coord/src/rmr/rmr.h` (two new declarations) — merged cleanly without adjustments.

---

# Original PR description

**Summary**

When shards become unreachable, `FT.SEARCH` and `FT.AGGREGATE` silently ignore the connection issue, while `FT.HYBRID` hangs indefinitely. This PR adds pre-fanout connection validation to fail explicitly with a clear error message instead.

**Changes**

**Core Fix**
- **Topology validation**: Before sending commands to shards, validate that all connections are established. If any connection is invalid, return a synthetic error (`"Could not send query to cluster"`) via the callback instead of attempting to send commands that will fail or hang.

**Scope**
- Validates connections only on initial query fanout (`iterStartCb`, `MRCluster_FanoutCommand`)
- Does **not** validate on subsequent cursor reads

[MOD-14475]: https://redislabs.atlassian.net/browse/MOD-14475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed query fanout to pre-validate shard connections and return an immediate error instead of hanging or returning partial results; affects core cluster query behavior under topology/connectivity issues.
> 
> **Overview**
> **Release note:** Distributed queries (`FT.SEARCH`, `FT.AGGREGATE`, including cursor/`WITHCOUNT` variants) now **fail fast with a clear error** when the coordinator detects unreachable/missing shard connections, instead of hanging indefinitely or producing partial behavior during incomplete topology.
> 
> This adds an optional *pre-fanout connection validation* path in the coordinator map-reduce layer (`MRCtx`/`MRCluster_FanoutCommand`, iterator startup) and propagates a synthetic `MR_REPLY_ERROR` ("Could not send query to cluster") when validation fails, with new regression tests covering "all shards unreachable" and "one shard unreachable" scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25034586667052ac5ca0502834717e2889785cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->