### PR TITLE
[2.10] MOD-14268: Remove coordinator MRCtx refcount

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1396,11 +1396,9 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
 static void searchResultReducer_wrapper(void *mc_v) {
   struct MRCtx *mc = mc_v;
   searchResultReducer(mc, MRCtx_GetNumReplied(mc), MRCtx_GetReplies(mc));
-  MRCtx_DecrRef(mc);
 }
 
 static int searchResultReducer_background(struct MRCtx *mc, int count, MRReply **replies) {
-  MRCtx_IncrRef(mc);
   ConcurrentSearch_ThreadPoolRun(searchResultReducer_wrapper, mc, DIST_AGG_THREADPOOL);
   return REDISMODULE_OK;
 }
@@ -1537,12 +1535,16 @@ cleanup:
   }
 
   RedisModule_BlockedClientMeasureTimeEnd(bc);
-  // Reducer already replied — unblock with NULL to prevent
-  // DistSearchUnblockClient from double-replying.
   RedisModule_UnblockClient(bc, NULL);
   RedisModule_FreeThreadSafeContext(ctx);
-  // Compensate for DistSearchFreePrivData not receiving mc.
-  MRCtx_DecrRef(mc);
+  // We could pass `mc` to the unblock function to perform the next 3 cleanup steps, but
+  // this way we free the memory from the background after the client is unblocked,
+  // which is a bit more efficient.
+  // The unblocking callback also replies with error if there was 0 replies from the shards,
+  // and since we already replied with error in this case (in the beginning of this function),
+  // we can't pass `mc` to the unblock function.
+  searchRequestCtx_Free(req);
+  MRCtx_Free(mc);
   return res;
 }
 
@@ -1805,22 +1807,17 @@ void sendRequiredFields(searchRequestCtx *req, MRCommand *cmd) {
 }
 
 static void bailOut(RedisModuleBlockedClient *bc, QueryError *status) {
-  struct MRCtx *mrctx = RedisModule_BlockClientGetPrivateData(bc);
   RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
   QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
   QueryError_ReplyAndClear(clientCtx, status);
   RedisModule_BlockedClientMeasureTimeEnd(bc);
-  // Unblock with NULL since we already replied. DistSearchUnblockClient will
-  // see NULL privdata and skip replying, avoiding a double-reply.
-  // Manually DecrRef mrctx to compensate for DistSearchFreePrivData not
-  // receiving it (it gets NULL and does nothing).
   RedisModule_UnblockClient(bc, NULL);
   RedisModule_FreeThreadSafeContext(clientCtx);
-  MRCtx_DecrRef(mrctx);
 }
 
 static void prepareCommand(MRCommand *cmd, searchRequestCtx *req, int protocol,
                            RedisModuleString **argv, int argc) {
+
   cmd->protocol = protocol;
 
   // Handle KNN with shard ratio optimization for both multi-shard and standalone
@@ -1872,15 +1869,29 @@ static void prepareCommand(MRCommand *cmd, searchRequestCtx *req, int protocol,
   }
 }
 
