### PR TITLE
[MOD-15023] skip flaky test

### DIFF
--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1979,6 +1979,7 @@ def _test_pending_jobs_metrics(env, command_type):
 
     wait_for_condition(check_reset_metrics, "wait_for_workers_pending_jobs_metric_reset")
 
+@skip_until("2026-07-01", reason="Flaky test, see MOD-15023")
 def test_pending_jobs_metrics_search():
   env = Env(moduleArgs='DEFAULT_DIALECT 2')
   _test_pending_jobs_metrics(env, 'SEARCH')


### PR DESCRIPTION

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that disables a known flaky test; no production code paths or data handling are affected.
> 
> **Overview**
> Marks `test_pending_jobs_metrics_search` in `tests/pytests/test_info_modules.py` as skipped until `2026-07-01` due to flakiness (tracked as `MOD-15023`), leaving the aggregate variant unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fef0e56a37112195f9908c6268c065f7e6efaac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->