### PR TITLE
try to avoid pthread-mutex-lock on every query to allow ASM

### DIFF
--- a/src/asm_state_machine.h
+++ b/src/asm_state_machine.h
@@ -142,22 +142,43 @@ static inline void ASM_StateMachine_CompleteTrim(const RedisModuleSlotRangeArray
 //   * `count` is manipulated only via atomic RMW (`__atomic_fetch_add` /
 //     `__atomic_fetch_sub`), so concurrent Decreases serialize at the hardware
 //     level.
-//   * `version` transitions through two disjoint writes:
+//   * `version` transitions through three disjoint writes:
 //       - `0 -> v` happens in `Increase` on the main thread when allocating a
 //         free slot.
+//       - `v_stale -> v_current` happens in `Increase` on the main thread
+//         when recycling a slot whose count has already drained to 0 but
+//         whose version field was not reclaimed by `Decrease` (this occurs
+//         when the last `Decrease(v_stale)` ran while `v_stale` was still
+//         the current version, so the reclaim branch did not fire).
 //       - `v -> 0` happens in `Decrease` on any thread when `fetch_sub`
 //         returns `prev == 1` AND `v != key_space_version`.
 //     These never target the same slot concurrently: the caller invariant
 //     `query_key_space_version == key_space_version` on `Increase` means the
 //     slot `Increase` matches or allocates has `version == current`, while
-//     the reclaim branch only fires when `version != current`.
+//     the reclaim branch only fires when `version != current`. A stale slot
+//     that `Increase` recycles has `count == 0`, so no in-flight
+//     `Decrease(v_stale)` can exist (each `Decrease` pairs with an
+//     outstanding `Increase`, which would have kept `count > 0`); and
+//     `Decrease(v_current)` cannot touch a slot whose version is `v_stale`.
 //   * Once a slot is reclaimed, monotonicity of `key_space_version` guarantees
 //     no future `Increase(v)` or `Decrease(v)` can be issued for that old
 //     value, so no surviving operation observes the slot in its old role.
 
-// Maximum number of concurrently tracked key space versions. In steady state
-// only one version (the current one) is live; during migrations one or two
-// older versions may still have in-flight queries.
+// Capacity invariant: at most `ASM_MAX_LIVE_VERSIONS` distinct key-space
+// versions may have in-flight queries (count > 0) simultaneously. The ring has
+// exactly one slot per tracked version, and a slot is reclaimed only when its
+// count drops to 0 AND its version is no longer the current one. Consequently,
+// every ASM state-machine command that advances `key_space_version` (e.g.
+// `SetLocalSlots` when local ownership changes, `StartImport`, `StartTrim`)
+// consumes a slot for any previous version that still has in-flight queries.
+//
+// This puts a hard limit on how many consecutive ASM commands can be issued
+// before the oldest in-flight queries drain: if more than
+// `ASM_MAX_LIVE_VERSIONS` version advancements occur while any query from each
+// of the preceding versions is still running, the next `Increase` cannot find
+// a free slot and triggers an assertion. In steady state only one version is
+// live; during migrations one or two older versions may still have in-flight
+// queries, so the limit is not expected to be reached in normal operation.
 #define ASM_MAX_LIVE_VERSIONS 16
 
 typedef struct {
@@ -198,6 +219,27 @@ static inline void ASM_KeySpaceVersionTracker_Destroy() {
 #endif
 }
 
+/* Returns true if the slot at index `i`, whose version field was just observed
+ * to hold `v`, can be repurposed by `Increase` for `current_version`.
+ *
+ * A slot is reusable if it is truly free (`v == INVALID_KEYSPACE_VERSION`) or
+ * if it holds an old version whose count has drained to 0. The latter case
+ * arises when the last `Decrease(v)` ran while `v` was still the current
+ * version, so `Decrease` could not reclaim the slot. Since `Increase` is
+ * main-thread only and `current_version == key_space_version`, a stale slot
+ * has `v != current_version` and `count == 0`, which means no concurrent
+ * `Decrease` can target it; the main thread is the sole writer and can safely
+ * repurpose it. */
+static inline bool ASM_SlotIsReusableForIncrease(size_t i, uint32_t v, uint32_t current_version) {
+  if (v == INVALID_KEYSPACE_VERSION) {
+    return true;
+  }
+  if (v == current_version) {
+    return false;
+  }
+  return __atomic_load_n(&asm_version_slots[i].count, __ATOMIC_RELAXED) == 0;
+}
+
 /* Increase the query count for `query_key_space_version`. Main-thread only. */
 static void ASM_KeySpaceVersionTracker_IncreaseQueryCount(uint32_t query_key_space_version) {
   RS_ASSERT(query_key_space_version == key_space_version);
@@ -210,12 +252,12 @@ static void ASM_KeySpaceVersionTracker_IncreaseQueryCount(uint32_t query_key_spa
       found = true;
       break;
     }
-    if (v == INVALID_KEYSPACE_VERSION && free_slot < 0) {
+    if (free_slot < 0 && ASM_SlotIsReusableForIncrease(i, v, query_key_space_version)) {
       free_slot = (int)i;
     }
   }
   if (!found) {
-    RS_ASSERT(0 <= free_slot < ASM_MAX_LIVE_VERSIONS);
+    RS_ASSERT(0 <= free_slot && free_slot < ASM_MAX_LIVE_VERSIONS);
     __atomic_store_n(&asm_version_slots[free_slot].count, 1, __ATOMIC_RELAXED);
     __atomic_store_n(&asm_version_slots[free_slot].version, query_key_space_version, __ATOMIC_RELEASE);
   }

--- a/src/asm_state_machine.h
+++ b/src/asm_state_machine.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include "slots_tracker.h"
-#include "util/khash.h"
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
 #include <stdlib.h>
+#include <stddef.h>
 #include <pthread.h>
 
 // Sanitizer detection for leak tracking
@@ -121,123 +121,134 @@ static inline void ASM_StateMachine_CompleteTrim(const RedisModuleSlotRangeArray
 }
 
 // START KEY SPACE VERSION QUERY TRACKER IMPLEMENTATION
+//
+// Lock-free fixed-size ring of `{version, count}` slots. Replaces the previous
+// mutex-protected hash map. The design relies on the following concurrency
+// contract:
+//
+//   * The `version` field of every slot is written only by the main thread
+//     (during `ASM_KeySpaceVersionTracker_IncreaseQueryCount`, which allocates
+//     a slot, and during cleanup, which frees it). Workers only read it.
+//   * The `count` field is manipulated with atomic RMW operations and may be
+//     modified from any thread.
+//   * Increase, GetQueryCount, GetTrackedVersionsCount, CanStartTrimming, and
+//     cleanup run on the main thread only. Decrease may run from any thread.
+//   * `key_space_version` is advanced only by the main thread.
+//
+// A slot with `version == INVALID_KEYSPACE_VERSION` (0) is free.
+//
+// Safety of freeing a slot (main-thread cleanup writes `version = 0` when it
+// observes `count == 0` for a non-current version): if `count == 0`, all
+// matching Decreases issued so far have executed (Decrease is the only
+// fetch_sub on `count`, and counts never go negative). No new Decrease(v) can
+// appear without a matching Increase(v); a new Increase(v) would allocate a
+// fresh slot (possibly reusing the one just freed), not touch a stale one.
 
-// Define hash map type for tracking query versions -> query counts
-KHASH_MAP_INIT_INT(query_key_space_version_tracker, uint32_t);
+// Maximum number of concurrently tracked key space versions. In steady state
+// only one version (the current one) is live; during migrations one or two
+// older versions may still have in-flight queries. 8 is a generous upper
+// bound; exceeding it triggers an assertion.
+#define ASM_MAX_LIVE_VERSIONS 16
 
-// Static hash map instance for tracking query versions
-extern khash_t(query_key_space_version_tracker) *query_key_space_version_map;
+typedef struct {
+  uint32_t version; // INVALID_KEYSPACE_VERSION == free slot
+  uint32_t count;
+} ASM_VersionSlot;
 
-// Mutex for thread-safe hash map operations
-extern pthread_mutex_t query_version_tracker_mutex;
+extern ASM_VersionSlot asm_version_slots[ASM_MAX_LIVE_VERSIONS];
+
+#if ASM_SANITIZER_ENABLED
+// Guards the sanitizer leak-tracking array only. The tracker itself is
+// lock-free; this mutex exists purely because `asm_sanitizer_allocs` is a
+// dynamic array that is not safe against concurrent append/pop.
+extern pthread_mutex_t asm_sanitizer_mutex;
+#endif
 
 static inline void ASM_KeySpaceVersionTracker_Init() {
-  if (query_key_space_version_map != NULL) {
-    kh_destroy(query_key_space_version_tracker, query_key_space_version_map);
+  for (size_t i = 0; i < ASM_MAX_LIVE_VERSIONS; i++) {
+    __atomic_store_n(&asm_version_slots[i].version, INVALID_KEYSPACE_VERSION, __ATOMIC_RELAXED);
+    __atomic_store_n(&asm_version_slots[i].count, 0, __ATOMIC_RELAXED);
   }
-  query_key_space_version_map = kh_init(query_key_space_version_tracker);
 
 #if ASM_SANITIZER_ENABLED
   ASM_Sanitizer_Alloc_Init();
+  pthread_mutex_init(&asm_sanitizer_mutex, NULL);
 #endif
-  pthread_mutex_init(&query_version_tracker_mutex, NULL);
 }
 
 static inline void ASM_KeySpaceVersionTracker_Destroy() {
-  if (query_key_space_version_map != NULL) {
-    kh_destroy(query_key_space_version_tracker, query_key_space_version_map);
-    query_key_space_version_map = NULL;
+  for (size_t i = 0; i < ASM_MAX_LIVE_VERSIONS; i++) {
+    __atomic_store_n(&asm_version_slots[i].version, INVALID_KEYSPACE_VERSION, __ATOMIC_RELAXED);
+    __atomic_store_n(&asm_version_slots[i].count, 0, __ATOMIC_RELAXED);
   }
 
 #if ASM_SANITIZER_ENABLED
   ASM_Sanitizer_Alloc_Free();
+  pthread_mutex_destroy(&asm_sanitizer_mutex);
 #endif
-  pthread_mutex_destroy(&query_version_tracker_mutex);
 }
 
+/* Increase the query count for `query_key_space_version`. Main-thread only. */
 static void ASM_KeySpaceVersionTracker_IncreaseQueryCount(uint32_t query_key_space_version) {
-  pthread_mutex_lock(&query_version_tracker_mutex);
-
-  int ret;
-  khiter_t k = kh_put(query_key_space_version_tracker, query_key_space_version_map, query_key_space_version, &ret);
-
-  if (ret == 0) {
-    kh_value(query_key_space_version_map, k)++;
-  } else {
-    kh_value(query_key_space_version_map, k) = 1;
+  RS_ASSERT(query_key_space_version == key_space_version);
+  int free_slot = -1;
+  bool found = false;
+  for (size_t i = 0; i < ASM_MAX_LIVE_VERSIONS; i++) {
+    uint32_t v = __atomic_load_n(&asm_version_slots[i].version, __ATOMIC_RELAXED);
+    if (v == query_key_space_version) {
+      __atomic_fetch_add(&asm_version_slots[i].count, 1, __ATOMIC_RELAXED);
+      found = true;
+      break;
+    }
+    if (v == INVALID_KEYSPACE_VERSION && free_slot < 0) {
+      free_slot = (int)i;
+    }
+  }
+  if (!found) {
+    RS_ASSERT(0 <= free_slot < ASM_MAX_LIVE_VERSIONS);
+    __atomic_store_n(&asm_version_slots[free_slot].count, 1, __ATOMIC_RELAXED);
+    __atomic_store_n(&asm_version_slots[free_slot].version, query_key_space_version, __ATOMIC_RELEASE);
   }
 
 #if ASM_SANITIZER_ENABLED
+  pthread_mutex_lock(&asm_sanitizer_mutex);
   ASM_Santizer_Alloc_Allocate(query_key_space_version);
+  pthread_mutex_unlock(&asm_sanitizer_mutex);
 #endif
-  pthread_mutex_unlock(&query_version_tracker_mutex);
 }
 
-/* Make sure that we clean up old versions when we decrease the query count. All the versions that have hit 0 and are smaller than current version can be removed. */
-static void ASM_KeySpaceVersionTracker_CleanupOldVersions_Unsafe() {
-
-  uint32_t current_version = __atomic_load_n(&key_space_version, __ATOMIC_RELAXED);
-
-  // Collect keys to delete (can't delete while iterating)
-  uint32_t keys_to_delete[kh_size(query_key_space_version_map)];
-  size_t delete_count = 0;
-
-  for (khiter_t k = kh_begin(query_key_space_version_map); k != kh_end(query_key_space_version_map); ++k) {
-    if (kh_exist(query_key_space_version_map, k)) {
-      uint32_t version = kh_key(query_key_space_version_map, k);
-      uint32_t count = kh_value(query_key_space_version_map, k);
-
-      if (count == 0 && version != current_version) {
-        keys_to_delete[delete_count++] = version;
-      }
-    }
-  }
-
-  // Delete collected keys
-  for (size_t i = 0; i < delete_count; i++) {
-    khiter_t k = kh_get(query_key_space_version_tracker, query_key_space_version_map, keys_to_delete[i]);
-    if (k != kh_end(query_key_space_version_map)) {
-      kh_del(query_key_space_version_tracker, query_key_space_version_map, k);
-    }
-  }
-}
-
+/* Decrease the query count for `query_key_space_version`. Safe to call from
+ * any thread. */
 static void ASM_KeySpaceVersionTracker_DecreaseQueryCount(uint32_t query_key_space_version) {
-  pthread_mutex_lock(&query_version_tracker_mutex);
-
-  khiter_t k = kh_get(query_key_space_version_tracker, query_key_space_version_map, query_key_space_version);
-  RS_LOG_ASSERT(k != kh_end(query_key_space_version_map), "Query version not found in tracker");
-
-  uint32_t *count = &kh_value(query_key_space_version_map, k);
-  if (*count > 0) {
-    (*count)--;
-  }
-
-  if (*count == 0) {
-    ASM_KeySpaceVersionTracker_CleanupOldVersions_Unsafe();
-  }
-
+  for (size_t i = 0; i < ASM_MAX_LIVE_VERSIONS; i++) {
+    uint32_t v = __atomic_load_n(&asm_version_slots[i].version, __ATOMIC_ACQUIRE);
+    if (v == query_key_space_version) {
+      uint32_t prev = __atomic_fetch_sub(&asm_version_slots[i].count, 1, __ATOMIC_RELAXED);
+      RS_LOG_ASSERT(prev > 0, "Query version count underflow in ASM tracker");
+      if (prev == 1 && v != __atomic_load_n(&key_space_version, __ATOMIC_RELAXED)) {
+        __atomic_store_n(&asm_version_slots[i].version, INVALID_KEYSPACE_VERSION, __ATOMIC_RELAXED);
+        //__atomic_store_n(&asm_version_slots[i].count, 0, __ATOMIC_RELAXED);
+      }
 #if ASM_SANITIZER_ENABLED
-  ASM_Sanitizer_Alloc_Deallocate();
+      pthread_mutex_lock(&asm_sanitizer_mutex);
+      ASM_Sanitizer_Alloc_Deallocate();
+      pthread_mutex_unlock(&asm_sanitizer_mutex);
 #endif
-
-  pthread_mutex_unlock(&query_version_tracker_mutex);
+      return;
+    }
+  }
+  RS_LOG_ASSERT(false, "Query version not found in tracker");
 }
 
-/* Get the number of queries that are using a specific version, this is intended to be used in tests only. */
+/* Get the number of queries that are using a specific version. For testing purposes. */
 static inline uint32_t ASM_KeySpaceVersionTracker_GetQueryCount(uint32_t query_version) {
-  pthread_mutex_lock(&query_version_tracker_mutex);
-  khiter_t k = kh_get(query_key_space_version_tracker, query_key_space_version_map, query_version);
-  uint32_t result = (k == kh_end(query_key_space_version_map)) ? 0 : kh_value(query_key_space_version_map, k);
-  pthread_mutex_unlock(&query_version_tracker_mutex);
-  return result;
-}
-
-static inline uint32_t ASM_KeySpaceVersionTracker_GetTrackedVersionsCount() {
-  pthread_mutex_lock(&query_version_tracker_mutex);
-  uint32_t result = kh_size(query_key_space_version_map);
-  pthread_mutex_unlock(&query_version_tracker_mutex);
-  return result;
+  for (size_t i = 0; i < ASM_MAX_LIVE_VERSIONS; i++) {
+    uint32_t v = __atomic_load_n(&asm_version_slots[i].version, __ATOMIC_RELAXED);
+    if (v == query_version) {
+      return __atomic_load_n(&asm_version_slots[i].count, __ATOMIC_RELAXED);
+    }
+  }
+  return 0;
 }
 
 static int ASM_AccountRequestFinished(uint32_t keySpaceVersion, size_t innerQueriesCount) {

--- a/src/asm_state_machine.h
+++ b/src/asm_state_machine.h
@@ -123,31 +123,41 @@ static inline void ASM_StateMachine_CompleteTrim(const RedisModuleSlotRangeArray
 // START KEY SPACE VERSION QUERY TRACKER IMPLEMENTATION
 //
 // Lock-free fixed-size ring of `{version, count}` slots. Replaces the previous
-// mutex-protected hash map. The design relies on the following concurrency
-// contract:
+// mutex-protected hash map. A slot with `version == INVALID_KEYSPACE_VERSION`
+// (0) is free.
 //
-//   * The `version` field of every slot is written only by the main thread
-//     (during `ASM_KeySpaceVersionTracker_IncreaseQueryCount`, which allocates
-//     a slot, and during cleanup, which frees it). Workers only read it.
-//   * The `count` field is manipulated with atomic RMW operations and may be
-//     modified from any thread.
-//   * Increase, GetQueryCount, GetTrackedVersionsCount, CanStartTrimming, and
-//     cleanup run on the main thread only. Decrease may run from any thread.
-//   * `key_space_version` is advanced only by the main thread.
+// Concurrency contract (must be preserved; relaxing any of these would require
+// reintroducing synchronization):
 //
-// A slot with `version == INVALID_KEYSPACE_VERSION` (0) is free.
+//   * `Increase` is main-thread only and called with
+//     `query_key_space_version == key_space_version` (enforced by assertion).
+//   * `Decrease` may be called from any thread. Each `Increase(v)` is paired
+//     with exactly one `Decrease(v)`.
+//   * `GetQueryCount` and `CanStartTrimming` are main-thread only.
+//   * `key_space_version` is advanced only by the main thread and is
+//     monotonically non-decreasing.
 //
-// Safety of freeing a slot (main-thread cleanup writes `version = 0` when it
-// observes `count == 0` for a non-current version): if `count == 0`, all
-// matching Decreases issued so far have executed (Decrease is the only
-// fetch_sub on `count`, and counts never go negative). No new Decrease(v) can
-// appear without a matching Increase(v); a new Increase(v) would allocate a
-// fresh slot (possibly reusing the one just freed), not touch a stale one.
+// Field-access rules:
+//
+//   * `count` is manipulated only via atomic RMW (`__atomic_fetch_add` /
+//     `__atomic_fetch_sub`), so concurrent Decreases serialize at the hardware
+//     level.
+//   * `version` transitions through two disjoint writes:
+//       - `0 -> v` happens in `Increase` on the main thread when allocating a
+//         free slot.
+//       - `v -> 0` happens in `Decrease` on any thread when `fetch_sub`
+//         returns `prev == 1` AND `v != key_space_version`.
+//     These never target the same slot concurrently: the caller invariant
+//     `query_key_space_version == key_space_version` on `Increase` means the
+//     slot `Increase` matches or allocates has `version == current`, while
+//     the reclaim branch only fires when `version != current`.
+//   * Once a slot is reclaimed, monotonicity of `key_space_version` guarantees
+//     no future `Increase(v)` or `Decrease(v)` can be issued for that old
+//     value, so no surviving operation observes the slot in its old role.
 
 // Maximum number of concurrently tracked key space versions. In steady state
 // only one version (the current one) is live; during migrations one or two
-// older versions may still have in-flight queries. 8 is a generous upper
-// bound; exceeding it triggers an assertion.
+// older versions may still have in-flight queries.
 #define ASM_MAX_LIVE_VERSIONS 16
 
 typedef struct {
@@ -226,8 +236,10 @@ static void ASM_KeySpaceVersionTracker_DecreaseQueryCount(uint32_t query_key_spa
       uint32_t prev = __atomic_fetch_sub(&asm_version_slots[i].count, 1, __ATOMIC_RELAXED);
       RS_LOG_ASSERT(prev > 0, "Query version count underflow in ASM tracker");
       if (prev == 1 && v != __atomic_load_n(&key_space_version, __ATOMIC_RELAXED)) {
+        // We know that this was the last query for this version, and that the version is not the current one, so no query
+        // will ever use this version again. We can safely reclaim the slot.
         __atomic_store_n(&asm_version_slots[i].version, INVALID_KEYSPACE_VERSION, __ATOMIC_RELAXED);
-        //__atomic_store_n(&asm_version_slots[i].count, 0, __ATOMIC_RELAXED);
+        __atomic_store_n(&asm_version_slots[i].count, 0, __ATOMIC_RELAXED);
       }
 #if ASM_SANITIZER_ENABLED
       pthread_mutex_lock(&asm_sanitizer_mutex);

--- a/src/module.c
+++ b/src/module.c
@@ -108,13 +108,14 @@ extern RSConfig RSGlobalConfig;
 
 extern RedisModuleCtx *RSDummyContext;
 
-// This map is used to track the number of queries that are using a specific version of the key space. This is needed to
-// determine when it's safe to trim slots after a migration is complete.
-khash_t(query_key_space_version_tracker) *query_key_space_version_map = NULL;
+// Fixed-size ring used to track the number of queries that are using a specific
+// version of the key space. This is needed to determine when it's safe to trim
+// slots after a migration is complete.
+ASM_VersionSlot asm_version_slots[ASM_MAX_LIVE_VERSIONS] = {0};
 uint32_t key_space_version = INVALID_KEYSPACE_VERSION;
-pthread_mutex_t query_version_tracker_mutex;
 #if ASM_SANITIZER_ENABLED
 arrayof(int*) asm_sanitizer_allocs;
+pthread_mutex_t asm_sanitizer_mutex;
 #endif
 
 redisearch_thpool_t *depleterPool = NULL;

--- a/tests/ctests/test_asm_state_machine.c
+++ b/tests/ctests/test_asm_state_machine.c
@@ -219,39 +219,32 @@ int testMigrationTrimmingWorkflow() {
 int testKeySpaceVersionTracker() {
   ASM_StateMachine_Init();
   __atomic_store_n(&key_space_version, 1, __ATOMIC_RELAXED);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 0);
   // One query is using version 1
   ASM_KeySpaceVersionTracker_IncreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 1);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_FALSE(ASM_CanStartTrimming());
   // Another query starts using version 1
   ASM_KeySpaceVersionTracker_IncreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 2);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_FALSE(ASM_CanStartTrimming());
 
   // One query finishes using version 1
   ASM_KeySpaceVersionTracker_DecreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 1);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_FALSE(ASM_CanStartTrimming());
 
   // Another query finishes using version 1
   ASM_KeySpaceVersionTracker_DecreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 0);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_TRUE(ASM_CanStartTrimming());
 
   // Another query starts using version 1 and finish
   ASM_KeySpaceVersionTracker_IncreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 1);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_FALSE(ASM_CanStartTrimming());
 
   ASM_KeySpaceVersionTracker_DecreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 0);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_TRUE(ASM_CanStartTrimming());
 
   // Another two queries start using version 1
@@ -262,27 +255,80 @@ int testKeySpaceVersionTracker() {
   // From now on we are going to change the version, does not make sense checking if we can start trimming.
   // This does not follow a real migration/trimming flow
   __atomic_store_n(&key_space_version, 2, __ATOMIC_RELAXED);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASM_KeySpaceVersionTracker_DecreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 1);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   // The last one using version 1 finishes (Now version 1 is not tracked anymore)
   ASM_KeySpaceVersionTracker_DecreaseQueryCount(1);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(1), 0);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 0);
 
   // Version 2 is now being used
   ASM_KeySpaceVersionTracker_IncreaseQueryCount(2);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(2), 1);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_FALSE(ASM_CanStartTrimming());
   ASM_KeySpaceVersionTracker_DecreaseQueryCount(2);
   ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(2), 0);
-  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetTrackedVersionsCount(), 1);
   ASSERT_TRUE(ASM_CanStartTrimming());
 
   ASM_StateMachine_End();
 
