### PR TITLE
MOD-14916 MOD-15104 Expiration perf improvements

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -225,14 +225,19 @@ static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
   return (int64_t)t.tv_sec * 1000000000LL + (int64_t)t.tv_nsec;
 }
 
+// Inlines the doc-level TTL on the DMD unconditionally so the result-processor
+// can drop the TTL-table lookup, and only routes field-level expirations into
+// the TTL table. This keeps the table strictly an HFE store, which lets
+// iterators use `t->ttl == NULL` as their per-spec gate. Takes ownership of
+// `sortedFieldWithExpiration` either by handing it to the table or freeing it
+// when there are no field-level entries to register.
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
-  if (hasExpirationTimeInformation(dmd->flags)) {
-    dmd->expirationTimeNs = expirationTimePointToNs(ttl);
+  dmd->expirationTimeNs = expirationTimePointToNs(ttl);
+  if (sortedFieldWithExpiration && array_len(sortedFieldWithExpiration) > 0) {
     TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
-    TimeToLiveTable_Add(t->ttl, dmd->id, ttl, sortedFieldWithExpiration);
-    if (sortedFieldWithExpiration && array_len(sortedFieldWithExpiration) > 0) {
-      t->hasFieldExpiration = true;
-    }
+    TimeToLiveTable_Add(t->ttl, dmd->id, sortedFieldWithExpiration);
+  } else {
+    array_free(sortedFieldWithExpiration);
   }
 }
 
@@ -244,20 +249,13 @@ bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct ti
   return dmd->expirationTimeNs <= now_ns;
 }
 
-static void clearExpirationFlagCallback(t_docId docId, void *ctx) {
-  DocTable *t = ctx;
-  RSDocumentMetadata *dmd = DocTable_GetOwn(t, docId);
-  if (dmd) {
-    dmd->flags &= ~Document_HasExpiration;
-    dmd->expirationTimeNs = 0;
-  }
-}
-
 void DocTable_ClearExpirationData(DocTable *t) {
-  if (t->ttl) {
-    TimeToLiveTable_ForEach(t->ttl, clearExpirationFlagCallback, t);
-    TimeToLiveTable_Destroy(&t->ttl);
-  }
+  // Walk every DMD: doc-level TTL lives inline on the DMD (not in the TTL
+  // table), and field-level TTL is only present for docs that are also in
+  // the table. Either may be set, so a single sweep over all DMDs is the
+  // simplest correct path.
+  DOCTABLE_FOREACH(t, dmd->expirationTimeNs = 0);
+  TimeToLiveTable_Destroy(&t->ttl);
 }
 
 /* Put a new document into the table, assign it an incremental id and store the metadata in the
@@ -381,7 +379,11 @@ RSDocumentMetadata *DocTable_Pop(DocTable *t, const char *s, size_t n) {
       return NULL;
     }
 
-    if (t->ttl && hasExpirationTimeInformation(md->flags)) {
+    // The TTL table holds field-level (HEXPIRE) entries only. Remove is a
+    // no-op if this doc never had one, and the IsEmpty check destroys the
+    // table once the last HFE doc leaves the index, restoring the iterator
+    // gate to its NULL "no HFE in this spec" state.
+    if (t->ttl) {
       TimeToLiveTable_Remove(t->ttl, md->id);
       if (TimeToLiveTable_IsEmpty(t->ttl)) {
         TimeToLiveTable_Destroy(&t->ttl);

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -219,7 +219,7 @@ void DocTable_SetByteOffsets(RSDocumentMetadata *dmd, RSByteOffsets *v) {
 
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
   if (hasExpirationTimeInformation(dmd->flags)) {
-    TimeToLiveTable_VerifyInit(&t->ttl);
+    TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
     TimeToLiveTable_Add(t->ttl, dmd->id, ttl, sortedFieldWithExpiration);
   }
 }
@@ -232,18 +232,17 @@ bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct ti
   return TimeToLiveTable_HasDocExpired(t->ttl, dmd->id, expirationPoint);
 }
 
+static void clearExpirationFlagCallback(t_docId docId, void *ctx) {
+  DocTable *t = ctx;
+  RSDocumentMetadata *dmd = DocTable_GetOwn(t, docId);
+  if (dmd) {
+    dmd->flags &= ~Document_HasExpiration;
+  }
+}
+
 void DocTable_ClearExpirationData(DocTable *t) {
   if (t->ttl) {
-    dictIterator *ttlIter = dictGetIterator(t->ttl);
-    dictEntry *ttlEntry;
-    while ((ttlEntry = dictNext(ttlIter))) {
-      t_docId docId = (t_docId)dictGetKey(ttlEntry);
-      RSDocumentMetadata *dmd = DocTable_GetOwn(t, docId);
-      if (dmd) {
-        dmd->flags &= ~Document_HasExpiration;
-      }
-    }
-    dictReleaseIterator(ttlIter);
+    TimeToLiveTable_ForEach(t->ttl, clearExpirationFlagCallback, t);
     TimeToLiveTable_Destroy(&t->ttl);
   }
 }

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -217,8 +217,17 @@ void DocTable_SetByteOffsets(RSDocumentMetadata *dmd, RSByteOffsets *v) {
   dmd->flags |= Document_HasOffsetVector;
 }
 
+// Pack a t_expirationTimePoint into nanoseconds since the epoch, preserving
+// the {0,0} "no expiration" sentinel as 0 so callers can use a single scalar
+// compare on the result-processor hot path.
+static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
+  if (t.tv_sec == 0 && t.tv_nsec == 0) return 0;
+  return (int64_t)t.tv_sec * 1000000000LL + (int64_t)t.tv_nsec;
+}
+
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
   if (hasExpirationTimeInformation(dmd->flags)) {
+    dmd->expirationTimeNs = expirationTimePointToNs(ttl);
     TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
     TimeToLiveTable_Add(t->ttl, dmd->id, ttl, sortedFieldWithExpiration);
     if (sortedFieldWithExpiration && array_len(sortedFieldWithExpiration) > 0) {
@@ -228,11 +237,11 @@ void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expiratio
 }
 
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint) {
-  if (!hasExpirationTimeInformation(dmd->flags)) {
-      return false;
+  if (dmd->expirationTimeNs == 0) {
+    return false;
   }
-  RS_LOG_ASSERT(t->ttl, "Document has expiration time information but no TTL table");
-  return TimeToLiveTable_HasDocExpired(t->ttl, dmd->id, expirationPoint);
+  const int64_t now_ns = (int64_t)expirationPoint->tv_sec * 1000000000LL + (int64_t)expirationPoint->tv_nsec;
+  return dmd->expirationTimeNs <= now_ns;
 }
 
 static void clearExpirationFlagCallback(t_docId docId, void *ctx) {
@@ -240,6 +249,7 @@ static void clearExpirationFlagCallback(t_docId docId, void *ctx) {
   RSDocumentMetadata *dmd = DocTable_GetOwn(t, docId);
   if (dmd) {
     dmd->flags &= ~Document_HasExpiration;
+    dmd->expirationTimeNs = 0;
   }
 }
 

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -220,7 +220,19 @@ void DocTable_SetByteOffsets(RSDocumentMetadata *dmd, RSByteOffsets *v) {
 // Pack a t_expirationTimePoint into nanoseconds since the epoch, preserving
 // the {0,0} "no expiration" sentinel as 0 so callers can use a single scalar
 // compare on the result-processor hot path.
+//
+// `t_expirationTimePoint` is a POSIX `struct timespec` (IEEE Std 1003.1), which
+// is the OS-level resolution ceiling: `tv_nsec` is in [0, 999999999], and any
+// finer-grained clock would require a different type. `int64_t` of nanoseconds
+// covers ~292 years from the epoch (year 2262), far beyond any TTL Redis can
+// produce — `RM_GetAbsExpire` and `RM_HashFieldMinExpire` both return an
+// `mstime_t` (signed milliseconds since epoch), which we expand into a
+// `timespec` in `document_basic.c::timespecFromMilliseconds` before reaching
+// here. The debug assert traps any future caller that violates the timespec
+// invariant.
 static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
+  RS_LOG_ASSERT(t.tv_nsec >= 0 && t.tv_nsec < 1000000000L,
+                "tv_nsec out of POSIX timespec range");
   return (int64_t)t.tv_sec * 1000000000LL + (int64_t)t.tv_nsec;
 }
 
@@ -244,8 +256,7 @@ bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct ti
   if (dmd->expirationTimeNs == 0) {
     return false;
   }
-  const int64_t now_ns = (int64_t)expirationPoint->tv_sec * 1000000000LL + (int64_t)expirationPoint->tv_nsec;
-  return dmd->expirationTimeNs <= now_ns;
+  return dmd->expirationTimeNs <= expirationTimePointToNs(*expirationPoint);
 }
 
 void DocTable_ClearExpirationData(DocTable *t) {

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -221,6 +221,9 @@ void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expiratio
   if (hasExpirationTimeInformation(dmd->flags)) {
     TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
     TimeToLiveTable_Add(t->ttl, dmd->id, ttl, sortedFieldWithExpiration);
+    if (sortedFieldWithExpiration && array_len(sortedFieldWithExpiration) > 0) {
+      t->hasFieldExpiration = true;
+    }
   }
 }
 

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -221,7 +221,6 @@ void DocTable_SetByteOffsets(RSDocumentMetadata *dmd, RSByteOffsets *v) {
 // the {0,0} "no expiration" sentinel as 0 so callers can use a single scalar
 // compare on the result-processor hot path.
 static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
-  if (t.tv_sec == 0 && t.tv_nsec == 0) return 0;
   return (int64_t)t.tv_sec * 1000000000LL + (int64_t)t.tv_nsec;
 }
 
@@ -233,7 +232,7 @@ static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
 // when there are no field-level entries to register.
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
   dmd->expirationTimeNs = expirationTimePointToNs(ttl);
-  if (sortedFieldWithExpiration && array_len(sortedFieldWithExpiration) > 0) {
+  if (array_len(sortedFieldWithExpiration) > 0) {
     TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
     TimeToLiveTable_Add(t->ttl, dmd->id, sortedFieldWithExpiration);
   } else {

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -76,6 +76,10 @@ typedef struct {
   DMDChain *buckets;
   DocIdMap dim;             // Mapping between document name to internal id
   TimeToLiveTable* ttl;
+  // One-way latch: false until the first field-expiration (HEXPIRE) is written
+  // through DocTable_UpdateExpiration; never reset within the spec's lifetime.
+  // Lets iterators skip TTL lookups entirely when only doc-level EXPIRE is in use.
+  bool hasFieldExpiration;
 } DocTable;
 
 #define DOCTABLE_FOREACH(dt, code)                                           \

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -75,11 +75,11 @@ typedef struct {
 
   DMDChain *buckets;
   DocIdMap dim;             // Mapping between document name to internal id
+  // Holds field-level expirations only; created lazily on the first HEXPIRE
+  // and destroyed when the last entry is removed. Iterators use a NULL check
+  // on this pointer as their HFE gate, so a NULL `ttl` means no doc in this
+  // index has ever had (or still has) a field-level expiration.
   TimeToLiveTable* ttl;
-  // One-way latch: false until the first field-expiration (HEXPIRE) is written
-  // through DocTable_UpdateExpiration; never reset within the spec's lifetime.
-  // Lets iterators skip TTL lookups entirely when only doc-level EXPIRE is in use.
-  bool hasFieldExpiration;
 } DocTable;
 
 #define DOCTABLE_FOREACH(dt, code)                                           \
@@ -136,7 +136,7 @@ void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expiratio
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint);
 
 // Clear all expiration data from this doc table.
-// Clears Document_HasExpiration flags from all documents and destroys the TTL table.
+// Resets `expirationTimeNs` on every DMD and destroys the TTL table.
 // Must be called with the index write lock held.
 void DocTable_ClearExpirationData(DocTable *t);
 

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -20,10 +20,11 @@ namespace GeoShape {
 bool CPPQueryIterator::should_check_field_expiration(const RedisSearchCtx *sctx,
                                                      const FieldFilterContext *filterCtx) noexcept {
   // Mirrors the hoisted gate in HybridIterator / InvIndIterator: all inputs are
-  // iterator-invariant, so snapshot the AND once here.
+  // iterator-invariant, so snapshot the AND once here. A non-NULL `ttl` is a
+  // sufficient and tight gate by itself: the table holds field-level entries
+  // only and is destroyed when the last one leaves the index.
   return sctx && filterCtx->field.index != RS_INVALID_FIELD_INDEX &&
-         sctx->spec->docs.ttl && sctx->spec->docs.hasFieldExpiration &&
-         sctx->spec->monitorFieldExpiration;
+         sctx->spec->docs.ttl;
 }
 
 auto CPPQueryIterator::base() noexcept -> QueryIterator * {

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -119,6 +119,12 @@ std::size_t QIter_NumEstimated(const QueryIterator *ctx) {
 void QIter_Rewind(QueryIterator *ctx) {
   reinterpret_cast<CPPQueryIterator *>(ctx)->rewind();
 }
+ValidateStatus QIter_Revalidate(QueryIterator *ctx) {
+  auto *qi = reinterpret_cast<CPPQueryIterator *>(ctx);
+  qi->check_field_expiration_ =
+      CPPQueryIterator::should_check_field_expiration(qi->sctx_, &qi->filterCtx_);
+  return VALIDATE_OK;
+}
 
 }  // anonymous namespace
 
@@ -131,7 +137,7 @@ QueryIterator CPPQueryIterator::init_base() {
       .NumEstimated = QIter_NumEstimated,
       .Read = QIter_Read,
       .SkipTo = QIter_SkipTo,
-      .Revalidate = Default_Revalidate,
+      .Revalidate = QIter_Revalidate,
       .Free = QIter_Free,
       .Rewind = QIter_Rewind,
   };

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -8,12 +8,23 @@
 */
 #include "query_iterator.hpp"
 #include "doc_table.h"
