### PR TITLE
[8.4] Fix `FT.PROFILE HYBRID` empty reply edge case - [MOD-14778]

### DIFF
--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -17,7 +17,6 @@
 #include "../rmutil/util.h"
 #include "reply_empty.h"
 #include "info/global_stats.h"
-#include "../profile/options.h"
 
 // Helper function that performs minimal parsing of query arguments to support sendChunk output
 static int shallow_parse_query_args(RedisModuleString **argv, int argc, AREQ *req) {
@@ -105,9 +104,7 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
     return ret;
 }
 
-// Empty reply for hybrid queries. Currently used during OOM conditions.
-// Creates QueryError with OOM warning and uses sendChunk_ReplyOnly_HybridEmptyResults.
-int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal) {
+int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal, bool isProfile) {
 
     QueryError status = QueryError_Default();
     QueryError_SetError(&status, errCode, NULL);
@@ -120,7 +117,15 @@ int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode,
     // Shards notify error by setting cursor id to 0
     if (internal) {
         RedisModule_Reply _coordInfoReply = RedisModule_NewReply(ctx), *coordInfoReply = &_coordInfoReply;
-        RedisModule_Reply_Map(coordInfoReply); // root {}
+
+        RedisModule_Reply_Map(coordInfoReply); // outer/root {}
+
+        if (isProfile) {
+            // Profile wrapping: open an outer map, then nest "Results" and "Profile"
+            // inside it, consistent with search/aggregate profile reply structure.
+            Profile_PrepareMapForReply(coordInfoReply); // opens "Results" map
+        }
+
         RedisModule_ReplyKV_LongLong(coordInfoReply, "SEARCH", 0);
         RedisModule_ReplyKV_LongLong(coordInfoReply, "VSIM", 0);
         RedisModule_ReplyKV_Array(coordInfoReply,"warnings"); // warnings []
@@ -129,14 +134,37 @@ int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode,
             RedisModule_Reply_SimpleString(coordInfoReply, QueryError_Strerror(QUERY_EOOM));
         }
         RedisModule_Reply_ArrayEnd(coordInfoReply); // ~warnings
-        RedisModule_Reply_MapEnd(coordInfoReply); // ~root
+
+        if (isProfile) {
+            RedisModule_Reply_MapEnd(coordInfoReply); // close "Results" map
+            Profile_PrintInFormat(coordInfoReply, NULL, NULL, NULL, NULL);
+        }
+
+        RedisModule_Reply_MapEnd(coordInfoReply); // close outer / root map
         RedisModule_EndReply(coordInfoReply);
         QueryError_ClearError(&status);
         return REDISMODULE_OK;
     }
 
     RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+
+    if (isProfile) {
+        // Profile wrapping: open outer map containing "Results" and "Profile" sections.
+        // sendChunk_ReplyOnly_HybridEmptyResults opens/closes its own map, so we use it
+        // directly as the value of the "Results" key.
+        RedisModule_Reply_Map(reply); // outer {}
+        if (reply->resp3) {
+            RedisModule_Reply_SimpleString(reply, "Results"); // key
+        }
+    }
+
     sendChunk_ReplyOnly_HybridEmptyResults(reply, &status);
+
+    if (isProfile) {
+        Profile_PrintInFormat(reply, NULL, NULL, NULL, NULL);
+        RedisModule_Reply_MapEnd(reply); // close outer map
+    }
+
     RedisModule_EndReply(reply);
     QueryError_ClearError(&status);
     return REDISMODULE_OK;

--- a/src/aggregate/reply_empty.h
+++ b/src/aggregate/reply_empty.h
@@ -24,10 +24,10 @@ int coord_search_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv
 // Requires command arguments to extract formatting requirements.
 int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, QueryErrorCode errCode);
 
