### PR TITLE
[MOD-15026] pass grace period and bump RLTest

### DIFF
--- a/tests/pytests/pyproject.toml
+++ b/tests/pytests/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "packaging<=24.2",
     "deepdiff==8.6.2",
     "redis>=5.2.1,<7.0.0", # Pin to avoid redis-py 7.x incompatibility (todo: update once fixed)
-    "RLTest==0.7.24",
+    "RLTest==0.7.25",
     "numpy<=2.2.4",
     "scipy<=1.15.2",
     "faker<=37.1.0",

--- a/tests/pytests/test_aux_save2.py
+++ b/tests/pytests/test_aux_save2.py
@@ -39,7 +39,10 @@ def testLoadRdbWithIndexAuxData(env: Env):
     env.stop()
     # Restart without modules
     _removeModuleArgs(env)
-    # Attempt to load RDB should fail because the RDB contains module aux data
+    # Attempt to load RDB should fail because the RDB contains module aux data.
+    # Use a large startup grace period so the server has time to abort during
+    # RDB load before RLTest's readiness probe races with the abort.
+    env.envRunner.startupGraceSecs = 10
     try:
         env.start()
     except Exception as e:
@@ -91,7 +94,10 @@ def testLoadRdbWithSpellcheckDictAuxData(env: Env):
     env.stop()
     # Restart without modules
     _removeModuleArgs(env)
-    # Attempt to load RDB should fail because the RDB contains module aux data
+    # Attempt to load RDB should fail because the RDB contains module aux data.
+    # Use a large startup grace period so the server has time to abort during
+    # RDB load before RLTest's readiness probe races with the abort.
+    env.envRunner.startupGraceSecs = 10
     try:
         env.start()
     except Exception as e:
@@ -195,7 +201,10 @@ def testLoadRdbWithSuggestionData(env: Env):
     # Save state to RDB
     env.stop()
     _removeModuleArgs(env)
-    # Attempt to load RDB should fail because the RDB contains module data
+    # Attempt to load RDB should fail because the RDB contains module data.
+    # Use a large startup grace period so the server has time to abort during
+    # RDB load before RLTest's readiness probe races with the abort.
+    env.envRunner.startupGraceSecs = 10
     try:
         env.start()
     except Exception as e:

--- a/tests/pytests/test_aux_save2.py
+++ b/tests/pytests/test_aux_save2.py
@@ -42,7 +42,7 @@ def testLoadRdbWithIndexAuxData(env: Env):
     # Attempt to load RDB should fail because the RDB contains module aux data.
     # Use a large startup grace period so the server has time to abort during
     # RDB load before RLTest's readiness probe races with the abort.
-    env.envRunner.startupGraceSecs = 10
+    env.envRunner.startupGraceSecs = 1
     try:
         env.start()
     except Exception as e:
@@ -97,7 +97,7 @@ def testLoadRdbWithSpellcheckDictAuxData(env: Env):
     # Attempt to load RDB should fail because the RDB contains module aux data.
     # Use a large startup grace period so the server has time to abort during
     # RDB load before RLTest's readiness probe races with the abort.
-    env.envRunner.startupGraceSecs = 10
+    env.envRunner.startupGraceSecs = 1
     try:
         env.start()
     except Exception as e:
@@ -204,7 +204,7 @@ def testLoadRdbWithSuggestionData(env: Env):
     # Attempt to load RDB should fail because the RDB contains module data.
     # Use a large startup grace period so the server has time to abort during
     # RDB load before RLTest's readiness probe races with the abort.
-    env.envRunner.startupGraceSecs = 10
+    env.envRunner.startupGraceSecs = 1
     try:
         env.start()
     except Exception as e:

--- a/tests/pytests/test_default_scorer.py
+++ b/tests/pytests/test_default_scorer.py
@@ -221,15 +221,19 @@ def test_default_scorer_startup_validation():
         ext_path = os.environ['EXT_TEST_PATH']
     else:
         ext_path = 'tests/ctests/ext-example/libexample_extension.so'
+    # Use a large startup grace period so the server has time to abort during
+    # module init before RLTest's readiness probe runs. With the default 0.1s
+    # the probe races with the abort and occasionally surfaces a spurious
+    # "<Environment destroyed>" failure.
     try:
-        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer2')
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer2', startupGraceSecs=10)
         assert not env.isUp()
     except Exception as e:
         # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
         assert not isinstance(e, AssertionError)
 
     try:
-        env = Env(moduleArgs=f'DEFAULT_SCORER example_scorer')
+        env = Env(moduleArgs=f'DEFAULT_SCORER example_scorer', startupGraceSecs=10)
         assert not env.isUp()
     except Exception as e:
         # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test

--- a/tests/pytests/test_default_scorer.py
+++ b/tests/pytests/test_default_scorer.py
@@ -226,14 +226,14 @@ def test_default_scorer_startup_validation():
     # the probe races with the abort and occasionally surfaces a spurious
     # "<Environment destroyed>" failure.
     try:
-        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer2', startupGraceSecs=10)
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer2', startupGraceSecs=1)
         assert not env.isUp()
     except Exception as e:
         # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
         assert not isinstance(e, AssertionError)
 
     try:
