### PR TITLE
benchmarks: add aarch64 CI runners

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -39,11 +39,17 @@ on:
         type: string
         required: true
         description: "Name of the artifact (uploaded by flow-build-benchmark-binary.yml) containing the prebuilt redisearch.so"
+      arch:
+        type: string
+        default: x86_64
+        description: "CPU arch the built .so targets. Passed to `redisbench-admin run-remote --architecture <arch>` so terraform picks the matching oss-standalone-redisearch-m7[-aarch64] dir. Valid: `x86_64` | `aarch64`."
 
 jobs:
   benchmark-steps:
-    name: "Benchmark ${{ inputs.allowed_setups }} (${{ inputs.benchmark_runner_group_member_id }}/${{ inputs.benchmark_runner_group_total }}) filter=${{ inputs.benchmark_glob }}${{ inputs.benchmark_filter && format(' narrowed={0}', inputs.benchmark_filter) || '' }}"
-    runs-on: ubuntu-24.04  # We need the os to be a match to the base image used in the benchmarks.
+    name: "Benchmark ${{ inputs.arch }} ${{ inputs.allowed_setups }} (${{ inputs.benchmark_runner_group_member_id }}/${{ inputs.benchmark_runner_group_total }}) filter=${{ inputs.benchmark_glob }}${{ inputs.benchmark_filter && format(' narrowed={0}', inputs.benchmark_filter) || '' }}"
+    # Match the orchestrator runner arch to inputs.arch because tests/deps/setup_rejson.sh
+    # builds rejson.so here and it must be ABI-compatible with the target EC2 DB.
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -94,8 +100,9 @@ jobs:
         with:
           name: ${{ inputs.binary_artifact_name }}
           # Place the .so where `inputs.module_path` expects it, e.g.
