### PR TITLE
[8.4] MOD-14268: Remove coordinator MRCtx refcount

### DIFF
--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -28,7 +28,6 @@
 #include <pthread.h>
 #include <sys/param.h>
 #include <stddef.h>
-#include <stdatomic.h>
 
 #include "hiredis/hiredis.h"
 #include "hiredis/async.h"
@@ -61,7 +60,6 @@ long long timeout_g = 5000; // unused value. will be set in MR_Init
 
 /* MapReduce context for a specific command's execution */
 typedef struct MRCtx {
-  _Atomic(int) refcount;
   int numReplied;
   int numExpected;
   int numErrored;
@@ -88,7 +86,6 @@ typedef struct MRCtx {
    * needs to unblock the client.
    */
   MRReduceFunc fn;
-  MRCtxFreePrivDataCB freePrivDataCB;
 } MRCtx;
 
 // Data structure to pass iterator and private data to callback
@@ -101,7 +98,6 @@ typedef struct {
 MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *privdata, int replyCap) {
   RS_ASSERT(cluster_g);
   MRCtx *ret = rm_calloc(1, sizeof(MRCtx));
-  atomic_init(&ret->refcount, 1);
   ret->numReplied = 0;
   ret->numErrored = 0;
   ret->numExpected = 0;
@@ -115,18 +111,10 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   ret->fn = NULL;
   ret->validateConnections = false;
   ret->ioRuntime = MRCluster_GetIORuntimeCtx(cluster_g, MRCluster_AssignRoundRobinIORuntimeIdx(cluster_g));
-  ret->freePrivDataCB = NULL;
   return ret;
 }
 
-void MRCtx_SetFreePrivDataCB(MRCtx *ctx, MRCtxFreePrivDataCB cb) {
-  ctx->freePrivDataCB = cb;
-}
-
-static void MRCtx_FreeInternal(MRCtx *ctx) {
-  if (ctx->freePrivDataCB) {
-    ctx->freePrivDataCB(ctx);
-  }
+void MRCtx_Free(MRCtx *ctx) {
 
   MRCommand_Free(&ctx->cmd);
 
@@ -142,22 +130,6 @@ static void MRCtx_FreeInternal(MRCtx *ctx) {
   rm_free(ctx);
 }
 
-void MRCtx_IncrRef(MRCtx *ctx) {
-  int refcount = atomic_fetch_add(&ctx->refcount, 1) + 1;
-  REFCOUNT_INCR_MSG("MRCtx_IncrRef", refcount);
-}
-
-void MRCtx_DecrRef(MRCtx *ctx) {
-  int prev_refcount = atomic_fetch_sub(&ctx->refcount, 1);
-  RS_ASSERT(prev_refcount > 0);
-
-  int refcount = prev_refcount - 1;
-  REFCOUNT_DECR_MSG("MRCtx_DecrRef", refcount);
-  if (refcount == 0) {
-    MRCtx_FreeInternal(ctx);
-  }
-}
-
 /* Get the user stored private data from the context */
 void *MRCtx_GetPrivData(struct MRCtx *ctx) {
   return ctx->privdata;
@@ -169,10 +141,6 @@ int MRCtx_GetNumReplied(struct MRCtx *ctx) {
 
 MRReply** MRCtx_GetReplies(struct MRCtx *ctx) {
   return ctx->replies;
-}
-
-void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc) {
-  ctx->bc = bc;
 }
 
 RedisModuleCtx *MRCtx_GetRedisCtx(struct MRCtx *ctx) {
@@ -199,8 +167,7 @@ static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
   UNUSED(ctx);
   if (p) {
     MRCtx *mc = p;
-    /* RQ completion is owned by the libuv fanout-completion paths. */
-    MRCtx_DecrRef(mc);
+    MRCtx_Free(mc);
   }
 }
 
@@ -238,20 +205,15 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   // If we've received the last reply, the fanout/network phase is complete.
   // Release the RQ slot here before unblocking or handing off to reduction.
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
+    IORuntimeCtx_RequestCompleted(ioRuntime);
     if (ctx->fn) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
-      // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
-      // before this libuv callback is scheduled again. Complete the RQ request via
-      // the saved ioRuntime instead of reading more state from `ctx` after the handoff.
-      IORuntimeCtx_RequestCompleted(ioRuntime);
     } else {
-      IORuntimeCtx_RequestCompleted(ioRuntime);
       RedisModuleBlockedClient *bc = ctx->bc;
       RS_ASSERT(bc);
       RedisModule_BlockedClientMeasureTimeEnd(bc);
       RedisModule_UnblockClient(bc, ctx);
     }
-    MRCtx_DecrRef(ctx);
   }
 }
 
@@ -276,8 +238,6 @@ static void uvFanoutRequest(void *p) {
     RS_ASSERT(bc);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mrctx);
-
-    MRCtx_DecrRef(mrctx);
   }
 }
 