-        env = Env(moduleArgs=f'DEFAULT_SCORER example_scorer', startupGraceSecs=10)
+        env = Env(moduleArgs=f'DEFAULT_SCORER example_scorer', startupGraceSecs=1)
         assert not env.isUp()
     except Exception as e:
         # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -619,7 +619,10 @@ def test_JSON_RDB_load_fail_without_JSON_module(env: Env):
     env.envRunner.moduleArgs.pop()
     env.envRunner.masterCmdArgs = env.envRunner.createCmdArgs('master')
     # Restart without JSON module. Attempt to load RDB - should fail.
-    # RLTest may or may not fail to start the server with an exception
+    # RLTest may or may not fail to start the server with an exception.
+    # Use a large startup grace period so the server has time to abort during
+    # RDB load before RLTest's readiness probe races with the abort.
+    env.envRunner.startupGraceSecs = 10
     try:
         env.start()
     except Exception as e:

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -622,7 +622,7 @@ def test_JSON_RDB_load_fail_without_JSON_module(env: Env):
     # RLTest may or may not fail to start the server with an exception.
     # Use a large startup grace period so the server has time to abort during
     # RDB load before RLTest's readiness probe races with the abort.
-    env.envRunner.startupGraceSecs = 10
+    env.envRunner.startupGraceSecs = 1
     try:
         env.start()
     except Exception as e:

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -535,8 +535,12 @@ def testconfigMultiTextOffsetDeltaSlop0():
 @skip(cluster=True, asan=True, no_json=True)
 def testconfigMultiTextOffsetDeltaSlopNeg():
     """ test ft.config `MULTI_TEXT_SLOP` rejects negative values """
+    # Use a large startup grace period so the server has time to abort during
+    # module init before RLTest's readiness probe runs. With the default 0.1s
+    # the probe races with the abort and occasionally surfaces a spurious
+    # "<Environment destroyed>" failure.
     try:
-        env = Env(moduleArgs='MULTI_TEXT_SLOP -1')
+        env = Env(moduleArgs='MULTI_TEXT_SLOP -1', startupGraceSecs=10)
         assert not env.isUp()
     except Exception as e:
         # It sometimes captures the error of it not being up (PID dead and sometimes not).

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -540,7 +540,7 @@ def testconfigMultiTextOffsetDeltaSlopNeg():
     # the probe races with the abort and occasionally surfaces a spurious
     # "<Environment destroyed>" failure.
     try:
-        env = Env(moduleArgs='MULTI_TEXT_SLOP -1', startupGraceSecs=10)
+        env = Env(moduleArgs='MULTI_TEXT_SLOP -1', startupGraceSecs=1)
         assert not env.isUp()
     except Exception as e:
         # It sometimes captures the error of it not being up (PID dead and sometimes not).

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [{ name = "pip" }]
 
 [[package]]
 name = "rltest"
-version = "0.7.24"
+version = "0.7.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distro" },
@@ -474,9 +474,9 @@ dependencies = [
     { name = "pytest-cov" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/b4/b0e4dc5ba51fc936715df9da2b814237de749f8607ebad79f727dec6625a/rltest-0.7.24.tar.gz", hash = "sha256:ddfe27ccee14410caa60d4c8920c000d190cb03dfc69776a1e117526787a590f", size = 42017, upload-time = "2026-04-15T11:25:45.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/07/41e2a7acb84460edf504e1894b30d3dff38ef26bcc2e49225e2fae496a06/rltest-0.7.25.tar.gz", hash = "sha256:0836ab407a3ab5629be98e2d98bc0c3113a96e388a72e69cdb4137e439471625", size = 42629, upload-time = "2026-04-26T10:52:50.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/33/4e18365da9a18f61a36486e7ed75863e029ff9fc7b597c39126f724eed36/rltest-0.7.24-py3-none-any.whl", hash = "sha256:a79dff7c422547f20fd34faa118d99474d72ce682d14e9fc06b7639de568333c", size = 47275, upload-time = "2026-04-15T11:25:46.427Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/1b78f12f887742a48ebe3c5cfed4e008c91d4db68e3695797b8e647e15d7/rltest-0.7.25-py3-none-any.whl", hash = "sha256:7a599bae73e858530369e7f68248ed0228134550c23ac724efc4adaa128079b2", size = 47886, upload-time = "2026-04-26T10:52:52.039Z" },
 ]
 
 [[package]]
@@ -508,7 +508,7 @@ requires-dist = [
     { name = "orderly-set", specifier = "<=5.4.1" },
     { name = "packaging", specifier = "<=24.2" },
     { name = "redis", specifier = ">=5.2.1,<7.0.0" },
-    { name = "rltest", specifier = "==0.7.24" },
+    { name = "rltest", specifier = "==0.7.25" },
     { name = "scipy", specifier = "<=1.15.2" },
 ]
 


### PR DESCRIPTION
## Describe the changes in the pull request

See https://github.com/RedisLabsModules/RLTest/pull/247 for an explanation
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and a small dependency bump; primary risk is minor CI behavior changes due to altered startup timing.
> 
> **Overview**
> Updates the Python test harness dependency from `RLTest==0.7.24` to `0.7.25` (including `uv.lock`).
> 
> Stabilizes several negative-startup tests by increasing RLTest’s startup grace period (via `startupGraceSecs` or `env.envRunner.startupGraceSecs = 1`) so Redis has time to abort during module init/RDB load, reducing readiness-probe race flakes (e.g., spurious "<Environment destroyed>" / "Redis server is dead" timing issues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6948f34755114244ece7ff791b29f238e6d077be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->