### PR TITLE
[2.8] Add skip_until decorator for time-limited test skipping

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -396,6 +396,58 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
+def skip_until(date_str, reason=None):
+    """
+    Decorator to skip a test until a specific date.
+    After the date passes, the test will run normally.
+
+    This is useful for temporarily skipping flaky tests while ensuring
+    they are not forgotten - the test will automatically start running
+    again after the specified date.
+
+    Args:
+        date_str: A date string in ISO format "YYYY-MM-DD" (e.g., "2024-06-15")
+        reason: Optional reason for skipping the test
+
+    Usage:
+        @skip_until("2024-06-15", reason="Flaky test, investigating MOD-1234")
+        def testSomething(env):
+            ...
+    """
+    from datetime import datetime
+
+    def decorate(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            skip_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+            today = datetime.now().date()
+            if today < skip_date:
+                reason_msg = f" ({reason})" if reason else ""
+                print(f"Skipping {f.__name__} until {date_str}{reason_msg}")
+                raise SkipTest(f"Skipped until {date_str}{reason_msg}")
+            # Date has passed, run the test
+            return f(*args, **kwargs)
+        return wrapper
+    return decorate
+
+# Wraps the decorator `skip_until` for calling from within a test function
+def skipTestUntil(date_str, reason=None):
+    """
+    Skip the current test until a specific date.
+    Call this from within a test function.
+
+    Args:
+        date_str: A date string in ISO format "YYYY-MM-DD" (e.g., "2024-06-15")
+        reason: Optional reason for skipping the test
+
+    Usage:
+        def testSomething(env):
+            if some_condition:
+                skipTestUntil("2024-06-15", reason="Flaky under certain conditions")
+            ...
+    """
+    skip_until(date_str, reason)(lambda: None)()
+
 def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None):
     def decorate(f):
         def wrapper():


### PR DESCRIPTION
Backport of #9063 to 2.8.

## Description

Add `skip_until` decorator and `skipTestUntil` function to temporarily skip flaky tests until a specified date.

This helps prevent "forgotten" skipped tests - after the date passes, the test automatically runs again, ensuring flaky tests don't remain skipped indefinitely.

## Changes

- Added `skip_until(date_str, reason=None)` decorator in `tests/pytests/common.py`
- Added `skipTestUntil(date_str, reason=None)` function for use within test functions

## Usage Examples

### As a decorator (most common)

```python
from common import skip_until

@skip_until("2026-05-01", reason="Flaky test, tracking in MOD-1234")
def testSomething(env):
    # test code...
```

### Combined with other decorators

```python
@skip_until("2026-05-01", reason="Flaky on cluster")
@skip(cluster=True)
def testSomethingElse(env):
    # test code...
```

### From within a test function

```python
from common import skipTestUntil

def testConditionalSkip(env):
    if env.isCluster():
        skipTestUntil("2026-05-01", reason="Flaky on cluster only")

    # rest of test code...
```

## Conflict resolution

Cherry-pick conflicted in `tests/pytests/common.py` because on 2.8 the `skip(...)` signature still contains `noWorkers=False` (and does not yet have the later `no_json=False` parameter). Resolution: keep the branch's existing `skip` signature unchanged and insert the new `skip_until` / `skipTestUntil` functions immediately above it. No other changes.

## Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

## Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new test utility helpers and does not change production code paths; main risk is minor behavior differences in how skipped tests are reported/logged.
> 
> **Overview**
> Adds `skip_until(date_str, reason)` and `skipTestUntil(date_str, reason)` in `tests/pytests/common.py` to **skip tests only until a specified date**, automatically re-enabling them after the deadline.
> 
> When the skip window is active, the helper raises `SkipTest` (and prints a short message including the optional reason); otherwise it runs the test normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add5f128addbe2a7951231ee130d9e27b90f51b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->