### PR TITLE
MOD-9637: Refactor Config Get Calls to Use Redis Module API

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1724,22 +1724,17 @@ void UpgradeDeprecatedMTConfigs() {
 }
 
 char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName) {
-  RedisModuleCallReply *rep = RedisModule_Call(ctx, "config", "cc", "get", confName);
-  RS_ASSERT(RedisModule_CallReplyType(rep) == REDISMODULE_REPLY_ARRAY);
-  if (RedisModule_CallReplyLength(rep) == 0){
-    RedisModule_FreeCallReply(rep);
+  RedisModuleString *valueStr = NULL;
+  if (RedisModule_ConfigGet(ctx, confName, &valueStr) != REDISMODULE_OK) {
     return NULL;
   }
-  RS_ASSERT(RedisModule_CallReplyLength(rep) == 2);
-  RedisModuleCallReply *valueRep = RedisModule_CallReplyArrayElement(rep, 1);
-  RS_ASSERT(RedisModule_CallReplyType(valueRep) == REDISMODULE_REPLY_STRING);
   size_t len;
-  const char* valueRepCStr = RedisModule_CallReplyStringPtr(valueRep, &len);
+  const char *valueCStr = RedisModule_StringPtrLen(valueStr, &len);
 
-  char* res = rm_calloc(1, len + 1);
-  memcpy(res, valueRepCStr, len);
+  char *res = rm_calloc(1, len + 1);
+  memcpy(res, valueCStr, len);
 
-  RedisModule_FreeCallReply(rep);
+  RedisModule_FreeString(ctx, valueStr);
 
   return res;
 }
@@ -2394,7 +2389,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       get_bool_config, set_bool_config, NULL,
       (void *)&(RSGlobalConfig.fallbackToMainThreadWhenBlockClientUnavailable)
     )
-  ) 
+  )
 
   return REDISMODULE_OK;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -1739,6 +1739,14 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName) {
   return res;
 }
 
+bool getRedisConfigBool(RedisModuleCtx *ctx, const char *confName, bool defaultValue) {
+  int value = 0;
+  if (RedisModule_ConfigGetBool(ctx, confName, &value) != REDISMODULE_OK) {
+    return defaultValue;
+  }
+  return value != 0;
+}
+
 sds RSConfig_GetInfoString(const RSConfig *config) {
   sds ss = sdsempty();
 

--- a/src/config.c
+++ b/src/config.c
@@ -1723,20 +1723,12 @@ void UpgradeDeprecatedMTConfigs() {
   }
 }
 
