### PR TITLE
[MOD-14997] Encapsulate hybrid/optimizer iterators data access

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -678,6 +678,14 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   return ri;
 }
 
+RLookupKey **HybridIterator_GetOwnKeyRef(QueryIterator *it) {
+  return &((HybridIterator *)it)->ownKey;
+}
+
+void HybridIterator_SetKeyHandle(QueryIterator *it, struct RLookupKeyHandle *h) {
+  ((HybridIterator *)it)->keyHandle = h;
+}
+
 // Accessors for profile printing.
 const QueryIterator *HybridIterator_GetChild(const QueryIterator *it) {
   const HybridIterator *hi = (const HybridIterator *)it;

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -679,41 +679,49 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
 }
 
 RLookupKey **HybridIterator_GetOwnKeyRef(QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   return &((HybridIterator *)it)->ownKey;
 }
 
 void HybridIterator_SetKeyHandle(QueryIterator *it, struct RLookupKeyHandle *h) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   ((HybridIterator *)it)->keyHandle = h;
 }
 
 // Accessors for profile printing.
 const QueryIterator *HybridIterator_GetChild(const QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   const HybridIterator *hi = (const HybridIterator *)it;
   return hi->child;
 }
 
 const char *HybridIterator_GetSearchModeString(const QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   const HybridIterator *hi = (const HybridIterator *)it;
   return VecSimSearchMode_ToString(hi->searchMode);
 }
 
 bool HybridIterator_IsBatchMode(const QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   const HybridIterator *hi = (const HybridIterator *)it;
   return hi->searchMode == VECSIM_HYBRID_BATCHES ||
          hi->searchMode == VECSIM_HYBRID_BATCHES_TO_ADHOC_BF;
 }
 
 size_t HybridIterator_GetNumIterations(const QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   const HybridIterator *hi = (const HybridIterator *)it;
   return hi->numIterations;
 }
 
 size_t HybridIterator_GetMaxBatchSize(const QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   const HybridIterator *hi = (const HybridIterator *)it;
   return hi->maxBatchSize;
 }
 
 size_t HybridIterator_GetMaxBatchIteration(const QueryIterator *it) {
+  RS_ASSERT(it->type == HYBRID_ITERATOR);
   const HybridIterator *hi = (const HybridIterator *)it;
   return hi->maxBatchIteration;
 }

--- a/src/iterators/hybrid_reader.h
+++ b/src/iterators/hybrid_reader.h
@@ -63,6 +63,9 @@ extern "C" {
 
 QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError *status);
 
+RLookupKey    **HybridIterator_GetOwnKeyRef(QueryIterator *it);
+void            HybridIterator_SetKeyHandle(QueryIterator *it, struct RLookupKeyHandle *h);
+
 // Accessors for profile printing.
 const QueryIterator *HybridIterator_GetChild(const QueryIterator *it);
 const char *HybridIterator_GetSearchModeString(const QueryIterator *it);
@@ -70,6 +73,8 @@ bool HybridIterator_IsBatchMode(const QueryIterator *it);
 size_t HybridIterator_GetNumIterations(const QueryIterator *it);
 size_t HybridIterator_GetMaxBatchSize(const QueryIterator *it);
 size_t HybridIterator_GetMaxBatchIteration(const QueryIterator *it);
+
+
 
 #ifdef __cplusplus
 }

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -274,11 +274,13 @@ QueryIterator *NewOptimizerIterator(QOptimizer *qOpt, QueryIterator *root, Itera
 
 // Accessors for profile printing.
 const QueryIterator *OptimizerIterator_GetChild(const QueryIterator *it) {
+  RS_ASSERT(it->type == OPTIMUS_ITERATOR);
   const OptimizerIterator *oi = (const OptimizerIterator *)it;
   return oi->child;
 }
 
 const char *OptimizerIterator_GetOptimizationType(const QueryIterator *it) {
+  RS_ASSERT(it->type == OPTIMUS_ITERATOR);
   const OptimizerIterator *oi = (const OptimizerIterator *)it;
   return QOptimizer_PrintType(oi->optim);
 }

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -282,3 +282,4 @@ const char *OptimizerIterator_GetOptimizationType(const QueryIterator *it) {
   const OptimizerIterator *oi = (const OptimizerIterator *)it;
   return QOptimizer_PrintType(oi->optim);
 }
+

--- a/src/query.c
+++ b/src/query.c
@@ -1081,9 +1081,8 @@ static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn) {
     handle->is_valid = true;
 
     if (it->type == HYBRID_ITERATOR) {
-      HybridIterator *hybridIt = (HybridIterator *)it;
-      handle->key_ptr = &hybridIt->ownKey;
-      hybridIt->keyHandle = handle; // Set up back-reference
+      handle->key_ptr = HybridIterator_GetOwnKeyRef(it);
+      HybridIterator_SetKeyHandle(it, handle); // Set up back-reference
     } else { // Must be METRIC_ITERATOR due to the condition above
       handle->key_ptr = GetMetricOwnKeyRef(it);
       SetMetricRLookupHandle(it, handle); // Set up back-reference


### PR DESCRIPTION
- I based this on top of https://github.com/RediSearch/RediSearch/pull/9169 but it's not strictly mandatory.

This PR only encapsulates iterator data access to anticipate their migration to Rust. Some macro don't make sense as they were using direct field access which we can't do now because of different accessors (see comment in diff).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal refactor that replaces direct struct field access with accessor functions and adds iterator-type assertions; behavior should be unchanged aside from earlier failures on misuse.
> 
> **Overview**
> Encapsulates `HYBRID_ITERATOR` key/handle access by adding `HybridIterator_GetOwnKeyRef` and `HybridIterator_SetKeyHandle`, and updates vector metric handle setup in `Query_EvalVectorNode` to use these accessors instead of direct struct field reads/writes.
> 
> Tightens iterator accessor safety by adding `RS_ASSERT` type checks to hybrid and optimizer profiling accessors (e.g., `HybridIterator_GetChild`, `OptimizerIterator_GetChild`), reducing reliance on public struct layouts in preparation for future iterator implementation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ab9b41594b2f076b5369b7afae3007c66e3559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->