### PR TITLE
[2.10] Fix max value of search-connect-timeout config - [MOD-15100]

### DIFF
--- a/coord/src/config.c
+++ b/coord/src/config.c
@@ -137,9 +137,9 @@ static inline size_t connectTimeoutToMS(const struct timeval *tv) {
 
 CONFIG_SETTER(setConnectTimeout) {
   SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
-  size_t ms;
-  int acrc = AC_GetSize(ac, &ms, AC_F_GE0);
-  if (acrc == AC_OK) connectTimeoutFromMS(&realConfig->connectTimeout, ms);
+  int ms;
+  int acrc = AC_GetInt(ac, &ms, AC_F_GE0); // ms can be up to INT_MAX
+  if (acrc == AC_OK) connectTimeoutFromMS(&realConfig->connectTimeout, (size_t)ms);
   RETURN_STATUS(acrc);
 }
 


### PR DESCRIPTION
# Description
Backport of #9288 to `2.10`.

## Problem

The `search-connect-timeout` config was registered with an upper bound of `LLONG_MAX` ms. That bound is wider than what the underlying hiredis connection layer can accept: hiredis converts the supplied milliseconds into a `struct timeval` and rejects (in `redisContextConnectBindTcp` / `_redisContextConnectTcp`) any value whose `tv_sec` exceeds `(LONG_MAX - 999) / 1000`, then additionally clamps the resulting msec to `INT_MAX` internally.

When `search-connect-timeout` was set near `LLONG_MAX`, every shard connection attempt failed with `Could not connect to node: Invalid timeout specified`, the topology validation never completed, and (in builds that drain pending tasks at shutdown) ASan flagged a leak of the queued `UpdateConnPoolSizeCtx` items that never ran. This was caught by `testConfigIndependence_max_values`, which sets every numeric config to its declared maximum.

## Fix

Lower the registered max for `search-connect-timeout` to `INT_MAX` (ms) so the declared bound matches what hiredis actually accepts. The Python test suite is updated to use the new bound.

## New maximum value

`INT_MAX = 2,147,483,647` ms

  ≈ 2,147,483.647 seconds
  ≈ 35,791 minutes
  ≈ 596.5 hours
  ≈ **~24.86 days**

This is the largest connect-timeout that can ever take effect end-to-end through hiredis, so any value above it would either be rejected or silently clamped.


#### Mark if applicable
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes
- [ ] This PR requires release notes
- [x] This PR does not require release notes


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tightens input parsing for `CONNECT_TIMEOUT` to match hiredis limits; only affects users attempting to set extremely large timeouts, which will now be rejected instead of causing connection failures.
> 
> **Overview**
> Fixes `CONNECT_TIMEOUT`/`search-connect-timeout` to accept only values up to `INT_MAX` milliseconds by switching parsing from `AC_GetSize` to `AC_GetInt` and storing the result into the underlying `struct timeval`.
> 
> User impact: setting very large connect timeouts no longer breaks shard connection attempts; values above the supported range are now rejected up front.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5afa2d3c1fa4a76669874a7729fa37aea96d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->