### PR TITLE
[MOD-14201] TopKIterator Core State Machine (Rust)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ RUST_TOOLCHAIN_MODIFIER="" # Rust toolchain to use (e.g., +nightly)
 
 # Rust code is built first, so exclude benchmarking crates that link C code,
 # since the static libraries they depend on haven't been built yet.
-EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi"
+EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher"
 
 # Retrieve our pinned nightly version.
 NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)

--- a/build.sh
+++ b/build.sh
@@ -884,7 +884,7 @@ run_rust_tests() {
       --doctests
       $EXCLUDE_RUST_BENCHING_CRATES_LINKING_C
       --codecov
-      --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*"
+      --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*,top_k_bencher/*"
       --output-path=$BINROOT/rust_cov.info
     "
   elif [[ "$RUN_MIRI" == "1" ]]; then

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2715,7 +2715,30 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 name = "top_k"
 version = "0.0.1"
 dependencies = [
+ "build_utils",
  "ffi",
+ "inverted_index",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_iterator_type",
+ "rqe_iterators",
+ "rqe_iterators_test_utils",
+ "top_k",
+ "workspace_hack",
+]
+
+[[package]]
+name = "top_k_bencher"
+version = "0.0.1"
+dependencies = [
+ "bindgen",
+ "build_utils",
+ "criterion",
+ "rand 0.9.3",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_iterators",
+ "top_k",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2717,6 +2717,8 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "ffi",
+ "index_result",
+ "index_spec",
  "inverted_index",
  "redis_mock",
  "redisearch_rs",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "tracing_redismodule",
     "trie_bencher",
     "top_k",
+    "top_k_bencher",
     "trie_rs",
     "ttl_table",
     "value",

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -8,6 +8,28 @@ publish.workspace = true
 [lib]
 bench = false
 
+[features]
+# Exposes MockScoreSource and MockScoreBatch for use in tests and benchmarks.
+test-utils = []
+# Links C static libraries at test time (see build.rs).
+# https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+unittest = []
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }
+
 [dependencies]
 ffi.workspace = true
+inverted_index.workspace = true
+rqe_iterator_type.workspace = true
+rqe_iterators.workspace = true
 workspace_hack.workspace = true
+
+[dev-dependencies]
+top_k = { path = ".", features = ["unittest", "test-utils"] }
+redis_mock.workspace = true
+rqe_iterators = { workspace = true, features = ["unittest"] }
+rqe_iterators_test_utils.workspace = true
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -10,7 +10,7 @@ bench = false
 doctest = false
 
 [features]
-# Exposes MockScoreSource and MockScoreBatch for use in tests and benchmarks.
+# Exposes mocks for use in tests and benchmarks.
 test-utils = []
 # Links C static libraries at test time (see build.rs).
 # https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
@@ -25,6 +25,8 @@ inverted_index.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
 workspace_hack.workspace = true
+index_result.workspace = true
+index_spec.workspace = true
 
 [dev-dependencies]
 top_k = { path = ".", features = ["unittest", "test-utils"] }

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 
 [lib]
 bench = false
+doctest = false
 
 [features]
 # Exposes MockScoreSource and MockScoreBatch for use in tests and benchmarks.

--- a/src/redisearch_rs/top_k/build.rs
+++ b/src/redisearch_rs/top_k/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`TopKIterator`] — the generic top-k state machine.
+
+use std::num::NonZeroUsize;
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+
+use crate::traits::{ScoreBatch, ScoreSource};
+
+// ── Public enums ─────────────────────────────────────────────────────────────
+
+/// Determines which collection algorithm [`TopKIterator`] uses.
+///
+/// Selected at construction based on whether a child filter is present,
+/// and may be switched mid-execution when the source decides a different
+/// strategy is more efficient.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopKMode {
+    /// No child filter — stream directly from the source's single batch.
+    /// The heap is bypassed entirely.
+    Unfiltered,
+}
+
+// ── Private phase enum ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Collection has not started; the first call to [`read`](TopKIterator::read)
+    /// will trigger it.
+    NotStarted,
+    /// Actively collecting results (transient; only visible inside collection methods).
+    Collecting,
+    /// Collection is done; yielding results from `results` in order.
+    #[expect(
+        dead_code,
+        reason = "TopKMode::Unfiltered is without child so no yielding necessary"
+    )]
+    Yielding,
+    /// Unfiltered path: yielding directly from `direct_batch` without a heap.
+    YieldingDirect,
+}
+
+// ── TopKIterator ──────────────────────────────────────────────────────────────
+
+/// A generic top-k iterator parameterized over a [`ScoreSource`].
+///
+/// Implements the execution mode described in the design doc:
+/// [`Unfiltered`](TopKMode::Unfiltered).
+pub struct TopKIterator<'index, S: ScoreSource<'index>> {
+    source: S,
+    child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+    mode: TopKMode,
+    /// Preserved so [`rewind`](Self::rewind) can restore the original mode.
+    initial_mode: TopKMode,
+    /// Holds the in-progress batch for the Unfiltered path.
+    direct_batch: Option<S::Batch>,
+    k: NonZeroUsize,
+    phase: Phase,
+    current: Option<RSIndexResult<'index>>,
+    last_doc_id: t_docId,
+    at_eof: bool,
+}
+
+impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
+    /// Create a new [`TopKIterator`].
+    ///
+    /// The execution mode is inferred from `child`.
+    ///
+    /// For now, only [`TopKMode::Unfiltered`] exists.
+    pub fn new(
+        source: S,
+        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        k: NonZeroUsize,
+    ) -> Self {
+        let mode = TopKMode::Unfiltered;
+        Self::new_with_mode(source, child, k, mode)
+    }
+
+    /// Create a new [`TopKIterator`] with an explicit initial mode.
+    pub fn new_with_mode(
+        source: S,
+        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        k: NonZeroUsize,
+        mode: TopKMode,
+    ) -> Self {
+        Self {
+            source,
+            child,
+            mode,
+            initial_mode: mode,
+            direct_batch: None,
+            k,
+            phase: Phase::NotStarted,
+            current: None,
+            last_doc_id: 0,
+            at_eof: false,
+        }
+    }
+
+    // ── Collection dispatch ───────────────────────────────────────────────────
+
+    /// Drive collection based on the current mode.
+    fn collect(&mut self) -> Result<(), RQEIteratorError> {
+        self.phase = Phase::Collecting;
+        let result = match self.mode {
+            TopKMode::Unfiltered => self.prepare_unfiltered_direct(),
+        };
+        if result.is_err() {
+            // Restore a stable phase so that a subsequent read() call can retry.
+            // Phase::Collecting is only valid transiently inside this method.
+            // TODO: MOD-14209: bubble up errors
+            self.phase = Phase::NotStarted;
+        }
+        result
+    }
+
+    // ── Unfiltered path ───────────────────────────────────────────────────────
+
+    /// Set up the unfiltered direct-yield path.
+    ///
+    /// Calls [`ScoreSource::next_batch`] exactly once.  Results are streamed
+    /// directly from the batch cursor — no heap is involved.
+    fn prepare_unfiltered_direct(&mut self) -> Result<(), RQEIteratorError> {
+        self.direct_batch = self.source.next_batch()?;
+        if self.direct_batch.is_none() {
+            self.at_eof = true;
+        }
+        self.phase = Phase::YieldingDirect;
+        Ok(())
+    }
+
+    // ── Yielding helpers ─────────────────────────────────────────────────────
+
+    /// Yield the next result from the unfiltered direct batch.
+    fn advance_unfiltered_direct(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        let item = if let Some(batch) = &mut self.direct_batch {
+            batch.next()
+        } else {
+            None
+        };
+
+        match item {
+            Some((doc_id, score)) => {
+                let result = self.source.build_result(doc_id, score);
+                self.current = Some(result);
+                self.last_doc_id = doc_id;
+                Ok(self.current.as_mut())
+            }
+            None => {
+                self.at_eof = true;
+                Ok(None)
+            }
+        }
+    }
+}
+
+// ── RQEIterator impl ──────────────────────────────────────────────────────────
+
+impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index, S> {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.current.as_mut()
+    }
+
+    #[inline(always)]
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if self.at_eof {
+            return Ok(None);
+        }
+
+        if self.phase == Phase::NotStarted {
+            self.collect()?;
+        }
+
+        match self.phase {
+            Phase::YieldingDirect => self.advance_unfiltered_direct(),
+            Phase::Yielding => {
+                unreachable!("collect() must set phase to YieldingDirect or Yielding")
+            }
+            Phase::NotStarted | Phase::Collecting => {
+                unreachable!("collect() must set phase to YieldingDirect or Yielding")
+            }
+        }
+    }
+
+    fn skip_to(
+        &mut self,
+        _doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        // TopKIterator is a root-only iterator that yields results sorted by
+        // score, not by doc_id.  It cannot be used as a child in a larger
+        // iterator tree, so skip_to is unsupported.
+        unimplemented!("TopKIterator is a root-only iterator; skip_to is not supported")
+    }
+
+    #[inline(always)]
+    unsafe fn revalidate(
+        &mut self,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        if let Some(child) = &mut self.child {
+            // SAFETY: Delegating to child with the same `spec` passed by our caller.
+            return unsafe { child.revalidate(spec) };
+        }
+        Ok(RQEValidateStatus::Ok)
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        self.source.rewind();
+        if let Some(child) = &mut self.child {
+            child.rewind();
+        }
+        self.mode = self.initial_mode;
+        self.direct_batch = None;
+        self.current = None;
+        self.last_doc_id = 0;
+        self.at_eof = false;
+        self.phase = Phase::NotStarted;
+        // We explicitly do NOT reset self.metrics because they're used for diagnostics.
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        self.k.get().min(self.source.num_estimated())
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        self.last_doc_id
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        self.at_eof
+    }
+
+    #[inline(always)]
+    fn type_(&self) -> IteratorType {
+        self.source.iterator_type()
+    }
+
+    #[inline(always)]
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -12,13 +12,12 @@
 use std::num::NonZeroUsize;
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 use crate::traits::{ScoreBatch, ScoreSource};
-
-// ── Public enums ─────────────────────────────────────────────────────────────
 
 /// Determines which collection algorithm [`TopKIterator`] uses.
 ///
@@ -29,10 +28,16 @@ use crate::traits::{ScoreBatch, ScoreSource};
 pub enum TopKMode {
     /// No child filter — stream directly from the source's single batch.
     /// The heap is bypassed entirely.
+    ///
+    /// # Invariants
+    ///
+    /// The [`ScoreSource`] used with this mode **must** produce at most one
+    /// batch (i.e. the first [`ScoreSource::next_batch`] call returns the
+    /// complete result set, and a second call would return `Ok(None)`).
+    /// Any additional batches are not consumed and their results are silently
+    /// lost.  In debug builds, [`TopKIterator`] asserts this invariant.
     Unfiltered,
 }
-
-// ── Private phase enum ────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Phase {
@@ -51,12 +56,9 @@ enum Phase {
     YieldingDirect,
 }
 
-// ── TopKIterator ──────────────────────────────────────────────────────────────
-
 /// A generic top-k iterator parameterized over a [`ScoreSource`].
 ///
-/// Implements the execution mode described in the design doc:
-/// [`Unfiltered`](TopKMode::Unfiltered).
+/// Implements [`Unfiltered`](TopKMode::Unfiltered).
 pub struct TopKIterator<'index, S: ScoreSource<'index>> {
     source: S,
     child: Option<Box<dyn RQEIterator<'index> + 'index>>,
@@ -75,7 +77,7 @@ pub struct TopKIterator<'index, S: ScoreSource<'index>> {
 impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
     /// Create a new [`TopKIterator`].
     ///
-    /// The execution mode is inferred from `child`.
+    /// The execution mode is always Unfiltered.
     ///
     /// For now, only [`TopKMode::Unfiltered`] exists.
     pub fn new(
@@ -108,8 +110,6 @@ impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
         }
     }
 
-    // ── Collection dispatch ───────────────────────────────────────────────────
-
     /// Drive collection based on the current mode.
     fn collect(&mut self) -> Result<(), RQEIteratorError> {
         self.phase = Phase::Collecting;
@@ -117,40 +117,43 @@ impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
             TopKMode::Unfiltered => self.prepare_unfiltered_direct(),
         };
         if result.is_err() {
-            // Restore a stable phase so that a subsequent read() call can retry.
-            // Phase::Collecting is only valid transiently inside this method.
+            // Reset so a retry via read() works: Phase::Collecting has no handler there.
             // TODO: MOD-14209: bubble up errors
             self.phase = Phase::NotStarted;
         }
         result
     }
 
-    // ── Unfiltered path ───────────────────────────────────────────────────────
-
     /// Set up the unfiltered direct-yield path.
     ///
     /// Calls [`ScoreSource::next_batch`] exactly once.  Results are streamed
     /// directly from the batch cursor — no heap is involved.
+    ///
+    /// # Invariants
+    ///
+    /// [`TopKMode::Unfiltered`] requires the source to produce at most one
+    /// batch.  In debug builds this method calls [`ScoreSource::next_batch`] a
+    /// second time and panics if another batch is returned, catching
+    /// misbehaving implementations early.
     fn prepare_unfiltered_direct(&mut self) -> Result<(), RQEIteratorError> {
         self.direct_batch = self.source.next_batch()?;
         if self.direct_batch.is_none() {
             self.at_eof = true;
         }
+        debug_assert!(
+            matches!(self.source.next_batch(), Ok(None)),
+            "ScoreSource did not return Ok(None) in TopKMode::Unfiltered \
+             (extra batch or error); use a batched mode instead"
+        );
         self.phase = Phase::YieldingDirect;
         Ok(())
     }
-
-    // ── Yielding helpers ─────────────────────────────────────────────────────
 
     /// Yield the next result from the unfiltered direct batch.
     fn advance_unfiltered_direct(
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        let item = if let Some(batch) = &mut self.direct_batch {
-            batch.next()
-        } else {
-            None
-        };
+        let item = self.direct_batch.as_mut().and_then(S::Batch::next);
 
         match item {
             Some((doc_id, score)) => {
@@ -161,13 +164,12 @@ impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
             }
             None => {
                 self.at_eof = true;
+                self.current = None;
                 Ok(None)
             }
         }
     }
 }
-
-// ── RQEIterator impl ──────────────────────────────────────────────────────────
 
 impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index, S> {
     #[inline(always)]
@@ -188,7 +190,7 @@ impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index
         match self.phase {
             Phase::YieldingDirect => self.advance_unfiltered_direct(),
             Phase::Yielding => {
-                unreachable!("collect() must set phase to YieldingDirect or Yielding")
+                unreachable!("`Phase::Yielding` is dead code (planned for batches - MOD-14203).")
             }
             Phase::NotStarted | Phase::Collecting => {
                 unreachable!("collect() must set phase to YieldingDirect or Yielding")
@@ -207,13 +209,12 @@ impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if let Some(child) = &mut self.child {
-            // SAFETY: Delegating to child with the same `spec` passed by our caller.
-            return unsafe { child.revalidate(spec) };
+            return child.revalidate(spec);
         }
         Ok(RQEValidateStatus::Ok)
     }
@@ -230,7 +231,6 @@ impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index
         self.last_doc_id = 0;
         self.at_eof = false;
         self.phase = Phase::NotStarted;
-        // We explicitly do NOT reset self.metrics because they're used for diagnostics.
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -7,7 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! A fixed-capacity heap that retains the top-k scored documents.
 //! Generic top-k iterator shared by the vector (hybrid) and numeric (optimizer)
 //! query iterators.
 //!
@@ -17,7 +16,6 @@
 //! top-k collection in three modes:
 //!
 //! - **Unfiltered** — no child filter; stream results directly from the source's batch.
-//!   for each document.
 //!
 //! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
 //! traits.

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -26,6 +26,11 @@ pub mod heap;
 pub mod iterator;
 pub mod traits;
 
+#[cfg(test)]
+extern crate redisearch_rs;
+#[cfg(test)]
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 #[cfg(feature = "test-utils")]
 pub mod mock;
 

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -8,7 +8,27 @@
 */
 
 //! A fixed-capacity heap that retains the top-k scored documents.
+//! Generic top-k iterator shared by the vector (hybrid) and numeric (optimizer)
+//! query iterators.
+//!
+//! # Architecture
+//!
+//! The core abstraction is [`TopKIterator<S>`], a state machine that drives
+//! top-k collection in three modes:
+//!
+//! - **Unfiltered** — no child filter; stream results directly from the source's batch.
+//!   for each document.
+//!
+//! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
+//! traits.
 
 pub mod heap;
+pub mod iterator;
+pub mod traits;
+
+#[cfg(feature = "test-utils")]
+pub mod mock;
 
 pub use heap::{ScoredResult, TopKHeap};
+pub use iterator::{TopKIterator, TopKMode};
+pub use traits::{ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Mock implementations of [`ScoreBatch`] and [`ScoreSource`] for use in unit
+//! tests and benchmarks.
+//!
+//! Gated behind the `test-utils` feature.
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+use rqe_iterators::RQEIteratorError;
+
+use crate::traits::{ScoreBatch, ScoreSource};
+
+// ── MockScoreBatch ────────────────────────────────────────────────────────────
+
+/// A [`ScoreBatch`] backed by a pre-sorted `Vec<(t_docId, f64)>`.
+///
+/// Doc IDs must be strictly increasing; this is not validated at runtime.
+pub struct MockScoreBatch {
+    items: Vec<(t_docId, f64)>,
+    pos: usize,
+}
+
+impl MockScoreBatch {
+    /// Creates a batch from a vector of `(doc_id, score)` pairs.
+    ///
+    /// The pairs must be sorted by `doc_id` in strictly ascending order.
+    pub fn new(items: Vec<(t_docId, f64)>) -> Self {
+        Self { items, pos: 0 }
+    }
+}
+
+impl ScoreBatch for MockScoreBatch {
+    fn next(&mut self) -> Option<(t_docId, f64)> {
+        let item = self.items.get(self.pos).copied();
+        if item.is_some() {
+            self.pos += 1;
+        }
+        item
+    }
+}
+
+// ── MockScoreSource ───────────────────────────────────────────────────────────
+
+/// A [`ScoreSource`] backed by fixed data for use in tests and benchmarks.
+///
+/// # Usage
+///
+/// ```rust
+/// # use top_k::mock::MockScoreSource;
+/// let source = MockScoreSource::new(
+///     // Two batches: each is a Vec<(doc_id, score)>
+///     vec![
+///         vec![(1, 0.5), (3, 0.8)],
+///         vec![(5, 0.2), (7, 0.9)],
+///     ],
+/// );
+/// ```
+pub struct MockScoreSource {
+    batches: Vec<Vec<(t_docId, f64)>>,
+    batch_pos: usize,
+    num_estimated: usize,
+}
+
+impl MockScoreSource {
+    /// Creates a new `MockScoreSource`.
+    ///
+    /// - `batches` — sequence of batches; each inner `Vec` is one [`MockScoreBatch`].
+    /// - `strategy` — function called after each batch.
+    ///
+    /// `num_estimated` defaults to the total number of entries across all batches.
+    pub fn new(batches: Vec<Vec<(t_docId, f64)>>) -> Self {
+        let num_estimated = batches.iter().map(Vec::len).sum();
+        Self {
+            batches,
+            batch_pos: 0,
+            num_estimated,
+        }
+    }
+
+    /// Override the `num_estimated` value.
+    pub fn with_num_estimated(mut self, n: usize) -> Self {
+        self.num_estimated = n;
+        self
+    }
+}
+
+impl<'index> ScoreSource<'index> for MockScoreSource {
+    type Batch = MockScoreBatch;
+
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        let batch = self
+            .batches
+            .get(self.batch_pos)
+            .cloned()
+            .map(MockScoreBatch::new);
+        if batch.is_some() {
+            self.batch_pos += 1;
+        }
+        Ok(batch)
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
+    }
+
+    fn rewind(&mut self) {
+        self.batch_pos = 0;
+    }
+
+    fn build_result(&self, doc_id: t_docId, _score: f64) -> RSIndexResult<'index> {
+        RSIndexResult::build_virt().doc_id(doc_id).build()
+    }
+
+    fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+}

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -13,16 +13,14 @@
 //! Gated behind the `test-utils` feature.
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use rqe_iterators::RQEIteratorError;
 
 use crate::traits::{ScoreBatch, ScoreSource};
 
