### PR TITLE
RED-186133 Support Boost versions older than 1.86 for SHA1 digest

### DIFF
--- a/src/util/hash/hash.cpp
+++ b/src/util/hash/hash.cpp
@@ -8,12 +8,28 @@
 */
 
 #include "hash.h"
+#include <boost/version.hpp>
 #include <boost/uuid/detail/sha1.hpp>
 
 void Sha1_Compute(const char *value, size_t len, Sha1* output) {
   boost::uuids::detail::sha1 sha1;
   sha1.process_bytes(value, len);
+#if BOOST_VERSION >= 108600
+  // Boost 1.86+: digest_type is unsigned char[20], stored as big-endian bytes.
   sha1.get_digest(output->hash);
+#else
+  // Boost < 1.86: digest_type is unsigned int[5] (host-endian words).
+  // Convert each 32-bit word to big-endian bytes to match the layout
+  // expected by Sha1_FormatIntoBuffer.
+  boost::uuids::detail::sha1::digest_type digest;
+  sha1.get_digest(digest);
+  for (int i = 0; i < 5; i++) {
+    output->hash[i*4]   = static_cast<unsigned char>((digest[i] >> 24) & 0xFF);
+    output->hash[i*4+1] = static_cast<unsigned char>((digest[i] >> 16) & 0xFF);
+    output->hash[i*4+2] = static_cast<unsigned char>((digest[i] >> 8)  & 0xFF);
+    output->hash[i*4+3] = static_cast<unsigned char>( digest[i]        & 0xFF);
+  }
+#endif
 }
 
 void Sha1_FormatIntoBuffer(const Sha1 *sha1, char *buffer) {


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SHA-1 byte formatting based on Boost version; any mistake could change generated hashes and thus obfuscated identifiers across builds or upgrades.
> 
> **Overview**
> Updates `Sha1_Compute` to handle Boost’s SHA1 `digest_type` change in 1.86 by branching on `BOOST_VERSION`.
> 
> For Boost < 1.86, it now reads the 5x32-bit-word digest and explicitly converts it to big-endian bytes so downstream formatting (e.g., `Sha1_FormatIntoBuffer`) produces consistent 40-char hex output across Boost versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a42bd5491bf3f3bffd5b72926239c75e1110f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->