### PR TITLE
Implement custom Debug and Pointer traits

### DIFF
--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -9,10 +9,15 @@
 
 //! Safe wrapper around [`ffi::HiddenString`].
 
-use std::{ffi::CStr, marker::PhantomData, ptr::NonNull};
+use std::{
+    ffi::CStr,
+    fmt::{self, Debug, Pointer},
+    marker::PhantomData,
+    ptr::NonNull,
+};
 
 /// A safe wrapper around a non-null `ffi::HiddenString` reference.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct HiddenStringRef<'a>(
     NonNull<ffi::HiddenString>,
@@ -57,5 +62,19 @@ impl<'a> HiddenStringRef<'a> {
         let bytes = unsafe { core::slice::from_raw_parts(data.cast::<u8>(), n) };
 
         CStr::from_bytes_with_nul(bytes).expect("malformed C string")
+    }
+}
+
+impl Debug for HiddenStringRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("HiddenStringRef")
+            .field(&format_args!("****"))
+            .finish()
+    }
+}
+
+impl Pointer for HiddenStringRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Pointer::fmt(&self.0, f)
     }
 }

--- a/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
@@ -30,3 +30,37 @@ fn get_secret_value() {
 
     unsafe { ffi::HiddenString_Free(ffi_hs, false) };
 }
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn debug_output() {
+    let input = c"Ab#123!";
+    let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };
+    let hs = unsafe { HiddenStringRef::from_raw(ffi_hs) };
+
+    let actual = format!("{hs:?}");
+
+    assert_eq!(actual, "HiddenStringRef(****)");
+
+    unsafe { ffi::HiddenString_Free(ffi_hs, false) };
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn pointer_output() {
+    let input = c"Ab#123!";
+    let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };
+    let hs = unsafe { HiddenStringRef::from_raw(ffi_hs) };
+
+    let actual = format!("{hs:p}");
+
+    assert!(actual.starts_with("0x"));
+
+    unsafe { ffi::HiddenString_Free(ffi_hs, false) };
+}


### PR DESCRIPTION
## Describe the changes in the pull request
Remove derived Debug implementation and add custom implementations for Debug and Pointer traits on HiddenStringRef. The Debug impl now masks the secret value with asterisks to prevent accidental exposure in logs, while the Pointer impl allows displaying the underlying pointer address when needed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested formatting-only change that reduces the chance of leaking secrets via logging; no functional changes to FFI access or memory handling.
> 
> **Overview**
> `HiddenStringRef` no longer derives `Debug`; it now implements a custom `Debug` formatter that **masks the underlying secret value** (prints `HiddenStringRef(****)`) to avoid accidental exposure in logs.
> 
> Adds a `Pointer` impl for `HiddenStringRef` so `{:p}` prints the underlying address, and adds unit tests to lock in both the masked debug output and pointer formatting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee019f6f092cee2b48ccadce1baf5928ea172f24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->