-          # bin/linux-x64-release/search-community/redisearch.so
-          path: bin/linux-x64-release/search-community
+          # bin/linux-x64-release/search-community/redisearch.so on x86_64,
+          # bin/linux-aarch64-release/search-community/redisearch.so on aarch64.
+          path: ${{ format('bin/linux-{0}-release/search-community', inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
       - name: Make redisearch.so executable
         if: steps.benchmark-filter.outputs.skip != 'true'
         env:
@@ -168,6 +175,7 @@ jobs:
               --required-module ReJSON
               --github_sha ${{ github.event.pull_request.head.sha || github.sha }}
               --github_branch ${{ github.head_ref || github.ref_name }}
+              --architecture ${{ inputs.arch }}
               --upload_results_s3
               --triggering_env $TRIGGERING_ENV
               --allowed-envs $ALLOWED_ENVS

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -124,6 +124,10 @@ jobs:
         if: steps.benchmark-filter.outputs.skip != 'true'
         env:
           REJSON_BRANCH: ${{ inputs.rejson_branch }}
+          # setup_rejson.sh defaults BINROOT to bin/linux-x64-release regardless
+          # of the host arch; on aarch64 runners we must redirect it to the
+          # matching linux-aarch64-release tree so rejson_module_path resolves.
+          BINROOT: ${{ format('{0}/bin/linux-{1}-release', github.workspace, inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
         run: ./tests/deps/setup_rejson.sh
 
       - name: Run CI benchmarks on aws for envs ${{ inputs.allowed_envs }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -164,6 +164,10 @@ jobs:
           TRIGGERING_ENV: ${{ inputs.triggering_env }}
           ALLOWED_ENVS: ${{ inputs.allowed_envs }}
           ALLOWED_SETUPS: ${{ inputs.allowed_setups }}
+          # Route inputs.arch through env rather than inline ${{ inputs.arch }}
+          # in the shell template — SonarCloud's script-injection rule treats
+          # inputs.* as untrusted in a run: block and flags the direct form.
+          ARCH: ${{ inputs.arch }}
         # --github_sha: on pull_request events github.sha is the ephemeral
         # merge commit, which is garbage-collected after the PR merges and
         # breaks later reproducibility of RTS time-series and Polar Signals
@@ -179,7 +183,7 @@ jobs:
               --required-module ReJSON
               --github_sha ${{ github.event.pull_request.head.sha || github.sha }}
               --github_branch ${{ github.head_ref || github.ref_name }}
-              --architecture ${{ inputs.arch }}
+              --architecture "$ARCH"
               --upload_results_s3
               --triggering_env $TRIGGERING_ENV
               --allowed-envs $ALLOWED_ENVS
@@ -194,6 +198,9 @@ jobs:
         env:
           PERFORMANCE_GH_TOKEN: ${{ secrets.PERFORMANCE_GH_TOKEN }}
           PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
+          # Route inputs.arch through env to satisfy SonarCloud's
+          # script-injection rule (same reasoning as the run-remote step).
+          ARCH: ${{ inputs.arch }}
         # --baseline_architecture / --comparison_architecture filter the
         # RedisTimeSeries lookup on `arch=<value>`. x86_64 keeps the existing
         # backwards-compat behavior (redisbench-admin treats it as "no arch
@@ -204,8 +211,8 @@ jobs:
               --defaults_filename ./tests/benchmarks/defaults.yml
               --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
               --baseline-branch ${{ github.event.pull_request.base.ref }}
-              --baseline_architecture ${{ inputs.arch }}
-              --comparison_architecture ${{ inputs.arch }}
+              --baseline_architecture "$ARCH"
+              --comparison_architecture "$ARCH"
               --auto-approve
               --pull-request ${{ github.event.number }}
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -198,21 +198,20 @@ jobs:
         env:
           PERFORMANCE_GH_TOKEN: ${{ secrets.PERFORMANCE_GH_TOKEN }}
           PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
-          # Route inputs.arch through env to satisfy SonarCloud's
-          # script-injection rule (same reasoning as the run-remote step).
-          ARCH: ${{ inputs.arch }}
-        # --baseline_architecture / --comparison_architecture filter the
-        # RedisTimeSeries lookup on `arch=<value>`. x86_64 keeps the existing
-        # backwards-compat behavior (redisbench-admin treats it as "no arch
-        # filter" so pre-#521 unlabeled samples still match); aarch64 jobs
-        # explicitly scope to aarch64 so they don't regress against x86
-        # baselines.
+        # --architectures enables the multi-arch PR comment layout from
+        # redisbench-admin 0.12.25+: one H2 section per arch covering
+        # branch-over-branch, plus a cross-arch delta section on the PR
+        # commit (x86_64 -> aarch64). Each matrix entry's compare call
+        # queries ALL arches from RTS; modules without aarch64 data (e.g.
+        # early in a run, before aarch64 jobs complete) render a warning
+        # block instead of an empty table, and the cross-arch section
+        # auto-suppresses. The last-to-finish upsert wins -- same behavior
+        # as today, but with the richer multi-arch body.
         run: redisbench-admin compare
               --defaults_filename ./tests/benchmarks/defaults.yml
               --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
               --baseline-branch ${{ github.event.pull_request.base.ref }}
-              --baseline_architecture "$ARCH"
-              --comparison_architecture "$ARCH"
+              --architectures x86_64,aarch64
               --auto-approve
               --pull-request ${{ github.event.number }}
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -194,10 +194,18 @@ jobs:
         env:
           PERFORMANCE_GH_TOKEN: ${{ secrets.PERFORMANCE_GH_TOKEN }}
           PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
+        # --baseline_architecture / --comparison_architecture filter the
+        # RedisTimeSeries lookup on `arch=<value>`. x86_64 keeps the existing
+        # backwards-compat behavior (redisbench-admin treats it as "no arch
+        # filter" so pre-#521 unlabeled samples still match); aarch64 jobs
+        # explicitly scope to aarch64 so they don't regress against x86
+        # baselines.
         run: redisbench-admin compare
               --defaults_filename ./tests/benchmarks/defaults.yml
               --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
               --baseline-branch ${{ github.event.pull_request.base.ref }}
+              --baseline_architecture ${{ inputs.arch }}
+              --comparison_architecture ${{ inputs.arch }}
               --auto-approve
               --pull-request ${{ github.event.number }}
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -39,12 +39,19 @@ on:
         description: "if true, will notify failure on slack"
 
 jobs:
-  # Build RediSearch ONCE here. Every benchmark job below downloads the
+  # Build RediSearch ONCE per-arch. Every benchmark job below downloads the
   # resulting redisearch.so as an artifact instead of rebuilding it.
   build-redisearch:
     uses: ./.github/workflows/flow-build-benchmark-binary.yml
     with:
+      arch: x86_64
       artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+
+  build-redisearch-aarch64:
+    uses: ./.github/workflows/flow-build-benchmark-binary.yml
+    with:
+      arch: aarch64
+      artifact_name: redisearch-bin-aarch64-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
@@ -60,9 +67,34 @@ jobs:
       benchmark_filter: ${{ inputs.benchmark_filter }}
       allowed_envs: oss-standalone
       allowed_setups: oss-standalone
+      arch: x86_64
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+
+  # aarch64 sibling of benchmark-search-oss-standalone. Targets the
+  # oss-standalone-redisearch-m7-aarch64 terraform dir (m7g.8xlarge DB +
+  # m7g.4xlarge client, matched AMI/installer scripts to the x86 m7 pair).
+  benchmark-search-oss-standalone-aarch64:
+    if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
+    needs: build-redisearch-aarch64
+    strategy:
+      fail-fast: false
+      matrix:
+        member_id: [1, 2, 3]
+    uses: ./.github/workflows/benchmark-flow.yml
+    secrets: inherit
+    with:
+      benchmark_glob: "search*.yml"
+      benchmark_filter: ${{ inputs.benchmark_filter }}
+      allowed_envs: oss-standalone
+      allowed_setups: oss-standalone
+      arch: aarch64
+      module_path: bin/linux-aarch64-release/search-community/redisearch.so
+      rejson_module_path: bin/linux-aarch64-release/RedisJSON/master/rejson.so
+      benchmark_runner_group_member_id: ${{ matrix.member_id }}
+      benchmark_runner_group_total: ${{ strategy.job-total }}
+      binary_artifact_name: redisearch-bin-aarch64-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-standalone-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
@@ -261,6 +293,7 @@ jobs:
   notify-failure:
     needs:
       - benchmark-search-oss-standalone
+      - benchmark-search-oss-standalone-aarch64
       - benchmark-search-oss-standalone-threads-6
       - benchmark-vecsim-oss-standalone
       - benchmark-vecsim-oss-standalone-threads-6

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -10,17 +10,26 @@ on:
         type: string
         required: true
         description: "Name of the artifact to upload the built redisearch.so under"
+      arch:
+        type: string
+        default: x86_64
+        description: "CPU arch to build for. `x86_64` (default) runs on GitHub's ubuntu-24.04; `aarch64` runs on ubuntu-24.04-arm. Must match the target EC2 DB architecture at benchmark time."
 
 jobs:
   build:
-    name: "Build RediSearch"
-    # Must match the runner used by benchmark-flow.yml so the binary is ABI-compatible
-    runs-on: ubuntu-24.04
+    name: "Build RediSearch ${{ inputs.arch }}"
+    # Runner matches inputs.arch so the produced .so is ABI-compatible with
+    # the target EC2 instance. build.sh derives the output dir from `uname -m`,
+    # so we run the build natively on the matching-arch runner instead of
+    # cross-compiling.
+    runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
     env:
-      BUILD_DIR: bin/linux-x64-release/search-community
+      # build.sh maps `uname -m == x86_64` -> `x64` and `uname -m == aarch64` -> `aarch64`;
+      # BUILD_DIR mirrors that so the upload step finds the .so.
+      BUILD_DIR: ${{ format('bin/linux-{0}-release/search-community', inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Turns on aarch64 as a first-class CI track alongside x86_64, and lights up the Intel-vs-ARM comparison inside the PR performance comment.

| Job | x86_64 (existing) | aarch64 (new) |
|-----|------------------|---------------|
| Build `redisearch.so` | `build-redisearch` → `ubuntu-24.04` | `build-redisearch-aarch64` → `ubuntu-24.04-arm` |
| oss-standalone benchmark | `benchmark-search-oss-standalone` → EC2 `m7i.8xlarge` | `benchmark-search-oss-standalone-aarch64` → EC2 `m7g.8xlarge` |

Every cross-arch delta reported by `redisbench-admin compare` now reflects **arch only**, not instance-family / OS / installer drift, because the `redisearch-m7` pair upstream is byte-identical on both sides except for `instance_ami` + instance family.

### Two checks per PR, not one

Paired with [redis-performance/redisbench-admin#530](https://github.com/redis-performance/redisbench-admin/pull/530) (released as `0.12.25`), the single automated performance comment on every PR now contains:

1. **`## Architecture: x86_64 — branch-over-branch`** — the existing `master` vs PR-branch regression table, scoped to x86_64 samples.
2. **`## Architecture: aarch64 — branch-over-branch`** — same, scoped to aarch64 samples.
3. **`## Cross-arch delta on <branch> (x86_64 → aarch64)`** — the PR commit compared across architectures; positive deltas = aarch64 outperforms x86_64. Display-only; not counted toward branch-regression totals.

If a PR's aarch64 benchmarks haven't finished yet (or the module has no ARM track at all), the aarch64 section renders a `⚠️ No aarch64 benchmark data found` warning block and the cross-arch delta is auto-suppressed.

### What changed

1. **`flow-build-benchmark-binary.yml`** — new `arch` input (default `x86_64`). `runs-on` is `ubuntu-24.04-arm` when `arch=aarch64`, else `ubuntu-24.04`. `BUILD_DIR` parametrizes on arch: `bin/linux-x64-release/search-community` for x86_64, `bin/linux-aarch64-release/search-community` for aarch64.
2. **`benchmark-flow.yml`** — new `arch` input. `runs-on` matches the arch so `tests/deps/setup_rejson.sh` builds a `rejson.so` ABI-compatible with the target EC2 DB. `BINROOT` is derived from `inputs.arch` so rejson lands in `bin/linux-aarch64-release/…` on aarch64 runners. `--architecture` is piped through the `env:` block (`ARCH`) to satisfy SonarCloud's script-injection rule. Compare call switches from `--baseline_architecture/--comparison_architecture "$ARCH"` (single-arch) to `--architectures x86_64,aarch64` (multi-arch comment with cross-arch delta).
3. **`benchmark-runner.yml`** — new `build-redisearch-aarch64` job + `benchmark-search-oss-standalone-aarch64` job. `notify-failure.needs` picks up the new job.

### Scope / non-goals

**Minimal first cut.** Only `oss-standalone` gets an aarch64 sibling. Cluster / vecsim / threads-6 / msmarco aarch64 variants are follow-up PRs. ARM vs Intel cross-arch deltas in the PR comment apply to every benchmark matrix entry that has both-arch data, but only `oss-standalone` currently produces aarch64 samples.

### Runner availability

Relies on GitHub's [public `ubuntu-24.04-arm` runner](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) (free for public repos). If org quota is exhausted, the aarch64 job queues; the x86 track is unaffected.

## Dependencies (all landed)

- ✅ [redis-performance/testing-infrastructure#153](https://github.com/redis-performance/testing-infrastructure/pull/153) — `oss-standalone-redisearch-m7-aarch64` terraform dir + rebuilt aligned ARM AMI + parca-agent cloud-init with `projectID` gRPC header.
- ✅ [redis-performance/testing-infrastructure#154](https://github.com/redis-performance/testing-infrastructure/pull/154) — bump aarch64 root volume default from 128GB to 256GB (required by the rebuilt ARM AMI's root snapshot).
- ✅ [redis-performance/redisbench-admin#525](https://github.com/redis-performance/redisbench-admin/pull/525) — per-test parca `metadata-external-labels` injection + `TESTING_INFRASTRUCTURE_BRANCH` env override (released as `0.12.22`).
- ✅ [redis-performance/redisbench-admin#529](https://github.com/redis-performance/redisbench-admin/pull/529) — snap restart after metadata-external-labels set/clear so new labels reach the live parca-agent process (released as `0.12.23`).
- ✅ [redis-performance/redisbench-admin#527](https://github.com/redis-performance/redisbench-admin/pull/527) — compare PR-comment environment/arch header (released as `0.12.24`).
- ✅ [redis-performance/redisbench-admin#530](https://github.com/redis-performance/redisbench-admin/pull/530) — `--architectures` + cross-arch delta + empty-arch warning (released as `0.12.25`, auto-installed by CI).
- ✅ **#9257** — migrated `defaults.yml` to `redisearch-m7` setup + wired parca env vars.

## Test plan

- [x] x86 path validated end-to-end on `redisearch-m7`: `search-ftsb-10K-enwiki_abstract-hashes-fulltext-search-sortby-limit-0-100` ran 124s @ 5755.88 Ops/sec with parca samples flowing to project `73d7b9ec-...`.
- [x] aarch64 path: real CI run [24860854575](https://github.com/RediSearch/RediSearch/actions/runs/24860854575) — `Build RediSearch aarch64` job green, all 3 `benchmark-search-oss-standalone-aarch64` jobs green, terraform resolved `oss-standalone-redisearch-m7-aarch64` (m7g.8xlarge DB + m7g.4xlarge client), module loaded, benchmark completed.
- [x] Per-job log evidence: `rba=redisbench-admin 0.12.24+`, `parca_detected>0`, `labels_set>0`, `snap_restart=2×tests` (set + clear).
- [x] Polar Signals project `73d7b9ec-...` confirmed via MCP `values` to have **both** `arch=aarch64` and `arch=x86_64` values present, with real CPU samples (526B sample-nanoseconds per arch) symbolized to RediSearch C + Rust hot paths.
- [x] PR comment shows both arches + cross-arch delta sections, rendered from `redisbench-admin compare --architectures x86_64,aarch64`.

## Release notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI benchmark orchestration (runner selection, artifact paths, and `redisbench-admin` invocation) and adds new jobs, which could break benchmark runs or reporting if misconfigured, but it does not affect product/runtime code.
> 
> **Overview**
> Adds an `arch` parameter to the benchmark build and run workflows so benchmark orchestration can run on `ubuntu-24.04` (x86_64) or `ubuntu-24.04-arm` (aarch64), with architecture-specific artifact/output paths and ReJSON build placement.
> 
> Extends the benchmark runner to build `redisearch.so` for both arches and introduces an aarch64 `oss-standalone` benchmark job, while updating `redisbench-admin` calls to pass `--architecture` for runs and to generate a multi-arch PR comment via `compare --architectures x86_64,aarch64`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ea8195e7f098e34df2e918e33ece5ef160ffdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->