### PR TITLE
MOD-14855: Add Disk Metrics Basic API

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -393,23 +393,17 @@ uint64_t SearchDisk_CollectIndexMetrics(RedisSearchDiskIndexSpec* index) {
 }
 
 uint64_t SearchDisk_GetDocTableTotalMemory(RedisSearchDiskIndexSpec* index) {
-  if (!disk || !disk_db || !index || !disk->metrics.getDocTableTotalMemory) {
-    return 0;
-  }
+  RS_ASSERT(disk && disk_db && index);
   return disk->metrics.getDocTableTotalMemory(disk_db, index);
 }
 
 uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
-  if (!disk || !disk_db || !index || !disk->metrics.getInvertedIndexTotalMemory) {
-    return 0;
-  }
+  RS_ASSERT(disk && disk_db && index);
   return disk->metrics.getInvertedIndexTotalMemory(disk_db, index);
 }
 
 uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
-  if (!disk || !disk_db || !index || !disk->metrics.getVectorIndexTotalMemory) {
-    return 0;
-  }
+  RS_ASSERT(disk && disk_db && index);
   return disk->metrics.getVectorIndexTotalMemory(disk_db, index);
 }
 

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -392,6 +392,27 @@ uint64_t SearchDisk_CollectIndexMetrics(RedisSearchDiskIndexSpec* index) {
   return disk->metrics.collectIndexMetrics(disk_db, index);
 }
 