+#include "search_ctx.h"
+#include "spec.h"
 #include "util/timeout.h"
 
 #include <iterator>   // ranges::distance
 
 namespace RediSearch {
 namespace GeoShape {
+
+bool CPPQueryIterator::should_check_field_expiration(const RedisSearchCtx *sctx,
+                                                     const FieldFilterContext *filterCtx) noexcept {
+  // Mirrors the hoisted gate in HybridIterator / InvIndIterator: all inputs are
+  // iterator-invariant, so snapshot the AND once here.
+  return sctx && filterCtx->field.index != RS_INVALID_FIELD_INDEX &&
+         sctx->spec->docs.ttl && sctx->spec->docs.hasFieldExpiration &&
+         sctx->spec->monitorFieldExpiration;
+}
 
 auto CPPQueryIterator::base() noexcept -> QueryIterator * {
   return &base_;
@@ -24,8 +35,10 @@ IteratorStatus CPPQueryIterator::read_single() noexcept {
     return ITERATOR_EOF;
   }
   t_docId docId = iter_[index_++];
-  const t_fieldIndex fieldIndex = filterCtx_.field.index;
-  if (sctx_ && fieldIndex != RS_INVALID_FIELD_INDEX && !DocTable_CheckFieldExpirationPredicate(&sctx_->spec->docs, docId, fieldIndex, filterCtx_.predicate, &sctx_->time.current)) {
+  if (check_field_expiration_
+      && !DocTable_CheckFieldExpirationPredicate(&sctx_->spec->docs, docId,
+                                                 filterCtx_.field.index,
+                                                 filterCtx_.predicate, &sctx_->time.current)) {
     return ITERATOR_NOTFOUND;
   }
 

--- a/src/geometry/query_iterator.hpp
+++ b/src/geometry/query_iterator.hpp
@@ -27,8 +27,7 @@ struct CPPQueryIterator {
   const RedisSearchCtx *sctx_;
   const FieldFilterContext filterCtx_;
   const uint32_t initTimeoutCounter_;  // Value to reset counter to on each read() call
-  // Hoisted at construction: true iff we must run the per-posting
-  // field-expiration check. See should_check_field_expiration().
+  // Hoisted gate; refreshed in QIter_Revalidate.
   bool check_field_expiration_;
 
   explicit CPPQueryIterator() = delete;
@@ -62,11 +61,11 @@ struct CPPQueryIterator {
   void rewind() noexcept;
 
   static QueryIterator init_base();
-private:
-  IteratorStatus read_single() noexcept;
   // Defined in query_iterator.cpp where the spec/doc-table headers are included.
   static bool should_check_field_expiration(const RedisSearchCtx *sctx,
                                             const FieldFilterContext *filterCtx) noexcept;
+private:
+  IteratorStatus read_single() noexcept;
 };
 
 }  // namespace GeoShape

--- a/src/geometry/query_iterator.hpp
+++ b/src/geometry/query_iterator.hpp
@@ -27,6 +27,9 @@ struct CPPQueryIterator {
   const RedisSearchCtx *sctx_;
   const FieldFilterContext filterCtx_;
   const uint32_t initTimeoutCounter_;  // Value to reset counter to on each read() call
+  // Hoisted at construction: true iff we must run the per-posting
+  // field-expiration check. See should_check_field_expiration().
+  bool check_field_expiration_;
 
   explicit CPPQueryIterator() = delete;
 
@@ -37,7 +40,8 @@ struct CPPQueryIterator {
   explicit CPPQueryIterator(const RedisSearchCtx *sctx, const FieldFilterContext* filterCtx, R &&range, std::size_t &alloc, uint32_t timeoutCounter = 0, Proj proj = {})
       : base_{init_base()},
         iter_{std::ranges::begin(range), std::ranges::end(range), alloc_type{alloc}},
-        index_{0}, sctx_(sctx), filterCtx_(*filterCtx), initTimeoutCounter_(timeoutCounter) {
+        index_{0}, sctx_(sctx), filterCtx_(*filterCtx), initTimeoutCounter_(timeoutCounter),
+        check_field_expiration_{should_check_field_expiration(sctx, filterCtx)} {
     std::ranges::sort(iter_, std::ranges::less{}, proj);
   }
 
@@ -60,6 +64,9 @@ struct CPPQueryIterator {
   static QueryIterator init_base();
 private:
   IteratorStatus read_single() noexcept;
+  // Defined in query_iterator.cpp where the spec/doc-table headers are included.
+  static bool should_check_field_expiration(const RedisSearchCtx *sctx,
+                                            const FieldFilterContext *filterCtx) noexcept;
 };
 
 }  // namespace GeoShape

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -281,7 +281,10 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
       Document* doc = cur->doc;
       const bool hasExpiration = doc->docExpirationTime.tv_sec || doc->docExpirationTime.tv_nsec || doc->fieldExpirations;
       if (hasExpiration) {
-        md->flags |= Document_HasExpiration;
+        // No need to mark the DMD with Document_HasExpiration: the result
+        // processor already fetches the DMD from the doc table on every hit,
+        // so it can read `expirationTimeNs` directly without going through
+        // a flag-gated branch.
         DocTable_UpdateExpiration(&ctx->spec->docs, md, doc->docExpirationTime, doc->fieldExpirations);
       }
       DMD_Return(md);

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -436,9 +436,10 @@ static IteratorStatus HR_ReadHybridUnsortedSingle(HybridIterator *hr) {
   }
   hr->base.current = mmh_pop_min(hr->topResults);
 
-  const t_fieldIndex fieldIndex = hr->filterCtx.field.index;
-  if (hr->sctx && fieldIndex != RS_INVALID_FIELD_INDEX
-      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId, fieldIndex, hr->filterCtx.predicate, &hr->sctx->time.current)) {
+  if (hr->checkFieldExpiration
+      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId,
+                                                 hr->filterCtx.field.index,
+                                                 hr->filterCtx.predicate, &hr->sctx->time.current)) {
     return ITERATOR_NOTFOUND;
   }
   hr->base.lastDocId = hr->base.current->docId;
@@ -473,9 +474,10 @@ static IteratorStatus HR_ReadKnnUnsortedSingle(HybridIterator *hr) {
     return ITERATOR_EOF;
   }
 
-  const t_fieldIndex fieldIndex = hr->filterCtx.field.index;
-  if (hr->sctx && fieldIndex != RS_INVALID_FIELD_INDEX
-      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId, fieldIndex, hr->filterCtx.predicate, &hr->sctx->time.current)) {
+  if (hr->checkFieldExpiration
+      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId,
+                                                 hr->filterCtx.field.index,
+                                                 hr->filterCtx.predicate, &hr->sctx->time.current)) {
     return ITERATOR_NOTFOUND;
   }
 
@@ -627,6 +629,12 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   hi->runtimeParams.timeoutCtx = &hi->timeoutCtx;
   hi->sctx = hParams.sctx;
   hi->filterCtx = *hParams.filterCtx;
+  // Hoist the per-posting field-expiration gate: sctx, fieldIndex and the spec
+  // TTL/HFE state are all iterator-invariant, so we snapshot the AND once here.
+  hi->checkFieldExpiration =
+      hParams.sctx && hParams.filterCtx->field.index != RS_INVALID_FIELD_INDEX &&
+      hParams.sctx->spec->docs.ttl && hParams.sctx->spec->docs.hasFieldExpiration &&
+      hParams.sctx->spec->monitorFieldExpiration;
 
   if (hParams.childIt == NULL || hParams.query.k == 0) {
     // If there is no child iterator, or the query is going to return 0 results, we can use simple KNN.

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -630,11 +630,13 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   hi->sctx = hParams.sctx;
   hi->filterCtx = *hParams.filterCtx;
   // Hoist the per-posting field-expiration gate: sctx, fieldIndex and the spec
-  // TTL/HFE state are all iterator-invariant, so we snapshot the AND once here.
+  // TTL pointer are all iterator-invariant, so we snapshot the AND once here.
+  // The TTL table holds field-level (HEXPIRE) entries only and is destroyed
+  // when the last one leaves the index, so a non-NULL `ttl` is a sufficient
+  // and tight gate by itself.
   hi->checkFieldExpiration =
       hParams.sctx && hParams.filterCtx->field.index != RS_INVALID_FIELD_INDEX &&
-      hParams.sctx->spec->docs.ttl && hParams.sctx->spec->docs.hasFieldExpiration &&
-      hParams.sctx->spec->monitorFieldExpiration;
+      hParams.sctx->spec->docs.ttl;
 
   if (hParams.childIt == NULL || hParams.query.k == 0) {
     // If there is no child iterator, or the query is going to return 0 results, we can use simple KNN.

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -584,6 +584,8 @@ static ValidateStatus HR_Revalidate(QueryIterator *ctx) {
   if (hr->child && hr->child->Revalidate(hr->child) == VALIDATE_ABORTED) {
     return VALIDATE_ABORTED;
   }
+  hr->checkFieldExpiration = hr->sctx && hr->filterCtx.field.index != RS_INVALID_FIELD_INDEX &&
+                             hr->sctx->spec->docs.ttl;
   return VALIDATE_OK;
 }
 

--- a/src/iterators/hybrid_reader.h
+++ b/src/iterators/hybrid_reader.h
@@ -52,10 +52,9 @@ typedef struct {
   size_t maxBatchSize;             // Maximum batch size used during batches mode
   size_t maxBatchIteration;        // Iteration (zero-based) where the maximum batch size occurred
   bool canTrimDeepResults;         // Ignore the document scores, only vector score matters. No need to deep copy the results from the child iterator.
+  bool checkFieldExpiration;       // Hoisted gate; refreshed in HR_Revalidate.
   TimeoutCtx timeoutCtx;           // Timeout parameters
   FieldFilterContext filterCtx;
-  bool checkFieldExpiration;       // Hoisted at construction: true iff we must run the per-posting
-                                   // field-expiration check. See NewHybridVectorIterator.
 } HybridIterator;
 
 #ifdef __cplusplus

--- a/src/iterators/hybrid_reader.h
+++ b/src/iterators/hybrid_reader.h
@@ -54,6 +54,8 @@ typedef struct {
   bool canTrimDeepResults;         // Ignore the document scores, only vector score matters. No need to deep copy the results from the child iterator.
   TimeoutCtx timeoutCtx;           // Timeout parameters
   FieldFilterContext filterCtx;
+  bool checkFieldExpiration;       // Hoisted at construction: true iff we must run the per-posting
+                                   // field-expiration check. See NewHybridVectorIterator.
 } HybridIterator;
 
 #ifdef __cplusplus

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -89,11 +89,6 @@ void RedisSearchCtx_LockSpecRead(RedisSearchCtx *ctx) {
   // pause rehashing while we're using the dict for reads only
   // Assert that the pause value before we pause is valid.
   RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->keysDict));
-  // Also pause rehashing on the TTL table if it exists, to avoid concurrent
-  // rehash steps from multiple query threads corrupting the dict during reads.
-  if (ctx->spec->docs.ttl) {
-    RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->docs.ttl));
-  }
   ctx->flags = RS_CTX_READONLY;
 }
 
@@ -107,11 +102,6 @@ int RedisSearchCtx_TryLockSpecRead(RedisSearchCtx *ctx) {
   // pause rehashing while we're using the dict for reads only
   // Assert that the pause value before we pause is valid.
   RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->keysDict));
-  // Also pause rehashing on the TTL table if it exists, to avoid concurrent
-  // rehash steps from multiple query threads corrupting the dict during reads.
-  if (ctx->spec->docs.ttl) {
-    RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->docs.ttl));
-  }
   ctx->flags = RS_CTX_READONLY;
   return REDISMODULE_OK;
 }
