### PR TITLE
Fix MRConnManager_Add sync connect failure hang

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -329,7 +329,10 @@ int MRConnManager_Add(MRConnManager *m, uv_loop_t *loop, const char *id, MREndpo
   MRConnPool *pool = _MR_NewConnPool(ep, m->nodeConns, loop);
   if (connect) {
     for (size_t i = 0; i < pool->num; i++) {
-      MRConn_Connect(pool->conns[i]);
+      // Route through StartNewConnection so a synchronous MRConn_Connect
+      // failure lands in Connecting with the retry timer armed, instead of
+      // leaving the conn stuck in Disconnected with no recovery scheduled.
+      MRConn_StartNewConnection(pool->conns[i]);
     }
   }
 


### PR DESCRIPTION
### Bug
`MRConnManager_Add` calls `MRConn_Connect(pool->conns[i])` and discards the return value. On synchronous failure (e.g., hiredis cannot allocate the async context, or `redisLibuvAttach` fails), the connection stays in `MRConn_Disconnected` with no retry timer armed, so the shard connection never recovers.

### Fix
Route through `MRConn_StartNewConnection`, which already handles `REDIS_ERR` by calling `MRConn_SwitchState(conn, MRConn_Connecting)` — arming the 250ms retry timer.

### Backport
Applies to all supported lines.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author