### PR TITLE
MOD-14381: Support Disk Obfuscation

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -532,6 +532,7 @@ bool getHideUserDataFromLogs() {
 
 void onUpdatedHideUserDataFromLogs(RedisModuleCtx *ctx) {
   RSGlobalConfig.hideUserDataFromLog = getHideUserDataFromLogs();
+  SearchDisk_SetLogObfuscation(RSGlobalConfig.hideUserDataFromLog);
   if (RSGlobalConfig.hideUserDataFromLog) {
     RedisModule_Log(ctx, "notice", "Hide user data from search logs is now enabled, "
                    "search entity names (such as indexes and fields) in the logs will now be obfuscated");

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -532,7 +532,7 @@ bool getHideUserDataFromLogs() {
 
 void onUpdatedHideUserDataFromLogs(RedisModuleCtx *ctx) {
   RSGlobalConfig.hideUserDataFromLog = getHideUserDataFromLogs();
-  SearchDisk_SetLogObfuscation(RSGlobalConfig.hideUserDataFromLog);
+  SearchDisk_UpdateLogObfuscation();
   if (RSGlobalConfig.hideUserDataFromLog) {
     RedisModule_Log(ctx, "notice", "Hide user data from search logs is now enabled, "
                    "search entity names (such as indexes and fields) in the logs will now be obfuscated");

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -60,7 +60,7 @@ bool SearchDisk_Initialize(RedisModuleCtx *ctx) {
   disk->basic.setThrottleCallbacks(VecSim_EnableThrottle, VecSim_DisableThrottle);
 
   // Pass the disk buffer percentage from config
-  disk_db = disk->basic.open(ctx, (int)RSGlobalConfig.diskBufferPercentage);
+  disk_db = disk->basic.open(ctx, (int)RSGlobalConfig.diskBufferPercentage, RSGlobalConfig.hideUserDataFromLog);
   bool disk_initialized = disk_db != NULL;
 
   if (!disk_initialized) {
@@ -133,9 +133,9 @@ RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const Hidden
     return disk->basic.openIndexSpec(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, deleteBeforeOpen);
 }
 
-void SearchDisk_SetLogObfuscation(bool enable) {
+void SearchDisk_UpdateLogObfuscation() {
     if (disk && disk_db) {
-        disk->basic.setLogObfuscation(disk_db, enable);
+        disk->basic.setLogObfuscation(disk_db, RSGlobalConfig.hideUserDataFromLog);
     }
 }
 

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -128,9 +128,15 @@ void SearchDisk_Close(RedisModuleCtx *ctx) {
 }
 
 // Basic API wrappers
-RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const char *indexName, size_t indexNameLen, DocumentType type, bool deleteBeforeOpen) {
+RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const HiddenString *indexName, const char *obfuscatedName, DocumentType type, bool deleteBeforeOpen) {
     RS_ASSERT(disk_db);
-    return disk->basic.openIndexSpec(ctx, disk_db, indexName, indexNameLen, type, deleteBeforeOpen);
+    return disk->basic.openIndexSpec(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, deleteBeforeOpen);
+}
+
+void SearchDisk_SetLogObfuscation(bool enable) {
+    if (disk && disk_db) {
+        disk->basic.setLogObfuscation(disk_db, enable);
+    }
 }
 
 void SearchDisk_MarkIndexForDeletion(RedisSearchDiskIndexSpec *index) {
@@ -164,12 +170,12 @@ RedisSearchDiskRdbState* SearchDisk_LoadRdbToTempObject(RedisModuleIO *rdb) {
 }
 
 RedisSearchDiskIndexSpec* SearchDisk_OpenIndexWithRdbState(RedisModuleCtx *ctx,
-                                                            const char *indexName,
-                                                            size_t indexNameLen,
+                                                            const HiddenString *indexName,  
+                                                            const char *obfuscatedName,
                                                             DocumentType type,
                                                             RedisSearchDiskRdbState *rdbState) {
   RS_ASSERT(disk && disk_db && indexName && rdbState);
-  return disk->basic.openIndexSpecWithRdbState(ctx, disk_db, indexName, indexNameLen, type, rdbState);
+  return disk->basic.openIndexSpecWithRdbState(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, rdbState);
 }
 
 void SearchDisk_FreeRdbState(RedisSearchDiskRdbState *rdbState) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -57,19 +57,26 @@ bool SearchDisk_RegisterBigModuleCallbacks(RedisModuleCtx *ctx);
  */
 void SearchDisk_Close(RedisModuleCtx *ctx);
 
+/**
+ * @brief Enable or disable obfuscation of index names and field names in Disk log output
+ *
+ * @param enable true to enable obfuscation, false to disable
+ */
+void SearchDisk_SetLogObfuscation(bool enable);
+
 // Basic API wrappers
 
 /**
  * @brief Open an index, **Important** must be called once and only once for every index
  * @param ctx Redis module context for BigModule APIs
  * @param indexName Name of the index to open
- * @param indexNameLen Length of the index name
+ * @param obfuscatedName Obfuscated name of the index (for logging)
  * @param type Document type
  * @param deleteBeforeOpen If true, delete any existing data before opening (used when loading
  *        without SST persistence to ensure stale data is cleared)
  * @return Pointer to the index, or NULL if it does not exist
  */
-RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const char *indexName, size_t indexNameLen, DocumentType type, bool deleteBeforeOpen);
+RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const HiddenString *indexName, const char *obfuscatedName, DocumentType type, bool deleteBeforeOpen);
 
 /**
  * @brief Mark an index for deletion, the index will be deleted from the disk only after SearchDisk_CloseIndex is called
@@ -136,14 +143,14 @@ RedisSearchDiskRdbState* SearchDisk_LoadRdbToTempObject(RedisModuleIO *rdb);
  *
 * @param ctx Redis module context for BigModule APIs
  * @param indexName Name of the index
- * @param indexNameLen Length of the index name
+ * @param obfuscatedName Obfuscated name of the index (for logging)
  * @param type Document type for this index
  * @param rdbState Temporary RDB state from SearchDisk_LoadRdbToTempObject (will be consumed)
  * @return Pointer to the created IndexSpec, or NULL on error
  */
 RedisSearchDiskIndexSpec* SearchDisk_OpenIndexWithRdbState(RedisModuleCtx *ctx,
-                                                            const char *indexName,
-                                                            size_t indexNameLen,
+                                                            const HiddenString *indexName,  
+                                                            const char *obfuscatedName,
                                                             DocumentType type,
                                                             RedisSearchDiskRdbState *rdbState);
 

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -58,11 +58,9 @@ bool SearchDisk_RegisterBigModuleCallbacks(RedisModuleCtx *ctx);
 void SearchDisk_Close(RedisModuleCtx *ctx);
 
 /**
- * @brief Enable or disable obfuscation of index names and field names in Disk log output
- *
- * @param enable true to enable obfuscation, false to disable
+ * @brief Update the log obfuscation setting for the search disk module
  */
-void SearchDisk_SetLogObfuscation(bool enable);
+void SearchDisk_UpdateLogObfuscation();
 
 // Basic API wrappers
 

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -54,9 +54,10 @@ typedef struct BasicDiskAPI {
    * @brief Open the disk storage context
    * @param ctx Redis module context
    * @param buffer_percentage Percentage of available memory to use for write buffer (0-100)
+   * @param logObfuscation true to enable obfuscation, false to disable
    * @return Pointer to the disk context, or NULL on error
    */
-  RedisSearchDisk *(*open)(RedisModuleCtx *ctx, int buffer_percentage);
+  RedisSearchDisk *(*open)(RedisModuleCtx *ctx, int buffer_percentage, bool logObfuscation);
   void (*close)(RedisModuleCtx *ctx, RedisSearchDisk *disk);
 
   /**

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -19,6 +19,9 @@ extern "C" {
 // Forward declarations to avoid circular dependencies
 typedef struct QueryIterator QueryIterator;
 
+// Forward declaration for HiddenString
+typedef struct HiddenString HiddenString;
+
 // Helper opaque types for the disk API
 typedef const void* RedisSearchDisk;
 typedef const void* RedisSearchDiskIndexSpec;
@@ -55,12 +58,21 @@ typedef struct BasicDiskAPI {
    */
   RedisSearchDisk *(*open)(RedisModuleCtx *ctx, int buffer_percentage);
   void (*close)(RedisModuleCtx *ctx, RedisSearchDisk *disk);
+
+  /**
+   * @brief Enable or disable obfuscation of index names and field names in Disk log output
+   * @param disk Pointer to the disk
+   * @param enable true to enable obfuscation, false to disable
+   */
+  void (*setLogObfuscation)(RedisSearchDisk *disk, bool enable);
+
   /**
    * @brief Open an index spec
    * @param ctx Redis module context for BigModule APIs (required for getting DB path)
    * @param disk Pointer to the disk
    * @param indexName Name of the index
-   * @param indexNameLen Length of the index name
+   * @param obfuscatedName Obfuscated name of the index (for logging)
+   * @param obfuscatedNameLen Length of the obfuscated name
    * @param type Document type
    * @param deleteBeforeOpen If true, delete any existing data before opening
    * @return Pointer to the index spec, or NULL on error
@@ -68,7 +80,7 @@ typedef struct BasicDiskAPI {
    * @note This opens the database but does NOT register it with Redis. Call registerIndex after this
    *       to register with BigModule APIs.
    */
-  RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisModuleCtx *ctx, RedisSearchDisk *disk, const char *indexName, size_t indexNameLen, DocumentType type, bool deleteBeforeOpen);
+  RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisModuleCtx *ctx, RedisSearchDisk *disk, const HiddenString *indexName, const char *obfuscatedName, size_t obfuscatedNameLen, DocumentType type, bool deleteBeforeOpen);
   /**
    * @brief Close an index spec
    * @param disk Pointer to the disk context (for cleanup of index metrics)
@@ -132,15 +144,17 @@ typedef struct BasicDiskAPI {
    *
    * @param disk Pointer to the disk context
    * @param indexName Name of the index
-   * @param indexNameLen Length of the index name
+   * @param obfuscatedName Obfuscated name of the index (for logging)
+   * @param obfuscatedNameLen Length of the obfuscated name
    * @param type Document type for this index
    * @param rdbState Temporary RDB state from loadRdbToTempObject (will be consumed)
    * @return Pointer to the created IndexSpec, or NULL on error
    */
   RedisSearchDiskIndexSpec *(*openIndexSpecWithRdbState)(RedisModuleCtx *ctx,
                                                           RedisSearchDisk *disk,
-                                                          const char *indexName,
-                                                          size_t indexNameLen,
+                                                          const HiddenString *indexName,
+                                                          const char *obfuscatedName,
+                                                          size_t obfuscatedNameLen,
                                                           DocumentType type,
                                                           RedisSearchDiskRdbState *rdbState);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1841,9 +1841,7 @@ StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const c
   spec->diskSpec = NULL;
   if (isSpecOnDisk(spec)) {
     RS_ASSERT(disk_db);
-    size_t len;
-    const char* name = HiddenString_GetUnsafe(spec->specName, &len);
-    spec->diskSpec = SearchDisk_OpenIndex(ctx, name, len, spec->rule->type, false);
+    spec->diskSpec = SearchDisk_OpenIndex(ctx, spec->specName, spec->obfuscatedName, spec->rule->type, false);
     RS_LOG_ASSERT(spec->diskSpec, "Failed to open disk spec")
     if (!spec->diskSpec) {
       QueryError_SetError(status, QUERY_ERROR_CODE_DISK_CREATION, "Could not open disk index");

--- a/src/spec.c
+++ b/src/spec.c
@@ -3444,16 +3444,13 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
   // Open the index on disk only if we are on Flex, and this is not a duplicate.
   if (isSpecOnDisk(sp) && !sp->isDuplicate) {
     RS_ASSERT(disk_db);
-    size_t len;
-    const char* name = HiddenString_GetUnsafe(sp->specName, &len);
-
     if (diskRdbState) {
       // Use the new API that applies the RDB state during index opening
-      sp->diskSpec = SearchDisk_OpenIndexWithRdbState(ctx, name, len, sp->rule->type, diskRdbState);
+      sp->diskSpec = SearchDisk_OpenIndexWithRdbState(ctx, sp->specName, sp->obfuscatedName, sp->rule->type, diskRdbState);
       diskRdbState = NULL; // Ownership transferred
     } else {
       // No RDB state (non-SST flow), just open the index normally
-      sp->diskSpec = SearchDisk_OpenIndex(ctx, name, len, sp->rule->type, false);
+      sp->diskSpec = SearchDisk_OpenIndex(ctx, sp->specName, sp->obfuscatedName, sp->rule->type, false);
     }
 
     IndexSpec_PopulateVectorDiskParams(sp);


### PR DESCRIPTION
Support disk obfuscation, 
- notifying disk when hide-user-data-from-logs is modified
- passing hidden string pointer and obfuscated index names to open APIs.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the SearchDisk API surface (`open`, `openIndexSpec*`) and how index names are passed/obfuscated, which could break disk backends or logging behavior if implementations aren’t updated consistently.
> 
> **Overview**
> Adds disk-level support for the `hide-user-data-from-log` setting by notifying the disk backend when the config changes (`SearchDisk_UpdateLogObfuscation`) and by passing the obfuscation flag into disk initialization.
> 
> Updates SearchDisk open APIs to take a `HiddenString*` plus a separate `obfuscatedName` for logging, and wires these new signatures through index creation and RDB-load paths so disk backends can log without exposing raw index names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915521c94d2bcdfdac77ac1457d6ab53130c84c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->