@@ -149,10 +139,6 @@ void RedisSearchCtx_UnlockSpec(RedisSearchCtx *sctx) {
     // We paused rehashing when we locked the spec for read. Now we can resume it.
     // Assert that it was actually previously paused
     RS_ASSERT_ALWAYS(dictResumeRehashing(sctx->spec->keysDict));
-    // Also resume rehashing on the TTL table if it exists
-    if (sctx->spec->docs.ttl) {
-      RS_ASSERT_ALWAYS(dictResumeRehashing(sctx->spec->docs.ttl));
-    }
   }
   pthread_rwlock_unlock(&sctx->spec->rwlock);
   sctx->flags = RS_CTX_UNSET;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -127,19 +127,16 @@ typedef struct RSDocumentMetadata_s {
 
   uint16_t ref_count;
 
+  /* Document-level expiration time in nanoseconds since the epoch (0 = none).
+   * Inlined to avoid a TTL-table lookup on the result-processor hot path. */
+  int64_t expirationTimeNs;
+
   struct RSSortingVector sortVector;
   /* Offsets of all terms in the document (in bytes). Used by highlighter */
   struct RSByteOffsets *byteOffsets;
   struct RSDocumentMetadata_s *nextInChain;
 
-  /* Document-level expiration time in nanoseconds since the epoch.
-   * Zero means no doc-level TTL is set. Inlined here to avoid a per-result
-   * TTL-table lookup in DocTable_IsDocExpired on the result-processor hot path.
-   * Placed before `payload` so the lean-allocation in DocTable_Put (which omits
-   * the trailing pointer when no payload is set) is preserved. */
-  int64_t expirationTimeNs;
-
-  /* Optional user payload */
+  /* Optional user payload. Must remain last for DocTable_Put's lean alloc. */
   RSPayload *payload;
 
 } RSDocumentMetadata;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -132,6 +132,13 @@ typedef struct RSDocumentMetadata_s {
   struct RSByteOffsets *byteOffsets;
   struct RSDocumentMetadata_s *nextInChain;
 
+  /* Document-level expiration time in nanoseconds since the epoch.
+   * Zero means no doc-level TTL is set. Inlined here to avoid a per-result
+   * TTL-table lookup in DocTable_IsDocExpired on the result-processor hot path.
+   * Placed before `payload` so the lean-allocation in DocTable_Put (which omits
+   * the trailing pointer when no payload is set) is preserved. */
+  int64_t expirationTimeNs;
+
   /* Optional user payload */
   RSPayload *payload;
 

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -617,10 +617,6 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
   /* We might have multiple readers that reads from the index,
    * Avoid rehashing the terms dictionary */
   dictPauseRehashing(sp->keysDict);
-  /* Also pause rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictPauseRehashing(sp->docs.ttl);
-  }
 
   RSSearchOptions options = {0};
   QueryError status = QueryError_Default();
@@ -672,9 +668,6 @@ end:
      * If iter->sp is set, RediSearch_ResultsIteratorFree will handle cleanup. */
     if (!it->sp) {
       dictResumeRehashing(sp->keysDict);
-      if (sp->docs.ttl) {
-        dictResumeRehashing(sp->docs.ttl);
-      }
       pthread_rwlock_unlock(&sp->rwlock);
     }
     RediSearch_ResultsIteratorFree(it);
@@ -754,9 +747,6 @@ void RediSearch_ResultsIteratorFree(RS_ApiIter* iter) {
   if (iter->sp) {
     if (iter->sp->keysDict) {
       dictResumeRehashing(iter->sp->keysDict);
-    }
-    if (iter->sp->docs.ttl) {
-      dictResumeRehashing(iter->sp->docs.ttl);
     }
     pthread_rwlock_unlock(&iter->sp->rwlock);
   }
@@ -912,10 +902,6 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   /* We might have multiple readers that reads from the index,
    * Avoid rehashing the terms dictionary */
   dictPauseRehashing(sp->keysDict);
-  /* Also pause rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictPauseRehashing(sp->docs.ttl);
-  }
 
   // Report fork when any GC is present
   info->gcPolicy = sp->gc ? GC_POLICY_FORK : GC_POLICY_NONE;
@@ -959,10 +945,6 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   }
 
   dictResumeRehashing(sp->keysDict);
-  /* Also resume rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictResumeRehashing(sp->docs.ttl);
-  }
   /* Release spec read lock */
   pthread_rwlock_unlock(&sp->rwlock);
   RWLOCK_RELEASE();

--- a/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
@@ -93,8 +93,10 @@ impl ExpirationChecker for FieldExpirationChecker {
         // SAFETY: Guaranteed by the safety contract of `new`.
         let spec = unsafe { *(sctx.spec) };
 
-        // Check if TTL is configured and field expiration monitoring is enabled
-        if spec.docs.ttl.is_null() || !spec.monitorFieldExpiration {
+        // Check if TTL is configured and field expiration monitoring is enabled.
+        // The `hasFieldExpiration` latch lets us skip the per-posting TTL lookup
+        // entirely when only doc-level EXPIRE has ever been observed on this spec.
+        if spec.docs.ttl.is_null() || !spec.docs.hasFieldExpiration || !spec.monitorFieldExpiration {
             return false;
         }
 

--- a/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
@@ -111,17 +111,22 @@ impl ExpirationChecker for FieldExpirationChecker {
     }
 
     fn is_expired(&self, result: &RSIndexResult) -> bool {
-        // `has_expiration()` should have been checked before calling this method.
-        // If TTL is not configured, the iterator should use the fast path without expiration checks.
-        debug_assert!(
-            self.has_expiration(),
-            "is_expired() should not be called when has_expiration() returns false"
-        );
-
         // SAFETY: Guaranteed by the safety contract of `new`.
         let sctx = unsafe { self.sctx.as_ref() };
         // SAFETY: Guaranteed by the safety contract of `new`.
         let spec = unsafe { *(sctx.spec) };
+
+        // The TTL table may transition from non-NULL to NULL mid-query when the
+        // last HFE doc is removed via `DocTable_Pop` (with the spec lock briefly
+        // released around an iterator yield). The InvIndIterator caches its
+        // `read_impl`/`skip_to_impl` function pointers at construction based on
+        // `has_expiration()` and does not refresh them in `revalidate()`, so we
+        // can be entered here with a now-NULL `ttl`. Mirror the C-side guard in
+        // `DocTable_CheckFieldExpirationPredicate` and treat that as "not
+        // expired" — passing NULL into the FFI verifier would deref it.
+        if spec.docs.ttl.is_null() {
+            return false;
+        }
 
         let current_time = &sctx.time.current as *const _;
         let doc_id = result.doc_id;

--- a/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
@@ -93,10 +93,11 @@ impl ExpirationChecker for FieldExpirationChecker {
         // SAFETY: Guaranteed by the safety contract of `new`.
         let spec = unsafe { *(sctx.spec) };
 
-        // Check if TTL is configured and field expiration monitoring is enabled.
-        // The `hasFieldExpiration` latch lets us skip the per-posting TTL lookup
-        // entirely when only doc-level EXPIRE has ever been observed on this spec.
-        if spec.docs.ttl.is_null() || !spec.docs.hasFieldExpiration || !spec.monitorFieldExpiration {
+        // The TTL table holds field-level (HEXPIRE) entries only and is
+        // destroyed once the last one leaves the index, so a NULL `ttl`
+        // pointer is a sufficient and tight gate by itself: it means no doc
+        // in this spec currently has a field-level expiration.
+        if spec.docs.ttl.is_null() {
             return false;
         }
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -732,6 +732,10 @@ impl TestContext {
             // Enable expiration monitoring (required for expiration checks to work)
             spec.monitorDocumentExpiration = true;
             spec.monitorFieldExpiration = true;
+            // Test helpers always exercise the field-expiration path, so flip
+            // the HFE-observed latch up front to mirror what
+            // DocTable_UpdateExpiration would do at runtime.
+            spec.docs.hasFieldExpiration = true;
             ffi::TimeToLiveTable_VerifyInit(&mut spec.docs.ttl, spec.docs.maxSize as usize);
         }
     }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -732,7 +732,7 @@ impl TestContext {
             // Enable expiration monitoring (required for expiration checks to work)
             spec.monitorDocumentExpiration = true;
             spec.monitorFieldExpiration = true;
-            ffi::TimeToLiveTable_VerifyInit(&mut spec.docs.ttl);
+            ffi::TimeToLiveTable_VerifyInit(&mut spec.docs.ttl, spec.docs.maxSize as usize);
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -732,10 +732,6 @@ impl TestContext {
             // Enable expiration monitoring (required for expiration checks to work)
             spec.monitorDocumentExpiration = true;
             spec.monitorFieldExpiration = true;
-            // Test helpers always exercise the field-expiration path, so flip
-            // the HFE-observed latch up front to mirror what
-            // DocTable_UpdateExpiration would do at runtime.
-            spec.docs.hasFieldExpiration = true;
             ffi::TimeToLiveTable_VerifyInit(&mut spec.docs.ttl, spec.docs.maxSize as usize);
         }
     }
@@ -792,20 +788,9 @@ impl TestContext {
             }
         };
 
-        // Document expiration time set to far future (we only care about field expiration)
-        let doc_expiration_time = ffi::t_expirationTimePoint {
-            tv_sec: i64::MAX,
-            tv_nsec: i64::MAX,
-        };
-
         // SAFETY: self.spec is valid, TTL table is initialized, fe is a valid array
         unsafe {
-            ffi::TimeToLiveTable_Add(
-                self.spec.as_ref().docs.ttl,
-                doc_id,
-                doc_expiration_time,
-                fe as _,
-            );
+            ffi::TimeToLiveTable_Add(self.spec.as_ref().docs.ttl, doc_id, fe as _);
         }
     }
 

--- a/src/ttl_table/ttl_table.c
+++ b/src/ttl_table/ttl_table.c
@@ -23,20 +23,20 @@
 //    prefetcher can pull upcoming bucket headers into L1 ahead of demand.
 //    This primarily benefits the "miss" hot path — docs without TTL, the
 //    common case at query time — where each `ttl_find_entry` probes a
-//    TTLBucket (16 B: pointer + count + pad), sees count == 0, and returns
-//    NULL. Four such probes fit in one 64-byte cache line, and the stride-1
-//    access pattern matches the hardware prefetcher's sequential detector
-//    so it streams the next lines in without demand-miss stalls as long as
-//    the iterator walks docIds in ascending order.
+//    bucket pointer (8 B), sees NULL, and returns. Eight such probes fit in
+//    one 64-byte cache line, and the stride-1 access pattern matches the
+//    hardware prefetcher's sequential detector so it streams the next lines
+//    in without demand-miss stalls as long as the iterator walks docIds in
+//    ascending order.
 //  - When maxDocId exceeds `maxSize`, multiple docIds collide on the same
 //    slot. A per-bucket contiguous-vec chain keeps walks cache-line
 //    sequential and bounds worst-case behavior (Poisson tail at load factor
 //    1 gives chain length ≤ ~5) — unlike linear probing, which degrades to
 //    O(cap) once deletes create probe-gaps in a near-full table.
-//  - Writes happen once per notification-driven reindex under the spec write
-//    lock, so we can afford an rm_realloc per insert/delete instead of
-//    maintaining a geometric `cap` field per bucket. No-shrink-on-delete caps
-//    the realloc count per bucket at its lifetime high-water mark.
+//  - Each non-empty bucket is an arr.h fat pointer: len/cap live in the
+//    `array_hdr_t` immediately preceding the elements, so the slot itself
+//    is just an 8 B pointer. Writes go through arr.h's geometric growth
+//    rather than a +1 realloc per insert.
 //  - Lazy growth mirrors DocTable_Set: `maxSize` (the modulus used by the
 //    slot formula) is captured once at init and never changes, while `cap`
 //    (the number of buckets actually allocated) starts at 0 and grows on
@@ -54,15 +54,12 @@ typedef struct {
   arrayof(FieldExpiration) fieldExpirations;  // owned, sorted by field index, never empty
 } TimeToLiveEntry;
 
-typedef struct {
-  TimeToLiveEntry *entries;             // rm_malloc'd block of `count`, NULL when count == 0
-  uint32_t count;
-  uint32_t _pad;                        // reserved for future per-bucket stats
-} TTLBucket;
+// A bucket is a NULL-or-arr.h-managed chain of entries. NULL means empty.
+typedef arrayof(TimeToLiveEntry) TTLBucket;
 
 struct TimeToLiveTable {
-  TTLBucket *buckets;                   // allocated for the first `cap` entries
-  size_t cap;                           // number of buckets physically allocated
+  TTLBucket *buckets;                   // allocated for the first `cap` slots
+  size_t cap;                           // number of bucket slots physically allocated
   size_t maxSize;                       // modulus for slot calculation, fixed at init
   size_t count;                         // total live entries
 };
@@ -102,11 +99,11 @@ static void ttl_grow(TimeToLiveTable *t, size_t slot) {
 static inline TimeToLiveEntry *ttl_find_entry(const TimeToLiveTable *t, t_docId docId) {
   const size_t slot = ttl_slot(t, docId);
   if (slot >= t->cap) return NULL;  // bucket unallocated => entry cannot exist
-  const TTLBucket *b = &t->buckets[slot];
-  for (uint32_t i = 0; i < b->count; i++) {
-    if (b->entries[i].docId == docId) {
-      return &b->entries[i];
-    }
+  TTLBucket bucket = t->buckets[slot];
+  if (!bucket) return NULL;
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId == docId) return &bucket[i];
   }
   return NULL;
 }
@@ -115,9 +112,10 @@ static inline TimeToLiveEntry *ttl_find_entry(const TimeToLiveTable *t, t_docId 
 // keep the Add call site readable (`assert(!ttl_bucket_contains(...))`); the
 // invariant itself is enforced upstream by the spec write lock in
 // DocTable_Put, so eliding the scan in release is intentional.
-static bool ttl_bucket_contains(const TTLBucket *b, t_docId docId) {
-  for (uint32_t i = 0; i < b->count; i++) {
-    if (b->entries[i].docId == docId) return true;
+static bool ttl_bucket_contains(TTLBucket bucket, t_docId docId) {
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId == docId) return true;
   }
   return false;
 }
@@ -145,11 +143,13 @@ void TimeToLiveTable_Destroy(TimeToLiveTable **table) {
   if (!*table) return;
   TimeToLiveTable *t = *table;
   for (size_t s = 0; s < t->cap; s++) {
-    TTLBucket *b = &t->buckets[s];
-    for (uint32_t i = 0; i < b->count; i++) {
-      ttl_entry_release(&b->entries[i]);
+    TTLBucket bucket = t->buckets[s];
+    if (!bucket) continue;
+    const uint32_t n = array_len(bucket);
+    for (uint32_t i = 0; i < n; i++) {
+      ttl_entry_release(&bucket[i]);
     }
-    rm_free(b->entries);
+    array_free(bucket);
   }
   rm_free(t->buckets);
   rm_free(t);
@@ -160,37 +160,32 @@ void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, arrayof(FieldExpirat
   RS_ASSERT(sortedById && array_len(sortedById) > 0);
   const size_t slot = ttl_slot(t, docId);
   ttl_grow(t, slot);
-  TTLBucket *b = &t->buckets[slot];
   // docIds are monotonically assigned in DocTable_Put under the spec write
   // lock, so duplicates should not reach here; the assert catches a broken
   // locking discipline during development before it corrupts the table.
-  RS_LOG_ASSERT(!ttl_bucket_contains(b, docId), "duplicate docId in TTL table");
-  b->entries = rm_realloc(b->entries, (b->count + 1) * sizeof(*b->entries));
-  TimeToLiveEntry *e = &b->entries[b->count];
-  b->count++;
+  RS_LOG_ASSERT(!ttl_bucket_contains(t->buckets[slot], docId), "duplicate docId in TTL table");
+  TimeToLiveEntry entry = { .docId = docId, .fieldExpirations = sortedById };
+  t->buckets[slot] = array_ensure_append_1(t->buckets[slot], entry);
   t->count++;
-  e->docId = docId;
-  e->fieldExpirations = sortedById;
 }
 
 void TimeToLiveTable_Remove(TimeToLiveTable *t, t_docId docId) {
   const size_t slot = ttl_slot(t, docId);
   if (slot >= t->cap) return;  // bucket unallocated => nothing to remove
-  TTLBucket *b = &t->buckets[slot];
-  for (uint32_t i = 0; i < b->count; i++) {
-    if (b->entries[i].docId != docId) continue;
-    ttl_entry_release(&b->entries[i]);
-    // swap-last to avoid memmove and keep the chain contiguous
-    b->entries[i] = b->entries[b->count - 1];
-    b->count--;
+  TTLBucket bucket = t->buckets[slot];
+  if (!bucket) return;
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId != docId) continue;
+    ttl_entry_release(&bucket[i]);
+    array_del_fast(bucket, i);  // swap-last + dec len; in-place, no realloc
     t->count--;
-    if (b->count == 0) {
-      rm_free(b->entries);
-      b->entries = NULL;
+    if (array_len(bucket) == 0) {
+      array_free(bucket);
+      t->buckets[slot] = NULL;
     }
-    // No-shrink-on-delete: keep the allocation at its high-water mark; the
-    // few wasted bytes per chained bucket are dwarfed by the bucket header
-    // array itself and avoid realloc churn for buckets that churn.
+    // No-shrink-on-delete: arr.h keeps the allocation at its high-water
+    // mark via remain_cap, avoiding realloc churn for buckets that churn.
     return;
   }
 }

--- a/src/ttl_table/ttl_table.c
+++ b/src/ttl_table/ttl_table.c
@@ -13,57 +13,205 @@
 #include "util/misc.h"
 #include "rmutil/rm_assert.h"
 
+// Direct-modulo bucket array with contiguous-vec collision chains.
+//
+// Rationale:
+//  - docIds are allocated monotonically via ++maxDocId in DocTable, so the
+//    iterator-time lookups of `VerifyDocAndField*` see them in ascending,
+//    mostly-sequential order. Hashing would scatter that locality; direct
+//    modulo keeps sequential docIds in sequential slots so the CPU hardware
+//    prefetcher can pull upcoming bucket headers into L1 ahead of demand.
+//    This primarily benefits the "miss" hot path — docs without TTL, the
+//    common case at query time — where each `ttl_find_entry` probes a
+//    TTLBucket (16 B: pointer + count + pad), sees count == 0, and returns
+//    NULL. Four such probes fit in one 64-byte cache line, and the stride-1
+//    access pattern matches the hardware prefetcher's sequential detector
+//    so it streams the next lines in without demand-miss stalls as long as
+//    the iterator walks docIds in ascending order.
+//  - When maxDocId exceeds `maxSize`, multiple docIds collide on the same
+//    slot. A per-bucket contiguous-vec chain keeps walks cache-line
+//    sequential and bounds worst-case behavior (Poisson tail at load factor
+//    1 gives chain length ≤ ~5) — unlike linear probing, which degrades to
+//    O(cap) once deletes create probe-gaps in a near-full table.
+//  - Writes happen once per notification-driven reindex under the spec write
+//    lock, so we can afford an rm_realloc per insert/delete instead of
+//    maintaining a geometric `cap` field per bucket. No-shrink-on-delete caps
+//    the realloc count per bucket at its lifetime high-water mark.
+//  - Lazy growth mirrors DocTable_Set: `maxSize` (the modulus used by the
+//    slot formula) is captured once at init and never changes, while `cap`
+//    (the number of buckets actually allocated) starts at 0 and grows on
+//    demand via rm_realloc up to `maxSize`. Because the slot formula depends
+//    only on `maxSize`, growing `cap` never relocates an existing entry —
+//    it only extends the tail of the bucket array. Reads for docIds whose
+//    slot lies in the still-unallocated tail treat the entry as absent,
+//    which is correct because Add always grows `cap` to cover the slot
+//    before writing. This keeps the per-index footprint proportional to the
+//    number of TTL docs ever inserted rather than to maxDocTableSize, which
+//    matters in deployments with many indexes that sparsely use TTL.
+
 typedef struct {
+  t_docId docId;                        // 0 is reserved / unused
   t_expirationTimePoint documentExpirationPoint;
-  FieldExpiration* fieldExpirations;
+  arrayof(FieldExpiration) fieldExpirations;  // owned, sorted by field index
 } TimeToLiveEntry;
 
-static uint64_t hashFunction_DocId(const void *key) {
-  return (t_docId)key;
-}
-static void destructor_TimeToLiveEntry(void *privdata, void *val) {
-    TimeToLiveEntry* entry = (TimeToLiveEntry*)val;
-    array_free(entry->fieldExpirations);
-    rm_free(entry);
-}
+typedef struct {
+  TimeToLiveEntry *entries;             // rm_malloc'd block of `count`, NULL when count == 0
+  uint32_t count;
+  uint32_t _pad;                        // reserved for future per-bucket stats
+} TTLBucket;
 
-static dictType dictTimeToLive = {
-  .hashFunction = hashFunction_DocId,
-  .keyDup = NULL,
-  .valDup = NULL,
-  .keyCompare = NULL,
-  .keyDestructor = NULL,
-  .valDestructor = destructor_TimeToLiveEntry,
+struct TimeToLiveTable {
+  TTLBucket *buckets;                   // allocated for the first `cap` entries
+  size_t cap;                           // number of buckets physically allocated
+  size_t maxSize;                       // modulus for slot calculation, fixed at init
+  size_t count;                         // total live entries
 };
 
-void TimeToLiveTable_VerifyInit(TimeToLiveTable **table) {
-    if (!*table) {
-      *table = dictCreate(&dictTimeToLive, NULL);
+static inline size_t ttl_slot(const TimeToLiveTable *t, t_docId docId) {
+  return docId < t->maxSize ? (size_t)docId : (size_t)(docId % t->maxSize);
+}
+
+// Initial bucket-array size the first time we grow from zero. Chosen so an
+// index that only ever holds a handful of TTL docs pays one small allocation
+// and no reallocs. Must be ≥ 1.
+#define TTL_BUCKET_INITIAL_CAP ((size_t)64)
+
+// Upper bound on the geometric +1.5x step once the bucket array is non-empty,
+// mirroring DocTable_Set's cap so huge tables don't take a single multi-MB
+// realloc hit and so the two allocators scale in lockstep.
+#define TTL_BUCKET_MAX_GROW_STEP ((size_t)(1 << 20))  // 1 Mi buckets
+
+// Ensure buckets[slot] is allocated. Called from Add only; reads treat
+// slot >= cap as "not present" and never grow. Growth curve matches
+// DocTable_Set: +1.5x geometric up to TTL_BUCKET_MAX_GROW_STEP, clamped to
+// maxSize, with TTL_BUCKET_INITIAL_CAP as the first-grow seed.
+static void ttl_grow(TimeToLiveTable *t, size_t slot) {
+  if (slot < t->cap) return;
+  RS_ASSERT(t->cap < t->maxSize);  // slot is always < maxSize, so room must exist
+  const size_t oldcap = t->cap;
+  size_t newcap = t->cap == 0
+      ? TTL_BUCKET_INITIAL_CAP
+      : t->cap + 1 + MIN(t->cap / 2, TTL_BUCKET_MAX_GROW_STEP);
+  if (newcap > t->maxSize) newcap = t->maxSize;
+  if (newcap < slot + 1) newcap = slot + 1;
+  t->buckets = rm_realloc(t->buckets, newcap * sizeof(*t->buckets));
+  memset(t->buckets + oldcap, 0, (newcap - oldcap) * sizeof(*t->buckets));
+  t->cap = newcap;
+}
+
+static inline TimeToLiveEntry *ttl_find_entry(const TimeToLiveTable *t, t_docId docId) {
+  const size_t slot = ttl_slot(t, docId);
+  if (slot >= t->cap) return NULL;  // bucket unallocated => entry cannot exist
+  const TTLBucket *b = &t->buckets[slot];
+  for (uint32_t i = 0; i < b->count; i++) {
+    if (b->entries[i].docId == docId) {
+      return &b->entries[i];
     }
+  }
+  return NULL;
+}
+
+// Debug-only duplicate probe for the monotonic-docId invariant. Extracted to
+// keep the Add call site readable (`assert(!ttl_bucket_contains(...))`); the
+// invariant itself is enforced upstream by the spec write lock in
+// DocTable_Put, so eliding the scan in release is intentional.
+static bool ttl_bucket_contains(const TTLBucket *b, t_docId docId) {
+  for (uint32_t i = 0; i < b->count; i++) {
+    if (b->entries[i].docId == docId) return true;
+  }
+  return false;
+}
+
+// Release the owned allocations of a single entry. The entry slot itself is
+// owned by the bucket's `entries` block and is freed with it.
+static inline void ttl_entry_release(TimeToLiveEntry *e) {
+  array_free(e->fieldExpirations);
+}
+
+void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize) {
+  if (*table) return;
+  // maxSize == 0 would make ttl_slot divide by zero; the caller (DocTable)
+  // floors its own maxSize to 1 on load, so treat this as a hard invariant.
+  RS_LOG_ASSERT_ALWAYS(maxSize >= 1, "TTL table maxSize must be >= 1");
+  TimeToLiveTable *t = rm_malloc(sizeof(*t));
+  t->buckets = NULL;
+  t->cap = 0;
+  t->maxSize = maxSize;
+  t->count = 0;
+  *table = t;
 }
 
 void TimeToLiveTable_Destroy(TimeToLiveTable **table) {
-    if (*table) {
-      dictRelease(*table);
-      *table = NULL;
+  if (!*table) return;
+  TimeToLiveTable *t = *table;
+  for (size_t s = 0; s < t->cap; s++) {
+    TTLBucket *b = &t->buckets[s];
+    for (uint32_t i = 0; i < b->count; i++) {
+      ttl_entry_release(&b->entries[i]);
     }
+    rm_free(b->entries);
+  }
+  rm_free(t->buckets);
+  rm_free(t);
+  *table = NULL;
 }
 
-void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpirationTime, arrayof(FieldExpiration) sortedById) {
-  TimeToLiveEntry* entry = (TimeToLiveEntry*)rm_malloc(sizeof(TimeToLiveEntry));
-  entry->documentExpirationPoint = docExpirationTime;
-  entry->fieldExpirations = sortedById;
-  // we don't want the operation to fail so we use dictReplace
-  const bool added = dictAdd(table, (void*)docId, entry) == DICT_OK;
-  RS_LOG_ASSERT(added, "Failed to add document to ttl table");
+void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, t_expirationTimePoint docExpirationTime, arrayof(FieldExpiration) sortedById) {
+  const size_t slot = ttl_slot(t, docId);
+  ttl_grow(t, slot);
+  TTLBucket *b = &t->buckets[slot];
+  // docIds are monotonically assigned in DocTable_Put under the spec write
+  // lock, so duplicates should not reach here; the assert catches a broken
+  // locking discipline during development before it corrupts the table.
+  RS_LOG_ASSERT(!ttl_bucket_contains(b, docId), "duplicate docId in TTL table");
+  b->entries = rm_realloc(b->entries, (b->count + 1) * sizeof(*b->entries));
+  TimeToLiveEntry *e = &b->entries[b->count];
+  b->count++;
+  t->count++;
+  e->docId = docId;
+  e->documentExpirationPoint = docExpirationTime;
+  e->fieldExpirations = sortedById;
 }
 
-void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId) {
-  dictDelete(table, (void*)docId);
+void TimeToLiveTable_Remove(TimeToLiveTable *t, t_docId docId) {
+  const size_t slot = ttl_slot(t, docId);
+  if (slot >= t->cap) return;  // bucket unallocated => nothing to remove
+  TTLBucket *b = &t->buckets[slot];
+  for (uint32_t i = 0; i < b->count; i++) {
+    if (b->entries[i].docId != docId) continue;
+    ttl_entry_release(&b->entries[i]);
+    // swap-last to avoid memmove and keep the chain contiguous
+    b->entries[i] = b->entries[b->count - 1];
+    b->count--;
+    t->count--;
+    if (b->count == 0) {
+      rm_free(b->entries);
+      b->entries = NULL;
+    }
+    // No-shrink-on-delete: keep the allocation at its high-water mark; the
+    // few wasted bytes per chained bucket are dwarfed by the bucket header
+    // array itself and avoid realloc churn for buckets that churn.
+    return;
+  }
 }
 
-bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table) {
-  return dictSize(table) == 0;
+bool TimeToLiveTable_IsEmpty(TimeToLiveTable *t) {
+  return t->count == 0;
+}
+
+size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *t) {
+  return t ? t->cap : 0;
+}
+
+void TimeToLiveTable_ForEach(TimeToLiveTable *t, TimeToLiveTable_DocIdCallback cb, void *ctx) {
+  if (!t) return;
+  for (size_t s = 0; s < t->cap; s++) {
+    const TTLBucket *b = &t->buckets[s];
+    for (uint32_t i = 0; i < b->count; i++) {
+      cb(b->entries[i].docId, ctx);
+    }
+  }
 }
 
 static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirationTimePoint* now) {
@@ -74,34 +222,29 @@ static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirat
   return !((field->tv_sec > now->tv_sec) || (field->tv_sec == now->tv_sec && field->tv_nsec > now->tv_nsec));
 }
 
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const struct timespec* expirationPoint) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
-    return false;
-  }
-
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  return DidExpire(&ttlEntry->documentExpirationPoint, expirationPoint);
+bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *t, t_docId docId, const struct timespec* expirationPoint) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) return false;
+  return DidExpire(&e->documentExpirationPoint, expirationPoint);
 }
 
-bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex field, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *t, t_docId docId, t_fieldIndex field, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
   if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
     return true;
   }
 
   for (size_t currentFieldIndex = 0; currentFieldIndex < fieldWithExpirationCount; currentFieldIndex++) {
-    FieldExpiration* fieldExpiration = &ttlEntry->fieldExpirations[currentFieldIndex];
+    FieldExpiration* fieldExpiration = &e->fieldExpirations[currentFieldIndex];
     if (field == fieldExpiration->index) {
       // the field has an expiration time
       const bool expired = DidExpire(&fieldExpiration->point, expirationPoint);
@@ -115,21 +258,20 @@ bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_
     }
   }
   // the field was not found in the document's field expirations,
-  // which means it is valid unless the predicate is FIELD_EXPIRATION_MISSING
+  // which means it is valid unless the predicate is FIELD_EXPIRATION_PREDICATE_MISSING
   return (predicate != FIELD_EXPIRATION_PREDICATE_MISSING);
 }
 
-bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *t, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
   const size_t fieldCount = __builtin_popcount(fieldMask);
   if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
@@ -149,20 +291,20 @@ bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId
     t_fieldIndex fieldIndexToCheck = ftIdToFieldIndex[bitIndex];
 
     // Attempt to find the next field expiration that matches the current field index
-    while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > ttlEntry->fieldExpirations[currentFieldIndex].index) {
+    while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > e->fieldExpirations[currentFieldIndex].index) {
       currentFieldIndex++;
     }
     if (currentFieldIndex >= fieldWithExpirationCount) {
       // No more fields with expiration times to check
       break;
-    } else if (fieldIndexToCheck < ttlEntry->fieldExpirations[currentFieldIndex].index) {
+    } else if (fieldIndexToCheck < e->fieldExpirations[currentFieldIndex].index) {
       // The field we are checking is not present in the current field expiration
       continue;
     }
 
-    RS_ASSERT(fieldIndexToCheck == ttlEntry->fieldExpirations[currentFieldIndex].index);
+    RS_ASSERT(fieldIndexToCheck == e->fieldExpirations[currentFieldIndex].index);
     // Match found - we need to check if it has an expiration time
-    const bool expired = DidExpire(&ttlEntry->fieldExpirations[currentFieldIndex].point, expirationPoint);
+    const bool expired = DidExpire(&e->fieldExpirations[currentFieldIndex].point, expirationPoint);
     if (!expired && predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
       return true;
     } else if (expired && predicate == FIELD_EXPIRATION_PREDICATE_MISSING) {
@@ -173,7 +315,7 @@ bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId
   if (predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
     // If we are checking for the default predicate, we need at least one valid field
     return predicateMisses < fieldCount;
-  } else { // if (predicate == FIELD_EXPIRATION_MISSING)
+  } else { // if (predicate == FIELD_EXPIRATION_PREDICATE_MISSING)
     // If we are checking for the missing predicate, we need at least one expired field
     // If we reached here, it means we did not find any expired fields
     return false;
@@ -182,15 +324,14 @@ bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId
 
 
 // TODO: Rust - unify with the implementation above using generic field mask
-bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *t, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
-
 
   uint64_t fieldMask64[2];
   if (sizeof(fieldMask) == sizeof(uint64_t)) {
@@ -201,8 +342,7 @@ bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId d
     fieldMask64[1] = fieldMask >> 64;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
   const size_t fieldCount = __builtin_popcountll(fieldMask64[0]) + __builtin_popcountll(fieldMask64[1]);
   if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
@@ -223,20 +363,20 @@ bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId d
       t_fieldIndex fieldIndexToCheck = ftIdToFieldIndex[bitIndex + (i * 64)];
 
       // Attempt to find the next field expiration that matches the current field index
-      while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > ttlEntry->fieldExpirations[currentFieldIndex].index) {
+      while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > e->fieldExpirations[currentFieldIndex].index) {
         currentFieldIndex++;
       }
       if (currentFieldIndex >= fieldWithExpirationCount) {
         // No more fields with expiration times to check
         goto end; // Break out of all loops
-      } else if (fieldIndexToCheck < ttlEntry->fieldExpirations[currentFieldIndex].index) {
+      } else if (fieldIndexToCheck < e->fieldExpirations[currentFieldIndex].index) {
         // The field we are checking is not present in the current field expiration
         continue;
       }
 
-      RS_ASSERT(fieldIndexToCheck == ttlEntry->fieldExpirations[currentFieldIndex].index);
+      RS_ASSERT(fieldIndexToCheck == e->fieldExpirations[currentFieldIndex].index);
       // Match found - we need to check if it has an expiration time
-      const bool expired = DidExpire(&ttlEntry->fieldExpirations[currentFieldIndex].point, expirationPoint);
+      const bool expired = DidExpire(&e->fieldExpirations[currentFieldIndex].point, expirationPoint);
       if (!expired && predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
         return true;
       } else if (expired && predicate == FIELD_EXPIRATION_PREDICATE_MISSING) {
@@ -249,7 +389,7 @@ end:
   if (predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
     // If we are checking for the default predicate, we need at least one valid field
     return predicateMisses < fieldCount;
-  } else { // if (predicate == FIELD_EXPIRATION_MISSING)
+  } else { // if (predicate == FIELD_EXPIRATION_PREDICATE_MISSING)
     // If we are checking for the missing predicate, we need at least one expired field
     // If we reached here, it means we did not find any expired fields
     return false;

--- a/src/ttl_table/ttl_table.c
+++ b/src/ttl_table/ttl_table.c
@@ -50,9 +50,8 @@
 //    matters in deployments with many indexes that sparsely use TTL.
 
 typedef struct {
-  t_docId docId;                        // 0 is reserved / unused
-  t_expirationTimePoint documentExpirationPoint;
-  arrayof(FieldExpiration) fieldExpirations;  // owned, sorted by field index
+  t_docId docId;                              // 0 is reserved / unused
+  arrayof(FieldExpiration) fieldExpirations;  // owned, sorted by field index, never empty
 } TimeToLiveEntry;
 
 typedef struct {
@@ -157,7 +156,8 @@ void TimeToLiveTable_Destroy(TimeToLiveTable **table) {
   *table = NULL;
 }
 
-void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, t_expirationTimePoint docExpirationTime, arrayof(FieldExpiration) sortedById) {
+void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, arrayof(FieldExpiration) sortedById) {
+  RS_ASSERT(sortedById && array_len(sortedById) > 0);
   const size_t slot = ttl_slot(t, docId);
   ttl_grow(t, slot);
   TTLBucket *b = &t->buckets[slot];
@@ -170,7 +170,6 @@ void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, t_expirationTimePoin
   b->count++;
   t->count++;
   e->docId = docId;
-  e->documentExpirationPoint = docExpirationTime;
   e->fieldExpirations = sortedById;
 }
 
@@ -204,28 +203,12 @@ size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *t) {
   return t ? t->cap : 0;
 }
 
-void TimeToLiveTable_ForEach(TimeToLiveTable *t, TimeToLiveTable_DocIdCallback cb, void *ctx) {
-  if (!t) return;
-  for (size_t s = 0; s < t->cap; s++) {
-    const TTLBucket *b = &t->buckets[s];
-    for (uint32_t i = 0; i < b->count; i++) {
-      cb(b->entries[i].docId, ctx);
-    }
-  }
-}
-
 static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirationTimePoint* now) {
   if (!field->tv_sec && !field->tv_nsec) {
     return false;
   }
 
   return !((field->tv_sec > now->tv_sec) || (field->tv_sec == now->tv_sec && field->tv_nsec > now->tv_nsec));
-}
-
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *t, t_docId docId, const struct timespec* expirationPoint) {
-  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
-  if (!e) return false;
-  return DidExpire(&e->documentExpirationPoint, expirationPoint);
 }
 
 bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *t, t_docId docId, t_fieldIndex field, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {

--- a/src/ttl_table/ttl_table.c
+++ b/src/ttl_table/ttl_table.c
@@ -83,6 +83,7 @@ static inline size_t ttl_slot(const TimeToLiveTable *t, t_docId docId) {
 // DocTable_Set: +1.5x geometric up to TTL_BUCKET_MAX_GROW_STEP, clamped to
 // maxSize, with TTL_BUCKET_INITIAL_CAP as the first-grow seed.
 static void ttl_grow(TimeToLiveTable *t, size_t slot) {
+  RS_ASSERT(slot < t->maxSize);    // ttl_slot's contract; tightens the call boundary
   if (slot < t->cap) return;
   RS_ASSERT(t->cap < t->maxSize);  // slot is always < maxSize, so room must exist
   const size_t oldcap = t->cap;

--- a/src/ttl_table/ttl_table.h
+++ b/src/ttl_table/ttl_table.h
@@ -24,29 +24,26 @@ typedef struct {
 
 typedef struct TimeToLiveTable TimeToLiveTable;
 
-// Callback for TimeToLiveTable_ForEach. Return value is ignored.
-typedef void (*TimeToLiveTable_DocIdCallback)(t_docId docId, void *ctx);
-
 // Lazy-init: allocates the table on first use with `maxSize` as the fixed
 // modulus for the slot formula. Caller (DocTable) passes its own
 // `t->maxSize` so the two tables' slot formulas are identical by
 // construction and cannot drift if `search-max-doctablesize` is later
 // mutated. No-op if the table is already initialized.
+//
+// The table only holds field-level (HEXPIRE) expirations: doc-level TTL is
+// inlined directly on `RSDocumentMetadata::expirationTimeNs` so the
+// result-processor hot path can avoid this lookup entirely.
 void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize);
 void TimeToLiveTable_Destroy(TimeToLiveTable **table);
-void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpiration, arrayof(FieldExpiration) sortedById);
+// Adds a field-level expiration entry. `sortedById` must be non-empty;
+// ownership of the array transfers to the table.
+void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, arrayof(FieldExpiration) sortedById);
 void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId);
 bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table);
