### PR TITLE
[2.8][MOD-14944] test: fix flakiness test_query_while_flush

### DIFF
--- a/tests/pytests/test_query_while_flush.py
+++ b/tests/pytests/test_query_while_flush.py
@@ -42,7 +42,15 @@ def test_query_while_flush():
         'flush_completed': False
     }
 
-    def query_worker(stats):
+    # Per-thread iteration counters, incremented at the end of each loop iteration.
+    # Used to deterministically drain in-flight iterations after toggling state
+    # (flushall_called / flush_completed): once every counter has advanced by at
+    # least one, every worker has re-evaluated the state and no stale attribution
+    # to the pre-flush counters can still be pending.
+    num_threads = 5
+    iteration_counts = [0] * num_threads
+
+    def query_worker(stats, thread_id):
         """Worker thread that continuously queries the index"""
         local_conn = env.getClusterConnectionIfNeeded()
 
@@ -66,30 +74,42 @@ def test_query_while_flush():
                 else:
                     stats['after_flush_errors'] += 1
 
+          iteration_counts[thread_id] += 1
           # Small delay to avoid overwhelming the system
           time.sleep(0.001)
 
-    # Start 5 query threads (pass the event)
-    num_threads = 5
+    # Start query threads (pass the event)
     threads = []
     for i in range(num_threads):
         thread = threading.Thread(
             target=query_worker,
-            args=(stats, ),
+            args=(stats, i),
             daemon=True
         )
         threads.append(thread)
         thread.start()
 
-    # Let queries run for a bit to accumulate some successes
-    time.sleep(0.5)
+    # Wait until query threads have accumulated some successes
+    wait_for_condition(
+        lambda: (stats['before_flush_successes'] > 0, stats),
+        message='no successful pre-flush queries observed',
+        timeout=30,
+    )
 
     # Signal that flushall is about to be called
     flushall_called.set()
-    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
-    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
-    # so this is a simpler better approach
-    time.sleep(0.5)
+    # Wait for in-flight pre-flush attributions to drain: every worker must complete
+    # at least one loop iteration after flushall_called.set(), guaranteeing each has
+    # re-evaluated flushall_called.is_set() at the increment site with the flag set.
+    snap = list(iteration_counts)
+    wait_for_condition(
+        lambda: (
+            all(c > s for c, s in zip(iteration_counts, snap)),
+            {'snap': snap, 'cur': list(iteration_counts)},
+        ),
+        message='not all workers completed an iteration after flushall_called.set()',
+        timeout=10,
+    )
     env.assertGreater(stats['before_flush_successes'], 0)
     env.assertEqual(stats['before_flush_errors'], 0)
 
@@ -98,11 +118,19 @@ def test_query_while_flush():
 
     # Mark flush as completed
     stats['flush_completed'] = True
-    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
-    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
-    # so this is a simpler better approach
-    # Otherwise I could see successes attributed to before flush that should have been after
-    time.sleep(0.5)
+    # Wait for any thread that already passed the `flushall_called.is_set()` check but has
+    # not yet read `flush_completed` to finish its iteration, so we don't misattribute a
+    # post-flush observation to the before-flush bucket when we later clear the event.
+    # Same drain purpose as above, expressed against the per-thread iteration counters.
+    snap = list(iteration_counts)
+    wait_for_condition(
+        lambda: (
+            all(c > s for c, s in zip(iteration_counts, snap)),
+            {'snap': snap, 'cur': list(iteration_counts)},
+        ),
+        message='not all workers completed an iteration after flush_completed=True',
+        timeout=10,
+    )
     flushall_called.clear()  # Reset the event
     # Create index2 and verify it works properly
     env.expect('FT.CREATE', 'index2', 'ON', 'HASH', 'SCHEMA', 'text', 'TEXT').ok()


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a flaky pytest, replacing sleep-based synchronization with deterministic waiting around `FLUSHALL` to stabilize assertions.
> 
> **Overview**
> Makes `test_query_while_flush` deterministic by replacing fixed `sleep()`-based synchronization with `wait_for_condition()` checks.
> 
> The test now tracks per-thread loop iterations and explicitly drains in-flight query iterations after toggling `flushall_called` and after setting `flush_completed`, reducing misattribution of query successes/errors across the `FLUSHALL` boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4098a547e7bdc8208e4338ed89903af1b1508eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->