### PR TITLE
[MOD-14200] Implement TopKHeap Utility

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2706,6 +2706,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "top_k"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "workspace_hack",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "tools/safety_report",
     "tracing_redismodule",
     "trie_bencher",
+    "top_k",
     "trie_rs",
     "value",
     "varint",
@@ -124,6 +125,7 @@ search_result = { path = "./search_result" }
 slots_tracker = { path = "./slots_tracker" }
 sorting_vector = { path = "./sorting_vector" }
 thin_vec = { path = "./thin_vec" }
+top_k = { path = "./top_k" }
 tracing_redismodule = { path = "./tracing_redismodule" }
 trie_rs = { path = "./trie_rs" }
 value = { path = "./value" }
@@ -175,7 +177,12 @@ triomphe = "0.1.2"
 toml = "0.9"
 tracing = "0.1.44"
 tracing-core = "0.1"
-tracing-subscriber = { version = "0.3.22", default-features = false, features = ["std", "fmt", "ansi", "env-filter"] }
+tracing-subscriber = { version = "0.3.22", default-features = false, features = [
+    "std",
+    "fmt",
+    "ansi",
+    "env-filter",
+] }
 unsafe-tools = "0.1.2"
 ureq = "3.1"
 walkdir = "2"

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "top_k"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+ffi.workspace = true
+workspace_hack.workspace = true

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A fixed-capacity heap that retains the top-k scored documents.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use ffi::t_docId;
+
+/// A (doc_id, score) pair stored in the heap.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScoredResult {
+    /// Document identifier.
+    pub doc_id: t_docId,
+    /// Score for the document (lower or higher is "better" depending on the comparator).
+    pub score: f64,
+}
+
+/// Wraps a [`ScoredResult`] so that [`BinaryHeap`] (a max-heap) keeps the *worst*
+/// element at the top, making it cheap to evict.
+///
+/// "Worst" is defined by the [`TopKHeap`]'s comparator:
+///
+/// - `compare(a, b) == Less`  → `a` is **better** than `b`.
+/// - `compare(a, b) == Greater` → `a` is **worse** than `b` (= heap-max, evicted first).
+///
+/// Tie-breaking: equal scores → higher `doc_id` is considered worse (evicted first),
+/// so lower `doc_id` is kept.
+struct HeapEntry {
+    result: ScoredResult,
+    /// Cached comparison function so [`Ord`] can be implemented without extra state.
+    compare: fn(f64, f64) -> Ordering,
+}
+
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for HeapEntry {}
+
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // We want BinaryHeap's root to be the *worst* element so eviction is O(log k).
+        // `compare(self, other) == Greater` means self is worse than other
+        //   → self should be "greater" in BinaryHeap ordering → root.
+        let score_ord = (self.compare)(self.result.score, other.result.score);
+        match score_ord {
+            // self is better than other  → self should NOT be at root → self is "less"
+            Ordering::Less => Ordering::Less,
+            // self is worse than other   → self should be at root → self is "greater"
+            Ordering::Greater => Ordering::Greater,
+            // Tie on score: higher doc_id is worse (evicted first) → Greater
+            Ordering::Equal => self.result.doc_id.cmp(&other.result.doc_id),
+        }
+    }
+}
+
+/// A fixed-capacity heap that retains the k best-scored documents.
+///
+/// Internally a max-heap whose root is the *worst* of the retained elements,
+/// making insertion and eviction O(log k).
+///
+/// # Comparator convention
+///
+/// `compare(a, b)` must return:
+/// - [`Ordering::Less`]    if score `a` is **better** than score `b`
+/// - [`Ordering::Greater`] if score `a` is **worse**  than score `b`
+/// - [`Ordering::Equal`]   if the scores are equally good
+///
+/// For ascending order (lower score = better, e.g. vector distance):
+/// `compare = |a, b| a.partial_cmp(&b).unwrap_or(Ordering::Equal)`
+///
+/// For descending order (higher score = better, e.g. numeric SORTBY):
+/// `compare = |a, b| b.partial_cmp(&a).unwrap_or(Ordering::Equal)`
+pub struct TopKHeap {
+    inner: BinaryHeap<HeapEntry>,
+    capacity: usize,
+    compare: fn(f64, f64) -> Ordering,
+}
+
+impl TopKHeap {
+    /// Creates a new heap that holds at most `capacity` elements,
+    /// using the supplied `compare` function to determine score order.
+    pub fn new(capacity: usize, compare: fn(f64, f64) -> Ordering) -> Self {
+        Self {
+            inner: BinaryHeap::with_capacity(capacity),
+            capacity,
+            compare,
+        }
+    }
+
+    /// Returns the number of elements currently in the heap.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the heap contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns `true` if the heap has reached its capacity.
+    pub fn is_full(&self) -> bool {
+        self.inner.len() >= self.capacity
+    }
+
+    /// Returns the worst element currently retained (the one that would be evicted next),
+    /// without removing it.
+    pub fn peek_worst(&self) -> Option<ScoredResult> {
+        self.inner.peek().map(|e| e.result)
+    }
+
+    /// Attempts to insert `(doc_id, score)` into the heap.
+    ///
+    /// - If the heap is not full, the element is always inserted.
+    /// - If the heap is full and the new element is **better** than the current worst,
+    ///   the worst is evicted and the new element takes its place.
+    /// - Otherwise the element is discarded.
+    ///
+    /// Returns `true` if the element was inserted.
+    pub fn push(&mut self, doc_id: t_docId, score: f64) -> bool {
+        let entry = HeapEntry {
+            result: ScoredResult { doc_id, score },
+            compare: self.compare,
+        };
+
+        if !self.is_full() {
+            self.inner.push(entry);
+            return true;
+        }
+
+        // The heap is full. Only insert if the new element is strictly better than the
+        // current worst (root). `entry > root` means entry is worse → discard.
+        // `entry < root` means entry is better → evict root, insert entry.
+        // Equal (same score AND same doc_id) → discard to avoid duplicates.
+        let should_insert = match self.inner.peek() {
+            Some(worst) => entry.cmp(worst) == Ordering::Less,
+            None => false,
+        };
+
+        if should_insert {
+            self.inner.pop();
+            self.inner.push(entry);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes and returns the worst element currently retained.
+    pub fn pop_worst(&mut self) -> Option<ScoredResult> {
+        self.inner.pop().map(|e| e.result)
+    }
+
+    /// Drains all elements and returns them sorted best-first.
+    ///
+    /// Consumes the heap.
+    pub fn drain_sorted(self) -> Vec<ScoredResult> {
+        // BinaryHeap::into_sorted_vec() returns elements in ascending Ord order.
+        // In our Ord impl "better" == "Less", so ascending == best-first already.
+        self.inner
+            .into_sorted_vec()
+            .into_iter()
+            .map(|e| e.result)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ascending comparator: lower score is better (e.g. vector distance).
+    fn asc(a: f64, b: f64) -> Ordering {
+        a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+    }
+
+    /// Descending comparator: higher score is better (e.g. numeric SORTBY).
+    fn desc(a: f64, b: f64) -> Ordering {
+        b.partial_cmp(&a).unwrap_or(Ordering::Equal)
+    }
+
+    // ── T1 tests ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn heap_fewer_than_k_preserves_all() {
+        let mut heap = TopKHeap::new(5, asc);
+        heap.push(1, 3.0);
+        heap.push(2, 1.0);
+        heap.push(3, 2.0);
+        assert_eq!(heap.len(), 3);
+
+        let results = heap.drain_sorted();
+        // Best first (lowest score first for ASC)
+        assert_eq!(results[0].score, 1.0);
+        assert_eq!(results[1].score, 2.0);
+        assert_eq!(results[2].score, 3.0);
+    }
+
+    #[test]
+    fn heap_evicts_worst_when_full_asc() {
+        let mut heap = TopKHeap::new(3, asc);
+        heap.push(1, 5.0);
+        heap.push(2, 3.0);
+        heap.push(3, 4.0);
+        // Full, worst = 5.0 (doc 1)
+
+        let inserted = heap.push(4, 2.0); // 2.0 is better than 5.0 → evict doc 1
+        assert!(inserted);
+        assert_eq!(heap.len(), 3);
+
+        let not_inserted = heap.push(5, 6.0); // 6.0 is worse than current worst (4.0) → discard
+        assert!(!not_inserted);
+
+        let results = heap.drain_sorted();
+        let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
+        assert_eq!(scores, vec![2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn heap_evicts_worst_when_full_desc() {
+        let mut heap = TopKHeap::new(3, desc);
+        heap.push(1, 1.0);
+        heap.push(2, 3.0);
+        heap.push(3, 2.0);
+        // Full, worst = 1.0 (doc 1)
+
+        let inserted = heap.push(4, 4.0); // 4.0 is better (higher) → evict doc 1
+        assert!(inserted);
+
+        let not_inserted = heap.push(5, 0.5); // 0.5 is worse → discard
+        assert!(!not_inserted);
+
+        let results = heap.drain_sorted();
+        let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
+        assert_eq!(scores, vec![4.0, 3.0, 2.0]); // best-first = highest-first for DESC
+    }
+
+    #[test]
+    fn heap_capacity_one_keeps_best_asc() {
+        let mut heap = TopKHeap::new(1, asc);
+        heap.push(1, 5.0);
+        heap.push(2, 3.0); // better
+        heap.push(3, 4.0); // worse than 3.0, not inserted
+
+        let results = heap.drain_sorted();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].score, 3.0);
+        assert_eq!(results[0].doc_id, 2);
+    }
+
+    #[test]
+    fn heap_tie_breaking_keeps_lower_doc_id() {
+        let mut heap = TopKHeap::new(2, asc);
+        heap.push(10, 1.0);
+        heap.push(5, 1.0);
+        // Both have score 1.0. Capacity=2, both fit.
+        // Now insert a third with the same score → evict highest doc_id (10)
+        heap.push(3, 1.0);
+
+        let results = heap.drain_sorted();
+        let ids: Vec<t_docId> = results.iter().map(|r| r.doc_id).collect();
+        // Should keep doc_ids 3 and 5 (lower ids win ties)
+        assert!(ids.contains(&3));
+        assert!(ids.contains(&5));
+        assert!(!ids.contains(&10));
+    }
+
+    #[test]
+    fn heap_peek_worst_returns_eviction_candidate() {
+        let mut heap = TopKHeap::new(3, asc);
+        heap.push(1, 2.0);
+        heap.push(2, 5.0);
+        heap.push(3, 3.0);
+        // Worst in ASC mode = highest score = 5.0
+        assert_eq!(heap.peek_worst().unwrap().score, 5.0);
+    }
+
+    #[test]
+    fn drain_sorted_best_first_asc() {
+        let mut heap = TopKHeap::new(4, asc);
+        for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
+            heap.push(id, score);
+        }
+        let results = heap.drain_sorted();
+        let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
+        assert_eq!(scores, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn drain_sorted_best_first_desc() {
+        let mut heap = TopKHeap::new(4, desc);
+        for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
+            heap.push(id, score);
+        }
+        let results = heap.drain_sorted();
+        let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
+        assert_eq!(scores, vec![4.0, 3.0, 2.0, 1.0]);
+    }
+
+    #[test]
+    fn pop_worst_removes_eviction_candidate_asc() {
+        let mut heap = TopKHeap::new(3, asc);
+        heap.push(1, 2.0);
+        heap.push(2, 5.0);
+        heap.push(3, 3.0);
+        // Worst in ASC = highest score = 5.0 (doc 2)
+        let worst = heap.pop_worst().unwrap();
+        assert_eq!(worst.score, 5.0);
+        assert_eq!(worst.doc_id, 2);
+        assert_eq!(heap.len(), 2);
+    }
+
+    #[test]
+    fn pop_worst_removes_eviction_candidate_desc() {
+        let mut heap = TopKHeap::new(3, desc);
+        heap.push(1, 4.0);
+        heap.push(2, 1.0);
+        heap.push(3, 2.0);
+        // Worst in DESC = lowest score = 1.0 (doc 2)
+        let worst = heap.pop_worst().unwrap();
+        assert_eq!(worst.score, 1.0);
+        assert_eq!(worst.doc_id, 2);
+        assert_eq!(heap.len(), 2);
+    }
+
+    #[test]
+    fn pop_worst_on_empty_returns_none() {
+        let mut heap = TopKHeap::new(3, asc);
+        assert!(heap.pop_worst().is_none());
+    }
+
+    #[test]
+    fn pop_worst_allows_reinsertion() {
+        let mut heap = TopKHeap::new(2, asc);
+        heap.push(1, 3.0);
+        heap.push(2, 1.0);
+        // Full; worst = 3.0. Pop it, then a previously-rejected score can enter.
+        heap.pop_worst();
+        assert!(!heap.is_full());
+        let inserted = heap.push(3, 2.5);
+        assert!(inserted);
+        assert_eq!(heap.len(), 2);
+    }
+
+    #[test]
+    fn heap_is_empty_and_is_full() {
+        let mut heap = TopKHeap::new(2, asc);
+        assert!(heap.is_empty());
+        assert!(!heap.is_full());
+
+        heap.push(1, 1.0);
+        assert!(!heap.is_empty());
+        assert!(!heap.is_full());
+
+        heap.push(2, 2.0);
+        assert!(!heap.is_empty());
+        assert!(heap.is_full());
+    }
+}

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -11,6 +11,7 @@
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
+use std::num::NonZeroUsize;
 
 use ffi::t_docId;
 
@@ -55,14 +56,11 @@ impl PartialOrd for HeapEntry {
 
 impl Ord for HeapEntry {
     fn cmp(&self, other: &Self) -> Ordering {
-        // We want BinaryHeap's root to be the *worst* element so eviction is O(log k).
-        // `compare(self, other) == Greater` means self is worse than other
-        //   → self should be "greater" in BinaryHeap ordering → root.
+        // We want the worst element at the top of the heap so eviction is O(log k).
+        // `compare(self, other) == Greater` means self is worse.
         let score_ord = (self.compare)(self.result.score, other.result.score);
         match score_ord {
-            // self is better than other  → self should NOT be at root → self is "less"
             Ordering::Less => Ordering::Less,
-            // self is worse than other   → self should be at root → self is "greater"
             Ordering::Greater => Ordering::Greater,
             // Tie on score: higher doc_id is worse (evicted first) → Greater
             Ordering::Equal => self.result.doc_id.cmp(&other.result.doc_id),
@@ -96,7 +94,8 @@ pub struct TopKHeap {
 impl TopKHeap {
     /// Creates a new heap that holds at most `capacity` elements,
     /// using the supplied `compare` function to determine score order.
-    pub fn new(capacity: usize, compare: fn(f64, f64) -> Ordering) -> Self {
+    pub fn new(capacity: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+        let capacity = capacity.into();
         Self {
             inner: BinaryHeap::with_capacity(capacity),
             capacity,
@@ -141,19 +140,13 @@ impl TopKHeap {
 
         if !self.is_full() {
             self.inner.push(entry);
-            return true;
+            true
         }
-
         // The heap is full. Only insert if the new element is strictly better than the
-        // current worst (root). `entry > root` means entry is worse → discard.
-        // `entry < root` means entry is better → evict root, insert entry.
+        // current worst (root). `entry > worst` means entry is worse → discard.
+        // `entry < worst` means entry is better → evict worst, insert entry.
         // Equal (same score AND same doc_id) → discard to avoid duplicates.
-        let should_insert = match self.inner.peek() {
-            Some(worst) => entry.cmp(worst) == Ordering::Less,
-            None => false,
-        };
-
-        if should_insert {
+        else if self.inner.peek().is_some_and(|worst| &entry < worst) {
             self.inner.pop();
             self.inner.push(entry);
             true
@@ -185,6 +178,10 @@ impl TopKHeap {
 mod tests {
     use super::*;
 
+    fn non_zero_capacity(capacity: usize) -> NonZeroUsize {
+        NonZeroUsize::new(capacity).unwrap()
+    }
+
     /// Ascending comparator: lower score is better (e.g. vector distance).
     fn asc(a: f64, b: f64) -> Ordering {
         a.partial_cmp(&b).unwrap_or(Ordering::Equal)
@@ -195,18 +192,16 @@ mod tests {
         b.partial_cmp(&a).unwrap_or(Ordering::Equal)
     }
 
-    // ── T1 tests ─────────────────────────────────────────────────────────────
-
     #[test]
     fn heap_fewer_than_k_preserves_all() {
-        let mut heap = TopKHeap::new(5, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(5), asc);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
-        assert_eq!(heap.len(), 3);
 
         let results = heap.drain_sorted();
-        // Best first (lowest score first for ASC)
+
+        assert_eq!(results.len(), 3);
         assert_eq!(results[0].score, 1.0);
         assert_eq!(results[1].score, 2.0);
         assert_eq!(results[2].score, 3.0);
@@ -214,17 +209,18 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_asc() {
-        let mut heap = TopKHeap::new(3, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
-        // Full, worst = 5.0 (doc 1)
 
-        let inserted = heap.push(4, 2.0); // 2.0 is better than 5.0 → evict doc 1
+        // Better score evicts the current worst (5.0)
+        let inserted = heap.push(4, 2.0);
         assert!(inserted);
         assert_eq!(heap.len(), 3);
 
-        let not_inserted = heap.push(5, 6.0); // 6.0 is worse than current worst (4.0) → discard
+        // Worse score is rejected without changing the heap
+        let not_inserted = heap.push(5, 6.0);
         assert!(!not_inserted);
 
         let results = heap.drain_sorted();
@@ -234,31 +230,33 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_desc() {
-        let mut heap = TopKHeap::new(3, desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), desc);
         heap.push(1, 1.0);
         heap.push(2, 3.0);
         heap.push(3, 2.0);
-        // Full, worst = 1.0 (doc 1)
 
-        let inserted = heap.push(4, 4.0); // 4.0 is better (higher) → evict doc 1
+        // Better score (higher in DESC) evicts the current worst (1.0)
+        let inserted = heap.push(4, 4.0);
         assert!(inserted);
 
-        let not_inserted = heap.push(5, 0.5); // 0.5 is worse → discard
+        // Worse score (lower in DESC) is rejected
+        let not_inserted = heap.push(5, 0.5);
         assert!(!not_inserted);
 
         let results = heap.drain_sorted();
         let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
-        assert_eq!(scores, vec![4.0, 3.0, 2.0]); // best-first = highest-first for DESC
+        assert_eq!(scores, vec![4.0, 3.0, 2.0]);
     }
 
     #[test]
     fn heap_capacity_one_keeps_best_asc() {
-        let mut heap = TopKHeap::new(1, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(1), asc);
         heap.push(1, 5.0);
-        heap.push(2, 3.0); // better
-        heap.push(3, 4.0); // worse than 3.0, not inserted
+        heap.push(2, 3.0);
+        heap.push(3, 4.0);
 
         let results = heap.drain_sorted();
+
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].score, 3.0);
         assert_eq!(results[0].doc_id, 2);
@@ -266,16 +264,44 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id() {
-        let mut heap = TopKHeap::new(2, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
-        // Both have score 1.0. Capacity=2, both fit.
-        // Now insert a third with the same score → evict highest doc_id (10)
-        heap.push(3, 1.0);
+        heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie)
 
         let results = heap.drain_sorted();
         let ids: Vec<t_docId> = results.iter().map(|r| r.doc_id).collect();
-        // Should keep doc_ids 3 and 5 (lower ids win ties)
+
+        assert!(ids.contains(&3));
+        assert!(ids.contains(&5));
+        assert!(!ids.contains(&10));
+    }
+
+    #[test]
+    fn heap_exact_duplicate_not_inserted_when_full() {
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        heap.push(1, 1.0);
+        heap.push(2, 2.0);
+
+        let inserted = heap.push(2, 2.0);
+
+        assert!(!inserted);
+        assert_eq!(heap.len(), 2);
+        let results = heap.drain_sorted();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.iter().filter(|r| r.doc_id == 2).count(), 1);
+    }
+
+    #[test]
+    fn heap_tie_breaking_keeps_lower_doc_id_desc() {
+        let mut heap = TopKHeap::new(non_zero_capacity(2), desc);
+        heap.push(10, 1.0);
+        heap.push(5, 1.0);
+        heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie, regardless of sort direction)
+
+        let results = heap.drain_sorted();
+        let ids: Vec<t_docId> = results.iter().map(|r| r.doc_id).collect();
+
         assert!(ids.contains(&3));
         assert!(ids.contains(&5));
         assert!(!ids.contains(&10));
@@ -283,44 +309,49 @@ mod tests {
 
     #[test]
     fn heap_peek_worst_returns_eviction_candidate() {
-        let mut heap = TopKHeap::new(3, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
-        // Worst in ASC mode = highest score = 5.0
+
         assert_eq!(heap.peek_worst().unwrap().score, 5.0);
     }
 
     #[test]
     fn drain_sorted_best_first_asc() {
-        let mut heap = TopKHeap::new(4, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), asc);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
+
         let results = heap.drain_sorted();
+
         let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
         assert_eq!(scores, vec![1.0, 2.0, 3.0, 4.0]);
     }
 
     #[test]
     fn drain_sorted_best_first_desc() {
-        let mut heap = TopKHeap::new(4, desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), desc);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
+
         let results = heap.drain_sorted();
+
         let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
         assert_eq!(scores, vec![4.0, 3.0, 2.0, 1.0]);
     }
 
     #[test]
     fn pop_worst_removes_eviction_candidate_asc() {
-        let mut heap = TopKHeap::new(3, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
-        // Worst in ASC = highest score = 5.0 (doc 2)
+
         let worst = heap.pop_worst().unwrap();
+
         assert_eq!(worst.score, 5.0);
         assert_eq!(worst.doc_id, 2);
         assert_eq!(heap.len(), 2);
@@ -328,12 +359,13 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_desc() {
-        let mut heap = TopKHeap::new(3, desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), desc);
         heap.push(1, 4.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
-        // Worst in DESC = lowest score = 1.0 (doc 2)
+
         let worst = heap.pop_worst().unwrap();
+
         assert_eq!(worst.score, 1.0);
         assert_eq!(worst.doc_id, 2);
         assert_eq!(heap.len(), 2);
@@ -341,26 +373,32 @@ mod tests {
 
     #[test]
     fn pop_worst_on_empty_returns_none() {
-        let mut heap = TopKHeap::new(3, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
         assert!(heap.pop_worst().is_none());
     }
 
     #[test]
+    fn peek_worst_on_empty_returns_none() {
+        let heap = TopKHeap::new(non_zero_capacity(3), asc);
+        assert!(heap.peek_worst().is_none());
+    }
+
+    #[test]
     fn pop_worst_allows_reinsertion() {
-        let mut heap = TopKHeap::new(2, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
-        // Full; worst = 3.0. Pop it, then a previously-rejected score can enter.
         heap.pop_worst();
-        assert!(!heap.is_full());
+
         let inserted = heap.push(3, 2.5);
+
         assert!(inserted);
         assert_eq!(heap.len(), 2);
     }
 
     #[test]
     fn heap_is_empty_and_is_full() {
-        let mut heap = TopKHeap::new(2, asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
         assert!(heap.is_empty());
         assert!(!heap.is_full());
 

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -146,9 +146,10 @@ impl TopKHeap {
         // current worst (root). `entry > worst` means entry is worse → discard.
         // `entry < worst` means entry is better → evict worst, insert entry.
         // Equal (same score AND same doc_id) → discard to avoid duplicates.
-        else if self.inner.peek().is_some_and(|worst| &entry < worst) {
-            self.inner.pop();
-            self.inner.push(entry);
+        else if let Some(mut worst) = self.inner.peek_mut()
+            && entry < *worst
+        {
+            *worst = entry;
             true
         } else {
             false

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A fixed-capacity heap that retains the top-k scored documents.
+
+pub mod heap;
+
+pub use heap::{ScoredResult, TopKHeap};


### PR DESCRIPTION
Add heap utility with ASC/DESC comparator support, capacity enforcement, replace/peek/pop behavior, and unit tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Introduces a new, self-contained utility crate with thorough unit tests and no changes to existing runtime logic beyond workspace wiring.
> 
> **Overview**
> Adds a new workspace crate, `top_k`, providing a fixed-capacity `TopKHeap` for keeping the best k `(doc_id, score)` results with a caller-supplied ASC/DESC comparator, plus `peek_worst`, `pop_worst`, and best-first `drain_sorted` behavior and unit tests.
> 
> Wires the crate into the Rust workspace (`Cargo.toml`/`Cargo.lock`) and applies a small formatting-only change to the `tracing-subscriber` dependency specification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0cb95270375c606d2d390f6d497d00afa4d59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->