### PR TITLE
[8.2] MOD-14268: Fix coordinator deadlock under mixed `FT.SEARCH + FT.AGGREGATE` load

### DIFF
--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -223,3 +223,12 @@ int ConcurrentSearch_resume() {
   redisearch_thpool_resume_threads(threadpools_g[0]);
   return REDISMODULE_OK;
 }
+
+thpool_stats ConcurrentSearch_getStats() {
+  thpool_stats stats = {0};
+  if (!threadpools_g) {
+    return stats;
+  }
+  RS_LOG_ASSERT(array_len(threadpools_g) == 1, "assuming 1 ConcurrentSearch pool");
+  return redisearch_thpool_get_stats(threadpools_g[0]);
+}

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -168,6 +168,8 @@ int ConcurrentSearch_pause();
 
 int ConcurrentSearch_resume();
 
+thpool_stats ConcurrentSearch_getStats();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/param.h>
+#include <stdatomic.h>
 
 #include "hiredis/hiredis.h"
 #include "hiredis/async.h"
@@ -47,6 +48,7 @@ long long timeout_g = 5000; // unused value. will be set in MR_Init
 
 /* MapReduce context for a specific command's execution */
 typedef struct MRCtx {
+  _Atomic(int) refcount;
   int numReplied;
   int numExpected;
   int numErrored;
@@ -73,6 +75,7 @@ typedef struct MRCtx {
    * needs to unblock the client.
    */
   MRReduceFunc fn;
+  MRCtxFreePrivDataCB freePrivDataCB;
 } MRCtx;
 
 void MR_SetCoordinationStrategy(MRCtx *ctx, bool mastersOnly) {
@@ -81,7 +84,8 @@ void MR_SetCoordinationStrategy(MRCtx *ctx, bool mastersOnly) {
 
 /* Create a new MapReduce context */
 MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *privdata, int replyCap) {
-  MRCtx *ret = rm_malloc(sizeof(MRCtx));
+  MRCtx *ret = rm_calloc(1, sizeof(MRCtx));
+  atomic_init(&ret->refcount, 1);
   ret->numReplied = 0;
   ret->numErrored = 0;
   ret->numExpected = 0;
@@ -98,7 +102,14 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   return ret;
 }
 
-void MRCtx_Free(MRCtx *ctx) {
+void MRCtx_SetFreePrivDataCB(MRCtx *ctx, MRCtxFreePrivDataCB cb) {
+  ctx->freePrivDataCB = cb;
+}
+
+static void MRCtx_FreeInternal(MRCtx *ctx) {
+  if (ctx->freePrivDataCB) {
+    ctx->freePrivDataCB(ctx);
+  }
 
   MRCommand_Free(&ctx->cmd);
 
@@ -114,6 +125,22 @@ void MRCtx_Free(MRCtx *ctx) {
   rm_free(ctx);
 }
 
+void MRCtx_IncrRef(MRCtx *ctx) {
+  int refcount = atomic_fetch_add(&ctx->refcount, 1) + 1;
+  REFCOUNT_INCR_MSG("MRCtx_IncrRef", refcount);
+}
+
+void MRCtx_DecrRef(MRCtx *ctx) {
+  int prev_refcount = atomic_fetch_sub(&ctx->refcount, 1);
+  RS_ASSERT(prev_refcount > 0);
+
+  int refcount = prev_refcount - 1;
+  REFCOUNT_DECR_MSG("MRCtx_DecrRef", refcount);
+  if (refcount == 0) {
+    MRCtx_FreeInternal(ctx);
+  }
+}
+
 /* Get the user stored private data from the context */
 void *MRCtx_GetPrivData(struct MRCtx *ctx) {
   return ctx->privdata;
@@ -125,6 +152,10 @@ int MRCtx_GetNumReplied(struct MRCtx *ctx) {
 
 MRReply** MRCtx_GetReplies(struct MRCtx *ctx) {
   return ctx->replies;
+}
+
+void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc) {
+  ctx->bc = bc;
 }
 
 RedisModuleCtx *MRCtx_GetRedisCtx(struct MRCtx *ctx) {
@@ -148,10 +179,10 @@ bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
 }
 
 static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
-  MR_requestCompleted();
   if (p) {
     MRCtx *mc = p;
-    MRCtx_Free(mc);
+    /* RQ completion is owned by the libuv fanout-completion paths. */
+    MRCtx_DecrRef(mc);
   }
 }
 
@@ -170,7 +201,8 @@ static int unblockHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   return mc->reducer(mc, mc->numReplied, mc->replies);
 }
 
-/* The callback called from each fanout request to aggregate their replies */
+// If we've received the last reply, the fanout/network phase is complete.
+// Release the RQ slot here before unblocking or handing off to reduction.
 static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   MRCtx *ctx = privdata;
 
@@ -190,12 +222,17 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
     if (ctx->fn) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
+      // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
+      // before this libuv callback is scheduled again. Complete the RQ request
+      MR_requestCompleted();
     } else {
+      MR_requestCompleted();
       RedisModuleBlockedClient *bc = ctx->bc;
       RS_ASSERT(bc);
       RedisModule_BlockedClientMeasureTimeEnd(bc);
       RedisModule_UnblockClient(bc, ctx);
     }
+    MRCtx_DecrRef(ctx);
   }
 }
 