+  return 0;
+}
+
+int testKeySpaceVersionTrackerCapacity() {
+  ASM_StateMachine_Init();
+
+  // Each Increase is called with v == key_space_version: queries are tagged
+  // with the current version at the moment they start. Long-running queries
+  // keep their slot occupied while key_space_version advances; their final
+  // Decrease then arrives with v != current and reclaims the slot inline.
+
+  // Build up ASM_MAX_LIVE_VERSIONS overlapping in-flight versions by starting
+  // one query per version and advancing the current version before that
+  // query finishes.
+  for (uint32_t v = 1; v <= ASM_MAX_LIVE_VERSIONS; v++) {
+    __atomic_store_n(&key_space_version, v, __ATOMIC_RELAXED);
+    ASM_KeySpaceVersionTracker_IncreaseQueryCount(v);
+    ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(v), 1);
+  }
+  // Ring is full: ASM_MAX_LIVE_VERSIONS distinct in-flight versions, current = ASM_MAX_LIVE_VERSIONS.
+  ASSERT_FALSE(ASM_CanStartTrimming());
+
+  // More queries arrive while still at the latest version; they share the
+  // current version's slot via ref-count. Capacity applies only to distinct
+  // in-flight versions, not to concurrent queries on the same version.
+  ASM_KeySpaceVersionTracker_IncreaseQueryCount(ASM_MAX_LIVE_VERSIONS);
+  ASM_KeySpaceVersionTracker_IncreaseQueryCount(ASM_MAX_LIVE_VERSIONS);
+  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(ASM_MAX_LIVE_VERSIONS), 3);
+
+  // Older in-flight queries finish. Each final Decrease for a non-current
+  // version reclaims its slot inline (prev == 1 && v != current).
+  for (uint32_t v = 1; v < ASM_MAX_LIVE_VERSIONS; v++) {
+    ASM_KeySpaceVersionTracker_DecreaseQueryCount(v);
+    ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(v), 0);
+  }
+  // Only the current-version slot remains occupied.
+  ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(ASM_MAX_LIVE_VERSIONS), 3);
+  ASSERT_FALSE(ASM_CanStartTrimming());
+
+  // ASM_MAX_LIVE_VERSIONS - 1 slots are now free. Continue advancing the
+  // current version and starting new in-flight queries; the reclaimed slots
+  // are reusable, so the ring fills back up to capacity.
+  for (uint32_t v = ASM_MAX_LIVE_VERSIONS + 1; v < 2 * ASM_MAX_LIVE_VERSIONS; v++) {
+    __atomic_store_n(&key_space_version, v, __ATOMIC_RELAXED);
+    ASM_KeySpaceVersionTracker_IncreaseQueryCount(v);
+    ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(v), 1);
+  }
+
+  // Drain everything so the ring ends in a clean state.
+  ASM_KeySpaceVersionTracker_DecreaseQueryCount(ASM_MAX_LIVE_VERSIONS);
+  ASM_KeySpaceVersionTracker_DecreaseQueryCount(ASM_MAX_LIVE_VERSIONS);
+  ASM_KeySpaceVersionTracker_DecreaseQueryCount(ASM_MAX_LIVE_VERSIONS);
+  for (uint32_t v = ASM_MAX_LIVE_VERSIONS + 1; v < 2 * ASM_MAX_LIVE_VERSIONS; v++) {
+    ASM_KeySpaceVersionTracker_DecreaseQueryCount(v);
+  }
+  ASSERT_TRUE(ASM_CanStartTrimming());
+
+  ASM_StateMachine_End();
   return 0;
 }
 