@@ -294,7 +254,7 @@ int MR_Fanout(struct MRCtx *mrctx, MRReduceFunc reducer, MRCommand cmd, bool blo
   mrctx->reducer = reducer;
   mrctx->cmd = cmd;
 
-  MRCtx_IncrRef(mrctx);
+
   IORuntimeCtx_Schedule(mrctx->ioRuntime, uvFanoutRequest, mrctx);
   return REDIS_OK;
 }

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -33,7 +33,6 @@ void iterCursorMappingCb(void *p);
 
 /* Prototype for all reduce functions */
 typedef int (*MRReduceFunc)(struct MRCtx *ctx, int count, MRReply **replies);
-typedef void (*MRCtxFreePrivDataCB)(struct MRCtx *ctx);
 
 /* Fanout map - send the same command to all the shards, sending the collective
  * reply to the reducer callback */
@@ -90,12 +89,9 @@ MRReply** MRCtx_GetReplies(struct MRCtx *ctx);
 RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx);
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn);
 
-void MRCtx_IncrRef(struct MRCtx *ctx);
-void MRCtx_DecrRef(struct MRCtx *ctx);
-void MRCtx_SetFreePrivDataCB(struct MRCtx *ctx, MRCtxFreePrivDataCB cb);
 
-/* Set the blocked client for the context (used when MRCtx is created before blocking) */
-void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc);
+/* Free the MapReduce context */
+void MRCtx_Free(struct MRCtx *ctx);
 
 void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
 bool MRCtx_GetValidateConnections(struct MRCtx *ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -3112,11 +3112,9 @@ void sendSearchResults_EmptyResults(RedisModule_Reply *reply, searchRequestCtx *
 static void searchResultReducer_wrapper(void *mc_v) {
   struct MRCtx *mc = mc_v;
   searchResultReducer(mc, MRCtx_GetNumReplied(mc), MRCtx_GetReplies(mc));
-  MRCtx_DecrRef(mc);
 }
 
 static int searchResultReducer_background(struct MRCtx *mc, int count, MRReply **replies) {
-  MRCtx_IncrRef(mc);
   ConcurrentSearch_ThreadPoolRun(searchResultReducer_wrapper, mc, DIST_THREADPOOL);
   return REDISMODULE_OK;
 }
@@ -3275,12 +3273,13 @@ cleanup:
   }
 
   RedisModule_BlockedClientMeasureTimeEnd(bc);
-  // Reducer already replied — unblock with NULL to prevent
-  // DistSearchUnblockClient from double-replying.
+  // The reducer already replied, so unblock with NULL to prevent
+  // DistSearchUnblockClient from double-replying. The RQ slot is released
+  // from fanoutCallback when the shard fanout finishes.
   RedisModule_UnblockClient(bc, NULL);
   RedisModule_FreeThreadSafeContext(ctx);
-  // Compensate for DistSearchFreePrivData not receiving mc.
-  MRCtx_DecrRef(mc);
+  searchRequestCtx_Free(req);
+  MRCtx_Free(mc);
   return res;
 }
 
@@ -3696,23 +3695,16 @@ void sendRequiredFields(searchRequestCtx *req, MRCommand *cmd) {
 }
 
 static void bailOut(RedisModuleBlockedClient *bc, QueryError *status) {
-  struct MRCtx *mrctx = RedisModule_BlockClientGetPrivateData(bc);
   RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
   QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
   QueryError_ReplyAndClear(clientCtx, status);
   RedisModule_BlockedClientMeasureTimeEnd(bc);
-  // Unblock with NULL since we already replied. DistSearchUnblockClient will
-  // see NULL privdata and skip replying, avoiding a double-reply.
-  // Manually DecrRef mrctx to compensate for DistSearchFreePrivData not
-  // receiving it (it gets NULL and does nothing).
   RedisModule_UnblockClient(bc, NULL);
   RedisModule_FreeThreadSafeContext(clientCtx);
-  MRCtx_DecrRef(mrctx);
 }
 