@@ -245,10 +282,13 @@ static void uvFanoutRequest(void *p) {
                               MRCtx_GetValidateConnections(mrctx));
 
   if (mrctx->numExpected == 0) {
+    // No shard command was sent, so fanoutCallback() will never fire.
+    MR_requestCompleted();
     RedisModuleBlockedClient *bc = mrctx->bc;
     RS_ASSERT(bc);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mrctx);
+    MRCtx_DecrRef(mrctx);
   }
 }
 
@@ -259,10 +299,13 @@ static void uvMapRequest(void *p) {
   mrctx->numExpected = (rc == REDIS_OK) ? 1 : 0;
 
   if (mrctx->numExpected == 0) {
+    // No shard command was sent, so fanoutCallback() will never fire.
+    MR_requestCompleted();
     RedisModuleBlockedClient *bc = mrctx->bc;
     RS_ASSERT(bc);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mrctx);
+    MRCtx_DecrRef(mrctx);
   }
 }
 
@@ -281,6 +324,7 @@ int MR_Fanout(struct MRCtx *mrctx, MRReduceFunc reducer, MRCommand cmd, bool blo
   }
   mrctx->reducer = reducer;
   mrctx->cmd = cmd;
+  MRCtx_IncrRef(mrctx);
   RQ_Push(rq_g, uvFanoutRequest, mrctx);
   return REDIS_OK;
 }
@@ -291,6 +335,7 @@ int MR_MapSingle(struct MRCtx *ctx, MRReduceFunc reducer, MRCommand cmd) {
   RS_ASSERT(!ctx->bc);
   ctx->bc = RedisModule_BlockClient(ctx->redisCtx, unblockHandler, timeoutHandler, freePrivDataCB, 0); // timeout_g);
   RedisModule_BlockedClientMeasureTimeStart(ctx->bc);
+  MRCtx_IncrRef(ctx);
   RQ_Push(rq_g, uvMapRequest, ctx);
   return REDIS_OK;
 }

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -27,6 +27,7 @@ void iterStartCb(void *p);
 
 /* Prototype for all reduce functions */
 typedef int (*MRReduceFunc)(struct MRCtx *ctx, int count, MRReply **replies);
+typedef void (*MRCtxFreePrivDataCB)(struct MRCtx *ctx);
 
 /* Fanout map - send the same command to all the shards, sending the collective
  * reply to the reducer callback */
@@ -69,9 +70,12 @@ RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx);
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn);
 void MR_requestCompleted();
 
