### PR TITLE
claude: rust-review: add test placement rules to review checklist

### DIFF
--- a/.skills/rust-review/SKILL.md
+++ b/.skills/rust-review/SKILL.md
@@ -143,9 +143,15 @@ For each C/C++ test, verify that an equivalent Rust test exists that covers the 
 scenario. Use [`/check-rust-coverage`](../check-rust-coverage/SKILL.md) to confirm
 line-level coverage of the new Rust code.
 
+**Test placement rules:**
+- Public (`pub`) functions must be tested in `tests/integration/` (integration tests).
+- `pub(crate)` and private functions should be tested in `#[cfg(test)] mod test`
+  (unit tests inside the source file), since integration tests cannot access them.
+
 Violations:
 - A C/C++ test scenario that has no corresponding Rust test.
 - Rust code paths that are uncovered by any test.
+- Public functions tested only in `mod test` instead of `tests/integration/`.
 
 ### 5. Emit the report
 


### PR DESCRIPTION
Check tests in `rust-review`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that tightens the Rust porting review checklist by adding guidance on where tests should live; no runtime or build behavior is affected.
> 
> **Overview**
> Updates the `rust-review` checklist to explicitly enforce **test placement rules** during porting reviews: `pub` APIs should be covered via `tests/integration/`, while `pub(crate)`/private helpers should be covered via in-file unit tests (`#[cfg(test)] mod test`).
> 
> Extends the 4b **Test coverage** violations list to flag public functions that are only tested via unit tests instead of integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8ac2297dec4ffe9b6ba82bba8a46ed598d590e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->