### PR TITLE
[MOD-14679] RsValue: Bring back nul-terminator check in RsString

### DIFF
--- a/src/aggregate/reducers/count_distinct.c
+++ b/src/aggregate/reducers/count_distinct.c
@@ -126,10 +126,11 @@ static RSValue *hllFinalize(Reducer *parent, void *ctx) {
 
   // Serialize field map.
   HLLSerializedHeader hdr = {.flags = 0, .bits = ctr->hll.bits};
-  char *str = rm_malloc(sizeof(hdr) + ctr->hll.size);
+  char *str = rm_malloc(sizeof(hdr) + ctr->hll.size + 1);
   size_t hdrsize = sizeof(hdr);
   memcpy(str, &hdr, hdrsize);
   memcpy(str + hdrsize, ctr->hll.registers, ctr->hll.size);
+  str[hdrsize + ctr->hll.size] = 0;
   RSValue *ret = RSValue_NewString(str, sizeof(hdr) + ctr->hll.size);
   return ret;
 }

--- a/src/aggregate/reducers/count_distinct.c
+++ b/src/aggregate/reducers/count_distinct.c
@@ -126,11 +126,11 @@ static RSValue *hllFinalize(Reducer *parent, void *ctx) {
 
   // Serialize field map.
   HLLSerializedHeader hdr = {.flags = 0, .bits = ctr->hll.bits};
-  char *str = rm_malloc(sizeof(hdr) + ctr->hll.size + 1);
   size_t hdrsize = sizeof(hdr);
+  char *str = rm_malloc(hdrsize + ctr->hll.size + 1);
+  str[hdrsize + ctr->hll.size] = 0; // Null termination
   memcpy(str, &hdr, hdrsize);
   memcpy(str + hdrsize, ctr->hll.registers, ctr->hll.size);
-  str[hdrsize + ctr->hll.size] = 0;
   RSValue *ret = RSValue_NewString(str, sizeof(hdr) + ctr->hll.size);
   return ret;
 }

--- a/src/redisearch_rs/query_term/src/lib.rs
+++ b/src/redisearch_rs/query_term/src/lib.rs
@@ -52,13 +52,7 @@ impl RSQueryTerm {
     ///
     /// The resulting term has `idf = 1.0` and `bm25_idf = 0.0`.
     pub fn new(s: &str, id: i32, flags: RSTokenFlags) -> Box<Self> {
-        Box::new(Self {
-            str_: Some(s.as_bytes().into()),
-            idf: 1.0,
-            id,
-            flags,
-            bm25_idf: 0.0,
-        })
+        Self::new_bytes(s.as_bytes(), id, flags)
     }
 
     /// Create a new [`RSQueryTerm`] from a raw byte slice, copying it into a
@@ -69,8 +63,12 @@ impl RSQueryTerm {
     /// byte sequences that are not valid UTF-8 (e.g. after case-folding
     /// applied to some Unicode codepoints).
     pub fn new_bytes(s: &[u8], id: i32, flags: RSTokenFlags) -> Box<Self> {
+        let mut buf = Vec::with_capacity(s.len() + 1);
+        buf.extend_from_slice(s);
+        buf.push(0); // add nul-terminator because this string ends up in RsValue which requires that.
+
         Box::new(Self {
-            str_: Some(s.into()),
+            str_: Some(buf.into_boxed_slice()),
             idf: 1.0,
             id,
             flags,
@@ -120,7 +118,7 @@ impl RSQueryTerm {
 
     /// Get the term string length in bytes.
     pub fn len(&self) -> usize {
-        self.str_.as_deref().map_or(0, <[u8]>::len)
+        self.as_bytes().map_or(0, <[u8]>::len)
     }
 
     /// Check if the term string is empty (null or zero length).
@@ -130,7 +128,7 @@ impl RSQueryTerm {
 
     /// Get the term as a byte slice, if the string is non-null.
     pub fn as_bytes(&self) -> Option<&[u8]> {
-        self.str_.as_deref()
+        self.str_.as_deref().map(|s| &s[0..(s.len() - 1)])
     }
 }
 
@@ -141,7 +139,7 @@ impl Eq for RSQueryTerm {}
 impl fmt::Debug for RSQueryTerm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSQueryTerm")
-            .field("str", &self.str_.as_deref().map(String::from_utf8_lossy))
+            .field("str", &self.as_bytes().map(String::from_utf8_lossy))
             .field("idf", &self.idf)
             .field("id", &self.id)
             .field("flags", &self.flags)

--- a/src/redisearch_rs/value/src/string.rs
+++ b/src/redisearch_rs/value/src/string.rs
@@ -74,8 +74,11 @@ impl String {
     ///    takes ownership of the allocation.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    #[expect(clippy::multiple_unsafe_ops_per_block)]
     pub unsafe fn rm_alloc_string(ptr: *const c_char, len: u32) -> Self {
         debug_assert!(!ptr.is_null());
+        // Safety: ensured by caller (1., 2., 3.)
+        debug_assert!(unsafe { ptr.add(len as usize).read() } as u8 == b'\0');
 
         Self {
             ptr,
@@ -95,8 +98,11 @@ impl String {
     ///    this [`String`] is exists.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    #[expect(clippy::multiple_unsafe_ops_per_block)]
     pub unsafe fn borrowed_string(ptr: *const c_char, len: u32) -> Self {
         debug_assert!(!ptr.is_null());
+        // Safety: ensured by caller (1., 2., 3.)
+        debug_assert!(unsafe { ptr.add(len as usize).read() } as u8 == b'\0');
 
         Self {
             ptr,


### PR DESCRIPTION
## Describe the changes in the pull request

This ensure the nul-terminator guarantee can be upholded again by RsString as several downstream users of RsString require string to be nul-terminated (e.g. aggregate date and string functions and result processor)

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FFI-facing string allocations/serialization and adds stricter nul-terminator assumptions, which could expose latent bugs or cause asserts/crashes if any caller passes non-terminated buffers. Changes are small but in memory-management paths shared across C/Rust.
> 
> **Overview**
> Restores the *nul-terminated string invariant* expected by `RsValue`/`RsString` consumers across both C and Rust paths.
> 
> C HLL reducer serialization now allocates an extra byte and explicitly appends a `\0` terminator, and Rust `RSQueryTerm` now stores term bytes with a trailing NUL (with `as_bytes()`/`len()` returning the slice excluding it). `RsString::rm_alloc_string` and `borrowed_string` reintroduce debug assertions that the byte at `ptr + len` is `\0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee04170490fbf545a23009cbd6a33adfbfb0105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->