+void MRCtx_IncrRef(struct MRCtx *ctx);
+void MRCtx_DecrRef(struct MRCtx *ctx);
+void MRCtx_SetFreePrivDataCB(struct MRCtx *ctx, MRCtxFreePrivDataCB cb);
 
-/* Free the MapReduce context */
-void MRCtx_Free(struct MRCtx *ctx);
+/* Set the blocked client for the context (used when MRCtx is created before blocking) */
+void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc);
 
 void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
 bool MRCtx_GetValidateConnections(struct MRCtx *ctx);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1471,7 +1471,7 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
 }
 
 /**
- * FT.DEBUG COORD_THREADS [PAUSE / RESUME ]
+ * FT.DEBUG COORD_THREADS [PAUSE / RESUME / IS_PAUSED / STATS]
  *
  */
 DEBUG_COMMAND(CoordThreadsSwitch) {
@@ -1494,6 +1494,13 @@ DEBUG_COMMAND(CoordThreadsSwitch) {
     }
   } else if (!strcasecmp(op, "is_paused")) {
     return RedisModule_ReplyWithLongLong(ctx, ConcurrentSearch_isPaused());
+  } else if (!strcasecmp(op, "stats")) {
+    thpool_stats stats = ConcurrentSearch_getStats();
+    START_POSTPONED_LEN_ARRAY(num_stats_fields);
+    REPLY_WITH_LONG_LONG("totalJobsDone", stats.total_jobs_done, ARRAY_LEN_VAR(num_stats_fields));
+    REPLY_WITH_LONG_LONG("totalPendingJobs", stats.total_pending_jobs, ARRAY_LEN_VAR(num_stats_fields));
+    END_POSTPONED_LEN_ARRAY(num_stats_fields);
+    return REDISMODULE_OK;
   } else {
     return RedisModule_ReplyWithError(ctx, "Invalid argument for 'COORD_THREADS' subcommand");
   }

--- a/src/module.c
+++ b/src/module.c
@@ -3462,7 +3462,7 @@ static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, struct MRCtx *m
   IndexSpec *sp = StrongRef_Get(strong_ref);
   if (!sp) {
     MRCommand_Free(cmd);
-    searchRequestCtx_Free(req);
+    // Don't free req here - DistSearchMRCtxFreePrivData will handle it via MRCtx cleanup
     QueryError_SetCode(status, QUERY_EDROPPEDBACKGROUND);
     bailOut(bc, status);
     return REDISMODULE_ERR;
@@ -4038,7 +4038,7 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
   req->coordQueueTime = handlerCtx->coordQueueTime;
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(base_argc, argv);
-  int rc = prepareCommand(&cmd, req, bc, protocol, argv, argc, handlerCtx->spec_ref, &status);
+  int rc = prepareCommand(&cmd, req, mrctx, protocol, argv, argc, handlerCtx->spec_ref, &status);
   if (!(rc == REDISMODULE_OK)) {
     return REDISMODULE_OK;
   }

--- a/src/module.c
+++ b/src/module.c
@@ -2857,9 +2857,11 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
 static void searchResultReducer_wrapper(void *mc_v) {
   struct MRCtx *mc = mc_v;
   searchResultReducer(mc, MRCtx_GetNumReplied(mc), MRCtx_GetReplies(mc));
+  MRCtx_DecrRef(mc);
 }
 
 static int searchResultReducer_background(struct MRCtx *mc, int count, MRReply **replies) {
+  MRCtx_IncrRef(mc);
   ConcurrentSearch_ThreadPoolRun(searchResultReducer_wrapper, mc, DIST_THREADPOOL);
   return REDISMODULE_OK;
 }
@@ -3007,17 +3009,12 @@ cleanup:
   }
 
   RedisModule_BlockedClientMeasureTimeEnd(bc);
+  // Reducer already replied — unblock with NULL to prevent
+  // DistSearchUnblockClient from double-replying.
   RedisModule_UnblockClient(bc, NULL);
   RedisModule_FreeThreadSafeContext(ctx);
