### PR TITLE
Suppress 'no symbols' warnings on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,21 @@ elseif(UNIX)
 endif()
 message(STATUS "OS detected: ${OS}")
 
+# Suppress 'has no symbols' warnings from ranlib on macOS.
+# Cross-platform deps (cpu_features, hiredis) compile platform stubs that are
+# empty on irrelevant architectures, producing harmless noise.
+# CMake may pick up LLVM's llvm-ranlib from PATH, which doesn't support
+# -no_warning_for_no_symbols. Use xcrun to locate Apple's native ranlib.
+if(APPLE)
+    execute_process(
+        COMMAND xcrun --find ranlib
+        OUTPUT_VARIABLE APPLE_RANLIB
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(CMAKE_C_ARCHIVE_FINISH "${APPLE_RANLIB} -no_warning_for_no_symbols <TARGET>")
+    set(CMAKE_CXX_ARCHIVE_FINISH "${APPLE_RANLIB} -no_warning_for_no_symbols <TARGET>")
+endif()
+
 # Always use .so extension even on macOS
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 # Export the underlying compiler invocations in a compile_commands.json, located in the bin directory.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -276,7 +276,7 @@ if(APPLE)
     # macOS: use libtool to merge static libraries
     add_custom_command(
         OUTPUT ${REDISEARCH_ALL_OUTPUT}
-        COMMAND libtool -static -o ${REDISEARCH_ALL_OUTPUT} ${LIBS_TO_MERGE}
+        COMMAND libtool -static -no_warning_for_no_symbols -o ${REDISEARCH_ALL_OUTPUT} ${LIBS_TO_MERGE}
         DEPENDS ${MERGE_DEPENDS}
         COMMENT "Creating unified libredisearch_all.a with libtool"
         VERBATIM


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: macOS builds produce noisy "has no symbols" warnings from `ranlib` and `libtool` when processing cross-platform deps (cpu_features, hiredis) that compile empty platform stubs.
2. **Change**: Pass `-no_warning_for_no_symbols` to both `ranlib` (via `xcrun` to locate Apple's native ranlib) and `libtool` in the static library merge step. Both changes are `APPLE`-guarded.
3. **Outcome**: Clean macOS build output with no spurious warnings.

_Build on Platforms_ run
https://github.com/RediSearch/RediSearch/actions/runs/24632266764

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified
1. `CMakeLists.txt` — ranlib suppression via `CMAKE_C_ARCHIVE_FINISH` / `CMAKE_CXX_ARCHIVE_FINISH`
2. `src/CMakeLists.txt` — libtool `-no_warning_for_no_symbols` flag

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system-only change gated to `APPLE`; main risk is mis-detecting/overriding `ranlib` behavior on macOS toolchains.
> 
> **Overview**
> Reduces macOS build noise by suppressing "has no symbols" warnings when creating/finishing static archives.
> 
> On `APPLE`, the build now resolves Apple’s `ranlib` via `xcrun` and uses `-no_warning_for_no_symbols` for `CMAKE_C_ARCHIVE_FINISH`/`CMAKE_CXX_ARCHIVE_FINISH`, and also passes the same flag to `libtool` when generating `libredisearch_all.a`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a97a96873721d95540fbf63a36cb317a7baac3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->