-
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const struct timespec* expirationPoint);
 
 bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex fieldIndex, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint);
 bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
 bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
-
-// Invoke `cb` for every live docId in the table. Used by DocTable to clear
-// per-doc expiration flags at shutdown. Order is not defined.
-void TimeToLiveTable_ForEach(TimeToLiveTable *table, TimeToLiveTable_DocIdCallback cb, void *ctx);
 
 // Test-only: number of buckets currently allocated (lazy-growth high-water
 // mark). Not exposed for runtime use.

--- a/src/ttl_table/ttl_table.h
+++ b/src/ttl_table/ttl_table.h
@@ -10,7 +10,6 @@
 #ifndef TTL_TABLE_H
 #define TTL_TABLE_H
 #include "redisearch.h"
-#include "util/dict/dict.h"
 #include "stdbool.h"
 #include "util/arr.h"
 
@@ -23,9 +22,17 @@ typedef struct {
   t_expirationTimePoint point;
 } FieldExpiration;
 
-typedef dict TimeToLiveTable;
+typedef struct TimeToLiveTable TimeToLiveTable;
 
-void TimeToLiveTable_VerifyInit(TimeToLiveTable **table);
+// Callback for TimeToLiveTable_ForEach. Return value is ignored.
+typedef void (*TimeToLiveTable_DocIdCallback)(t_docId docId, void *ctx);
+
+// Lazy-init: allocates the table on first use with `maxSize` as the fixed
+// modulus for the slot formula. Caller (DocTable) passes its own
+// `t->maxSize` so the two tables' slot formulas are identical by
+// construction and cannot drift if `search-max-doctablesize` is later
+// mutated. No-op if the table is already initialized.
+void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize);
 void TimeToLiveTable_Destroy(TimeToLiveTable **table);
 void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpiration, arrayof(FieldExpiration) sortedById);
 void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId);