-char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName) {
+RedisModuleString *getRedisConfigValue(RedisModuleCtx *ctx, const char *confName) {
   RedisModuleString *valueStr = NULL;
   if (RedisModule_ConfigGet(ctx, confName, &valueStr) != REDISMODULE_OK) {
     return NULL;
   }
-  size_t len;
-  const char *valueCStr = RedisModule_StringPtrLen(valueStr, &len);
-
-  char *res = rm_calloc(1, len + 1);
-  memcpy(res, valueCStr, len);
-
-  RedisModule_FreeString(ctx, valueStr);
-
-  return res;
+  return valueStr;
 }
 
 bool getRedisConfigBool(RedisModuleCtx *ctx, const char *confName, bool defaultValue) {

--- a/src/config.c
+++ b/src/config.c
@@ -1725,10 +1725,8 @@ void UpgradeDeprecatedMTConfigs() {
 
 RedisModuleString *getRedisConfigValue(RedisModuleCtx *ctx, const char *confName) {
   RedisModuleString *valueStr = NULL;
-  if (RedisModule_ConfigGet(ctx, confName, &valueStr) != REDISMODULE_OK) {
-    return NULL;
-  }
-  return valueStr;
+  RedisModule_ConfigGet(ctx, confName, &valueStr);
+  return valueStr; // Unset on error, caller should check for NULL
 }
 
 bool getRedisConfigBool(RedisModuleCtx *ctx, const char *confName, bool defaultValue) {
@@ -1737,6 +1735,14 @@ bool getRedisConfigBool(RedisModuleCtx *ctx, const char *confName, bool defaultV
     return defaultValue;
   }
   return value != 0;
+}
+
+long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long long defaultValue) {
+  long long value = 0;
+  if (RedisModule_ConfigGetNumeric(ctx, confName, &value) != REDISMODULE_OK) {
+    return defaultValue;
+  }
+  return value;
 }
 
 sds RSConfig_GetInfoString(const RSConfig *config) {

--- a/src/config.h
+++ b/src/config.h
@@ -302,6 +302,12 @@ void UpgradeDeprecatedMTConfigs();
 
 char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
 
+/*
+ * Get the boolean value of a Redis config. Returns `defaultValue` if the
+ * config does not exist or isn't a boolean config.
+ */
+bool getRedisConfigBool(RedisModuleCtx *ctx, const char *confName, bool defaultValue);
+
 // We limit the number of worker threads to limit the amount of memory used by the thread pool
 // and to prevent the system from running out of resources.
 // The number of worker threads should be proportional to the number of cores in the system at most,

--- a/src/config.h
+++ b/src/config.h
@@ -313,6 +313,12 @@ RedisModuleString *getRedisConfigValue(RedisModuleCtx *ctx, const char *confName
  */
 bool getRedisConfigBool(RedisModuleCtx *ctx, const char *confName, bool defaultValue);
 
+/*
+ * Get the numeric value of a Redis config. Returns `defaultValue` if the
+ * config does not exist or isn't a numeric config.
+ */
+long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long long defaultValue);
+
 // We limit the number of worker threads to limit the amount of memory used by the thread pool
 // and to prevent the system from running out of resources.
 // The number of worker threads should be proportional to the number of cores in the system at most,

--- a/src/config.h
+++ b/src/config.h
@@ -300,7 +300,12 @@ sds RSConfig_GetInfoString(const RSConfig *config);
 
 void UpgradeDeprecatedMTConfigs();
 
-char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
+/*
+ * Get the value of a Redis config as a `RedisModuleString`. Returns NULL if the
+ * config does not exist. The caller is responsible for freeing the returned
+ * string using `RedisModule_FreeString`.
+ */
+RedisModuleString *getRedisConfigValue(RedisModuleCtx *ctx, const char *confName);
 
 /*
  * Get the boolean value of a Redis config. Returns `defaultValue` if the

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -650,15 +650,13 @@ static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_c
   int ret = 1;
   RedisModuleCtx *ctx = RSDummyContext;
   RedisModule_ThreadSafeContextLock(ctx);
-  RedisModuleString *tlsPort = NULL;
 
   // If `tls-cluster` is not set to `yes`, and `tls-port` is not set or zero,
   // we do not connect to the other nodes with TLS. We always want to connect with TLS
   // when the tls-port is set to a non-zero value, since this is the port we
   // get from the proxy on Enterprise, and the preferred port on OSS (see RedisCluster_GetTopology).
   if (!getRedisConfigBool(ctx, "tls-cluster", false)) {
-    tlsPort = getRedisConfigValue(ctx, "tls-port");
-    if (!tlsPort || !strcmp(RedisModule_StringPtrLen(tlsPort, NULL), "0")) {
+    if (getRedisConfigNumeric(ctx, "tls-port", 0) == 0) {
       ret = 0;
       goto done;
     }
@@ -690,9 +688,6 @@ static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_c
   }
 
 done:
-  if (tlsPort) {
-    RedisModule_FreeString(ctx, tlsPort);
-  }
   RedisModule_ThreadSafeContextUnlock(ctx);
   return ret;
 }

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -649,15 +649,13 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
   int ret = 1;
   RedisModuleCtx *ctx = RSDummyContext;
   RedisModule_ThreadSafeContextLock(ctx);
-  char* clusterTls = NULL;
   char* tlsPort = NULL;
 
   // If `tls-cluster` is not set to `yes`, and `tls-port` is not set or zero,
   // we do not connect to the other nodes with TLS. We always want to connect with TLS
   // when the tls-port is set to a non-zero value, since this is the port we
   // get from the proxy on Enterprise, and the preferred port on OSS (see RedisCluster_GetTopology).
-  clusterTls = getRedisConfigValue(ctx, "tls-cluster");
-  if (!clusterTls || strcmp(clusterTls, "yes")) {
+  if (!getRedisConfigBool(ctx, "tls-cluster", false)) {
     tlsPort = getRedisConfigValue(ctx, "tls-port");
     if (!tlsPort || !strcmp(tlsPort, "0")) {
       ret = 0;
@@ -691,9 +689,6 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
   }
 
 done:
-  if (clusterTls) {
-    rm_free(clusterTls);
-  }
   if (tlsPort) {
     rm_free(tlsPort);
   }

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -645,11 +645,12 @@ error:
 }
 
 extern RedisModuleCtx *RSDummyContext;
-static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char** key_pass){
+static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_cert,
+                    RedisModuleString **ca_cert, RedisModuleString **key_pass) {
   int ret = 1;
   RedisModuleCtx *ctx = RSDummyContext;
   RedisModule_ThreadSafeContextLock(ctx);
-  char* tlsPort = NULL;
+  RedisModuleString *tlsPort = NULL;
 
   // If `tls-cluster` is not set to `yes`, and `tls-port` is not set or zero,
   // we do not connect to the other nodes with TLS. We always want to connect with TLS
@@ -657,7 +658,7 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
   // get from the proxy on Enterprise, and the preferred port on OSS (see RedisCluster_GetTopology).
   if (!getRedisConfigBool(ctx, "tls-cluster", false)) {
     tlsPort = getRedisConfigValue(ctx, "tls-port");
-    if (!tlsPort || !strcmp(tlsPort, "0")) {
+    if (!tlsPort || !strcmp(RedisModule_StringPtrLen(tlsPort, NULL), "0")) {
       ret = 0;
       goto done;
     }
@@ -671,26 +672,26 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
   if (!*client_key || !*client_cert || !*ca_cert){
     ret = 0;
     if(*client_key){
-      rm_free(*client_key);
+      RedisModule_FreeString(ctx, *client_key);
       *client_key = NULL;
     }
     if(*client_cert){
-      rm_free(*client_cert);
+      RedisModule_FreeString(ctx, *client_cert);
       *client_cert = NULL;
     }
     if(*ca_cert){
-      rm_free(*ca_cert);
+      RedisModule_FreeString(ctx, *ca_cert);
       *ca_cert = NULL;
     }
     if (*key_pass) {
-      rm_free(*key_pass);
+      RedisModule_FreeString(ctx, *key_pass);
       *key_pass = NULL;
     }
   }
 
 done:
   if (tlsPort) {
-    rm_free(tlsPort);
+    RedisModule_FreeString(ctx, tlsPort);
   }
   RedisModule_ThreadSafeContextUnlock(ctx);
   return ret;
@@ -728,17 +729,22 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
   }
 
   // todo: check if tls is require and if it does initiate a tls connection
-  char* client_cert = NULL;
-  char* client_key = NULL;
-  char* ca_cert = NULL;
-  char* key_file_pass = NULL;
+  RedisModuleString *client_cert = NULL;
+  RedisModuleString *client_key = NULL;
+  RedisModuleString *ca_cert = NULL;
+  RedisModuleString *key_file_pass = NULL;
   if(checkTLS(&client_key, &client_cert, &ca_cert, &key_file_pass)){
     redisSSLContextError ssl_error = 0;
-    SSL_CTX *ssl_context = MRConn_CreateSSLContext(ca_cert, client_cert, client_key, key_file_pass, &ssl_error);
-    rm_free(client_key);
-    rm_free(client_cert);
-    rm_free(ca_cert);
-    if (key_file_pass) rm_free(key_file_pass);
+    SSL_CTX *ssl_context = MRConn_CreateSSLContext(
+        RedisModule_StringPtrLen(ca_cert, NULL),
+        RedisModule_StringPtrLen(client_cert, NULL),
+        RedisModule_StringPtrLen(client_key, NULL),
+        key_file_pass ? RedisModule_StringPtrLen(key_file_pass, NULL) : NULL,
+        &ssl_error);
+    RedisModule_FreeString(RSDummyContext, client_key);
+    RedisModule_FreeString(RSDummyContext, client_cert);
+    RedisModule_FreeString(RSDummyContext, ca_cert);
+    if (key_file_pass) RedisModule_FreeString(RSDummyContext, key_file_pass);
     if(ssl_context == NULL || ssl_error != 0) {
       CONN_LOG_WARNING(conn, "Error on ssl context creation: %s", (ssl_error != 0) ? redisSSLContextGetError(ssl_error) : "Unknown error");
       detachFromConn(conn, true);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -13,7 +13,6 @@
 #include "config.h"
 #include "redisearch_api.h"
 #include <assert.h>
-#include <ctype.h>
 #include <dlfcn.h>
 #include "concurrent_ctx.h"
 #include "cursor.h"
@@ -55,22 +54,15 @@ static int validateAofSettings(RedisModuleCtx *ctx) {
     return rc;
   }
 
-  // Can't execute commands on the loading context, so make a new one
-  RedisModuleCallReply *reply =
-      RedisModule_Call(RSDummyContext, "CONFIG", "cc", "GET", "aof-use-rdb-preamble");
-  RS_ASSERT(reply);
-  RS_ASSERT(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ARRAY);
-  RS_ASSERT(RedisModule_CallReplyLength(reply) == 2);
-  const char *value =
-      RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(reply, 1), NULL);
+  // Can't execute commands on the loading context, so use the dummy one
+  int value = 0;
+  int rv = RedisModule_ConfigGetBool(RSDummyContext, "aof-use-rdb-preamble", &value);
+  RS_ASSERT(rv == REDISMODULE_OK);
 
-  // I tried using strcasecmp, but it seems that the yes/no replies have a trailing
-  // embedded newline in them
-  if (tolower(*value) == 'n') {
+  if (!value) {
     RedisModule_Log(RSDummyContext, "warning", "FATAL: aof-use-rdb-preamble required if AOF is used!");
     rc = 0;
   }
-  RedisModule_FreeCallReply(reply);
   return rc;
 }
 

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -55,11 +55,7 @@ static int validateAofSettings(RedisModuleCtx *ctx) {
   }
 
   // Can't execute commands on the loading context, so use the dummy one
-  int value = 0;
-  int rv = RedisModule_ConfigGetBool(RSDummyContext, "aof-use-rdb-preamble", &value);
-  RS_ASSERT(rv == REDISMODULE_OK);
-
-  if (!value) {
+  if (!getRedisConfigBool(RSDummyContext, "aof-use-rdb-preamble", false)) {
     RedisModule_Log(RSDummyContext, "warning", "FATAL: aof-use-rdb-preamble required if AOF is used!");
     rc = 0;
   }

--- a/src/module.c
+++ b/src/module.c
@@ -4644,10 +4644,7 @@ void Initialize_CoordKeyspaceNotifications(RedisModuleCtx *ctx) {
 }
 
 static bool checkClusterEnabled(RedisModuleCtx *ctx) {
-  int isClusterEnabled = 0;
-  int rv = RedisModule_ConfigGetBool(ctx, "cluster-enabled", &isClusterEnabled);
-  RS_ASSERT_ALWAYS(rv == REDISMODULE_OK);
-  return isClusterEnabled;
+  return getRedisConfigBool(ctx, "cluster-enabled", false);
 }
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/module.c
+++ b/src/module.c
@@ -4644,13 +4644,9 @@ void Initialize_CoordKeyspaceNotifications(RedisModuleCtx *ctx) {
 }
 
 static bool checkClusterEnabled(RedisModuleCtx *ctx) {
-  RedisModuleCallReply *rep = RedisModule_Call(ctx, "CONFIG", "cc", "GET", "cluster-enabled");
-  RS_ASSERT_ALWAYS(rep && RedisModule_CallReplyType(rep) == REDISMODULE_REPLY_ARRAY &&
-                     RedisModule_CallReplyLength(rep) == 2);
-  size_t len;
-  const char *isCluster = RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(rep, 1), &len);
-  bool isClusterEnabled = STR_EQCASE(isCluster, len, "yes");
-  RedisModule_FreeCallReply(rep);
+  int isClusterEnabled = 0;
+  int rv = RedisModule_ConfigGetBool(ctx, "cluster-enabled", &isClusterEnabled);
+  RS_ASSERT_ALWAYS(rv == REDISMODULE_OK);
   return isClusterEnabled;
 }
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -523,11 +523,7 @@ void ShutdownDiskClose(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subev
 #define BIGREDIS_MAX_RAM "bigredis-max-ram"
 
 bool getHideUserDataFromLogs() {
-  char *value = getRedisConfigValue(RSDummyContext, HIDE_USER_DATA_FROM_LOGS);
-  RedisModule_Assert(value);
-  const bool hideUserData = !strcasecmp(value, "yes");
-  rm_free(value);
-  return hideUserData;
+  return getRedisConfigBool(RSDummyContext, HIDE_USER_DATA_FROM_LOGS, false);
 }
 
 void onUpdatedHideUserDataFromLogs(RedisModuleCtx *ctx) {

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -170,7 +170,7 @@ RedisSearchDiskRdbState* SearchDisk_LoadRdbToTempObject(RedisModuleIO *rdb) {
 }
 
 RedisSearchDiskIndexSpec* SearchDisk_OpenIndexWithRdbState(RedisModuleCtx *ctx,
-                                                            const HiddenString *indexName,  
+                                                            const HiddenString *indexName,
                                                             const char *obfuscatedName,
                                                             DocumentType type,
                                                             RedisSearchDiskRdbState *rdbState) {
@@ -343,13 +343,7 @@ bool SearchDisk_DeleteDocumentById(RedisSearchDiskIndexSpec *handle, t_docId doc
 }
 
 bool SearchDisk_CheckEnableConfiguration(RedisModuleCtx *ctx) {
-  bool isFlexConfigured = false;
-  char *isFlexEnabledStr = getRedisConfigValue(ctx, "bigredis-enabled");
-  if (isFlexEnabledStr && !strcasecmp(isFlexEnabledStr, "yes")) {
-    isFlexConfigured = true;
-  } // Default is false, so nothing to change in that case.
-  rm_free(isFlexEnabledStr);
-  return isFlexConfigured;
+  return getRedisConfigBool(ctx, "bigredis-enabled", false);
 }
 
 bool SearchDisk_IsEnabled() {


### PR DESCRIPTION
## Describe the changes in the pull request

Simplifying any configuration reading flow by using new dedicated API, instead of `RedisModule_Call("CONFIG", "GET", "...")` and parsing.

#### Main objects this PR modified
1. Make `getRedisConfigValue` return a `RedisModuleString*`, using new API
2. Add `getRedisConfigBool` and `getRedisConfigNumeric` for no allocation reading
3. Refactor callers to use new helpers
4. Use new helpers instead of calling `RedisModule_Call` manually

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how critical runtime flags (TLS, AOF preamble requirement, cluster-enabled, log obfuscation, disk enablement) are read and how their memory is managed, which could affect initialization and inter-node connectivity if semantics differ.
> 
> **Overview**
> Refactors Redis configuration reads away from `RedisModule_Call("CONFIG", "GET", ...)` parsing to the Redis Modules configuration APIs.
> 
> `getRedisConfigValue` now returns a `RedisModuleString*` (caller frees with `RedisModule_FreeString`), and new helpers `getRedisConfigBool`/`getRedisConfigNumeric` provide typed reads with defaults. Call sites are updated accordingly, including TLS setup in `coord/rmr/conn.c`, AOF validation in `module-init.c`, cluster detection in `module.c`, log obfuscation in `notifications.c`, and Flex/disk enable checks in `search_disk.c`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42fc1bf49ddcbadd0978c33b69a41b2ca77a4b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->