### PR TITLE
Fix Intel CI build: bindgen fails on asprintf in rmalloc.h

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -114,6 +114,10 @@ fn main() {
         let _ = rerun_if_c_changes(&include);
     }
 
+    // Required so `<stdio.h>` declares `asprintf`/`vasprintf` (used by
+    // `deps/rmalloc/rmalloc.h`) when bindgen parses the headers with clang.
+    bindings = bindings.clang_arg("-D_GNU_SOURCE");
+
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .blocklist_file(".*/document_rs.h")


### PR DESCRIPTION
Bindgen's clang parse of deps/rmalloc/rmalloc.h was failing on Linux CI with:

```error: call to undeclared function 'asprintf'; ```
ISO C99 and later do not support implicit function declarations
`asprintf/vasprintf` are GNU extensions that `<stdio.h>` only declares when `_GNU_SOURCE` is defined. Clang 16+ promotes `-Wimplicit-function-declaration` to an error by default, which is why it only reproduces on the Linux runners.

Fix
Pass `-D_GNU_SOURCE` to bindgen's clang in `src/redisearch_rs/ffi/build.rs`. No changes to the C build itself.

Failure
[CI failure](https://github.com/RediSearch/RediSearch/actions/runs/24689342359/job/72208517576#step:22:1039)

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change that tweaks bindgen’s parsing flags; main risk is unintended header/API differences in generated bindings across platforms.
> 
> **Overview**
> Fixes Linux/Intel CI bindgen failures by passing `-D_GNU_SOURCE` to bindgen’s clang invocation in `src/redisearch_rs/ffi/build.rs`, ensuring `<stdio.h>` exposes GNU-only `asprintf`/`vasprintf` used by `deps/rmalloc` during header parsing.
> 
> No C build flags or runtime behavior are changed; this only affects Rust FFI bindings generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbbe6bc107a7fe6c031a0b9984b577c1f5937352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->