### PR TITLE
[8.4] Bound async connect with search-connect-timeout to prevent blackhole hang (#9222) - [MOD-12739]

### DIFF
--- a/module.conf
+++ b/module.conf
@@ -215,6 +215,13 @@
 #
 # search-topology-validation-timeout 30000
 
+# Per-attempt timeout for inter-shard connection setup (in milliseconds). Bounds
+# the TCP+TLS handshake so a blackholed SYN does not stall a connection
+# indefinitely. 0 disables the timeout.
+# numeric, valid range: [0, LLONG_MAX], default: 10000
+#
+# search-connect-timeout 10000
+
 # Set the BM25STD.TANH stretch factor. This is an integer value that divides the argument
 # of the tanh function that is used to normalize the score computed by the BM25STD scorer.
 # numeric, valid range: [1, 10000], default: 4

--- a/src/config.c
+++ b/src/config.c
@@ -47,6 +47,7 @@ configPair_t __configPairs[] = {
   {"_PRIORITIZE_INTERSECT_UNION_CHILDREN", "search-_prioritize-intersect-union-children"},
   {"_BG_INDEX_MEM_PCT_THR",           "search-_bg-index-mem-pct-thr"},
   {"BG_INDEX_SLEEP_GAP",              "search-bg-index-sleep-gap"},
+  {"CONNECT_TIMEOUT",                 "search-connect-timeout"},
   {"CONN_PER_SHARD",                  "search-conn-per-shard"},
   {"CURSOR_MAX_IDLE",                 "search-cursor-max-idle"},
   {"CURSOR_REPLY_THRESHOLD",          "search-cursor-reply-threshold"},

--- a/src/coord/config.c
+++ b/src/coord/config.c
@@ -227,6 +227,45 @@ long long get_topology_validation_timeout(
   return realConfig->topologyValidationTimeoutMS;
 }
 
+// CONNECT_TIMEOUT
+static inline void connectTimeoutFromMS(struct timeval *tv, size_t ms) {
+  tv->tv_sec = ms / 1000;
+  tv->tv_usec = (ms % 1000) * 1000;
+}
+
+static inline size_t connectTimeoutToMS(const struct timeval *tv) {
+  return (size_t)tv->tv_sec * 1000 + (size_t)tv->tv_usec / 1000;
+}
+
+CONFIG_SETTER(setConnectTimeout) {
+  SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
+  size_t ms;
+  int acrc = AC_GetSize(ac, &ms, AC_F_GE0);
+  if (acrc == AC_OK) connectTimeoutFromMS(&realConfig->connectTimeout, ms);
+  RETURN_STATUS(acrc);
+}
+
+CONFIG_GETTER(getConnectTimeout) {
+  SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
+  return sdsfromlonglong(connectTimeoutToMS(&realConfig->connectTimeout));
+}
+
+// connect-timeout
+int set_connect_timeout(const char *name,
+                      long long val, void *privdata, RedisModuleString **err) {
+  RSConfig *config = (RSConfig *)privdata;
+  SearchClusterConfig *realConfig = getOrCreateRealConfig(config);
+  connectTimeoutFromMS(&realConfig->connectTimeout, (size_t)val);
+  return REDISMODULE_OK;
+}
+
+long long get_connect_timeout(
+                const char *name, void *privdata) {
+  RSConfig *config = (RSConfig *)privdata;
+  SearchClusterConfig *realConfig = getOrCreateRealConfig(config);
+  return (long long)connectTimeoutToMS(&realConfig->connectTimeout);
+}
+
 static RSConfigOptions clusterOptions_g = {
     .vars =
         {
@@ -268,6 +307,12 @@ static RSConfigOptions clusterOptions_g = {
                          "Default is 30000 (30 seconds). 0 means no timeout.",
              .setValue = setTopologyValidationTimeout,
              .getValue = getTopologyValidationTimeout,},
+            {.name = "CONNECT_TIMEOUT",
+             .helpText = "Sets the per-attempt timeout for inter-shard connection setup (in milliseconds). "
+                         "Bounds the TCP+TLS handshake so a blackholed SYN does not stall a connection "
+                         "indefinitely. Default is 10000 (10 seconds). 0 disables the timeout.",
+             .setValue = setConnectTimeout,
+             .getValue = getConnectTimeout,},
             {.name = NULL}
             // fin
         }
@@ -351,6 +396,15 @@ int RegisterClusterModuleConfig(RedisModuleCtx *ctx) {
       ctx, "search-conn-per-shard", DEFAULT_CONN_PER_SHARD,
       REDISMODULE_CONFIG_UNPREFIXED, 0, UINT32_MAX,
       get_conn_per_shard, set_conn_per_shard, NULL,
+      (void*)&RSGlobalConfig
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterNumericConfig (
+      ctx, "search-connect-timeout", DEFAULT_CONNECT_TIMEOUT,
+      REDISMODULE_CONFIG_UNPREFIXED, 0, LLONG_MAX,
+      get_connect_timeout, set_connect_timeout, NULL,
       (void*)&RSGlobalConfig
     )
   )

--- a/src/coord/config.h
+++ b/src/coord/config.h
@@ -14,6 +14,7 @@
 #include "../../src/config.h"
 
 #include <string.h>
+#include <sys/time.h>
 
 typedef enum { ClusterType_RedisOSS = 0, ClusterType_RedisLabs = 1 } MRClusterType;
 
@@ -25,6 +26,7 @@ typedef struct {
   size_t coordinatorPoolSize; // number of threads in the coordinator thread pool
   size_t coordinatorIOThreads; // number of I/O threads in the coordinator
   size_t topologyValidationTimeoutMS;
+  struct timeval connectTimeout; // per-attempt inter-shard connect timeout; {0,0} disables
 } SearchClusterConfig;
 
 extern SearchClusterConfig clusterConfig;
@@ -38,6 +40,7 @@ extern RedisModuleString *config_dummy_password;
 #define DEFAULT_TOPOLOGY_VALIDATION_TIMEOUT 30000
 #define DEFAULT_CURSOR_REPLY_THRESHOLD 1
 #define DEFAULT_CONN_PER_SHARD 0
+#define DEFAULT_CONNECT_TIMEOUT 10000
 
 #define DEFAULT_CLUSTER_CONFIG                                                 \
   (SearchClusterConfig) {                                                      \
@@ -48,6 +51,8 @@ extern RedisModuleString *config_dummy_password;
     .coordinatorPoolSize = COORDINATOR_POOL_DEFAULT_SIZE,                      \
     .coordinatorIOThreads = COORDINATOR_IO_THREADS_DEFAULT_SIZE,               \
     .topologyValidationTimeoutMS = DEFAULT_TOPOLOGY_VALIDATION_TIMEOUT,        \
+    .connectTimeout = {.tv_sec = DEFAULT_CONNECT_TIMEOUT / 1000,               \
+                       .tv_usec = (DEFAULT_CONNECT_TIMEOUT % 1000) * 1000},    \
   }
 
 /* Detect the cluster type, by trying to see if we are running inside RLEC.

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -855,8 +855,17 @@ static MRConn *MR_NewConn(MREndpoint *ep, uv_loop_t *loop) {
 
 /* Connect to a cluster node. Return REDIS_OK if either connected, or if  */
 static int MRConn_Connect(MRConn *conn) {
+  // Bounds the async TCP+TLS handshake. Without it, a blackholed SYN can leave
+  // the ac stuck in SYN-SENT indefinitely, because neither ConnectCallback nor
+  // DisconnectCallback will fire and no retry is scheduled. With it, hiredis
+  // surfaces a timeout via ConnectCallback(REDIS_ERR), which drops the conn
+  // into Connecting with the retry timer armed. No command_timeout is set:
+  // legitimate queries may run for many seconds.
+  const struct timeval *connectTimeout = &clusterConfig.connectTimeout;
+  const bool connectTimeoutEnabled = connectTimeout->tv_sec || connectTimeout->tv_usec;
   redisOptions options = {.type = REDIS_CONN_TCP,
                           .options = REDIS_OPT_NOAUTOFREEREPLIES,
+                          .connect_timeout = connectTimeoutEnabled ? connectTimeout : NULL,
                           .endpoint.tcp = {.ip = conn->ep.host, .port = conn->ep.port}};
 
   redisAsyncContext *c = redisAsyncConnectWithOptions(&options);

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -573,6 +573,7 @@ numericConfigs = [
     ('search-topology-validation-timeout', 'TOPOLOGY_VALIDATION_TIMEOUT', 30_000, 0, LLONG_MAX, False, True),
     ('search-cursor-reply-threshold', 'CURSOR_REPLY_THRESHOLD', 1, 1, LLONG_MAX, False, True),
     ('search-conn-per-shard', 'CONN_PER_SHARD', 0, 0, UINT32_MAX, False, True),
+    ('search-connect-timeout', 'CONNECT_TIMEOUT', 10_000, 0, LLONG_MAX, False, True),
 ]
 
 @skip(redis_less_than='7.9.227')


### PR DESCRIPTION
Backport of #9222 to `8.4`.

Jira: [MOD-12739](https://redislabs.atlassian.net/browse/MOD-12739)

## Backport notes

Cherry-picked from master (commit `2a13018d764b264e33f4ad3869d074c668f083bc`). Git auto-merged `module.conf`, `src/config.c`, `src/coord/rmr/conn.c`, and `tests/pytests/test_config.py` due to nearby unrelated content; no manual conflict resolution was required. Resulting diff is identical to the upstream commit.

---

## Original PR description (#9222)

### Problem

`MRConn_Connect` calls `redisAsyncConnectWithOptions` without a connect timeout. If a peer shard is unreachable in a way that silently drops SYNs (firewall blackhole, half-broken NIC, dropped route), the async context stays in `SYN-SENT` indefinitely:
- `ConnectCallback` never fires, so `MRConn_StartNewConnection`'s retry timer is never armed from the callback path.
- `DisconnectCallback` never fires.
- The coordinator's connection is stuck in `Connecting` forever, and no user command targeting that shard will ever complete.

### Fix

Expose `search-connect-timeout` (default 10s, 0 disables). Pass it as `redisOptions.connect_timeout`; hiredis then fires `ConnectCallback` with `REDIS_ERR` on expiry, which drops the conn into the existing `Connecting` reconnect path.

Both `CONFIG` and legacy `FT.CONFIG CONNECT_TIMEOUT` are supported.

### Release note
- Added `search-connect-timeout` configuration (default 10 seconds, `0` disables) to bound inter-shard TCP/TLS connection setup time, preventing coordinator connections from hanging indefinitely when a peer shard is unreachable (e.g., firewall blackhole).

#### Mark if applicable
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes

[MOD-12739]: https://redislabs.atlassian.net/browse/MOD-12739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