### PR TITLE
[2.10] Bound async connect with search-connect-timeout to prevent blackhole hang (#9222) - [MOD-12739]

### DIFF
--- a/coord/src/config.c
+++ b/coord/src/config.c
@@ -125,6 +125,29 @@ CONFIG_GETTER(getTopologyValidationTimeout) {
   return sdsfromlonglong(realConfig->topologyValidationTimeoutMS);
 }
 
+// CONNECT_TIMEOUT
+static inline void connectTimeoutFromMS(struct timeval *tv, size_t ms) {
+  tv->tv_sec = ms / 1000;
+  tv->tv_usec = (ms % 1000) * 1000;
+}
+
+static inline size_t connectTimeoutToMS(const struct timeval *tv) {
+  return (size_t)tv->tv_sec * 1000 + (size_t)tv->tv_usec / 1000;
+}
+
+CONFIG_SETTER(setConnectTimeout) {
+  SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
+  size_t ms;
+  int acrc = AC_GetSize(ac, &ms, AC_F_GE0);
+  if (acrc == AC_OK) connectTimeoutFromMS(&realConfig->connectTimeout, ms);
+  RETURN_STATUS(acrc);
+}
+
+CONFIG_GETTER(getConnectTimeout) {
+  SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
+  return sdsfromlonglong(connectTimeoutToMS(&realConfig->connectTimeout));
+}
+
 static RSConfigOptions clusterOptions_g = {
     .vars =
         {
@@ -161,6 +184,12 @@ static RSConfigOptions clusterOptions_g = {
                          "Default is 30000 (30 seconds). 0 means no timeout.",
              .setValue = setTopologyValidationTimeout,
              .getValue = getTopologyValidationTimeout,},
+            {.name = "CONNECT_TIMEOUT",
+             .helpText = "Sets the per-attempt timeout for inter-shard connection setup (in milliseconds). "
+                         "Bounds the TCP+TLS handshake so a blackholed SYN does not stall a connection "
+                         "indefinitely. Default is 10000 (10 seconds). 0 disables the timeout.",
+             .setValue = setConnectTimeout,
+             .getValue = getConnectTimeout,},
             {.name = NULL}
             // fin
         }

--- a/coord/src/config.h
+++ b/coord/src/config.h
@@ -12,6 +12,7 @@
 #include "../../src/config.h"
 
 #include <string.h>
+#include <sys/time.h>
 
 typedef enum { ClusterType_RedisOSS = 0, ClusterType_RedisLabs = 1 } MRClusterType;
 
@@ -23,6 +24,7 @@ typedef struct {
   size_t cursorReplyThreshold;
   size_t coordinatorPoolSize; // number of threads in the coordinator thread pool
   size_t topologyValidationTimeoutMS;
+  struct timeval connectTimeout; // per-attempt inter-shard connect timeout; {0,0} disables
 } SearchClusterConfig;
 
 extern SearchClusterConfig clusterConfig;
@@ -31,6 +33,8 @@ extern SearchClusterConfig clusterConfig;
 #define CLUSTER_TYPE_RLABS "redislabs"
 
 #define COORDINATOR_POOL_DEFAULT_SIZE 20
+
+#define DEFAULT_CONNECT_TIMEOUT 10000
 
 #define DEFAULT_CLUSTER_CONFIG                                                             \
   (SearchClusterConfig) {                                                                  \
@@ -41,6 +45,8 @@ extern SearchClusterConfig clusterConfig;
     .cursorReplyThreshold = 1,                                                             \
     .coordinatorPoolSize = COORDINATOR_POOL_DEFAULT_SIZE,                                  \
     .topologyValidationTimeoutMS = 30000,                                                  \
+    .connectTimeout = {.tv_sec = DEFAULT_CONNECT_TIMEOUT / 1000,                           \
+                       .tv_usec = (DEFAULT_CONNECT_TIMEOUT % 1000) * 1000},                \
   }
 
 /* Detect the cluster type, by trying to see if we are running inside RLEC.

--- a/coord/src/rmr/conn.c
+++ b/coord/src/rmr/conn.c
@@ -10,6 +10,7 @@
 #include "rmutil/rm_assert.h"
 #include "hiredis/adapters/libuv.h"
 #include "util/config_api.h"
+#include "../config.h"
 
 #include <uv.h>
 #include <signal.h>
@@ -673,8 +674,17 @@ static MRConn *MR_NewConn(MREndpoint *ep) {
 static int MRConn_Connect(MRConn *conn) {
   RS_ASSERT(!conn->conn);
 
+  // Bounds the async TCP+TLS handshake. Without it, a blackholed SYN can leave
+  // the ac stuck in SYN-SENT indefinitely, because neither ConnectCallback nor
+  // DisconnectCallback will fire and no retry is scheduled. With it, hiredis
+  // surfaces a timeout via ConnectCallback(REDIS_ERR), which drops the conn
+  // into Connecting with the retry timer armed. No command_timeout is set:
+  // legitimate queries may run for many seconds.
+  const struct timeval *connectTimeout = &clusterConfig.connectTimeout;
+  const bool connectTimeoutEnabled = connectTimeout->tv_sec || connectTimeout->tv_usec;
   redisOptions options = {.type = REDIS_CONN_TCP,
                           .options = REDIS_OPT_NOAUTOFREEREPLIES,
+                          .connect_timeout = connectTimeoutEnabled ? connectTimeout : NULL,
                           .endpoint.tcp = {.ip = conn->ep.host, .port = conn->ep.port}};
 
   redisAsyncContext *c = redisAsyncConnectWithOptions(&options);

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -388,6 +388,7 @@ def testGetConfigOptionsCoord(env):
         env.expect('_ft.config', 'get', conf).noError().apply(lambda x: x[0][0]).equal(conf)
 
     check_config('SEARCH_THREADS')
+    check_config('CONNECT_TIMEOUT')
 
 @skip(cluster=COORD) # Change to `skip(cluster=False)`
 def testAllConfigCoord(env):
@@ -402,6 +403,18 @@ def testInitConfigCoord():
 
     test_arg_num('SEARCH_THREADS', 3)
     test_arg_num('CONN_PER_SHARD', 3)
+    test_arg_num('CONNECT_TIMEOUT', 5000)
+
+@skip(cluster=False)
+def testConnectTimeoutCoord(env):
+    # Default is 10000 ms (see DEFAULT_CONNECT_TIMEOUT in coord/src/config.h)
+    env.expect('_ft.config', 'get', 'CONNECT_TIMEOUT').equal([['CONNECT_TIMEOUT', '10000']])
+    # Set/get round-trip
+    env.expect('_ft.config', 'set', 'CONNECT_TIMEOUT', '2500').ok()
+    env.expect('_ft.config', 'get', 'CONNECT_TIMEOUT').equal([['CONNECT_TIMEOUT', '2500']])
+    # 0 disables the timeout
+    env.expect('_ft.config', 'set', 'CONNECT_TIMEOUT', '0').ok()
+    env.expect('_ft.config', 'get', 'CONNECT_TIMEOUT').equal([['CONNECT_TIMEOUT', '0']])
 
 @skip(cluster=False)
 def testImmutableCoord(env):


### PR DESCRIPTION
Backport of #9222 to `2.10`.

Jira: [MOD-12739](https://redislabs.atlassian.net/browse/MOD-12739)

## Backport notes

Cherry-picked from master (commit `2a13018d764b264e33f4ad3869d074c668f083bc`). The `2.10` branch has a significantly different layout than master (coordinator lives under `coord/src/` rather than `src/coord/`, and `src/config.c` does not yet use the Redis module config API), so most hunks had to be resolved manually.

### Conflicts resolved

- **`module.conf`**: Does not exist on `2.10`. The upstream hunk was dropped.
- **`src/config.c`**: On `2.10` this file does not use the Redis module config registration API (no `configPair_t` table, no `set_long_numeric_config` helpers). The upstream commit's additions there are not applicable. `search-connect-timeout` is still exposed via the legacy `FT.CONFIG CONNECT_TIMEOUT` / `_FT.CONFIG` commands through the cluster config options table. Kept the file as on HEAD.
- **`tests/pytests/test_config.py`**: The upstream test relies on the new module-level `CONFIG SET search-connect-timeout` path, which does not exist on `2.10`. Kept the file as on HEAD (no new test added for this backport).
- **`coord/src/config.h`** (corresponds to `src/coord/config.h` on master): Added `struct timeval connectTimeout` to `SearchClusterConfig`, `#include <sys/time.h>`, `DEFAULT_CONNECT_TIMEOUT` (10000 ms), and the default initializer in `DEFAULT_CLUSTER_CONFIG`.
- **`coord/src/config.c`** (corresponds to `src/coord/config.c` on master): Added `setConnectTimeout`/`getConnectTimeout` callbacks plus ms<->timeval helpers, and registered a new `CONNECT_TIMEOUT` entry in `clusterOptions_g` (exposed via `FT.CONFIG`).
- **`coord/src/rmr/conn.c`** (corresponds to `src/coord/rmr/conn.c` on master): Inserted the new timeout logic in `MRConn_Connect` immediately after the existing `RS_ASSERT(!conn->conn);`, and wired `connect_timeout` into `redisOptions`. Also added `#include "../config.h"` because this file did not previously include the coordinator config header (unlike master, which includes `coord/config.h`).

Result: 3 files changed, 45 insertions.

---

## Original PR description (#9222)

### Problem

`MRConn_Connect` calls `redisAsyncConnectWithOptions` without a connect timeout. If a peer shard is unreachable in a way that silently drops SYNs (firewall blackhole, half-broken NIC, dropped route), the async context stays in `SYN-SENT` indefinitely:
- `ConnectCallback` never fires, so `MRConn_StartNewConnection`'s retry timer is never armed from the callback path.
- `DisconnectCallback` never fires.
- The coordinator's connection is stuck in `Connecting` forever, and no user command targeting that shard will ever complete.

### Fix

Expose `search-connect-timeout` (default 10s, 0 disables). Pass it as `redisOptions.connect_timeout`; hiredis then fires `ConnectCallback` with `REDIS_ERR` on expiry, which drops the conn into the existing `Connecting` reconnect path.

On `2.10` the setting is exposed via the legacy `FT.CONFIG CONNECT_TIMEOUT` / `_FT.CONFIG CONNECT_TIMEOUT` commands (the `CONFIG` / module-level config registration path is not available on this branch).

### Release note
- Added `CONNECT_TIMEOUT` cluster configuration (exposed via `FT.CONFIG`, default 10 seconds, `0` disables) to bound inter-shard TCP/TLS connection setup time, preventing coordinator connections from hanging indefinitely when a peer shard is unreachable (e.g., firewall blackhole).

#### Mark if applicable
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes

[MOD-12739]: https://redislabs.atlassian.net/browse/MOD-12739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator networking by adding a connect-timeout to hiredis async connects; misconfiguration (too low or disabled) could affect shard connectivity and query availability under network issues.
> 
> **Overview**
> Prevents coordinator inter-shard connections from hanging indefinitely when a shard is unreachable (e.g., SYN blackhole) by **bounding the async TCP/TLS handshake** with a configurable `CONNECT_TIMEOUT`.
> 
> Introduces a new coordinator config `CONNECT_TIMEOUT` (default **10s**, `0` disables) exposed via `_FT.CONFIG`, stores it in `SearchClusterConfig`, and passes it into hiredis via `redisOptions.connect_timeout`; adds pytests covering default and set/get behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455470ac779c3b46c3e767c3dd0c37f3bf3b00fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->