-// Empty reply for hybrid queries.
-// Uses RESP3 map structure with proper hybrid result formatting.
-// Works for both coordinator and single-shard hybrid queries.
-int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal);
+// Empty reply for hybrid queries. Currently used during OOM conditions and pre-execution timeouts.
+// Creates QueryError with OOM/timeout warning and uses sendChunk_ReplyOnly_HybridEmptyResults.
+// When isProfile is true, wraps the reply with profile structure.
+int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal, bool isProfile);
 
 // Single-shard empty reply for SEARCH and AGGREGATE commands.
 // Handles both RESP2 and RESP3 with command-appropriate formatting.

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -668,7 +668,8 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     }
     // Assuming OOM policy is return since we didn't ignore the memory guardrail
     RS_ASSERT(RSGlobalConfig.requestConfigParams.oomPolicy == OomPolicy_Return);
-    return common_hybrid_query_reply_empty(ctx, QUERY_EOOM, internal);
+    return common_hybrid_query_reply_empty(ctx, QUERY_EOOM, internal,
+                                           profileOptions & EXEC_WITH_PROFILE);
   }
 
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
@@ -683,7 +684,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
   hybridRequest->profile = printHybridProfile;
-  hybridRequest->tailPipeline->qctx.isProfile = profileOptions != EXEC_NO_FLAGS;
+  hybridRequest->tailPipeline->qctx.isProfile = profileOptions & EXEC_WITH_PROFILE;
   StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
   HybridPipelineParams hybridParams = {0};
 

--- a/src/module.c
+++ b/src/module.c
@@ -3509,7 +3509,7 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                       struct ConcurrentCmdCtx *cmdCtx);
 
-int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isProfile) {
   if (NumShards == 0) {
     return RedisModule_ReplyWithError(ctx, CLUSTERDOWN_ERR);
   } else if (argc < 3) {
@@ -3525,7 +3525,7 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
     // Assuming OOM policy is return since we didn't ignore the memory guardrail
     RS_ASSERT(RSGlobalConfig.requestConfigParams.oomPolicy == OomPolicy_Return);
-    return common_hybrid_query_reply_empty(ctx, QUERY_EOOM, false);
+    return common_hybrid_query_reply_empty(ctx, QUERY_EOOM, false, isProfile);
   }
 
   // Coord callback
@@ -3558,6 +3558,10 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                &handlerCtx);
+}
+
+int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return DistHybridCommandInternal(ctx, argv, argc, false);
 }
 
 static void CursorCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, struct ConcurrentCmdCtx *cmdCtx) {
@@ -3978,7 +3982,7 @@ int ProfileCommandHandlerImp(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   } else if (RMUtil_ArgExists("AGGREGATE", argv, 3, 2)) {
     return DistAggregateCommandImp(ctx, argv, argc, isDebug);
   } else if (RMUtil_ArgExists("HYBRID", argv, 3, 2)) {
-    return DistHybridCommand(ctx, argv, argc);
+    return DistHybridCommandInternal(ctx, argv, argc, true);
   }
   return RedisModule_ReplyWithError(ctx, "No `SEARCH`, `AGGREGATE`, or `HYBRID` provided");
 }

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -92,6 +92,25 @@ def test_oom_verbosity_standalone():
     env.assertEqual(res['Results']['warning'][0], COORD_OOM_WARNING)
     res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*')
     env.assertEqual(res['Results']['warning'][0], COORD_OOM_WARNING)