-int FlatSearchCommandHandler(struct MRCtx *mrctx, int protocol, RedisModuleString **argv, int argc) {
+static searchRequestCtx *createReq(RedisModuleString **argv, int argc, RedisModuleBlockedClient *bc, QueryError *status) {
+  searchRequestCtx *req = rscParseRequest(argv, argc, status);
+
+  if (!req) {
+    bailOut(bc, status);
+    return NULL;
+  }
+  return req;
+}
+
+int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol, RedisModuleString **argv, int argc) {
   QueryError status = {0};
-  // req was created on the main thread and set as mrctx privdata
-  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-  RS_ASSERT(req);
+  searchRequestCtx *req = createReq(argv, argc, bc, &status);
+
+  if (!req) {
+    return REDISMODULE_OK;
+  }
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
   prepareCommand(&cmd, req, protocol, argv, argc);
 
+  // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
+  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
   // FT.SEARCH coordinator should validate connections before sending the command to the cluster
   MRCtx_SetValidateConnections(mrctx, true);
 
@@ -1889,58 +1900,45 @@ int FlatSearchCommandHandler(struct MRCtx *mrctx, int protocol, RedisModuleStrin
   return REDISMODULE_OK;
 }
 
-static void DistSearchMRCtxFreePrivData(struct MRCtx *mrctx) {
-  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-  if (!req) {
-    return;
-  }
-  searchRequestCtx_Free(req);
-}
-
-// Free privdata callback for distributed search.
-// Called after the reply callback (or timeout callback) completes.
-// Releases only the blocked-client reference; MRCtx cleanup runs on the final release.
-static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
-  // UNUSED(ctx);
-  if (privdata) {
-    struct MRCtx *mrctx = privdata;
-    MRCtx_DecrRef(mrctx);
-  }
-}
-
 typedef struct SearchCmdCtx {
   RedisModuleString **argv;
   int argc;
   RedisModuleBlockedClient* bc;
-  struct MRCtx *mrctx;
   int protocol;
 }SearchCmdCtx;
 
 static void DistSearchCommandHandler(void* pd) {
   SearchCmdCtx* sCmdCtx = pd;
-  FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc);
+  FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
-  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }
 
-// Reply callback for the blocked client. Called when the client is unblocked.
-// The privdata passed to UnblockClient is the MRCtx. Cleanup is handled by
-// DistSearchFreePrivData (the free_privdata callback).
+// If the client is unblocked with a private data, we have to free it.
+// This currently happens only when the client is unblocked without calling its reduce function,
+// because we expect 0 replies. This function handles this case as well.
+static void DistSearchFreePrivData(RedisModuleCtx *ctx, void *privdata) {
+  // UNUSED(ctx);
+  if (privdata) {
+    struct MRCtx *mrctx = privdata;
+    searchRequestCtx_Free(MRCtx_GetPrivData(mrctx));
+    MRCtx_Free(mrctx);
+  }
+}
+
 static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  // Nothing to do here - the reducer already replied to the client.
-  // If no reducer ran (0 replies), we need to reply with an error.
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
-  if (mrctx && MRCtx_GetNumReplied(mrctx) == 0) {
-    // Can happen in a topology error, before or after we sent the command to the cluster
-    RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
+  if (mrctx) {
+    if (MRCtx_GetNumReplied(mrctx) == 0) {
+      // Can happen in a topology error, before or after we sent the command to the cluster
+      RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
+    }
   }
   return REDISMODULE_OK;
 }
-
 
 int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
@@ -1966,37 +1964,7 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     dist_callback = DEBUG_DistSearchCommandHandler;
   }
 
-  QueryError parseStatus = {0};
-  int parse_argc = argc;
-  if (isDebug) {
-    AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &parseStatus);
-    if (QueryError_HasError(&parseStatus)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&parseStatus), 1, COORD_ERR_WARN);
-      return QueryError_ReplyAndClear(ctx, &parseStatus);
-    }
-    parse_argc = argc - (debug_params.debug_params_count + 2);
-  }
-
-  // Parse the search request on the main thread so both the standard and debug
-  // paths attach req to mrctx before dispatching to the worker thread.
-  searchRequestCtx *req = rscParseRequest(argv, parse_argc, &parseStatus);
-  if (!req) {
-    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&parseStatus), 1, COORD_ERR_WARN);
-    return QueryError_ReplyAndClear(ctx, &parseStatus);
-  }
-
-  // Create MRCtx on main thread with searchRequestCtx as privdata.
-  // NumShards is used as a hint for reply capacity - unsafe read is fine.
-  struct MRCtx *mrctx = MR_CreateCtx(ctx, NULL, req, NumShards);
-  MRCtx_SetFreePrivDataCB(mrctx, DistSearchMRCtxFreePrivData);
-
-  // Block client - MRCtx is set as privdata so unblock/free callbacks can access it
   RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, DistSearchFreePrivData, 0);