-// ── MockScoreBatch ────────────────────────────────────────────────────────────
-
 /// A [`ScoreBatch`] backed by a pre-sorted `Vec<(t_docId, f64)>`.
 ///
-/// Doc IDs must be strictly increasing; this is not validated at runtime.
+/// Doc IDs must be strictly increasing; this is validated in debug builds.
 pub struct MockScoreBatch {
     items: Vec<(t_docId, f64)>,
     pos: usize,
@@ -31,8 +29,12 @@ pub struct MockScoreBatch {
 impl MockScoreBatch {
     /// Creates a batch from a vector of `(doc_id, score)` pairs.
     ///
-    /// The pairs must be sorted by `doc_id` in strictly ascending order.
+    /// The pairs must be sorted by `doc_id` in strictly ascending order (asserted in debug builds).
     pub fn new(items: Vec<(t_docId, f64)>) -> Self {
+        debug_assert!(
+            items.windows(2).all(|w| w[0].0 < w[1].0),
+            "MockScoreBatch: doc IDs must be strictly increasing"
+        );
         Self { items, pos: 0 }
     }
 }
@@ -46,8 +48,6 @@ impl ScoreBatch for MockScoreBatch {
         item
     }
 }
-
-// ── MockScoreSource ───────────────────────────────────────────────────────────
 
 /// A [`ScoreSource`] backed by fixed data for use in tests and benchmarks.
 ///

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Core traits that score sources must implement to plug into [`TopKIterator`].
+//!
+//! [`TopKIterator`]: crate::TopKIterator
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::RQEIteratorError;
+
+// ── ScoreBatch ────────────────────────────────────────────────────────────────
+
+/// A cursor over a single score-ordered batch of `(doc_id, score)` pairs.
+///
+/// Produced by [`ScoreSource::next_batch`] and streamed by [`TopKIterator`].
+/// Doc IDs within a batch must be **strictly increasing**.
+///
+/// [`TopKIterator`]: crate::TopKIterator
+pub trait ScoreBatch {
+    /// Advance to the next `(doc_id, score)` pair.
+    ///
+    /// Returns `None` when the batch is exhausted.
+    fn next(&mut self) -> Option<(t_docId, f64)>;
+}
+
+// ── ScoreSource ───────────────────────────────────────────────────────────────
+
+/// The score-producing half of a [`TopKIterator`].
+///
+/// A [`ScoreSource`] knows how to:
+/// 1. Produce score-ordered batches ([`next_batch`]).
+/// 2. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
+///
+/// [`TopKIterator`]: crate::TopKIterator
+/// [`next_batch`]: ScoreSource::next_batch
+/// [`build_result`]: ScoreSource::build_result
+pub trait ScoreSource<'index> {
+    /// The type of batch cursor this source produces.
+    type Batch: ScoreBatch;
+
+    /// Fetch the next score-ordered batch.
+    ///
+    /// Returns:
+    /// - `Ok(Some(batch))` — a new batch is available.
+    /// - `Ok(None)` — the source is exhausted; no more batches.
+    /// - `Err(RQEIteratorError::TimedOut)` — the query time limit was reached.
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError>;
+
+    /// Return an upper-bound estimate for the number of documents this source
+    /// can produce.
+    fn num_estimated(&self) -> usize;
+
+    /// Rewind the source to its initial state so batch iteration can restart.
+    fn rewind(&mut self);
+
+    /// Build the [`RSIndexResult`] that the [`TopKIterator`] will yield for a
+    /// given `(doc_id, score)` pair.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn build_result(&self, doc_id: t_docId, score: f64) -> RSIndexResult<'index>;
+
+    /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn iterator_type(&self) -> IteratorType;
+}

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -12,11 +12,9 @@
 //! [`TopKIterator`]: crate::TopKIterator
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::RQEIteratorError;
-
-// ── ScoreBatch ────────────────────────────────────────────────────────────────
 
 /// A cursor over a single score-ordered batch of `(doc_id, score)` pairs.
 ///
