### PR TITLE
[MOD-13424] RSE const and mut updates

### DIFF
--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -68,10 +68,14 @@ impl IndexSpec {
     pub fn lock(&mut self) -> IndexSpecLockGuard<'_> {
         IndexSpecLockGuard::new(&mut self.0)
     }
-}
 
-impl Default for IndexSpec {
-    fn default() -> Self {
+    /// Create a default `IndexSpec` with all fields set to zero or null.
+    ///
+    /// # Safety
+    /// The caller must ensure that the returned `IndexSpec` is properly initialized before use. Some
+    /// tests don't require initialization, hence why this method exists. You should never need to
+    /// call this outside of tests.
+    pub const unsafe fn zeroed() -> Self {
         // SAFETY: zeroed IndexSpec is valid to create, but not to use until properly initialized.
         unsafe { std::mem::zeroed() }
     }

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -68,17 +68,6 @@ impl IndexSpec {
     pub fn lock(&mut self) -> IndexSpecLockGuard<'_> {
         IndexSpecLockGuard::new(&mut self.0)
     }
-
-    /// Create a default `IndexSpec` with all fields set to zero or null.
-    ///
-    /// # Safety
-    /// The caller must ensure that the returned `IndexSpec` is properly initialized before use. Some
-    /// tests don't require initialization, hence why this method exists. You should never need to
-    /// call this outside of tests.
-    pub const unsafe fn zeroed() -> Self {
-        // SAFETY: zeroed IndexSpec is valid to create, but not to use until properly initialized.
-        unsafe { std::mem::zeroed() }
-    }
 }
 
 /// A guard that holds the IndexSpec write lock and releases it on drop.

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -87,7 +87,7 @@ impl IndexSpec {
 /// is created and released when the guard is dropped, ensuring the lock is always
 /// released even on early returns or panics.
 ///
-/// # Safety
+/// # Invariants
 ///
 /// The pointer passed to [`IndexSpecLockGuard::new`] must be a valid `IndexSpec*`
 /// that remains valid for the lifetime of this guard.
@@ -97,11 +97,6 @@ impl<'lock> IndexSpecLockGuard<'lock> {
     /// Creates a new guard, acquiring the write lock.
     ///
     /// Returns `None` if the pointer is null.
-    ///
-    /// # Safety
-    ///
-    /// `ptr` must be a valid pointer to a C `IndexSpec` struct that remains
-    /// valid for the lifetime of this guard.
     fn new(index_spec: &'lock mut ffi::IndexSpec) -> Self {
         // Safety: (1.) due to creation with `IndexSpec::from_raw`, and caller must ensure proper synchronization when mutating.
         unsafe { ffi::IndexSpec_AcquireWriteLock(index_spec) };

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Safe wrapper around [`ffi::IndexSpec`].
 
-use std::slice;
+use std::{ffi::c_char, slice};
 
 use field_spec::FieldSpec;
 use schema_rule::SchemaRule;
@@ -32,6 +32,18 @@ impl IndexSpec {
         unsafe { ptr.cast::<Self>().as_ref().unwrap() }
     }
 
+    /// Create a mutable `IndexSpec` wrapper from a non-null pointer.
+    ///
+    /// # Safety
+    /// 1. `ptr` must be a [valid], non-null pointer to an `ffi::IndexSpec` that is properly initialized.
+    ///    This also applies to any of its subfields.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::IndexSpec) -> &'a mut Self {
+        // Safety: ensured by caller (1.)
+        unsafe { ptr.cast::<Self>().as_mut().unwrap() }
+    }
+
     /// Get the underlying schema rule.
     pub const fn rule(&self) -> &SchemaRule {
         // Safety: (1.) due to creation with `IndexSpec::from_raw`
@@ -49,5 +61,75 @@ impl IndexSpec {
             .expect("numFields must fit into usize");
         // Safety: (1.) due to creation with `IndexSpec::from_raw`
         unsafe { slice::from_raw_parts(data, len) }
+    }
+
+    /// Acquire the write lock for this `IndexSpec`. This is required before performing any
+    /// modifications to the index spec, such as applying deltas from compaction.
+    pub fn lock(&mut self) -> IndexSpecLockGuard<'_> {
+        IndexSpecLockGuard::new(&mut self.0)
+    }
+}
+
+impl Default for IndexSpec {
+    fn default() -> Self {
+        // SAFETY: zeroed IndexSpec is valid to create, but not to use until properly initialized.
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+/// A guard that holds the IndexSpec write lock and releases it on drop.
+///
+/// This guard implements the RAII pattern: the lock is acquired when the guard
+/// is created and released when the guard is dropped, ensuring the lock is always
+/// released even on early returns or panics.
+///
+/// # Safety
+///
+/// The pointer passed to [`IndexSpecLockGuard::new`] must be a valid `IndexSpec*`
+/// that remains valid for the lifetime of this guard.
+pub struct IndexSpecLockGuard<'lock>(&'lock mut ffi::IndexSpec);
+
+impl<'lock> IndexSpecLockGuard<'lock> {
+    /// Creates a new guard, acquiring the write lock.
+    ///
+    /// Returns `None` if the pointer is null.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid pointer to a C `IndexSpec` struct that remains
+    /// valid for the lifetime of this guard.
+    fn new(index_spec: &'lock mut ffi::IndexSpec) -> Self {
+        // Safety: (1.) due to creation with `IndexSpec::from_raw`, and caller must ensure proper synchronization when mutating.
+        unsafe { ffi::IndexSpec_AcquireWriteLock(index_spec) };
+        Self(index_spec)
+    }
+
+    /// Decrements the document count for a term.
+    pub fn decrement_trie_term_count(&mut self, term: &[u8], decr: u64) -> bool {
+        // SAFETY: We hold the write lock (enforced by Self::new),
+        // and the C side handles non-null-terminated strings with length.
+        unsafe {
+            ffi::IndexSpec_DecrementTrieTermCount(
+                self.0,
+                term.as_ptr() as *const c_char,
+                term.len(),
+                decr as usize,
+            )
+        }
+    }
+
+    /// Decrements the num terms counter by the given amount.
+    pub fn decrement_num_terms(&mut self, decr: u64) {
+        // SAFETY: We hold the write lock (enforced by Self::new).
+        unsafe {
+            ffi::IndexSpec_DecrementNumTerms(self.0, decr);
+        }
+    }
+}
+
+impl Drop for IndexSpecLockGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: We acquired the lock in new(), so we must release it.
+        unsafe { ffi::IndexSpec_ReleaseWriteLock(self.0) };
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -294,7 +294,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
     /// given weight.
     fn new_wildcard_on_disk<'index>(
         &self,
-        index: &'index ffi::RedisSearchDiskIndexSpec,
+        index: &'index mut ffi::RedisSearchDiskIndexSpec,
         weight: f64,
     ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>>;
 
@@ -306,7 +306,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
     /// term positions.
     fn new_term_on_disk_with_offsets<'index>(
         &self,
-        index: &'index ffi::RedisSearchDiskIndexSpec,
+        index: &'index mut ffi::RedisSearchDiskIndexSpec,
         query_term: Box<RSQueryTerm>,
         field_mask: t_fieldMask,
         weight: f64,
@@ -320,7 +320,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
     /// positions.
     fn new_term_on_disk_without_offsets<'index>(
         &self,
-        index: &'index ffi::RedisSearchDiskIndexSpec,
+        index: &'index mut ffi::RedisSearchDiskIndexSpec,
         query_term: Box<RSQueryTerm>,
         field_mask: t_fieldMask,
         weight: f64,
@@ -330,7 +330,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
     /// then iterator will have the given weight.
     fn new_tag_on_disk<'index>(
         &self,
-        index: &'index ffi::RedisSearchDiskIndexSpec,
+        index: &'index mut ffi::RedisSearchDiskIndexSpec,
         token: &ffi::RSToken,
         field_index: ffi::t_fieldIndex,
         weight: f64,

--- a/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
@@ -161,7 +161,7 @@ where
         let wcii = if disk_index_available {
             // SAFETY: Caller guarantees `spec.diskSpec` is valid, non-null and
             // remains valid for `'index` (5).
-            let disk_spec = unsafe { &*spec.diskSpec };
+            let disk_spec = unsafe { &mut *spec.diskSpec };
             // SAFETY: Caller guarantees all preconditions of `new_wildcard_iterator_on_disk` hold (5).
             unsafe { new_wildcard_iterator_on_disk(disk_spec, weight) }
         } else {

--- a/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
@@ -99,7 +99,7 @@ where
                 let wcii = if disk_index_available {
                     // SAFETY: We checked `disk_index_available` (i.e. `!spec.diskSpec.is_null()`)
                     // above, and (6) guarantees the pointer is valid for `'index`.
-                    let disk_spec = unsafe { &*spec.diskSpec };
+                    let disk_spec = unsafe { &mut *spec.diskSpec };
                     // SAFETY: (6).
                     unsafe { new_wildcard_iterator_on_disk(disk_spec, weight) }
                 } else {

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -413,7 +413,7 @@ pub unsafe fn new_wildcard_iterator_optimized<'index>(
 ///    that remains valid for `'index`.
 /// 2. [`SEARCH_ENTERPRISE_ITERATORS`] must be initialized before calling this function.
 pub unsafe fn new_wildcard_iterator_on_disk<'index>(
-    disk_spec: &'index ffi::RedisSearchDiskIndexSpec,
+    disk_spec: &'index mut ffi::RedisSearchDiskIndexSpec,
     weight: f64,
 ) -> NewWildcardIterator<'index> {
     // SAFETY: Caller guarantees `SEARCH_ENTERPRISE_ITERATORS` is
@@ -479,7 +479,7 @@ pub unsafe fn new_wildcard_iterator<'index>(
         // SAFETY: Caller guarantees `spec.diskSpec` is a valid, non-null
         // pointer to a `RedisSearchDiskIndexSpec` that remains valid for
         // `'index` (7).
-        let disk_spec = unsafe { &*spec.diskSpec };
+        let disk_spec = unsafe { &mut *spec.diskSpec };
         // SAFETY: Caller guarantees all preconditions of
         // `new_wildcard_iterator_on_disk` hold (7, 8).
         return unsafe { new_wildcard_iterator_on_disk(disk_spec, weight) };

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -37,7 +37,7 @@ pub(crate) struct MockEnterpriseIterators;
 impl SearchEnterpriseIterators for MockEnterpriseIterators {
     fn new_wildcard_on_disk<'index>(
         &self,
-        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        _index: &'index mut ffi::RedisSearchDiskIndexSpec,
         weight: f64,
     ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
         Ok(Box::new(Wildcard::new(MOCK_DISK_WILDCARD_TOP_ID, weight)))
@@ -45,7 +45,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
 
     fn new_term_on_disk_with_offsets<'index>(
         &self,
-        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        _index: &'index mut ffi::RedisSearchDiskIndexSpec,
         _query_term: Box<query_term::RSQueryTerm>,
         _field_mask: inverted_index::t_fieldMask,
         _weight: f64,
@@ -69,7 +69,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
 
     fn new_tag_on_disk<'index>(
         &self,
-        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        _index: &'index mut ffi::RedisSearchDiskIndexSpec,
         _token: &ffi::RSToken,
         _field_index: ffi::t_fieldIndex,
         _weight: f64,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -57,7 +57,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
 
     fn new_term_on_disk_without_offsets<'index>(
         &self,
-        _index: &'index ffi::RedisSearchDiskIndexSpec,
+        _index: &'index mut ffi::RedisSearchDiskIndexSpec,
         _query_term: Box<query_term::RSQueryTerm>,
         _field_mask: inverted_index::t_fieldMask,
         _weight: f64,

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -27,7 +27,7 @@ typedef const void* RedisSearchDisk;
 typedef const void* RedisSearchDiskIndexSpec;
 typedef const void* RedisSearchDiskInvertedIndex;
 typedef const void* RedisSearchDiskIterator;
-typedef const void* RedisSearchDiskAsyncReadPool;
+typedef void* RedisSearchDiskAsyncReadPool;
 typedef const void* RedisSearchDiskRdbState;
 
 // Callback function to allocate memory for the key in the scope of the search module memory


### PR DESCRIPTION
## Describe the changes in the pull request
Changes needed for RSE to have less `unsafe` code and to use `mut` types correctly (it currently uses unsafe code to take `const` to `mut`).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FFI boundaries and iterator APIs by changing several pointers from immutable to mutable and introducing new lock-guard behavior; incorrect lifetimes/locking assumptions could cause subtle concurrency or UB issues. Scope is contained to wrappers and iterator construction paths.
> 
> **Overview**
> Reduces unsafe const-to-mut casts across the Rust/C boundary by **switching disk-index iterator APIs to take `&mut ffi::RedisSearchDiskIndexSpec`** and updating all wildcard/disk call sites and test mocks accordingly.
> 
> Adds a safer mutation surface for `IndexSpec` by introducing `IndexSpec::from_raw_mut()` plus an RAII `IndexSpecLockGuard` (`IndexSpec::lock()`) that acquires/releases the C write lock and exposes locked decrement helpers for compaction deltas.
> 
> Adjusts the disk API header to make `RedisSearchDiskAsyncReadPool` mutable (`void*`) rather than `const void*`, aligning ownership/mutability with its use in async read operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c09e55a091c461b029d9c8e8934f948104b396b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->