### PR TITLE
[8.2] RED-193707: Omit bots from reviewers list

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -137,12 +137,17 @@ jobs:
           ISSUES_SHIFT_ASSIGNEE: ${{ vars.ISSUES_SHIFT_ASSIGNEE }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
+          # Omit GITHUB_ACTOR from reviewers if it is a bot account
+          REVIEWERS="$TEAM_LEADERS,$ISSUES_SHIFT_ASSIGNEE"
+          if [[ "$GITHUB_ACTOR" != *"[bot]" ]]; then
+            REVIEWERS="$REVIEWERS,$GITHUB_ACTOR"
+          fi
           gh pr create \
             --title    "Bump version from $CUR_VERSION to $NEXT_VERSION" \
             --body     "This PR was automatically created by the release workflow of $RELEASE_TAG." \
             --head     "$BRANCH" \
             --base     "$RELEASE_BRANCH" \
-            --reviewer "$TEAM_LEADERS,$ISSUES_SHIFT_ASSIGNEE,$GITHUB_ACTOR" \
+            --reviewer "$REVIEWERS" \
             --draft
 
       - name: Trigger CI


### PR DESCRIPTION
Cherry-pick of #8991 to the 8.2 release branch.

- Ticket: [RED-193707](https://redislabs.atlassian.net/browse/RED-193707)
- Original PR on master: #8991 (RED-182188: Omit bots from reviewers list)
- Cherry-picked commit: `b94b0c089`
- Applies cleanly, no conflicts.


[RED-193707]: https://redislabs.atlassian.net/browse/RED-193707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small GitHub Actions workflow tweak that only changes the reviewer list on auto-created PRs and doesn’t affect build or release artifacts.
> 
> **Overview**
> When the release workflow auto-creates the version bump PR, it now **skips adding `github.actor` as a reviewer if the actor is a bot** (while still including team leaders and the on-call assignee). This prevents automated accounts from being assigned as reviewers on release PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79275f846f202d7b1b4b9b984c7915cd495edca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->