-  MRCtx_SetBlockedClient(mrctx, bc);
-
-  // Set MRCtx as privdata for the blocked client
-  RedisModule_BlockClientSetPrivateData(bc, mrctx);
-
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
   for (size_t i = 0 ; i < argc ; ++i) {
@@ -2005,10 +1973,8 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;
-  sCmdCtx->mrctx = mrctx;
   sCmdCtx->protocol = is_resp3(ctx) ? 3 : 2;
   RedisModule_BlockedClientMeasureTimeStart(bc);
-  MRCtx_IncrRef(mrctx);
   ConcurrentSearch_ThreadPoolRun(dist_callback, sCmdCtx, DIST_AGG_THREADPOOL);
 
   return REDISMODULE_OK;
@@ -2279,7 +2245,7 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 /* ======================= DEBUG ONLY ======================= */
 
-static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlockedClient *bc, int protocol, RedisModuleString **argv, int argc) {
+static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol, RedisModuleString **argv, int argc) {
   QueryError status = {0};
   AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
 
@@ -2290,9 +2256,11 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
 
   int debug_argv_count = debug_params.debug_params_count + 2;
   int base_argc = argc - debug_argv_count;
-  // req was created on the main thread and set as mrctx privdata before dispatch.
-  searchRequestCtx *req = MRCtx_GetPrivData(mrctx);
-  RS_ASSERT(req);
+  searchRequestCtx *req = createReq(argv, argc, bc, &status);
+
+  if (!req) {
+    return REDISMODULE_OK;
+  }
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(base_argc, argv);
   prepareCommand(&cmd, req, protocol, argv, argc);
@@ -2305,6 +2273,7 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
     MRCommand_Append(&cmd, arg, n);
   }
 
+  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
   // FT.SEARCH coordinator should validate connections before sending the command to the cluster
   MRCtx_SetValidateConnections(mrctx, true);
 
@@ -2316,11 +2285,10 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
 static void DEBUG_DistSearchCommandHandler(void* pd) {
   SearchCmdCtx* sCmdCtx = pd;
   // send argv not including the _FT.DEBUG
-  DEBUG_FlatSearchCommandHandler(sCmdCtx->mrctx, sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc);
+  DEBUG_FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
   }
   rm_free(sCmdCtx->argv);
-  MRCtx_DecrRef(sCmdCtx->mrctx);
   rm_free(sCmdCtx);
 }

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -25,15 +25,14 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/param.h>
-#include <stdatomic.h>
 
 #include "hiredis/hiredis.h"
 #include "hiredis/async.h"
 
 #define REFCOUNT_INCR_MSG(caller, refcount) \
-  RS_DEBUG_LOG_FMT("%s: increased refCount to == %d", caller, refcount);
+  RS_DEBUG_LOG_FMT("%s: increased refCount to == %d", caller, refcount)
 #define REFCOUNT_DECR_MSG(caller, refcount) \
-  RS_DEBUG_LOG_FMT("%s: decreased refCount to == %d", caller, refcount);
+  RS_DEBUG_LOG_FMT("%s: decreased refCount to == %d", caller, refcount)
 
 #define CLUSTER_QUERY_ERROR "Could not send query to cluster"
 
