### PR TITLE
[8.6-rse] MOD-14916: enable inline LSE atomics on AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,41 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 function(setup_cc_options)
     message("# CMAKE_C_COMPILER_ID: " ${CMAKE_C_COMPILER_ID})
 
-    # Common compiler flags
-    set(CMAKE_C_FLAGS "-fPIC -g -pthread -fno-strict-aliasing -Wno-unused-function -Wno-unused-variable -Wno-sign-compare -fcommon -funsigned-char" PARENT_SCOPE)
-    set(CMAKE_CXX_FLAGS "-fPIC -g -pthread -fno-strict-aliasing -Wno-unused-function -Wno-unused-variable -Wno-sign-compare" PARENT_SCOPE)
+    # Accumulate C/CXX flags locally and publish once. set(... PARENT_SCOPE)
+    # does NOT update the function-local variable, so a later read of
+    # ${CMAKE_C_FLAGS} would miss earlier additions (MOD-14916).
+    set(_common_c_flags "${CMAKE_C_FLAGS} -fPIC -g -pthread -fno-strict-aliasing -Wno-unused-function -Wno-unused-variable -Wno-sign-compare -fcommon -funsigned-char")
+    set(_common_cxx_flags "${CMAKE_CXX_FLAGS} -fPIC -g -pthread -fno-strict-aliasing -Wno-unused-function -Wno-unused-variable -Wno-sign-compare")
     set(CMAKE_CXX_STANDARD 20)
