### PR TITLE
Remove redundant SwitchState(ReAuth) on MRConn_SendAuth enqueue failure

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -553,7 +553,12 @@ static int MRConn_SendAuth(MRConn *conn) {
   CONN_LOG(conn, "Authenticating...");
   uv_loop_t *loop = conn->loop;
 
-  // if we failed to send the auth command, start a reconnect loop
+  // On enqueue failure we just return REDIS_ERR; the caller is responsible for
+  // detaching the (broken) ac and switching to Connecting. Switching to ReAuth
+  // here would arm the REAUTH timer on a dead ac, and because activate_timer
+  // is a no-op when a timer is already active, the caller's subsequent
+  // SwitchState(Connecting) would inherit the shorter REAUTH_TIMEOUT instead
+  // of RSCONN_RECONNECT_TIMEOUT.
   size_t len = 0;
 
   if (!IsEnterprise()) {
@@ -563,9 +568,6 @@ static int MRConn_SendAuth(MRConn *conn) {
     // Create a local copy of the secret so we can release the GIL.
     int status = redisAsyncCommand(conn->conn, MRConn_AuthCallback, loop,
         "AUTH %s %b", INTERNALAUTH_USERNAME, internal_secret, len);
-    if (status == REDIS_ERR) {
-      MRConn_SwitchState(conn, MRConn_ReAuth);
-    }
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
     return status;
   } else {
@@ -573,7 +575,6 @@ static int MRConn_SendAuth(MRConn *conn) {
     // If we got here, we know we have a password.
     if (redisAsyncCommand(conn->conn, MRConn_AuthCallback, loop, "AUTH %s",
           conn->ep.password) == REDIS_ERR) {
-      MRConn_SwitchState(conn, MRConn_ReAuth);
       return REDIS_ERR;
     }
     return REDIS_OK;


### PR DESCRIPTION
## Problem

When `redisAsyncCommand` inside `MRConn_SendAuth` returns `REDIS_ERR`
(the ac's output buffer is already broken, usually because hiredis has
marked it for disconnect), the function calls
`MRConn_SwitchState(conn, MRConn_ReAuth)` before returning the error.

Both callers (`MRConn_ConnectCallback` and the `ReAuth` branch of
`signalCallback`) inspect the return value and on `REDIS_ERR` already
do `detachFromConn + SwitchState(MRConn_Connecting)` to start a fresh
reconnect cycle. The inner `SwitchState(ReAuth)` is therefore
redundant, and worse, it arms a timer with `RSCONN_REAUTH_TIMEOUT`:
`SwitchState`'s `activate_timer` is a no-op when a timer is already
active, so the caller's subsequent `SwitchState(Connecting)` silently
inherits the shorter REAUTH timeout instead of
`RSCONN_RECONNECT_TIMEOUT`.

This makes reconnect intervals on enqueue failure shorter than the
intended 1s floor, which under a flapping peer can masquerade as a
busy reconnect loop with log spam.

## Fix

`MRConn_SendAuth` now simply returns `REDIS_ERR` on enqueue failure
and leaves state handling to its callers, which already do the right
thing. No behavioral change on success paths.

## Test plan

- 893/893 C/C++ unit tests.
- No Python test added: the behavior difference is a timer-interval
  off-by-one that is not externally observable without a purpose-built
  fault injector.

## Backport
`backport 8.2`, `backport 8.4`, `backport 8.6`, `backport 8.6-rse`,
`backport 8.8`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author