### PR TITLE
MOD-14089: Deferring the effectiveK calculation to the IO thread

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -81,14 +81,10 @@ static void aggregateIteratorContext_Init(void *ptr, const MRIterator *it) {
 // Command modifier callback for SHARD_K_RATIO optimization in FT.AGGREGATE
 // Called from iterStartCb on IO thread before commands are sent to shards
 static void aggregateKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
-  if (!privateData || !cmd) {
-    return;
-  }
+  RS_ASSERT(privateData && cmd);
   AggregateIteratorContext *ctx = (AggregateIteratorContext *)privateData;
   AggregateKnnContext *knnCtx = ctx->knnCtx;
-  if (!knnCtx || !knnCtx->vq) {
-    return;
-  }
+  RS_ASSERT(knnCtx && knnCtx->vq);
   const KNNVectorQuery *knn_query = &knnCtx->vq->knn;
   // Only apply optimization for multi-shard deployments with valid ratio
   if (numShards <= 1 || knn_query->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -44,6 +44,78 @@ static const RLookupKey *keyForField(RPNet *nc, const char *s) {
   return NULL;
 }
 
+// Context for SHARD_K_RATIO optimization in FT.AGGREGATE
+// Stores information needed to modify the KNN K value in the command
+typedef struct {
+  VectorQuery *vq;        // VectorQuery containing K position info (NOT owned)
+  size_t queryArgIndex;   // Index of the query argument in the MRCommand
+} AggregateKnnContext;
+
+// Combined context for MR_IterateWithPrivateData in FT.AGGREGATE
+// Contains optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
+typedef struct {
+  ShardResponseBarrier *barrier;  // May be NULL if WITHCOUNT not enabled
+  AggregateKnnContext *knnCtx;    // May be NULL if no KNN optimization needed
+} AggregateIteratorContext;
+
+// Free the AggregateIteratorContext and its contents
+static void aggregateIteratorContext_Free(void *ptr) {
+  AggregateIteratorContext *ctx = (AggregateIteratorContext *)ptr;
+  if (ctx) {
+    if (ctx->barrier) {
+      shardResponseBarrier_Free(ctx->barrier);
+    }
+    rm_free(ctx->knnCtx);  // knnCtx->vq is not owned, so just free the struct
+    rm_free(ctx);
+  }
+}
+
+// Initialize the barrier in AggregateIteratorContext (called from iterStartCb)
+static void aggregateIteratorContext_Init(void *ptr, const MRIterator *it) {
+  AggregateIteratorContext *ctx = (AggregateIteratorContext *)ptr;
+  if (ctx && ctx->barrier) {
+    shardResponseBarrier_Init(ctx->barrier, it);
+  }
+}
+
+// Command modifier callback for SHARD_K_RATIO optimization in FT.AGGREGATE
+// Called from iterStartCb on IO thread before commands are sent to shards
+static void aggregateKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
+  if (!privateData || !cmd) {
+    return;
+  }
+  AggregateIteratorContext *ctx = (AggregateIteratorContext *)privateData;
+  AggregateKnnContext *knnCtx = ctx->knnCtx;
+  if (!knnCtx || !knnCtx->vq) {
+    return;
+  }
+  const KNNVectorQuery *knn_query = &knnCtx->vq->knn;
+  // Only apply optimization for multi-shard deployments with valid ratio
+  if (numShards <= 1 || knn_query->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
+    return;
+  }
+  size_t effectiveK = calculateEffectiveK(knn_query->k, knn_query->shardWindowRatio, numShards);
+  if (effectiveK == knn_query->k) {
+    return;
+  }
+
+  // Modify the command to replace KNN k
+  modifyKNNCommand(cmd, knnCtx->queryArgIndex, effectiveK, knnCtx->vq);
+}
+
+// Aggregate-specific cursor callback that extracts ShardResponseBarrier from
+// AggregateIteratorContext
+// This wraps the common netCursorCallback logic but correctly handles the
+// wrapper context type
+static void aggregateNetCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
+  // Extract the actual ShardResponseBarrier from the AggregateIteratorContext wrapper
+  AggregateIteratorContext *iterCtx = (AggregateIteratorContext *)MRIteratorCallback_GetPrivateData(ctx);
+  ShardResponseBarrier *barrier = iterCtx ? iterCtx->barrier : NULL;
+
+  // Call the common cursor callback logic with the extracted barrier
+  netCursorCallbackWithBarrier(ctx, rep, barrier);
+}
+
 void processResultFormat(uint32_t *flags, MRReply *map) {
   // Logic of which format to use is done by the shards
   MRReply *format = MRReply_MapElement(map, "format");
@@ -59,6 +131,23 @@ void processResultFormat(uint32_t *flags, MRReply *map) {
 static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   RPNet *nc = (RPNet *)rp;
 
+  // Create the iterator context wrapper for privateData
+  // This holds both optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
+  AggregateIteratorContext *iterCtx = rm_calloc(1, sizeof(AggregateIteratorContext));
+  if (!iterCtx) {
+    return RS_RESULT_ERROR;
+  }
+
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): park BG just before the initial timeout check.
+  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_RPNET_START, areq_timed_out, nc->areq);
+#endif
+
+  // Check if the request timed out before starting the iterator
+  if (AREQ_TimedOut(nc->areq)) {
+    return RS_RESULT_TIMEDOUT;
+  }
+
 #ifdef ENABLE_ASSERT
   // Sync point (debug): park BG just before the initial timeout check.
   SyncPoint_WaitUntil(SYNC_POINT_BEFORE_RPNET_START, areq_timed_out, nc->areq);
@@ -73,27 +162,44 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   if (HasWithCount(nc->areq) && IsAggregate(nc->areq)) {
     ShardResponseBarrier *barrier = shardResponseBarrier_New();
     if (!barrier) {
+      rm_free(iterCtx);
       return RS_RESULT_ERROR;
     }
-    nc->shardResponseBarrier = barrier;
+    iterCtx->barrier = barrier;
+    nc->shardResponseBarrier = barrier;  // Keep reference for getNextReply
   }
 
-  // Pass barrier as private data to callback (only if WITHCOUNT enabled)
-  // The barrier is freed by MRIterator via shardResponseBarrier_Free destructor
-  // shardResponseBarrier_Init is called from iterStartCb when numShards is known from topology
-  MRIterator *it = nc->shardResponseBarrier
-                   ? MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, nc->shardResponseBarrier,
-                                               shardResponseBarrier_Free, shardResponseBarrier_Init,
-                                               iterStartCb, NULL)
-                   : MR_Iterate(&nc->cmd, netCursorCallback);
+  // Initialize KNN context if SHARD_K_RATIO optimization is needed
+  if (nc->knnVectorQuery) {
+    AggregateKnnContext *knnCtx = rm_calloc(1, sizeof(AggregateKnnContext));
+    if (!knnCtx) {
+      nc->shardResponseBarrier = NULL;
+      aggregateIteratorContext_Free(iterCtx);
+      return RS_RESULT_ERROR;
+    }
+    knnCtx->vq = nc->knnVectorQuery;
+    knnCtx->queryArgIndex = nc->knnQueryArgIndex;
+    iterCtx->knnCtx = knnCtx;
+  }
+
+  // Determine if we need the command modifier callback
+  MRCommandModifier cmdModifier = iterCtx->knnCtx ? &aggregateKnnCommandModifier : NULL;
+
+  // Always use MR_IterateWithPrivateData with the wrapper context
+  // The iterator takes ownership of iterCtx and will free it via
+  // aggregateIteratorContext_Free
+  // Use aggregateNetCursorCallback to properly extract ShardResponseBarrier
+  // from AggregateIteratorContext
+  MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, aggregateNetCursorCallback, iterCtx,
+                                              aggregateIteratorContext_Free,
+                                              aggregateIteratorContext_Init,
+                                              cmdModifier, iterStartCb, NULL);
 
   if (!it) {
     // Clean up on error - iterator never started so no callbacks running
     // Must free manually since iterator didn't take ownership
-    if (nc->shardResponseBarrier) {
-      shardResponseBarrier_Free(nc->shardResponseBarrier);
-      nc->shardResponseBarrier = NULL;
-    }
+    nc->shardResponseBarrier = NULL;  // Will be freed by aggregateIteratorContext_Free
+    aggregateIteratorContext_Free(iterCtx);
     return RS_RESULT_ERROR;
   }
 
@@ -110,26 +216,55 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   return rpnetNext(rp, r);
 }
 
+// Helper to calculate the number of profile arguments
+static inline int getProfileArgs(ProfileOptions profileOptions) {
+  int profileArgs = 0;
+  if (profileOptions != EXEC_NO_FLAGS) {
+    profileArgs += 2; // SEARCH/AGGREGATE + QUERY
+    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
+      profileArgs++;
+    }
+  }
+  return profileArgs;
+}
+
+// Extract KNN context for SHARD_K_RATIO optimization if applicable
+// Outputs VectorQuery and query arg index for command modifier
+static void extractKnnOptimizationContext(specialCaseCtx *knnCtx, ProfileOptions profileOptions,
+                                          VectorQuery **outKnnVq, size_t *outQueryArgIndex) {
+  if (outKnnVq) *outKnnVq = NULL;
+  if (outQueryArgIndex) *outQueryArgIndex = 0;
+
+  const KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
+  double ratio = knn_query->shardWindowRatio;
+
+  if (ratio < MAX_SHARD_WINDOW_RATIO) {
+    int profileArgs = getProfileArgs(profileOptions);
+    // Store the VectorQuery and query arg index for the command modifier
+    if (outKnnVq) *outKnnVq = knnCtx->knn.queryNode->vn.vq;
+    if (outQueryArgIndex) *outQueryArgIndex = 2 + profileArgs;  // Query is at index 2 + profileArgs
+  }
+}
+
+// Build the distributed MR command for FT.AGGREGATE
 static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions profileOptions,
-                           AREQDIST_UpstreamInfo *us, MRCommand *xcmd, IndexSpec *sp, specialCaseCtx *knnCtx) {
+                           AREQDIST_UpstreamInfo *us, MRCommand *xcmd, IndexSpec *sp) {
   // We need to prepend the array with the command, index, and query that
   // we want to use.
   const char **tmparr = array_new(const char *, array_len(us->serialized));
 
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
-  int profileArgs = 0;
+  int profileArgs = getProfileArgs(profileOptions);
   if (profileOptions == EXEC_NO_FLAGS) {
     array_append(tmparr, RS_AGGREGATE_CMD);                         // Command
     array_append(tmparr, index_name);  // Index name
   } else {
-    profileArgs += 2; // SEARCH/AGGREGATE + QUERY
     array_append(tmparr, RS_PROFILE_CMD);
     array_append(tmparr, index_name);  // Index name
     array_append(tmparr, "AGGREGATE");
     if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
       array_append(tmparr, "LIMITED");
-      profileArgs++;
     }
     array_append(tmparr, "QUERY");
   }
@@ -209,22 +344,6 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
     }
   }
 
-  // Handle KNN with shard ratio optimization for both multi-shard and standalone
-  if (knnCtx) {
-    KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
-    double ratio = knn_query->shardWindowRatio;
-
-    if (ratio < MAX_SHARD_WINDOW_RATIO) {
-      // Apply optimization only if ratio is valid and < 1.0 (ratio = 1.0 means no optimization)
-      // Calculate effective K based on deployment mode
-      size_t numShards = GetNumShards_UnSafe();
-      size_t effectiveK = calculateEffectiveK(knn_query->k, ratio, numShards);
-
-      // Modify the command to replace KNN k (shards will ignore $SHARD_K_RATIO)
-      modifyKNNCommand(xcmd, 2 + profileArgs, effectiveK, knnCtx->knn.queryNode->vn.vq);
-    }
-  }
-
   // check for timeout argument and append it to the command.
   // If TIMEOUT exists, it was already validated at AREQ_Compile.
   int timeout_index = RMUtil_ArgIndex("TIMEOUT", argv + 3 + profileArgs, argc - 4 - profileArgs);
@@ -246,13 +365,20 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
   array_free(tmparr);
 }
 