-  // We could pass `mc` to the unblock function to perform the next 3 cleanup steps, but
-  // this way we free the memory from the background after the client is unblocked,
-  // which is a bit more efficient.
-  // The unblocking callback also replies with error if there was 0 replies from the shards,
-  // and since we already replied with error in this case (in the beginning of this function),
-  // we can't pass `mc` to the unblock function.
-  searchRequestCtx_Free(req);
-  MR_requestCompleted();
-  MRCtx_Free(mc);
+  // Compensate for DistSearchFreePrivData not receiving mc.
+  MRCtx_DecrRef(mc);
   return res;
 }
 
@@ -3392,17 +3389,24 @@ void sendRequiredFields(searchRequestCtx *req, MRCommand *cmd) {
 }
 
 static void bailOut(RedisModuleBlockedClient *bc, QueryError *status) {
+  struct MRCtx *mrctx = RedisModule_BlockClientGetPrivateData(bc);
   RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
   QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
   QueryError_ReplyAndClear(clientCtx, status);
   RedisModule_BlockedClientMeasureTimeEnd(bc);
+  // Unblock with NULL since we already replied. DistSearchUnblockClient will
+  // see NULL privdata and skip replying, avoiding a double-reply.
+  // Manually DecrRef mrctx to compensate for DistSearchFreePrivData not
+  // receiving it (it gets NULL and does nothing).
   RedisModule_UnblockClient(bc, NULL);
   RedisModule_FreeThreadSafeContext(clientCtx);
+  MRCtx_DecrRef(mrctx);
 }
 
-static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, RedisModuleBlockedClient *bc, int protocol,
+static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, struct MRCtx *mrctx, int protocol,
   RedisModuleString **argv, int argc, WeakRef spec_ref, QueryError *status) {
 
+  RedisModuleBlockedClient *bc = MRCtx_GetBlockedClient(mrctx);
   cmd->protocol = protocol;
 
   // Handle KNN with shard ratio optimization for both multi-shard and standalone
@@ -3486,37 +3490,23 @@ static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, RedisModuleBloc
   return REDISMODULE_OK;
 }
 
-static searchRequestCtx *createReq(RedisModuleString **argv, int argc, RedisModuleBlockedClient *bc, QueryError *status) {
-  searchRequestCtx *req = rscParseRequest(argv, argc, status);
-
-  if (!req) {
-    bailOut(bc, status);
-    return NULL;
-  }
-  return req;
-}
-
-int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
+int FlatSearchCommandHandler(struct MRCtx *mrctx, int protocol,
   RedisModuleString **argv, int argc, ConcurrentSearchHandlerCtx *handlerCtx) {
   QueryError status = {0};
 
-  searchRequestCtx *req = createReq(argv, argc, bc, &status);
-
-  if (!req) {
-    return REDISMODULE_OK;
-  }
+  // req was created on the main thread and set as mrctx privdata
+  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
+  RS_ASSERT(req);
 
   // Copy coordinator queue time for profile output
   req->coordQueueTime = handlerCtx->coordQueueTime;
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
-  int rc = prepareCommand(&cmd, req, bc, protocol, argv, argc, handlerCtx->spec_ref, &status);
+  int rc = prepareCommand(&cmd, req, mrctx, protocol, argv, argc, handlerCtx->spec_ref, &status);
   if (!(rc == REDISMODULE_OK)) {
     return REDISMODULE_OK;
   }
 
-  // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
-  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
   // FT.SEARCH coordinator should validate connections before sending the command to the cluster
   MRCtx_SetValidateConnections(mrctx, true);
 
@@ -3525,11 +3515,31 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   return REDISMODULE_OK;
 }
 
