### PR TITLE
Fix max value of search-connect-timeout config - [MOD-15100]

### DIFF
--- a/src/coord/config.c
+++ b/src/coord/config.c
@@ -239,9 +239,9 @@ static inline size_t connectTimeoutToMS(const struct timeval *tv) {
 
 CONFIG_SETTER(setConnectTimeout) {
   SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
-  size_t ms;
-  int acrc = AC_GetSize(ac, &ms, AC_F_GE0);
-  if (acrc == AC_OK) connectTimeoutFromMS(&realConfig->connectTimeout, ms);
+  int ms;
+  int acrc = AC_GetInt(ac, &ms, AC_F_GE0); // ms can be up to INT_MAX
+  if (acrc == AC_OK) connectTimeoutFromMS(&realConfig->connectTimeout, (size_t)ms);
   RETURN_STATUS(acrc);
 }
 

--- a/src/coord/config.c
+++ b/src/coord/config.c
@@ -403,7 +403,7 @@ int RegisterClusterModuleConfig(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig (
       ctx, "search-connect-timeout", DEFAULT_CONNECT_TIMEOUT,
-      REDISMODULE_CONFIG_UNPREFIXED, 0, LLONG_MAX,
+      REDISMODULE_CONFIG_UNPREFIXED, 0, INT_MAX,
       get_connect_timeout, set_connect_timeout, NULL,
       (void*)&RSGlobalConfig
     )

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -540,6 +540,7 @@ def _getRDBFilePath(env: Env):
     return os.path.join(dbDir, dbFileName)
 
 LLONG_MAX = (1 << 63) - 1
+INT_MAX = (1 << 31) - 1
 UINT64_MAX = (1 << 64) - 1
 UINT32_MAX = (1 << 32) - 1
 MAX_AGGREGATE_REQUEST_RESULTS = (1 << 31)
@@ -587,7 +588,7 @@ numericConfigs = [
     ('search-topology-validation-timeout', 'TOPOLOGY_VALIDATION_TIMEOUT', 30_000, 0, LLONG_MAX, False, True),
     ('search-cursor-reply-threshold', 'CURSOR_REPLY_THRESHOLD', 1, 1, LLONG_MAX, False, True),
     ('search-conn-per-shard', 'CONN_PER_SHARD', 0, 0, UINT32_MAX, False, True),
-    ('search-connect-timeout', 'CONNECT_TIMEOUT', 10_000, 0, LLONG_MAX, False, True),
+    ('search-connect-timeout', 'CONNECT_TIMEOUT', 10_000, 0, INT_MAX, False, True),
 ]
 
 @skip(redis_less_than='7.9.227')


### PR DESCRIPTION
## Problem

The `search-connect-timeout` config was registered with an upper bound of `LLONG_MAX` ms. That bound is wider than what the underlying hiredis connection layer can accept: hiredis converts the supplied milliseconds into a `struct timeval` and rejects (in `redisContextConnectBindTcp` / `_redisContextConnectTcp`) any value whose `tv_sec` exceeds `(LONG_MAX - 999) / 1000`, then additionally clamps the resulting msec to `INT_MAX` internally.

When `search-connect-timeout` was set near `LLONG_MAX`, every shard connection attempt failed with `Could not connect to node: Invalid timeout specified`, the topology validation never completed, and (in builds that drain pending tasks at shutdown) ASan flagged a leak of the queued `UpdateConnPoolSizeCtx` items that never ran. This was caught by `testConfigIndependence_max_values`, which sets every numeric config to its declared maximum.

## Fix

Lower the registered max for `search-connect-timeout` to `INT_MAX` (ms) so the declared bound matches what hiredis actually accepts. The Python test suite is updated to use the new bound.

## New maximum value

`INT_MAX = 2,147,483,647` ms

  ≈ 2,147,483.647 seconds
  ≈ 35,791 minutes
  ≈ 596.5 hours
  ≈ **~24.86 days**

This is the largest connect-timeout that can ever take effect end-to-end through hiredis, so any value above it would either be rejected or silently clamped.


#### Mark if applicable
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes
- [ ] This PR requires release notes
- [x] This PR does not require release notes


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tightens an existing numeric config bound and aligns parsing with the effective limits of the underlying connection library; behavior only changes for extremely large timeout values.
> 
> **Overview**
> Fixes `search-connect-timeout` to reject unrealistically large values by lowering its registered maximum from `LLONG_MAX` to `INT_MAX` and parsing it as an `int` in `setConnectTimeout` before converting to `struct timeval`.
> 
> Updates the Python config tests to use the new `INT_MAX` upper bound when validating numeric config maxima.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6234a5bde8236752216b9fc1d95389bf9ed009b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->