### PR TITLE
[2.8] [MOD-14793] fix trimUnionIterator in DESC mode#9248

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -656,7 +656,7 @@ void trimUnionIterator(IndexIterator *iter, size_t offset, size_t limit, bool as
         curTotal += it->NumEstimated(it->ctx);
         if (curTotal > limit) {
           ui->num = i + 1;
-          memset(ui->its + ui->num, 0, ui->norig - ui->num);
+          memset(ui->its + ui->num, 0, (ui->norig - ui->num) * sizeof(*ui->its));
           break;
         }
       }
@@ -666,8 +666,8 @@ void trimUnionIterator(IndexIterator *iter, size_t offset, size_t limit, bool as
         curTotal += it->NumEstimated(it->ctx);
         if (curTotal > limit) {
           ui->num -= i;
-          memmove(ui->its, ui->its + i, ui->num);
-          memset(ui->its + ui->num, 0, ui->norig - ui->num);
+          memmove(ui->its, ui->its + i, ui->num * sizeof(*ui->its));
+          memset(ui->its + ui->num, 0, (ui->norig - ui->num) * sizeof(*ui->its));
           break;
         }
       }

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -533,6 +533,44 @@ def testAggregate(env):
             compare_optimized_to_not(env, ['ft.aggregate', 'idx', '*'], params, 'case 12')
         #input('stop')
 
+@skip(cluster=True)
+def testTrimUnionDesc(env):
+    """Cover the DESC branch of trimUnionIterator (query_optimizer.c lines 56-63).
+
+    The numeric tree needs >2 leaf nodes so that trimming is not skipped
+    (num_orig <= 2 early-return). With MINIMUM_RANGE_CARDINALITY=16 and
+    CARDINALITY_GROWTH_FACTOR=4, depth-1 nodes split at cardinality 64.
+    Using 500 unique values guarantees 4+ leaf nodes at depth 2.
+    """
+    conn = getConnectionByEnv(env)
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
+
+    # 500 docs with unique n values 0..499 → many numeric tree leaf nodes.
+    for i in range(500):
+        conn.execute_command('hset', i, 'n', i)
+
+    limits = [[0, 2], [0, 10], [0, 100]]
+    ranges = [[-1, 500], [0, 499], [50, 450], [100, 300]]
+    params = ['limit', 0, 0]
+
+    for lim in limits:
+        params[1] = lim[0]
+        params[2] = lim[1]
+        for rng in ranges:
+            numRange = '@n:[%d %d]' % (rng[0], rng[1])
+
+            # DESC: exercises lines 56-63
+            compare_optimized_to_not(
+                env, ['ft.search', 'idx', numRange, 'SORTBY', 'n', 'DESC'],
+                params, 'DESC ' + numRange)
+
+            # ASC: exercises lines 47-52 (already covered elsewhere, but
+            # validates the same data set)
+            compare_optimized_to_not(
+                env, ['ft.search', 'idx', numRange, 'SORTBY', 'n', 'ASC'],
+                params, 'ASC ' + numRange)
+
+
 @skip()  # TODO: solve flakiness (MOD-5257)
 def testCoordinator(env):
     # separate test which only has queries with sortby since otherwise the coordinator has random results


### PR DESCRIPTION
# Description
Backport of #8972 to `2.8`.

## Describe the changes in the pull request

  - Add `testTrimUnionDesc` to cover the DESC branch of `trimUnionIterator`, using 500 unique numeric values to ensure >2 tree leaf nodes                                                                                                                   
  - Fix `memmove`/`memset` calls in `trimUnionIterator` that used element counts instead of byte counts — the DESC path returned wrong results on 64-bit systems               

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it replaces the project’s CI/release pipeline and significantly rewrites `CMakeLists.txt` and platform setup scripts, which can break builds, tests, artifact publishing, or releases across multiple OS/architectures.
> 
> **Overview**
> **Replaces CircleCI and legacy GitHub Actions with a new modular GitHub Actions CI system.** This deletes `.circleci/config.yml` and the older build/coverage/sanitizer workflows, and introduces reusable `task-*` and `flow-*` workflows for PRs, merge-queue validation, nightly/weekly runs, benchmark triggering, snapshot deploys, and tagged releases (including artifact promotion and Slack notifications).
> 
> **Adds a new cross-platform `.install/` toolchain used by the workflows.** New scripts install compilers/deps, Python via `uv`, Rust toolchains, CMake/Boost, AWS CLI, and provide dependency verification; artifacts builds now include OIDC/keys-based AWS uploads and special handling for platforms lacking `node20`.
> 
> **Build system updates.** `CMakeLists.txt` is refactored to remove `deps/readies` usage, add sanitizer/coverage and feature toggles (`MT_BUILD`, `ENABLE_ASSERT`, `VERBOSE_UTESTS`), adjust sources/targets (e.g., include `coord/src/rmr/reply.c` in coordinator static libs), and control optional test/example-extension builds. Also updates Codecov config, ignores new cache/venv artifacts, removes `deps/readies` submodule, and switches `deps/hiredis` to the `redis/hiredis` repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254ccb65bac40507f37a421f441a923efc94a50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->