### PR TITLE
[wontfix] Revise README layout and logo dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<img src="docs/images/logo.svg" title="RediSearch's Logo" width="175">
+
+# RediSearch
+
 [![Discord](https://img.shields.io/discord/697882427875393627)](https://discord.gg/xTbqgTB)
 
 | Total Coverage | Unit Tests | Flow Tests |
@@ -9,9 +13,7 @@
 [![Latest 2.8](https://img.shields.io/github/v/release/RediSearch/RediSearch?filter=v2.8%2A&label=latest%20maintenance%20release%20for%202.8)](https://github.com/RediSearch/RediSearch/releases?q=tag:v2.8%20draft:false)
 [![Latest 2.6](https://img.shields.io/github/v/release/RediSearch/RediSearch?filter=v2.6%2A&label=latest%20maintenance%20release%20for%202.6)](https://github.com/RediSearch/RediSearch/releases?q=tag:v2.6%20draft:false)
 
-# RediSearch
 
-<img src="docs/images/logo.svg" title="RediSearch's Logo" width="300">
 
 > [!NOTE]
 > Starting with Redis 8, Redis Query Engine (RediSearch) is integral to Redis. You don't need to install this module separately.


### PR DESCRIPTION
## Describe the changes in the pull request
Revise README layout and logo dimensions

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that reorders the README header and resizes the logo; no code or runtime behavior is affected.
> 
> **Overview**
> Updates `README.md` to **reorder the top header** so the logo appears above `# RediSearch`, and **reduces the logo width** from `300` to `175` while removing the previous duplicate title/logo block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feae6169122c23c4e16405c8e9403fc5e4c8be35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->