@@ -30,8 +28,6 @@ pub trait ScoreBatch {
     /// Returns `None` when the batch is exhausted.
     fn next(&mut self) -> Option<(t_docId, f64)>;
 }
-
-// ── ScoreSource ───────────────────────────────────────────────────────────────
 
 /// The score-producing half of a [`TopKIterator`].
 ///
@@ -52,6 +48,16 @@ pub trait ScoreSource<'index> {
     /// - `Ok(Some(batch))` — a new batch is available.
     /// - `Ok(None)` — the source is exhausted; no more batches.
     /// - `Err(RQEIteratorError::TimedOut)` — the query time limit was reached.
+    ///
+    /// # Multi-batch support
+    ///
+    /// The API allows an implementation to spread results across multiple
+    /// batches (the caller loops until `Ok(None)`). However, [`TopKMode::Unfiltered`]
+    /// only calls this method once; sources used in that mode **must** return
+    /// all their results in the first batch.  Returning a second batch there
+    /// is a logic error — results would be silently lost.
+    ///
+    /// [`TopKMode::Unfiltered`]: crate::TopKMode::Unfiltered
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError>;
 
     /// Return an upper-bound estimate for the number of documents this source

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Integration tests for [`TopKIterator`].
+
+use std::num::NonZeroUsize;
+
+use rqe_iterators::RQEIterator;
+use top_k::{TopKIterator, mock::MockScoreSource};
+
+// ── State machine ─────────────────────────────────────────────────────────────
+
+#[test]
+fn read_triggers_collection_on_first_call() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    assert!(!it.at_eof());
+    let result = it.read().unwrap().expect("should have a result");
+    assert_eq!(result.doc_id, 1);
+}
+
+#[test]
+fn rewind_resets_to_not_started() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    it.read().unwrap();
+    it.read().unwrap();
+    it.read().unwrap(); // EOF
+
+    assert!(it.at_eof());
+    it.rewind();
+    assert!(!it.at_eof());
+
+    let result = it
+        .read()
+        .unwrap()
+        .expect("should have a result after rewind");
+    assert_eq!(result.doc_id, 1);
+}
+
+#[test]
+fn eof_set_after_results_exhausted() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    it.read().unwrap();
+    let eof = it.read().unwrap();
+    assert!(eof.is_none());
+    assert!(it.at_eof());
+}
+
+#[test]
+fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+
+    assert_eq!(it.last_doc_id(), 0);
+
+    it.read().unwrap();
+    assert_eq!(it.last_doc_id(), 1);
+    it.read().unwrap();
+    assert_eq!(it.last_doc_id(), 2);
+
+    it.rewind();
+    assert_eq!(it.last_doc_id(), 0);
+}
+
+#[test]
+fn num_estimated_capped_at_k() {
+    let source =
+        MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]]).with_num_estimated(100);
+    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap());
+    assert_eq!(it.num_estimated(), 3);
+}
+
+// ── Unfiltered path ───────────────────────────────────────────────────────────
+
+#[test]
+fn unfiltered_yields_batch_in_source_order() {
+    // Unfiltered mode streams directly from the batch without sorting.
+    let source = MockScoreSource::new(vec![vec![(3, 0.1), (1, 0.5), (2, 0.9)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap());
+    let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(ids, vec![3, 1, 2]);
+}
+
+#[test]
+fn unfiltered_empty_source_is_immediate_eof() {
+    let source = MockScoreSource::new(vec![]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    assert!(it.read().unwrap().is_none());
+    assert!(it.at_eof());
+}
+
+// ── Revalidation ──────────────────────────────────────────────────────────────
+
+/// Child iterator whose `revalidate` unconditionally returns `Aborted`.
+///
+/// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
+/// already returns `Ok` from `revalidate`.  This stub only exists for the
+/// case that cannot be expressed with any existing public iterator type.
+struct AbortOnRevalidate;
+
+impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
+    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+        None
+    }
+
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
+    {
+        Ok(None)
+    }
+
+    fn skip_to(
+        &mut self,
+        _doc_id: ffi::t_docId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        unimplemented!()
+    }
+
+    unsafe fn revalidate(
+        &mut self,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
+        Ok(rqe_iterators::RQEValidateStatus::Aborted)
+    }
+
+    fn rewind(&mut self) {}
+
+    fn num_estimated(&self) -> usize {
+        0
+    }
+
+    fn last_doc_id(&self) -> ffi::t_docId {
+        0
+    }
+
+    fn at_eof(&self) -> bool {
+        true
+    }
+
+    fn type_(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}
+
+#[test]
+fn revalidate_without_child_returns_ok() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    // SAFETY: child-less path returns Ok unconditionally; spec is never read.
+    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
+}
+
+#[test]
+fn revalidate_with_child_delegates_ok() {
+    // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
+    // for any child iterator that leaves the parent in a valid state.
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
+    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap());
+    // SAFETY: Empty::revalidate ignores spec; nothing is dereferenced.
+    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
+}
+
+#[test]
+fn revalidate_with_child_delegates_aborted() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
+    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap());
+    // SAFETY: AbortOnRevalidate::revalidate ignores spec; nothing is dereferenced.
+    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
+}
+
+#[test]
+fn unfiltered_timeout_propagated() {
+    use rqe_iterators::RQEIteratorError;
+    use top_k::{ScoreSource, mock::MockScoreBatch};
+
+    struct TimingOutSource;
+    impl<'index> ScoreSource<'index> for TimingOutSource {
+        type Batch = MockScoreBatch;
+
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            Err(RQEIteratorError::TimedOut)
+        }
+
+        fn num_estimated(&self) -> usize {
+            0
+        }
+
+        fn rewind(&mut self) {}
+
+        fn build_result(
+            &self,
+            doc_id: ffi::t_docId,
+            _: f64,
+        ) -> inverted_index::RSIndexResult<'index> {
+            inverted_index::RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .build()
+        }
+
+        fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
+            rqe_iterator_type::IteratorType::Mock
+        }
+    }
+
+    let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap());
+    assert!(matches!(
+        it.read().unwrap_err(),
+        rqe_iterators::RQEIteratorError::TimedOut
+    ));
+}

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -11,8 +11,95 @@
 
 use std::num::NonZeroUsize;
 
