### PR TITLE
query.c: replace defensive code paths by assertion

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1111,11 +1111,6 @@ static QueryIterator *Query_EvalIdFilterNode(QueryEvalCtx *q, QueryIdFilterNode 
 static QueryIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_LOG_ASSERT(qn->type == QN_UNION, "query node type should be union")
 
-  // a union stage with one child is the same as the child, so we just return it
-  if (QueryNode_NumChildren(qn) == 1) {
-    return Query_EvalNode(q, qn->children[0]);
-  }
-
   // recursively eval the children
   QueryIterator **iters = rm_malloc(QueryNode_NumChildren(qn) * sizeof(QueryIterator *));
   for (size_t i = 0; i < QueryNode_NumChildren(qn); ++i) {

--- a/src/query.c
+++ b/src/query.c
@@ -1105,6 +1105,8 @@ static QueryIterator *Query_EvalIdFilterNode(QueryEvalCtx *q, QueryIdFilterNode 
 
 static QueryIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_LOG_ASSERT(qn->type == QN_UNION, "query node type should be union")
+  // Parsers and expanders always create unions with 2+ children.
+  RS_ASSERT(QueryNode_NumChildren(qn) > 1);
 
   // recursively eval the children
   QueryIterator **iters = rm_malloc(QueryNode_NumChildren(qn) * sizeof(QueryIterator *));

--- a/src/query.c
+++ b/src/query.c
@@ -139,8 +139,8 @@ void QueryNode_Free(QueryNode *n) {
     case QN_NULL:
     case QN_PHRASE:
       break;
-    case QN_MAX:
-      RS_ABORT("Invalid query node type");
+    case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
+      RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }
   rm_free(n);
 }
@@ -412,20 +412,17 @@ QueryNode *NewVectorNode_WithParams(struct QueryParseCtx *q, VectorQueryType typ
       QueryNode_SetParam(q, &ret->params[1], &vq->range.radius, NULL, value);
       vq->range.order = BY_ID;
       break;
-    default:
-      QueryNode_Free(ret);
+    default: // LCOV_EXCL_START — exhaustive switch: only KNN and RANGE vector query types exist
+      RS_ABORT("Invalid vector query type");
       return NULL;
-  }
+  } // LCOV_EXCL_STOP
   return ret;
 }
 
 void SetFilterNode(QueryAST *q, QueryNode *filterNode) {
   if (filterNode == NULL) return;
-  if (q->root == NULL) {
-    // Cannot add filter to empty AST - free the node to avoid leaking its resources
-    QueryNode_Free(filterNode);
-    return;
-  }
+  // parser always produces a root node before filters are added
+  RS_ASSERT(q->root != NULL);
 
   // for a simple phrase node we just add the numeric node
   if (q->root->type == QN_PHRASE) {
@@ -664,9 +661,8 @@ static QueryIterator *Query_EvalPrefixNode(QueryEvalCtx *q, QueryNode *qn) {
   Trie *t = spec->terms;
   TrieCallbackCtx ctx = {.q = q, .opts = &qn->opts};
 
-  if (!t) {
-    return NULL;
-  }
+  // terms trie always exists when prefix queries reach evaluation
+  RS_ASSERT(t);
 
   size_t nstr;
   rune *str = qn->pfx.tok.str ? strToLowerRunes(qn->pfx.tok.str, qn->pfx.tok.len, &nstr) : NULL;
@@ -720,9 +716,8 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
   TrieCallbackCtx ctx = {.q = q, .opts = &qn->opts};
   RSToken *token = &qn->verb.tok;
 
-  if (!t || !token->str) {
-    return NULL;
-  }
+  // terms trie and token always exist when wildcard queries reach evaluation
+  RS_ASSERT(t && token->str);
 
   token->len = Wildcard_RemoveEscape(token->str, token->len);
   size_t nstr;
@@ -1207,9 +1202,8 @@ static QueryIterator *Query_EvalTagLexRangeNode(QueryEvalCtx *q, TagIndex *idx, 
 static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, QueryNode *qn, double weight,
                                               int withSuffixTrie, t_fieldIndex fieldIndex,
                                               bool caseSensitive) {
-  if (qn->type != QN_PREFIX) {
-    return NULL;
-  }
+  // only called from QN_PREFIX dispatch
+  RS_ASSERT(qn->type == QN_PREFIX);
   RSToken *tok = &qn->pfx.tok;
 
   tag_strtolower(&(tok->str), &tok->len, caseSensitive);
@@ -1233,10 +1227,8 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
       }
     }
     TrieMapIterator *it = TrieMap_IterateWithFilter(idx->values, tok->str, tok->len, iter_mode);
-    if (!it) {
-      rm_free(its);
-      return NULL;
-    }
+    // TrieMap_IterateWithFilter only returns NULL on allocation failure
+    RS_ASSERT(it);
     if (!q->sctx->time.skipTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, q->sctx->time.timeout);
     }
@@ -1413,12 +1405,10 @@ static QueryIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
     case QN_PHRASE: {
       char *terms[QueryNode_NumChildren(n)];
       for (size_t i = 0; i < QueryNode_NumChildren(n); ++i) {
-        if (n->children[i]->type == QN_TOKEN) {
-          tag_strtolower(&(n->children[i]->tn.str), &n->children[i]->tn.len, caseSensitive);
-          terms[i] = n->children[i]->tn.str;
-        } else {
-          terms[i] = "";
-        }
+        // tag phrase children are always tokens from query syntax
+        RS_ASSERT(n->children[i]->type == QN_TOKEN);
+        tag_strtolower(&(n->children[i]->tn.str), &n->children[i]->tn.len, caseSensitive);
+        terms[i] = n->children[i]->tn.str;
       }
 
       sds s = sdsjoin(terms, QueryNode_NumChildren(n), " ");
@@ -1428,9 +1418,10 @@ static QueryIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
       break;
     }
 
-    default:
+    default: // LCOV_EXCL_START — only TOKEN, PREFIX, WILDCARD_QUERY, LEXRANGE, PHRASE reach tag eval
+      RS_ABORT("Invalid tag query node type");
       return NULL;
-  }
+  } // LCOV_EXCL_STOP
 
   return ret;
 }