@@ -46,7 +45,6 @@ long long timeout_g = 5000; // unused value. will be set in MR_Init
 
 /* MapReduce context for a specific command's execution */
 typedef struct MRCtx {
-  _Atomic(int) refcount;
   int numReplied;
   int numExpected;
   int numErrored;
@@ -73,7 +71,6 @@ typedef struct MRCtx {
    * needs to unblock the client.
    */
   MRReduceFunc fn;
-  MRCtxFreePrivDataCB freePrivDataCB;
 } MRCtx;
 
 void MR_SetCoordinationStrategy(MRCtx *ctx, bool mastersOnly) {
@@ -83,7 +80,6 @@ void MR_SetCoordinationStrategy(MRCtx *ctx, bool mastersOnly) {
 /* Create a new MapReduce context */
 MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *privdata, int replyCap) {
   MRCtx *ret = rm_calloc(1, sizeof(MRCtx));
-  atomic_init(&ret->refcount, 1);
   ret->numReplied = 0;
   ret->numErrored = 0;
   ret->numExpected = 0;
@@ -97,18 +93,10 @@ MRCtx *MR_CreateCtx(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc, void *pri
   RS_ASSERT(ctx || bc);
   ret->fn = NULL;
   ret->validateConnections = false;
-  ret->freePrivDataCB = NULL;
   return ret;
 }
 
-void MRCtx_SetFreePrivDataCB(MRCtx *ctx, MRCtxFreePrivDataCB cb) {
-  ctx->freePrivDataCB = cb;
-}
-
-static void MRCtx_FreeInternal(MRCtx *ctx) {
-  if (ctx->freePrivDataCB) {
-    ctx->freePrivDataCB(ctx);
-  }
+void MRCtx_Free(MRCtx *ctx) {
 
   MRCommand_Free(&ctx->cmd);
 
@@ -124,22 +112,6 @@ static void MRCtx_FreeInternal(MRCtx *ctx) {
   rm_free(ctx);
 }
 
-void MRCtx_IncrRef(MRCtx *ctx) {
-  int refcount = atomic_fetch_add(&ctx->refcount, 1) + 1;
-  REFCOUNT_INCR_MSG("MRCtx_IncrRef", refcount);
-}
-
-void MRCtx_DecrRef(MRCtx *ctx) {
-  int prev_refcount = atomic_fetch_sub(&ctx->refcount, 1);
-  RS_ASSERT(prev_refcount > 0);
-
-  int refcount = prev_refcount - 1;
-  REFCOUNT_DECR_MSG("MRCtx_DecrRef", refcount);
-  if (refcount == 0) {
-    MRCtx_FreeInternal(ctx);
-  }
-}
-
 /* Get the user stored private data from the context */
 void *MRCtx_GetPrivData(struct MRCtx *ctx) {
   return ctx->privdata;
@@ -151,10 +123,6 @@ int MRCtx_GetNumReplied(struct MRCtx *ctx) {
 
 MRReply** MRCtx_GetReplies(struct MRCtx *ctx) {
   return ctx->replies;
-}
-
-void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc) {
-  ctx->bc = bc;
 }
 
 RedisModuleCtx *MRCtx_GetRedisCtx(struct MRCtx *ctx) {
@@ -180,8 +148,7 @@ bool MRCtx_GetValidateConnections(struct MRCtx *ctx) {
 static void freePrivDataCB(RedisModuleCtx *ctx, void *p) {
   if (p) {
     MRCtx *mc = p;
-    /* RQ completion is owned by the libuv fanout-completion paths. */
-    MRCtx_DecrRef(mc);
+    MRCtx_Free(mc);
   }
 }
 
@@ -200,7 +167,8 @@ static int unblockHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   return mc->reducer(mc, mc->numReplied, mc->replies);
 }
 
-/* The callback called from each fanout request to aggregate their replies */
+// If we've received the last reply, the fanout/network phase is complete.
+// Release the RQ slot here before unblocking or handing off to reduction.
 static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
   MRCtx *ctx = privdata;
 
@@ -216,23 +184,17 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
     ctx->replies[ctx->numReplied++] = r;
   }
 
-  // If we've received the last reply, the fanout/network phase is complete.
-  // Release the RQ slot here before unblocking or handing off to reduction.
+  // If we've received the last reply - unblock the client
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
+    MR_requestCompleted();
     if (ctx->fn) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
-      // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
-      // before this libuv callback is scheduled again. Complete the RQ request via
-      // the saved ioRuntime instead of reading more state from `ctx` after the handoff.
-      MR_requestCompleted();
     } else {
-      MR_requestCompleted();
       RedisModuleBlockedClient *bc = ctx->bc;
       RS_ASSERT(bc);
       RedisModule_BlockedClientMeasureTimeEnd(bc);
       RedisModule_UnblockClient(bc, ctx);
     }
-    MRCtx_DecrRef(ctx);
   }
 }
 
@@ -274,7 +236,6 @@ static void uvFanoutRequest(void *p) {
     RS_ASSERT(bc);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mrctx);
-    MRCtx_DecrRef(mrctx);
   }
 }
 
@@ -291,7 +252,6 @@ static void uvMapRequest(void *p) {
     RS_ASSERT(bc);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, mrctx);
-    MRCtx_DecrRef(mrctx);
   }
 }
 
