### PR TITLE
[MOD-14951] Fix return types for RDB_Save RDB_Load on DocIDMeta

### DIFF
--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -14,7 +14,6 @@
 #include "rdb.h"
 #include <stdbool.h>
 #include <assert.h>
-#include <inttypes.h>
 
 #define DOCID_META_INVALID 0
 #define DOCID_META_CLASS_NAME "D-ID"
@@ -63,41 +62,19 @@ static inline bool isSpecValid(uint64_t specId) {
 // DocIdMeta V1: a dict of specId (void*) -> docId (void*), using dictTypeUint64.
 // The meta value stored on a key is a `dict*` cast to `uint64_t` directly (no wrapper struct).
 #define DOCID_META_VERSION 1
-// Compose side-effect suppressors individually instead of REDISMODULE_OPEN_KEY_NOEFFECTS.
-// The aggregate NOEFFECTS flag also inhibits BigRedis swap-in, which would leave the key
-// meta unloaded on disk-resident keys and cause DocIdMeta_Get to return meta=0.
-#define KEY_OPEN_META_NO_SIDE_EFFECTS (REDISMODULE_OPEN_KEY_NOTOUCH   | \
-                                       REDISMODULE_OPEN_KEY_NONOTIFY  | \
-                                       REDISMODULE_OPEN_KEY_NOSTATS   | \
-                                       REDISMODULE_OPEN_KEY_NOEXPIRE)
-#define KEY_OPEN_META_SET_FLAGS (REDISMODULE_READ | REDISMODULE_WRITE | KEY_OPEN_META_NO_SIDE_EFFECTS)
-#define KEY_OPEN_META_GET_FLAGS (REDISMODULE_READ | KEY_OPEN_META_NO_SIDE_EFFECTS)
+#define KEY_OPEN_META_SET_FLAGS (REDISMODULE_READ | REDISMODULE_WRITE | REDISMODULE_OPEN_KEY_NOEFFECTS)
+#define KEY_OPEN_META_GET_FLAGS (REDISMODULE_READ | REDISMODULE_OPEN_KEY_NOEFFECTS)
 
 /* Free callback - called when metadata needs to be freed */
 static void docIdMetaFree(const char *keyname, uint64_t meta) {
-  size_t nEntries = (meta != 0) ? dictSize((dict *)meta) : 0;
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[FREE] key='%s' meta=%s entries=%zu",
-                  keyname ? keyname : "(null)",
-                  meta == 0 ? "NULL" : "non-null",
-                  nEntries);
+  REDISMODULE_NOT_USED(keyname);
   if (meta == 0) return;
   dict *d = (dict *)meta;
   dictRelease(d);
 }
 
 static int docIdMetaMove(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
-  const RedisModuleString *fromKey = RedisModule_GetKeyNameFromOptCtx(ctx);
-  const RedisModuleString *toKey = RedisModule_GetToKeyNameFromOptCtx(ctx);
-  size_t fromLen = 0, toLen = 0;
-  const char *fromStr = fromKey ? RedisModule_StringPtrLen((RedisModuleString *)fromKey, &fromLen) : NULL;
-  const char *toStr = toKey ? RedisModule_StringPtrLen((RedisModuleString *)toKey, &toLen) : NULL;
-  size_t nEntries = (meta && *meta) ? dictSize((dict *)*meta) : 0;
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[MOVE] from='%.*s' to='%.*s' entries=%zu (dropping meta)",
-                  (int)fromLen, fromStr ? fromStr : "",
-                  (int)toLen, toStr ? toStr : "",
-                  nEntries);
+  REDISMODULE_NOT_USED(ctx);
   REDISMODULE_NOT_USED(meta);
   // We do not want to move the meta, as the docID will not have meaning in the destination DB.
   // Returning 0 tells redis to drop the meta and not move it with the key - see the docs for more info.
@@ -112,41 +89,21 @@ static int docIdMetaMove(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
  * This fires before the keyspace notification, which is why we handle
  * deletion here rather than in the notification handler. */
 static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
-  const RedisModuleString *keyName = RedisModule_GetKeyNameFromOptCtx(ctx);
-  size_t keyLen = 0;
-  const char *keyStr = keyName ? RedisModule_StringPtrLen((RedisModuleString *)keyName, &keyLen) : NULL;
-  if (*meta == 0) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[UNLINK] key='%.*s' meta=NULL (nothing to do)",
-                    (int)keyLen, keyStr ? keyStr : "");
-    return;
-  }
+  REDISMODULE_NOT_USED(ctx);
+  if (*meta == 0) return;
 
   dict *specIdToDocId = (dict *)*meta;