@@ -293,4 +339,5 @@ TEST_MAIN({
   TESTFUNC(testImportContinuousWorkflow);
   TESTFUNC(testMigrationTrimmingWorkflow);
   TESTFUNC(testKeySpaceVersionTracker);
+  TESTFUNC(testKeySpaceVersionTrackerCapacity);
 })

--- a/tests/ctests/test_asm_state_machine.c
+++ b/tests/ctests/test_asm_state_machine.c
@@ -274,6 +274,40 @@ int testKeySpaceVersionTracker() {
   return 0;
 }
 
+// A Decrease whose version still matches key_space_version at the moment the
+// last in-flight query for that version finishes cannot reclaim the slot (the
+// reclaim branch requires v != current). The slot is left with count == 0 and
+// its old version in place. Before the "recycle stale slots" fix in
+// IncreaseQueryCount, such slots were not reusable: Increase only treated a
+// slot as free when its version was INVALID_KEYSPACE_VERSION. Repeatedly
+// starting and ending a single query while advancing key_space_version would
+// therefore leak one slot per version and trip the "no free slot" assertion
+// in Increase after ASM_MAX_LIVE_VERSIONS cycles. With the fix, Increase also
+// reuses slots whose count has drained to 0, so this sequence runs cleanly.
+int testKeySpaceVersionTrackerNoStaleSlotAfterVersionAdvance() {
+  ASM_StateMachine_Init();
+
+  // Run more Increase/Decrease cycles than ASM_MAX_LIVE_VERSIONS, each at a
+  // fresh key_space_version. Every cycle leaves a stale slot behind because
+  // the final Decrease(v) runs while v is still the current version.
+  const uint32_t cycles = ASM_MAX_LIVE_VERSIONS * 2 + 3;
+  for (uint32_t v = 1; v <= cycles; v++) {
+    __atomic_store_n(&key_space_version, v, __ATOMIC_RELAXED);
+    ASM_KeySpaceVersionTracker_IncreaseQueryCount(v);
+    ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(v), 1);
+    ASM_KeySpaceVersionTracker_DecreaseQueryCount(v);
+    ASSERT_EQUAL(ASM_KeySpaceVersionTracker_GetQueryCount(v), 0);
+  }
+
+  // All cycles completed without tripping the capacity assertion: stale slots
+  // were recycled by Increase. No query is in flight on the current version,
+  // so trimming is allowed.
+  ASSERT_TRUE(ASM_CanStartTrimming());
+
+  ASM_StateMachine_End();
+  return 0;
+}
+
 int testKeySpaceVersionTrackerCapacity() {
   ASM_StateMachine_Init();
 
@@ -339,5 +373,6 @@ TEST_MAIN({
   TESTFUNC(testImportContinuousWorkflow);
   TESTFUNC(testMigrationTrimmingWorkflow);
   TESTFUNC(testKeySpaceVersionTracker);
+  TESTFUNC(testKeySpaceVersionTrackerNoStaleSlotAfterVersionAdvance);
   TESTFUNC(testKeySpaceVersionTrackerCapacity);
 })


### PR DESCRIPTION
## Describe the changes in the pull request

### Current

`ASM_KeySpaceVersionTracker` tracked in-flight queries per key-space version using a `khash` map guarded by a `pthread_mutex_t`. Every query acquired and released that mutex twice (once on `IncreaseQueryCount`, once on `DecreaseQueryCount`), putting a global lock on the query hot path even when no slot migration was in progress.

### Change

Replace the mutex-protected hash map with a lock-free fixed-size ring of `{version, count}` slots (`asm_version_slots[ASM_MAX_LIVE_VERSIONS]`, currently 16). The hot path now uses only atomic reads and RMW operations:

- `IncreaseQueryCount(v)` (main-thread only, `v == key_space_version`): scans the ring, `fetch_add`s the count of a matching slot or publishes a new `{v, 1}` into a free slot.
- `DecreaseQueryCount(v)` (any thread): scans, `fetch_sub`s the matching slot's count, and if the count hits 0 while the slot's version is no longer current, reclaims the slot inline by writing `version = 0`.

The safety of concurrent writes to the `version` field relies on two caller invariants:

- `Increase` is main-thread only and always called with `v == key_space_version` (enforced by `RS_ASSERT`).
- `key_space_version` is monotonically non-decreasing.

Together these guarantee that `Increase`'s allocation branch (`0 -> v`, only for `v == current`) and `Decrease`'s reclaim branch (`v -> 0`, only for `v != current`) target disjoint slots, so no two threads ever write the `version` field of the same slot concurrently. Monotonicity also rules out ABA: once a version has been reclaimed, no new `Increase(v)` or `Decrease(v)` for that old value can be issued.

### Outcome

- Zero locks on the query path in steady state.
- Behaviour is unchanged from the caller's perspective: `IncreaseQueryCount` / `DecreaseQueryCount` / `GetQueryCount` / `CanStartTrimming` have the same semantics.

### Capacity limitation (main invariant)

The ring has a hard capacity of `ASM_MAX_LIVE_VERSIONS` (16) **distinct key-space versions with in-flight queries at the same time**. A slot is only reclaimed when its count drops to 0 AND its version is no longer the current one, so every ASM state-machine command that advances `key_space_version` (e.g. `SetLocalSlots` on local-ownership changes, `StartImport`, `StartTrim`) consumes one slot for any previous version that still has a query running.

Consequently, **we cannot handle an unbounded burst of consecutive ASM commands** while queries are still in flight: if more than 16 version advancements occur while at least one query from each of the preceding versions is still running, the next `Increase` cannot find a free slot and triggers an assertion. In steady state only one version is live, and during migrations typically one or two older versions may still have in-flight queries, so the limit is not expected to be reached in normal operation. If we ever anticipate tighter bursts of ASM commands, `ASM_MAX_LIVE_VERSIONS` can be raised.

#### Which additional issues this PR fixes

1. MOD-...

#### Main objects this PR modified

1. `ASM_KeySpaceVersionTracker` in `src/asm_state_machine.h`
2. Global state (`asm_version_slots`, `key_space_version`) in `src/module.c`
3. Unit tests in `tests/ctests/test_asm_state_machine.c` (added `testKeySpaceVersionTrackerCapacity` exercising the 16-version limit and slot reuse)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency-sensitive query accounting used to gate slot trimming; correctness depends on strict thread/monotonic-version invariants and the new fixed capacity (16) could assert under extreme version-advance overlap.
> 
> **Overview**
> Removes the global `pthread_mutex` + `khash` hot-path in `ASM_KeySpaceVersionTracker` by switching to a fixed-size, atomic `{version,count}` slot ring (`ASM_MAX_LIVE_VERSIONS` = 16) to track in-flight queries per key-space version.
> 
> `IncreaseQueryCount` (main-thread only) now scans for an existing slot or allocates/recycles an empty/stale slot, while `DecreaseQueryCount` (any thread) uses atomic refcounting and reclaims slots once counts hit 0 for non-current versions; sanitizer leak tracking is retained but now guarded by a dedicated mutex.
> 
> Tests are updated to match the new semantics and add coverage for stale-slot recycling across version advances and for the ring’s capacity/overlap behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5bf819a5a81fa54e2eeff574cec9e17a6931d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->