@@ -310,7 +270,6 @@ int MR_Fanout(struct MRCtx *mrctx, MRReduceFunc reducer, MRCommand cmd, bool blo
   }
   mrctx->reducer = reducer;
   mrctx->cmd = cmd;
-  MRCtx_IncrRef(mrctx);
   RQ_Push(rq_g, uvFanoutRequest, mrctx);
   return REDIS_OK;
 }
@@ -321,7 +280,6 @@ int MR_MapSingle(struct MRCtx *ctx, MRReduceFunc reducer, MRCommand cmd) {
   RS_ASSERT(!ctx->bc);
   ctx->bc = RedisModule_BlockClient(ctx->redisCtx, unblockHandler, timeoutHandler, freePrivDataCB, 0); // timeout_g);
   RedisModule_BlockedClientMeasureTimeStart(ctx->bc);
-  MRCtx_IncrRef(ctx);
   RQ_Push(rq_g, uvMapRequest, ctx);
   return REDIS_OK;
 }

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -21,7 +21,6 @@ void iterStartCb(void *p);
 
 /* Prototype for all reduce functions */
 typedef int (*MRReduceFunc)(struct MRCtx *ctx, int count, MRReply **replies);
-typedef void (*MRCtxFreePrivDataCB)(struct MRCtx *ctx);
 
 /* Fanout map - send the same command to all the shards, sending the collective
  * reply to the reducer callback */
@@ -64,12 +63,9 @@ RedisModuleBlockedClient *MRCtx_GetBlockedClient(struct MRCtx *ctx);
 void MRCtx_SetReduceFunction(struct MRCtx *ctx, MRReduceFunc fn);
 void MR_requestCompleted();
 
-void MRCtx_IncrRef(struct MRCtx *ctx);
-void MRCtx_DecrRef(struct MRCtx *ctx);
-void MRCtx_SetFreePrivDataCB(struct MRCtx *ctx, MRCtxFreePrivDataCB cb);
 
-/* Set the blocked client for the context (used when MRCtx is created before blocking) */
-void MRCtx_SetBlockedClient(struct MRCtx *ctx, RedisModuleBlockedClient *bc);
+/* Free the MapReduce context */
+void MRCtx_Free(struct MRCtx *ctx);
 
 void MRCtx_SetValidateConnections(struct MRCtx *ctx, bool validateConnections);
 bool MRCtx_GetValidateConnections(struct MRCtx *ctx);


### PR DESCRIPTION
## Summary

Original PR: https://github.com/RediSearch/RediSearch/pull/8774

Remove the MRCtx refcount/lifetime layer added by the MOD-14268 backport while preserving the actual queue-drain fix: request completion is owned by the fanout completion path.

This branch uses `MR_requestCompleted`, so the completion call stays in `fanoutCallback` and the no-shard fanout/map paths, while the old free paths no longer complete the queue slot.

## Diff References

- Expected net diff (pure original backport + partial revert): https://github.com/RediSearch/RediSearch/compare/06cbe1d26eafbee8755229825d11ae589504e082...mod-14268-expected-net-2.10

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MRCtx lifetime/cleanup and blocked-client unblocking paths in the coordinator, which could cause leaks or use-after-free if any edge case is missed. Scope is limited to distributed search/map-reduce coordination and does not alter query semantics.
> 
> **Overview**
> Removes coordinator `MRCtx` refcounting and the associated free callbacks, switching to explicit `MRCtx_Free()` ownership at unblock/cleanup time while keeping the queue-drain fix (`MR_requestCompleted()`) owned by the fanout completion path.
> 
> Refactors distributed `FT.SEARCH` (and debug path) to parse `searchRequestCtx` on the worker thread and to perform request/context cleanup after replying, with explicit handling for the *0 shard replies* error/unblock case to avoid double replies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed45865dcd212e8abb2d2e32998a043099bcfcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->