### PR TITLE
[8.4] [MOD-14944] test: fix flakiness test_query_while_flush (#9191)

### DIFF
--- a/tests/pytests/test_query_while_flush.py
+++ b/tests/pytests/test_query_while_flush.py
@@ -41,7 +41,15 @@ def test_query_while_flush():
         'flush_completed': False
     }
 
-    def query_worker(stats):
+    # Per-thread iteration counters, incremented at the end of each loop iteration.
+    # Used to deterministically drain in-flight iterations after toggling state
+    # (flushall_called / flush_completed): once every counter has advanced by at
+    # least one, every worker has re-evaluated the state and no stale attribution
+    # to the pre-flush counters can still be pending.
+    num_threads = 5
+    iteration_counts = [0] * num_threads
+
+    def query_worker(stats, thread_id):
         """Worker thread that continuously queries the index"""
         local_conn = env.getClusterConnectionIfNeeded()
 
@@ -65,30 +73,42 @@ def test_query_while_flush():
                 else:
                     stats['after_flush_errors'] += 1
 
+          iteration_counts[thread_id] += 1
           # Small delay to avoid overwhelming the system
           time.sleep(0.001)
 
-    # Start 5 query threads (pass the event)
-    num_threads = 5
+    # Start query threads (pass the event)
     threads = []
     for i in range(num_threads):
         thread = threading.Thread(
             target=query_worker,
-            args=(stats, ),
+            args=(stats, i),
             daemon=True
         )
         threads.append(thread)
         thread.start()
 
-    # Let queries run for a bit to accumulate some successes
-    time.sleep(0.5)
+    # Wait until query threads have accumulated some successes
+    wait_for_condition(
+        lambda: (stats['before_flush_successes'] > 0, stats),
+        message='no successful pre-flush queries observed',
+        timeout=30,
+    )
 
     # Signal that flushall is about to be called
     flushall_called.set()
-    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
-    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
-    # so this is a simpler better approach
-    time.sleep(0.5)
+    # Wait for in-flight pre-flush attributions to drain: every worker must complete
+    # at least one loop iteration after flushall_called.set(), guaranteeing each has
+    # re-evaluated flushall_called.is_set() at the increment site with the flag set.
+    snap = list(iteration_counts)
+    wait_for_condition(
+        lambda: (
+            all(c > s for c, s in zip(iteration_counts, snap)),
+            {'snap': snap, 'cur': list(iteration_counts)},
+        ),
+        message='not all workers completed an iteration after flushall_called.set()',
+        timeout=10,
+    )
     env.assertGreater(stats['before_flush_successes'], 0)
     env.assertEqual(stats['before_flush_errors'], 0)
 
@@ -97,11 +117,19 @@ def test_query_while_flush():
 
     # Mark flush as completed
     stats['flush_completed'] = True
-    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
-    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
-    # so this is a simpler better approach
-    # Otherwise I could see successes attributed to before flush that should have been after
-    time.sleep(0.5)
+    # Wait for any thread that already passed the `flushall_called.is_set()` check but has
+    # not yet read `flush_completed` to finish its iteration, so we don't misattribute a
+    # post-flush observation to the before-flush bucket when we later clear the event.
+    # Same drain purpose as above, expressed against the per-thread iteration counters.
+    snap = list(iteration_counts)
+    wait_for_condition(
+        lambda: (
+            all(c > s for c, s in zip(iteration_counts, snap)),
+            {'snap': snap, 'cur': list(iteration_counts)},
+        ),
+        message='not all workers completed an iteration after flush_completed=True',
+        timeout=10,
+    )
     flushall_called.clear()  # Reset the event
     # Create index2 and verify it works properly
     env.expect('FT.CREATE', 'index2', 'ON', 'HASH', 'SCHEMA', 'text', 'TEXT').ok()


### PR DESCRIPTION
* test: fix flakiness test_query_while_flush

* make more deterministic

(cherry picked from commit a158af2df7daeb804d3046ee6e21f02d9b5f4216)


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a flaky pytest and only affect CI/test determinism, not production logic.
> 
> **Overview**
> Reduces flakiness in `test_query_while_flush` by replacing fixed `sleep()`-based synchronization with deterministic waits.
> 
> Query worker threads now track per-thread loop iterations and the test uses `wait_for_condition` to (1) wait for pre-flush successes and (2) drain in-flight iterations around `flushall_called`/`flush_completed` state changes to avoid misattributing successes/errors across the `FLUSHALL` boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c632d54af5e7d5564f3d2ff0085b922b0a63364d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->