-use rqe_iterators::RQEIterator;
-use top_k::{TopKIterator, mock::MockScoreSource};
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use rqe_iterators::{RQEIterator, RQEIteratorError};
+use top_k::{ScoreSource, TopKIterator, mock::MockScoreBatch, mock::MockScoreSource};
+
+// ── Error path stubs ─────────────────────────────────────────────────────────────
+
+/// Child iterator whose `revalidate` unconditionally returns `Aborted`.
+///
+/// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
+/// already returns `Ok` from `revalidate`.  This stub only exists for the
+/// case that cannot be expressed with any existing public iterator type.
+struct AbortOnRevalidate;
+
+impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        None
+    }
+
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        Ok(None)
+    }
+
+    fn skip_to(
+        &mut self,
+        _doc_id: ffi::t_docId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        unimplemented!()
+    }
+
+    fn revalidate(
+        &mut self,
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
+        Ok(rqe_iterators::RQEValidateStatus::Aborted)
+    }
+
+    fn rewind(&mut self) {}
+
+    fn num_estimated(&self) -> usize {
+        0
+    }
+
+    fn last_doc_id(&self) -> ffi::t_docId {
+        0
+    }
+
+    fn at_eof(&self) -> bool {
+        true
+    }
+
+    fn type_(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}
+
+/// [`ScoreSource`] whose [`ScoreSource::next_batch`] unconditionally returns [`RQEIteratorError::TimedOut`].
+///
+/// Used to verify that timeout errors propagate correctly through [`TopKIterator`].
+struct TimingOutSource;
+
+impl<'index> ScoreSource<'index> for TimingOutSource {
+    type Batch = MockScoreBatch;
+
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        Err(RQEIteratorError::TimedOut)
+    }
+
+    fn num_estimated(&self) -> usize {
+        0
+    }
+
+    fn rewind(&mut self) {}
+
+    fn build_result(&self, doc_id: ffi::t_docId, _: f64) -> RSIndexResult<'index> {
+        RSIndexResult::build_virt().doc_id(doc_id).build()
+    }
+
+    fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+}
 
 // ── State machine ─────────────────────────────────────────────────────────────
 