@@ -36,6 +43,14 @@ bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const 
 bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex fieldIndex, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint);
 bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
 bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
+
+// Invoke `cb` for every live docId in the table. Used by DocTable to clear
+// per-doc expiration flags at shutdown. Order is not defined.
+void TimeToLiveTable_ForEach(TimeToLiveTable *table, TimeToLiveTable_DocIdCallback cb, void *ctx);
+
+// Test-only: number of buckets currently allocated (lazy-growth high-water
+// mark). Not exposed for runtime use.
+size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *table);
 
 #ifdef __cplusplus
 }

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -124,6 +124,6 @@ private:
         array_append(spec.fieldIdToIndex, i);
       }
     }
-    TimeToLiveTable_VerifyInit(&spec.docs.ttl);
+    TimeToLiveTable_VerifyInit(&spec.docs.ttl, RSGlobalConfig.maxDocTableSize);
   }
 };

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -91,17 +91,12 @@ public:
     array_free(spec.fieldIdToIndex);
   }
 
-  void TTL_Add(t_docId docId, t_expirationTimePoint expiration = {LONG_MAX, LONG_MAX}) {
-    VerifyTTLInit();
-    TimeToLiveTable_Add(spec.docs.ttl, docId, expiration, NULL);
-  }
-
   void TTL_Add(t_docId docId, t_fieldIndex field, t_expirationTimePoint expiration = {LONG_MAX, LONG_MAX}) {
     VerifyTTLInit();
     arrayof(FieldExpiration) fe = array_new(FieldExpiration, 1);
     FieldExpiration fe_entry = {field, expiration};
     array_append(fe, fe_entry);
-    TimeToLiveTable_Add(spec.docs.ttl, docId, {LONG_MAX, LONG_MAX}, fe);
+    TimeToLiveTable_Add(spec.docs.ttl, docId, fe);
   }
   void TTL_Add(t_docId docId, t_fieldMask fieldMask, t_expirationTimePoint expiration = {LONG_MAX, LONG_MAX}) {
     VerifyTTLInit();
@@ -112,7 +107,7 @@ public:
         array_append(fe, fe_entry);
       }
     }
-    TimeToLiveTable_Add(spec.docs.ttl, docId, {LONG_MAX, LONG_MAX}, fe);
+    TimeToLiveTable_Add(spec.docs.ttl, docId, fe);
   }
 
 private:

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -92,6 +92,21 @@ TEST_F(ExpireTest, testSkipTo) {
   RedisModule_FreeThreadSafeContext(ctx);
 }
 
+// Helper: build a one-entry FieldExpiration array on field index 0. Ownership
+// transfers to the table on TimeToLiveTable_Add.
+static arrayof(FieldExpiration) makeFE(t_expirationTimePoint p) {
+  arrayof(FieldExpiration) fe = array_new(FieldExpiration, 1);
+  FieldExpiration entry = {0, p};
+  array_append(fe, entry);
+  return fe;
+}
+
+// Returns true if field 0 is expired for the given docId. Mirrors what the
+// VerifyDocAndField slow path observes during query iteration.
+static bool fieldExpired(TimeToLiveTable *ttl, t_docId d, const struct timespec *now) {
+  return !TimeToLiveTable_VerifyDocAndField(ttl, d, 0, FIELD_EXPIRATION_PREDICATE_DEFAULT, now);
+}
+
 // Exercises the direct-modulo + contiguous-vec chain implementation of
 // TimeToLiveTable: seed it with more docIds than the bucket cap so every slot
 // carries multiple entries, then verify each docId's expiration state is
@@ -112,14 +127,13 @@ TEST_F(ExpireTest, testTTLCollisionChain) {
   struct timespec past = {1, 0};
   struct timespec future = {LONG_MAX, LONG_MAX};
   for (t_docId d = 1; d <= N; ++d) {
-    const t_expirationTimePoint p = (d & 1) ? past : future;
-    TimeToLiveTable_Add(ttl, d, p, nullptr);
+    TimeToLiveTable_Add(ttl, d, makeFE((d & 1) ? past : future));
   }
 
   struct timespec now = {2, 0};
   for (t_docId d = 1; d <= N; ++d) {
     const bool expected = (d & 1) != 0;
-    ASSERT_EQ(TimeToLiveTable_HasDocExpired(ttl, d, &now), expected) << "docId=" << d;
+    ASSERT_EQ(fieldExpired(ttl, d, &now), expected) << "docId=" << d;
   }
 
   // Remove every third docId and re-verify. This deletes from arbitrary chain
@@ -129,13 +143,23 @@ TEST_F(ExpireTest, testTTLCollisionChain) {
   }
   for (t_docId d = 1; d <= N; ++d) {
     if (d % 3 == 0) {
-      // removed entries look like "no TTL" => HasDocExpired returns false
-      ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, d, &now)) << "docId=" << d;
+      // Removed entries are absent => VerifyDocAndField treats the field as
+      // valid, i.e. fieldExpired returns false.
+      ASSERT_FALSE(fieldExpired(ttl, d, &now)) << "docId=" << d;
     } else {
       const bool expected = (d & 1) != 0;
-      ASSERT_EQ(TimeToLiveTable_HasDocExpired(ttl, d, &now), expected) << "docId=" << d;
+      ASSERT_EQ(fieldExpired(ttl, d, &now), expected) << "docId=" << d;
     }
   }
+
+  // Drain the rest and verify the table reports empty so the lifecycle
+  // mechanism in DocTable_Pop can destroy it.
+  for (t_docId d = 1; d <= N; ++d) {
+    if (d % 3 != 0) {
+      TimeToLiveTable_Remove(ttl, d);
+    }
+  }
+  ASSERT_TRUE(TimeToLiveTable_IsEmpty(ttl));
 
   TimeToLiveTable_Destroy(&ttl);
   ASSERT_EQ(ttl, nullptr);
@@ -157,17 +181,17 @@ TEST_F(ExpireTest, testTTLDocIdWrap) {
   struct timespec future = {LONG_MAX, LONG_MAX};
   struct timespec now = {2, 0};
   for (t_docId x = 1; x < 8; ++x) {
-    TimeToLiveTable_Add(ttl, x, past, nullptr);
-    TimeToLiveTable_Add(ttl, x + CAP, future, nullptr);
-    TimeToLiveTable_Add(ttl, x + 2 * CAP, past, nullptr);
+    TimeToLiveTable_Add(ttl, x, makeFE(past));
+    TimeToLiveTable_Add(ttl, x + CAP, makeFE(future));
+    TimeToLiveTable_Add(ttl, x + 2 * CAP, makeFE(past));
   }
   for (t_docId x = 1; x < 8; ++x) {
-    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x, &now));
-    ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, x + CAP, &now));
-    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x + 2 * CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x, &now));
+    ASSERT_FALSE(fieldExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x + 2 * CAP, &now));
     // A docId that hashes to the same slot but was never inserted must report
-    // "no TTL" => HasDocExpired returns false without matching another entry.
-    ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, x + 3 * CAP, &now));
+    // "no TTL" => fieldExpired returns false without matching another entry.
+    ASSERT_FALSE(fieldExpired(ttl, x + 3 * CAP, &now));
   }
 
   // Remove the "middle" entries and confirm the remaining two are still
@@ -176,9 +200,9 @@ TEST_F(ExpireTest, testTTLDocIdWrap) {
     TimeToLiveTable_Remove(ttl, x + CAP);
   }
   for (t_docId x = 1; x < 8; ++x) {
-    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x, &now));
-    ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, x + CAP, &now));
-    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x + 2 * CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x, &now));
+    ASSERT_FALSE(fieldExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x + 2 * CAP, &now));
   }
 
   TimeToLiveTable_Destroy(&ttl);
@@ -209,32 +233,32 @@ TEST_F(ExpireTest, testTTLLazyGrowth) {
   // of 100 — nowhere near MAX.
   const t_docId small_ids[] = {1, 5, 42, 100};
   for (t_docId d : small_ids) {
-    TimeToLiveTable_Add(ttl, d, past, nullptr);
+    TimeToLiveTable_Add(ttl, d, makeFE(past));
   }
   const size_t cap_after_small = TimeToLiveTable_DebugAllocatedBuckets(ttl);
   ASSERT_GE(cap_after_small, 101u);   // must cover slot 100
   ASSERT_LT(cap_after_small, MAX / 10);  // must be far below maxSize
 
   // Reads for docIds whose slot is still unallocated must report not-found.
-  ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, 999999, &now));
+  ASSERT_FALSE(fieldExpired(ttl, 999999, &now));
   // Writes must still work for those, and bump cap to cover them.
-  TimeToLiveTable_Add(ttl, 999999, past, nullptr);
+  TimeToLiveTable_Add(ttl, 999999, makeFE(past));
   ASSERT_GE(TimeToLiveTable_DebugAllocatedBuckets(ttl), 999999u + 1);
-  ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, 999999, &now));
+  ASSERT_TRUE(fieldExpired(ttl, 999999, &now));
 
   // Previously-inserted entries must not have moved during the grow.
   for (t_docId d : small_ids) {
-    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, d, &now)) << "docId=" << d;
+    ASSERT_TRUE(fieldExpired(ttl, d, &now)) << "docId=" << d;
   }
 
   // A wrap-around docId (>= maxSize) routes via modulo into an already-
   // allocated slot, so it works without further growth.
   const size_t cap_before_wrap = TimeToLiveTable_DebugAllocatedBuckets(ttl);
-  TimeToLiveTable_Add(ttl, MAX + 5, past, nullptr);  // slot = 5, already in range
+  TimeToLiveTable_Add(ttl, MAX + 5, makeFE(past));  // slot = 5, already in range
   ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), cap_before_wrap);
-  ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, MAX + 5, &now));
+  ASSERT_TRUE(fieldExpired(ttl, MAX + 5, &now));
   // The original docId=5 entry must still be distinct from the wrapped one.
-  ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, 5, &now));
+  ASSERT_TRUE(fieldExpired(ttl, 5, &now));
 
   TimeToLiveTable_Destroy(&ttl);
   RSGlobalConfig.maxDocTableSize = savedMax;

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -15,9 +15,11 @@
 #include "redismock/internal.h"
 #include "spec.h"
 #include "common.h"
+#include "config.h"
 #include "module.h"
 #include "version.h"
 #include "tag_index.h"
+#include "ttl_table.h"
 #include "info/info_redis/threads/current_thread.h"
 
 #include <vector>
@@ -89,3 +91,152 @@ TEST_F(ExpireTest, testSkipTo) {
   args.clear();
   RedisModule_FreeThreadSafeContext(ctx);
 }
+
+// Exercises the direct-modulo + contiguous-vec chain implementation of
+// TimeToLiveTable: seed it with more docIds than the bucket cap so every slot
+// carries multiple entries, then verify each docId's expiration state is
+// observed correctly. Also exercises removal from the middle of a chain via
+// the swap-last path.
+TEST_F(ExpireTest, testTTLCollisionChain) {
+  // Force a small cap so the chain path is actually exercised at this size.
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const size_t cap = 32;
+  RSGlobalConfig.maxDocTableSize = cap;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, cap);
+
+  // Insert 4x the cap so every slot has ~4 entries on average. Alternate
+  // expired/fresh so we can assert the chain walk returns the right entry.
+  const t_docId N = (t_docId)cap * 4;
+  struct timespec past = {1, 0};
+  struct timespec future = {LONG_MAX, LONG_MAX};
+  for (t_docId d = 1; d <= N; ++d) {
+    const t_expirationTimePoint p = (d & 1) ? past : future;
+    TimeToLiveTable_Add(ttl, d, p, nullptr);
+  }
+
+  struct timespec now = {2, 0};
+  for (t_docId d = 1; d <= N; ++d) {
+    const bool expected = (d & 1) != 0;
+    ASSERT_EQ(TimeToLiveTable_HasDocExpired(ttl, d, &now), expected) << "docId=" << d;
+  }
+
+  // Remove every third docId and re-verify. This deletes from arbitrary chain
+  // positions and triggers the swap-last codepath repeatedly.
+  for (t_docId d = 3; d <= N; d += 3) {
+    TimeToLiveTable_Remove(ttl, d);
+  }
+  for (t_docId d = 1; d <= N; ++d) {
+    if (d % 3 == 0) {
+      // removed entries look like "no TTL" => HasDocExpired returns false
+      ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, d, &now)) << "docId=" << d;
+    } else {
+      const bool expected = (d & 1) != 0;
+      ASSERT_EQ(TimeToLiveTable_HasDocExpired(ttl, d, &now), expected) << "docId=" << d;
+    }
+  }
+
+  TimeToLiveTable_Destroy(&ttl);
+  ASSERT_EQ(ttl, nullptr);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+
+// Exercises the docId wrap at the cap boundary: docId < cap uses slot = docId,
+// while docId >= cap uses slot = docId % cap. The two branches must land on
+// the same bucket and stay distinguishable from each other.
+TEST_F(ExpireTest, testTTLDocIdWrap) {
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const t_docId CAP = 32;
+  RSGlobalConfig.maxDocTableSize = CAP;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, CAP);
+  // Collide docId X (fast path) with docId X + CAP and X + 2*CAP (modulo path).
+  struct timespec past = {1, 0};
+  struct timespec future = {LONG_MAX, LONG_MAX};
+  struct timespec now = {2, 0};
+  for (t_docId x = 1; x < 8; ++x) {
+    TimeToLiveTable_Add(ttl, x, past, nullptr);
+    TimeToLiveTable_Add(ttl, x + CAP, future, nullptr);
+    TimeToLiveTable_Add(ttl, x + 2 * CAP, past, nullptr);
+  }
+  for (t_docId x = 1; x < 8; ++x) {
+    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x, &now));
+    ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x + 2 * CAP, &now));
+    // A docId that hashes to the same slot but was never inserted must report
+    // "no TTL" => HasDocExpired returns false without matching another entry.
+    ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, x + 3 * CAP, &now));
+  }
+
+  // Remove the "middle" entries and confirm the remaining two are still
+  // found in both directions (the swap-last must not corrupt the chain).
+  for (t_docId x = 1; x < 8; ++x) {
+    TimeToLiveTable_Remove(ttl, x + CAP);
+  }
+  for (t_docId x = 1; x < 8; ++x) {
+    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x, &now));
+    ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, x + 2 * CAP, &now));
+  }
+
+  TimeToLiveTable_Destroy(&ttl);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+
+// Exercises lazy bucket-array growth: with a large configured maxSize, a
+// table that only ever holds a handful of entries must not allocate the
+// full maxSize worth of buckets. Also verifies that the grown `cap` covers
+// every slot that has been written, and that wrap-around docIds are still
+// routed to their correct (already-allocated) slot after growth.
+TEST_F(ExpireTest, testTTLLazyGrowth) {
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const size_t MAX = 1000000;  // matches production default
+  RSGlobalConfig.maxDocTableSize = MAX;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, MAX);
+  // Init alone must not allocate any buckets.
+  ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), 0u);
+
+  struct timespec past = {1, 0};
+  struct timespec now = {2, 0};
+
+  // Insert a small, sparse set of low docIds. Growth should stop well below
+  // MAX; concretely, the high-water slot is 100, so cap is bounded by the
+  // geometric growth curve's next step above that, which is a small factor
+  // of 100 — nowhere near MAX.
+  const t_docId small_ids[] = {1, 5, 42, 100};
+  for (t_docId d : small_ids) {
+    TimeToLiveTable_Add(ttl, d, past, nullptr);
+  }
+  const size_t cap_after_small = TimeToLiveTable_DebugAllocatedBuckets(ttl);
+  ASSERT_GE(cap_after_small, 101u);   // must cover slot 100
+  ASSERT_LT(cap_after_small, MAX / 10);  // must be far below maxSize
+
+  // Reads for docIds whose slot is still unallocated must report not-found.
+  ASSERT_FALSE(TimeToLiveTable_HasDocExpired(ttl, 999999, &now));
+  // Writes must still work for those, and bump cap to cover them.
+  TimeToLiveTable_Add(ttl, 999999, past, nullptr);
+  ASSERT_GE(TimeToLiveTable_DebugAllocatedBuckets(ttl), 999999u + 1);
+  ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, 999999, &now));
+
+  // Previously-inserted entries must not have moved during the grow.
+  for (t_docId d : small_ids) {
+    ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, d, &now)) << "docId=" << d;
+  }
+
+  // A wrap-around docId (>= maxSize) routes via modulo into an already-
+  // allocated slot, so it works without further growth.
+  const size_t cap_before_wrap = TimeToLiveTable_DebugAllocatedBuckets(ttl);
+  TimeToLiveTable_Add(ttl, MAX + 5, past, nullptr);  // slot = 5, already in range
+  ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), cap_before_wrap);
+  ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, MAX + 5, &now));
+  // The original docId=5 entry must still be distinct from the wrapped one.
+  ASSERT_TRUE(TimeToLiveTable_HasDocExpired(ttl, 5, &now));
+
+  TimeToLiveTable_Destroy(&ttl);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1243,7 +1243,7 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_EQ(N + 1, dt.size);
   ASSERT_EQ(N, dt.maxDocId);
 #ifdef __x86_64__
