### PR TITLE
[8.6-rse] MOD-14268: Fix coordinator RQ completion timing

### DIFF
--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -257,7 +257,6 @@ static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
   UNUSED(ctx);
   if (p) {
     MRCtx *mc = p;
-    /* RQ completion is owned by the libuv fanout-completion paths. */
     MRCtx_DecrRef(mc);
   }
 }
@@ -302,17 +301,12 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
     ctx->replies[ctx->numReplied++] = r;
   }
 
-  // If we've received the last reply, the fanout/network phase is complete.
-  // Release the RQ slot here before unblocking or handing off to reduction.
+  // If we've received the last reply - unblock the client
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
+    IORuntimeCtx_RequestCompleted(ioRuntime);
     if (!timedOut && ctx->fn) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
-      // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
-      // before this libuv callback is scheduled again. Complete the RQ request via
-      // the saved ioRuntime instead of reading more state from `ctx` after the handoff.
-      IORuntimeCtx_RequestCompleted(ioRuntime);
     } else {
-      IORuntimeCtx_RequestCompleted(ioRuntime);
       if (!timedOut) {
         RedisModuleBlockedClient *bc = ctx->bc;
         RS_ASSERT(bc);
@@ -340,6 +334,7 @@ static void uvFanoutRequest(void *p) {
   if (mrctx->numExpected == 0) {
     // No shard command was sent, so fanoutCallback() will never fire.
     IORuntimeCtx_RequestCompleted(ioRuntime);
+
     if (!MRCtx_IsTimedOut(mrctx)) {
       RedisModuleBlockedClient *bc = mrctx->bc;
       RS_ASSERT(bc);


### PR DESCRIPTION
## Summary

Original PR: https://github.com/RediSearch/RediSearch/pull/8774

This 8.6-rse PR now keeps the MRCtx lifetime/refcount guard. The sanitizer timeout run showed this branch still needs it: blocked-client timeout cleanup can run while fanout/reducer work still holds and uses the same MRCtx.

The scoped fix kept here is the queue-drain behavior: `IORuntimeCtx_RequestCompleted()` is completed once from the fanout completion path, before reducer/unblock decisions, including the no-shards path.

## Diff References

- Expected net diff (pure original backport + partial revert/fix): https://github.com/RediSearch/RediSearch/compare/f3baa7544d8492d2f292e9cadf1cdf07826a205f...mod-14268-expected-net-8.6-rse

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes