### PR TITLE
[master] RED-193518 Fix S3 prefix mismatch in set-artifacts

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -222,7 +222,7 @@ jobs:
                           yield obj["Key"]
 
           def list_snapshots_by_branch(dir):
-              return list_files_by_branch(f"{dir}/snapshots/{dir}")
+              return list_files_by_branch(f"{dir}/snapshots/")
 
           # Return the git sha from the module.json file in the zip file (build sha)
           def extract_sha(key):


### PR DESCRIPTION
Forward-port of #9061 from `99.88` to `master`.

## Summary
Fixes the S3 prefix construction in the `set-artifacts` job of the release workflow. The path was incorrectly doubling the directory segment:

```diff
-              return list_files_by_branch(f"{dir}/snapshots/{dir}")
+              return list_files_by_branch(f"{dir}/snapshots/")
```

## Context
- Bug originally fixed on `99.88` via #9061 (merged 2026-04-19).
- Not forward-porting #9039's `--auto --merge` change, as that was specifically for branches without a merge queue; `master` has a merge queue enabled.

## Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to S3 prefix construction in the GitHub Actions release workflow that only affects which snapshot artifacts are discovered and copied.
> 
> **Overview**
> Fixes an S3 prefix mismatch in the release workflow’s `set-artifacts` job by adjusting `list_snapshots_by_branch` to list under `f"{dir}/snapshots/"` instead of incorrectly appending the directory twice.
> 
> This ensures snapshot artifacts are correctly discovered for a branch/tag and then promoted/copied to the release location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c593dcc9b6c529fdc0b0ce02c385994187f86ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->