-  size_t nEntries = dictSize(specIdToDocId);
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[UNLINK] key='%.*s' entries=%zu",
-                  (int)keyLen, keyStr ? keyStr : "", nEntries);
-  if (nEntries == 0) return;
+  if (dictSize(specIdToDocId) == 0) return;
 
   dictIterator *iter = dictGetIterator(specIdToDocId);
   dictEntry *de;
   while ((de = dictNext(iter))) {
     uint64_t docId = VAL_TO_DOCID(dictGetVal(de));
-    uint64_t specId = KEY_TO_SPECID(dictGetKey(de));
-    if (docId == DOCID_META_INVALID) {
-      RedisModule_Log(RSDummyContext, "notice",
-                      "DocIdMeta[UNLINK]   key='%.*s' specId=%" PRIu64 " docId=INVALID (skip)",
-                      (int)keyLen, keyStr ? keyStr : "", specId);
-      continue;
-    }
+    if (docId == DOCID_META_INVALID) continue;
 
     // Find the IndexSpec by specId in the global dict (O(1) lookup).
+    uint64_t specId = KEY_TO_SPECID(dictGetKey(de));
     IndexSpec *spec = findSpecBySpecId(specId);
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[UNLINK]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " spec=%s (deleting)",
-                    (int)keyLen, keyStr ? keyStr : "", specId, docId,
-                    spec ? "found" : "NULL");
     if (spec) {
       // Delete the document from this index by its docId
       IndexSpec_DeleteDocById(spec, docId);
@@ -171,28 +128,17 @@ static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
 static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   RS_LOG_ASSERT(encver == 1, "DocIdMeta: unexpected encver in RDB load");
 
-  const RedisModuleString *keyName = RedisModule_GetKeyNameFromIO(rdb);
-  size_t keyLen = 0;
-  const char *keyStr = keyName ? RedisModule_StringPtrLen((RedisModuleString *)keyName, &keyLen) : NULL;
-
   if (PersistenceInProgress) {
     // Skip actual loading during persistence events. We don't store this metadata in the RDB/AOF files.
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[RDB_LOAD] key='%.*s' SKIPPED (PersistenceInProgress)",
-                    (int)keyLen, keyStr ? keyStr : "");
     *meta = 0;
     return DOCID_META_RDB_LOAD_SKIP;
   }
 
   dict *specIdToDocId = dictCreate(&dictTypeUint64, NULL);
   size_t numEntries;
-  size_t kept = 0, dropped = 0;
 
   // Load the number of entries
   numEntries = LoadUnsigned_IOError(rdb, goto cleanup);
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[RDB_LOAD] key='%.*s' numEntries=%zu",
-                  (int)keyLen, keyStr ? keyStr : "", numEntries);
 
   // Load each entry (specId + docId), skipping entries whose spec no longer exists.
   for (size_t i = 0; i < numEntries; i++) {
@@ -201,30 +147,16 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
 
     // Skip entries belonging to indexes that are no longer in specIdDict_g (O(1) lookup).
     if (!isSpecValid(specId)) {
-      RedisModule_Log(RSDummyContext, "notice",
-                      "DocIdMeta[RDB_LOAD]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " DROPPED (spec invalid)",
-                      (int)keyLen, keyStr ? keyStr : "", specId, docId);
-      dropped++;
       continue;
     }
 
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[RDB_LOAD]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " LOADED",
-                    (int)keyLen, keyStr ? keyStr : "", specId, docId);
-    kept++;
     dictAdd(specIdToDocId, SPECID_TO_KEY(specId), DOCID_TO_VAL(docId));
   }
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[RDB_LOAD] key='%.*s' done kept=%zu dropped=%zu",
-                  (int)keyLen, keyStr ? keyStr : "", kept, dropped);
 
   *meta = (uint64_t)(specIdToDocId);
   return DOCID_META_RDB_LOAD_ATTACH;
 
 cleanup:
-  RedisModule_Log(RSDummyContext, "warning",
-                  "DocIdMeta[RDB_LOAD] key='%.*s' FAILED (io error)",
-                  (int)keyLen, keyStr ? keyStr : "");
   if (specIdToDocId) {
     dictRelease(specIdToDocId);
   }
@@ -235,22 +167,12 @@ cleanup:
 static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
   REDISMODULE_NOT_USED(value);
 
-  const RedisModuleString *keyName = RedisModule_GetKeyNameFromIO(rdb);
-  size_t keyLen = 0;
-  const char *keyStr = keyName ? RedisModule_StringPtrLen((RedisModuleString *)keyName, &keyLen) : NULL;
-
   if (PersistenceInProgress) {
     // Skip saving during persistence events. We don't want to save this metadata to an RDB/AOF file
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[RDB_SAVE] key='%.*s' SKIPPED (PersistenceInProgress)",
-                    (int)keyLen, keyStr ? keyStr : "");
     return;
   }
 
   if (*meta == 0) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[RDB_SAVE] key='%.*s' meta=NULL (nothing to save)",
-                    (int)keyLen, keyStr ? keyStr : "");
     return;
   }
 
@@ -271,10 +193,6 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
     }
     dictReleaseIterator(iter);
   }
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[RDB_SAVE] key='%.*s' totalEntries=%lu validEntries=%zu",
-                  (int)keyLen, keyStr ? keyStr : "",
-                  (unsigned long)dictSize(specIdToDocId), validEntries);
 
   // Save entry count. Version is handled by encver in the KeyMeta API.
   RedisModule_SaveUnsigned(rdb, validEntries);
@@ -292,9 +210,6 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
     if (docId == DOCID_META_INVALID || !isSpecValid(specId)) {
       continue;
     }
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[RDB_SAVE]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64,
-                    (int)keyLen, keyStr ? keyStr : "", specId, docId);
     RedisModule_SaveUnsigned(rdb, specId);
     RedisModule_SaveUnsigned(rdb, docId);
   }