@@ -1518,11 +1509,12 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
       return NewEmptyIterator();
     case QN_MISSING:
       return Query_EvalMissingNode(q, n);
-    case QN_MAX:
-      RS_ABORT("Invalid query node type");
+    case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
+      RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }
 
-  return NULL;
+  RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE — unreachable: all valid node types handled in switch
+  return NULL; // LCOV_EXCL_LINE
 }
 
 int QAST_Parse(QueryAST *dst, const RedisSearchCtx *sctx, const RSSearchOptions *sopts,
@@ -1558,13 +1550,8 @@ int QAST_Parse(QueryAST *dst, const RedisSearchCtx *sctx, const RSSearchOptions 
       dst->root = NewQueryNode(QN_NULL);
     }
   }
-  if (QueryError_HasError(status)) {
-    if (dst->root) {
-      QueryNode_Free(dst->root);
-      dst->root = NULL;
-    }
-    return REDISMODULE_ERR;
-  }
+  // lexer breaks on error before query rule reduces, so root+error is unreachable
+  RS_ASSERT(!QueryError_HasError(status));
   dst->numTokens = qpCtx.numTokens;
   dst->numParams = qpCtx.numParams;
   return REDISMODULE_OK;
@@ -1672,8 +1659,8 @@ int QueryNode_EvalParams(dict *params, QueryNode *n, unsigned int dialectVersion
     case QN_MISSING:
       withChildren = 0;
       break;
-    case QN_MAX:
-      RS_ABORT("Invalid query node type");
+    case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
+      RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }
   // Handle children
   if (withChildren && res == REDISMODULE_OK) {
@@ -1844,8 +1831,8 @@ static int QueryNode_CheckIsValid(QueryNode *n, IndexSpec *spec, RSSearchOptions
     case QN_WILDCARD:
     case QN_GEOMETRY:
       break;
-    case QN_MAX:
-      RS_ABORT("Invalid query node type");
+    case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
+      RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }
 
   // Handle children
@@ -1862,9 +1849,8 @@ static int QueryNode_CheckIsValid(QueryNode *n, IndexSpec *spec, RSSearchOptions
 // Checks whether query nodes are valid
 // Currently Phrase nodes are checked whether slop/inorder are allowed
 int QAST_CheckIsValid(QueryAST *q, IndexSpec *spec, RSSearchOptions *opts, QueryError *status) {
-  if (!q || !q->root) {
-    return REDISMODULE_OK;
-  }
+  // callers always pass a parsed AST with a root node
+  RS_ASSERT(q && q->root);
 
   // Always validate disk indexes (for unsupported query types like prefix/fuzzy/wildcard/lexrange)
   // For non-disk indexes, skip validation if there's no TEXT/TAG field that doesn't index empty
@@ -1961,22 +1947,20 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
 
   if (qs->opts.fieldMask && qs->opts.fieldMask != RS_FIELDMASK_ALL && qs->type != QN_NUMERIC &&
       qs->type != QN_GEO && qs->type != QN_IDS) {
-    if (!spec) {
-      s = sdscatprintf(s, "@%" PRIu64, (uint64_t)qs->opts.fieldMask);
-    } else {
-      s = sdscat(s, "@");
-      t_fieldMask fm = qs->opts.fieldMask;
-      int i = 0, n = 0;
-      while (fm) {
-        t_fieldMask bit = (fm & 1) << i;
-        if (bit) {
-          const char *f = IndexSpec_GetFieldNameByBit(spec, bit);
-          s = sdscatprintf(s, "%s%s", n ? "|" : "", f ? f : "n/a");
-          n++;
-        }
-        fm = fm >> 1;
-        i++;
+    // QAST_DumpExplain always passes a valid spec
+    RS_ASSERT(spec);
+    s = sdscat(s, "@");
+    t_fieldMask fm = qs->opts.fieldMask;
+    int i = 0, n = 0;
+    while (fm) {
+      t_fieldMask bit = (fm & 1) << i;
+      if (bit) {
+        const char *f = IndexSpec_GetFieldNameByBit(spec, bit);
+        s = sdscatprintf(s, "%s%s", n ? "|" : "", f ? f : "n/a");
+        n++;
       }
+      fm = fm >> 1;
+      i++;
     }
     s = sdscat(s, ":");
   }
@@ -2127,8 +2111,8 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
     case QN_MISSING:
       s = sdscatprintf(s, "ISMISSING{%s}", HiddenString_GetUnsafe(qs->miss.field->fieldName, NULL));
       break;
-    case QN_MAX:
-      RS_ABORT("Invalid query node type");
+    case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
+      RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }
 
   // print attributes if not the default
@@ -2161,10 +2145,8 @@ static sds QueryNode_DumpChildren(sds s, const IndexSpec *spec, const QueryNode 
  * Assumes that the spec is guarded by the GIL or its own lock (read or write)
  */
 char *QAST_DumpExplain(const QueryAST *q, const IndexSpec *spec) {
-  // empty query
-  if (!q || !q->root) {
-    return rm_strdup("NULL");
-  }
+  // callers always pass a parsed AST with a root node
+  RS_ASSERT(q && q->root);
 
   sds s = QueryNode_DumpSds(sdsnew(""), spec, q->root, 0);
   char *ret = rm_strndup(s, sdslen(s));


### PR DESCRIPTION
Moved from https://github.com/RediSearch/RediSearch/pull/9133

Replace unreachable defensive code paths by assertion. Remove dead code and will help clarify the invariants when porting this code to Rust.

Also add lcov exclusion markers to improve coverage stats.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes from “return NULL/free and continue” to hard assertions/aborts if previously-unexpected states occur, which could surface as crashes if any caller violates these assumptions.
> 
> **Overview**
> Replaces multiple *unreachable* defensive branches in `src/query.c` with `RS_ASSERT`/`RS_ABORT`, tightening invariants in query parsing/evaluation (e.g., filter insertion requires a root, UNION nodes must have 2+ children, trie/token inputs must exist, tag phrase children must be tokens, and parse success cannot coincide with an error).
> 
> Adds `LCOV_EXCL_LINE/START/STOP` markers around abort-only/default switch cases and other unreachable paths to keep coverage reporting accurate while removing dead cleanup/NULL-return fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82ddce0f03df0126bd880dcbba48f0942de6554f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->