+uint64_t SearchDisk_GetDocTableTotalMemory(RedisSearchDiskIndexSpec* index) {
+  if (!disk || !disk_db || !index || !disk->metrics.getDocTableTotalMemory) {
+    return 0;
+  }
+  return disk->metrics.getDocTableTotalMemory(disk_db, index);
+}
+
+uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
+  if (!disk || !disk_db || !index || !disk->metrics.getInvertedIndexTotalMemory) {
+    return 0;
+  }
+  return disk->metrics.getInvertedIndexTotalMemory(disk_db, index);
+}
+
+uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
+  if (!disk || !disk_db || !index || !disk->metrics.getVectorIndexTotalMemory) {
+    return 0;
+  }
+  return disk->metrics.getVectorIndexTotalMemory(disk_db, index);
+}
+
 void SearchDisk_OutputInfoMetrics(RedisModuleInfoCtx* ctx) {
   RS_ASSERT(disk && disk_db && ctx);
   disk->metrics.outputInfoMetrics(disk_db, ctx);

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -456,6 +456,12 @@ void SearchDisk_FreeVectorIndex(void *vecIndex);
 
 // Metrics API wrappers
 
+/*
+ * FT.INFO disk usage:
+ * 1) SearchDisk_CollectIndexMetrics(index)
+ * 2) Read the per-component getters below
+ */
+
 /**
  * @brief Collect metrics for an index and store them in the disk context
  *
@@ -470,10 +476,10 @@ uint64_t SearchDisk_CollectIndexMetrics(RedisSearchDiskIndexSpec* index);
 /**
  * @brief Get doc table memory for a disk index
  *
- * Returns the latest collected doc table memory in bytes.
- * Preconditions: SearchDisk is initialized and index is non-null.
- * Violating preconditions triggers RS_ASSERT.
- * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
+ * Returns disk-side doc table memory in bytes from the latest collected snapshot.
+ * Does not include RAM-only accounting from non-disk paths.
+ * Call SearchDisk_CollectIndexMetrics(index) before this getter.
+ * Requires initialized SearchDisk and non-null index (RS_ASSERT).
  *
  * @param index Pointer to the disk index spec
  * @return Doc table memory in bytes
@@ -483,10 +489,10 @@ uint64_t SearchDisk_GetDocTableTotalMemory(RedisSearchDiskIndexSpec* index);
 /**
  * @brief Get inverted index memory for a disk index
  *
- * Returns the latest collected inverted index memory in bytes.
- * Preconditions: SearchDisk is initialized and index is non-null.
- * Violating preconditions triggers RS_ASSERT.
- * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
+ * Returns disk-side inverted index memory in bytes from the latest collected snapshot.
+ * Does not include RAM-only accounting from non-disk paths.
+ * Call SearchDisk_CollectIndexMetrics(index) before this getter.
+ * Requires initialized SearchDisk and non-null index (RS_ASSERT).
  *
  * @param index Pointer to the disk index spec
  * @return Inverted index memory in bytes
@@ -496,10 +502,10 @@ uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index)
 /**
  * @brief Get vector index memory for a disk index
  *
- * Returns the latest collected vector index memory in bytes.
- * Preconditions: SearchDisk is initialized and index is non-null.
- * Violating preconditions triggers RS_ASSERT.
- * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
+ * Returns disk-side vector index memory in bytes from the latest collected snapshot.
+ * Does not include RAM-only accounting from non-disk paths.
+ * Call SearchDisk_CollectIndexMetrics(index) before this getter.
+ * Requires initialized SearchDisk and non-null index (RS_ASSERT).
  *
  * @param index Pointer to the disk index spec
  * @return Vector index memory in bytes

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -468,6 +468,42 @@ void SearchDisk_FreeVectorIndex(void *vecIndex);
 uint64_t SearchDisk_CollectIndexMetrics(RedisSearchDiskIndexSpec* index);
 
 /**
+ * @brief Get doc table memory for a disk index
+ *
+ * Returns the latest collected doc table memory in bytes.
+ * On null or invalid handles, returns 0.
+ * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
+ *
+ * @param index Pointer to the disk index spec
+ * @return Doc table memory in bytes
+ */
+uint64_t SearchDisk_GetDocTableTotalMemory(RedisSearchDiskIndexSpec* index);
+
+/**
+ * @brief Get inverted index memory for a disk index
+ *
+ * Returns the latest collected inverted index memory in bytes.
+ * On null or invalid handles, returns 0.
+ * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
+ *
+ * @param index Pointer to the disk index spec
+ * @return Inverted index memory in bytes
+ */
+uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index);
+
+/**
+ * @brief Get vector index memory for a disk index
+ *
+ * Returns the latest collected vector index memory in bytes.
+ * On null or invalid handles, returns 0.
+ * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
+ *
+ * @param index Pointer to the disk index spec
+ * @return Vector index memory in bytes
+ */
+uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index);
+
+/**
  * @brief Output aggregated disk metrics to Redis INFO
  *
  * Iterates over all collected index metrics, aggregates them, and outputs

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -471,7 +471,8 @@ uint64_t SearchDisk_CollectIndexMetrics(RedisSearchDiskIndexSpec* index);
  * @brief Get doc table memory for a disk index
  *
  * Returns the latest collected doc table memory in bytes.
- * On null or invalid handles, returns 0.
+ * Preconditions: SearchDisk is initialized and index is non-null.
+ * Violating preconditions triggers RS_ASSERT.
  * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
  *
  * @param index Pointer to the disk index spec
@@ -483,7 +484,8 @@ uint64_t SearchDisk_GetDocTableTotalMemory(RedisSearchDiskIndexSpec* index);
  * @brief Get inverted index memory for a disk index
  *
  * Returns the latest collected inverted index memory in bytes.
- * On null or invalid handles, returns 0.
+ * Preconditions: SearchDisk is initialized and index is non-null.
+ * Violating preconditions triggers RS_ASSERT.
  * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
  *
  * @param index Pointer to the disk index spec
@@ -495,7 +497,8 @@ uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index)
  * @brief Get vector index memory for a disk index
  *
  * Returns the latest collected vector index memory in bytes.
- * On null or invalid handles, returns 0.
+ * Preconditions: SearchDisk is initialized and index is non-null.
+ * Violating preconditions triggers RS_ASSERT.
  * For fresh values, call SearchDisk_CollectIndexMetrics(index) before this getter.
  *
  * @param index Pointer to the disk index spec

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -515,7 +515,7 @@ typedef struct MetricsDiskAPI {
    * @brief Get total doc table memory for a specific index
    *
    * Returns the latest collected doc table memory in bytes.
-   * Invalid or null handles should return 0.
+   * Called with valid disk and index pointers.
    *
    * @param disk Pointer to the disk context
    * @param index Pointer to the index spec
@@ -528,7 +528,7 @@ typedef struct MetricsDiskAPI {
    *
    * Returns the latest collected inverted index memory in bytes.
    * This value includes both text and tag inverted indexes.
-   * Invalid or null handles should return 0.
+   * Called with valid disk and index pointers.
    *
    * @param disk Pointer to the disk context
    * @param index Pointer to the index spec
@@ -540,7 +540,7 @@ typedef struct MetricsDiskAPI {
    * @brief Get total vector index memory for a specific index
    *
    * Returns the latest collected vector index memory in bytes.
-   * Invalid or null handles should return 0.
+   * Called with valid disk and index pointers.
    *
    * @param disk Pointer to the disk context
    * @param index Pointer to the index spec

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -514,8 +514,8 @@ typedef struct MetricsDiskAPI {
   /**
    * @brief Get total doc table memory for a specific index
    *
-   * Returns the latest collected doc table memory in bytes.
-   * Called with valid disk and index pointers.
+   * Returns disk-side doc table memory in bytes from the latest collected snapshot.
+   * Does not include RAM-only accounting from non-disk paths.
    *
    * @param disk Pointer to the disk context
    * @param index Pointer to the index spec
@@ -526,9 +526,9 @@ typedef struct MetricsDiskAPI {
   /**
    * @brief Get total inverted index memory for a specific index
    *
-   * Returns the latest collected inverted index memory in bytes.
+   * Returns disk-side inverted index memory in bytes from the latest collected snapshot.
    * This value includes both text and tag inverted indexes.
-   * Called with valid disk and index pointers.
+   * Does not include RAM-only accounting from non-disk paths.
    *
    * @param disk Pointer to the disk context
    * @param index Pointer to the index spec
@@ -539,8 +539,8 @@ typedef struct MetricsDiskAPI {
   /**
    * @brief Get total vector index memory for a specific index
    *
-   * Returns the latest collected vector index memory in bytes.
-   * Called with valid disk and index pointers.
+   * Returns disk-side vector index memory in bytes from the latest collected snapshot.
+   * Does not include RAM-only accounting from non-disk paths.
    *
    * @param disk Pointer to the disk context
    * @param index Pointer to the index spec

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -512,6 +512,43 @@ typedef struct MetricsDiskAPI {
   uint64_t (*collectIndexMetrics)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
 
   /**
+   * @brief Get total doc table memory for a specific index
+   *
+   * Returns the latest collected doc table memory in bytes.
+   * Invalid or null handles should return 0.
+   *
+   * @param disk Pointer to the disk context
+   * @param index Pointer to the index spec
+   * @return Doc table memory in bytes
+   */
+  uint64_t (*getDocTableTotalMemory)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
+
+  /**
+   * @brief Get total inverted index memory for a specific index
+   *
+   * Returns the latest collected inverted index memory in bytes.
+   * This value includes both text and tag inverted indexes.
+   * Invalid or null handles should return 0.
+   *
+   * @param disk Pointer to the disk context
+   * @param index Pointer to the index spec
+   * @return Inverted index memory in bytes
+   */
+  uint64_t (*getInvertedIndexTotalMemory)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
+
+  /**
+   * @brief Get total vector index memory for a specific index
+   *
+   * Returns the latest collected vector index memory in bytes.
+   * Invalid or null handles should return 0.
+   *
+   * @param disk Pointer to the disk context
+   * @param index Pointer to the index spec
+   * @return Vector index memory in bytes
+   */
+  uint64_t (*getVectorIndexTotalMemory)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
+
+  /**
    * @brief Output aggregated disk metrics to Redis INFO
    *
    * Iterates over all collected index metrics, aggregates them, and outputs


### PR DESCRIPTION
Add basic disk metric API

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an API/ABI surface change by adding new function pointers to `RedisSearchDiskAPI.metrics`, requiring all disk backend implementations to provide them and potentially affecting compatibility if not updated.
> 
> **Overview**
> Extends the disk metrics API to expose **per-component memory totals** (doc table, inverted index, vector index) in addition to the existing aggregate snapshot.
> 
> Adds new `SearchDisk_Get*TotalMemory()` wrapper functions and corresponding `RedisSearchDiskAPI.metrics` function pointers, with header documentation clarifying that callers should invoke `SearchDisk_CollectIndexMetrics()` first (intended for `FT.INFO` disk usage breakdown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c60db20972712383287318b845daecd6fdfd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->