@@ -387,65 +302,33 @@ static int DocIdMeta_DeleteInternal(RedisModuleKey *key, uint64_t specId) {
 // Set docId using key name and spec incarnation ID.
 int DocIdMeta_Set(RedisModuleCtx *ctx, RedisModuleString *keyName,
                   uint64_t specId, uint64_t docId) {
-  size_t keyLen = 0;
-  const char *keyStr = RedisModule_StringPtrLen(keyName, &keyLen);
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, KEY_OPEN_META_SET_FLAGS);
   if (!key) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[SET] key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " OpenKey=NULL -> ERR",
-                    (int)keyLen, keyStr, specId, docId);
     return REDISMODULE_ERR;
   }
   int result = DocIdMeta_SetInternal(key, specId, docId);
   RedisModule_CloseKey(key);
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[SET] key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " result=%s",
-                  (int)keyLen, keyStr, specId, docId,
-                  result == REDISMODULE_OK ? "OK" : "ERR");
   return result;
 }
 
 // Get docId using key name and spec incarnation ID
 int DocIdMeta_Get(RedisModuleCtx *ctx, RedisModuleString *keyName,
                   uint64_t specId, uint64_t *docId) {
-  size_t keyLen = 0;
-  const char *keyStr = RedisModule_StringPtrLen(keyName, &keyLen);
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, KEY_OPEN_META_GET_FLAGS);
   if (!key) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[GET] key='%.*s' specId=%" PRIu64 " OpenKey=NULL -> ERR",
-                    (int)keyLen, keyStr, specId);
     return REDISMODULE_ERR;
   }
   int result = DocIdMeta_GetInternal(key, specId, docId);
   RedisModule_CloseKey(key);
-  if (result == REDISMODULE_OK) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[GET] key='%.*s' specId=%" PRIu64 " -> OK docId=%" PRIu64,
-                    (int)keyLen, keyStr, specId, *docId);
-  } else {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[GET] key='%.*s' specId=%" PRIu64 " -> ERR",
-                    (int)keyLen, keyStr, specId);
-  }
   return result;
 }
 
 int DocIdMeta_Delete(RedisModuleCtx *ctx, RedisModuleString *keyName, uint64_t specId) {
-  size_t keyLen = 0;
-  const char *keyStr = RedisModule_StringPtrLen(keyName, &keyLen);
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, KEY_OPEN_META_SET_FLAGS);
   if (!key) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "DocIdMeta[DEL] key='%.*s' specId=%" PRIu64 " OpenKey=NULL -> ERR",
-                    (int)keyLen, keyStr, specId);
     return REDISMODULE_ERR;
   }
   int result = DocIdMeta_DeleteInternal(key, specId);
   RedisModule_CloseKey(key);
-  RedisModule_Log(RSDummyContext, "notice",
-                  "DocIdMeta[DEL] key='%.*s' specId=%" PRIu64 " result=%s",
-                  (int)keyLen, keyStr, specId,
-                  result == REDISMODULE_OK ? "OK" : "ERR");
   return result;
 }

--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -14,6 +14,7 @@
 #include "rdb.h"
 #include <stdbool.h>
 #include <assert.h>
+#include <inttypes.h>
 
 #define DOCID_META_INVALID 0
 #define DOCID_META_CLASS_NAME "D-ID"
@@ -74,7 +75,17 @@ static void docIdMetaFree(const char *keyname, uint64_t meta) {
 }
 
 static int docIdMetaMove(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
-  REDISMODULE_NOT_USED(ctx);
+  const RedisModuleString *fromKey = RedisModule_GetKeyNameFromOptCtx(ctx);
+  const RedisModuleString *toKey = RedisModule_GetToKeyNameFromOptCtx(ctx);
+  size_t fromLen = 0, toLen = 0;
+  const char *fromStr = fromKey ? RedisModule_StringPtrLen((RedisModuleString *)fromKey, &fromLen) : NULL;
+  const char *toStr = toKey ? RedisModule_StringPtrLen((RedisModuleString *)toKey, &toLen) : NULL;
+  size_t nEntries = (meta && *meta) ? dictSize((dict *)*meta) : 0;
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[MOVE] from='%.*s' to='%.*s' entries=%zu (dropping meta)",
+                  (int)fromLen, fromStr ? fromStr : "",
+                  (int)toLen, toStr ? toStr : "",
+                  nEntries);
   REDISMODULE_NOT_USED(meta);
   // We do not want to move the meta, as the docID will not have meaning in the destination DB.
   // Returning 0 tells redis to drop the meta and not move it with the key - see the docs for more info.
@@ -89,21 +100,41 @@ static int docIdMetaMove(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
  * This fires before the keyspace notification, which is why we handle
  * deletion here rather than in the notification handler. */
 static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
-  REDISMODULE_NOT_USED(ctx);
-  if (*meta == 0) return;
+  const RedisModuleString *keyName = RedisModule_GetKeyNameFromOptCtx(ctx);
+  size_t keyLen = 0;
+  const char *keyStr = keyName ? RedisModule_StringPtrLen((RedisModuleString *)keyName, &keyLen) : NULL;
+  if (*meta == 0) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[UNLINK] key='%.*s' meta=NULL (nothing to do)",
+                    (int)keyLen, keyStr ? keyStr : "");
+    return;
+  }
 
   dict *specIdToDocId = (dict *)*meta;