-  ASSERT_EQ(9380 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(10180 + doc_table_size, (int)dt.memsize);
 #endif
   for (int i = 0; i < N; i++) {
     snprintf(buf, sizeof(buf), "doc_%d", i);
@@ -1280,7 +1280,7 @@ TEST_F(IndexTest, testDocTable) {
   RSDocumentMetadata *dmd = DocTable_Put(&dt, "Hello", 5, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   t_docId strDocId = dmd->id;
   ASSERT_TRUE(0 != strDocId);
-  ASSERT_EQ(63 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(71 + doc_table_size, (int)dt.memsize);
 
   // Test that binary keys also work here
   static const char binBuf[] = {"Hello\x00World"};
@@ -1289,7 +1289,7 @@ TEST_F(IndexTest, testDocTable) {
   DMD_Return(dmd);
   dmd = DocTable_Put(&dt, binBuf, binBufLen, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   ASSERT_TRUE(dmd);
-  ASSERT_EQ(132 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(148 + doc_table_size, (int)dt.memsize);
   ASSERT_NE(dmd->id, strDocId);
   ASSERT_EQ(dmd->id, DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1284,7 +1284,7 @@ TEST_F(LLApiTest, testInfo) {
   // common stats
   ASSERT_EQ(info.numDocuments, 2);
   ASSERT_EQ(info.maxDocId, 2);
-  ASSERT_EQ(info.docTableSize, 124 + doc_table_size);
+  ASSERT_EQ(info.docTableSize, 140 + doc_table_size);
   ASSERT_EQ(info.sortablesSize, 80);
   ASSERT_EQ(info.docTrieSize, 120);
   ASSERT_EQ(info.numTerms, 5);
@@ -1386,23 +1386,23 @@ TEST_F(LLApiTest, testInfoSize) {
 
   // Memory values use the original magic numbers, adjusted for TrieNode size changes.
   // The numDocs field added 8 bytes per trie entry.
-  EXPECT_EQ(RediSearch_MemUsage(index), 319 + additional_overhead + get_trie_entry_extra_overhead(1));
+  EXPECT_EQ(RediSearch_MemUsage(index), 327 + additional_overhead + get_trie_entry_extra_overhead(1));
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 597 + additional_overhead + get_trie_entry_extra_overhead(2));
+  EXPECT_EQ(RediSearch_MemUsage(index), 613 + additional_overhead + get_trie_entry_extra_overhead(2));
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 463 + additional_overhead + get_trie_entry_extra_overhead(2));
+  EXPECT_EQ(RediSearch_MemUsage(index), 471 + additional_overhead + get_trie_entry_extra_overhead(2));
   RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx, false);
-  EXPECT_EQ(RediSearch_MemUsage(index), 320 + additional_overhead + get_trie_entry_extra_overhead(1));
+  EXPECT_EQ(RediSearch_MemUsage(index), 328 + additional_overhead + get_trie_entry_extra_overhead(1));
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
   EXPECT_EQ(RediSearch_MemUsage(index), 234 + additional_overhead + get_trie_entry_extra_overhead(1));
@@ -1448,23 +1448,23 @@ TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
 
   // Memory values use the original magic numbers, adjusted for TrieNode size changes.
   // The numDocs field added 8 bytes per trie entry.
-  EXPECT_EQ(RediSearch_MemUsage(index), 400 + additional_overhead + get_trie_entry_extra_overhead(1));
+  EXPECT_EQ(RediSearch_MemUsage(index), 408 + additional_overhead + get_trie_entry_extra_overhead(1));
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 679 + additional_overhead + get_trie_entry_extra_overhead(2));
+  EXPECT_EQ(RediSearch_MemUsage(index), 695 + additional_overhead + get_trie_entry_extra_overhead(2));
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 545 + additional_overhead + get_trie_entry_extra_overhead(2));
+  EXPECT_EQ(RediSearch_MemUsage(index), 553 + additional_overhead + get_trie_entry_extra_overhead(2));
   RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx, false);
-  EXPECT_EQ(RediSearch_MemUsage(index), 401 + additional_overhead + get_trie_entry_extra_overhead(1));
+  EXPECT_EQ(RediSearch_MemUsage(index), 409 + additional_overhead + get_trie_entry_extra_overhead(1));
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
   EXPECT_EQ(RediSearch_MemUsage(index), 315 + additional_overhead + get_trie_entry_extra_overhead(1));

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -686,7 +686,7 @@ def test_background_index_no_lazy_expiration_json(env):
 
 
 @skip(cluster=True, redis_less_than='7.4')
-def test_ttl_table_collision_chain(env: Env):
+def test_ttl_table_collision_chain():
     # Regression for the direct-modulo TTL table: seed the index with far more
     # HEXPIRE-covered docs than the TTL bucket cap, so every slot must carry
     # a collision chain. Then query for fresh and expired entries and verify

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -683,3 +683,35 @@ def test_background_index_no_lazy_expiration_json(env):
     # Accessing doc:1 directly should cause lazy expire and its removal from the DB.
     env.expect('JSON.GET', 'doc:1', "$").equal(None)
     env.expect('DBSIZE').equal(1)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_ttl_table_collision_chain(env: Env):
+    # Regression for the direct-modulo TTL table: seed the index with far more
+    # HEXPIRE-covered docs than the TTL bucket cap, so every slot must carry
+    # a collision chain. Then query for fresh and expired entries and verify
+    # the chain walk returns the right ones.
+    env = Env(moduleArgs='MAXDOCTABLESIZE 4')
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA', 'n', 'NUMERIC', 't', 'TAG').ok()
+
+    # Docs 1..odd are long-lived; docs 1..even get a fast HPEXPIRE so they
+    # will be reported as expired at query time.
+    N = 64  # > 16x the bucket cap => many collisions per slot
+    for d in range(1, N + 1):
+        env.expect('HSET', f'doc:{d}', 'n', str(d), 't', 'tag').equal(2)
+        if d % 2 == 0:
+            env.expect('HPEXPIRE', f'doc:{d}', '1', 'FIELDS', '2', 'n', 't').equal([1, 1])
+
+    time.sleep(0.050)
+
+    # Tag filter should still find every odd doc; evens are all expired.
+    res = env.cmd('FT.SEARCH', 'idx', '@t:{tag}', 'NOCONTENT', 'LIMIT', '0', str(N))
+    returned = sorted(int(d.split(':')[1]) for d in res[1:])
+    expected = list(range(1, N + 1, 2))
+    env.assertEqual(returned, expected)
+
+    # Numeric filter over the full range: same expectation.
+    res = env.cmd('FT.SEARCH', 'idx', f'@n:[1 {N}]', 'NOCONTENT', 'LIMIT', '0', str(N))
+    returned = sorted(int(d.split(':')[1]) for d in res[1:])
+    env.assertEqual(returned, expected)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -345,9 +345,9 @@ def testDocTableInfo(env):
     # = leanSize + sdsAllocSize(keyPtr)
     # = (sizeof(RSDocumentMetadata) - sizeof(RSPayload *))  (No payload)
     #   + (strlen(key) + 2)
-    # = (64 - 8) + 3 = 59
-    # 2 docs * 59 = 118
-    exp_doc_table_size = (n * doc_table_size_mb) + (118 / (1024 * 1024))
+    # = (72 - 8) + 3 = 67
+    # 2 docs * 67 = 134
+    exp_doc_table_size = (n * doc_table_size_mb) + (134 / (1024 * 1024))
     env.assertEqual(doctable_size1, exp_doc_table_size)
     sortable_size1 = float(d['sortable_values_size_mb'])
     env.assertGreater(sortable_size1, 0)


### PR DESCRIPTION
## Describe the changes in the pull request

Three perf improvements to the expiration feature, ported and adapted from the 8.4 investigation branches (originally redislabsdev PRs #225 and #226).

### 1. Redesign the TTL table for cache-friendly iterator lookups
Replace the dict-backed `TimeToLiveTable` with a direct-modulo bucket array whose collision chains are contiguous-vec blocks. docIds are allocated monotonically via `++maxDocId` in `DocTable`, so iterator-time `VerifyDocAndField*` lookups see them in ascending, mostly-sequential order; direct modulo keeps sequential docIds in sequential slots, letting the hardware prefetcher pull upcoming bucket headers into L1 ahead of demand. Primarily benefits the "miss" hot path - docs without TTL, the common case at query time. `DocTable_UpdateExpiration` now passes `t->maxSize` through to `TimeToLiveTable_VerifyInit` so the slot formula cannot drift from `DocTable`'s own modulus.

### 2. Gate per-posting TTL lookup on the presence of HFE entries
The TTL table now holds field-level (HEXPIRE) entries only and is destroyed by `DocTable_Pop` when the last one leaves the index, so a non-NULL `docs.ttl` is a sufficient and tight gate by itself. Iterators (`HybridIterator`, geometry `CPPQueryIterator`, Rust `FieldExpirationChecker`) bypass the TTL lookup entirely on indexes that have no field-level TTL right now, with no extra latch to maintain.

### 3. Inline doc-level expiration on DMD to bypass TTL lookup
Inline the doc-level expiration timestamp directly on the DMD as an `int64_t` nanoseconds-since-epoch (8 B per DMD, after `nextInChain` and before `payload` so `DocTable_Put`'s lean-allocation path is preserved). The new `DocTable_IsDocExpired` check is a single scalar compare on a cache line we are already touching (the caller has just read `dmd->flags`), eliminating the per-result table lookup on the result-processor hot path. The `Document_HasExpiration` flag is no longer set or read on the in-memory DMD path - the result processor fetches the DMD on every hit anyway, so a flag-gated branch buys nothing there.

#### Which additional issues this PR fixes
1. MOD-14916

#### Main objects this PR modified
1. `TimeToLiveTable` (`src/ttl_table/`): direct-modulo bucket array; HFE-only payload
2. `DocTable` / `RSDocumentMetadata` (`src/doc_table.*`, `src/redisearch.h`): inlined `expirationTimeNs`; HFE gate via `docs.ttl`
3. Iterators (`src/iterators/hybrid_reader.c`, `src/geometry/query_iterator.cpp`, `src/redisearch_rs/rqe_iterators/src/expiration_checker.rs`): hoisted gate

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core expiration storage and lookup paths (DocTable metadata layout, TTL table implementation, and iterator gating), which could affect query-time expiration correctness and memory behavior despite added regression tests.
> 
> **Overview**
> Improves expiration query performance by **inlining document-level TTL** onto `RSDocumentMetadata` as `expirationTimeNs` and switching doc-expired checks to a direct scalar compare (removing reliance on `Document_HasExpiration`/TTL-table lookups on the hot path).
> 
> Redesigns `TimeToLiveTable` from a dict-backed map into a **direct-modulo bucket array with contiguous collision chains**, and narrows it to store **field-level (HEXPIRE) expirations only**; it is lazily created on first field-expiration and destroyed when empty.
> 
> Updates C++ geometry and hybrid iterators plus the Rust expiration checker to **hoist and revalidate** a `docs.ttl != NULL` gate to skip per-posting expiration checks when no field-level expirations exist, and removes TTL-table dict rehash pausing in read locks since it’s no longer a Redis dict. Adds targeted C++ and Python tests for TTL collisions/wraparound/lazy growth and adjusts memory-usage expectations for the larger DMD.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f06cec160b22b50a4f70cd87600e67739e6111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->