+static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
+  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
+  if (!req) {
+    return;
+  }
+  searchRequestCtx_Free(req);
+}
+
+// Free privdata callback for distributed search.
+// Called after the reply callback (or timeout callback) completes.
+// Releases only the blocked-client reference; MRCtx cleanup runs on the final release.
+static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
+  // UNUSED(ctx);
+  if (privdata) {
+    struct MRCtx *mrctx = privdata;
+    MRCtx_DecrRef(mrctx);
+  }
+}
+
 typedef struct SearchCmdCtx {
   RedisModuleString **argv;
   int argc;
   RedisModuleBlockedClient* bc;
   int protocol;
+  struct MRCtx *mrctx;
   ConcurrentSearchHandlerCtx handlerCtx;
 } SearchCmdCtx;
 
@@ -3538,27 +3548,25 @@ static void DistSearchCommandHandler(void* pd) {
   if (sCmdCtx->handlerCtx.isProfile) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
-  FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
+  FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
+  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }
 
-// If the client is unblocked with a private data, we have to free it.
-// This currently happens only when the client is unblocked without calling its reduce function,
-// because we expect 0 replies. This function handles this case as well.
+// Reply callback for the blocked client. Called when the client is unblocked.
+// The privdata passed to UnblockClient is the MRCtx. Cleanup is handled by
+// DistSearchFreePrivData (the free_privdata callback).
 static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  // Nothing to do here - the reducer already replied to the client.
+  // If no reducer ran (0 replies), we need to reply with an error.
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
-  if (mrctx) {
-    if (MRCtx_GetNumReplied(mrctx) == 0) {
-      // Can happen in a topology error, before or after we sent the command to the cluster
-      RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
-    }
-    searchRequestCtx_Free(MRCtx_GetPrivData(mrctx));
-    MR_requestCompleted();
-    MRCtx_Free(mrctx);
+  if (mrctx && MRCtx_GetNumReplied(mrctx) == 0) {
+    // Can happen in a topology error, before or after we sent the command to the cluster
+    RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
   }
   return REDISMODULE_OK;
 }
@@ -3609,12 +3617,42 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
+  QueryError parseStatus = {0};
+  int parse_argc = argc;
+  if (isDebug) {
+    AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &parseStatus);
+    if (QueryError_HasError(&parseStatus)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&parseStatus), 1, COORD_ERR_WARN);
+      return QueryError_ReplyAndClear(ctx, &parseStatus);
+    }
+    parse_argc = argc - (debug_params.debug_params_count + 2);
+  }
+
+  // Parse the search request on the main thread so both the standard and debug
+  // paths attach req to mrctx before dispatching to the worker thread.
+  searchRequestCtx *req = rscParseRequest(argv, parse_argc, &parseStatus);
+  if (!req) {
+    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&parseStatus), 1, COORD_ERR_WARN);
+    return QueryError_ReplyAndClear(ctx, &parseStatus);
+  }
+
+  // Create MRCtx on main thread with searchRequestCtx as privdata.
+  // NumShards is used as a hint for reply capacity - unsafe read is fine.
+  struct MRCtx *mrctx = MR_CreateCtx(ctx, NULL, req, NumShards);
+  MRCtx_SetFreePrivDataCB(mrctx, DistSearchMRCtxFreePrivData);
+
+  // Block client - MRCtx is set as privdata so unblock/free callbacks can access it
+  RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, DistSearchFreePrivData, 0);
+  MRCtx_SetBlockedClient(mrctx, bc);
+
+  // Set MRCtx as privdata for the blocked client
+  RedisModule_BlockClientSetPrivateData(bc, mrctx);
+
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->handlerCtx.spec_ref = StrongRef_Demote(spec_ref);
   sCmdCtx->handlerCtx.coordStartTime = coordInitialTime;
   sCmdCtx->handlerCtx.coordQueueTime = 0;
   sCmdCtx->handlerCtx.isProfile = isProfile;