@@ -31,8 +118,9 @@ fn rewind_resets_to_not_started() {
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
     it.read().unwrap();
     it.read().unwrap();
-    it.read().unwrap(); // EOF
+    let eof = it.read().unwrap();
 
+    assert!(eof.is_none());
     assert!(it.at_eof());
     it.rewind();
     assert!(!it.at_eof());
@@ -82,11 +170,10 @@ fn num_estimated_capped_at_k() {
 
 #[test]
 fn unfiltered_yields_batch_in_source_order() {
-    // Unfiltered mode streams directly from the batch without sorting.
-    let source = MockScoreSource::new(vec![vec![(3, 0.1), (1, 0.5), (2, 0.9)]]);
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]]);
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap());
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
-    assert_eq!(ids, vec![3, 1, 2]);
+    assert_eq!(ids, vec![1, 2, 3]);
 }
 
 #[test]
@@ -99,70 +186,12 @@ fn unfiltered_empty_source_is_immediate_eof() {
 
 // ── Revalidation ──────────────────────────────────────────────────────────────
 
-/// Child iterator whose `revalidate` unconditionally returns `Aborted`.
-///
-/// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
-/// already returns `Ok` from `revalidate`.  This stub only exists for the
-/// case that cannot be expressed with any existing public iterator type.
-struct AbortOnRevalidate;
-
-impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
-    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
-        None
-    }
-
-    fn read(
-        &mut self,
-    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
-    {
-        Ok(None)
-    }
-
-    fn skip_to(
-        &mut self,
-        _doc_id: ffi::t_docId,
-    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
-    {
-        unimplemented!()
-    }
-
-    unsafe fn revalidate(
-        &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
-    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        Ok(rqe_iterators::RQEValidateStatus::Aborted)
-    }
-
-    fn rewind(&mut self) {}
-
-    fn num_estimated(&self) -> usize {
-        0
-    }
-
-    fn last_doc_id(&self) -> ffi::t_docId {
-        0
-    }
-
-    fn at_eof(&self) -> bool {
-        true
-    }
-
-    fn type_(&self) -> rqe_iterator_type::IteratorType {
-        rqe_iterator_type::IteratorType::Mock
-    }
-
-    fn intersection_sort_weight(&self, _: bool) -> f64 {
-        1.0
-    }
-}
-
 #[test]
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
-    // SAFETY: child-less path returns Ok unconditionally; spec is never read.
-    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
 
@@ -174,8 +203,7 @@ fn revalidate_with_child_delegates_ok() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
     let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap());
