### PR TITLE
Align Hybrid Should Check Timeout Function To Aggregate Behaviour

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1017,8 +1017,7 @@ static bool shouldCheckInPipelineTimeoutHybrid(RedisModuleCtx* ctx, HybridReques
   // We should check for timeout in pipeline only if timeout is > 0
   // and when the policy is RETURN or the policy is FAIL, without workers.
   return hreq->reqConfig.queryTimeoutMS > 0 &&
-         (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Return ||
-          (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Fail && !RunInThread(ctx)));
+         (hreq->reqConfig.timeoutPolicy == TimeoutPolicy_Return || !RunInThread(ctx));
 
 }
 


### PR DESCRIPTION
`shouldCheckInPipelineTimeoutHybrid` was recently updated for aggregate but wasn't updated for hybrid.
Aligning the behaviour here.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `FT.HYBRID` performs in-pipeline timeout checks, which can alter timeout behavior and replies for `TimeoutPolicy_Fail` in non-threaded execution. Scope is small but touches query timeout enforcement logic.
> 
> **Overview**
> Aligns `FT.HYBRID` timeout-check behavior with `FT.AGGREGATE` by simplifying `shouldCheckInPipelineTimeoutHybrid` to enable in-pipeline timeout checks whenever a timeout is configured and the request is either `ON_TIMEOUT RETURN` *or* running without worker threads.
> 
> This removes the previous special-case that only enabled `ON_TIMEOUT FAIL` checks when not running in threads, making hybrid’s skip-timeout-check decision consistent with aggregate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb5b0bf4264957f28b96cfe8a42a00d20b40ea65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->