-  if (dictSize(specIdToDocId) == 0) return;
+  size_t nEntries = dictSize(specIdToDocId);
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[UNLINK] key='%.*s' entries=%zu",
+                  (int)keyLen, keyStr ? keyStr : "", nEntries);
+  if (nEntries == 0) return;
 
   dictIterator *iter = dictGetIterator(specIdToDocId);
   dictEntry *de;
   while ((de = dictNext(iter))) {
     uint64_t docId = VAL_TO_DOCID(dictGetVal(de));
-    if (docId == DOCID_META_INVALID) continue;
+    uint64_t specId = KEY_TO_SPECID(dictGetKey(de));
+    if (docId == DOCID_META_INVALID) {
+      RedisModule_Log(RSDummyContext, "notice",
+                      "DocIdMeta[UNLINK]   key='%.*s' specId=%" PRIu64 " docId=INVALID (skip)",
+                      (int)keyLen, keyStr ? keyStr : "", specId);
+      continue;
+    }
 
     // Find the IndexSpec by specId in the global dict (O(1) lookup).
-    uint64_t specId = KEY_TO_SPECID(dictGetKey(de));
     IndexSpec *spec = findSpecBySpecId(specId);
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[UNLINK]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " spec=%s (deleting)",
+                    (int)keyLen, keyStr ? keyStr : "", specId, docId,
+                    spec ? "found" : "NULL");
     if (spec) {
       // Delete the document from this index by its docId
       IndexSpec_DeleteDocById(spec, docId);
@@ -120,17 +151,28 @@ static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
 static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   RS_LOG_ASSERT(encver == 1, "DocIdMeta: unexpected encver in RDB load");
 
+  const RedisModuleString *keyName = RedisModule_GetKeyNameFromIO(rdb);
+  size_t keyLen = 0;
+  const char *keyStr = keyName ? RedisModule_StringPtrLen((RedisModuleString *)keyName, &keyLen) : NULL;
+
   if (PersistenceInProgress) {
     // Skip actual loading during persistence events. We don't store this metadata in the RDB/AOF files.
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[RDB_LOAD] key='%.*s' SKIPPED (PersistenceInProgress)",
+                    (int)keyLen, keyStr ? keyStr : "");
     *meta = 0;
     return REDISMODULE_OK;
   }
 
   dict *specIdToDocId = dictCreate(&dictTypeUint64, NULL);
   size_t numEntries;
+  size_t kept = 0, dropped = 0;
 
   // Load the number of entries
   numEntries = LoadUnsigned_IOError(rdb, goto cleanup);
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[RDB_LOAD] key='%.*s' numEntries=%zu",
+                  (int)keyLen, keyStr ? keyStr : "", numEntries);
 
   // Load each entry (specId + docId), skipping entries whose spec no longer exists.
   for (size_t i = 0; i < numEntries; i++) {
@@ -139,16 +181,30 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
 
     // Skip entries belonging to indexes that are no longer in specIdDict_g (O(1) lookup).
     if (!isSpecValid(specId)) {
+      RedisModule_Log(RSDummyContext, "notice",
+                      "DocIdMeta[RDB_LOAD]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " DROPPED (spec invalid)",
+                      (int)keyLen, keyStr ? keyStr : "", specId, docId);
+      dropped++;
       continue;
     }
 
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[RDB_LOAD]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " LOADED",
+                    (int)keyLen, keyStr ? keyStr : "", specId, docId);
+    kept++;
     dictAdd(specIdToDocId, SPECID_TO_KEY(specId), DOCID_TO_VAL(docId));
   }
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[RDB_LOAD] key='%.*s' done kept=%zu dropped=%zu",
+                  (int)keyLen, keyStr ? keyStr : "", kept, dropped);
 
   *meta = (uint64_t)(specIdToDocId);
   return REDISMODULE_OK;
 
 cleanup:
+  RedisModule_Log(RSDummyContext, "warning",
+                  "DocIdMeta[RDB_LOAD] key='%.*s' FAILED (io error)",
+                  (int)keyLen, keyStr ? keyStr : "");
   if (specIdToDocId) {
     dictRelease(specIdToDocId);
   }
@@ -159,12 +215,22 @@ cleanup:
 static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
   REDISMODULE_NOT_USED(value);
 
+  const RedisModuleString *keyName = RedisModule_GetKeyNameFromIO(rdb);
+  size_t keyLen = 0;
+  const char *keyStr = keyName ? RedisModule_StringPtrLen((RedisModuleString *)keyName, &keyLen) : NULL;
+
   if (PersistenceInProgress) {
     // Skip saving during persistence events. We don't want to save this metadata to an RDB/AOF file
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[RDB_SAVE] key='%.*s' SKIPPED (PersistenceInProgress)",
+                    (int)keyLen, keyStr ? keyStr : "");
     return;
   }
 
   if (*meta == 0) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[RDB_SAVE] key='%.*s' meta=NULL (nothing to save)",
+                    (int)keyLen, keyStr ? keyStr : "");
     return;
   }
 
@@ -185,6 +251,10 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
     }
     dictReleaseIterator(iter);
   }
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[RDB_SAVE] key='%.*s' totalEntries=%lu validEntries=%zu",
+                  (int)keyLen, keyStr ? keyStr : "",
+                  (unsigned long)dictSize(specIdToDocId), validEntries);
 
   // Save entry count. Version is handled by encver in the KeyMeta API.
   RedisModule_SaveUnsigned(rdb, validEntries);
@@ -202,6 +272,9 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
     if (docId == DOCID_META_INVALID || !isSpecValid(specId)) {
       continue;
     }
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[RDB_SAVE]   key='%.*s' specId=%" PRIu64 " docId=%" PRIu64,
+                    (int)keyLen, keyStr ? keyStr : "", specId, docId);
     RedisModule_SaveUnsigned(rdb, specId);
     RedisModule_SaveUnsigned(rdb, docId);
   }
