### PR TITLE
test_index_error: cover geo string length validation in parseGeo

### DIFF
--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -167,3 +167,30 @@ def testGeoOnReopen(env:Env):
     checkResults(res)
 
   env.assertEqual(len(ids), n)
+
+@skip(cluster=True)
+def testGeoLargeRadiusDecreaseStep(env):
+  """Exercise the decrease_step path in geohashGetAreasByRadius.
+  At high latitudes, longitude cells are physically compressed
+  (cos(85°) ≈ 0.087), so a 620 km radius at lat=85 exceeds the
+  east/west neighbor cell boundaries at step 3 (~45° cells =
+  ~556 km physical width), triggering the step decrease."""
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
+
+  points = [
+    ('doc1', '30.0,85.0'),   # at the query center
+    ('doc2', '31.0,84.5'),   # very close to center
+    ('doc3', '0.0,85.0'),    # ~288 km west, within radius
+    ('doc4', '0.0,0.0'),     # equator, well outside radius
+  ]
+  for name, loc in points:
+    conn.execute_command('HSET', name, 'g', loc)
+  waitForIndex(env, 'idx')
+
+  # 620 km radius at (30, 85): at step 3 (313-626 km range), east neighbor
+  # far edge at 90° lon is ~556 km from center — less than 620 km radius,
+  # so decrease_step triggers.
+  res = env.cmd('FT.SEARCH', 'idx', '@g:[30.0 85.0 620 km]', 'NOCONTENT')
+  env.assertGreaterEqual(res[0], 2, message=res)
+  env.assertNotContains('doc4', res)

--- a/tests/pytests/test_index_error.py
+++ b/tests/pytests/test_index_error.py
@@ -266,6 +266,36 @@ def test_geo_index_failures(env):
     env.assertEqual(error_dict, {**expected_error_dict, **index_errors_unique_entries_dict}
 )
 
+  con.flushall()
+
+  env.expect('ft.create', 'idx', 'SCHEMA', 'g', 'geo').ok()
+
+  # Insert two documents, one with a geo string longer than 128 bytes and one valid.
+  # The long string should trigger the length validation in parseGeo.
+
+  long_geo = 'x' * 129
+  con.execute_command('hset', 'doc{1}', 'g', long_geo)
+  con.execute_command('hset', 'doc{2}', 'g', '1,1')
+
+  expected_error_dict = {
+                          indexing_failures_str: 1,
+                          last_indexing_error_str: 'SEARCH_PARSE_ARGS Geo string cannot be longer than 128 bytes',
+                          last_indexing_error_key_str: 'doc{1}',
+                        }
+
+  for _ in env.reloadingIterator():
+    info = index_info(env)
+    env.assertEqual(info['num_docs'], 1)
+
+    field_spec_dict = get_field_stats_dict(info)
+    error_dict = to_dict(field_spec_dict["Index Errors"])
+
+    env.assertEqual(error_dict, expected_error_dict)
+
+    error_dict = to_dict(info["Index Errors"])
+    env.assertEqual(error_dict, {**expected_error_dict, **index_errors_unique_entries_dict}
+)
+
 
 # TODO: Talk with Omer about this test
 


### PR DESCRIPTION
Improve `rs_geo.c` coverage by testing the two missing lines: https://app.codecov.io/gh/RediSearch/RediSearch/blob/master/src%2Frs_geo.c?flags%5B0%5D=flow

Also adding a test improving `geohash_helper.c` coverage.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to pytest coverage and assertions for geo indexing failures, with no production code or API behavior modified.
> 
> **Overview**
> Adds a new case to `test_geo_index_failures` to verify that indexing a GEO field rejects strings longer than 128 bytes.
> 
> The test now flushes and recreates the index, inserts one overlong geo value plus one valid document, and asserts `FT.INFO`/field stats report a single indexing failure with the expected `SEARCH_PARSE_ARGS Geo string cannot be longer than 128 bytes` error and key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31170c056b13f37b31fad5dba2cf767d731894d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->