### PR TITLE
[MOD-14475] Fix FT.AGGREGATE WITHCOUNT error reporting on incomplete topology

### DIFF
--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -744,6 +744,15 @@ void iterStartCb(void *p) {
     if (!conn) {
       // At least one connection is not established - fail with a single error.
       // it->len/pending/inProcess remain at their initial value of 1.
+      // Run privateDataInit so ShardResponseBarrier (used by FT.AGGREGATE
+      // WITHCOUNT) accepts the synthetic error notification; otherwise its
+      // numShards stays 0, Notify's bounds check short-circuits, and the real
+      // error gets replaced by a misleading timeout message in
+      // shardResponseBarrier_HandleTimeout.
+      void *privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
+      if (privateData && it->ctx.privateDataInit) {
+        it->ctx.privateDataInit(privateData, it);
+      }
       MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
       it->ctx.cb(&it->cbxs[0], err);
       rm_free(data);

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -340,6 +340,10 @@ def _test_all_queries_fail_on_unreachable_shard(env: Env, scenario: str):
     with TimeLimit(5, f'FT.AGGREGATE WITHCURSOR hung ({scenario})'):
         env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR').error().contains('Could not send query to cluster')
 
+    # FT.AGGREGATE WITHCOUNT returns an error (does not hang)
+    with TimeLimit(5, f'FT.AGGREGATE WITHCOUNT hung ({scenario})'):
+        env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT').error().contains('Could not send query to cluster')
+
     # FT.HYBRID returns an error (does not hang)
     with TimeLimit(5, f'FT.HYBRID hung ({scenario})'):
         env.expect('FT.HYBRID', 'idx',


### PR DESCRIPTION
## Summary

Fixes a misleading error message when `FT.AGGREGATE ... WITHCOUNT` is run against a cluster with incomplete topology: instead of the real `Could not send query to cluster` error (added in #8884), the client received `ShardResponseBarrier: Timeout while waiting for first responses from all shards`.

## Root cause

`iterStartCb` (`src/coord/rmr/rmr.c`) pre-validates shard connections and, on failure, returns early with a synthetic `CLUSTER_QUERY_ERROR`. The early return happened **before** `ctx.privateDataInit` was invoked, so `ShardResponseBarrier.numShards` stayed at `0`. When the synthetic error was dispatched via the reply callback, `shardResponseBarrier_Notify`'s bounds check (`shardIndex >= numShards`) short-circuited and the error notification was dropped. Subsequently `shardResponseBarrier_HandleTimeout` observed `numShards == 0` and overwrote the real error with the timeout message.

## Fix

Run `it->ctx.privateDataInit` in the early-return path before dispatching the synthetic error so the barrier is initialized and the topology error propagates correctly.

## Test

Added `FT.AGGREGATE ... WITHCOUNT` to `_test_all_queries_fail_on_unreachable_shard`, which runs under both `test_queries_fail_on_all_shards_unreachable` and `test_queries_fail_on_one_shard_unreachable`.

Verified locally:
```
test_coordinator:test_queries_fail_on_all_shards_unreachable[PASS]
test_coordinator:test_queries_fail_on_one_shard_unreachable[PASS]
```
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator fanout/iterator startup error paths; small change but in core cluster query dispatch, so mistakes could impact error propagation or iterator lifecycle under partial connectivity.
> 
> **Overview**
> Ensures `iterStartCb` initializes iterator private data (via `privateDataInit`) *even on early connection-validation failure* before emitting the synthetic `Could not send query to cluster` error, so `FT.AGGREGATE ... WITHCOUNT` reports the correct error instead of a misleading `ShardResponseBarrier` timeout.
> 
> Extends the coordinator unreachable-shard test to cover `FT.AGGREGATE ... WITHCOUNT`, asserting it errors promptly rather than hanging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead821e62c22ac1624b89163a1943327d743ea9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->