@@ -294,33 +367,65 @@ static int DocIdMeta_DeleteInternal(RedisModuleKey *key, uint64_t specId) {
 // Set docId using key name and spec incarnation ID.
 int DocIdMeta_Set(RedisModuleCtx *ctx, RedisModuleString *keyName,
                   uint64_t specId, uint64_t docId) {
+  size_t keyLen = 0;
+  const char *keyStr = RedisModule_StringPtrLen(keyName, &keyLen);
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, KEY_OPEN_META_SET_FLAGS);
   if (!key) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[SET] key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " OpenKey=NULL -> ERR",
+                    (int)keyLen, keyStr, specId, docId);
     return REDISMODULE_ERR;
   }
   int result = DocIdMeta_SetInternal(key, specId, docId);
   RedisModule_CloseKey(key);
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[SET] key='%.*s' specId=%" PRIu64 " docId=%" PRIu64 " result=%s",
+                  (int)keyLen, keyStr, specId, docId,
+                  result == REDISMODULE_OK ? "OK" : "ERR");
   return result;
 }
 
 // Get docId using key name and spec incarnation ID
 int DocIdMeta_Get(RedisModuleCtx *ctx, RedisModuleString *keyName,
                   uint64_t specId, uint64_t *docId) {
+  size_t keyLen = 0;
+  const char *keyStr = RedisModule_StringPtrLen(keyName, &keyLen);
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, KEY_OPEN_META_GET_FLAGS);
   if (!key) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[GET] key='%.*s' specId=%" PRIu64 " OpenKey=NULL -> ERR",
+                    (int)keyLen, keyStr, specId);
     return REDISMODULE_ERR;
   }
   int result = DocIdMeta_GetInternal(key, specId, docId);
   RedisModule_CloseKey(key);
+  if (result == REDISMODULE_OK) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[GET] key='%.*s' specId=%" PRIu64 " -> OK docId=%" PRIu64,
+                    (int)keyLen, keyStr, specId, *docId);
+  } else {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[GET] key='%.*s' specId=%" PRIu64 " -> ERR",
+                    (int)keyLen, keyStr, specId);
+  }
   return result;
 }
 
 int DocIdMeta_Delete(RedisModuleCtx *ctx, RedisModuleString *keyName, uint64_t specId) {
+  size_t keyLen = 0;
+  const char *keyStr = RedisModule_StringPtrLen(keyName, &keyLen);
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, KEY_OPEN_META_SET_FLAGS);
   if (!key) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "DocIdMeta[DEL] key='%.*s' specId=%" PRIu64 " OpenKey=NULL -> ERR",
+                    (int)keyLen, keyStr, specId);
     return REDISMODULE_ERR;
   }
   int result = DocIdMeta_DeleteInternal(key, specId);
   RedisModule_CloseKey(key);
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[DEL] key='%.*s' specId=%" PRIu64 " result=%s",
+                  (int)keyLen, keyStr, specId,
+                  result == REDISMODULE_OK ? "OK" : "ERR");
   return result;
 }

--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -63,12 +63,24 @@ static inline bool isSpecValid(uint64_t specId) {
 // DocIdMeta V1: a dict of specId (void*) -> docId (void*), using dictTypeUint64.
 // The meta value stored on a key is a `dict*` cast to `uint64_t` directly (no wrapper struct).
 #define DOCID_META_VERSION 1
-#define KEY_OPEN_META_SET_FLAGS (REDISMODULE_READ | REDISMODULE_WRITE | REDISMODULE_OPEN_KEY_NOEFFECTS)
-#define KEY_OPEN_META_GET_FLAGS (REDISMODULE_READ | REDISMODULE_OPEN_KEY_NOEFFECTS)
+// Compose side-effect suppressors individually instead of REDISMODULE_OPEN_KEY_NOEFFECTS.
+// The aggregate NOEFFECTS flag also inhibits BigRedis swap-in, which would leave the key
+// meta unloaded on disk-resident keys and cause DocIdMeta_Get to return meta=0.
+#define KEY_OPEN_META_NO_SIDE_EFFECTS (REDISMODULE_OPEN_KEY_NOTOUCH   | \
+                                       REDISMODULE_OPEN_KEY_NONOTIFY  | \
+                                       REDISMODULE_OPEN_KEY_NOSTATS   | \
+                                       REDISMODULE_OPEN_KEY_NOEXPIRE)
+#define KEY_OPEN_META_SET_FLAGS (REDISMODULE_READ | REDISMODULE_WRITE | KEY_OPEN_META_NO_SIDE_EFFECTS)
+#define KEY_OPEN_META_GET_FLAGS (REDISMODULE_READ | KEY_OPEN_META_NO_SIDE_EFFECTS)
 
 /* Free callback - called when metadata needs to be freed */
 static void docIdMetaFree(const char *keyname, uint64_t meta) {
-  REDISMODULE_NOT_USED(keyname);
+  size_t nEntries = (meta != 0) ? dictSize((dict *)meta) : 0;
+  RedisModule_Log(RSDummyContext, "notice",
+                  "DocIdMeta[FREE] key='%s' meta=%s entries=%zu",
+                  keyname ? keyname : "(null)",
+                  meta == 0 ? "NULL" : "non-null",
+                  nEntries);
   if (meta == 0) return;
   dict *d = (dict *)meta;
   dictRelease(d);
@@ -148,6 +160,14 @@ static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
   dictReleaseIterator(iter);
 }
 