-static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, struct MRCtx *mrctx, int protocol,
+static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, WeakRef spec_ref, QueryError *status) {
-  RedisModuleBlockedClient *bc = MRCtx_GetBlockedClient(mrctx);
 
   cmd->protocol = protocol;
 
@@ -3769,7 +3761,7 @@ static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, struct MRCtx *m
   IndexSpec *sp = StrongRef_Get(strong_ref);
   if (!sp) {
     MRCommand_Free(cmd);
-    // Don't free req here - DistSearchMRCtxFreePrivData will handle it via MRCtx cleanup
+    searchRequestCtx_Free(req);
     QueryError_SetCode(status, QUERY_EDROPPEDBACKGROUND);
     bailOut(bc, status);
     return REDISMODULE_ERR;
@@ -3801,22 +3793,38 @@ static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, struct MRCtx *m
   return REDISMODULE_OK;
 }
 
-int FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, int protocol,
+static searchRequestCtx *createReq(RedisModuleString **argv, int argc, RedisModuleBlockedClient *bc, QueryError *status) {
+  searchRequestCtx *req = rscParseRequest(argv, argc, status);
+
+  if (!req) {
+    bailOut(bc, status);
+    return NULL;
+  }
+  return req;
+}
+
+int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, ConcurrentSearchHandlerCtx *handlerCtx) {
   QueryError status = QueryError_Default();
 
-  // req was created on the main thread and set as mrctx privdata
-  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-  RS_ASSERT(req);
+  searchRequestCtx *req = createReq(argv, argc, bc, &status);
+
+  if (!req) {
+    return REDISMODULE_OK;
+  }
 
   // Copy coordinator queue time for profile output
   req->coordQueueTime = handlerCtx->coordQueueTime;
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
-  int rc = prepareCommand(&cmd, req, mrctx, protocol, argv, argc, handlerCtx->spec_ref, &status);
+
+  int rc = prepareCommand(&cmd, req, bc, protocol, argv, argc, handlerCtx->spec_ref, &status);
   if (!(rc == REDISMODULE_OK)) {
     return REDISMODULE_OK;
   }
+  // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
+  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+
   // FT.SEARCH coordinator should validate connections before sending the command to the cluster
   MRCtx_SetValidateConnections(mrctx, true);
 
@@ -3825,30 +3833,10 @@ int FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, 
   return REDISMODULE_OK;
 }
 
-static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
-  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-  if (!req) {
-    return;
-  }
-  searchRequestCtx_Free(req);
-}
-
-// Free privdata callback for distributed search.
-// Called after the reply callback (or timeout callback) completes.
-// Releases only the blocked-client reference; MRCtx cleanup runs on the final release.
-static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
-  UNUSED(ctx);
-  if (privdata) {
-    struct MRCtx *mrctx = privdata;
-    MRCtx_DecrRef(mrctx);
-  }
-}
-
 typedef struct SearchCmdCtx {
   RedisModuleString **argv;
   int argc;
   RedisModuleBlockedClient* bc;
-  struct MRCtx *mrctx;
   int protocol;
   ConcurrentSearchHandlerCtx handlerCtx;
 } SearchCmdCtx;
@@ -3858,25 +3846,33 @@ static void DistSearchCommandHandler(void* pd) {
   if (sCmdCtx->handlerCtx.isProfile) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
-  FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
+  FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
-  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }
 
-// Reply callback for the blocked client. Called when the client is unblocked.
-// The privdata passed to UnblockClient is the MRCtx. Cleanup is handled by
-// DistSearchFreePrivData (the free_privdata callback).
+// If the client is unblocked with a private data, we have to free it.
+// This currently happens only when the client is unblocked without calling its reduce function,
+// because we expect 0 replies. This function handles this case as well.
+static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
+  UNUSED(ctx);
+  if (privdata) {
+    struct MRCtx *mrctx = privdata;
+    searchRequestCtx_Free(MRCtx_GetPrivData(mrctx));
+    MRCtx_Free(mrctx);
+  }
+}
+
 static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  // Nothing to do here - the reducer already replied to the client.
-  // If no reducer ran (0 replies), we need to reply with an error.
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
-  if (mrctx && MRCtx_GetNumReplied(mrctx) == 0) {
+  if (mrctx) {
+    if (MRCtx_GetNumReplied(mrctx) == 0) {
       // Can happen in a topology error, before or after we sent the command to the cluster
-    RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
+      RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
+    }
   }
   return REDISMODULE_OK;
 }
@@ -3944,42 +3940,12 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  QueryError parseStatus = QueryError_Default();
-  int parse_argc = argc;
-  if (isDebug) {
-    AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &parseStatus);
-    if (QueryError_HasError(&parseStatus)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&parseStatus), 1, COORD_ERR_WARN);
-      return QueryError_ReplyAndClear(ctx, &parseStatus);
-    }
-    parse_argc = argc - (debug_params.debug_params_count + 2);
-  }
-
-  // Parse the search request on the main thread so both the standard and debug
-  // paths attach req to mrctx before dispatching to the worker thread.
-  searchRequestCtx *req = rscParseRequest(argv, parse_argc, &parseStatus);
-  if (!req) {
-    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&parseStatus), 1, COORD_ERR_WARN);
-    return QueryError_ReplyAndClear(ctx, &parseStatus);
-  }
-
-  // Create MRCtx on main thread with searchRequestCtx as privdata.
-  // NumShards is used as a hint for reply capacity - unsafe read is fine.
-  struct MRCtx *mrctx = MR_CreateCtx(ctx, NULL, req, NumShards);
-  MRCtx_SetFreePrivDataCB(mrctx, DistSearchMRCtxFreePrivData);
-
-  // Block client - MRCtx is set as privdata so unblock/free callbacks can access it
-  RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, DistSearchFreePrivData, 0);
-  MRCtx_SetBlockedClient(mrctx, bc);
-
-  // Set MRCtx as privdata for the blocked client
-  RedisModule_BlockClientSetPrivateData(bc, mrctx);
-
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->handlerCtx.spec_ref = StrongRef_Demote(spec_ref);
   sCmdCtx->handlerCtx.coordStartTime = coordInitialTime;
   sCmdCtx->handlerCtx.coordQueueTime = 0;
   sCmdCtx->handlerCtx.isProfile = isProfile;
