### PR TITLE
benchmarks: Polar Signals profiling + redisearch-m7 setup

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -161,7 +161,12 @@ jobs:
               --github_org ${{ github.repository_owner }}
               --module_path ../../$REJSON_MODULE_PATH
               --required-module ReJSON
-              --github_sha ${{ github.sha }}
+              # On pull_request events github.sha is the ephemeral merge commit,
+              # which is garbage-collected after the PR merges and breaks later
+              # reproducibility of RTS time-series and Polar Signals `git_hash`
+              # labels. Use the PR head SHA instead; fall back to github.sha on
+              # push events (where it already is the head).
+              --github_sha ${{ github.event.pull_request.head.sha || github.sha }}
               --github_branch ${{ github.head_ref || github.ref_name }}
               --upload_results_s3
               --triggering_env $TRIGGERING_ENV

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -134,6 +134,20 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.PERFORMANCE_EC2_REGION }}
           EC2_PRIVATE_PEM: ${{ secrets.PERFORMANCE_EC2_PRIVATE_PEM }}
+          # Polar Signals / parca-agent configuration. Terraform reads these
+          # as `TF_VAR_<name>` env vars when redisbench-admin run-remote
+          # shells out to `terraform apply`. When enable_parca_agent is true
+          # the cloud-init on the DB server installs parca-agent (from the
+          # `edge` snap channel so `remote-store-grpc-headers=projectID=...`
+          # is honored) and streams profile samples to Polar Signals project
+          # $PERFORMANCE_PARCA_AGENT_PROJECT_ID during the benchmark.
+          # redisbench-admin additionally sets `metadata-external-labels`
+          # per-test (test_name, git_hash, tested_commands, ...) so samples
+          # are queryable by the same dimensions as the RTS result.
+          TF_VAR_enable_parca_agent: true
+          TF_VAR_parca_agent_token: ${{ secrets.PERFORMANCE_PARCA_AGENT_TOKEN }}
+          TF_VAR_parca_agent_project_id: ${{ secrets.PERFORMANCE_PARCA_AGENT_PROJECT_ID }}
+          TF_VAR_parca_agent_snap_channel: edge
           # Inputs
           PROFILE: ${{ inputs.profile_env }}
           BENCHMARK_GLOB: ${{ steps.benchmark-filter.outputs.effective_glob }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -153,6 +153,11 @@ jobs:
           TRIGGERING_ENV: ${{ inputs.triggering_env }}
           ALLOWED_ENVS: ${{ inputs.allowed_envs }}
           ALLOWED_SETUPS: ${{ inputs.allowed_setups }}
+        # --github_sha: on pull_request events github.sha is the ephemeral
+        # merge commit, which is garbage-collected after the PR merges and
+        # breaks later reproducibility of RTS time-series and Polar Signals
+        # `git_hash` labels. Use the PR head SHA instead; fall back to
+        # github.sha on push events (where it already is the head).
         run: redisbench-admin run-remote
               --module_path ../../$MODULE_PATH
               --required-module search
@@ -161,11 +166,6 @@ jobs:
               --github_org ${{ github.repository_owner }}
               --module_path ../../$REJSON_MODULE_PATH
               --required-module ReJSON
-              # On pull_request events github.sha is the ephemeral merge commit,
-              # which is garbage-collected after the PR merges and breaks later
-              # reproducibility of RTS time-series and Polar Signals `git_hash`
-              # labels. Use the PR head SHA instead; fall back to github.sha on
-              # push events (where it already is the head).
               --github_sha ${{ github.event.pull_request.head.sha || github.sha }}
               --github_branch ${{ github.head_ref || github.ref_name }}
               --upload_results_s3

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -14,8 +14,6 @@ on:
       rejson_module_path:
         type: string
         default: bin/linux-x64-release/RedisJSON/master/rejson.so
-      profile_env:
-        type: number # for default of 0
       benchmark_glob:
         type: string
         default: "*.yml"
@@ -97,7 +95,7 @@ jobs:
           name: ${{ inputs.binary_artifact_name }}
           # Place the .so where `inputs.module_path` expects it, e.g.
           # bin/linux-x64-release/search-community/redisearch.so
-          path: ${{ inputs.profile_env == 1 && 'bin/linux-x64-release-profile/search-community' || 'bin/linux-x64-release/search-community' }}
+          path: bin/linux-x64-release/search-community
       - name: Make redisearch.so executable
         if: steps.benchmark-filter.outputs.skip != 'true'
         env:
@@ -126,9 +124,6 @@ jobs:
         timeout-minutes: 360 # timeout for the step
         working-directory: tests/benchmarks
         env:
-          # Hard-coded
-          PERF_CALLGRAPH_MODE: dwarf
-          MAX_PROFILERS: 3
           # Secrets
           AWS_ACCESS_KEY_ID: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -149,7 +144,6 @@ jobs:
           TF_VAR_parca_agent_project_id: ${{ secrets.PERFORMANCE_PARCA_AGENT_PROJECT_ID }}
           TF_VAR_parca_agent_snap_channel: edge
           # Inputs
-          PROFILE: ${{ inputs.profile_env }}
           BENCHMARK_GLOB: ${{ steps.benchmark-filter.outputs.effective_glob }}
           BENCHMARK_RUNNER_GROUP_M_ID: ${{ inputs.benchmark_runner_group_member_id }}
           BENCHMARK_RUNNER_GROUP_TOTAL: ${{ inputs.benchmark_runner_group_total }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -9,10 +9,6 @@ on:
         type: boolean
         description: "Run extended benchmarks"
         default: false
-      profiler:
-        type: boolean
-        description: "Run profiler on standalone benchmarks"
-        default: false
       allowed_setup:
         type: string
         description: "if empty allows all setups. if not, will only trigger for a specific setup"
@@ -28,9 +24,6 @@ on:
   workflow_call:
     inputs:
       extended:
-        type: boolean
-        default: false
-      profiler:
         type: boolean
         default: false
       allowed_setup:
@@ -51,16 +44,7 @@ jobs:
   build-redisearch:
     uses: ./.github/workflows/flow-build-benchmark-binary.yml
     with:
-      profile_env: 0
       artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
-
-  # Profile build is only needed when profiler benchmarks are enabled.
-  build-redisearch-profile:
-    if: ${{ inputs.profiler }}
-    uses: ./.github/workflows/flow-build-benchmark-binary.yml
-    with:
-      profile_env: 1
-      artifact_name: redisearch-bin-profile-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
@@ -274,50 +258,6 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
-  benchmark-search-oss-standalone-profiler:
-    if: ${{ inputs.profiler && (inputs.allowed_setup == '' || inputs.allowed_setup == 'standalone') }}
-    needs: build-redisearch-profile
-    strategy:
-      fail-fast: false
-      matrix:
-        member_id: [1, 2, 3]
-    uses: ./.github/workflows/benchmark-flow.yml
-    secrets: inherit
-    with:
-      profile_env: 1
-      # TODO: change to "github-actions.profilers" when ready on grafana
-      triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
-      module_path: bin/linux-x64-release-profile/search-community/redisearch.so
-      benchmark_glob: "search*.yml"
-      benchmark_filter: ${{ inputs.benchmark_filter }}
-      allowed_envs: oss-standalone
-      allowed_setups: oss-standalone
-      benchmark_runner_group_member_id: ${{ matrix.member_id }}
-      benchmark_runner_group_total: ${{ strategy.job-total }}
-      binary_artifact_name: redisearch-bin-profile-${{ github.run_id }}-${{ github.run_attempt }}
-
-  benchmark-vecsim-oss-standalone-profiler:
-    if: ${{ inputs.profiler && (inputs.allowed_setup == '' || inputs.allowed_setup == 'standalone') }}
-    needs: build-redisearch-profile
-    strategy:
-      fail-fast: false
-      matrix:
-        member_id: [1, 2]
-    uses: ./.github/workflows/benchmark-flow.yml
-    secrets: inherit
-    with:
-      profile_env: 1
-      # TODO: change to "github-actions.profilers" when ready on grafana
-      triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
-      module_path: bin/linux-x64-release-profile/search-community/redisearch.so
-      benchmark_glob: "vecsim*.yml"
-      benchmark_filter: ${{ inputs.benchmark_filter }}
-      allowed_envs: oss-standalone
-      allowed_setups: oss-standalone
-      benchmark_runner_group_member_id: ${{ matrix.member_id }}
-      benchmark_runner_group_total: ${{ strategy.job-total }}
-      binary_artifact_name: redisearch-bin-profile-${{ github.run_id }}-${{ github.run_attempt }}
-
   notify-failure:
     needs:
       - benchmark-search-oss-standalone
@@ -331,8 +271,6 @@ jobs:
       - benchmark-search-oss-cluster-16-primaries
       - benchmark-search-oss-cluster-20-primaries
       - benchmark-search-oss-cluster-24-primaries
-      - benchmark-search-oss-standalone-profiler
-      - benchmark-vecsim-oss-standalone-profiler
       - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
     if: ${{ always() && contains(needs.*.result, 'failure') && inputs.notify_failure }}
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -6,10 +6,6 @@ name: Build RediSearch Binary for Benchmarks
 on:
   workflow_call:
     inputs:
-      profile_env:
-        type: number
-        default: 0
-        description: "If 1, build with PROFILE=1 (output under bin/linux-x64-release-profile)"
       artifact_name:
         type: string
         required: true
@@ -17,14 +13,14 @@ on:
 
 jobs:
   build:
-    name: "Build RediSearch${{ inputs.profile_env == 1 && ' (profile)' || '' }}"
+    name: "Build RediSearch"
     # Must match the runner used by benchmark-flow.yml so the binary is ABI-compatible
     runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
     env:
-      BUILD_DIR: ${{ inputs.profile_env == 1 && 'bin/linux-x64-release-profile/search-community' || 'bin/linux-x64-release/search-community' }}
+      BUILD_DIR: bin/linux-x64-release/search-community
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +37,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
       - name: Build RediSearch
-        run: make build LTO=1 ${{ inputs.profile_env == 1 && 'PROFILE' || '' }}
+        run: make build LTO=1
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats
       - name: Upload redisearch.so artifact

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 remote:
  - type: oss-standalone
- - setup: redisearch-m5
+ - setup: redisearch-m7
 
 exporter:
   redistimeseries:


### PR DESCRIPTION
## Summary

Wires [Polar Signals](https://www.polarsignals.com/) continuous profiling into the benchmark workflow and migrates the terraform target from `redisearch-m5` to the aligned `redisearch-m7` pair.

### What changes

`.github/workflows/benchmark-flow.yml` — the `Run CI benchmarks on aws` step now also exports:

```yaml
TF_VAR_enable_parca_agent: true
TF_VAR_parca_agent_token:        ${{ secrets.PERFORMANCE_PARCA_AGENT_TOKEN }}
TF_VAR_parca_agent_project_id:   ${{ secrets.PERFORMANCE_PARCA_AGENT_PROJECT_ID }}
TF_VAR_parca_agent_snap_channel: edge
```

These flow through to the `terraform apply` that `redisbench-admin run-remote` invokes, which drives the cloud-init on the DB server to install parca-agent and stream CPU samples to the RediSearch Polar Signals project during the benchmark. `redisbench-admin` additionally sets `metadata-external-labels` per-test (then restarts the parca-agent snap service so the labels are picked up by the live process, fixed in 0.12.23) so samples are queryable by `test_name`, `git_hash`, `tested_commands`, `git_branch`, `arch`, etc.

`tests/benchmarks/defaults.yml` — `remote.setup: redisearch-m5` → `redisearch-m7`. The new pair is byte-identical between x86 (`m7i.8xlarge`) and aarch64 (`m7g.8xlarge`) except for instance family and AMI, with parca-agent cloud-init, projectID gRPC header, and a matched perf-base-image build date. The old `m5` pair is kept on the testing-infrastructure side for historical comparison.

`--github_sha` — switched from `github.sha` to `github.event.pull_request.head.sha || github.sha`. On `pull_request` events `github.sha` resolves to the ephemeral merge commit that GitHub garbage-collects once the PR merges, which breaks reproducibility of RTS time-series and Polar Signals `git_hash` labels. Using the PR head SHA keeps the identifier stable.

### Edge-channel snap: why

parca-agent v0.46.0 (snap stable) silently drops the `--remote-store-grpc-headers=projectID=<id>` flag when authenticating with a `psc_v1_<secret>_<projectId>` token. v0.47.1 (edge) honors it. Diagnosed by live-running against the Polar Signals gRPC endpoint — with stable the agent returned `PermissionDenied desc = project id not found`, with edge every upload returned `grpc_code=OK`. When the snap `stable` channel catches up to v0.47.1+, we can set `TF_VAR_parca_agent_snap_channel: stable`.

### Secrets needed (already set on this repo)

- `PERFORMANCE_PARCA_AGENT_TOKEN` — set ✓
- `PERFORMANCE_PARCA_AGENT_PROJECT_ID` — set ✓

## Dependencies (all merged)

- ✅ [redis-performance/testing-infrastructure#153](https://github.com/redis-performance/testing-infrastructure/pull/153) — `oss-standalone-redisearch-m7{,-aarch64}` terraform dirs with parca-agent cloud-init, projectID gRPC header, snap channel variable; aligned ARM perf-base-image install scripts; rebuilt ARM AMI.
- ✅ [redis-performance/redisbench-admin#525](https://github.com/redis-performance/redisbench-admin/pull/525) — per-test `snap set parca-agent metadata-external-labels=...` hook + `TESTING_INFRASTRUCTURE_BRANCH` env var override (released as `0.12.22`).
- ✅ [redis-performance/redisbench-admin#529](https://github.com/redis-performance/redisbench-admin/pull/529) — `snap restart parca-agent.parca-agent-svc` after every label set/clear; without this the snap wrapper baked in the empty metadata-external-labels at boot and never picked up runtime updates (released as `0.12.23`, now on PyPI and auto-installed by CI).

## Out of scope (follow-up)

- **ARM CI runners.** This PR only flips on parca and migrates the setup; stacked PR #9258 adds the aarch64 build matrix + `benchmark-search-oss-standalone-aarch64` job on top.

## Test plan

- [x] End-to-end dry-run validated on `redisearch-m7` x86 with the exact env vars in this PR — `search-ftsb-10K-enwiki_abstract-hashes-fulltext-search-sortby-limit-0-100` ran 124s @ 5755.88 Ops/sec, agent uploads returned `grpc_code=OK`, samples visible in the Polar Signals UI.
- [x] Real CI run on this branch (run [24860852192](https://github.com/RediSearch/RediSearch/actions/runs/24860852192)): all 11 benchmark jobs green. Per-job log shows `Using: redisbench-admin 0.12.23`, `parca-agent detected and active on <ip> -- labels will be injected`, full label set including `test_name=...;git_hash=...;arch=x86_64;coordinator_version=0.12.23;...`, and the `snap restart parca-agent.parca-agent-svc` lines that make labels take effect.
- [x] Polar Signals project `73d7b9ec-...` confirmed to show both `arch=x86_64` and `arch=aarch64` values with a fully populated label set (test_name, git_hash, tested_groups, platform, topology, coordinator_version, ...) via the MCP `list_values` tool.
- [x] Historical data under the `redisearch-m5` setup remains intact on RedisTimeSeries — `redisbench-admin compare --baseline-branch <older-branch>` still resolves it; going forward, comparisons are within the `redisearch-m7` series.

## Release notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes benchmark CI orchestration and remote Terraform-driven infrastructure/profiling configuration, which can break benchmark runs or skew results if misconfigured.
> 
> **Overview**
> **Benchmark CI now enables continuous profiling during remote runs.** `benchmark-flow.yml` exports new `TF_VAR_*` settings to turn on parca-agent/Polar Signals via Terraform, and uses the PR head SHA for `--github_sha` to keep time-series/profile labels reproducible.
> 
> **Simplifies benchmark build/runner configuration.** Removes `profile_env`/profiler variants and hard-codes artifact download/build output paths to the non-profile build.
> 
> **Updates benchmark target setup.** `tests/benchmarks/defaults.yml` switches the default remote `setup` from `redisearch-m5` to `redisearch-m7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871dfc0077a8c0cb85cd71bc140bf6981ca46936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->