+    # Check profile hybrid returns COORD_OOM_WARNING with correct profile structure
+    res = env.cmd('FT.PROFILE', 'idx', 'HYBRID', 'QUERY', 'SEARCH', '*', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', '1')
+    env.assertEqual(res['Results']['warnings'][0], COORD_OOM_WARNING)
+    env.assertContains('Profile', res)
+
+@skip(cluster=False)
+def test_oom_verbosity_cluster_hybrid_profile():
+    env = Env(shardsCount=3, protocol=3)
+
+    allShards_change_oom_policy(env, 'return')
+    _common_hybrid_cluster_test_scenario(env)
+    allShards_change_maxmemory_low(env)
+
+    query_vector = np.array([1.2, 0.2]).astype(np.float32).tobytes()
+    res = env.cmd('FT.PROFILE', 'idx', 'HYBRID', 'QUERY', 'SEARCH', '*', 'VSIM', '@embedding',
+                  '$BLOB', 'COMBINE', 'RRF', '2', 'WINDOW', '1000', 'PARAMS', '2', 'BLOB',
+                  query_vector)
+    env.assertEqual(res['Results']['warnings'][0], COORD_OOM_WARNING)
+    env.assertContains('Profile', res)
 
 
 class testOomClusterBehavior:


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #8959 to `8.4`

This pull request updates the handling of empty replies for hybrid queries, especially in cases of out-of-memory (OOM) and pre-execution timeouts, to support profiling output. The main change is that when profiling is active, the reply structure is wrapped with both "Results" and "Profile" sections, consistent with the behavior for other query types. The changes also propagate the profiling options throughout the codebase and add test coverage to ensure the correct reply structure for hybrid queries under profiling.

**Hybrid Query Reply Structure and Profiling Enhancements:**

* `common_hybrid_query_reply_empty` now accepts a `ProfileOptions` argument and wraps replies in a profile structure when profiling is active, ensuring hybrid queries produce consistent output with SEARCH and AGGREGATE when profiling is enabled. [[1]](diffhunk://#diff-6d90557796fc4ddb681ec6696658e94fdede7f8f4b1ef45448b8493dfaf35e22L109-R115) [[2]](diffhunk://#diff-6d90557796fc4ddb681ec6696658e94fdede7f8f4b1ef45448b8493dfaf35e22R128-R138) [[3]](diffhunk://#diff-6d90557796fc4ddb681ec6696658e94fdede7f8f4b1ef45448b8493dfaf35e22L136-R180)
* Updated function signatures and calls to pass `ProfileOptions` through all code paths that may generate empty hybrid query replies, including OOM and timeout conditions. [[1]](diffhunk://#diff-a7b2fa415ac4ec4848f47b4b9a0ec15d673a9227ac9e0e5d241b6e7f955e6772L30-R33) [[2]](diffhunk://#diff-a5ae6e09772f05e75d3df7d485af73ef13b65bb3815d0d6dfe359606a1fcd92aL93-R93) [[3]](diffhunk://#diff-a5ae6e09772f05e75d3df7d485af73ef13b65bb3815d0d6dfe359606a1fcd92aL1044-R1044) [[4]](diffhunk://#diff-6109c354d7e009093f811238069b581bcb9bdbfc638d7d089814031776801632L3686-R3686)

**Codebase Consistency and Maintenance:**

* Added missing include of `profile.h` and `options.h` where required to support new profiling logic. [[1]](diffhunk://#diff-6d90557796fc4ddb681ec6696658e94fdede7f8f4b1ef45448b8493dfaf35e22R21) [[2]](diffhunk://#diff-a7b2fa415ac4ec4848f47b4b9a0ec15d673a9227ac9e0e5d241b6e7f955e6772R17)

**Testing Improvements:**

* Added a test to verify that hybrid queries with profiling and pre-execution timeouts produce the correct reply structure, matching the behavior of SEARCH and AGGREGATE. [[1]](diffhunk://#diff-3b68d01149f0ea9a84d2ec8217ef447c879d58671ce5caa5c5e3518b92639508L364-R364) [[2]](diffhunk://#diff-3b68d01149f0ea9a84d2ec8217ef447c879d58671ce5caa5c5e3518b92639508R420-R429)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RESP3 reply shape for `FT.PROFILE HYBRID` in OOM/early-bailout paths, which could affect clients relying on the previous empty-reply structure. Scope is limited to hybrid empty replies and is covered by added standalone/cluster tests.
> 
> **Overview**
> **Release note:** Fixes an edge case where `FT.PROFILE HYBRID` could return an incorrectly shaped empty response during OOM (and other early-bailout) conditions.
> 
> Empty hybrid replies are now wrapped in the standard profiling envelope (`Results` + `Profile`) and profiling flags are propagated through standalone and distributed hybrid execution, with added tests to validate the warning and structure in both standalone and cluster modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9868375c63229227972c90cf59b0bd11f8878bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->