+  RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, DistSearchFreePrivData, 0);
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
   for (size_t i = 0 ; i < argc ; ++i) {
     // We need to copy the argv because it will be freed in the callback (from another thread).
@@ -3987,11 +3953,9 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;
-  sCmdCtx->mrctx = mrctx;
   sCmdCtx->protocol = is_resp3(ctx) ? 3 : 2;
   RedisModule_BlockedClientMeasureTimeStart(bc);
 
-  MRCtx_IncrRef(mrctx);
   ConcurrentSearch_ThreadPoolRun(dist_callback, sCmdCtx, DIST_THREADPOOL);
 
   return REDISMODULE_OK;
@@ -4356,7 +4320,7 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
 }
 /* ======================= DEBUG ONLY ======================= */
 
-static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, int protocol,
+static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, ConcurrentSearchHandlerCtx *handlerCtx) {
   QueryError status = QueryError_Default();
   AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
@@ -4368,15 +4332,17 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
 
   int debug_argv_count = debug_params.debug_params_count + 2;
   int base_argc = argc - debug_argv_count;
-  // req was created on the main thread and set as mrctx privdata before dispatch.
-  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-  RS_ASSERT(req);
+  searchRequestCtx *req = createReq(argv, base_argc, bc, &status);
+
+  if (!req) {
+    return REDISMODULE_OK;
+  }
 
   // Copy coordinator queue time for profile output
   req->coordQueueTime = handlerCtx->coordQueueTime;
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(base_argc, argv);
-  int rc = prepareCommand(&cmd, req, mrctx, protocol, argv, argc, handlerCtx->spec_ref, &status);
+  int rc = prepareCommand(&cmd, req, bc, protocol, argv, argc, handlerCtx->spec_ref, &status);
   if (!(rc == REDISMODULE_OK)) {
     return REDISMODULE_OK;
   }
@@ -4388,6 +4354,9 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
     const char *arg = RedisModule_StringPtrLen(debug_params.debug_argv[i], &n);
     MRCommand_Append(&cmd, arg, n);
   }
+
+  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+
   // FT.SEARCH coordinator should validate connections before sending the command to the cluster
   MRCtx_SetValidateConnections(mrctx, true);
 
@@ -4402,12 +4371,11 @@ static void DEBUG_DistSearchCommandHandler(void* pd) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
   // send argv not including the _FT.DEBUG
-  DEBUG_FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
+  DEBUG_FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
-  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }
 


### PR DESCRIPTION
## Summary

Original PR: https://github.com/RediSearch/RediSearch/pull/8774

Remove the MRCtx refcount/lifetime layer added by the MOD-14268 backport while preserving the actual queue-drain fix: request completion is owned by the fanout completion path.

This restores the previous distributed search ownership flow and keeps request completion in `fanoutCallback` and the no-shard path.

## Diff References

- Expected net diff (pure original backport + partial revert): https://github.com/RediSearch/RediSearch/compare/2b07a41a85cf6d03bfbf4286aae3c39a8dac2ccb...mod-14268-expected-net-8.4

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MapReduce context lifetime management in the coordinator and distributed search paths, which could cause leaks or use-after-free if any edge case still relied on refcounting. Touches request-completion/unblock timing across threads.
> 
> **Overview**
> Removes `MRCtx` atomic refcounting and related APIs, switching to direct `MRCtx_Free()` ownership and cleanup.
> 
> Distributed `FT.SEARCH` (including debug/profile paths) now creates the request context (`searchRequestCtx`) and `MRCtx` in the worker thread, and explicitly frees both after replying; the blocked-client free-privdata handler now only frees when unblocked with a non-NULL privdata.
> 
> Preserves the queue-drain fix by ensuring the RQ slot is released in `fanoutCallback` (and the no-shard path) as soon as shard fanout completes, before any reduction/unblock work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805adb79a3e6f0992337f32367d3efc16251699c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->