### PR TITLE
[CI] Improve the Backport Workflow

### DIFF
--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -32,9 +32,9 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_PR_APP_ID }}
+          client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
       - name: Checkout

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@v4
         with:
           github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'
@@ -53,15 +53,6 @@ jobs:
 
             ${pull_description}
           merge_commits: 'skip'
-          copy_assignees: true
-          add_author_as_assignee: true
+          add_author_as_reviewer: true
           auto_merge_enabled: true
           copy_labels_pattern: '.*' # copy all labels. Excluding the backport labels automatically
-      - name: Trigger CI
-        env:
-          GH_TOKEN: ${{ steps.generate-app-token.outputs.token }}
-          REVIEWER: ${{ github.event.pull_request.user.login || github.event.issue.user.login || github.actor }}
-        run: |
-          for pr in ${{ steps.backport.outputs.created_pull_numbers }}; do
-            gh pr edit $pr --add-reviewer "$REVIEWER"
-          done


### PR DESCRIPTION
## Describe the changes in the pull request

Bump action version, and use new inputs

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the backport GitHub Actions workflow; misconfigured action inputs or changed defaults could break automated backport PR creation/reviewer assignment.
> 
> **Overview**
> Updates the backport workflow to newer action versions: `actions/create-github-app-token@v3` (switching from `app-id` to `client-id`) and `korthout/backport-action@v4`.
> 
> Simplifies PR metadata handling by removing assignee-copying and the post-step `gh pr edit` loop, and instead relies on `add_author_as_reviewer: true` to request review on created backport PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbd0c47dc16e402ba78af911cf053ba213e109a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->