### PR TITLE
[MOD-14944] test: fix flakiness test_query_while_flush

### DIFF
--- a/tests/pytests/test_query_while_flush.py
+++ b/tests/pytests/test_query_while_flush.py
@@ -41,7 +41,15 @@ def test_query_while_flush():
         'flush_completed': False
     }
 
-    def query_worker(stats):
+    # Per-thread iteration counters, incremented at the end of each loop iteration.
+    # Used to deterministically drain in-flight iterations after toggling state
+    # (flushall_called / flush_completed): once every counter has advanced by at
+    # least one, every worker has re-evaluated the state and no stale attribution
+    # to the pre-flush counters can still be pending.
+    num_threads = 5
+    iteration_counts = [0] * num_threads
+
+    def query_worker(stats, thread_id):
         """Worker thread that continuously queries the index"""
         local_conn = env.getClusterConnectionIfNeeded()
 
@@ -65,16 +73,16 @@ def test_query_while_flush():
                 else:
                     stats['after_flush_errors'] += 1
 
+          iteration_counts[thread_id] += 1
           # Small delay to avoid overwhelming the system
           time.sleep(0.001)
 
-    # Start 5 query threads (pass the event)
-    num_threads = 5
+    # Start query threads (pass the event)
     threads = []
     for i in range(num_threads):
         thread = threading.Thread(
             target=query_worker,
-            args=(stats, ),
+            args=(stats, i),
         )
         threads.append(thread)
         thread.start()
@@ -88,17 +96,16 @@ def test_query_while_flush():
 
     # Signal that flushall is about to be called
     flushall_called.set()
-    # Wait for in-flight pre-flush attributions to drain: poll until the pre-flush counters
-    # stop changing across a short interval. Equivalent to the previous fixed sleep, but
-    # adaptive (returns quickly when the system is idle, waits longer on slow machines).
-    def _pre_flush_counters_stable():
-        snap = (stats['before_flush_successes'], stats['before_flush_errors'])
-        time.sleep(0.05)
-        cur = (stats['before_flush_successes'], stats['before_flush_errors'])
-        return snap == cur, {'snap': snap, 'cur': cur}
+    # Wait for in-flight pre-flush attributions to drain: every worker must complete
+    # at least one loop iteration after flushall_called.set(), guaranteeing each has
+    # re-evaluated flushall_called.is_set() at the increment site with the flag set.
+    snap = list(iteration_counts)
     wait_for_condition(
-        _pre_flush_counters_stable,
-        message='pre-flush counters did not stabilize after flushall_called.set()',
+        lambda: (
+            all(c > s for c, s in zip(iteration_counts, snap)),
+            {'snap': snap, 'cur': list(iteration_counts)},
+        ),
+        message='not all workers completed an iteration after flushall_called.set()',
         timeout=10,
     )
     env.assertGreater(stats['before_flush_successes'], 0)
@@ -112,15 +119,14 @@ def test_query_while_flush():
     # Wait for any thread that already passed the `flushall_called.is_set()` check but has
     # not yet read `flush_completed` to finish its iteration, so we don't misattribute a
     # post-flush observation to the before-flush bucket when we later clear the event.
-    # Same drain purpose as the previous sleep, expressed as a stability check.
-    def _pre_flush_counters_stable_post():
-        snap = (stats['before_flush_successes'], stats['before_flush_errors'])
-        time.sleep(0.05)
-        cur = (stats['before_flush_successes'], stats['before_flush_errors'])
-        return snap == cur, {'snap': snap, 'cur': cur}
+    # Same drain purpose as above, expressed against the per-thread iteration counters.
+    snap = list(iteration_counts)
     wait_for_condition(
-        _pre_flush_counters_stable_post,
-        message='pre-flush counters did not stabilize after flush_completed=True',
+        lambda: (
+            all(c > s for c, s in zip(iteration_counts, snap)),
+            {'snap': snap, 'cur': list(iteration_counts)},
+        ),
+        message='not all workers completed an iteration after flush_completed=True',
         timeout=10,
     )
     flushall_called.clear()  # Reset the event

--- a/tests/pytests/test_query_while_flush.py
+++ b/tests/pytests/test_query_while_flush.py
@@ -79,15 +79,28 @@ def test_query_while_flush():
         threads.append(thread)
         thread.start()
 
-    # Let queries run for a bit to accumulate some successes
-    time.sleep(0.5)
+    # Wait until query threads have accumulated some successes
+    wait_for_condition(
+        lambda: (stats['before_flush_successes'] > 0, stats),
+        message='no successful pre-flush queries observed',
+        timeout=30,
+    )
 
     # Signal that flushall is about to be called
     flushall_called.set()