+// Return values for RedisModuleKeyMetaLoadFunc (documented on RM_CreateKeyMetaClass):
+//   1: attach the loaded meta to the key
+//   0: skip/ignore (do not attach) - not an error
+//  -1: error, abort RDB load
+#define DOCID_META_RDB_LOAD_ATTACH 1
+#define DOCID_META_RDB_LOAD_SKIP   0
+#define DOCID_META_RDB_LOAD_ERROR  (-1)
+
 static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   RS_LOG_ASSERT(encver == 1, "DocIdMeta: unexpected encver in RDB load");
 
@@ -161,7 +181,7 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
                     "DocIdMeta[RDB_LOAD] key='%.*s' SKIPPED (PersistenceInProgress)",
                     (int)keyLen, keyStr ? keyStr : "");
     *meta = 0;
-    return REDISMODULE_OK;
+    return DOCID_META_RDB_LOAD_SKIP;
   }
 
   dict *specIdToDocId = dictCreate(&dictTypeUint64, NULL);
@@ -199,7 +219,7 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
                   (int)keyLen, keyStr ? keyStr : "", kept, dropped);
 
   *meta = (uint64_t)(specIdToDocId);
-  return REDISMODULE_OK;
+  return DOCID_META_RDB_LOAD_ATTACH;
 
 cleanup:
   RedisModule_Log(RSDummyContext, "warning",
@@ -209,7 +229,7 @@ cleanup:
     dictRelease(specIdToDocId);
   }
   *meta = 0;