-    # Release/Debug/Profile specific flags
+
+    # MOD-14916: inline LSE atomics on Linux AArch64 -- avoid libgcc
+    # __aarch64_* outline-atomics helpers on every atomic RMW.
+    #   -march=armv8-a+lse   adds LSE without raising -march, so deps that
+    #                        probe `-march=armv8-a` (e.g. VecSim's CXX_ARMV8A
+    #                        gate on NEON_HP.cpp) still pass.
+    #   -mno-outline-atomics canonical disable spelling (the "=no" form is
+    #                        silently ignored by GCC).
+    # Apple excluded: Apple clang rejects -mno-outline-atomics and Apple
+    # Silicon already emits inline LSE.
+    if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+        include(CheckCCompilerFlag)
+        include(CheckCXXCompilerFlag)
+        set(_aarch64_lse_flags "-march=armv8-a+lse -mtune=neoverse-n1 -mno-outline-atomics")
+        check_c_compiler_flag("${_aarch64_lse_flags}" _c_lse_ok)
+        check_cxx_compiler_flag("${_aarch64_lse_flags}" _cxx_lse_ok)
+        if(_c_lse_ok AND _cxx_lse_ok)
+            set(_common_c_flags   "${_common_c_flags} ${_aarch64_lse_flags}")
+            set(_common_cxx_flags "${_common_cxx_flags} ${_aarch64_lse_flags}")
+        else()
+            message(WARNING "AArch64 LSE build flags not accepted by compiler; "
+                            "outline atomics will remain in the .so")
+        endif()
+    endif()
+
+    set(CMAKE_C_FLAGS   "${_common_c_flags}"   PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${_common_cxx_flags}" PARENT_SCOPE)
+
+    # Config-specific flags only — CMake appends these to CMAKE_C/CXX_FLAGS automatically
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -O0 -fno-omit-frame-pointer -ggdb" PARENT_SCOPE)
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0 -fno-omit-frame-pointer -ggdb" PARENT_SCOPE)

--- a/build.sh
+++ b/build.sh
@@ -500,6 +500,14 @@ prepare_cmake_arguments() {
     # Add the dynamic C runtime flag to RUSTFLAGS
     RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C target-feature=-crt-static"
   fi
+  # MOD-14916: inline LSE atomics for Rust on AArch64. `-C target-cpu=neoverse-n1`
+  # implies +lse so rustc emits LDADDH/LDADD instead of an ldxrh/stxrh LL/SC loop.
+  # macOS is excluded to match the CMake NOT APPLE gate: Apple Silicon's default
+  # target-cpu (apple-m1) is already ≥Armv8.5-a with inline LSE, so overriding it
+  # with neoverse-n1 would only downgrade scheduling.
+  if [[ "$ARCH" == "aarch64" && "$OS_NAME" != "macos" ]]; then
+    RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C target-cpu=neoverse-n1"
+  fi
   # Set up RUSTFLAGS for warnings
   if [[ "$RUST_DENY_WARNS" == "1" ]]; then
     RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-D warnings"


### PR DESCRIPTION
# Description
Backport of #9262 to `8.6-rse`.

## Describe the changes in the pull request

**Current:** On Linux AArch64, GCC's default `-moutline-atomics` routes every atomic RMW through a libgcc dispatcher (`__aarch64_ldadd{1,2,4,8}_{relax,acq,rel,acq_rel}`, 37 symbols in the `.so`) for ABI compat with pre-v8.1-a cores that RL Enterprise does not run. Profiles of upgrade on Neoverse-V2 show `__aarch64_ldadd2_relax` at ~7.4 % flat CPU, 100 % from `RSDocumentMetadata::ref_count` (`DocTable_Borrow` 51.9 %, `SearchResult_Clear` 48.1 %). rustc emits a matching `ldxrh`/`stxrh` LL/SC loop on the same field in `DocumentMetadata` Drop.

**Change:** Pure build-flag commit, no source changes.
- **C / C++ (`CMakeLists.txt`, `setup_cc_options`):** Linux-AArch64-only stanza adding `-march=armv8-a+lse -mtune=neoverse-n1 -mno-outline-atomics`, behind a `check_c/cxx_compiler_flag` soft gate. macOS is excluded (Apple clang rejects `-mno-outline-atomics`; Apple Silicon already inlines LSE). `-march=armv8-a+lse` (not `-mcpu`) is deliberate — `-mcpu` would trip deps that probe `check_cxx_compiler_flag("-march=armv8-a")`, notably VecSim's `CXX_ARMV8A` gate on `NEON_HP.cpp`, leaving `Choose_FP16_L2_implementation_NEON_HP` undefined at `MODULE LOAD`. Function also refactored to accumulate flags locally and publish once to `PARENT_SCOPE` (old shape silently dropped additions).
- **Rust (`build.sh`):** `-C target-cpu=neoverse-n1` added to `RUSTFLAGS` when `ARCH=aarch64` and `OS_NAME != macos`.

**Outcome:** 37 `__aarch64_*` helpers drop out of the `.so`; `DocTable_Borrow` compiles to a single `ldaddh w1, w1, [x0]`.

**Hardware compat:** Produced `.so` requires Armv8.1-a+ (LSE). All RL Enterprise ARM SKUs (Neoverse-N1/V1/V2 = Graviton2/3/4) satisfy this; pre-v8.1-a cores (Cortex-A72 / Graviton1 / RPi4) will `SIGILL` at process start. OSS users on those cores must rebuild.

#### Main objects this PR modified
1. `CMakeLists.txt` — `setup_cc_options()` (refactor + AArch64 LSE stanza)
2. `build.sh` — Rust `-C target-cpu=neoverse-n1` on Linux AArch64

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-flag changes only, but they alter the generated binaries on Linux AArch64 and may reduce CPU compatibility (requires LSE-capable cores) if used outside the intended deployment targets.
> 
> **Overview**
> Enables Linux AArch64 builds to emit *inline LSE atomics* by adding C/C++ compiler flags (`-march=armv8-a+lse -mtune=neoverse-n1 -mno-outline-atomics`) behind a compiler-flag check, while explicitly excluding Apple builds.
> 
> Updates `setup_cc_options` to accumulate and publish common C/C++ flags in one place (avoiding missed additions via `PARENT_SCOPE`), and adds a matching Rust build tweak in `build.sh` to set `RUSTFLAGS` `-C target-cpu=neoverse-n1` on non-macOS AArch64.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2490a548a39817e832123bb7ecf9517d2a468faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->