-    // SAFETY: Empty::revalidate ignores spec; nothing is dereferenced.
-    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
 
@@ -185,45 +213,12 @@ fn revalidate_with_child_delegates_aborted() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
     let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap());
-    // SAFETY: AbortOnRevalidate::revalidate ignores spec; nothing is dereferenced.
-    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
 }
 
 #[test]
 fn unfiltered_timeout_propagated() {
-    use rqe_iterators::RQEIteratorError;
-    use top_k::{ScoreSource, mock::MockScoreBatch};
-
-    struct TimingOutSource;
-    impl<'index> ScoreSource<'index> for TimingOutSource {
-        type Batch = MockScoreBatch;
-
-        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
-            Err(RQEIteratorError::TimedOut)
-        }
-
-        fn num_estimated(&self) -> usize {
-            0
-        }
-
-        fn rewind(&mut self) {}
-
-        fn build_result(
-            &self,
-            doc_id: ffi::t_docId,
-            _: f64,
-        ) -> inverted_index::RSIndexResult<'index> {
-            inverted_index::RSIndexResult::build_virt()
-                .doc_id(doc_id)
-                .build()
-        }
-
-        fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
-            rqe_iterator_type::IteratorType::Mock
-        }
-    }
-
     let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap());
     assert!(matches!(
         it.read().unwrap_err(),

--- a/src/redisearch_rs/top_k/tests/integration/main.rs
+++ b/src/redisearch_rs/top_k/tests/integration/main.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Provide stubs for C symbols
+// that rqe_iterators and inverted_index reference at link time.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;
+
+mod iterator;

--- a/src/redisearch_rs/top_k_bencher/Cargo.toml
+++ b/src/redisearch_rs/top_k_bencher/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "top_k_bencher"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[[bench]]
+name = "top_k"
+harness = false
+
+[build-dependencies]
+bindgen.workspace = true
+build_utils = { path = "../build_utils" }
+
+[dependencies]
+criterion.workspace = true
+rand.workspace = true
+redis_mock.workspace = true
+rqe_iterators = { workspace = true }
+top_k = { workspace = true, features = ["test-utils"] }
+workspace_hack.workspace = true
+# Crate required to invoke C symbols and keep Rust-defined FFI symbols alive.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Micro-benchmarks for [`TopKHeap`] and [`TopKIterator`].
+//!
+//! These benchmarks use mock sources and synthetic data.  They are NOT
+//! comparable to the C iterator numbers — their purpose is to provide a
+//! regression guard for the shared skeleton before real sources are plugged in.
+
+// Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
+use top_k_bencher as _;
+
+use std::hint::black_box;
+use std::{cmp::Ordering, num::NonZeroUsize};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand::{SeedableRng as _, seq::SliceRandom as _};
+use top_k::TopKHeap;
+
+// ── Comparators ───────────────────────────────────────────────────────────────
+
+fn asc(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+// ── Heap benchmarks ───────────────────────────────────────────────────────────
+
+fn bench_heap_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("heap");
+    let (n, k) = (100_000, NonZeroUsize::new(1_000).unwrap());
+
+    // Best case: scores arrive worst-first; after the heap fills every
+    // subsequent element is immediately rejected without touching the heap.
+    group.bench_with_input(
+        BenchmarkId::new("insert_asc", format!("{n}→k{k}")),
+        &(n, k),
+        |b, &(n, k)| {
+            b.iter(|| {
+                let mut heap = TopKHeap::new(k, asc);
+                for i in 0..n {
+                    heap.push(i as u64, i as f64);
+                }
+                black_box(heap.len())
+            })
+        },
+    );
+
+    // Worst case: scores arrive best-first; every element after fill is
+    // strictly better than the current worst, forcing a pop + push
+    // (O(log k)) on each of the n-k remaining insertions.
+    group.bench_with_input(
+        BenchmarkId::new("insert_desc", format!("{n}→k{k}")),
+        &(n, k),
+        |b, &(n, k)| {
+            b.iter(|| {
+                let mut heap = TopKHeap::new(k, asc);
+                for i in (0..n).rev() {
+                    heap.push(i as u64, i as f64);
+                }
+                black_box(heap.len())
+            })
+        },
+    );
+
+    // Realistic case: shuffled scores give a mix of evictions and
+    // rejections representative of real query-result streams.
+    // The shuffle is done once outside the timed loop.
+    let scores: Vec<u64> = {
+        let mut v: Vec<u64> = (0..n as u64).collect();
+        v.shuffle(&mut rand::rngs::SmallRng::seed_from_u64(42));
+        v
+    };
+    group.bench_function(
+        BenchmarkId::new("insert_rand", format!("{n}→k{k}")),
+        |b| {
+            b.iter(|| {
+                let mut heap = TopKHeap::new(k, asc);
+                for &i in &scores {
+                    heap.push(i, i as f64);
+                }
+                black_box(heap.len())
+            })
+        },
+    );
+
+    group.finish();
+}
+
+fn bench_heap_pop_all(c: &mut Criterion) {
+    let mut group = c.benchmark_group("heap");
+    let k = NonZeroUsize::new(1_000).unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("drain_sorted", format!("k{k}")),
+        &k,
+        |b, &k| {
+            b.iter_batched(
+                || {
+                    let mut heap = TopKHeap::new(k, asc);
+                    for i in 0..k.get() {
+                        heap.push(i as u64, i as f64);
+                    }
+                    heap
+                },
+                |heap| black_box(heap.drain_sorted()),
+                BatchSize::SmallInput,
+            )
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, bench_heap_insert, bench_heap_pop_all);
+criterion_main!(benches);

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Micro-benchmarks for [`TopKHeap`] and [`TopKIterator`].
+//! Micro-benchmarks for [`TopKHeap`].
 //!
 //! These benchmarks use mock sources and synthetic data.  They are NOT
 //! comparable to the C iterator numbers — their purpose is to provide a
@@ -22,8 +22,6 @@ use std::{cmp::Ordering, num::NonZeroUsize};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{SeedableRng as _, seq::SliceRandom as _};
 use top_k::TopKHeap;
-
-// ── Comparators ───────────────────────────────────────────────────────────────
 
 fn asc(a: f64, b: f64) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)

--- a/src/redisearch_rs/top_k_bencher/build.rs
+++ b/src/redisearch_rs/top_k_bencher/build.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/top_k_bencher/src/lib.rs
+++ b/src/redisearch_rs/top_k_bencher/src/lib.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Some of the missing C symbols are actually Rust-provided.
+extern crate redisearch_rs;
+redis_mock::mock_or_stub_missing_redis_c_symbols!();


### PR DESCRIPTION
- based on https://github.com/RediSearch/RediSearch/pull/9170
- Also integrates Unfiltered Direct-Yield path.


## Add `TopKIterator` core state machine and unfiltered direct-yield path

### Summary

This PR introduces `TopKIterator`, the generic top-k query execution engine for RediSearch's vector search and scoring pipelines.

The iterator is parameterized over a `ScoreSource` trait, keeping it decoupled from any particular scoring backend (vector vs numeric field). This design allows the same state machine to serve different query shapes by swapping the source, not by duplicating logic.

The first execution mode implemented is **Unfiltered**: when there is no child filter iterator to intersect against, results are streamed directly from the source's batch without materializing a heap at all.
- This is not using https://github.com/RediSearch/RediSearch/pull/9170 as vector source implementation requires (for performance) a dedicated logic for the unfiltered path.
### What's included

- **`ScoreSource` / `ScoreBatch` traits** — the contract that pluggable scoring backends must implement
- **`TopKIterator`** — the state machine with phase tracking (`NotStarted → Collecting → Yielding`), `rewind()` support, `last_doc_id` bookkeeping.
- **`MockScoreSource`** — a test/benchmark harness that drives the iterator with synthetic data, gated behind a `test-utils` feature flag
- **Integration tests** — covering state transitions, rewind correctness, EOF behavior, and `num_estimated` capping
- **`top_k_bencher` crate** — Criterion micro-benchmarks for both the heap and the iterator, providing a regression baseline before real score sources are wired in

### What comes next

The `Batches` mode (merge-join intersection against a child filter) is not yet implemented — it is the next revision in this stack.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `TopKIterator` implementation and supporting traits/tests in the Rust query-iterator stack, which could affect result iteration semantics and error propagation once integrated. Build/coverage scripts are also updated to account for the new benchmark crate, with low but non-zero CI/build risk.
> 
> **Overview**
> **Adds a new generic top-k iterator core in Rust.** Introduces `TopKIterator` (with `TopKMode::Unfiltered` direct-yield execution), plus new `ScoreSource`/`ScoreBatch` traits and a `test-utils` mock implementation to drive unit/integration tests.
> 
> **Expands the workspace with benchmarking support.** Adds a new `top_k_bencher` Criterion crate and updates `build.sh` coverage and build exclusions to avoid linking issues from benchmark crates that depend on C symbols; `top_k` also gains `build.rs`, new feature flags, and additional dependencies to support the iterator and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4158fae8d881d9a217ca752c430c5744ee4a52e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->