### PR TITLE
[MOD-12457] remove C-Code comments

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
         return ptr::null_mut();
     };
 
-    // C-Code: each NumericIterator must carry its NumericFilter so that
+    // Each NumericIterator must carry its NumericFilter so that
     // `NumericInvIndIterator_GetNumericFilter` can hand it back to C profiling code, which uses
     // the embedded `geo_filter` pointer to display the geo term as coordinates instead of raw
     // geohash values. Once profiling is fully ported to Rust, this wrapper can be dropped and

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -25,7 +25,7 @@ use rqe_iterators::{
 pub(super) struct NumericIterator<'index> {
     /// The user numeric filter, or None if no filter was provided.
     ///
-    /// C-Code: kept here (rather than in `rqe_iterators`) solely so that
+    /// Kept here (rather than in `rqe_iterators`) solely so that
     /// `NumericInvIndIterator_GetNumericFilter` can hand the pointer back to C callers.
     /// Once those callers are ported to Rust, this field and `NumericIterator` itself can be
     /// removed — callers will use [`NumericIteratorVariant`] directly.

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -337,8 +337,6 @@ fn purely_numeric_children_always_true() {
 
 // ── is_within_range — full integration ───────────────────────────────────
 
-/// C-Code: Mirrors the C++ `testDistance` test using the full `is_within_range` entry point.
-///
 /// vw1 = {1, 9, 13, 16, 22}, vw2 = {4, 7, 32}
 #[test]
 fn full_test_mirrors_cpp_testdistance() {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
@@ -115,7 +115,7 @@ type GeoFilterAndRangeIterator<'index> =
 /// [`GEO_RANGE_COUNT`] contiguous geohash ranges; each range is queried via the numeric range
 /// tree. Returns one `(filter, variants)` pair per non-trivial range so that callers can
 /// associate each [`NumericIteratorVariant`] with its [`NumericFilter`] (needed by C profiling;
-/// see the `C-Code:` comment in `NewGeoRangeIterator`).
+/// see the comment in `NewGeoRangeIterator`).
 ///
 /// Returns:
 /// - `Err(`[`GeoRangeError::InvalidInput`]`)` if `gf`'s parameters are invalid.

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -191,9 +191,8 @@ where
         Ok(Some(&mut self.result))
     }
 
-    // C-Code: SkipTo for OPTIONAL iterator - Non-optimized version.
-    // Skip to a specific docId. If the child has a hit on this docId, return it.
-    // Otherwise, return a virtual hit.
+    /// Skip to a specific docId. If the child has a hit on this docId, return it.
+    /// Otherwise, return a virtual hit.
     fn skip_to(
         &mut self,
         doc_id: t_docId,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -67,8 +67,6 @@ mod optional_iterator_tests {
     const NUM_DOCS: usize = 5;
     const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30, 50, 80];
 
-    // C-Code: port of OptionalIteratorTest::SetUp
-    // as found in tests/cpptests/test_cpp_iterator_optional.cpp
     fn setup_optional_iterator_with_mock_child<'index>()
     -> Optional<'index, utils::Mock<'index, NUM_DOCS>> {
         // Create child iterator with specific docIds
@@ -350,8 +348,6 @@ mod optional_iterator_timeout_tests {
     const NUM_DOCS: usize = 3;
     const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30];
 
-    // C-Code: port of OptionalIteratorTimeoutTest::SetUp
-    // as found in tests/cpptests/test_cpp_iterator_optional.cpp
     fn setup_optional_iterator_with_mock_child<'index>()
     -> Optional<'index, utils::Mock<'index, NUM_DOCS>> {
         // Create child iterator with specific docIds
@@ -469,8 +465,6 @@ mod optional_iterator_with_empty_child_test {
     const MAX_DOC_ID: t_docId = 50;
     const WEIGHT: f64 = 3.;
 
-    // C-Code: port of OptionalIteratorWithEmptyChildTest::SetUp
-    // as found in tests/cpptests/test_cpp_iterator_optional.cpp
     fn setup_optional_iterator_with_empty_child<'index>() -> Optional<'index, Empty> {
         // Create empty child iterator
         let child = Empty::default();
@@ -658,8 +652,6 @@ mod optional_iterator_revalidate_test {
     const NUM_DOCS: usize = 5;
     const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30, 50, 80];
 
-    // C-Code: port of OptionalIteratorRevalidateTest::SetUp
-    // as found in tests/cpptests/test_cpp_iterator_optional.cpp
     fn setup_optional_iterator_with_mock_child_and_data<'index>() -> (
         Optional<'index, utils::Mock<'index, NUM_DOCS>>,
         utils::MockData,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -255,9 +255,6 @@ mod optional_optimized_iterator_tests {
         assert!(it.at_eof());
     }
 
-    /// C-Code: Exhaustive skip_to coverage ported from `OptionalIteratorOptimized::SkipTo`
-    /// (nested-loop section) in `tests/cpptests/test_cpp_iterator_optional.cpp`.
-    ///
     /// For every ordered pair `(from_id, skip_to_id)` drawn from the wildcard document
     /// range, rewinds the iterator, positions it at `from_id`, then calls `skip_to`
     /// targeting `skip_to_id`. Verifies that:
@@ -843,9 +840,6 @@ mod optional_optimized_iterator_revalidate_tests {
         assert_eq!(wcii_data.revalidate_count(), 1);
     }
 
-    /// C-Code: Ported from `RevalidateChildAborted_WildcardMoved` in
-    /// `tests/cpptests/test_cpp_iterator_optional.cpp`.
-    ///
     /// When `child` aborts and `wcii` moves simultaneously, the iterator must:
     /// - Replace `child` with `Empty`.
     /// - Return `Moved` at the new `wcii` position (virtual hit, since child is gone).
@@ -880,9 +874,6 @@ mod optional_optimized_iterator_revalidate_tests {
         assert_eq!(child_data.revalidate_count(), 1);
     }
 
-    /// C-Code: Ported from `RevalidateChildMoved_WildcardAborted` in
-    /// `tests/cpptests/test_cpp_iterator_optional.cpp`.
-    ///
     /// When `wcii` aborts the entire optional iterator must abort immediately,
     /// without even revalidating `child`.
     #[test]
@@ -906,9 +897,6 @@ mod optional_optimized_iterator_revalidate_tests {
         assert_eq!(child_data.revalidate_count(), 0);
     }
 
-    /// C-Code: Ported from `RevalidateChildMoved_WildcardMoved` in
-    /// `tests/cpptests/test_cpp_iterator_optional.cpp`.
-    ///
     /// When both `wcii` and `child` move, the iterator must return `Moved` at
     /// `wcii`'s new position, with the appropriate real-vs-virtual result.
     #[test]


### PR DESCRIPTION
Those comments used to reference C/C++ code that is now fully ported to Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits that remove outdated references to the former C/C++ implementation; no functional logic changes or data/FFI behavior modifications.
> 
> **Overview**
> Removes/rewrites outdated `C-Code:` references across geo/numeric iterator code and iterator tests, converting a few inline comments into regular Rust doc comments.
> 
> No behavior changes: the PR is strictly documentation/comment cleanup around geo/numeric iterator profiling notes and optional iterator test fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c717798d4e8f0ecdf2e836999e5baab294341d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->