### PR TITLE
Bring Back Expiration Benchmarks

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin>=0.12.15
+redisbench_admin>=0.12.29
 numpy>=2.0.0
 pandas
 requests

--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -18,7 +18,7 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-10ms"
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64

--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -1,0 +1,37 @@
+version: 0.2
+name: "search-expire-doc-10-milliseconds"
+description: |
+  TTL table benchmark for document expiration under heavy lookup pressure.
+  This variant focuses on lazy expiration by disabling active expiration so
+  documents stay in the dataset while expiration metadata churns.
+
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG SET-ACTIVE-EXPIRE 0"'
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"

--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -25,7 +25,7 @@ dbconfig:
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
   - init_commands:
-      - '"DEBUG SET-ACTIVE-EXPIRE 0"'
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
       - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
   - dataset_load_timeout_secs: 180
   - check:

--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -32,6 +32,6 @@ dbconfig:
       keyspacelen: 5204050
 
 clientconfig:
-  benchmark_type: "read-only"
+  benchmark_type: "mixed"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"

--- a/tests/benchmarks/search-expire-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-doc-1000-seconds.yml
@@ -1,0 +1,36 @@
+version: 0.2
+name: "search-expire-doc-1000-seconds"
+description: |
+  TTL table benchmark for document expiration with long TTL values.
+  This keeps keys in the dataset and stresses lookup behavior while expiration
+  metadata is updated continuously.
+
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 90 --command 'EXPIRE __key__ 1000' --command-ratio 10"

--- a/tests/benchmarks/search-expire-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-doc-1000-seconds.yml
@@ -18,7 +18,7 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s"
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64

--- a/tests/benchmarks/search-expire-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-doc-1000-seconds.yml
@@ -31,6 +31,6 @@ dbconfig:
       keyspacelen: 5204050
 
 clientconfig:
-  benchmark_type: "read-only"
+  benchmark_type: "mixed"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 90 --command 'EXPIRE __key__ 1000' --command-ratio 10"
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 90 --command 'EXPIRE __key__ 1000' --command-ratio 10"

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -1,5 +1,5 @@
 version: 0.2
-name: "search-expired-numeric-field-10-milliseconds"
+name: "search-expire-numeric-field-10-milliseconds"
 description: |
   TTL table benchmark for field-level expiration under heavy lookup pressure.
   This variant focuses on lazy expiration by disabling active expiration so

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -1,0 +1,37 @@
+version: 0.2
+name: "search-expired-numeric-field-10-milliseconds"
+description: |
+  TTL table benchmark for field-level expiration under heavy lookup pressure.
+  This variant focuses on lazy expiration by disabling active expiration so
+  indexed keys remain while field expiration metadata churns.
+
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG SET-ACTIVE-EXPIRE 0"'
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 95 --command 'HPEXPIRE __key__ 10 FIELDS 2 field6 field3' --command-ratio 5"

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -32,6 +32,6 @@ dbconfig:
       keyspacelen: 5204050
 
 clientconfig:
-  benchmark_type: "read-only"
+  benchmark_type: "mixed"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 95 --command 'HPEXPIRE __key__ 10 FIELDS 2 field6 field3' --command-ratio 5"
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 95 --command 'HPEXPIRE __key__ 10 FIELDS 2 field6 field3' --command-ratio 5"

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -18,7 +18,7 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-numeric-field-10ms"
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -25,7 +25,7 @@ dbconfig:
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
   - init_commands:
-      - '"DEBUG SET-ACTIVE-EXPIRE 0"'
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
       - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
   - dataset_load_timeout_secs: 180
   - check:

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -1,0 +1,36 @@
+version: 0.2
+name: "search-expired-numeric-field-1000-seconds"
+description: |
+  TTL table benchmark for field-level expiration with long TTL values.
+  This keeps keys available to search and stresses lookup behavior while
+  field expiration metadata is updated continuously.
+
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 90 --command 'HEXPIRE __key__ 1000 FIELDS 2 field6 field3' --command-ratio 10"

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -31,6 +31,6 @@ dbconfig:
       keyspacelen: 5204050
 
 clientconfig:
-  benchmark_type: "read-only"
+  benchmark_type: "mixed"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 4 -t 1 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 90 --command 'HEXPIRE __key__ 1000 FIELDS 2 field6 field3' --command-ratio 10"
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 90 --command 'HEXPIRE __key__ 1000 FIELDS 2 field6 field3' --command-ratio 10"

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -1,5 +1,5 @@
 version: 0.2
-name: "search-expired-numeric-field-1000-seconds"
+name: "search-expire-numeric-field-1000-seconds"
 description: |
   TTL table benchmark for field-level expiration with long TTL values.
   This keeps keys available to search and stresses lookup behavior while

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -18,7 +18,7 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-numeric-field-1000s"
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64


### PR DESCRIPTION
The benchmarks were removed as part of:
https://github.com/RediSearch/RediSearch/pull/5897

As part of the recent regression we noticed they are missing.
Not entirely sure why they were removed.
Would like to bring them back.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to benchmark definitions and a dependency version bump, with no impact on production code paths.
> 
> **Overview**
> Reintroduces Search TTL/expiration benchmark coverage by adding four new benchmark specs for document- and field-level expiration with both very short (10ms) and long (1000s) TTL scenarios, including variants that disable active expiration to stress lazy expiration behavior.
> 
> Updates `tests/benchmarks/requirements.txt` to require a newer `redisbench_admin` (>=0.12.29) to run these benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470049065b4186432ed7cf734b456d4f467e42a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->