-  RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, NULL, 0);
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
   for (size_t i = 0 ; i < argc ; ++i) {
     // We need to copy the argv because it will be freed in the callback (from another thread).
@@ -3622,8 +3660,10 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;
+  sCmdCtx->mrctx = mrctx;
   sCmdCtx->protocol = is_resp3(ctx) ? 3 : 2;
   RedisModule_BlockedClientMeasureTimeStart(bc);
+  MRCtx_IncrRef(mrctx);
 
   ConcurrentSearch_ThreadPoolRun(dist_callback, sCmdCtx, DIST_THREADPOOL);
 
@@ -3978,7 +4018,7 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
 }
 /* ======================= DEBUG ONLY ======================= */
 
-static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
+static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, ConcurrentSearchHandlerCtx *handlerCtx) {
   QueryError status = {0};
   AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
@@ -3990,11 +4030,9 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
 
   int debug_argv_count = debug_params.debug_params_count + 2;
   int base_argc = argc - debug_argv_count;
-  searchRequestCtx *req = createReq(argv, base_argc, bc, &status);
-
-  if (!req) {
-    return REDISMODULE_OK;
-  }
+  // req was created on the main thread and set as mrctx privdata before dispatch.
+  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
+  RS_ASSERT(req);
 
   // Copy coordinator queue time for profile output
   req->coordQueueTime = handlerCtx->coordQueueTime;
@@ -4013,7 +4051,6 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
     MRCommand_Append(&cmd, arg, n);
   }
 
-  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
   // FT.SEARCH coordinator should validate connections before sending the command to the cluster
   MRCtx_SetValidateConnections(mrctx, true);
 
@@ -4028,10 +4065,11 @@ static void DEBUG_DistSearchCommandHandler(void* pd) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
   // send argv not including the _FT.DEBUG
-  DEBUG_FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
+  DEBUG_FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
+  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -290,6 +290,19 @@ def getWorkersThpoolStats(env):
 def getWorkersThpoolNumThreads(env):
     return env.cmd(debug_cmd(), "WORKERS", "n_threads")
 