-static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us, int (*nextFunc)(ResultProcessor *, SearchResult *)) {
+
+static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us,
+                             int (*nextFunc)(ResultProcessor *, SearchResult *),
+                             VectorQuery *knnVq, size_t knnQueryArgIndex) {
   // Establish our root processor, which is the distributed processor
   RPNet *rpRoot = RPNet_New(xcmd, nextFunc); // This will take ownership of the command
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(r);
   rpRoot->base.parent = qctx;
   rpRoot->lookup = us->lookup;
   rpRoot->areq = r;
+
+  // Store KNN context for SHARD_K_RATIO optimization (used by rpnetNext_Start)
+  rpRoot->knnVectorQuery = knnVq;
+  rpRoot->knnQueryArgIndex = knnQueryArgIndex;
 
   ResultProcessor *rpProfile = NULL;
   if (IsProfile(r)) {
@@ -405,15 +531,22 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   // Construct the command string
   MRCommand xcmd;
-  buildMRCommand(argv , argc, profileOptions, &us, &xcmd, sp, knnCtx);
+  VectorQuery *knnVq = NULL;
+  size_t knnQueryArgIndex = 0;
+  buildMRCommand(argv, argc, profileOptions, &us, &xcmd, sp);
+
+  if (knnCtx) {
+    extractKnnOptimizationContext(knnCtx, profileOptions, &knnVq, &knnQueryArgIndex);
+  }
+
   xcmd.protocol = is_resp3(ctx) ? 3 : 2;
   xcmd.forCursor = AREQ_RequestFlags(r) & QEXEC_F_IS_CURSOR;
   xcmd.forProfiling = IsProfile(r);
   xcmd.rootCommand = C_AGG;  // Response is equivalent to a `CURSOR READ` response
   xcmd.coordStartTime = r->profileClocks.coordStartTime;
 
-  // Build the result processor chain
-  buildDistRPChain(r, &xcmd, &us, rpnetNext_Start);
+  // Build the result processor chain (pass KNN context for SHARD_K_RATIO optimization)
+  buildDistRPChain(r, &xcmd, &us, rpnetNext_Start, knnVq, knnQueryArgIndex);
 
   if (IsProfile(r)) r->profileClocks.profileParseTime = rs_wall_clock_elapsed_ns(&r->profileClocks.initClock);
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -44,11 +44,14 @@ static const RLookupKey *keyForField(RPNet *nc, const char *s) {
   return NULL;
 }
 
-// Context for SHARD_K_RATIO optimization in FT.AGGREGATE
+// Context for SHARD_K_RATIO optimization in FT.AGGREGATE.
 // Stores information needed to modify the KNN K value in the command
 typedef struct {
-  VectorQuery *vq;        // VectorQuery containing K position info (NOT owned)
-  size_t queryArgIndex;   // Index of the query argument in the MRCommand
+  size_t queryArgIndex;    // Index of the query argument in the MRCommand
+  size_t originalK;        // K value from the parsed query
+  double shardWindowRatio; // SHARD_K_RATIO
+  size_t kTokenPos;        // Byte offset of K within the query string
+  size_t kTokenLen;        // Length of K token in bytes
 } AggregateKnnContext;
 
 // Combined context for MR_IterateWithPrivateData in FT.AGGREGATE
@@ -56,8 +59,8 @@ typedef struct {
 //
 // Ownership: once MR_IterateWithPrivateData succeeds the MRIterator owns this
 // struct and is responsible for freeing it via aggregateIteratorContext_Free.
-// The struct in turn owns its `barrier` and `knnCtx` allocations (but not
-// knnCtx->vq, which is borrowed from the parsed query).
+// The struct in turn owns its `barrier` and `knnCtx` allocations. knnCtx is
+// a self-contained scalar snapshot (no borrowed pointers).
 typedef struct {
   ShardResponseBarrier *barrier;  // May be NULL if WITHCOUNT not enabled
   AggregateKnnContext *knnCtx;    // May be NULL if no KNN optimization needed
@@ -70,7 +73,7 @@ static void aggregateIteratorContext_Free(void *ptr) {
     if (ctx->barrier) {
       shardResponseBarrier_Free(ctx->barrier);
     }
-    rm_free(ctx->knnCtx);  // knnCtx->vq is not owned, so just free the struct
+    rm_free(ctx->knnCtx);
     rm_free(ctx);
   }
 }
@@ -84,24 +87,24 @@ static void aggregateIteratorContext_Init(void *ptr, const MRIterator *it) {
 }
 
 // Command modifier callback for SHARD_K_RATIO optimization in FT.AGGREGATE
-// Called from iterStartCb on IO thread before commands are sent to shards
+// Called from iterStartCb on IO thread before commands are sent to shards.
 static void aggregateKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
   RS_ASSERT(privateData && cmd);
   AggregateIteratorContext *ctx = (AggregateIteratorContext *)privateData;
   AggregateKnnContext *knnCtx = ctx->knnCtx;
-  RS_ASSERT(knnCtx && knnCtx->vq);
-  const KNNVectorQuery *knn_query = &knnCtx->vq->knn;
+  RS_ASSERT(knnCtx);
   // Only apply optimization for multi-shard deployments with valid ratio
-  if (numShards <= 1 || knn_query->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
+  if (numShards <= 1 || knnCtx->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
     return;
   }
-  size_t effectiveK = calculateEffectiveK(knn_query->k, knn_query->shardWindowRatio, numShards);
-  if (effectiveK == knn_query->k) {
+  size_t effectiveK = calculateEffectiveK(knnCtx->originalK, knnCtx->shardWindowRatio, numShards);
+  if (effectiveK == knnCtx->originalK) {
     return;
   }
 
   // Modify the command to replace KNN k
-  modifyKNNCommand(cmd, knnCtx->queryArgIndex, effectiveK, knnCtx->vq);
+  modifyKNNCommand(cmd, knnCtx->queryArgIndex, knnCtx->originalK, effectiveK,
+                   knnCtx->kTokenPos, knnCtx->kTokenLen);
 }
 
 // Aggregate-specific cursor callback that extracts ShardResponseBarrier from
@@ -157,11 +160,14 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
     nc->shardResponseBarrier = barrier;  // non-owning alias for getNextReply
   }
 
-  // Initialize KNN context if SHARD_K_RATIO optimization is needed
-  if (nc->knnVectorQuery) {
+  // Initialize KNN context if SHARD_K_RATIO optimization is needed.
+  if (nc->hasKnnContext) {
     AggregateKnnContext *knnCtx = rm_calloc(1, sizeof(AggregateKnnContext));
-    knnCtx->vq = nc->knnVectorQuery;
-    knnCtx->queryArgIndex = nc->knnQueryArgIndex;
+    knnCtx->queryArgIndex    = nc->knnQueryArgIndex;
+    knnCtx->originalK        = nc->knnOriginalK;
+    knnCtx->shardWindowRatio = nc->knnShardWindowRatio;
+    knnCtx->kTokenPos        = nc->knnKTokenPos;
+    knnCtx->kTokenLen        = nc->knnKTokenLen;
     iterCtx->knnCtx = knnCtx;
   }
 
@@ -212,22 +218,28 @@ static inline int getProfileArgs(ProfileOptions profileOptions) {
   return profileArgs;
 }
 
-// Extract KNN context for SHARD_K_RATIO optimization if applicable
-// Outputs VectorQuery and query arg index for command modifier
-static void extractKnnOptimizationContext(specialCaseCtx *knnCtx, ProfileOptions profileOptions,
-                                          VectorQuery **outKnnVq, size_t *outQueryArgIndex) {
-  RS_ASSERT(outKnnVq != NULL);
-  RS_ASSERT(outQueryArgIndex != NULL);
+// Extract a scalar KNN snapshot for SHARD_K_RATIO optimization if applicable.
+// Reads the parsed VectorQuery on the main thread (while specialCaseCtx is
+// still alive) and copies the fields the IO-thread command modifier needs
+// into outSnapshot. Returns true if the snapshot is populated.
+static bool extractKnnOptimizationContext(specialCaseCtx *knnCtx, ProfileOptions profileOptions,
+                                          AggregateKnnContext *outSnapshot) {
+  RS_ASSERT(outSnapshot != NULL);
 
   const KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
   double ratio = knn_query->shardWindowRatio;
 
-  if (ratio < MAX_SHARD_WINDOW_RATIO) {
-    int profileArgs = getProfileArgs(profileOptions);
-    // Store the VectorQuery and query arg index for the command modifier
-    *outKnnVq = knnCtx->knn.queryNode->vn.vq;
-    *outQueryArgIndex = 2 + profileArgs;  // Query is at index 2 + profileArgs
+  if (ratio >= MAX_SHARD_WINDOW_RATIO) {
+    return false;
   }
+
+  int profileArgs = getProfileArgs(profileOptions);
+  outSnapshot->queryArgIndex    = 2 + profileArgs;  // Query is at index 2 + profileArgs
+  outSnapshot->originalK        = knn_query->k;
+  outSnapshot->shardWindowRatio = ratio;
+  outSnapshot->kTokenPos        = knn_query->k_token_pos;
+  outSnapshot->kTokenLen        = knn_query->k_token_len;
+  return true;
 }
 
 // Build the distributed MR command for FT.AGGREGATE
@@ -352,7 +364,7 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
 
 static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us,
                              int (*nextFunc)(ResultProcessor *, SearchResult *),
-                             VectorQuery *knnVq, size_t knnQueryArgIndex) {
+                             const AggregateKnnContext *knnSnapshot) {
   // Establish our root processor, which is the distributed processor
   RPNet *rpRoot = RPNet_New(xcmd, nextFunc); // This will take ownership of the command
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(r);
@@ -360,9 +372,16 @@ static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us
   rpRoot->lookup = us->lookup;
   rpRoot->areq = r;
 
-  // Store KNN context for SHARD_K_RATIO optimization (used by rpnetNext_Start)
-  rpRoot->knnVectorQuery = knnVq;
-  rpRoot->knnQueryArgIndex = knnQueryArgIndex;
+  // Store KNN scalar snapshot for SHARD_K_RATIO optimization (used by
+  // rpnetNext_Start to build the iterator-owned AggregateKnnContext)
+  if (knnSnapshot) {
+    rpRoot->hasKnnContext      = true;
+    rpRoot->knnQueryArgIndex   = knnSnapshot->queryArgIndex;
+    rpRoot->knnOriginalK       = knnSnapshot->originalK;
+    rpRoot->knnShardWindowRatio = knnSnapshot->shardWindowRatio;
+    rpRoot->knnKTokenPos       = knnSnapshot->kTokenPos;
+    rpRoot->knnKTokenLen       = knnSnapshot->kTokenLen;
+  }
 
   ResultProcessor *rpProfile = NULL;
   if (IsProfile(r)) {
@@ -515,12 +534,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   // Construct the command string
   MRCommand xcmd;
-  VectorQuery *knnVq = NULL;
-  size_t knnQueryArgIndex = 0;
+  AggregateKnnContext knnSnapshot;
+  bool hasKnnSnapshot = false;
   buildMRCommand(argv, argc, profileOptions, &us, &xcmd, sp);
 
   if (knnCtx) {
-    extractKnnOptimizationContext(knnCtx, profileOptions, &knnVq, &knnQueryArgIndex);
+    hasKnnSnapshot = extractKnnOptimizationContext(knnCtx, profileOptions, &knnSnapshot);
   }
 
   xcmd.protocol = is_resp3(ctx) ? 3 : 2;
@@ -529,8 +548,8 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   xcmd.rootCommand = C_AGG;  // Response is equivalent to a `CURSOR READ` response
   xcmd.coordStartTime = r->profileClocks.coordStartTime;
 
-  // Build the result processor chain (pass KNN context for SHARD_K_RATIO optimization)
-  buildDistRPChain(r, &xcmd, &us, rpnetNext_Start, knnVq, knnQueryArgIndex);
+  // Build the result processor chain (pass KNN snapshot for SHARD_K_RATIO optimization)
+  buildDistRPChain(r, &xcmd, &us, rpnetNext_Start, hasKnnSnapshot ? &knnSnapshot : NULL);
 
   if (IsProfile(r)) r->profileClocks.profileParseTime = rs_wall_clock_elapsed_ns(&r->profileClocks.initClock);
 
@@ -949,7 +968,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
   // saved KNN query argument index so the SHARD_K_RATIO modifier rewrites the
   // right slot.
-  if (rpnet->knnVectorQuery) rpnet->knnQueryArgIndex += 1;
+  if (rpnet->hasKnnContext) rpnet->knnQueryArgIndex += 1;
   // insert also debug params at the end
   for (size_t i = 0; i < debug_argv_count; i++) {
     size_t n;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -53,6 +53,11 @@ typedef struct {
 
 // Combined context for MR_IterateWithPrivateData in FT.AGGREGATE
 // Contains optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
+//
+// Ownership: once MR_IterateWithPrivateData succeeds the MRIterator owns this
+// struct and is responsible for freeing it via aggregateIteratorContext_Free.
+// The struct in turn owns its `barrier` and `knnCtx` allocations (but not
+// knnCtx->vq, which is borrowed from the parsed query).
 typedef struct {
   ShardResponseBarrier *barrier;  // May be NULL if WITHCOUNT not enabled
   AggregateKnnContext *knnCtx;    // May be NULL if no KNN optimization needed
@@ -151,11 +156,15 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
     return RS_RESULT_TIMEDOUT;
   }
 
-  // Initialize shard response barrier if WITHCOUNT is enabled
+  // Initialize shard response barrier if WITHCOUNT is enabled.
+  // The barrier is owned by iterCtx (and thus by the MRIterator after
+  // MR_IterateWithPrivateData below); nc->shardResponseBarrier is a non-owning
+  // alias for use by the coord thread in getNextReply. rpnetFree releases the
+  // iterator and then frees nc without touching the alias again.
   if (HasWithCount(nc->areq) && IsAggregate(nc->areq)) {
     ShardResponseBarrier *barrier = shardResponseBarrier_New();
     iterCtx->barrier = barrier;
-    nc->shardResponseBarrier = barrier;  // Keep reference for getNextReply
+    nc->shardResponseBarrier = barrier;  // non-owning alias for getNextReply
   }
 
   // Initialize KNN context if SHARD_K_RATIO optimization is needed
@@ -180,9 +189,10 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
                                               cmdModifier, iterStartCb, NULL);
 
   if (!it) {
-    // Clean up on error - iterator never started so no callbacks running
-    // Must free manually since iterator didn't take ownership
-    nc->shardResponseBarrier = NULL;  // Will be freed by aggregateIteratorContext_Free
+    // Iterator never started, so no callbacks are running and the iterator did
+    // not take ownership of iterCtx. Drop the non-owning alias on nc and free
+    // iterCtx, which in turn frees the barrier it owns.
+    nc->shardResponseBarrier = NULL;
     aggregateIteratorContext_Free(iterCtx);
     return RS_RESULT_ERROR;
   }

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -226,8 +226,8 @@ static inline int getProfileArgs(ProfileOptions profileOptions) {
 // Outputs VectorQuery and query arg index for command modifier
 static void extractKnnOptimizationContext(specialCaseCtx *knnCtx, ProfileOptions profileOptions,
                                           VectorQuery **outKnnVq, size_t *outQueryArgIndex) {
-  if (outKnnVq) *outKnnVq = NULL;
-  if (outQueryArgIndex) *outQueryArgIndex = 0;
+  RS_ASSERT(outKnnVq != NULL);
+  RS_ASSERT(outQueryArgIndex != NULL);
 
   const KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
   double ratio = knn_query->shardWindowRatio;
@@ -235,8 +235,8 @@ static void extractKnnOptimizationContext(specialCaseCtx *knnCtx, ProfileOptions
   if (ratio < MAX_SHARD_WINDOW_RATIO) {
     int profileArgs = getProfileArgs(profileOptions);
     // Store the VectorQuery and query arg index for the command modifier
-    if (outKnnVq) *outKnnVq = knnCtx->knn.queryNode->vn.vq;
-    if (outQueryArgIndex) *outQueryArgIndex = 2 + profileArgs;  // Query is at index 2 + profileArgs
+    *outKnnVq = knnCtx->knn.queryNode->vn.vq;
+    *outQueryArgIndex = 2 + profileArgs;  // Query is at index 2 + profileArgs
   }
 }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -132,29 +132,19 @@ void processResultFormat(uint32_t *flags, MRReply *map) {
 static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   RPNet *nc = (RPNet *)rp;
 
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): park BG just before the initial timeout check.
+  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_RPNET_START, areq_timed_out, nc->areq);
+#endif
+
+  // Check if the request timed out before starting the iterator
+  if (AREQ_TimedOut(nc->areq)) {
+    return RS_RESULT_TIMEDOUT;
+  }
+
   // Create the iterator context wrapper for privateData
   // This holds both optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
   AggregateIteratorContext *iterCtx = rm_calloc(1, sizeof(AggregateIteratorContext));
-
-#ifdef ENABLE_ASSERT
-  // Sync point (debug): park BG just before the initial timeout check.
-  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_RPNET_START, areq_timed_out, nc->areq);
-#endif
-
-  // Check if the request timed out before starting the iterator
-  if (AREQ_TimedOut(nc->areq)) {
-    return RS_RESULT_TIMEDOUT;
-  }
-
-#ifdef ENABLE_ASSERT
-  // Sync point (debug): park BG just before the initial timeout check.
-  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_RPNET_START, areq_timed_out, nc->areq);
-#endif
-
-  // Check if the request timed out before starting the iterator
-  if (AREQ_TimedOut(nc->areq)) {
-    return RS_RESULT_TIMEDOUT;
-  }
 
   // Initialize shard response barrier if WITHCOUNT is enabled.
   // The barrier is owned by iterCtx (and thus by the MRIterator after

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -130,9 +130,6 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // Create the iterator context wrapper for privateData
   // This holds both optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
   AggregateIteratorContext *iterCtx = rm_calloc(1, sizeof(AggregateIteratorContext));
-  if (!iterCtx) {
-    return RS_RESULT_ERROR;
-  }
 
 #ifdef ENABLE_ASSERT
   // Sync point (debug): park BG just before the initial timeout check.
@@ -157,10 +154,6 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // Initialize shard response barrier if WITHCOUNT is enabled
   if (HasWithCount(nc->areq) && IsAggregate(nc->areq)) {
     ShardResponseBarrier *barrier = shardResponseBarrier_New();
-    if (!barrier) {
-      rm_free(iterCtx);
-      return RS_RESULT_ERROR;
-    }
     iterCtx->barrier = barrier;
     nc->shardResponseBarrier = barrier;  // Keep reference for getNextReply
   }
@@ -168,11 +161,6 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // Initialize KNN context if SHARD_K_RATIO optimization is needed
   if (nc->knnVectorQuery) {
     AggregateKnnContext *knnCtx = rm_calloc(1, sizeof(AggregateKnnContext));
-    if (!knnCtx) {
-      nc->shardResponseBarrier = NULL;
-      aggregateIteratorContext_Free(iterCtx);
-      return RS_RESULT_ERROR;
-    }
     knnCtx->vq = nc->knnVectorQuery;
     knnCtx->queryArgIndex = nc->knnQueryArgIndex;
     iterCtx->knnCtx = knnCtx;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -903,6 +903,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   StrongRef strong_ref = {0};
   int debug_argv_count = 0;
   MRCommand *cmd = NULL;
+  RPNet *rpnet = NULL;
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
@@ -951,9 +952,14 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   }
 
   // rpnet now owns the command
-  cmd = &(((RPNet *)AREQ_QueryProcessingCtx(r)->rootProc)->cmd);
+  rpnet = (RPNet *)AREQ_QueryProcessingCtx(r)->rootProc;
+  cmd = &rpnet->cmd;
 
   MRCommand_Insert(cmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+  // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
+  // saved KNN query argument index so the SHARD_K_RATIO modifier rewrites the
+  // right slot.
+  if (rpnet->knnVectorQuery) rpnet->knnQueryArgIndex += 1;
   // insert also debug params at the end
   for (size_t i = 0; i < debug_argv_count; i++) {
     size_t n;

--- a/src/coord/dist_utils.c
+++ b/src/coord/dist_utils.c
@@ -49,9 +49,15 @@ static bool extractTotalResults(MRReply *rep, MRCommand *cmd, long long *out_tot
   return false;
 }
 
+// Original callback that extracts barrier from privateData
 void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
-  MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
   ShardResponseBarrier *barrier = (ShardResponseBarrier *)MRIteratorCallback_GetPrivateData(ctx);
+  netCursorCallbackWithBarrier(ctx, rep, barrier);
+}
+
+// Core implementation that takes barrier explicitly
+void netCursorCallbackWithBarrier(MRIteratorCallbackCtx *ctx, MRReply *rep, ShardResponseBarrier *barrier) {
+  MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
 
   // If the root command of this reply is a DEL command, we don't want to
   // propagate it up the chain to the client

--- a/src/coord/dist_utils.h
+++ b/src/coord/dist_utils.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../coord/rmr/rmr.h"
+#include "rpnet.h"
 
 #define CURSOR_EOF 0
 
@@ -17,7 +18,13 @@
 extern "C" {
 #endif
 
+// Cursor callback for network responses that uses barrier passed via privateData
+// privateData is expected to be a ShardResponseBarrier* (or NULL)
 void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep);
+
+// Cursor callback for network responses that takes barrier explicitly
+// Use this when privateData is a different type that contains a ShardResponseBarrier*
+void netCursorCallbackWithBarrier(MRIteratorCallbackCtx *ctx, MRReply *rep, ShardResponseBarrier *barrier);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -667,6 +667,10 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     // append the debug parameters so the shard-side debug handler can apply them.
     if (debugParams) {
       MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+      // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
+      // saved K argument index so the SHARD_K_RATIO modifier rewrites the right
+      // slot.
+      if (hreq->kArgIndex >= 0) hreq->kArgIndex += 1;
       int debug_argv_count = (int)debugParams->debug_params_count + 2;
       for (int i = 0; i < debug_argv_count; i++) {
         size_t n;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -232,7 +232,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex) {
-  RS_LOG_ASSERT(outKArgIndex, "outKArgIndex must not be NULL");
+  RS_ASSERT(outKArgIndex != NULL);
   int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -127,7 +127,8 @@ static int MRCommand_appendVsimFilter(MRCommand *xcmd, RedisModuleString **argv,
  * @param argc - total argument count
  * @param vsimOffset - offset where VSIM keyword appears
  * @param kArgIndex - output parameter for the index of the K value argument in
- *        the built command (set to -1 if no KNN K argument found). Can be NULL.
+ *        the built command (set to -1 if no KNN K argument found).
+ *        Must not be NULL.
  */
 static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
                                  int argc, int vsimOffset, int *kArgIndex) {
@@ -225,11 +226,13 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 // The function transforms FT.HYBRID index SEARCH query VSIM field vector
 // into _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR
 // _NUM_SSTRING _INDEX_PREFIXES ...
+// stores the index of the K value argument in the MRCommand (for later
+// modification by the command modifier callback in SHARD_K_RATIO optimization).
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, const VectorQuery *vq,
-                            size_t numShards) {
+                            IndexSpec *sp, int *outKArgIndex) {
+  RS_LOG_ASSERT(outKArgIndex, "outKArgIndex must not be NULL");
   int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
@@ -251,20 +254,11 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   MRCommand_appendSearch(xcmd, argv, argc, searchOffset);
 
   // Add all VSIM-related arguments (VSIM, field, vector, methods, filter)
+  // Note: K value is appended as-is here; effectiveK calculation is deferred to
+  // the command modifier callback (HybridKnnCommandModifier) which runs on the
+  // IO thread with access to the actual topology/numShards.
   int vsimOffset = RMUtil_ArgIndex("VSIM", argv, argc);
-  int kArgIndex = -1;
-  MRCommand_appendVsim(xcmd, argv, argc, vsimOffset, &kArgIndex);
-
-  // Calculate and apply effective K for KNN queries if SHARD_K_RATIO is set
-  // TODO: Potentially edit in IO thread where numShards is actually known.
-  // Now we have a risk that by the time I/O thread sends the command, the number of shards changed, making the effective K inaccurate.
-  if (vq && vq->type == VECSIM_QT_KNN) {
-    double shardWindowRatio = vq->knn.shardWindowRatio;
-    if (shardWindowRatio < MAX_SHARD_WINDOW_RATIO && numShards > 1) {
-      size_t effectiveK = calculateEffectiveK(vq->knn.k, shardWindowRatio, numShards);
-      modifyVsimKNN(xcmd, kArgIndex, effectiveK, vq->knn.k);
-    }
-  }
+  MRCommand_appendVsim(xcmd, argv, argc, vsimOffset, outKArgIndex);
 
   int combineOffset = RMUtil_ArgIndex("COMBINE", argv + vsimOffset, argc - vsimOffset);
   combineOffset = combineOffset != -1 ? combineOffset + vsimOffset : -1;
@@ -582,7 +576,7 @@ static bool shouldCheckInPipelineTimeoutCoord(HybridRequest *req) {
 
 static int HybridRequest_prepareForExecution(HybridRequest *hreq,
         RedisModuleCtx *ctx, RedisModuleString **argv, int argc, IndexSpec *sp,
-        size_t numShards, QueryError *status,
+        QueryError *status,
         const HybridDebugParams *debugParams) {
 
     hreq->tailPipeline->qctx.err = status;
@@ -657,15 +651,11 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Construct the command string
     MRCommand xcmd;
-    // Get the VectorQuery from the vector request's AST for SHARD_K_RATIO
-    // optimization
-    // Note: parsedVectorData is only set on shards, not on coordinator
-    // The coordinator has the VectorQuery in the AST after parsing
-    const AREQ *vectorRequest = hreq->requests[VECTOR_INDEX];
-    const VectorQuery *vq = (vectorRequest->ast.root && vectorRequest->ast.root->type == QN_VECTOR)
-                      ? vectorRequest->ast.root->vn.vq : NULL;
+    // Track K argument index for SHARD_K_RATIO optimization (set during command building)
+    int kArgIndex = -1;
     HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized,
-                                 sp, vq, numShards);
+                                 sp, &kArgIndex);
+    hreq->kArgIndex = kArgIndex;
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;
@@ -710,7 +700,7 @@ static void FreeCursorMappings(void *mappings) {
   rm_free(mappings);
 }
 
-static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCtx *cmdCtx,
+static int HybridRequest_executePlan(HybridRequest *hreq,
                         RedisModule_Reply *reply, QueryError *status) {
 
     // Get RPNet structures from query context
@@ -731,11 +721,28 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     MRCommand *cmd = &searchRPNet->cmd;
     cmd->coordStartTime = hreq->profileClocks.coordStartTime;
 
+    // Create KNN context for SHARD_K_RATIO optimization if applicable
+    HybridKnnContext *knnCtx = NULL;
+    if (hreq->kArgIndex >= 0) {
+        // Get the VectorQuery from the vector request's AST
+        const AREQ *vectorRequest = hreq->requests[VECTOR_INDEX];
+        const VectorQuery *vq = (vectorRequest->ast.root && vectorRequest->ast.root->type == QN_VECTOR)
+                          ? vectorRequest->ast.root->vn.vq : NULL;
+        if (vq && vq->type == VECSIM_QT_KNN) {
+            knnCtx = rm_calloc(1, sizeof(HybridKnnContext));
+            *knnCtx = (HybridKnnContext){
+                .originalK = vq->knn.k,
+                .shardWindowRatio = vq->knn.shardWindowRatio,
+                .kArgIndex = hreq->kArgIndex,
+            };
+        }
+    }
+
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
     const RSTimeoutPolicy timeoutPolicy = hreq->reqConfig.timeoutPolicy;
     bool maxPrefixSearch = false;
     bool maxPrefixVsim = false;
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim)) {
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, hreq->tailPipeline->qctx.err, oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);
@@ -881,12 +888,12 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     // Get numShards captured from main thread for thread-safe access and to compute effective K
     size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
 
-    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status, NULL) != REDISMODULE_OK) {
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, &status, NULL) != REDISMODULE_OK) {
       DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
       return;
     }
 
-    if (HybridRequest_executePlan(hreq, cmdCtx, reply, &status) != REDISMODULE_OK) {
+    if (HybridRequest_executePlan(hreq, reply, &status) != REDISMODULE_OK) {
         DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
         return;
     }
@@ -956,13 +963,13 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
     // Use stripped_argc so parsing doesn't see debug params;
     // pass debugParams so the MR command gets _FT.DEBUG prefix + debug args.
-    if (HybridRequest_prepareForExecution(hreq, ctx, argv, stripped_argc, sp, numShards,
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, stripped_argc, sp,
                                           &status, &debugParams) != REDISMODULE_OK) {
       DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
       return;
     }
 
-    if (HybridRequest_executePlan(hreq, cmdCtx, reply, &status) != REDISMODULE_OK) {
+    if (HybridRequest_executePlan(hreq, reply, &status) != REDISMODULE_OK) {
         DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
         return;
     }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -885,9 +885,6 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     // Store coordinator start time for dispatch time tracking
     hreq->profileClocks.coordStartTime = ConcurrentCmdCtx_GetCoordStartTime(cmdCtx);
 
-    // Get numShards captured from main thread for thread-safe access and to compute effective K
-    size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
-
     if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, &status, NULL) != REDISMODULE_OK) {
       DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
       return;
@@ -959,7 +956,6 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     CoordRequestCtx_UnlockSetRequest(reqCtx);
 
     hreq->profileClocks.coordStartTime = ConcurrentCmdCtx_GetCoordStartTime(cmdCtx);
-    size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
 
     // Use stripped_argc so parsing doesn't see debug params;
     // pass debugParams so the MR command gets _FT.DEBUG prefix + debug args.

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -651,11 +651,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Construct the command string
     MRCommand xcmd;
-    // Track K argument index for SHARD_K_RATIO optimization (set during command building)
-    int kArgIndex = -1;
     HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized,
-                                 sp, &kArgIndex);
-    hreq->kArgIndex = kArgIndex;
+                                 sp, &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -28,13 +28,10 @@ int DistHybridTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, i
 int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // For testing purposes
-// numShards is passed from the main thread to ensure thread-safe access
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp,
-                            const VectorQuery *vq,
-                            size_t numShards);
+                            IndexSpec *sp, int *outKArgIndex);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -238,19 +238,22 @@ static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
     rm_free(ctx);
 }
 
-// Command modifier callback for SHARD_K_RATIO optimization.
-// Called from iterStartCb on IO thread before commands are sent to shards.
-void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
-    RS_ASSERT(privateData && cmd);
-    const processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
-    const HybridKnnContext *knnCtx = ctx->knnCtx;
-    RS_ASSERT(knnCtx && knnCtx->kArgIndex >= 0);
+void HybridKnnApplyShardKRatio(MRCommand *cmd, size_t numShards, const HybridKnnContext *knnCtx) {
+    RS_ASSERT(cmd && knnCtx && knnCtx->kArgIndex >= 0);
     // Only apply optimization for multi-shard deployments with valid ratio
     if (numShards <= 1 || knnCtx->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
         return;
     }
     size_t effectiveK = calculateEffectiveK(knnCtx->originalK, knnCtx->shardWindowRatio, numShards);
     modifyVsimKNN(cmd, knnCtx->kArgIndex, effectiveK, knnCtx->originalK);
+}
+
+// Command modifier callback for SHARD_K_RATIO optimization.
+// Called from iterStartCb on IO thread before commands are sent to shards.
+void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
+    RS_ASSERT(privateData && cmd);
+    const processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
+    HybridKnnApplyShardKRatio(cmd, numShards, ctx->knnCtx);
 }
 
 bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, HybridKnnContext *knnCtx, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim) {

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -13,6 +13,7 @@
 #include "rmalloc.h"
 #include "rmutil/rm_assert.h"
 #include "query_error_ffi.h"
+#include "shard_window_ratio.h"
 #include <string.h>
 #include "info/global_stats.h"
 
@@ -28,6 +29,7 @@ typedef struct {
     pthread_cond_t *completionCond;   // Condition variable for completion signaling
     int numShards;                    // Total number of expected shards
     bool initialized;                 // Whether numShards has been set by the IO thread
+    HybridKnnContext *knnCtx;         // KNN context for SHARD_K_RATIO optimization (may be NULL)
 } processCursorMappingCallbackContext;
 
 void CursorMapping_Release(CursorMapping *mapping) {
@@ -212,7 +214,7 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
 }
 
 // Init callback for the private data, so that numShards is set to the actual number of shards in the cluster, and the expected responses.
-static void processCursorMappingInit(void *privateData, MRIterator *it) {
+static void processCursorMappingInit(void *privateData, const MRIterator *it) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
     int actualNumShards = (int)MRIterator_GetNumShards(it);
     pthread_mutex_lock(ctx->mutex);
@@ -232,10 +234,30 @@ static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
     StrongRef_Release(ctx->searchMappings);
     StrongRef_Release(ctx->vsimMappings);
     array_free_ex(ctx->errors, QueryError_ClearError((QueryError*)ptr));
+    rm_free(ctx->knnCtx);
     rm_free(ctx);
 }
 
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim) {
+// Command modifier callback for SHARD_K_RATIO optimization.
+// Called from iterStartCb on IO thread before commands are sent to shards.
+static void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
+    if (!privateData || !cmd) {
+        return;
+    }
+    const processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
+    const HybridKnnContext *knnCtx = ctx->knnCtx;
+    if (!knnCtx || knnCtx->kArgIndex < 0) {
+        return;
+    }
+    // Only apply optimization for multi-shard deployments with valid ratio
+    if (numShards <= 1 || knnCtx->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
+        return;
+    }
+    size_t effectiveK = calculateEffectiveK(knnCtx->originalK, knnCtx->shardWindowRatio, numShards);
+    modifyVsimKNN(cmd, knnCtx->kArgIndex, effectiveK, knnCtx->originalK);
+}
+
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, HybridKnnContext *knnCtx, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
@@ -258,14 +280,21 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
         .mutex = ctx->mutex,
         .completionCond = ctx->completionCond,
         .numShards = 0,
-        .initialized = false
+        .initialized = false,
+        .knnCtx = knnCtx,  // Store KNN context for command modifier callback
       };
+
+    // Pass HybridKnnCommandModifier if knnCtx is provided (for SHARD_K_RATIO
+    // optimization)
+    MRCommandModifier cmdModifier = knnCtx ? &HybridKnnCommandModifier : NULL;
 
     // Start iteration (ctx is cleaned up manually in cleanupCtx, no destructor needed)
     // processCursorMappingInit is called from iterStartCb to update ctx->numShards
     // with the actual shard count from the live topology, preventing use-after-free
     // when topology changes during shard migration.
-    MRIterator *it = MR_IterateWithPrivateData(cmd, processCursorMappingCallback, ctx, NULL, processCursorMappingInit, iterStartCb, NULL);
+    MRIterator *it = MR_IterateWithPrivateData(cmd, processCursorMappingCallback,
+                                               ctx, NULL, processCursorMappingInit,
+                                               cmdModifier, iterStartCb, NULL);
     if (!it) {
         // Cleanup on error
         QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to communicate with shards");
@@ -282,6 +311,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
         pthread_cond_wait(ctx->completionCond, ctx->mutex);
     }
     pthread_mutex_unlock(ctx->mutex);
+
     bool success = true;
     if (array_len(ctx->errors)) {
         for (size_t i = 0; i < array_len(ctx->errors); i++) {

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -240,7 +240,7 @@ static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
 
 // Command modifier callback for SHARD_K_RATIO optimization.
 // Called from iterStartCb on IO thread before commands are sent to shards.
-static void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
+void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
     if (!privateData || !cmd) {
         return;
     }

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -241,14 +241,10 @@ static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
 // Command modifier callback for SHARD_K_RATIO optimization.
 // Called from iterStartCb on IO thread before commands are sent to shards.
 void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
-    if (!privateData || !cmd) {
-        return;
-    }
+    RS_ASSERT(privateData && cmd);
     const processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
     const HybridKnnContext *knnCtx = ctx->knnCtx;
-    if (!knnCtx || knnCtx->kArgIndex < 0) {
-        return;
-    }
+    RS_ASSERT(knnCtx && knnCtx->kArgIndex >= 0);
     // Only apply optimization for multi-shard deployments with valid ratio
     if (numShards <= 1 || knnCtx->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
         return;

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -37,13 +37,26 @@ typedef struct {
 typedef struct QueryError QueryError;
 
 /**
+ * Context for SHARD_K_RATIO optimization in FT.HYBRID commands.
+ * Contains information needed to calculate and apply effectiveK.
+ */
+typedef struct {
+  size_t originalK;         // Original K value from query
+  double shardWindowRatio;  // Ratio for shard window optimization
+  int kArgIndex;            // Index of the K value argument in the MRCommand
+} HybridKnnContext;
+
+
+/**
  * Process hybrid cursor mappings synchronously
  * Populates the searchMappings and vsimMappings arrays with cursor mappings from all shards.
  * Handles shard errors by recording them in the status parameter while continuing to process all shards.
  * Returns true even if all shards fail with warnings (e.g., OOM), resulting in empty mapping arrays and allowing the caller to handle the warnings.
+ *
  * @param cmd The MRCommand to execute
  * @param searchMappings Empty array to populate with search cursor mappings
  * @param vsimMappings Empty array to populate with vector similarity cursor mappings
+ * @param knnCtx KNN context for SHARD_K_RATIO optimization (NULL if not applicable)
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
  * @param timeoutPolicy Timeout policy to determine timeout error handling behavior
@@ -51,7 +64,7 @@ typedef struct QueryError QueryError;
  * @param maxPrefixVsim Output: set to true if VSIM subquery reported max prefix expansion warning
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim);
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, HybridKnnContext *knnCtx, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -67,6 +67,17 @@ typedef struct {
 bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, HybridKnnContext *knnCtx, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim);
 
 /**
+ * Apply SHARD_K_RATIO optimization to an MRCommand based on the provided
+ * HybridKnnContext. Computes the effective per-shard K and rewrites the K
+ * argument in the command in-place. No-op for single-shard deployments or
+ * when the ratio disables the optimization.
+ *
+ * Exposed primarily as the inner logic of HybridKnnCommandModifier so that
+ * it can be unit-tested without replicating the iteration callback context.
+ */
+void HybridKnnApplyShardKRatio(MRCommand *cmd, size_t numShards, const HybridKnnContext *knnCtx);
+
+/**
  * Release resources associated with a cursor mapping
  */
 void CursorMapping_Release(CursorMapping *mapping);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -623,7 +623,8 @@ struct MRIteratorCtx {
   int8_t itRefCount;
   IORuntimeCtx *ioRuntime;
   void (*privateDataDestructor)(void *);  // Destructor for privateData, called in MRIterator_Free
-  void (*privateDataInit)(void *, MRIterator *);  // Init callback for privateData, called from iterStartCb
+  void (*privateDataInit)(void *, const MRIterator *);  // Init callback for privateData, called from iterStartCb
+  MRCommandModifier commandModifier;  // Callback to modify command before sending, called from iterStartCb
 };
 
 struct MRIteratorCallbackCtx {
@@ -776,6 +777,11 @@ void iterStartCb(void *p) {
   // Set the dispatch time value in the prepared placeholder
   MRCommand_SetDispatchTime(cmd);
 
+  // Call command modifier callback if set (e.g., to calculate effectiveK based on actual numShards)
+  if (it->ctx.commandModifier) {
+    it->ctx.commandModifier(cmd, numShards, privateData);
+  }
+
   for (size_t targetShardIdx = 1; targetShardIdx < numShards; targetShardIdx++) {
     it->cbxs[targetShardIdx].it = it;
     it->cbxs[targetShardIdx].cmd = MRCommand_Copy(cmd);
@@ -920,12 +926,13 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
 }
 
 MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb) {
-  return MR_IterateWithPrivateData(cmd, cb, NULL, NULL, NULL, iterStartCb, NULL);
+  return MR_IterateWithPrivateData(cmd, cb, NULL, NULL, NULL, NULL, iterStartCb, NULL);
 }
 
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, MRIterator *),
+                                      void (*cbPrivateDataInit)(void *, const MRIterator *),
+                                      MRCommandModifier commandModifier,
                                       void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData) {
   MRIterator *ret = rm_new(MRIterator);
   // Initial initialization of the iterator.
@@ -947,6 +954,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
       .ioRuntime = MRCluster_GetIORuntimeCtx(cluster_g, MRCluster_AssignRoundRobinIORuntimeIdx(cluster_g)),
       .privateDataDestructor = cbPrivateDataDestructor,
       .privateDataInit = cbPrivateDataInit,
+      .commandModifier = commandModifier,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
     .len = 1,

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -925,10 +925,6 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   return channelSize > 0;
 }
 
-MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb) {
-  return MR_IterateWithPrivateData(cmd, cb, NULL, NULL, NULL, NULL, iterStartCb, NULL);
-}
-
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
                                       void (*cbPrivateDataInit)(void *, const MRIterator *),

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -10,7 +10,15 @@
 #pragma once
 
 #include <stdbool.h>
+
+#ifdef __cplusplus
+#include <atomic>
+#define RS_Atomic(T) std::atomic<T>
+extern "C" {
+#else
+#define RS_Atomic(T) _Atomic(T)
 #include <stdatomic.h>
+#endif
 
 #include "reply.h"
 #include "cluster.h"
@@ -146,7 +154,7 @@ MRReply *MRIterator_Next(MRIterator *it);
  * At least one of `abstime` / `abortFlag` must be non-NULL; for an indefinite
  * blocking next, use MRIterator_Next. */
 MRReply *MRIterator_NextWithTimeout(MRIterator *it, const struct timespec *abstime,
-                                    atomic_bool *abortFlag, bool *timedOut);
+                                    RS_Atomic(bool) *abortFlag, bool *timedOut);
 
 /* Return the underlying channel used by the iterator. Intended for callers that need to
  * invoke MRChannel_WakeAbort directly (e.g. from a timeout callback on another thread). */
@@ -189,3 +197,9 @@ short MRIterator_GetPending(MRIterator *it);
 void MRIterator_Release(MRIterator *it);
 
 sds MRCommand_SafeToString(const MRCommand *cmd);
+
+#undef RS_Atomic
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -152,8 +152,6 @@ MRReply *MRIterator_NextWithTimeout(MRIterator *it, const struct timespec *absti
  * invoke MRChannel_WakeAbort directly (e.g. from a timeout callback on another thread). */
 struct MRChannel *MRIterator_GetChannel(MRIterator *it);
 
-MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb);
-
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
                                       void (*cbPrivateDataInit)(void *, const MRIterator *),

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -123,6 +123,18 @@ typedef struct MRIterator MRIterator;
 
 typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
 
+/**
+ * Callback type for modifying commands before they are sent to shards.
+ * Called from iterStartCb on the IO thread after numShards is known but before
+ * commands are sent.
+ * This allows calculating values like effectiveK based on the actual topology.
+ *
+ * @param cmd The command to modify (will be copied for each shard after this callback)
+ * @param numShards The actual number of shards from the IO thread's topology
+ * @param privateData The private data passed to MR_IterateWithPrivateData
+ */
+typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privateData);
+
 // Trigger all the commands in the iterator to be sent.
 // Returns true if there may be more replies to come, false if we are done.
 bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold);
@@ -144,7 +156,8 @@ MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb);
 
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, MRIterator *),
+                                      void (*cbPrivateDataInit)(void *, const MRIterator *),
+                                      MRCommandModifier commandModifier,
                                       void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData);
 
 MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx);

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -77,6 +77,17 @@ static RSValue *MRReply_ToValue(MRReply *r) {
   return v;
 }
 