-    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
-    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
-    # so this is a simpler better approach
-    time.sleep(0.5)
+    # Wait for in-flight pre-flush attributions to drain: poll until the pre-flush counters
+    # stop changing across a short interval. Equivalent to the previous fixed sleep, but
+    # adaptive (returns quickly when the system is idle, waits longer on slow machines).
+    def _pre_flush_counters_stable():
+        snap = (stats['before_flush_successes'], stats['before_flush_errors'])
+        time.sleep(0.05)
+        cur = (stats['before_flush_successes'], stats['before_flush_errors'])
+        return snap == cur, {'snap': snap, 'cur': cur}
+    wait_for_condition(
+        _pre_flush_counters_stable,
+        message='pre-flush counters did not stabilize after flushall_called.set()',
+        timeout=10,
+    )
     env.assertGreater(stats['before_flush_successes'], 0)
     env.assertEqual(stats['before_flush_errors'], 0)
 
@@ -96,11 +109,20 @@ def test_query_while_flush():
 
     # Mark flush as completed
     stats['flush_completed'] = True
-    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
-    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
-    # so this is a simpler better approach
-    # Otherwise I could see successes attributed to before flush that should have been after
-    time.sleep(0.5)
+    # Wait for any thread that already passed the `flushall_called.is_set()` check but has
+    # not yet read `flush_completed` to finish its iteration, so we don't misattribute a
+    # post-flush observation to the before-flush bucket when we later clear the event.
+    # Same drain purpose as the previous sleep, expressed as a stability check.
+    def _pre_flush_counters_stable_post():
+        snap = (stats['before_flush_successes'], stats['before_flush_errors'])
+        time.sleep(0.05)
+        cur = (stats['before_flush_successes'], stats['before_flush_errors'])
+        return snap == cur, {'snap': snap, 'cur': cur}
+    wait_for_condition(
+        _pre_flush_counters_stable_post,
+        message='pre-flush counters did not stabilize after flush_completed=True',
+        timeout=10,
+    )
     flushall_called.clear()  # Reset the event
     # Create index2 and verify it works properly
     env.expect('FT.CREATE', 'index2', 'ON', 'HASH', 'SCHEMA', 'text', 'TEXT').ok()


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes flakiness in `test_query_while_flush` by replacing fixed-duration `time.sleep(0.5)` calls with `wait_for_condition`-based waits. The previous sleeps were insufficient on slow CI runners (notably macOS x86_64), where query threads occasionally produced zero successful queries within the 0.5 s window, causing `assertGreater(before_flush_successes, 0)` to fail.

### Changes

Three `time.sleep(0.5)` calls were replaced:

1. **Before `flushall_called.set()`** — previously slept 0.5 s hoping workers accumulated successes. Now uses `wait_for_condition` polling `before_flush_successes > 0` with a 30 s timeout. Fast-path on fast runners (exits in ms), tolerant on slow runners.

2. **After `flushall_called.set()`** — drain window for in-flight pre-flush attributions. Replaced with a stability check that polls `(before_flush_successes, before_flush_errors)` every 50 ms until the tuple stops changing, bounded by a 10 s timeout. Preserves the original drain semantic without depending on wall-clock duration.

3. **After `flush_completed = True`, before `flushall_called.clear()`** — same class of drain window; replaced with the same stability-check pattern.

### Why stability-check for 2 and 3

These sleeps are not "wait for something to happen" — they are drain windows protecting against a worker that read `flushall_called.is_set() == False` before the main thread set it and hasn't yet performed its counter increment. Observing that counters have stopped changing across a short polling interval is the direct, adaptive analogue of the original "sleep long enough" intent.

### Test semantics preserved

- Same pre-flush assertions: `before_flush_successes > 0`, `before_flush_errors == 0`
- Same post-flush assertions: `after_flush_errors > 0`, `after_flush_successes == 0`
- Same index lifecycle (create `index1`, FLUSHALL, create `index2`)
- No changes to the worker code or to the locking model

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts synchronization/wait logic; main risk is making the test hang or become overly strict if the new drain conditions are wrong.
> 
> **Overview**
> Makes `test_query_while_flush` deterministic by removing fixed `time.sleep(0.5)` synchronization windows and replacing them with `wait_for_condition` checks.
> 
> The test now (1) waits until at least one pre-flush query success is observed, and (2) introduces per-thread `iteration_counts` to *drain in-flight worker iterations* after toggling `flushall_called` and `flush_completed`, reducing misattribution and CI flakiness on slower runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b10441224588ecfe4938734779898700a0e7bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->