### PR TITLE
[8.8] MOD-14921: Search Commands: Fallback To Main Thread When Block Client Is Unavailable In Single Shard Environment

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -229,9 +229,9 @@ typedef struct {
 #define IsInternal(r) ((r)->reqflags & QEXEC_F_INTERNAL)
 #define IsDebug(r) ((r)->reqflags & QEXEC_F_DEBUG)
 
-// Indicates whether a query should run in the background. This
-// will also guarantee that there is a running thread pool with al least 1 thread.
-#define RunInThread() (RSGlobalConfig.numWorkerThreads)
+// Indicates whether a query should run in the background.
+// Requires context to check if the client can be blocked.
+bool RunInThread(RedisModuleCtx *ctx);
 
 typedef void (*profiler_func)(RedisModule_Reply *reply, void *ctx);
 
@@ -395,7 +395,7 @@ AREQ *AREQ_New(void);
  * Redis-specific states and may be unit-tested. This largely just
  * compiles the options and parses the commands..
  */
-int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status);
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status);
 
 /**
  * Parse aggregate plan arguments (GROUPBY, APPLY, LOAD, FILTER) from an ArgsCursor.

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1304,7 +1304,7 @@ static int buildRequest(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
   AREQ_AddRequestFlags(*r, QEXEC_FORMAT_DEFAULT);
 
-  if (AREQ_Compile(*r, argv + 2, argc - 2, SearchDisk_IsEnabledForValidation(), status) != REDISMODULE_OK) {
+  if (AREQ_Compile(*r, ctx, argv + 2, argc - 2, SearchDisk_IsEnabledForValidation(), status) != REDISMODULE_OK) {
     RS_LOG_ASSERT(QueryError_HasError(status), "Query has error");
     goto done;
   }
@@ -1494,7 +1494,7 @@ static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
 static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *status) {
   RedisSearchCtx *sctx = AREQ_SearchCtx(r);
-  if (RunInThread()) {
+  if (RunInThread(ctx)) {
     StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
 
     BlockClientCtx blockClientCtx = {0};
@@ -1810,7 +1810,7 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   // We have to check that we are not blocked yet from elsewhere (e.g. coordinator)
-  if (RunInThread() && !RedisModule_GetBlockedClientHandle(ctx)) {
+  if (RunInThread(ctx) && !RedisModule_GetBlockedClientHandle(ctx)) {
     CursorReadCtx *cr_ctx = rm_new(CursorReadCtx);
     cr_ctx->bc = BlockCursorClient(ctx, cursor, count, 0);
     cr_ctx->cursor = cursor;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1053,6 +1053,26 @@ static int handleLoad(AGGPlan *plan, uint32_t *reqflags, ArgsCursor *ac, bool is
   return REDISMODULE_OK;
 }
 
+bool RunInThread(RedisModuleCtx *ctx) {
+  const bool hasWorkerThreads = RSGlobalConfig.numWorkerThreads > 0;
+  if (!hasWorkerThreads) {
+    return false;
+  }
+
+  const bool blockClientUnavailable = RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_DENY_BLOCKING;
+  if (blockClientUnavailable && RSGlobalConfig.fallbackToMainThreadWhenBlockClientUnavailable) {
+    // We only log once to reduce log spam
+    static bool logged = false;
+    if (!logged) {
+      RedisModule_Log(ctx, "warning", "Detected a client that cannot be blocked, all similar requests including this one will fall back to run on the main thread.");
+      logged = true;
+    }
+    return false;
+  }
+
+  return true;
+}
+
 AREQ *AREQ_New(void) {
   AREQ* req = rm_calloc(1, sizeof(AREQ));
   /*
@@ -1142,16 +1162,15 @@ static bool IsNeededDepleter(AREQ *req) {
 
 // This function should only be called from the main thread (calling RunInThread() is not thread safe)
 // AREQ execution flags are not set when this function is called currently
-static bool shouldCheckInPipelineTimeout(AREQ *req) {
+static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
   // We should check for timeout in pipeline only if timeout is > 0
-  // and when the policy is RETURN or the policy is FAIL, without workers.
+  // and when the policy is RETURN or the policy is FAIL/RETURN-strict, without workers.
   return req->reqConfig.queryTimeoutMS > 0 &&
-         (req->reqConfig.timeoutPolicy == TimeoutPolicy_Return ||
-          (req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail && !RunInThread()));
+         (req->reqConfig.timeoutPolicy == TimeoutPolicy_Return || !RunInThread(ctx));
 
 }
 
-int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
   req->args = rm_malloc(sizeof(*req->args) * argc);
   req->nargs = argc;
   // Copy the arguments into an owned array of sds strings
@@ -1212,7 +1231,7 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, bool isDiskIndex
   }
 
   // Check if we should check for timeout in pipeline
-  AREQ_SetSkipTimeoutChecks(req, !shouldCheckInPipelineTimeout(req));
+  AREQ_SetSkipTimeoutChecks(req, !shouldCheckInPipelineTimeout(ctx, req));
 
   return REDISMODULE_OK;
 

--- a/src/config.c
+++ b/src/config.c
@@ -2387,5 +2387,14 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     )
   )
 
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
+      ctx, "search-_fallback-to-main-thread-when-block-client-unavailable", 1,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.fallbackToMainThreadWhenBlockClientUnavailable)
+    )
+  ) 
+
   return REDISMODULE_OK;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -216,6 +216,8 @@ typedef struct {
   bool monitorExpiration;
   // Percentage of available memory to use for disk write buffer (0-100).
   uint8_t diskBufferPercentage;
+  // If true, fallback to main thread when BlockClient is unavailable.
+  bool fallbackToMainThreadWhenBlockClientUnavailable;
 } RSConfig;
 
 typedef enum {
@@ -411,6 +413,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .simulateInFlex = false,                                                   \
     .monitorExpiration = true,                                                 \
     .diskBufferPercentage = DEFAULT_DISK_BUFFER_PERCENTAGE,                    \
+    .fallbackToMainThreadWhenBlockClientUnavailable = true,                    \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -346,7 +346,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
     }
   }
 
-  rc = AREQ_Compile(r, argv + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
+  rc = AREQ_Compile(r, ctx, argv + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   r->profile = printAggProfile;

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -999,10 +999,9 @@ void printHybridProfile(RedisModule_Reply *reply, void *ctx) {
 // HybridRequest execution flags are not set when this function is called currently
 static bool shouldCheckInPipelineTimeoutHybrid(RedisModuleCtx* ctx, HybridRequest *hreq) {
   // We should check for timeout in pipeline only if timeout is > 0
-  // and when the policy is RETURN or the policy is FAIL, without workers.
+  // and when the policy is RETURN or the policy is FAIL/RETURN-strict, without workers.
   return hreq->reqConfig.queryTimeoutMS > 0 &&
-         (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Return ||
-          (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Fail && !RunInThread(ctx)));
+         (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Return || !RunInThread(ctx));
 
 }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -903,7 +903,7 @@ static blockedClientHybridCtx *blockedClientHybridCtx_New(StrongRef hybrid_ref,
 static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *hybridParams, RedisModuleCtx *ctx,
                     RedisSearchCtx *sctx, QueryError* status, bool internal) {
   HybridRequest *hreq = StrongRef_Get(hybrid_ref);
-  if (RunInThread()) {
+  if (RunInThread(ctx)) {
     // Multi-threaded execution path
     StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
 
@@ -997,12 +997,12 @@ void printHybridProfile(RedisModule_Reply *reply, void *ctx) {
 
 // This function should only be called from the main thread (calling RunInThread() is not thread safe)
 // HybridRequest execution flags are not set when this function is called currently
-static bool shouldCheckInPipelineTimeoutHybrid(HybridRequest *hreq) {
+static bool shouldCheckInPipelineTimeoutHybrid(RedisModuleCtx* ctx, HybridRequest *hreq) {
   // We should check for timeout in pipeline only if timeout is > 0
   // and when the policy is RETURN or the policy is FAIL, without workers.
   return hreq->reqConfig.queryTimeoutMS > 0 &&
          (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Return ||
-          (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Fail && !RunInThread()));
+          (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Fail && !RunInThread(ctx)));
 
 }
 
@@ -1068,7 +1068,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
 
   // Check if we should check for timeout in pipeline
-  HybridRequest_SetSkipTimeoutChecks(hybridRequest, !shouldCheckInPipelineTimeoutHybrid(hybridRequest));
+  HybridRequest_SetSkipTimeoutChecks(hybridRequest, !shouldCheckInPipelineTimeoutHybrid(ctx, hybridRequest));
 
   // Copy dispatch time to each subquery AREQ for profile printing
   for (size_t i = 0; i < hybridRequest->nrequests; i++) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -303,7 +303,7 @@ static void HybridRequest_Free(HybridRequest *req) {
         RedisModuleCtx *thctx = areq->sctx->redisCtx;
         RedisSearchCtx *sctx = areq->sctx;
 
-        if (RunInThread()) {
+        if (areq->reqflags & QEXEC_F_RUN_IN_BACKGROUND) {
           // Background thread: schedule async cleanup
           ScheduleContextCleanup(thctx, sctx);
         } else {

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -57,7 +57,7 @@ TEST_F(AggTest, testBasic) {
 
   AREQ *rr = AREQ_New();
   RMCK::ArgvList aggArgs(ctx, "*");
-  rv = AREQ_Compile(rr, aggArgs, aggArgs.size(), false, &qerr);
+  rv = AREQ_Compile(rr, ctx, aggArgs, aggArgs.size(), false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, spec->specName, true);
@@ -305,7 +305,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
     AREQ *rr = AREQ_New();
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
-    int rv = AREQ_Compile(rr, aggArgs, aggArgs.size(), false, &qerr);
+    int rv = AREQ_Compile(rr, ctx, aggArgs, aggArgs.size(), false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;
     QueryError_ClearError(&qerr);

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -131,7 +131,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    int result = AREQ_Compile(req, argv.data(), argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error for: " << test_data.description;
@@ -221,7 +221,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    int result = AREQ_Compile(req, argv.data(), argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error";
@@ -256,7 +256,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
     // Test AREQ_Compile - should fail due to insufficient arguments
-    int result = AREQ_Compile(req, argv.data(), argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
     EXPECT_TRUE(QueryError_HasError(&status)) << "Should have query error";
@@ -298,7 +298,7 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
     // Test AREQ_Compile
-    int result = AREQ_Compile(req, argv.data(), argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error";

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -43,7 +43,7 @@ static void testAverage() {
                     "sortby", "2", "@avg_price", "DESC"                 // nl
   );
   QueryError status{QueryErrorCode(0)};
-  int rc = AREQ_Compile(r, vv, vv.size(), false, &status);
+  int rc = AREQ_Compile(r, ctx, vv, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();
@@ -102,7 +102,7 @@ static void testCountDistinct() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  int rc = AREQ_Compile(r, vv, vv.size(), false, &status);
+  int rc = AREQ_Compile(r, ctx, vv, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();
@@ -140,7 +140,7 @@ static void testSplit() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  int rc = AREQ_Compile(r, vv, vv.size(), false, &status);
+  int rc = AREQ_Compile(r, ctx, vv, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();


### PR DESCRIPTION
# Description
Backport of #9187 to `8.8`.

## Conflicts and Resolution
- `src/aggregate/aggregate_request.c`
  Conflict in `shouldCheckInPipelineTimeout(...)` because `8.8` still had the explicit `TimeoutPolicy_Fail && !RunInThread()` branch while #9187 changes timeout checks to respect fallback behavior through `RunInThread(ctx)`.
  Resolution: kept the #9187 logic: `req->reqConfig.timeoutPolicy == TimeoutPolicy_Return || !RunInThread(ctx)` and updated the related comment to match.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when queries/cursor reads run on worker threads by checking `REDISMODULE_CTX_FLAGS_DENY_BLOCKING` and optionally forcing main-thread execution, which can affect latency/timeout behavior and thread-safety assumptions.
> 
> **Overview**
> Adds a context-aware `RunInThread(ctx)` decision that **disables background execution** when the calling client cannot be blocked (and a new config flag allows opting out), with a one-time warning log.
> 
> Plumbs `RedisModuleCtx*` into `AREQ_Compile` and timeout-check decisions so `FT.SEARCH`/`FT.AGGREGATE`, hybrid execution, and cursor reads consistently respect the fallback behavior, and updates related tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b3962c6e2368290d8d1211ac233430dc7cc9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->