+def set_workers(env, workers):
+    """Set the worker thread count and verify that the change took effect."""
+    verify_command_OK_on_all_shards(env, config_cmd(), 'SET', 'WORKERS', workers)
+    env.assertEqual(getWorkersThpoolNumThreadsFromAllShards(env), [workers] * env.shardsCount)
+
+def getCoordThpoolStats(env):
+    return to_dict(env.cmd(debug_cmd(), "COORD_THREADS", "stats"))
+
+def getWorkersThpoolStatsFromAllShards(env):
+    return [getWorkersThpoolStatsFromShard(shard_conn) for shard_conn in env.getOSSMasterNodesConnectionList()]
+
+def getWorkersThpoolNumThreadsFromAllShards(env):
+    return [shard_conn.execute_command(debug_cmd(), "WORKERS", "n_threads") for shard_conn in env.getOSSMasterNodesConnectionList()]
 
 def getWorkersThpoolStatsFromShard(shard_conn):
     return to_dict(shard_conn.execute_command(debug_cmd(), "WORKERS", "stats"))

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -1,0 +1,219 @@
+from common import *
+import threading
+
+
+RQ_CAPACITY = 50  # CONN_PER_SHARD=1 and SEARCH_IO_THREADS=1 => 1 * PENDING_FACTOR(50)
+SHARD_COUNT = 3
+WORKER_COUNT = 3
+DOC_COUNT = 240
+
+# FT.SEARCH query and expected result
+search = ['FT.SEARCH', 'idx', 'searchable', 'LIMIT', 0, 3,
+          'SORTBY', 'price', 'DESC', 'NOCONTENT']
+expected_search_res = [240, 'doc:239', 'doc:238', 'doc:237']
+
+# FT.AGGREGATE query and expected result
+aggregate = ['FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', '@category',
+             'REDUCE', 'COUNT', '0', 'AS', 'count',
+             'SORTBY', 2, '@count', 'ASC']
+expected_aggregate_res = [
+                            3,
+                            ['category', 'books', 'count', '80'],
+                            ['category', 'food', 'count', '80'],
+                            ['category', 'electronics', 'count', '80']
+                        ]
+
+def _build_mixed_burst_commands():
+    # Intentionally build a 3:1 FT.SEARCH-to-FT.AGGREGATE prefix so the burst
+    # stays mixed while still driving the coordinator into the saturation region,
+    # then continue draining the aggregate-heavy tail.
+    return ([search] * 3 + [aggregate]) * 30 + [aggregate] * 120
+
+
+def _run_burst_command(env, command, exceptions, completed, lock):
+    try:
+        conn = getConnectionByEnv(env)
+        res = conn.execute_command(*command)
+        if command[0] == 'FT.SEARCH':
+            env.assertEqual(res, expected_search_res)
+        elif command[0] == 'FT.AGGREGATE':
+            env.assertEqual(res, expected_aggregate_res)
+    except Exception as exc:
+        with lock:
+            exceptions.append(f'{command}: {exc}')
+    finally:
+        with lock:
+            completed[0] += 1
+
+
+def _coordinator_reached_rq_limit(env, coord_initial_jobs_done, coord_initial_pending_jobs, completed):
+    stats = getCoordThpoolStats(env)
+    jobs_done_delta = stats['totalJobsDone'] - coord_initial_jobs_done
+    pending_jobs_delta = stats['totalPendingJobs'] - coord_initial_pending_jobs
+    done = jobs_done_delta >= RQ_CAPACITY or pending_jobs_delta >= RQ_CAPACITY
+    return done, {
+        'coord_stats': stats,
+        'jobs_done_delta': jobs_done_delta,
+        'pending_jobs_delta': pending_jobs_delta,
+        'completed': completed[0],
+    }
+
+
+def _shards_started_draining(env, shard_initial_jobs_done):
+    current = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+    done = all(cur > initial for cur, initial in zip(current, shard_initial_jobs_done))
+    return done, {'current_jobs_done': current, 'initial_jobs_done': shard_initial_jobs_done}
+
+
+def _burst_completed(commands, completed, exceptions):
+    return completed[0] == len(commands), {
+        'completed': completed[0],
+        'total': len(commands),
+        'exceptions': exceptions,
+    }
+
+
+def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pending_jobs,
+                       shard_initial_jobs_done, completed):
+    coord_current_stats = getCoordThpoolStats(env)
+    shard_current_jobs_done = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+    env.debugPrint('-' * 80, force=True)
+    env.debugPrint(
+        f'[{label}] '
+        f'coord_initial_jobs_done={coord_initial_jobs_done} '
+        f'coord_initial_pending_jobs={coord_initial_pending_jobs} '
+        f'shard_initial_jobs_done={shard_initial_jobs_done} '
+        f'coord_current_stats={coord_current_stats} '
+        f'shard_current_jobs_done={shard_current_jobs_done} '
+        f'completed={completed[0]}',
+        force=True,
+    )
+
+
+@skip(cluster=False)
+def test_search_and_aggregate_burst():
+    env = Env(
+        testName='Search and aggregate burst',
+        shardsCount=SHARD_COUNT,
+        enableDebugCommand=True,
+    )
+    verify_shard_init(env)
+    set_workers(env, WORKER_COUNT)
+    env.expect(config_cmd(), 'SET', 'CONN_PER_SHARD', '1').ok()
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'title', 'TEXT',
+               'body', 'TEXT',
+               'category', 'TAG',
+               'price', 'NUMERIC').ok()
+
+    categories = ['books', 'electronics', 'food']
+    for i in range(DOC_COUNT):
+        conn.execute_command(
+            'HSET', f'doc:{i}',
+            'title', f'document {i}',
+            'body', f'searchable body text {i}',
+            'category', categories[i % len(categories)],
+            'price', i,
+        )
+
+    waitForIndex(env, 'idx')
+
+    commands = _build_mixed_burst_commands()
+    exceptions = []
+    completed = [0]
+    lock = threading.Lock()
+    threads = []
+
+    coord_initial_stats = getCoordThpoolStats(env)
+    coord_initial_jobs_done = coord_initial_stats['totalJobsDone']
+    coord_initial_pending_jobs = coord_initial_stats['totalPendingJobs']
+    shard_initial_jobs_done = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+
+    _print_debug_stats(
+        'before_pause',
+        env,
+        coord_initial_jobs_done,
+        coord_initial_pending_jobs,
+        shard_initial_jobs_done,
+        completed,
+    )
+
+    verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'PAUSE')
+
+    try:
+        for i, command in enumerate(commands):
+            thread = threading.Thread(
+                target=_run_burst_command,
+                args=(env, command, exceptions, completed, lock),
+                name=f'search-and-aggregate-burst-query-{i}',
+                daemon=True,
+            )
+            thread.start()
+            threads.append(thread)
+
+        wait_for_condition(
+            lambda: _coordinator_reached_rq_limit(
+                env,
+                coord_initial_jobs_done,
+                coord_initial_pending_jobs,
+                completed,
+            ),
+            'Timeout waiting for coordinator to reach the RQ saturation threshold',
+            timeout=20,
+        )
+
+        # Happy-path handoff: once the coordinator is saturated, resume shard
+        # workers so the test can verify queued mixed requests start draining.
+        verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'RESUME')
+
+        wait_for_condition(
+            lambda: _shards_started_draining(env, shard_initial_jobs_done),
+            'Timeout waiting for shard workers to resume processing queued jobs',
+            timeout=20,
+        )
+
+        _print_debug_stats(
+            'after_shards_started_draining',
+            env,
+            coord_initial_jobs_done,
+            coord_initial_pending_jobs,
+            shard_initial_jobs_done,
+            completed,
+        )
+
+        wait_for_condition(
+            lambda: _burst_completed(commands, completed, exceptions),
+            'Timeout waiting for mixed FT.SEARCH/FT.AGGREGATE burst to drain',
+            timeout=15,
+        )
+
+        _print_debug_stats(
+            'after_burst_completed',
+            env,
+            coord_initial_jobs_done,
+            coord_initial_pending_jobs,
+            shard_initial_jobs_done,
+            completed,
+        )
+    # Best-effort cleanup: if the happy-path RESUME was skipped by a failure,
+    # try to leave shard workers runnable before joining the background threads.
+    finally:
+        try:
+            verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'RESUME')
+        except Exception:
+            pass
+        for thread in threads:
+            thread.join(timeout=1)
+
+    # Verify all burst queries completed successfully
+    env.assertEqual(exceptions, [],
+                    message=f'Background burst queries failed: {exceptions}')
+
+    # Verify Redis remains responsive after the burst
+    ping_result = env.cmd('PING')
+    env.assertTrue(ping_result in ['PONG', True],
+                   message='Coordinator should remain responsive after burst')
+    env.expect(*search).equal(expected_search_res)
+    env.expect(*aggregate).equal(expected_aggregate_res)


### PR DESCRIPTION
Backport #8774 to `8.2`

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed coordination lifecycle and threading (new atomic refcounting and request-completion ordering), so regressions could surface as leaks, double-unblocks, or stuck requests under load.
> 
> **Overview**
> Fixes a coordinator deadlock seen under mixed `FT.SEARCH` + `FT.AGGREGATE` burst traffic by making `MRCtx` lifetime and RQ-slot completion safe across async handoffs (atomic refcounting, deterministic `MR_requestCompleted()` timing, and adjusted unblock/free paths).
> 
> Adds `FT.DEBUG COORD_THREADS STATS` (via `ConcurrentSearch_getStats()`) and a new cluster pytest that saturates the coordinator queue while pausing/resuming shard workers to ensure the system drains without hanging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a5414ff0d1a4a298319c5c1228a059befa0ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->