### PR TITLE
MOD-14814: Add key lookup for Map and Array collections (`RSValue`s)

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2902,6 +2902,7 @@ dependencies = [
  "redis_mock",
  "redisearch_rs",
  "thiserror",
+ "tracing",
  "triomphe",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -13,6 +13,7 @@ libc.workspace = true
 query_error.workspace = true
 workspace_hack.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 triomphe.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -59,9 +59,25 @@ impl Array {
     /// alternating keys and values. In RESP3 this same data arrives as a
     /// proper [`Map`], where [`Map::get`] can be used instead.
     ///
-    /// A trailing element in an odd-length array is silently ignored.
+    /// # Odd-length arrays
+    ///
+    /// An odd number of elements indicates malformed data. A warning is emitted
+    /// via `tracing` and a `debug_assert!` fires in debug builds. The trailing
+    /// element is ignored and the search proceeds over the well-formed prefix.
+    ///
     /// Non-string keys are skipped.
     pub fn map_get(&self, key: &[u8]) -> Option<&RsValue> {
+        debug_assert!(
+            self.len() % 2 == 0,
+            "map_get called on an odd-length array (len={}); trailing element will be ignored",
+            self.len()
+        );
+        if self.len() % 2 != 0 {
+            tracing::warn!(
+                len = self.len(),
+                "map_get called on an odd-length array; trailing element will be ignored"
+            );
+        }
         self.chunks(2).find_map(|pair| {
             let value = pair.get(1)?;
             (pair[0].as_str_bytes()? == key).then_some(&**value)

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -49,6 +49,26 @@ impl Map {
     }
 }
 
+impl Array {
+    /// Looks up a value by string key in a flat key-value array layout
+    /// (`[k1, v1, k2, v2, ...]`), returning a clone of the first matching
+    /// value or `None` if no match is found.
+    ///
+    /// This is needed because RESP2 does not have a native map type.
+    /// Map-like data (e.g. `extra_attributes`) is sent as a flat array of
+    /// alternating keys and values. In RESP3 this same data arrives as a
+    /// proper [`Map`], where [`Map::get`] can be used instead.
+    ///
+    /// A trailing element in an odd-length array is silently ignored.
+    /// Non-string keys are skipped.
+    pub fn map_get(&self, key: &[u8]) -> Option<SharedRsValue> {
+        self.chunks(2).find_map(|pair| {
+            let value = pair.get(1)?;
+            (pair[0].as_str_bytes()? == key).then_some(value.clone())
+        })
+    }
+}
+
 impl<T> Deref for Collection<T> {
     type Target = [T];
 

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -42,7 +42,7 @@ impl Map {
     /// Looks up a value by its string key bytes, returning a reference to the first
     /// matching [`RsValue`] or `None` if no match is found.
     ///
-    /// Non-string keys (e.g. [`RsValue::Number`](crate::RsValue::Number)) are skipped.
+    /// Non-string keys (e.g. [`RsValue::Number`]) are skipped.
     pub fn get(&self, key: &[u8]) -> Option<&RsValue> {
         self.iter()
             .find_map(|(k, v)| (k.as_str_bytes()? == key).then_some(&**v))
@@ -68,11 +68,11 @@ impl Array {
     /// Non-string keys are skipped.
     pub fn map_get(&self, key: &[u8]) -> Option<&RsValue> {
         debug_assert!(
-            self.len() % 2 == 0,
+            self.len().is_multiple_of(2),
             "map_get called on an odd-length array (len={}); trailing element will be ignored",
             self.len()
         );
-        if self.len() % 2 != 0 {
+        if !self.len().is_multiple_of(2) {
             tracing::warn!(
                 len = self.len(),
                 "map_get called on an odd-length array; trailing element will be ignored"

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -9,7 +9,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use crate::{RsValue, SharedRsValue};
+use crate::{RsValue, SharedRsValue, util::debug_assert_warn};
 
 pub type Array = Collection<SharedRsValue>;
 pub type Map = Collection<(SharedRsValue, SharedRsValue)>;
@@ -67,21 +67,14 @@ impl Array {
     ///
     /// Non-string keys are skipped.
     pub fn map_get(&self, key: &[u8]) -> Option<&RsValue> {
-        debug_assert!(
-            self.len().is_multiple_of(2),
-            "map_get called on an odd-length array (len={}); trailing element will be ignored",
-            self.len()
+        let (pairs, remainder) = self.as_chunks::<2>();
+        debug_assert_warn!(
+            remainder.is_empty(),
+            "map_get called on an odd-length array;"
         );
-        if !self.len().is_multiple_of(2) {
-            tracing::warn!(
-                len = self.len(),
-                "map_get called on an odd-length array; trailing element will be ignored"
-            );
-        }
-        self.chunks(2).find_map(|pair| {
-            let value = pair.get(1)?;
-            (pair[0].as_str_bytes()? == key).then_some(&**value)
-        })
+        pairs
+            .iter()
+            .find_map(|[k, v]| (k.as_str_bytes()? == key).then_some(&**v))
     }
 }
 

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -9,7 +9,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use crate::SharedRsValue;
+use crate::{RsValue, SharedRsValue};
 
 pub type Array = Collection<SharedRsValue>;
 pub type Map = Collection<(SharedRsValue, SharedRsValue)>;
@@ -39,20 +39,20 @@ impl<T> Collection<T> {
 }
 
 impl Map {
-    /// Looks up a value by its string key bytes, returning a clone of
-    /// the first matching [`SharedRsValue`] or `None` if no match is found.
+    /// Looks up a value by its string key bytes, returning a reference to the first
+    /// matching [`RsValue`] or `None` if no match is found.
     ///
     /// Non-string keys (e.g. [`RsValue::Number`](crate::RsValue::Number)) are skipped.
-    pub fn get(&self, key: &[u8]) -> Option<SharedRsValue> {
+    pub fn get(&self, key: &[u8]) -> Option<&RsValue> {
         self.iter()
-            .find_map(|(k, v)| (k.as_str_bytes()? == key).then(|| v.clone()))
+            .find_map(|(k, v)| (k.as_str_bytes()? == key).then_some(&**v))
     }
 }
 
 impl Array {
     /// Looks up a value by string key in a flat key-value array layout
-    /// (`[k1, v1, k2, v2, ...]`), returning a clone of the first matching
-    /// value or `None` if no match is found.
+    /// (`[k1, v1, k2, v2, ...]`), returning a reference to the first matching
+    /// [`RsValue`] or `None` if no match is found.
     ///
     /// This is needed because RESP2 does not have a native map type.
     /// Map-like data (e.g. `extra_attributes`) is sent as a flat array of
@@ -61,10 +61,10 @@ impl Array {
     ///
     /// A trailing element in an odd-length array is silently ignored.
     /// Non-string keys are skipped.
-    pub fn map_get(&self, key: &[u8]) -> Option<SharedRsValue> {
+    pub fn map_get(&self, key: &[u8]) -> Option<&RsValue> {
         self.chunks(2).find_map(|pair| {
             let value = pair.get(1)?;
-            (pair[0].as_str_bytes()? == key).then(|| value.clone())
+            (pair[0].as_str_bytes()? == key).then_some(&**value)
         })
     }
 }

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -45,7 +45,7 @@ impl Map {
     /// Non-string keys (e.g. [`RsValue::Number`](crate::RsValue::Number)) are skipped.
     pub fn get(&self, key: &[u8]) -> Option<SharedRsValue> {
         self.iter()
-            .find_map(|(k, v)| (k.as_str_bytes()? == key).then_some(v.clone()))
+            .find_map(|(k, v)| (k.as_str_bytes()? == key).then(|| v.clone()))
     }
 }
 
@@ -64,7 +64,7 @@ impl Array {
     pub fn map_get(&self, key: &[u8]) -> Option<SharedRsValue> {
         self.chunks(2).find_map(|pair| {
             let value = pair.get(1)?;
-            (pair[0].as_str_bytes()? == key).then_some(value.clone())
+            (pair[0].as_str_bytes()? == key).then(|| value.clone())
         })
     }
 }

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -38,6 +38,17 @@ impl<T> Collection<T> {
     }
 }
 
+impl Map {
+    /// Looks up a value by its string key bytes, returning a clone of
+    /// the first matching [`SharedRsValue`] or `None` if no match is found.
+    ///
+    /// Non-string keys (e.g. [`RsValue::Number`](crate::RsValue::Number)) are skipped.
+    pub fn get(&self, key: &[u8]) -> Option<SharedRsValue> {
+        self.iter()
+            .find_map(|(k, v)| (k.as_str_bytes()? == key).then_some(v.clone()))
+    }
+}
+
 impl<T> Deref for Collection<T> {
     type Target = [T];
 

--- a/src/redisearch_rs/value/src/util.rs
+++ b/src/redisearch_rs/value/src/util.rs
@@ -20,11 +20,11 @@ use std::ffi::c_char;
 ///
 /// # Example
 ///
-/// ```rust
-/// use value::util::debug_assert_warn;
-///
+/// ```text
 /// debug_assert_warn!(items.len() % 2 == 0, "odd-length array");
 /// ```
+///
+/// See the `tests::example` unit test for a runnable demonstration.
 macro_rules! debug_assert_warn {
     ($cond:expr, $($arg:tt)+) => {{
         let ok = $cond;
@@ -77,4 +77,13 @@ pub fn num_to_str(num: f64, buf: &mut [u8; 32]) -> usize {
     }
 
     result as usize
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn example() {
+        let items: &[u8] = &[0, 1];
+        super::debug_assert_warn!(items.len() % 2 == 0, "odd-length array");
+    }
 }

--- a/src/redisearch_rs/value/src/util.rs
+++ b/src/redisearch_rs/value/src/util.rs
@@ -10,6 +10,32 @@
 use libc::snprintf;
 use std::ffi::c_char;
 
+/// Fires a [`debug_assert`] and emits a [`tracing::warn`] when `$cond` is `false`.
+///
+/// In debug builds the process panics immediately on violation; in release builds the
+/// warning is still surfaced at runtime without aborting.
+///
+/// The message tokens are forwarded verbatim to both macros, so structured
+/// [`tracing`] fields (e.g. `field = value, "message"`) work as usual.
+///
+/// # Example
+///
+/// ```rust
+/// use value::util::debug_assert_warn;
+///
+/// debug_assert_warn!(items.len() % 2 == 0, "odd-length array");
+/// ```
+macro_rules! debug_assert_warn {
+    ($cond:expr, $($arg:tt)+) => {{
+        let ok = $cond;
+        debug_assert!(ok, $($arg)+);
+        if !ok {
+            tracing::warn!($($arg)+);
+        }
+    }};
+}
+pub(crate) use debug_assert_warn;
+
 /// Converts a string into a float, returning `None` if it failed.
 pub fn str_to_float(input: &[u8]) -> Option<f64> {
     std::str::from_utf8(input).ok()?.parse::<f64>().ok()

--- a/src/redisearch_rs/value/tests/integration/collection.rs
+++ b/src/redisearch_rs/value/tests/integration/collection.rs
@@ -7,61 +7,100 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use value::{Map, SharedRsValue};
+use value::{Array, Map, SharedRsValue};
 
-fn make_string_key_value(key: &str, num: f64) -> (SharedRsValue, SharedRsValue) {
-    (
-        SharedRsValue::new_string(key.as_bytes().to_vec()),
-        SharedRsValue::new_num(num),
-    )
+fn make_map(pairs: &[(&str, f64)]) -> Map {
+    let entries: Vec<_> = pairs
+        .iter()
+        .map(|(k, v)| {
+            (
+                SharedRsValue::new_string(k.as_bytes().to_vec()),
+                SharedRsValue::new_num(*v),
+            )
+        })
+        .collect();
+    Map::new(entries.into_boxed_slice())
+}
+
+fn make_flat_map_array(pairs: &[(&str, f64)]) -> Array {
+    let elements: Vec<SharedRsValue> = pairs
+        .iter()
+        .flat_map(|(k, v)| {
+            [
+                SharedRsValue::new_string(k.as_bytes().to_vec()),
+                SharedRsValue::new_num(*v),
+            ]
+        })
+        .collect();
+    Array::new(elements.into_boxed_slice())
+}
+
+fn assert_get(map: &Map, arr: &Array, key: &[u8], expected: Option<f64>) {
+    assert_eq!(map.get(key).map(|v| v.as_num().unwrap()), expected);
+    assert_eq!(arr.map_get(key).map(|v| v.as_num().unwrap()), expected);
+}
+
+// -- Shared scenarios: Map::get and Array::map_get behave identically --
+
+#[test]
+fn found_key() {
+    let map = make_map(&[("price", 9.99), ("quantity", 3.0)]);
+    let arr = make_flat_map_array(&[("price", 9.99), ("quantity", 3.0)]);
+
+    assert_get(&map, &arr, b"price", Some(9.99));
+    assert_get(&map, &arr, b"quantity", Some(3.0));
 }
 
 #[test]
-fn map_get_found_key() {
-    let map = Map::new(Box::new([
-        make_string_key_value("price", 9.99),
-        make_string_key_value("quantity", 3.0),
-    ]));
+fn missing_key() {
+    let map = make_map(&[("price", 9.99)]);
+    let arr = make_flat_map_array(&[("price", 9.99)]);
 
-    let result = map.get(b"price");
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().as_num(), Some(9.99));
+    assert_get(&map, &arr, b"missing", None);
 }
 
 #[test]
-fn map_get_missing_key() {
-    let map = Map::new(Box::new([
-        make_string_key_value("price", 9.99),
-    ]));
-
-    assert!(map.get(b"missing").is_none());
-}
-
-#[test]
-fn map_get_empty_map() {
+fn empty() {
     let map = Map::new(Box::new([]));
+    let arr = Array::new(Box::new([]));
 
-    assert!(map.get(b"anything").is_none());
+    assert_get(&map, &arr, b"anything", None);
 }
 
 #[test]
-fn map_get_non_string_keys_skipped() {
+fn non_string_keys_skipped() {
     let map = Map::new(Box::new([
         (SharedRsValue::new_num(42.0), SharedRsValue::new_num(1.0)),
         (SharedRsValue::new_num(99.0), SharedRsValue::new_num(2.0)),
     ]));
+    let arr = Array::new(Box::new([
+        SharedRsValue::new_num(42.0),
+        SharedRsValue::new_num(1.0),
+        SharedRsValue::new_num(99.0),
+        SharedRsValue::new_num(2.0),
+    ]));
 
-    assert!(map.get(b"42").is_none());
+    assert_get(&map, &arr, b"42", None);
 }
 
 #[test]
-fn map_get_first_match_wins() {
-    let map = Map::new(Box::new([
-        make_string_key_value("key", 1.0),
-        make_string_key_value("key", 2.0),
+fn first_match_wins() {
+    let map = make_map(&[("key", 1.0), ("key", 2.0)]);
+    let arr = make_flat_map_array(&[("key", 1.0), ("key", 2.0)]);
+
+    assert_get(&map, &arr, b"key", Some(1.0));
+}
+
+// -- Array-only: odd-length trailing element --
+
+#[test]
+fn array_map_get_odd_length_trailing_element_ignored() {
+    let arr = Array::new(Box::new([
+        SharedRsValue::new_string(b"price".to_vec()),
+        SharedRsValue::new_num(9.99),
+        SharedRsValue::new_string(b"orphan".to_vec()),
     ]));
 
-    let result = map.get(b"key");
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().as_num(), Some(1.0));
+    assert_eq!(arr.map_get(b"price").unwrap().as_num(), Some(9.99));
+    assert!(arr.map_get(b"orphan").is_none());
 }

--- a/src/redisearch_rs/value/tests/integration/collection.rs
+++ b/src/redisearch_rs/value/tests/integration/collection.rs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use value::{Map, SharedRsValue};
+
+fn make_string_key_value(key: &str, num: f64) -> (SharedRsValue, SharedRsValue) {
+    (
+        SharedRsValue::new_string(key.as_bytes().to_vec()),
+        SharedRsValue::new_num(num),
+    )
+}
+
+#[test]
+fn map_get_found_key() {
+    let map = Map::new(Box::new([
+        make_string_key_value("price", 9.99),
+        make_string_key_value("quantity", 3.0),
+    ]));
+
+    let result = map.get(b"price");
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().as_num(), Some(9.99));
+}
+
+#[test]
+fn map_get_missing_key() {
+    let map = Map::new(Box::new([
+        make_string_key_value("price", 9.99),
+    ]));
+
+    assert!(map.get(b"missing").is_none());
+}
+
+#[test]
+fn map_get_empty_map() {
+    let map = Map::new(Box::new([]));
+
+    assert!(map.get(b"anything").is_none());
+}
+
+#[test]
+fn map_get_non_string_keys_skipped() {
+    let map = Map::new(Box::new([
+        (SharedRsValue::new_num(42.0), SharedRsValue::new_num(1.0)),
+        (SharedRsValue::new_num(99.0), SharedRsValue::new_num(2.0)),
+    ]));
+
+    assert!(map.get(b"42").is_none());
+}
+
+#[test]
+fn map_get_first_match_wins() {
+    let map = Map::new(Box::new([
+        make_string_key_value("key", 1.0),
+        make_string_key_value("key", 2.0),
+    ]));
+
+    let result = map.get(b"key");
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().as_num(), Some(1.0));
+}

--- a/src/redisearch_rs/value/tests/integration/collection.rs
+++ b/src/redisearch_rs/value/tests/integration/collection.rs
@@ -44,8 +44,9 @@ fn assert_get(map: &Map, arr: &Array, key: &[u8], expected: Option<f64>) {
 
 #[test]
 fn found_key() {
-    let map = make_map(&[("price", 9.99), ("quantity", 3.0)]);
-    let arr = make_flat_map_array(&[("price", 9.99), ("quantity", 3.0)]);
+    let pairs = &[("price", 9.99), ("quantity", 3.0)];
+    let map = make_map(pairs);
+    let arr = make_flat_map_array(pairs);
 
     assert_get(&map, &arr, b"price", Some(9.99));
     assert_get(&map, &arr, b"quantity", Some(3.0));
@@ -53,8 +54,9 @@ fn found_key() {
 
 #[test]
 fn missing_key() {
-    let map = make_map(&[("price", 9.99)]);
-    let arr = make_flat_map_array(&[("price", 9.99)]);
+    let pairs = &[("price", 9.99)];
+    let map = make_map(pairs);
+    let arr = make_flat_map_array(pairs);
 
     assert_get(&map, &arr, b"missing", None);
 }
@@ -85,8 +87,9 @@ fn non_string_keys_skipped() {
 
 #[test]
 fn first_match_wins() {
-    let map = make_map(&[("key", 1.0), ("key", 2.0)]);
-    let arr = make_flat_map_array(&[("key", 1.0), ("key", 2.0)]);
+    let pairs = &[("key", 1.0), ("key", 2.0)];
+    let map = make_map(pairs);
+    let arr = make_flat_map_array(pairs);
 
     assert_get(&map, &arr, b"key", Some(1.0));
 }

--- a/src/redisearch_rs/value/tests/integration/collection.rs
+++ b/src/redisearch_rs/value/tests/integration/collection.rs
@@ -91,16 +91,17 @@ fn first_match_wins() {
     assert_get(&map, &arr, b"key", Some(1.0));
 }
 
-// -- Array-only: odd-length trailing element --
+// -- Array-only: odd-length array panics in debug builds --
 
 #[test]
-fn array_map_get_odd_length_trailing_element_ignored() {
+#[cfg(debug_assertions)]
+#[should_panic(expected = "map_get called on an odd-length array")]
+fn array_map_get_odd_length_panics_in_debug() {
     let arr = Array::new(Box::new([
         SharedRsValue::new_string(b"price".to_vec()),
         SharedRsValue::new_num(9.99),
         SharedRsValue::new_string(b"orphan".to_vec()),
     ]));
 
-    assert_eq!(arr.map_get(b"price").unwrap().as_num(), Some(9.99));
-    assert!(arr.map_get(b"orphan").is_none());
+    let _ = arr.map_get(b"price");
 }

--- a/src/redisearch_rs/value/tests/integration/main.rs
+++ b/src/redisearch_rs/value/tests/integration/main.rs
@@ -12,6 +12,7 @@ extern crate redisearch_rs;
 // Mock or stub the ones that aren't provided by the line above
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
+mod collection;
 mod comparison;
 mod debug;
 mod hash;


### PR DESCRIPTION
## Add key lookup for `Map` and `Array` collections

Add `Map::get` and `Array::map_get` methods to the `value` crate for retrieving `SharedRsValue` entries by string key.

- `Map::get(&self, key: &[u8]) -> Option<SharedRsValue>`** - linear scan over key-value pairs, matching on string key bytes.
- `Array::map_get(&self, key: &[u8]) -> Option<SharedRsValue>` - same lookup over the flat `[k1, v1, k2, v2, ...]` layout used by RESP2, which lacks a native map type. In RESP3 the data arrives as a proper `Map`.

Both methods skip non-string keys and return the first match.

### Tests

Integration tests in `value/tests/integration/collection.rs` cover shared scenarios for both types (found key, missing key, empty collection, non-string keys skipped, duplicate key) plus an array-specific case for odd-length trailing elements.
#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and tests in the `value` crate with minimal behavioral impact outside new call sites; main risk is log noise/panic in debug builds when `map_get` is used on malformed odd-length arrays.
> 
> **Overview**
> Adds key-based lookup helpers to the `value` crate: `Map::get` for string-keyed pair collections and `Array::map_get` for RESP2-style flat `[k,v,...]` arrays, both returning the first match and skipping non-string keys.
> 
> Introduces `debug_assert_warn!` (debug assert + `tracing::warn!`) and wires in `tracing` as a dependency; adds integration tests covering lookup behavior and a debug-only panic for odd-length flat arrays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa3559ae9c9485abb97eae36ae6f2d532b0ea33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->