+static void shardResponseBarrier_UpdateTotalResults(RPNet *nc) {
+  // Set the accumulated total now that all shards have responded
+  // numShards == 0 means IO thread never initialized the barrier (timeout before init)
+  size_t numResponded = atomic_load(&nc->shardResponseBarrier->base.numResponded);
+  size_t numShards_loaded = atomic_load(&nc->shardResponseBarrier->base.numShards);
+  if (numShards_loaded > 0 && numResponded >= numShards_loaded) {
+    long long accumulatedTotal = atomic_load(&nc->shardResponseBarrier->accumulatedTotal);
+    nc->base.parent->totalResults = accumulatedTotal;
+  }
+}
+
 static void shardResponseBarrier_PendingReplies_Free(RPNet *nc) {
   if (nc->pendingReplies) {
     array_foreach(nc->pendingReplies, reply, MRReply_Free(reply));
@@ -246,15 +257,7 @@ int getNextReply(RPNet *nc) {
     if (shardResponseBarrier_HandleTimeout(nc)) {
       return RS_RESULT_TIMEDOUT;
     }
-
-    // Set the accumulated total now that all shards have responded
-    // numShards == 0 means IO thread never initialized the barrier (timeout before init)
-    size_t numResponded = atomic_load(&nc->shardResponseBarrier->base.numResponded);
-    size_t numShards_loaded = atomic_load(&nc->shardResponseBarrier->base.numShards);
-    if (numShards_loaded > 0 && numResponded >= numShards_loaded) {
-      long long accumulatedTotal = atomic_load(&nc->shardResponseBarrier->accumulatedTotal);
-      nc->base.parent->totalResults = accumulatedTotal;
-    }
+    shardResponseBarrier_UpdateTotalResults(nc);
   }
 
   // First, return any pending replies collected during the wait

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -77,96 +77,6 @@ static RSValue *MRReply_ToValue(MRReply *r) {
   return v;
 }
 
-// Free a ShardResponseBarrier - used as destructor callback for MRIterator
-void shardResponseBarrier_Free(void *ptr) {
-  ShardResponseBarrier *barrier = (ShardResponseBarrier *)ptr;
-  if (barrier) {
-    rm_free(barrier->shardResponded);
-    rm_free(barrier);
-  }
-}
-
-// Allocate and initialize a new ShardResponseBarrier
-// Notice: numShards and shardResponded init is postponed until NumShards is known
-// Returns NULL on allocation failure
-ShardResponseBarrier *shardResponseBarrier_New() {
-  ShardResponseBarrier *barrier = rm_calloc(1, sizeof(ShardResponseBarrier));
-  if (!barrier) {
-    return NULL;
-  }
-
-  // numShards is initialized to 0 here and later updated via atomic_store in
-  // shardResponseBarrier_Init when the actual shard count is known.
-  // We must use atomic_init here (not rely on calloc zeroing)
-  // because the coord thread may call atomic_load on numShards before
-  // shardResponseBarrier_Init runs.
-  atomic_init(&barrier->numShards, 0);
-  atomic_init(&barrier->numResponded, 0);
-  atomic_init(&barrier->accumulatedTotal, 0);
-  atomic_init(&barrier->hasShardError, false);
-
-  // Set the callback for processing replies in IO threads
-  barrier->notifyCallback = shardResponseBarrier_Notify;
-
-  return barrier;
-}
-
-// Initialize ShardResponseBarrier (called from iterStartCb when topology is known)
-void shardResponseBarrier_Init(void *ptr, MRIterator *it) {
-  ShardResponseBarrier *barrier = (ShardResponseBarrier *)ptr;
-  if (!barrier || !it) {
-    return;
-  }
-
-  size_t numShards = MRIterator_GetNumShards(it);
-  barrier->shardResponded = rm_calloc(numShards, sizeof(*barrier->shardResponded));
-  if (barrier->shardResponded) {
-    // rm_calloc already zero-initializes, so all elements are false
-    // Set numShards only after successful allocation to prevent
-    // shardResponseBarrier_Notify from accessing NULL shardResponded array
-    // Use atomic_store (not atomic_init) because coord thread may already be
-    // calling atomic_load on numShards concurrently in getNextReply()
-    atomic_store(&barrier->numShards, numShards);
-  }
-  // If allocation failed, numShards remains 0 (from atomic_init in shardResponseBarrier_New)
-  // so Notify callback won't try to access the NULL shardResponded array
-}
-
-// Callback invoked by IO thread for each shard reply to accumulate totals
-// This function implements the ReplyNotifyCallback signature
-void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults, bool isError, void *privateData) {
-  ShardResponseBarrier *barrier = (ShardResponseBarrier *)privateData;
-
-  // Validate shardId bounds
-  size_t numShards = atomic_load(&barrier->numShards);
-  if (shardIndex >= numShards) {
-    return;
-  }
-
-  // Check if this is the first response from this shard
-  // No atomic needed - only one IO thread accesses shardResponded for this barrier
-  if (!barrier->shardResponded[shardIndex]) {
-    barrier->shardResponded[shardIndex] = true;
-    if (!isError) {
-      atomic_fetch_add(&barrier->accumulatedTotal, totalResults);
-    } else {
-      atomic_store(&barrier->hasShardError, true);
-    }
-    atomic_fetch_add(&barrier->numResponded, 1);
-  }
-}
-
-static void shardResponseBarrier_UpdateTotalResults(RPNet *nc) {
-  // Set the accumulated total now that all shards have responded
-  // numShards == 0 means IO thread never initialized the barrier (timeout before init)
-  size_t numResponded = atomic_load(&nc->shardResponseBarrier->numResponded);
-  size_t numShards = atomic_load(&nc->shardResponseBarrier->numShards);
-  if (numShards > 0 && numResponded >= numShards) {
-    long long accumulatedTotal = atomic_load(&nc->shardResponseBarrier->accumulatedTotal);
-    nc->base.parent->totalResults = accumulatedTotal;
-  }
-}
-
 static void shardResponseBarrier_PendingReplies_Free(RPNet *nc) {
   if (nc->pendingReplies) {
     array_foreach(nc->pendingReplies, reply, MRReply_Free(reply));
@@ -187,8 +97,8 @@ static struct timespec *getAbsTimeout(RPNet *nc) {
 // Handle timeout (not enough shards responded) only if there were no errors
 // Also handles the case where numShards == 0 (IO thread never initialized barrier)
 static bool shardResponseBarrier_HandleTimeout(RPNet *nc) {
-  size_t numShards = atomic_load(&nc->shardResponseBarrier->numShards);
-  size_t numResponded = atomic_load(&nc->shardResponseBarrier->numResponded);
+  size_t numShards = atomic_load(&nc->shardResponseBarrier->base.numShards);
+  size_t numResponded = atomic_load(&nc->shardResponseBarrier->base.numResponded);
   // Timeout if: barrier not initialized (numShards == 0) OR not all shards responded
   if (!(atomic_load(&nc->shardResponseBarrier->hasShardError)) &&
       (numShards == 0 || numResponded < numShards)) {
@@ -288,8 +198,8 @@ int getNextReply(RPNet *nc) {
     // (in case the IO thread iterStartCb did not run yet and did not initialize the barrier yet).
     // Once a reply arrives, iterStartCb has finished and numShards will be set.
     size_t numShards;
-    while ((numShards = atomic_load(&nc->shardResponseBarrier->numShards)) == 0 ||
-           atomic_load(&nc->shardResponseBarrier->numResponded) < numShards) {
+    while ((numShards = atomic_load(&nc->shardResponseBarrier->base.numShards)) == 0 ||
+           atomic_load(&nc->shardResponseBarrier->base.numResponded) < numShards) {
 
       // Check for timeout to avoid blocking indefinitely (respecting skipTimeoutChecks flag)
       if (nc->areq && AREQ_ShouldCheckTimeout(nc->areq) && TimedOut(&nc->areq->sctx->time.timeout)) {
@@ -336,7 +246,15 @@ int getNextReply(RPNet *nc) {
     if (shardResponseBarrier_HandleTimeout(nc)) {
       return RS_RESULT_TIMEDOUT;
     }
-    shardResponseBarrier_UpdateTotalResults(nc);
+
+    // Set the accumulated total now that all shards have responded
+    // numShards == 0 means IO thread never initialized the barrier (timeout before init)
+    size_t numResponded = atomic_load(&nc->shardResponseBarrier->base.numResponded);
+    size_t numShards_loaded = atomic_load(&nc->shardResponseBarrier->base.numShards);
+    if (numShards_loaded > 0 && numResponded >= numShards_loaded) {
+      long long accumulatedTotal = atomic_load(&nc->shardResponseBarrier->accumulatedTotal);
+      nc->base.parent->totalResults = accumulatedTotal;
+    }
   }
 
   // First, return any pending replies collected during the wait
@@ -480,7 +398,10 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     nc->cmd.protocol = 3;
     rm_free(idx_copy);
 
-    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL, NULL, iterCursorMappingCb, &nc->mappings);
+    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL,
+                                       NULL, NULL, iterCursorMappingCb,
+                                       &nc->mappings);
+
     // Register the iterator's channel so the main-thread timeout callback can wake a
     // blocked reader after flipping AREQ's `timedOut` flag. Paired with
     // RequestSyncCtx_UnregisterAbortWakeChannel in rpnetFree.

--- a/src/coord/rpnet.h
+++ b/src/coord/rpnet.h
@@ -53,10 +53,15 @@ typedef struct {
   // BG has exited the pipeline, so no concurrent reader - plain bool is safe.
   bool drainOnly;
 
-  // KNN context for SHARD_K_RATIO optimization in FT.AGGREGATE
-  // Set by buildDistRPChain, used by rpnetNext_Start command modifier callback
-  struct VectorQuery *knnVectorQuery;  // NOT owned, may be NULL
-  size_t knnQueryArgIndex;             // Index of query argument in MRCommand
+  // KNN snapshot for SHARD_K_RATIO optimization in FT.AGGREGATE.
+  // Populated by buildDistRPChain from the parsed VectorQuery on the main thread,
+  // then used to initialize the iterator-owned AggregateKnnContext if needed.
+  bool hasKnnContext;
+  size_t knnQueryArgIndex;     // Index of query argument in MRCommand
+  size_t knnOriginalK;         // K value from the parsed query
+  double knnShardWindowRatio;  // SHARD_K_RATIO
+  size_t knnKTokenPos;         // Byte offset of K within the query string
+  size_t knnKTokenLen;         // Length of K token in bytes
 } RPNet;
 
 

--- a/src/coord/rpnet.h
+++ b/src/coord/rpnet.h
@@ -15,33 +15,11 @@
 #include "rmr/rmr.h"
 #include "aggregate/aggregate.h"
 #include "hybrid/hybrid_cursor_mappings.h"
+#include "shard_barrier.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// Forward declaration
-struct ShardResponseBarrier;
-
-// Callback invoked by IO thread for each reply, before pushing to channel
-// Parameters:
-//   shardIndex: which shard sent this reply
-//   totalResults: extracted total_results from the reply (-1 if error or not found)
-//   isError: true if this is an error reply
-//   privateData: the ShardResponseBarrier passed via MRIteratorCallback_GetPrivateData
-typedef void (*ReplyNotifyCallback)(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
-
-// Structure for collecting first responses from all shards
-// Shared with I/O threads via MRIterator's privateData
-// Safe to free after MRIterator_Release returns (all callbacks complete)
-typedef struct ShardResponseBarrier {
-  _Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by main thread)
-  bool *shardResponded;            // Array: has each shard sent its first response? (IO thread only, no atomic needed)
-  _Atomic(size_t) numResponded;    // Count of shards that have responded
-  _Atomic(long long) accumulatedTotal;  // Sum of total_results from all shards
-  _Atomic(bool) hasShardError;     // Set to true if any shard returns an error
-  ReplyNotifyCallback notifyCallback;  // Callback for processing replies (called from IO thread)
-} ShardResponseBarrier;
 
 typedef struct {
   ResultProcessor base;
@@ -74,6 +52,11 @@ typedef struct {
   // and maps timeouts to EOF. Set by the RETURN-STRICT timeout callback after
   // BG has exited the pipeline, so no concurrent reader - plain bool is safe.
   bool drainOnly;
+
+  // KNN context for SHARD_K_RATIO optimization in FT.AGGREGATE
+  // Set by buildDistRPChain, used by rpnetNext_Start command modifier callback
+  struct VectorQuery *knnVectorQuery;  // NOT owned, may be NULL
+  size_t knnQueryArgIndex;             // Index of query argument in MRCommand
 } RPNet;
 
 
@@ -88,20 +71,6 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r);
 // Return RS_RESULT_OK if there is a next reply to process, RS_RESULT_EOF if there are no more replies
 // Or RS_RESULT_TIMEDOUT if we timed out
 int getNextReply(RPNet *nc);
-
-// Allocate and initialize a new ShardResponseBarrier
-// Notice: numShards and shardResponded init is postponed until shardResponseBarrier_Init is called
-// Returns NULL on allocation failure
-ShardResponseBarrier *shardResponseBarrier_New();
-
-// Initialize ShardResponseBarrier (called from iterStartCb when topology is known)
-void shardResponseBarrier_Init(void *ptr, MRIterator *it);
-
-// Free a ShardResponseBarrier - used as destructor callback for MRIterator
-void shardResponseBarrier_Free(void *ptr);
-
-// Callback for accumulating total_results from shard replies (called from IO thread)
-void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
 
 #ifdef __cplusplus
 }

--- a/src/coord/shard_barrier.c
+++ b/src/coord/shard_barrier.c
@@ -20,23 +20,6 @@ void shardResponseBarrier_Free(void *ptr) {
   }
 }
 
-// Initialize ShardCountBarrier base fields (called from iterStartCb when
-// topology is known)
-// This is a generic init function that can be used as privateDataInit callback
-// when the privateData starts with a ShardCountBarrier (or is a
-// ShardCountBarrier*)
-void shardCountBarrier_Init(void *ptr, const MRIterator *it) {
-  ShardCountBarrier *barrier = (ShardCountBarrier *)ptr;
-  if (!barrier || !it) {
-    return;
-  }
-
-  size_t numShards = MRIterator_GetNumShards(it);
-  // Use atomic_store (not atomic_init) because coord thread may already be
-  // calling atomic_load on numShards concurrently
-  atomic_store(&barrier->numShards, numShards);
-}
-
 // Allocate and initialize a new ShardResponseBarrier
 // Notice: numShards and shardResponded init is postponed until NumShards is
 // known

--- a/src/coord/shard_barrier.c
+++ b/src/coord/shard_barrier.c
@@ -23,12 +23,8 @@ void shardResponseBarrier_Free(void *ptr) {
 // Allocate and initialize a new ShardResponseBarrier
 // Notice: numShards and shardResponded init is postponed until NumShards is
 // known
-// Returns NULL on allocation failure
 ShardResponseBarrier *shardResponseBarrier_New(void) {
   ShardResponseBarrier *barrier = rm_calloc(1, sizeof(ShardResponseBarrier));
-  if (!barrier) {
-    return NULL;
-  }
 
   // numShards is initialized to 0 here and later updated via atomic_store in
   // shardResponseBarrier_Init when the actual shard count is known.

--- a/src/coord/shard_barrier.c
+++ b/src/coord/shard_barrier.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "shard_barrier.h"
+#include "rmr/rmr.h"
+#include "rmalloc.h"
+
+// Free a ShardResponseBarrier - used as destructor callback for MRIterator
+void shardResponseBarrier_Free(void *ptr) {
+  ShardResponseBarrier *barrier = (ShardResponseBarrier *)ptr;
+  if (barrier) {
+    rm_free(barrier->shardResponded);
+    rm_free(barrier);
+  }
+}
+
+// Initialize ShardCountBarrier base fields (called from iterStartCb when
+// topology is known)
+// This is a generic init function that can be used as privateDataInit callback
+// when the privateData starts with a ShardCountBarrier (or is a
+// ShardCountBarrier*)
+void shardCountBarrier_Init(void *ptr, const MRIterator *it) {
+  ShardCountBarrier *barrier = (ShardCountBarrier *)ptr;
+  if (!barrier || !it) {
+    return;
+  }
+
+  size_t numShards = MRIterator_GetNumShards(it);
+  // Use atomic_store (not atomic_init) because coord thread may already be
+  // calling atomic_load on numShards concurrently
+  atomic_store(&barrier->numShards, numShards);
+}
+
+// Allocate and initialize a new ShardResponseBarrier
+// Notice: numShards and shardResponded init is postponed until NumShards is
+// known
+// Returns NULL on allocation failure
+ShardResponseBarrier *shardResponseBarrier_New(void) {
+  ShardResponseBarrier *barrier = rm_calloc(1, sizeof(ShardResponseBarrier));
+  if (!barrier) {
+    return NULL;
+  }
+
+  // numShards is initialized to 0 here and later updated via atomic_store in
+  // shardResponseBarrier_Init when the actual shard count is known.
+  // We must use atomic_init here (not rely on calloc zeroing)
+  // because the coord thread may call atomic_load on numShards before
+  // shardResponseBarrier_Init runs.
+  atomic_init(&barrier->base.numShards, 0);
+  atomic_init(&barrier->base.numResponded, 0);
+  atomic_init(&barrier->accumulatedTotal, 0);
+  atomic_init(&barrier->hasShardError, false);
+
+  // Set the callback for processing replies in IO threads
+  barrier->notifyCallback = shardResponseBarrier_Notify;
+
+  return barrier;
+}
+
+// Initialize ShardResponseBarrier (called from iterStartCb when topology is
+// known)
+// This initializes both the base ShardCountBarrier and the shardResponded array
+void shardResponseBarrier_Init(void *ptr, const MRIterator *it) {
+  ShardResponseBarrier *barrier = (ShardResponseBarrier *)ptr;
+  if (!barrier || !it) {
+    return;
+  }
+
+  size_t numShards = MRIterator_GetNumShards(it);
+  barrier->shardResponded = rm_calloc(numShards, sizeof(*barrier->shardResponded));
+  if (barrier->shardResponded) {
+    // rm_calloc already zero-initializes, so all elements are false
+    // Set numShards only after successful allocation to prevent
+    // shardResponseBarrier_Notify from accessing NULL shardResponded array
+    // Use atomic_store (not atomic_init) because coord thread may already be
+    // calling atomic_load on numShards concurrently in getNextReply()
+    atomic_store(&barrier->base.numShards, numShards);
+  }
+  // If allocation failed, numShards remains 0 (from atomic_init in
+  // shardResponseBarrier_New) so Notify callback won't try to access the NULL
+  // shardResponded array
+}
+
+// Callback invoked by IO thread for each shard reply to accumulate totals
+// This function implements the ReplyNotifyCallback signature
+void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults,
+                                 bool isError, void *privateData) {
+  ShardResponseBarrier *barrier = (ShardResponseBarrier *)privateData;
+
+  // Validate shardId bounds
+  size_t numShards = atomic_load(&barrier->base.numShards);
+  if (shardIndex >= numShards) {
+    return;
+  }
+
+  // Check if this is the first response from this shard
+  // No atomic needed - only one IO thread accesses shardResponded for this barrier
+  if (!barrier->shardResponded[shardIndex]) {
+    barrier->shardResponded[shardIndex] = true;
+    if (!isError) {
+      atomic_fetch_add(&barrier->accumulatedTotal, totalResults);
+    } else {
+      atomic_store(&barrier->hasShardError, true);
+    }
+    atomic_fetch_add(&barrier->base.numResponded, 1);
+  }
+}

--- a/src/coord/shard_barrier.c
+++ b/src/coord/shard_barrier.c
@@ -76,7 +76,12 @@ void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults,
                                  bool isError, void *privateData) {
   ShardResponseBarrier *barrier = (ShardResponseBarrier *)privateData;
 
-  // Validate shardId bounds
+  if (isError) {
+    // Set hasShardError immediately, even if numShards is 0 (i.e. barrier init failed/skipped)
+    atomic_store(&barrier->hasShardError, true);
+  }
+
+  // Validate shardId bounds before accessing shardResponded array
   size_t numShards = atomic_load(&barrier->base.numShards);
   if (shardIndex >= numShards) {
     return;
@@ -88,8 +93,6 @@ void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults,
     barrier->shardResponded[shardIndex] = true;
     if (!isError) {
       atomic_fetch_add(&barrier->accumulatedTotal, totalResults);
-    } else {
-      atomic_store(&barrier->hasShardError, true);
     }
     atomic_fetch_add(&barrier->base.numResponded, 1);
   }

--- a/src/coord/shard_barrier.h
+++ b/src/coord/shard_barrier.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Forward declaration
+struct MRIterator;
+
+// Base barrier for tracking shard response counts
+// Used by FT.AGGREGATE (via ShardResponseBarrier)
+// numShards is set atomically from IO thread when topology is known
+typedef struct ShardCountBarrier {
+  _Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by coordinator thread)
+  _Atomic(size_t) numResponded;    // Count of shards that have responded
+} ShardCountBarrier;
+
+// Callback invoked by IO thread for each reply, before pushing to channel
+// Parameters:
+//   shardIndex: which shard sent this reply
+//   totalResults: extracted total_results from the reply (-1 if error or not found)
+//   isError: true if this is an error reply
+//   privateData: the ShardResponseBarrier passed via MRIteratorCallback_GetPrivateData
+typedef void (*ReplyNotifyCallback)(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
+
+// Extended barrier for WITHCOUNT functionality in FT.AGGREGATE
+// Extends ShardCountBarrier with additional fields for accumulating totals
+// Shared with I/O threads via MRIterator's privateData
+// Safe to free after MRIterator_Release returns (all callbacks complete)
+typedef struct ShardResponseBarrier {
+  ShardCountBarrier base;          // Base barrier with numShards and numResponded
+  bool *shardResponded;            // Array: has each shard sent its first response? (IO thread only, no atomic needed)
+  _Atomic(long long) accumulatedTotal;  // Sum of total_results from all shards
+  _Atomic(bool) hasShardError;     // Set to true if any shard returns an error
+  ReplyNotifyCallback notifyCallback;  // Callback for processing replies (called from IO thread)
+} ShardResponseBarrier;
+
+// Initialize ShardCountBarrier base fields (called from iterStartCb when topology is known)
+// This is a generic init function that can be used as privateDataInit callback
+// when the privateData starts with a ShardCountBarrier (or is a ShardCountBarrier*)
+void shardCountBarrier_Init(void *ptr, const struct MRIterator *it);
+
+// Allocate and initialize a new ShardResponseBarrier
+// Notice: numShards and shardResponded init is postponed until shardResponseBarrier_Init is called
+// Returns NULL on allocation failure
+ShardResponseBarrier *shardResponseBarrier_New(void);
+
+// Initialize ShardResponseBarrier (called from iterStartCb when topology is known)
+// This initializes both the base ShardCountBarrier and the shardResponded array
+void shardResponseBarrier_Init(void *ptr, const struct MRIterator *it);
+
+// Free a ShardResponseBarrier - used as destructor callback for MRIterator
+void shardResponseBarrier_Free(void *ptr);
+
+// Callback for accumulating total_results from shard replies (called from IO thread)
+void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/coord/shard_barrier.h
+++ b/src/coord/shard_barrier.h
@@ -21,9 +21,9 @@ extern "C" {
 // Forward declaration
 struct MRIterator;
 
-// Base barrier for tracking shard response counts
-// Used by FT.AGGREGATE (via ShardResponseBarrier)
-// numShards is set atomically from IO thread when topology is known
+// Base barrier for tracking shard response counts.
+// Used by FT.AGGREGATE (via ShardResponseBarrier).
+// numShards is set atomically from IO thread when topology is known.
 typedef struct ShardCountBarrier {
   _Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by coordinator thread)
   _Atomic(size_t) numResponded;    // Count of shards that have responded
@@ -48,11 +48,6 @@ typedef struct ShardResponseBarrier {
   _Atomic(bool) hasShardError;     // Set to true if any shard returns an error
   ReplyNotifyCallback notifyCallback;  // Callback for processing replies (called from IO thread)
 } ShardResponseBarrier;
-
-// Initialize ShardCountBarrier base fields (called from iterStartCb when topology is known)
-// This is a generic init function that can be used as privateDataInit callback
-// when the privateData starts with a ShardCountBarrier (or is a ShardCountBarrier*)
-void shardCountBarrier_Init(void *ptr, const struct MRIterator *it);
 
 // Allocate and initialize a new ShardResponseBarrier
 // Notice: numShards and shardResponded init is postponed until shardResponseBarrier_Init is called

--- a/src/coord/shard_barrier.h
+++ b/src/coord/shard_barrier.h
@@ -51,7 +51,6 @@ typedef struct ShardResponseBarrier {
 
 // Allocate and initialize a new ShardResponseBarrier
 // Notice: numShards and shardResponded init is postponed until shardResponseBarrier_Init is called
-// Returns NULL on allocation failure
 ShardResponseBarrier *shardResponseBarrier_New(void);
 
 // Initialize ShardResponseBarrier (called from iterStartCb when topology is known)

--- a/src/coord/shard_barrier.h
+++ b/src/coord/shard_barrier.h
@@ -9,13 +9,17 @@
 
 #pragma once
 
-#include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
+#include <atomic>
+#define RS_Atomic(T) std::atomic<T>
 extern "C" {
+#else
+#define RS_Atomic(T) _Atomic(T)
+#include <stdatomic.h>
 #endif
 
 // Forward declaration
@@ -25,8 +29,8 @@ struct MRIterator;
 // Used by FT.AGGREGATE (via ShardResponseBarrier).
 // numShards is set atomically from IO thread when topology is known.
 typedef struct ShardCountBarrier {
-  _Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by coordinator thread)
-  _Atomic(size_t) numResponded;    // Count of shards that have responded
+  RS_Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by coordinator thread)
+  RS_Atomic(size_t) numResponded;    // Count of shards that have responded
 } ShardCountBarrier;
 
 // Callback invoked by IO thread for each reply, before pushing to channel
@@ -44,8 +48,8 @@ typedef void (*ReplyNotifyCallback)(uint16_t shardIndex, long long totalResults,
 typedef struct ShardResponseBarrier {
   ShardCountBarrier base;          // Base barrier with numShards and numResponded
   bool *shardResponded;            // Array: has each shard sent its first response? (IO thread only, no atomic needed)
-  _Atomic(long long) accumulatedTotal;  // Sum of total_results from all shards
-  _Atomic(bool) hasShardError;     // Set to true if any shard returns an error
+  RS_Atomic(long long) accumulatedTotal;  // Sum of total_results from all shards
+  RS_Atomic(bool) hasShardError;   // Set to true if any shard returns an error
   ReplyNotifyCallback notifyCallback;  // Callback for processing replies (called from IO thread)
 } ShardResponseBarrier;
 
@@ -62,6 +66,8 @@ void shardResponseBarrier_Free(void *ptr);
 
 // Callback for accumulating total_results from shard replies (called from IO thread)
 void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
+
+#undef RS_Atomic
 
 #ifdef __cplusplus
 }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -217,6 +217,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     hybridReq->requests = requests;
     hybridReq->nrequests = nrequests;
     hybridReq->sctx = sctx;
+    hybridReq->kArgIndex = -1;
 
     rs_wall_clock now = {0};
     rs_wall_clock_init(&now);
@@ -246,6 +247,8 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     RequestSyncCtx_Init(&hybridReq->syncCtx);
     pthread_mutex_init(&hybridReq->cursorMutex, NULL);
     hybridReq->storedReplyState.err = QueryError_Default();
+
+
 }
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests) {

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -77,6 +77,11 @@ typedef struct HybridRequest {
     // When non-NULL, debug timeouts are applied after pipeline building.
     // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
     HybridDebugParams *debugParams;
+    // Index of the K value argument in the MRCommand for SHARD_K_RATIO
+    // optimization.
+    // Set during command building, used by command modifier callback. -1 if
+    // not applicable.
+    int kArgIndex;
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)

--- a/src/module.c
+++ b/src/module.c
@@ -4136,7 +4136,8 @@ static int prepareCommand(MRCommand *cmd, const searchRequestCtx *req, int proto
           // No modification needed if K values are the same
           if (knn_query->k == effectiveK) break;
           // Modify the command to replace KNN k (shards will ignore $SHARD_K_RATIO)
-          modifyKNNCommand(cmd, 2 + req->profileArgs, effectiveK, knnCtx->knn.queryNode->vn.vq);
+          modifyKNNCommand(cmd, 2 + req->profileArgs, knn_query->k, effectiveK,
+                           knn_query->k_token_pos, knn_query->k_token_len);
         }
         break; // Only handle KNN context
       }

--- a/src/shard_window_ratio.c
+++ b/src/shard_window_ratio.c
@@ -33,17 +33,13 @@ bool validateShardKRatio(const char *value, double *ratio, QueryError *status) {
   return true;
 }
 
-void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq) {
-    // Get original K value from the VectorQuery
-    size_t originalK = vq->knn.k;
-
+void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index,
+                      size_t originalK, size_t effectiveK,
+                      size_t k_pos, size_t k_len) {
     // Fast path: No modification needed if K values are the same
     if (originalK == effectiveK) {
         return;
     }
-    // Get saved position information
-    size_t k_pos = vq->knn.k_token_pos;
-    size_t k_len = vq->knn.k_token_len;
 
     char effectiveK_str[32];
     size_t newK_len = snprintf(effectiveK_str, sizeof(effectiveK_str), "%zu", effectiveK);

--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -78,17 +78,19 @@ static inline size_t calculateEffectiveK(size_t originalK, double ratio, size_t 
 /**
  * Modify KNN command for shard distribution by replacing K value.
  *
- * This function handles two cases:
- * 1. Literal K (e.g., "KNN 50") - uses saved position for exact replacement
- * 2. Parameter K (e.g., "KNN $k") - replaces parameter reference in query string
+ * Replaces the K token in the query argument at query_arg_index with
+ * effectiveK, using the recorded byte offset/length of the K token.
  *
  * @param cmd The MRCommand to modify
  * @param query_arg_index Index of the query string argument in cmd
+ * @param originalK Original K value (no-op if equal to effectiveK)
  * @param effectiveK The calculated effective K value for shards
- * @param vq The VectorQuery containing K position information
-
+ * @param k_pos Byte offset where the K token starts in the query string
+ * @param k_len Length of the K token in bytes
  */
-void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq);
+void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index,
+                      size_t originalK, size_t effectiveK,
+                      size_t k_pos, size_t k_len);
 
 /**
  * Modify VSIM KNN K value in a built command.

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -11,8 +11,7 @@
 #include "vector_index.h"
 #include "shard_window_ratio.h"
 #include "redisearch_rs/headers/query_error.h"
-
-#include <vector>
+#include "hybrid/hybrid_cursor_mappings.h"
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
 
@@ -20,9 +19,9 @@ extern "C" {
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                                   ProfileOptions profileOptions,
                                   MRCommand *xcmd, arrayof(char *) serialized,
-                                  IndexSpec *sp,
-                                  const VectorQuery *vq,
-                                  size_t numShards);
+                                  IndexSpec *sp, int *outKArgIndex);
+
+void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData);
 }
 
 class HybridBuildMRCommandTest : public ::testing::Test {
@@ -40,6 +39,9 @@ protected:
     }
 
     void TearDown() override {
+        if (testIndexSpec) {
+            IndexSpec_RemoveFromGlobals(testIndexSpec->own_ref, false);
+        }
         if (ctx) {
             RedisModule_FreeThreadSafeContext(ctx);
         }
@@ -70,19 +72,15 @@ protected:
 
     // Helper function to test SHARD_K_RATIO command transformation
     // Uses stack-allocated variables following the pattern in hybrid_debug.c
+    // Tests the new architecture where:
+    // 1. HybridRequest_buildMRCommand builds the command with original K value
+    // 2. HybridKnnCommandModifier is called on IO thread to calculate effectiveK
     void testShardKRatioTransformation(const std::vector<const char*>& inputArgs,
                                        size_t numShards,
                                        size_t expectedK,
                                        double expectedRatio,
                                        long long expectedEffectiveK,
-                                       bool passNullVectorQuery = false) {
-        // Access the global NumShards variable for testing
-        extern size_t NumShards;
-
-        // Save and set NumShards
-        size_t originalNumShards = NumShards;
-        NumShards = numShards;
-
+                                       bool passNullKnnContext = false) {
         // Set up args
         std::vector<const char*> argsWithNull = inputArgs;
         argsWithNull.push_back(nullptr);
@@ -115,7 +113,6 @@ protected:
                 HybridScoringContext_Free(hybridParams.scoringCtx);
             }
             HybridRequest_DecrRef(hreq);
-            NumShards = originalNumShards;
             FAIL() << "Failed to parse hybrid command";
         }
 
@@ -123,20 +120,67 @@ protected:
         const VectorQuery *vq = validateVectorQuery(cmd.vector, expectedK, expectedRatio);
         ASSERT_NE(vq, nullptr) << "VectorQuery validation failed";
 
-        // Build MR command
+        // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
+        int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                     nullptr, testIndexSpec,
-                                     passNullVectorQuery ? nullptr : vq, numShards);
+                                     nullptr, testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
 
-        // Verify K value in output command
+        // Verify K value in output command is the ORIGINAL K value (before modifier)
         long long kValue;
         int kIndex = findKValue(&xcmd, &kValue);
         EXPECT_NE(kIndex, -1) << "K keyword should be present in output command";
-        EXPECT_EQ(kValue, expectedEffectiveK) << "K value mismatch";
+        EXPECT_EQ(kValue, (long long)expectedK) << "Initial K value should be original K";
+
+        // Verify kArgIndex points to the correct position (kIndex + 1 is the value)
+        EXPECT_EQ(kArgIndex, kIndex + 1) << "kArgIndex should point to K value position";
+
+        // Now simulate the IO thread calling HybridKnnCommandModifier
+        // Create a mock context structure that mimics processCursorMappingCallbackContext
+        // The actual struct layout is:
+        //   StrongRef searchMappings;
+        //   StrongRef vsimMappings;
+        //   arrayof(QueryError) errors;
+        //   size_t responseCount;
+        //   pthread_mutex_t *mutex;
+        //   pthread_cond_t *completionCond;
+        //   int numShards;
+        //   bool initialized;
+        //   HybridKnnContext *knnCtx;  <-- knnCtx is the LAST field
+        // We must match this layout exactly for the cast in HybridKnnCommandModifier to work
+        HybridKnnContext knnCtxValue;
+        struct MockCallbackContext {
+            StrongRef searchMappings;
+            StrongRef vsimMappings;
+            void *errors;           // arrayof(QueryError)
+            size_t responseCount;
+            pthread_mutex_t *mutex;
+            pthread_cond_t *completionCond;
+            int numShards;
+            bool initialized;
+            HybridKnnContext *knnCtx;  // Must match the real struct layout
+        };
+        MockCallbackContext mockCtx = {};
+
+        if (!passNullKnnContext) {
+            knnCtxValue.originalK = vq->knn.k;
+            knnCtxValue.shardWindowRatio = vq->knn.shardWindowRatio;
+            knnCtxValue.kArgIndex = kArgIndex;
+            mockCtx.knnCtx = &knnCtxValue;
+
+            // Call the command modifier (simulates IO thread callback)
+            // Pass &mockCtx since the callback casts privateData to processCursorMappingCallbackContext*
+            // and accesses ctx->knnCtx (a pointer)
+            HybridKnnCommandModifier(&xcmd, numShards, &mockCtx);
+
+            // Verify K value is now updated to effectiveK
+            kIndex = findKValue(&xcmd, &kValue);
+            EXPECT_NE(kIndex, -1) << "K keyword should still be present after modification";
+            EXPECT_EQ(kValue, expectedEffectiveK) << "K value should be effectiveK after modifier";
+        }
 
         // Cleanup (following hybrid_debug.c pattern)
         MRCommand_Free(&xcmd);
@@ -144,7 +188,6 @@ protected:
             HybridScoringContext_Free(hybridParams.scoringCtx);
         }
         HybridRequest_DecrRef(hreq);
-        NumShards = originalNumShards;
     }
 
     // Helper function to find K value in MRCommand
@@ -175,11 +218,11 @@ protected:
         // Create ArgvList from input
         RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
 
-        // Build MR command (pass NULL for VectorQuery - not testing
-        // SHARD_K_RATIO here)
+        // Build MR command
         MRCommand xcmd;
+        int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                     nullptr, nullptr, nullptr, NumShards);
+                                     nullptr, nullptr, &kArgIndex);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -220,14 +263,14 @@ protected:
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command (pass NULL for VectorQuery - not testing
-      // SHARD_K_RATIO here)
+      // Build MR command (not testing SHARD_K_RATIO here)
       MRCommand xcmd;
+      int kArgIndex = -1;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                   nullptr, sp, nullptr, NumShards);
+                                   nullptr, sp, &kArgIndex);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-        // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT
+      // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT
       for (size_t i = 1; i < inputArgs.size(); i++) {
           EXPECT_STREQ(xcmd.strs[i], inputArgs[i]) << "Argument at index " << i << " should be preserved";
       }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -20,8 +20,6 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                                   ProfileOptions profileOptions,
                                   MRCommand *xcmd, arrayof(char *) serialized,
                                   IndexSpec *sp, int *outKArgIndex);
-
-void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData);
 }
 
 class HybridBuildMRCommandTest : public ::testing::Test {
@@ -74,7 +72,7 @@ protected:
     // Uses stack-allocated variables following the pattern in hybrid_debug.c
     // Tests the new architecture where:
     // 1. HybridRequest_buildMRCommand builds the command with original K value
-    // 2. HybridKnnCommandModifier is called on IO thread to calculate effectiveK
+    // 2. HybridKnnApplyShardKRatio is called on IO thread to calculate effectiveK
     void testShardKRatioTransformation(const std::vector<const char*>& inputArgs,
                                        size_t numShards,
                                        size_t expectedK,
@@ -138,43 +136,17 @@ protected:
         // Verify kArgIndex points to the correct position (kIndex + 1 is the value)
         EXPECT_EQ(kArgIndex, kIndex + 1) << "kArgIndex should point to K value position";
 
-        // Now simulate the IO thread calling HybridKnnCommandModifier
-        // Create a mock context structure that mimics processCursorMappingCallbackContext
-        // The actual struct layout is:
-        //   StrongRef searchMappings;
-        //   StrongRef vsimMappings;
-        //   arrayof(QueryError) errors;
-        //   size_t responseCount;
-        //   pthread_mutex_t *mutex;
-        //   pthread_cond_t *completionCond;
-        //   int numShards;
-        //   bool initialized;
-        //   HybridKnnContext *knnCtx;  <-- knnCtx is the LAST field
-        // We must match this layout exactly for the cast in HybridKnnCommandModifier to work
-        HybridKnnContext knnCtxValue;
-        struct MockCallbackContext {
-            StrongRef searchMappings;
-            StrongRef vsimMappings;
-            void *errors;           // arrayof(QueryError)
-            size_t responseCount;
-            pthread_mutex_t *mutex;
-            pthread_cond_t *completionCond;
-            int numShards;
-            bool initialized;
-            HybridKnnContext *knnCtx;  // Must match the real struct layout
-        };
-        MockCallbackContext mockCtx = {};
-
+        // Simulate the IO thread applying the SHARD_K_RATIO optimization.
+        // Call HybridKnnApplyShardKRatio directly to avoid duplicating the
+        // file-local processCursorMappingCallbackContext layout used by the
+        // HybridKnnCommandModifier callback wrapper.
         if (!passNullKnnContext) {
+            HybridKnnContext knnCtxValue = {};
             knnCtxValue.originalK = vq->knn.k;
             knnCtxValue.shardWindowRatio = vq->knn.shardWindowRatio;
             knnCtxValue.kArgIndex = kArgIndex;
-            mockCtx.knnCtx = &knnCtxValue;
 
-            // Call the command modifier (simulates IO thread callback)
-            // Pass &mockCtx since the callback casts privateData to processCursorMappingCallbackContext*
-            // and accesses ctx->knnCtx (a pointer)
-            HybridKnnCommandModifier(&xcmd, numShards, &mockCtx);
+            HybridKnnApplyShardKRatio(&xcmd, numShards, &knnCtxValue);
 
             // Verify K value is now updated to effectiveK
             kIndex = findKValue(&xcmd, &kValue);

--- a/tests/ctests/coord_tests/test_shard_window_ratio.c
+++ b/tests/ctests/coord_tests/test_shard_window_ratio.c
@@ -87,7 +87,8 @@ static void runModifyKNNTest(const char** args, int argCount,
     node->vn.vq->knn.k_token_len = strlen(kTokenInQuery);
 
     // Test modifyKNNCommand with provided K values
-    modifyKNNCommand(&cmd, 2, effectiveK, node->vn.vq);
+    modifyKNNCommand(&cmd, 2, node->vn.vq->knn.k, effectiveK,
+                     node->vn.vq->knn.k_token_pos, node->vn.vq->knn.k_token_len);
 
     // Verify command modifications using dynamic validation
     char expectedK_str[32];

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -350,7 +350,7 @@ def test_shard_k_ratio_insufficient_docs():
         message=f"FT.HYBRID with SHARD_K_RATIO: expected {expected_result_count} results, got {total_count}")
 
 
-@skip(cluster=False)  # Bug only manifests on multi-shard via the coord modifier
+@skip(cluster=False)
 def test_debug_hybrid_with_shard_k_ratio():
     env = Env(moduleArgs='DEFAULT_DIALECT 2', enableDebugCommand=True)
 
@@ -372,7 +372,7 @@ def test_debug_hybrid_with_shard_k_ratio():
                   'VSIM', '@v', '$BLOB',
                     'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
                   'PARAMS', '2', 'BLOB', query_vec.tobytes(),
-                  'TIMEOUT_AFTER_N_TAIL', '1000000', 'DEBUG_PARAMS_COUNT', '2')
+                  'TIMEOUT_AFTER_N_SEARCH', '1000000', 'DEBUG_PARAMS_COUNT', '2')
 
     # Response format: ['total_results', N, 'results', [...], ...]
     actual_result_count = len(res[3])

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -348,3 +348,34 @@ def test_shard_k_ratio_insufficient_docs():
     env.assertEqual(
         total_count, expected_result_count,
         message=f"FT.HYBRID with SHARD_K_RATIO: expected {expected_result_count} results, got {total_count}")
+
+
+@skip(cluster=False)  # Bug only manifests on multi-shard via the coord modifier
+def test_debug_hybrid_with_shard_k_ratio():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', enableDebugCommand=True)
+
+    dim = 2
+    k = 6  # multiple of 3 shards so effectiveK is unambiguous
+    setup_basic_index(env, dim)
+
+    conn = getConnectionByEnv(env)
+    for i in range(1, 11):
+        vec = create_np_array_typed([float(i)] * dim)
+        conn.execute_command('HSET', f'doc{i}', 'v', vec.tobytes(), 't', 'some text')
+
+    query_vec = create_random_np_array_typed(dim, 'FLOAT32')
+    ratio = 0.5  # < 1.0, multi-shard => modifier path is active
+
+    # Use a non-matching SEARCH term so result count is driven solely by VSIM K.
+    res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx',
+                  'SEARCH', 'nonexistent_term_xyz',
+                  'VSIM', '@v', '$BLOB',
+                    'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
+                  'PARAMS', '2', 'BLOB', query_vec.tobytes(),
+                  'TIMEOUT_AFTER_N_TAIL', '1000000', 'DEBUG_PARAMS_COUNT', '2')
+
+    # Response format: ['total_results', N, 'results', [...], ...]
+    actual_result_count = len(res[3])
+    env.assertEqual(actual_result_count, k,
+                    message=f"_FT.DEBUG FT.HYBRID with SHARD_K_RATIO={ratio}, K={k}: "
+                            f"expected {k} results, got {actual_result_count}")

--- a/tests/pytests/test_shard_window_ratio.py
+++ b/tests/pytests/test_shard_window_ratio.py
@@ -260,3 +260,41 @@ def test_insufficient_docs_per_shard():
 
     res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args)
     env.assertEqual(len(res[1:]), expected_k)
+
+
+@skip(cluster=False)
+def test_debug_aggregate_with_shard_k_ratio():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', enableDebugCommand=True)
+
+    dim = 2
+    datatype = 'FLOAT32'
+    k = 30
+    # Use an index name long enough that, without the fix, the off-by-one
+    # MRCommand_ReplaceArgSubstring lands inside the index-name argument and
+    # corrupts it — the shards then reject the command with "no such index".
+    # The KNN query is `*=>[KNN 30 @v ...]`, so the K token sits at byte
+    # offset 8 in the query string. cmd->strs[index_name_pos] must therefore
+    # be at least len("30") + 8 = 10 bytes long.
+    index_name = 'long_index_name_for_regression_test'
+    num_docs = k * env.shardsCount * 3
+    set_up_database_with_vectors(env, dim, num_docs=num_docs,
+                                 index_name=index_name, datatype=datatype)
+
+    query_vec = create_random_np_array_typed(dim, datatype)
+    ratio = 0.5  # < 1.0, multi-shard => modifier path is active
+
+    query = f'*=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: {ratio}}}'
+
+    # TIMEOUT_AFTER_N with a count larger than any shard's processed result
+    # count keeps the query path fully functional while exercising the _FT.DEBUG
+    # wrapper.
+    res = env.cmd('_FT.DEBUG', 'FT.AGGREGATE', index_name, query,
+                  'PARAMS', 2, 'query_vec', query_vec.tobytes(),
+                  'LIMIT', 0, k + 1,
+                  'TIMEOUT_AFTER_N', '1000000', 'DEBUG_PARAMS_COUNT', '2')
+
+    actual_result_count = len(res[1:])
+    env.assertEqual(
+        actual_result_count, k,
+        message=f"_FT.DEBUG FT.AGGREGATE with SHARD_K_RATIO={ratio}, K={k}: "
+        f"expected {k} results, got {actual_result_count}")


### PR DESCRIPTION
This PR replaces #8456 
### Objective
The objective of these changes was to defer the calculus of `effectiveK` (used in the `SHARD_K_RATIO` optimization for KNN vector searches) to the IO thread. This is because the correct calculation depends on the exact cluster topology (number of participating shards) at the exact moment the command is dispatched, rather than an unsafe estimation from the coordinator's main thread.

### Summary of Changes
#### 1. FT.AGGREGATE (`src/coord/dist_aggregate.c`)
* **Before:** `buildMRCommand` synchronously called `GetNumShards_UnSafe()` to compute `effectiveK` and immediately mutated the `MRCommand` with the new K value.
* **After:** `buildMRCommand` no longer modifies K. Instead, it records the index of the K argument in the command. A new structure `AggregateKnnContext` holds a scalar snapshot of the KNN metadata the IO thread needs (`originalK`, `shardWindowRatio`, the K argument index, and the byte offset/length of the K token within the query string) — no borrowed `VectorQuery` pointer.
* `rpnetNext_Start` creates a wrapper `AggregateIteratorContext` and passes a new `MRCommandModifier` callback named `aggregateKnnCommandModifier` to `MR_IterateWithPrivateData`.
* When the IO thread starts processing, it invokes `aggregateKnnCommandModifier` with the **actual** `numShards` derived from the IO thread's exact topology snapshot. The callback computes `calculateEffectiveK` and edits the command before dispatching it to the shards.

#### 2. FT.HYBRID (`src/coord/hybrid/dist_hybrid.c` & `hybrid_cursor_mappings.c`)
* **Before:** `HybridRequest_buildMRCommand` computed `effectiveK` locally with a supplied `numShards` variable and changed the command.
* **After:** It just saves `kArgIndex` (the position of K in the command).
* `HybridRequest_executePlan` initializes a `HybridKnnContext` which is forwarded to `ProcessHybridCursorMappings`.
* A new `MRCommandModifier` callback `HybridKnnCommandModifier` is passed into `MR_IterateWithPrivateData`. Similar to the aggregate flow, the IO thread invokes this callback, calculates `effectiveK` securely using its locally-resolved `numShards`, and rewrites the command text using `MRCommand_ReplaceArg`.

#### 3. Topology State & Thread Safety (`src/coord/shard_barrier.c/h`)
* Extracted barrier logic into `shard_barrier.c/h`.
* Created a fundamental `ShardCountBarrier` that tracks `numShards` and `numResponded`.
* Using `shardCountBarrier_Init` on the IO thread, the coordinator's expectation of `numShards` is populated via `atomic_store` securely. This prevents the main thread from making race-condition guesses about how many shards are present.

#### 4. Testing Updates
* Adapted `test_cpp_hybrid_build_mr_cmd.cpp` to explicitly mock the IO thread callback (`HybridKnnCommandModifier`) to verify that the command mutates perfectly.
* Added new Python tests (`test_hybrid_timeout.py`) simulating delayed/blocking shards to verify that `ProcessHybridCursorMappings` cleanly respects timeouts waiting for barrier responses.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Deferring the effectiveK calculation to the IO thread


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed query dispatch and KNN command rewriting on cluster coordinators; incorrect indices or topology timing could affect result counts, though behavior is tightened to match dispatch-time shard count.
> 
> **Overview**
> **SHARD_K_RATIO** no longer rewrites K on the coordinator main thread using a guessed shard count. **FT.AGGREGATE** and **FT.HYBRID** now snapshot KNN metadata (query arg index, original **K**, ratio, token offset/length or VSIM **kArgIndex**) and apply **`calculateEffectiveK`** only when the map-reduce iterator starts on the **IO thread**, via a new **`MRCommandModifier`** hook in **`MR_IterateWithPrivateData`** (after live topology **`numShards`** is known).
> 
> For **FT.AGGREGATE**, **`buildMRCommand`** stops mutating the query string; **`rpnetNext_Start`** uses an **`AggregateIteratorContext`** that can hold both **WITHCOUNT** barrier state and optional KNN context, with **`aggregateKnnCommandModifier`** and a cursor callback that unwraps the barrier. **`_FT.DEBUG`** paths bump the saved query argument index when **`_FT.DEBUG`** is inserted at the front.
> 
> For **FT.HYBRID**, command build records **`kArgIndex`** only; **`HybridKnnApplyShardKRatio`** / **`HybridKnnCommandModifier`** run during **`ProcessHybridCursorMappings`**. Coordinator code no longer threads **`numShards`** from the main thread into **`HybridRequest_prepareForExecution`**.
> 
> **`modifyKNNCommand`** now takes explicit **originalK**, **effectiveK**, and byte positions (not a **`VectorQuery`** pointer), aligning aggregate KNN rewrites with substring replacement and fixing wrong-slot edits when arguments shift (e.g. long index names under **`_FT.DEBUG`**). **`ShardResponseBarrier`** moves to **`shard_barrier.c/h`** with a shared **`ShardCountBarrier`** base. **`MR_Iterate`** is removed; callers always pass a command modifier (or **NULL**). Tests cover the deferred modifier path and debug aggregate/hybrid regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d8cf97e3f6d6143f44088e231dd944ba4f6cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->