### PR TITLE
Fix missing env for mac user

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -269,6 +269,26 @@ setup_build_environment() {
   # Create full variant string for the build directory
   FULL_VARIANT="${OS_NAME}-${ARCH}-${FLAVOR}"
 
+  if [[ "$OS_NAME" == "macos" ]]; then
+    # `bindgen` needs the macOS SDK headers. Set the correct path
+    export SDKROOT="${SDKROOT:-$(xcrun --show-sdk-path)}"
+
+    if [[ "$COV" == "1" ]]; then
+      # If lcov isn't on PATH yet, try Homebrew's Apple Silicon bin dir
+      # before giving up.
+      if ! command -v lcov >/dev/null 2>&1; then
+        if [[ -d /opt/homebrew/bin ]]; then
+          export PATH="/opt/homebrew/bin:$PATH"
+        fi
+        if ! command -v lcov >/dev/null 2>&1; then
+          echo "Error: COV=1 requires 'lcov' on PATH but it was not found."
+          echo "Install it with: brew install lcov"
+          exit 1
+        fi
+      fi
+    fi
+  fi
+
   # Set BINDIR based on configuration and FULL_VARIANT
   if [[ "$COORD" == "oss" ]]; then
     OUTDIR="search-community"


### PR DESCRIPTION
## Describe the changes in the pull request

The followings are required for mac user:
- SDKROOT env vars points to the correct folder
- lcov should be installed for the coverage

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `build.sh` environment setup on macOS and only add checks/exports, but could affect local macOS build/coverage runs if assumptions about `xcrun`/Homebrew paths differ.
> 
> **Overview**
> Adds macOS-specific build environment setup in `build.sh`: exports `SDKROOT` from `xcrun` to ensure `bindgen` can find SDK headers, and when `COV=1` ensures `lcov` is available (optionally prepending `/opt/homebrew/bin`) or fails fast with install instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ccf944a7ca4c12b1c15e2de2b4b37c3024c8b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->