-  return REDISMODULE_ERR;
+  return DOCID_META_RDB_LOAD_ERROR;
 }
 
 static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -4143,18 +4143,8 @@ void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
 
 void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *from_key,
                                             RedisModuleString *to_key) {
-  size_t from_len_log, to_len_log;
-  const char *from_str_log = RedisModule_StringPtrLen(from_key, &from_len_log);
-  const char *to_str_log = RedisModule_StringPtrLen(to_key, &to_len_log);
-  RedisModule_Log(RSDummyContext, "notice",
-                  "RENAME[ENTER] from='%.*s' to='%.*s'",
-                  (int)from_len_log, from_str_log, (int)to_len_log, to_str_log);
-
   DocumentType type = getDocTypeFromString(to_key);
   if (type == DocumentType_Unsupported) {
-    RedisModule_Log(RSDummyContext, "notice",
-                    "RENAME[EXIT] from='%.*s' to='%.*s' reason=unsupported_doc_type",
-                    (int)from_len_log, from_str_log, (int)to_len_log, to_str_log);
     return;
   }
 
@@ -4165,28 +4155,16 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
   const char *from_str = RedisModule_StringPtrLen(from_key, &from_len);
   const char *to_str = RedisModule_StringPtrLen(to_key, &to_len);
 
-  RedisModule_Log(RSDummyContext, "notice",
-                  "RENAME[SPECS] from='%.*s' to='%.*s' from_specs=%u to_specs=%u",
-                  (int)from_len, from_str, (int)to_len, to_str,
-                  (unsigned)array_len(from_specs->specsOps),
-                  (unsigned)array_len(to_specs->specsOps));
-
   // Handle specs that match the old key (whether they match the new key or not)
   for (size_t i = 0; i < array_len(from_specs->specsOps); ++i) {
     SpecOpCtx *specOp = from_specs->specsOps + i;
     IndexSpec *spec = specOp->spec;
     if (specOp->op == SpecOp_Del) {
-      RedisModule_Log(RSDummyContext, "notice",
-                      "RENAME[FROM] spec='%s' op=DEL skip",
-                      spec->specName);
       // the document is not in the index from the first place
       continue;
     }
     dictEntry *entry = dictFind(to_specs->specs, spec->specName);
     if (entry) {
-      RedisModule_Log(RSDummyContext, "notice",
-                      "RENAME[FROM] spec='%s' specId=%llu branch=RENAME_IN_INDEX",
-                      spec->specName, (unsigned long long)spec->specId);
       // The document should be indexed by the new key as well, so we need to update the key name in the index.
       RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
       RedisSearchCtx_LockSpecWrite(&sctx);
@@ -4195,14 +4173,7 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
       if (SearchDisk_IsEnabled()) {
         uint64_t docId;
         // After RENAME, the metadata lives on to_key (rename callback keeps it).
-        int rc = DocIdMeta_Get(ctx, to_key, spec->specId, &docId);
-        RedisModule_Log(RSDummyContext, "notice",
-                        "RENAME[FROM]   spec='%s' DocIdMeta_Get(to='%.*s', specId=%llu) -> %s docId=%llu",
-                        spec->specName, (int)to_len, to_str,
-                        (unsigned long long)spec->specId,
-                        rc == REDISMODULE_OK ? "OK" : "ERR",
-                        rc == REDISMODULE_OK ? (unsigned long long)docId : 0ULL);
-        if (rc == REDISMODULE_OK) {
+        if (DocIdMeta_Get(ctx, to_key, spec->specId, &docId) == REDISMODULE_OK) {
           // Update the key name in the disk doc table
           SearchDisk_ReplaceKey(spec->diskSpec, docId, to_str, to_len);
         }
@@ -4215,28 +4186,14 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
       dictDelete(to_specs->specs, spec->specName);
       array_del_fast(to_specs->specsOps, index);
     } else {
-      RedisModule_Log(RSDummyContext, "notice",
-                      "RENAME[FROM] spec='%s' specId=%llu branch=DELETE_FROM_INDEX",
-                      spec->specName, (unsigned long long)spec->specId);
       // The document should not be indexed by the new key, so we need to delete the old document from the index.
       if (SearchDisk_IsEnabled()) {
         // After RENAME, from_key no longer exists. The metadata is on to_key.
         // Look up the docId from to_key's metadata and delete by id.
         uint64_t docId;
-        int rc = DocIdMeta_Get(ctx, to_key, spec->specId, &docId);
-        RedisModule_Log(RSDummyContext, "notice",
-                        "RENAME[FROM]   spec='%s' DocIdMeta_Get(to='%.*s', specId=%llu) -> %s docId=%llu",
-                        spec->specName, (int)to_len, to_str,
-                        (unsigned long long)spec->specId,
-                        rc == REDISMODULE_OK ? "OK" : "ERR",
-                        rc == REDISMODULE_OK ? (unsigned long long)docId : 0ULL);
-        if (rc == REDISMODULE_OK) {
+        if (DocIdMeta_Get(ctx, to_key, spec->specId, &docId) == REDISMODULE_OK) {
           IndexSpec_DeleteDocById(spec, (t_docId)docId);
           DocIdMeta_Delete(ctx, to_key, spec->specId);
-        } else {
-          RedisModule_Log(RSDummyContext, "warning",
-                          "RENAME[FROM]   spec='%s' DELETE SKIPPED because DocIdMeta_Get failed on to='%.*s'",
-                          spec->specName, (int)to_len, to_str);
         }
       } else {
         // For RAM case, look up by old key name and delete
@@ -4249,25 +4206,16 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
   for (size_t i = 0; i < array_len(to_specs->specsOps); ++i) {
     SpecOpCtx *specOp = to_specs->specsOps + i;
     if (specOp->op == SpecOp_Del) {
-      RedisModule_Log(RSDummyContext, "notice",
-                      "RENAME[TO] spec='%s' op=DEL skip",
-                      specOp->spec->specName);
       // not need to index
       // also no need to delete because we know that the document is
       // not in the index because if it was there we would handle it
       // on the spec from section.
       continue;
     }
-    RedisModule_Log(RSDummyContext, "notice",
-                    "RENAME[TO] spec='%s' branch=INDEX_NEW_DOC",
-                    specOp->spec->specName);
     IndexSpec_UpdateDoc(specOp->spec, ctx, to_key, type);
   }
   Indexes_SpecOpsIndexingCtxFree(from_specs);
   Indexes_SpecOpsIndexingCtxFree(to_specs);
-  RedisModule_Log(RSDummyContext, "notice",
-                  "RENAME[EXIT] from='%.*s' to='%.*s' done",
-                  (int)from_len, from_str, (int)to_len, to_str);
 }
 
 void Indexes_List(RedisModule_Reply* reply, bool obfuscate) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -4143,8 +4143,18 @@ void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
 
 void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *from_key,
                                             RedisModuleString *to_key) {
+  size_t from_len_log, to_len_log;
+  const char *from_str_log = RedisModule_StringPtrLen(from_key, &from_len_log);
+  const char *to_str_log = RedisModule_StringPtrLen(to_key, &to_len_log);
+  RedisModule_Log(RSDummyContext, "notice",
+                  "RENAME[ENTER] from='%.*s' to='%.*s'",
+                  (int)from_len_log, from_str_log, (int)to_len_log, to_str_log);
+
   DocumentType type = getDocTypeFromString(to_key);
   if (type == DocumentType_Unsupported) {
+    RedisModule_Log(RSDummyContext, "notice",
+                    "RENAME[EXIT] from='%.*s' to='%.*s' reason=unsupported_doc_type",
+                    (int)from_len_log, from_str_log, (int)to_len_log, to_str_log);
     return;
   }
 
@@ -4155,16 +4165,28 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
   const char *from_str = RedisModule_StringPtrLen(from_key, &from_len);
   const char *to_str = RedisModule_StringPtrLen(to_key, &to_len);
 
+  RedisModule_Log(RSDummyContext, "notice",
+                  "RENAME[SPECS] from='%.*s' to='%.*s' from_specs=%u to_specs=%u",
+                  (int)from_len, from_str, (int)to_len, to_str,
+                  (unsigned)array_len(from_specs->specsOps),
+                  (unsigned)array_len(to_specs->specsOps));
+
   // Handle specs that match the old key (whether they match the new key or not)
   for (size_t i = 0; i < array_len(from_specs->specsOps); ++i) {
     SpecOpCtx *specOp = from_specs->specsOps + i;
     IndexSpec *spec = specOp->spec;
     if (specOp->op == SpecOp_Del) {
+      RedisModule_Log(RSDummyContext, "notice",
+                      "RENAME[FROM] spec='%s' op=DEL skip",
+                      spec->specName);
       // the document is not in the index from the first place
       continue;
     }
     dictEntry *entry = dictFind(to_specs->specs, spec->specName);
     if (entry) {
+      RedisModule_Log(RSDummyContext, "notice",
+                      "RENAME[FROM] spec='%s' specId=%llu branch=RENAME_IN_INDEX",
+                      spec->specName, (unsigned long long)spec->specId);
       // The document should be indexed by the new key as well, so we need to update the key name in the index.
       RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
       RedisSearchCtx_LockSpecWrite(&sctx);
@@ -4173,7 +4195,14 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
       if (SearchDisk_IsEnabled()) {
         uint64_t docId;
         // After RENAME, the metadata lives on to_key (rename callback keeps it).
-        if (DocIdMeta_Get(ctx, to_key, spec->specId, &docId) == REDISMODULE_OK) {
+        int rc = DocIdMeta_Get(ctx, to_key, spec->specId, &docId);
+        RedisModule_Log(RSDummyContext, "notice",
+                        "RENAME[FROM]   spec='%s' DocIdMeta_Get(to='%.*s', specId=%llu) -> %s docId=%llu",
+                        spec->specName, (int)to_len, to_str,
+                        (unsigned long long)spec->specId,
+                        rc == REDISMODULE_OK ? "OK" : "ERR",
+                        rc == REDISMODULE_OK ? (unsigned long long)docId : 0ULL);
+        if (rc == REDISMODULE_OK) {
           // Update the key name in the disk doc table
           SearchDisk_ReplaceKey(spec->diskSpec, docId, to_str, to_len);
         }
@@ -4186,14 +4215,28 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
       dictDelete(to_specs->specs, spec->specName);
       array_del_fast(to_specs->specsOps, index);
     } else {
+      RedisModule_Log(RSDummyContext, "notice",
+                      "RENAME[FROM] spec='%s' specId=%llu branch=DELETE_FROM_INDEX",
+                      spec->specName, (unsigned long long)spec->specId);
       // The document should not be indexed by the new key, so we need to delete the old document from the index.
       if (SearchDisk_IsEnabled()) {
         // After RENAME, from_key no longer exists. The metadata is on to_key.
         // Look up the docId from to_key's metadata and delete by id.
         uint64_t docId;
-        if (DocIdMeta_Get(ctx, to_key, spec->specId, &docId) == REDISMODULE_OK) {
+        int rc = DocIdMeta_Get(ctx, to_key, spec->specId, &docId);
+        RedisModule_Log(RSDummyContext, "notice",
+                        "RENAME[FROM]   spec='%s' DocIdMeta_Get(to='%.*s', specId=%llu) -> %s docId=%llu",
+                        spec->specName, (int)to_len, to_str,
+                        (unsigned long long)spec->specId,
+                        rc == REDISMODULE_OK ? "OK" : "ERR",
+                        rc == REDISMODULE_OK ? (unsigned long long)docId : 0ULL);
+        if (rc == REDISMODULE_OK) {
           IndexSpec_DeleteDocById(spec, (t_docId)docId);
           DocIdMeta_Delete(ctx, to_key, spec->specId);
+        } else {
+          RedisModule_Log(RSDummyContext, "warning",
+                          "RENAME[FROM]   spec='%s' DELETE SKIPPED because DocIdMeta_Get failed on to='%.*s'",
+                          spec->specName, (int)to_len, to_str);
         }
       } else {
         // For RAM case, look up by old key name and delete
@@ -4206,16 +4249,25 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
   for (size_t i = 0; i < array_len(to_specs->specsOps); ++i) {
     SpecOpCtx *specOp = to_specs->specsOps + i;
     if (specOp->op == SpecOp_Del) {
+      RedisModule_Log(RSDummyContext, "notice",
+                      "RENAME[TO] spec='%s' op=DEL skip",
+                      specOp->spec->specName);
       // not need to index
       // also no need to delete because we know that the document is
       // not in the index because if it was there we would handle it
       // on the spec from section.
       continue;
     }
+    RedisModule_Log(RSDummyContext, "notice",
+                    "RENAME[TO] spec='%s' branch=INDEX_NEW_DOC",
+                    specOp->spec->specName);
     IndexSpec_UpdateDoc(specOp->spec, ctx, to_key, type);
   }
   Indexes_SpecOpsIndexingCtxFree(from_specs);
   Indexes_SpecOpsIndexingCtxFree(to_specs);
+  RedisModule_Log(RSDummyContext, "notice",
+                  "RENAME[EXIT] from='%.*s' to='%.*s' done",
+                  (int)from_len, from_str, (int)to_len, to_str);
 }
 
 void Indexes_List(RedisModule_Reply* reply, bool obfuscate) {

--- a/tests/cpptests/test_cpp_doc_id_meta.cpp
+++ b/tests/cpptests/test_cpp_doc_id_meta.cpp
@@ -133,7 +133,8 @@ protected:
     rdbIO->read_pos = 0;
     uint64_t loadedMeta = 0;
     int result = RMCK_KeyMetaRdbLoad(getDocIdMetaClassId(), rdbIO, &loadedMeta, 1);
-    EXPECT_EQ(result, REDISMODULE_OK);
+    // RedisModuleKeyMetaLoadFunc returns 1 to attach the loaded meta to the key.
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(RMCK_IsIOError(rdbIO), 0);
     EXPECT_NE(loadedMeta, 0);
     return loadedMeta;


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the RDB load path for key metadata; incorrect return values could affect startup/loading behavior, though the change is small and aligns with documented RedisModule API semantics.
> 
> **Overview**
> Fixes `DocIdMeta` key-metadata RDB load callback to follow the `RedisModuleKeyMetaLoadFunc` contract by returning explicit *attach/skip/error* codes instead of `REDISMODULE_OK/ERR`.
> 
> During persistence events, `docIdMetaRDBLoad` now returns *skip* (do not attach metadata) and on I/O failure returns *error* to abort loading, reducing the chance of silently attaching or accepting invalid metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee56313d63d9a63345b7108d6137f72e7706ae05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->