### PR TITLE
[2.10] [MOD-14793] fix trimUnionIterator in DESC mode#9248#9252

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -572,7 +572,7 @@ void trimUnionIterator(IndexIterator *iter, size_t offset, size_t limit, bool as
         curTotal += it->NumEstimated(it->ctx);
         if (curTotal > limit) {
           ui->num = i + 1;
-          memset(ui->its + ui->num, 0, ui->norig - ui->num);
+          memset(ui->its + ui->num, 0, (ui->norig - ui->num) * sizeof(*ui->its));
           break;
         }
       }
@@ -582,8 +582,8 @@ void trimUnionIterator(IndexIterator *iter, size_t offset, size_t limit, bool as
         curTotal += it->NumEstimated(it->ctx);
         if (curTotal > limit) {
           ui->num -= i;
-          memmove(ui->its, ui->its + i, ui->num);
-          memset(ui->its + ui->num, 0, ui->norig - ui->num);
+          memmove(ui->its, ui->its + i, ui->num * sizeof(*ui->its));
+          memset(ui->its + ui->num, 0, (ui->norig - ui->num) * sizeof(*ui->its));
           break;
         }
       }

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -533,6 +533,44 @@ def testAggregate(env):
             compare_optimized_to_not(env, ['ft.aggregate', 'idx', '*'], params, 'case 12')
         #input('stop')
 
+@skip(cluster=True)
+def testTrimUnionDesc(env):
+    """Cover the DESC branch of trimUnionIterator (query_optimizer.c lines 56-63).
+
+    The numeric tree needs >2 leaf nodes so that trimming is not skipped
+    (num_orig <= 2 early-return). With MINIMUM_RANGE_CARDINALITY=16 and
+    CARDINALITY_GROWTH_FACTOR=4, depth-1 nodes split at cardinality 64.
+    Using 500 unique values guarantees 4+ leaf nodes at depth 2.
+    """
+    conn = getConnectionByEnv(env)
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
+
+    # 500 docs with unique n values 0..499 → many numeric tree leaf nodes.
+    for i in range(500):
+        conn.execute_command('hset', i, 'n', i)
+
+    limits = [[0, 2], [0, 10], [0, 100]]
+    ranges = [[-1, 500], [0, 499], [50, 450], [100, 300]]
+    params = ['limit', 0, 0]
+
+    for lim in limits:
+        params[1] = lim[0]
+        params[2] = lim[1]
+        for rng in ranges:
+            numRange = '@n:[%d %d]' % (rng[0], rng[1])
+
+            # DESC: exercises lines 56-63
+            compare_optimized_to_not(
+                env, ['ft.search', 'idx', numRange, 'SORTBY', 'n', 'DESC'],
+                params, 'DESC ' + numRange)
+
+            # ASC: exercises lines 47-52 (already covered elsewhere, but
+            # validates the same data set)
+            compare_optimized_to_not(
+                env, ['ft.search', 'idx', numRange, 'SORTBY', 'n', 'ASC'],
+                params, 'ASC ' + numRange)
+
+
 @skip()  # TODO: solve flakiness (MOD-5257)
 def testCoordinator(env):
     # separate test which only has queries with sortby since otherwise the coordinator has random results


### PR DESCRIPTION
# Description
Backport of #8972 to `2.10`.

## Describe the changes in the pull request

  - Add `testTrimUnionDesc` to cover the DESC branch of `trimUnionIterator`, using 500 unique numeric values to ensure >2 tree leaf nodes                                                                                                                   
  - Fix `memmove`/`memset` calls in `trimUnionIterator` that used element counts instead of byte counts — the DESC path returned wrong results on 64-bit systems   

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: replaces the CI/release/benchmark pipelines and build dependency bootstrapping, which can break builds, artifact publishing, and release automation if any platform-specific path or credential flow is misconfigured.
> 
> **Overview**
> **Migrates CI off CircleCI to a new GitHub Actions-based pipeline** for PRs, merge-queue, nightly/weekly runs, benchmarks, snapshot deploys, and tagged releases (including artifact upload to S3 and Slack failure notifications).
> 
> **Adds a unified matrix-driven build/test system** (`generate-matrix`, `task-test`, `task-build-artifacts`, `.install/*`) with per-platform setup scripts, uv-based Python venv setup, Rust toolchain install, and special handling for platforms that can’t use Node 20.
> 
> **Build/coverage plumbing updates:** introduces `codecov.yml` and Codecov uploads from CI; updates `CMakeLists.txt` to drop `deps/readies`, add sanitizer/coverage flags, Boost-from-`.install` integration, and link `redisearch-hash`/additional sources for coordinator builds.
> 
> Minor repo hygiene: updates GitHub issue/PR templates (release-notes checkbox + label tweaks), adjusts stale policy to not auto-close, updates `.gitignore`, and removes the `deps/readies` submodule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aadcdc8bd8befb653723f541e834bdcddd531dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->