### PR TITLE
[8.6] MOD-14916 MOD-15104 Expiration perf improvements

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -228,35 +228,55 @@ void DocTable_SetByteOffsets(RSDocumentMetadata *dmd, RSByteOffsets *v) {
   dmd->flags |= Document_HasOffsetVector;
 }
 
+// Pack a t_expirationTimePoint into nanoseconds since the epoch, preserving
+// the {0,0} "no expiration" sentinel as 0 so callers can use a single scalar
+// compare on the result-processor hot path.
+//
+// `t_expirationTimePoint` is a POSIX `struct timespec` (IEEE Std 1003.1), which
+// is the OS-level resolution ceiling: `tv_nsec` is in [0, 999999999], and any
+// finer-grained clock would require a different type. `int64_t` of nanoseconds
+// covers ~292 years from the epoch (year 2262), far beyond any TTL Redis can
+// produce — `RM_GetAbsExpire` and `RM_HashFieldMinExpire` both return an
+// `mstime_t` (signed milliseconds since epoch), which we expand into a
+// `timespec` in `document_basic.c::timespecFromMilliseconds` before reaching
+// here. The debug assert traps any future caller that violates the timespec
+// invariant.
+static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
+  RS_LOG_ASSERT(t.tv_nsec >= 0 && t.tv_nsec < 1000000000L,
+                "tv_nsec out of POSIX timespec range");
+  return (int64_t)t.tv_sec * 1000000000LL + (int64_t)t.tv_nsec;
+}
+
+// Inlines the doc-level TTL on the DMD unconditionally so the result-processor
+// can drop the TTL-table lookup, and only routes field-level expirations into
+// the TTL table. This keeps the table strictly an HFE store, which lets
+// iterators use `t->ttl == NULL` as their per-spec gate. Takes ownership of
+// `sortedFieldWithExpiration` either by handing it to the table or freeing it
+// when there are no field-level entries to register.
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
-  if (hasExpirationTimeInformation(dmd->flags)) {
-    TimeToLiveTable_VerifyInit(&t->ttl);
-    TimeToLiveTable_Add(t->ttl, dmd->id, ttl, sortedFieldWithExpiration);
+  dmd->expirationTimeNs = expirationTimePointToNs(ttl);
+  if (array_len(sortedFieldWithExpiration) > 0) {
+    TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
+    TimeToLiveTable_Add(t->ttl, dmd->id, sortedFieldWithExpiration);
+  } else {
+    array_free(sortedFieldWithExpiration);
   }
 }
 
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint) {
-  if (!hasExpirationTimeInformation(dmd->flags)) {
-      return false;
+  if (dmd->expirationTimeNs == 0) {
+    return false;
   }
-  RS_LOG_ASSERT(t->ttl, "Document has expiration time information but no TTL table");
-  return TimeToLiveTable_HasDocExpired(t->ttl, dmd->id, expirationPoint);
+  return dmd->expirationTimeNs <= expirationTimePointToNs(*expirationPoint);
 }
 
 void DocTable_ClearExpirationData(DocTable *t) {
-  if (t->ttl) {
-    dictIterator *ttlIter = dictGetIterator(t->ttl);
-    dictEntry *ttlEntry;
-    while ((ttlEntry = dictNext(ttlIter))) {
-      t_docId docId = (t_docId)dictGetKey(ttlEntry);
-      RSDocumentMetadata *dmd = DocTable_GetOwn(t, docId);
-      if (dmd) {
-        dmd->flags &= ~Document_HasExpiration;
-      }
-    }
-    dictReleaseIterator(ttlIter);
-    TimeToLiveTable_Destroy(&t->ttl);
-  }
+  // Walk every DMD: doc-level TTL lives inline on the DMD (not in the TTL
+  // table), and field-level TTL is only present for docs that are also in
+  // the table. Either may be set, so a single sweep over all DMDs is the
+  // simplest correct path.
+  DOCTABLE_FOREACH(t, dmd->expirationTimeNs = 0);
+  TimeToLiveTable_Destroy(&t->ttl);
 }
 
 /* Put a new document into the table, assign it an incremental id and store the metadata in the
@@ -381,7 +401,11 @@ RSDocumentMetadata *DocTable_Pop(DocTable *t, const char *s, size_t n) {
       return NULL;
     }
 
-    if (t->ttl && hasExpirationTimeInformation(md->flags)) {
+    // The TTL table holds field-level (HEXPIRE) entries only. Remove is a
+    // no-op if this doc never had one, and the IsEmpty check destroys the
+    // table once the last HFE doc leaves the index, restoring the iterator
+    // gate to its NULL "no HFE in this spec" state.
+    if (t->ttl) {
       TimeToLiveTable_Remove(t->ttl, md->id);
       if (TimeToLiveTable_IsEmpty(t->ttl)) {
         TimeToLiveTable_Destroy(&t->ttl);

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -75,6 +75,10 @@ typedef struct {
 
   DMDChain *buckets;
   DocIdMap dim;             // Mapping between document name to internal id
+  // Holds field-level expirations only; created lazily on the first HEXPIRE
+  // and destroyed when the last entry is removed. Iterators use a NULL check
+  // on this pointer as their HFE gate, so a NULL `ttl` means no doc in this
+  // index has ever had (or still has) a field-level expiration.
   TimeToLiveTable* ttl;
 } DocTable;
 
@@ -132,7 +136,7 @@ void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expiratio
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint);
 
 // Clear all expiration data from this doc table.
-// Clears Document_HasExpiration flags from all documents and destroys the TTL table.
+// Resets `expirationTimeNs` on every DMD and destroys the TTL table.
 // Must be called with the index write lock held.
 void DocTable_ClearExpirationData(DocTable *t);
 

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -8,6 +8,8 @@
 */
 #include "query_iterator.hpp"
 #include "doc_table.h"
+#include "search_ctx.h"
+#include "spec.h"
 #include "util/timeout.h"
 
 #include <utility>    // std::move
@@ -16,6 +18,16 @@
 
 namespace RediSearch {
 namespace GeoShape {
+
+bool CPPQueryIterator::should_check_field_expiration(const RedisSearchCtx *sctx,
+                                                     const FieldFilterContext *filterCtx) noexcept {
+  // Mirrors the hoisted gate in HybridIterator / InvIndIterator: all inputs are
+  // iterator-invariant, so snapshot the AND once here. A non-NULL `ttl` is a
+  // sufficient and tight gate by itself: the table holds field-level entries
+  // only and is destroyed when the last one leaves the index.
+  return sctx && filterCtx->field.index != RS_INVALID_FIELD_INDEX &&
+         sctx->spec->docs.ttl;
+}
 
 auto CPPQueryIterator::base() noexcept -> QueryIterator * {
   return &base_;
@@ -26,8 +38,10 @@ IteratorStatus CPPQueryIterator::read_single() noexcept {
     return ITERATOR_EOF;
   }
   t_docId docId = iter_[index_++];
-  const t_fieldIndex fieldIndex = filterCtx_.field.index;
-  if (sctx_ && fieldIndex != RS_INVALID_FIELD_INDEX && !DocTable_CheckFieldExpirationPredicate(&sctx_->spec->docs, docId, fieldIndex, filterCtx_.predicate, &sctx_->time.current)) {
+  if (check_field_expiration_
+      && !DocTable_CheckFieldExpirationPredicate(&sctx_->spec->docs, docId,
+                                                 filterCtx_.field.index,
+                                                 filterCtx_.predicate, &sctx_->time.current)) {
     return ITERATOR_NOTFOUND;
   }
 
@@ -107,6 +121,12 @@ std::size_t QIter_NumEstimated(QueryIterator *ctx) {
 void QIter_Rewind(QueryIterator *ctx) {
   reinterpret_cast<CPPQueryIterator *>(ctx)->rewind();
 }
+ValidateStatus QIter_Revalidate(QueryIterator *ctx) {
+  auto *qi = reinterpret_cast<CPPQueryIterator *>(ctx);
+  qi->check_field_expiration_ =
+      CPPQueryIterator::should_check_field_expiration(qi->sctx_, &qi->filterCtx_);
+  return VALIDATE_OK;
+}
 
 }  // anonymous namespace
 
@@ -119,7 +139,7 @@ QueryIterator CPPQueryIterator::init_base() {
       .NumEstimated = QIter_NumEstimated,
       .Read = QIter_Read,
       .SkipTo = QIter_SkipTo,
-      .Revalidate = Default_Revalidate,
+      .Revalidate = QIter_Revalidate,
       .Free = QIter_Free,
       .Rewind = QIter_Rewind,
   };

--- a/src/geometry/query_iterator.hpp
+++ b/src/geometry/query_iterator.hpp
@@ -26,6 +26,8 @@ struct CPPQueryIterator {
   std::size_t index_;
   const RedisSearchCtx *sctx_;
   const FieldFilterContext filterCtx_;
+  // Hoisted gate; refreshed in QIter_Revalidate.
+  bool check_field_expiration_;
 
   explicit CPPQueryIterator() = delete;
 
@@ -36,7 +38,8 @@ struct CPPQueryIterator {
   explicit CPPQueryIterator(const RedisSearchCtx *sctx, const FieldFilterContext* filterCtx, R &&range, std::size_t &alloc, Proj proj = {})
       : base_{init_base()},
         iter_{std::ranges::begin(range), std::ranges::end(range), alloc_type{alloc}},
-        index_{0}, sctx_(sctx), filterCtx_(*filterCtx) {
+        index_{0}, sctx_(sctx), filterCtx_(*filterCtx),
+        check_field_expiration_{should_check_field_expiration(sctx, filterCtx)} {
     std::ranges::sort(iter_, std::ranges::less{}, proj);
   }
 
@@ -57,6 +60,9 @@ struct CPPQueryIterator {
   void rewind() noexcept;
 
   static QueryIterator init_base();
+  // Defined in query_iterator.cpp where the spec/doc-table headers are included.
+  static bool should_check_field_expiration(const RedisSearchCtx *sctx,
+                                            const FieldFilterContext *filterCtx) noexcept;
 private:
   IteratorStatus read_single() noexcept;
 };

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -244,7 +244,10 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
     Document* doc = cur->doc;
     const bool hasExpiration = doc->docExpirationTime.tv_sec || doc->docExpirationTime.tv_nsec || doc->fieldExpirations;
     if (hasExpiration) {
-      md->flags |= Document_HasExpiration;
+      // No need to mark the DMD with Document_HasExpiration: the result
+      // processor already fetches the DMD from the doc table on every hit,
+      // so it can read `expirationTimeNs` directly without going through
+      // a flag-gated branch.
       DocTable_UpdateExpiration(&ctx->spec->docs, md, doc->docExpirationTime, doc->fieldExpirations);
     }
     DMD_Return(md);

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -312,9 +312,10 @@ static IteratorStatus HR_ReadHybridUnsortedSingle(HybridIterator *hr) {
   }
   hr->base.current = mmh_pop_min(hr->topResults);
 
-  const t_fieldIndex fieldIndex = hr->filterCtx.field.index;
-  if (hr->sctx && fieldIndex != RS_INVALID_FIELD_INDEX
-      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId, fieldIndex, hr->filterCtx.predicate, &hr->sctx->time.current)) {
+  if (hr->checkFieldExpiration
+      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId,
+                                                 hr->filterCtx.field.index,
+                                                 hr->filterCtx.predicate, &hr->sctx->time.current)) {
     return ITERATOR_NOTFOUND;
   }
   hr->base.lastDocId = hr->base.current->docId;
@@ -349,9 +350,10 @@ static IteratorStatus HR_ReadKnnUnsortedSingle(HybridIterator *hr) {
     return ITERATOR_EOF;
   }
 
-  const t_fieldIndex fieldIndex = hr->filterCtx.field.index;
-  if (hr->sctx && fieldIndex != RS_INVALID_FIELD_INDEX
-      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId, fieldIndex, hr->filterCtx.predicate, &hr->sctx->time.current)) {
+  if (hr->checkFieldExpiration
+      && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId,
+                                                 hr->filterCtx.field.index,
+                                                 hr->filterCtx.predicate, &hr->sctx->time.current)) {
     return ITERATOR_NOTFOUND;
   }
 
@@ -458,6 +460,8 @@ static ValidateStatus HR_Revalidate(QueryIterator *ctx) {
   if (hr->child && hr->child->Revalidate(hr->child) == VALIDATE_ABORTED) {
     return VALIDATE_ABORTED;
   }
+  hr->checkFieldExpiration = hr->sctx && hr->filterCtx.field.index != RS_INVALID_FIELD_INDEX &&
+                             hr->sctx->spec->docs.ttl;
   return VALIDATE_OK;
 }
 
@@ -494,6 +498,14 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   hi->runtimeParams.timeoutCtx = &hi->timeoutCtx;
   hi->sctx = hParams.sctx;
   hi->filterCtx = *hParams.filterCtx;
+  // Hoist the per-posting field-expiration gate: sctx, fieldIndex and the spec
+  // TTL pointer are all iterator-invariant, so we snapshot the AND once here.
+  // The TTL table holds field-level (HEXPIRE) entries only and is destroyed
+  // when the last one leaves the index, so a non-NULL `ttl` is a sufficient
+  // and tight gate by itself.
+  hi->checkFieldExpiration =
+      hParams.sctx && hParams.filterCtx->field.index != RS_INVALID_FIELD_INDEX &&
+      hParams.sctx->spec->docs.ttl;
 
   if (hParams.childIt == NULL || hParams.query.k == 0) {
     // If there is no child iterator, or the query is going to return 0 results, we can use simple KNN.

--- a/src/iterators/hybrid_reader.h
+++ b/src/iterators/hybrid_reader.h
@@ -52,6 +52,7 @@ typedef struct {
   size_t maxBatchSize;             // Maximum batch size used during batches mode
   size_t maxBatchIteration;        // Iteration (zero-based) where the maximum batch size occurred
   bool canTrimDeepResults;         // Ignore the document scores, only vector score matters. No need to deep copy the results from the child iterator.
+  bool checkFieldExpiration;       // Hoisted gate; refreshed in HR_Revalidate.
   TimeoutCtx timeoutCtx;           // Timeout parameters
   FieldFilterContext filterCtx;
 } HybridIterator;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -89,11 +89,6 @@ void RedisSearchCtx_LockSpecRead(RedisSearchCtx *ctx) {
   // pause rehashing while we're using the dict for reads only
   // Assert that the pause value before we pause is valid.
   RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->keysDict));
-  // Also pause rehashing on the TTL table if it exists, to avoid concurrent
-  // rehash steps from multiple query threads corrupting the dict during reads.
-  if (ctx->spec->docs.ttl) {
-    RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->docs.ttl));
-  }
   ctx->flags = RS_CTX_READONLY;
 }
 
@@ -107,11 +102,6 @@ int RedisSearchCtx_TryLockSpecRead(RedisSearchCtx *ctx) {
   // pause rehashing while we're using the dict for reads only
   // Assert that the pause value before we pause is valid.
   RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->keysDict));
-  // Also pause rehashing on the TTL table if it exists, to avoid concurrent
-  // rehash steps from multiple query threads corrupting the dict during reads.
-  if (ctx->spec->docs.ttl) {
-    RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->docs.ttl));
-  }
   ctx->flags = RS_CTX_READONLY;
   return REDISMODULE_OK;
 }
@@ -149,10 +139,6 @@ void RedisSearchCtx_UnlockSpec(RedisSearchCtx *sctx) {
     // We paused rehashing when we locked the spec for read. Now we can resume it.
     // Assert that it was actually previously paused
     RS_ASSERT_ALWAYS(dictResumeRehashing(sctx->spec->keysDict));
-    // Also resume rehashing on the TTL table if it exists
-    if (sctx->spec->docs.ttl) {
-      RS_ASSERT_ALWAYS(dictResumeRehashing(sctx->spec->docs.ttl));
-    }
   }
   pthread_rwlock_unlock(&sctx->spec->rwlock);
   sctx->flags = RS_CTX_UNSET;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -126,12 +126,16 @@ typedef struct RSDocumentMetadata_s {
 
   uint16_t ref_count;
 
+  /* Document-level expiration time in nanoseconds since the epoch (0 = none).
+   * Inlined to avoid a TTL-table lookup on the result-processor hot path. */
+  int64_t expirationTimeNs;
+
   struct RSSortingVector *sortVector;
   /* Offsets of all terms in the document (in bytes). Used by highlighter */
   struct RSByteOffsets *byteOffsets;
   struct RSDocumentMetadata_s *nextInChain;
 
-  /* Optional user payload */
+  /* Optional user payload. Must remain last for DocTable_Put's lean alloc. */
   RSPayload *payload;
 
 } RSDocumentMetadata;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -607,10 +607,6 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
   /* We might have multiple readers that reads from the index,
    * Avoid rehashing the terms dictionary */
   dictPauseRehashing(sp->keysDict);
-  /* Also pause rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictPauseRehashing(sp->docs.ttl);
-  }
 
   RSSearchOptions options = {0};
   QueryError status = QueryError_Default();
@@ -659,9 +655,6 @@ end:
      * If iter->sp is set, RediSearch_ResultsIteratorFree will handle cleanup. */
     if (!it->sp) {
       dictResumeRehashing(sp->keysDict);
-      if (sp->docs.ttl) {
-        dictResumeRehashing(sp->docs.ttl);
-      }
       pthread_rwlock_unlock(&sp->rwlock);
     }
     RediSearch_ResultsIteratorFree(it);
@@ -740,9 +733,6 @@ void RediSearch_ResultsIteratorFree(RS_ApiIter* iter) {
   if (iter->sp) {
     if (iter->sp->keysDict) {
       dictResumeRehashing(iter->sp->keysDict);
-    }
-    if (iter->sp->docs.ttl) {
-      dictResumeRehashing(iter->sp->docs.ttl);
     }
     pthread_rwlock_unlock(&iter->sp->rwlock);
   }
@@ -898,10 +888,6 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   /* We might have multiple readers that reads from the index,
    * Avoid rehashing the terms dictionary */
   dictPauseRehashing(sp->keysDict);
-  /* Also pause rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictPauseRehashing(sp->docs.ttl);
-  }
 
   info->gcPolicy = sp->gc ? GC_POLICY_FORK : GC_POLICY_NONE;
   if (sp->rule) {
@@ -945,10 +931,6 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   }
 
   dictResumeRehashing(sp->keysDict);
-  /* Also resume rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictResumeRehashing(sp->docs.ttl);
-  }
   /* Release spec read lock */
   pthread_rwlock_unlock(&sp->rwlock);
   RWLOCK_RELEASE();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -389,6 +389,9 @@ pub(super) mod not_miri {
                 ptr.spec.monitorDocumentExpiration = true; // Only depends on API availability, so always true
                 ptr.spec.monitorFieldExpiration = true; // Only depends on API availability, so always true
                 ptr.spec.docs.maxDocId = max_doc_id;
+                // Match the DocTable's own slot formula so the lazy-init TTL
+                // table uses a non-zero modulus; tests never exceed maxDocId.
+                ptr.spec.docs.maxSize = std::cmp::max(max_doc_id, 1);
                 ptr.spec.docs.size = if num_docs > 0 {
                     num_docs
                 } else {
@@ -485,13 +488,8 @@ pub(super) mod not_miri {
                 }
             };
 
-            let doc_expiration_time = ffi::t_expirationTimePoint {
-                tv_sec: i64::MAX,
-                tv_nsec: i64::MAX,
-            };
-
             unsafe {
-                ffi::TimeToLiveTable_Add(self.spec.docs.ttl, doc_id, doc_expiration_time, fe as _);
+                ffi::TimeToLiveTable_Add(self.spec.docs.ttl, doc_id, fe as _);
             }
         }
 
@@ -514,7 +512,10 @@ pub(super) mod not_miri {
 
             self.spec.fieldIdToIndex = arr as _;
             unsafe {
-                ffi::TimeToLiveTable_VerifyInit(&mut self.spec.docs.ttl);
+                ffi::TimeToLiveTable_VerifyInit(
+                    &mut self.spec.docs.ttl,
+                    self.spec.docs.maxSize as usize,
+                );
             }
         }
     }

--- a/src/ttl_table/ttl_table.c
+++ b/src/ttl_table/ttl_table.c
@@ -13,57 +13,190 @@
 #include "util/misc.h"
 #include "rmutil/rm_assert.h"
 
+// Direct-modulo bucket array with contiguous-vec collision chains.
+//
+// Rationale:
+//  - docIds are allocated monotonically via ++maxDocId in DocTable, so the
+//    iterator-time lookups of `VerifyDocAndField*` see them in ascending,
+//    mostly-sequential order. Hashing would scatter that locality; direct
+//    modulo keeps sequential docIds in sequential slots so the CPU hardware
+//    prefetcher can pull upcoming bucket headers into L1 ahead of demand.
+//    This primarily benefits the "miss" hot path — docs without TTL, the
+//    common case at query time — where each `ttl_find_entry` probes a
+//    bucket pointer (8 B), sees NULL, and returns. Eight such probes fit in
+//    one 64-byte cache line, and the stride-1 access pattern matches the
+//    hardware prefetcher's sequential detector so it streams the next lines
+//    in without demand-miss stalls as long as the iterator walks docIds in
+//    ascending order.
+//  - When maxDocId exceeds `maxSize`, multiple docIds collide on the same
+//    slot. A per-bucket contiguous-vec chain keeps walks cache-line
+//    sequential and bounds worst-case behavior (Poisson tail at load factor
+//    1 gives chain length ≤ ~5) — unlike linear probing, which degrades to
+//    O(cap) once deletes create probe-gaps in a near-full table.
+//  - Each non-empty bucket is an arr.h fat pointer: len/cap live in the
+//    `array_hdr_t` immediately preceding the elements, so the slot itself
+//    is just an 8 B pointer. Writes go through arr.h's geometric growth
+//    rather than a +1 realloc per insert.
+//  - Lazy growth mirrors DocTable_Set: `maxSize` (the modulus used by the
+//    slot formula) is captured once at init and never changes, while `cap`
+//    (the number of buckets actually allocated) starts at 0 and grows on
+//    demand via rm_realloc up to `maxSize`. Because the slot formula depends
+//    only on `maxSize`, growing `cap` never relocates an existing entry —
+//    it only extends the tail of the bucket array. Reads for docIds whose
+//    slot lies in the still-unallocated tail treat the entry as absent,
+//    which is correct because Add always grows `cap` to cover the slot
+//    before writing. This keeps the per-index footprint proportional to the
+//    number of TTL docs ever inserted rather than to maxDocTableSize, which
+//    matters in deployments with many indexes that sparsely use TTL.
+
 typedef struct {
-  t_expirationTimePoint documentExpirationPoint;
-  FieldExpiration* fieldExpirations;
+  t_docId docId;                              // 0 is reserved / unused
+  arrayof(FieldExpiration) fieldExpirations;  // owned, sorted by field index, never empty
 } TimeToLiveEntry;
 
-static uint64_t hashFunction_DocId(const void *key) {
-  return (t_docId)key;
-}
-static void destructor_TimeToLiveEntry(void *privdata, void *val) {
-    TimeToLiveEntry* entry = (TimeToLiveEntry*)val;
-    array_free(entry->fieldExpirations);
-    rm_free(entry);
-}
+// A bucket is a NULL-or-arr.h-managed chain of entries. NULL means empty.
+typedef arrayof(TimeToLiveEntry) TTLBucket;
 
-static dictType dictTimeToLive = {
-  .hashFunction = hashFunction_DocId,
-  .keyDup = NULL,
-  .valDup = NULL,
-  .keyCompare = NULL,
-  .keyDestructor = NULL,
-  .valDestructor = destructor_TimeToLiveEntry,
+struct TimeToLiveTable {
+  TTLBucket *buckets;                   // allocated for the first `cap` slots
+  size_t cap;                           // number of bucket slots physically allocated
+  size_t maxSize;                       // modulus for slot calculation, fixed at init
+  size_t count;                         // total live entries
 };
 
-void TimeToLiveTable_VerifyInit(TimeToLiveTable **table) {
-    if (!*table) {
-      *table = dictCreate(&dictTimeToLive, NULL);
-    }
+static inline size_t ttl_slot(const TimeToLiveTable *t, t_docId docId) {
+  return docId < t->maxSize ? (size_t)docId : (size_t)(docId % t->maxSize);
+}
+
+// Initial bucket-array size the first time we grow from zero. Chosen so an
+// index that only ever holds a handful of TTL docs pays one small allocation
+// and no reallocs. Must be ≥ 1.
+#define TTL_BUCKET_INITIAL_CAP ((size_t)64)
+
+// Upper bound on the geometric +1.5x step once the bucket array is non-empty,
+// mirroring DocTable_Set's cap so huge tables don't take a single multi-MB
+// realloc hit and so the two allocators scale in lockstep.
+#define TTL_BUCKET_MAX_GROW_STEP ((size_t)(1 << 20))  // 1 Mi buckets
+
+// Ensure buckets[slot] is allocated. Called from Add only; reads treat
+// slot >= cap as "not present" and never grow. Growth curve matches
+// DocTable_Set: +1.5x geometric up to TTL_BUCKET_MAX_GROW_STEP, clamped to
+// maxSize, with TTL_BUCKET_INITIAL_CAP as the first-grow seed.
+static void ttl_grow(TimeToLiveTable *t, size_t slot) {
+  RS_ASSERT(slot < t->maxSize);    // ttl_slot's contract; tightens the call boundary
+  if (slot < t->cap) return;
+  RS_ASSERT(t->cap < t->maxSize);  // slot is always < maxSize, so room must exist
+  const size_t oldcap = t->cap;
+  size_t newcap = t->cap == 0
+      ? TTL_BUCKET_INITIAL_CAP
+      : t->cap + 1 + MIN(t->cap / 2, TTL_BUCKET_MAX_GROW_STEP);
+  if (newcap > t->maxSize) newcap = t->maxSize;
+  if (newcap < slot + 1) newcap = slot + 1;
+  t->buckets = rm_realloc(t->buckets, newcap * sizeof(*t->buckets));
+  memset(t->buckets + oldcap, 0, (newcap - oldcap) * sizeof(*t->buckets));
+  t->cap = newcap;
+}
+
+static inline TimeToLiveEntry *ttl_find_entry(const TimeToLiveTable *t, t_docId docId) {
+  const size_t slot = ttl_slot(t, docId);
+  if (slot >= t->cap) return NULL;  // bucket unallocated => entry cannot exist
+  TTLBucket bucket = t->buckets[slot];
+  if (!bucket) return NULL;
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId == docId) return &bucket[i];
+  }
+  return NULL;
+}
+
+// Debug-only duplicate probe for the monotonic-docId invariant. Extracted to
+// keep the Add call site readable (`assert(!ttl_bucket_contains(...))`); the
+// invariant itself is enforced upstream by the spec write lock in
+// DocTable_Put, so eliding the scan in release is intentional.
+static bool ttl_bucket_contains(TTLBucket bucket, t_docId docId) {
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId == docId) return true;
+  }
+  return false;
+}
+
+// Release the owned allocations of a single entry. The entry slot itself is
+// owned by the bucket's `entries` block and is freed with it.
+static inline void ttl_entry_release(TimeToLiveEntry *e) {
+  array_free(e->fieldExpirations);
+}
+
+void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize) {
+  if (*table) return;
+  // maxSize == 0 would make ttl_slot divide by zero; the caller (DocTable)
+  // floors its own maxSize to 1 on load, so treat this as a hard invariant.
+  RS_LOG_ASSERT_ALWAYS(maxSize >= 1, "TTL table maxSize must be >= 1");
+  TimeToLiveTable *t = rm_malloc(sizeof(*t));
+  t->buckets = NULL;
+  t->cap = 0;
+  t->maxSize = maxSize;
+  t->count = 0;
+  *table = t;
 }
 
 void TimeToLiveTable_Destroy(TimeToLiveTable **table) {
-    if (*table) {
-      dictRelease(*table);
-      *table = NULL;
+  if (!*table) return;
+  TimeToLiveTable *t = *table;
+  for (size_t s = 0; s < t->cap; s++) {
+    TTLBucket bucket = t->buckets[s];
+    if (!bucket) continue;
+    const uint32_t n = array_len(bucket);
+    for (uint32_t i = 0; i < n; i++) {
+      ttl_entry_release(&bucket[i]);
     }
+    array_free(bucket);
+  }
+  rm_free(t->buckets);
+  rm_free(t);
+  *table = NULL;
 }
 
-void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpirationTime, arrayof(FieldExpiration) sortedById) {
-  TimeToLiveEntry* entry = (TimeToLiveEntry*)rm_malloc(sizeof(TimeToLiveEntry));
-  entry->documentExpirationPoint = docExpirationTime;
-  entry->fieldExpirations = sortedById;
-  // we don't want the operation to fail so we use dictReplace
-  const bool added = dictAdd(table, (void*)docId, entry) == DICT_OK;
-  RS_LOG_ASSERT(added, "Failed to add document to ttl table");
+void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, arrayof(FieldExpiration) sortedById) {
+  RS_ASSERT(sortedById && array_len(sortedById) > 0);
+  const size_t slot = ttl_slot(t, docId);
+  ttl_grow(t, slot);
+  // docIds are monotonically assigned in DocTable_Put under the spec write
+  // lock, so duplicates should not reach here; the assert catches a broken
+  // locking discipline during development before it corrupts the table.
+  RS_LOG_ASSERT(!ttl_bucket_contains(t->buckets[slot], docId), "duplicate docId in TTL table");
+  TimeToLiveEntry entry = { .docId = docId, .fieldExpirations = sortedById };
+  t->buckets[slot] = array_ensure_append_1(t->buckets[slot], entry);
+  t->count++;
 }
 
-void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId) {
-  dictDelete(table, (void*)docId);
+void TimeToLiveTable_Remove(TimeToLiveTable *t, t_docId docId) {
+  const size_t slot = ttl_slot(t, docId);
+  if (slot >= t->cap) return;  // bucket unallocated => nothing to remove
+  TTLBucket bucket = t->buckets[slot];
+  if (!bucket) return;
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId != docId) continue;
+    ttl_entry_release(&bucket[i]);
+    array_del_fast(bucket, i);  // swap-last + dec len; in-place, no realloc
+    t->count--;
+    if (array_len(bucket) == 0) {
+      array_free(bucket);
+      t->buckets[slot] = NULL;
+    }
+    // No-shrink-on-delete: arr.h keeps the allocation at its high-water
+    // mark via remain_cap, avoiding realloc churn for buckets that churn.
+    return;
+  }
 }
 
-bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table) {
-  return dictSize(table) == 0;
+bool TimeToLiveTable_IsEmpty(TimeToLiveTable *t) {
+  return t->count == 0;
+}
+
+size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *t) {
+  return t ? t->cap : 0;
 }
 
 static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirationTimePoint* now) {
@@ -74,34 +207,23 @@ static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirat
   return !((field->tv_sec > now->tv_sec) || (field->tv_sec == now->tv_sec && field->tv_nsec > now->tv_nsec));
 }
 
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const struct timespec* expirationPoint) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
-    return false;
-  }
-
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  return DidExpire(&ttlEntry->documentExpirationPoint, expirationPoint);
-}
-
-bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex field, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *t, t_docId docId, t_fieldIndex field, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
   if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
     return true;
   }
 
   for (size_t currentFieldIndex = 0; currentFieldIndex < fieldWithExpirationCount; currentFieldIndex++) {
-    FieldExpiration* fieldExpiration = &ttlEntry->fieldExpirations[currentFieldIndex];
+    FieldExpiration* fieldExpiration = &e->fieldExpirations[currentFieldIndex];
     if (field == fieldExpiration->index) {
       // the field has an expiration time
       const bool expired = DidExpire(&fieldExpiration->point, expirationPoint);
@@ -115,21 +237,20 @@ bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_
     }
   }
   // the field was not found in the document's field expirations,
-  // which means it is valid unless the predicate is FIELD_EXPIRATION_MISSING
+  // which means it is valid unless the predicate is FIELD_EXPIRATION_PREDICATE_MISSING
   return (predicate != FIELD_EXPIRATION_PREDICATE_MISSING);
 }
 
-bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *t, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
   const size_t fieldCount = __builtin_popcount(fieldMask);
   if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
@@ -149,20 +270,20 @@ bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId
     t_fieldIndex fieldIndexToCheck = ftIdToFieldIndex[bitIndex];
 
     // Attempt to find the next field expiration that matches the current field index
-    while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > ttlEntry->fieldExpirations[currentFieldIndex].index) {
+    while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > e->fieldExpirations[currentFieldIndex].index) {
       currentFieldIndex++;
     }
     if (currentFieldIndex >= fieldWithExpirationCount) {
       // No more fields with expiration times to check
       break;
-    } else if (fieldIndexToCheck < ttlEntry->fieldExpirations[currentFieldIndex].index) {
+    } else if (fieldIndexToCheck < e->fieldExpirations[currentFieldIndex].index) {
       // The field we are checking is not present in the current field expiration
       continue;
     }
 
-    RS_ASSERT(fieldIndexToCheck == ttlEntry->fieldExpirations[currentFieldIndex].index);
+    RS_ASSERT(fieldIndexToCheck == e->fieldExpirations[currentFieldIndex].index);
     // Match found - we need to check if it has an expiration time
-    const bool expired = DidExpire(&ttlEntry->fieldExpirations[currentFieldIndex].point, expirationPoint);
+    const bool expired = DidExpire(&e->fieldExpirations[currentFieldIndex].point, expirationPoint);
     if (!expired && predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
       return true;
     } else if (expired && predicate == FIELD_EXPIRATION_PREDICATE_MISSING) {
@@ -173,7 +294,7 @@ bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId
   if (predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
     // If we are checking for the default predicate, we need at least one valid field
     return predicateMisses < fieldCount;
-  } else { // if (predicate == FIELD_EXPIRATION_MISSING)
+  } else { // if (predicate == FIELD_EXPIRATION_PREDICATE_MISSING)
     // If we are checking for the missing predicate, we need at least one expired field
     // If we reached here, it means we did not find any expired fields
     return false;
@@ -182,15 +303,14 @@ bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId
 
 
 // TODO: Rust - unify with the implementation above using generic field mask
-bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *t, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
-
 
   uint64_t fieldMask64[2];
   if (sizeof(fieldMask) == sizeof(uint64_t)) {
@@ -201,8 +321,7 @@ bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId d
     fieldMask64[1] = fieldMask >> 64;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
   const size_t fieldCount = __builtin_popcountll(fieldMask64[0]) + __builtin_popcountll(fieldMask64[1]);
   if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
@@ -223,20 +342,20 @@ bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId d
       t_fieldIndex fieldIndexToCheck = ftIdToFieldIndex[bitIndex + (i * 64)];
 
       // Attempt to find the next field expiration that matches the current field index
-      while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > ttlEntry->fieldExpirations[currentFieldIndex].index) {
+      while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > e->fieldExpirations[currentFieldIndex].index) {
         currentFieldIndex++;
       }
       if (currentFieldIndex >= fieldWithExpirationCount) {
         // No more fields with expiration times to check
         goto end; // Break out of all loops
-      } else if (fieldIndexToCheck < ttlEntry->fieldExpirations[currentFieldIndex].index) {
+      } else if (fieldIndexToCheck < e->fieldExpirations[currentFieldIndex].index) {
         // The field we are checking is not present in the current field expiration
         continue;
       }
 
-      RS_ASSERT(fieldIndexToCheck == ttlEntry->fieldExpirations[currentFieldIndex].index);
+      RS_ASSERT(fieldIndexToCheck == e->fieldExpirations[currentFieldIndex].index);
       // Match found - we need to check if it has an expiration time
-      const bool expired = DidExpire(&ttlEntry->fieldExpirations[currentFieldIndex].point, expirationPoint);
+      const bool expired = DidExpire(&e->fieldExpirations[currentFieldIndex].point, expirationPoint);
       if (!expired && predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
         return true;
       } else if (expired && predicate == FIELD_EXPIRATION_PREDICATE_MISSING) {
@@ -249,7 +368,7 @@ end:
   if (predicate == FIELD_EXPIRATION_PREDICATE_DEFAULT) {
     // If we are checking for the default predicate, we need at least one valid field
     return predicateMisses < fieldCount;
-  } else { // if (predicate == FIELD_EXPIRATION_MISSING)
+  } else { // if (predicate == FIELD_EXPIRATION_PREDICATE_MISSING)
     // If we are checking for the missing predicate, we need at least one expired field
     // If we reached here, it means we did not find any expired fields
     return false;

--- a/src/ttl_table/ttl_table.h
+++ b/src/ttl_table/ttl_table.h
@@ -10,7 +10,6 @@
 #ifndef TTL_TABLE_H
 #define TTL_TABLE_H
 #include "redisearch.h"
-#include "util/dict/dict.h"
 #include "stdbool.h"
 #include "util/arr.h"
 
@@ -23,19 +22,32 @@ typedef struct {
   t_expirationTimePoint point;
 } FieldExpiration;
 
-typedef dict TimeToLiveTable;
+typedef struct TimeToLiveTable TimeToLiveTable;
 
-void TimeToLiveTable_VerifyInit(TimeToLiveTable **table);
+// Lazy-init: allocates the table on first use with `maxSize` as the fixed
+// modulus for the slot formula. Caller (DocTable) passes its own
+// `t->maxSize` so the two tables' slot formulas are identical by
+// construction and cannot drift if `search-max-doctablesize` is later
+// mutated. No-op if the table is already initialized.
+//
+// The table only holds field-level (HEXPIRE) expirations: doc-level TTL is
+// inlined directly on `RSDocumentMetadata::expirationTimeNs` so the
+// result-processor hot path can avoid this lookup entirely.
+void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize);
 void TimeToLiveTable_Destroy(TimeToLiveTable **table);
-void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpiration, arrayof(FieldExpiration) sortedById);
+// Adds a field-level expiration entry. `sortedById` must be non-empty;
+// ownership of the array transfers to the table.
+void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, arrayof(FieldExpiration) sortedById);
 void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId);
 bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table);
-
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const struct timespec* expirationPoint);
 
 bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex fieldIndex, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint);
 bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
 bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
+
+// Test-only: number of buckets currently allocated (lazy-growth high-water
+// mark). Not exposed for runtime use.
+size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *table);
 
 #ifdef __cplusplus
 }

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -105,17 +105,12 @@ public:
     array_free(spec.fieldIdToIndex);
   }
 
-  void TTL_Add(t_docId docId, t_expirationTimePoint expiration = {LONG_MAX, LONG_MAX}) {
-    VerifyTTLInit();
-    TimeToLiveTable_Add(spec.docs.ttl, docId, expiration, NULL);
-  }
-
   void TTL_Add(t_docId docId, t_fieldIndex field, t_expirationTimePoint expiration = {LONG_MAX, LONG_MAX}) {
     VerifyTTLInit();
     arrayof(FieldExpiration) fe = array_new(FieldExpiration, 1);
     FieldExpiration fe_entry = {field, expiration};
     array_append(fe, fe_entry);
-    TimeToLiveTable_Add(spec.docs.ttl, docId, {LONG_MAX, LONG_MAX}, fe);
+    TimeToLiveTable_Add(spec.docs.ttl, docId, fe);
   }
   void TTL_Add(t_docId docId, t_fieldMask fieldMask, t_expirationTimePoint expiration = {LONG_MAX, LONG_MAX}) {
     VerifyTTLInit();
@@ -126,7 +121,7 @@ public:
         array_append(fe, fe_entry);
       }
     }
-    TimeToLiveTable_Add(spec.docs.ttl, docId, {LONG_MAX, LONG_MAX}, fe);
+    TimeToLiveTable_Add(spec.docs.ttl, docId, fe);
   }
 
 private:
@@ -138,6 +133,6 @@ private:
         array_append(spec.fieldIdToIndex, i);
       }
     }
-    TimeToLiveTable_VerifyInit(&spec.docs.ttl);
+    TimeToLiveTable_VerifyInit(&spec.docs.ttl, RSGlobalConfig.maxDocTableSize);
   }
 };

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -15,9 +15,11 @@
 #include "redismock/internal.h"
 #include "spec.h"
 #include "common.h"
+#include "config.h"
 #include "module.h"
 #include "version.h"
 #include "tag_index.h"
+#include "ttl_table.h"
 #include "info/info_redis/threads/current_thread.h"
 
 #include <vector>
@@ -89,3 +91,176 @@ TEST_F(ExpireTest, testSkipTo) {
   args.clear();
   RedisModule_FreeThreadSafeContext(ctx);
 }
+
+// Helper: build a one-entry FieldExpiration array on field index 0. Ownership
+// transfers to the table on TimeToLiveTable_Add.
+static arrayof(FieldExpiration) makeFE(t_expirationTimePoint p) {
+  arrayof(FieldExpiration) fe = array_new(FieldExpiration, 1);
+  FieldExpiration entry = {0, p};
+  array_append(fe, entry);
+  return fe;
+}
+
+// Returns true if field 0 is expired for the given docId. Mirrors what the
+// VerifyDocAndField slow path observes during query iteration.
+static bool fieldExpired(TimeToLiveTable *ttl, t_docId d, const struct timespec *now) {
+  return !TimeToLiveTable_VerifyDocAndField(ttl, d, 0, FIELD_EXPIRATION_PREDICATE_DEFAULT, now);
+}
+
+// Exercises the direct-modulo + contiguous-vec chain implementation of
+// TimeToLiveTable: seed it with more docIds than the bucket cap so every slot
+// carries multiple entries, then verify each docId's expiration state is
+// observed correctly. Also exercises removal from the middle of a chain via
+// the swap-last path.
+TEST_F(ExpireTest, testTTLCollisionChain) {
+  // Force a small cap so the chain path is actually exercised at this size.
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const size_t cap = 32;
+  RSGlobalConfig.maxDocTableSize = cap;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, cap);
+
+  // Insert 4x the cap so every slot has ~4 entries on average. Alternate
+  // expired/fresh so we can assert the chain walk returns the right entry.
+  const t_docId N = (t_docId)cap * 4;
+  struct timespec past = {1, 0};
+  struct timespec future = {LONG_MAX, LONG_MAX};
+  for (t_docId d = 1; d <= N; ++d) {
+    TimeToLiveTable_Add(ttl, d, makeFE((d & 1) ? past : future));
+  }
+
+  struct timespec now = {2, 0};
+  for (t_docId d = 1; d <= N; ++d) {
+    const bool expected = (d & 1) != 0;
+    ASSERT_EQ(fieldExpired(ttl, d, &now), expected) << "docId=" << d;
+  }
+
+  // Remove every third docId and re-verify. This deletes from arbitrary chain
+  // positions and triggers the swap-last codepath repeatedly.
+  for (t_docId d = 3; d <= N; d += 3) {
+    TimeToLiveTable_Remove(ttl, d);
+  }
+  for (t_docId d = 1; d <= N; ++d) {
+    if (d % 3 == 0) {
+      // Removed entries are absent => VerifyDocAndField treats the field as
+      // valid, i.e. fieldExpired returns false.
+      ASSERT_FALSE(fieldExpired(ttl, d, &now)) << "docId=" << d;
+    } else {
+      const bool expected = (d & 1) != 0;
+      ASSERT_EQ(fieldExpired(ttl, d, &now), expected) << "docId=" << d;
+    }
+  }
+
+  // Drain the rest and verify the table reports empty so the lifecycle
+  // mechanism in DocTable_Pop can destroy it.
+  for (t_docId d = 1; d <= N; ++d) {
+    if (d % 3 != 0) {
+      TimeToLiveTable_Remove(ttl, d);
+    }
+  }
+  ASSERT_TRUE(TimeToLiveTable_IsEmpty(ttl));
+
+  TimeToLiveTable_Destroy(&ttl);
+  ASSERT_EQ(ttl, nullptr);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+
+// Exercises the docId wrap at the cap boundary: docId < cap uses slot = docId,
+// while docId >= cap uses slot = docId % cap. The two branches must land on
+// the same bucket and stay distinguishable from each other.
+TEST_F(ExpireTest, testTTLDocIdWrap) {
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const t_docId CAP = 32;
+  RSGlobalConfig.maxDocTableSize = CAP;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, CAP);
+  // Collide docId X (fast path) with docId X + CAP and X + 2*CAP (modulo path).
+  struct timespec past = {1, 0};
+  struct timespec future = {LONG_MAX, LONG_MAX};
+  struct timespec now = {2, 0};
+  for (t_docId x = 1; x < 8; ++x) {
+    TimeToLiveTable_Add(ttl, x, makeFE(past));
+    TimeToLiveTable_Add(ttl, x + CAP, makeFE(future));
+    TimeToLiveTable_Add(ttl, x + 2 * CAP, makeFE(past));
+  }
+  for (t_docId x = 1; x < 8; ++x) {
+    ASSERT_TRUE(fieldExpired(ttl, x, &now));
+    ASSERT_FALSE(fieldExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x + 2 * CAP, &now));
+    // A docId that hashes to the same slot but was never inserted must report
+    // "no TTL" => fieldExpired returns false without matching another entry.
+    ASSERT_FALSE(fieldExpired(ttl, x + 3 * CAP, &now));
+  }
+
+  // Remove the "middle" entries and confirm the remaining two are still
+  // found in both directions (the swap-last must not corrupt the chain).
+  for (t_docId x = 1; x < 8; ++x) {
+    TimeToLiveTable_Remove(ttl, x + CAP);
+  }
+  for (t_docId x = 1; x < 8; ++x) {
+    ASSERT_TRUE(fieldExpired(ttl, x, &now));
+    ASSERT_FALSE(fieldExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x + 2 * CAP, &now));
+  }
+
+  TimeToLiveTable_Destroy(&ttl);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+
+// Exercises lazy bucket-array growth: with a large configured maxSize, a
+// table that only ever holds a handful of entries must not allocate the
+// full maxSize worth of buckets. Also verifies that the grown `cap` covers
+// every slot that has been written, and that wrap-around docIds are still
+// routed to their correct (already-allocated) slot after growth.
+TEST_F(ExpireTest, testTTLLazyGrowth) {
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const size_t MAX = 1000000;  // matches production default
+  RSGlobalConfig.maxDocTableSize = MAX;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, MAX);
+  // Init alone must not allocate any buckets.
+  ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), 0u);
+
+  struct timespec past = {1, 0};
+  struct timespec now = {2, 0};
+
+  // Insert a small, sparse set of low docIds. Growth should stop well below
+  // MAX; concretely, the high-water slot is 100, so cap is bounded by the
+  // geometric growth curve's next step above that, which is a small factor
+  // of 100 — nowhere near MAX.
+  const t_docId small_ids[] = {1, 5, 42, 100};
+  for (t_docId d : small_ids) {
+    TimeToLiveTable_Add(ttl, d, makeFE(past));
+  }
+  const size_t cap_after_small = TimeToLiveTable_DebugAllocatedBuckets(ttl);
+  ASSERT_GE(cap_after_small, 101u);   // must cover slot 100
+  ASSERT_LT(cap_after_small, MAX / 10);  // must be far below maxSize
+
+  // Reads for docIds whose slot is still unallocated must report not-found.
+  ASSERT_FALSE(fieldExpired(ttl, 999999, &now));
+  // Writes must still work for those, and bump cap to cover them.
+  TimeToLiveTable_Add(ttl, 999999, makeFE(past));
+  ASSERT_GE(TimeToLiveTable_DebugAllocatedBuckets(ttl), 999999u + 1);
+  ASSERT_TRUE(fieldExpired(ttl, 999999, &now));
+
+  // Previously-inserted entries must not have moved during the grow.
+  for (t_docId d : small_ids) {
+    ASSERT_TRUE(fieldExpired(ttl, d, &now)) << "docId=" << d;
+  }
+
+  // A wrap-around docId (>= maxSize) routes via modulo into an already-
+  // allocated slot, so it works without further growth.
+  const size_t cap_before_wrap = TimeToLiveTable_DebugAllocatedBuckets(ttl);
+  TimeToLiveTable_Add(ttl, MAX + 5, makeFE(past));  // slot = 5, already in range
+  ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), cap_before_wrap);
+  ASSERT_TRUE(fieldExpired(ttl, MAX + 5, &now));
+  // The original docId=5 entry must still be distinct from the wrapped one.
+  ASSERT_TRUE(fieldExpired(ttl, 5, &now));
+
+  TimeToLiveTable_Destroy(&ttl);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1296,7 +1296,7 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_EQ(N + 1, dt.size);
   ASSERT_EQ(N, dt.maxDocId);
 #ifdef __x86_64__
-  ASSERT_EQ(9380 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(10180 + doc_table_size, (int)dt.memsize);
 #endif
   for (int i = 0; i < N; i++) {
     snprintf(buf, sizeof(buf), "doc_%d", i);
@@ -1333,7 +1333,7 @@ TEST_F(IndexTest, testDocTable) {
   RSDocumentMetadata *dmd = DocTable_Put(&dt, "Hello", 5, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   t_docId strDocId = dmd->id;
   ASSERT_TRUE(0 != strDocId);
-  ASSERT_EQ(63 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(71 + doc_table_size, (int)dt.memsize);
 
   // Test that binary keys also work here
   static const char binBuf[] = {"Hello\x00World"};
@@ -1342,7 +1342,7 @@ TEST_F(IndexTest, testDocTable) {
   DMD_Return(dmd);
   dmd = DocTable_Put(&dt, binBuf, binBufLen, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   ASSERT_TRUE(dmd);
-  ASSERT_EQ(132 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(148 + doc_table_size, (int)dt.memsize);
   ASSERT_NE(dmd->id, strDocId);
   ASSERT_EQ(dmd->id, DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -51,7 +51,7 @@ protected:
         if (withExpiration) {
             // Initialize the TTL table with some expiration data. Results should not be expired so the test passes as expected.
             for (size_t i = 0; i < n_docs; ++i) {
-                q_mock.TTL_Add(resultSet[i]);
+                q_mock.TTL_Add(resultSet[i], t_fieldIndex{0});
             }
         }
 

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1284,7 +1284,7 @@ TEST_F(LLApiTest, testInfo) {
   // common stats
   ASSERT_EQ(info.numDocuments, 2);
   ASSERT_EQ(info.maxDocId, 2);
-  ASSERT_EQ(info.docTableSize, 124 + doc_table_size);
+  ASSERT_EQ(info.docTableSize, 140 + doc_table_size);
   ASSERT_EQ(info.sortablesSize, 48);
   ASSERT_EQ(info.docTrieSize, 120);
   ASSERT_EQ(info.numTerms, 5);
@@ -1380,23 +1380,23 @@ TEST_F(LLApiTest, testInfoSize) {
   // additional memory so from now on it will be easier to track the expected memory.
   size_t additional_overhead = sizeof(NumericRangeTree) + doc_table_size;
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 319 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 327 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 597 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 613 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 463 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 471 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 320 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 328 + additional_overhead);
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
   EXPECT_EQ(RediSearch_MemUsage(index), 234 + additional_overhead);
@@ -1440,23 +1440,23 @@ TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
   // additional memory so from now on it will be easier to track the expected memory.
   size_t additional_overhead = sizeof(NumericRangeTree) + doc_table_size;
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 400 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 408 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 679 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 695 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 545 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 553 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 401 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 409 + additional_overhead);
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
   EXPECT_EQ(RediSearch_MemUsage(index), 315 + additional_overhead);

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -682,3 +682,35 @@ def test_background_index_no_lazy_expiration_json(env):
     # Accessing doc:1 directly should cause lazy expire and its removal from the DB.
     env.expect('JSON.GET', 'doc:1', "$").equal(None)
     env.expect('DBSIZE').equal(1)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_ttl_table_collision_chain():
+    # Regression for the direct-modulo TTL table: seed the index with far more
+    # HEXPIRE-covered docs than the TTL bucket cap, so every slot must carry
+    # a collision chain. Then query for fresh and expired entries and verify
+    # the chain walk returns the right ones.
+    env = Env(moduleArgs='MAXDOCTABLESIZE 4')
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA', 'n', 'NUMERIC', 't', 'TAG').ok()
+
+    # Docs 1..odd are long-lived; docs 1..even get a fast HPEXPIRE so they
+    # will be reported as expired at query time.
+    N = 64  # > 16x the bucket cap => many collisions per slot
+    for d in range(1, N + 1):
+        env.expect('HSET', f'doc:{d}', 'n', str(d), 't', 'tag').equal(2)
+        if d % 2 == 0:
+            env.expect('HPEXPIRE', f'doc:{d}', '1', 'FIELDS', '2', 'n', 't').equal([1, 1])
+
+    time.sleep(0.050)
+
+    # Tag filter should still find every odd doc; evens are all expired.
+    res = env.cmd('FT.SEARCH', 'idx', '@t:{tag}', 'NOCONTENT', 'LIMIT', '0', str(N))
+    returned = sorted(int(d.split(':')[1]) for d in res[1:])
+    expected = list(range(1, N + 1, 2))
+    env.assertEqual(returned, expected)
+
+    # Numeric filter over the full range: same expectation.
+    res = env.cmd('FT.SEARCH', 'idx', f'@n:[1 {N}]', 'NOCONTENT', 'LIMIT', '0', str(N))
+    returned = sorted(int(d.split(':')[1]) for d in res[1:])
+    env.assertEqual(returned, expected)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -345,9 +345,9 @@ def testDocTableInfo(env):
     # = leanSize + sdsAllocSize(keyPtr)
     # = (sizeof(RSDocumentMetadata) - sizeof(RSPayload *))  (No payload)
     #   + (strlen(key) + 2)
-    # = (64 - 8) + 3 = 59
-    # 2 docs * 59 = 118
-    exp_doc_table_size = (n * doc_table_size_mb) + (118 / (1024 * 1024))
+    # = (72 - 8) + 3 = 67
+    # 2 docs * 67 = 134
+    exp_doc_table_size = (n * doc_table_size_mb) + (134 / (1024 * 1024))
     env.assertEqual(doctable_size1, exp_doc_table_size)
     sortable_size1 = float(d['sortable_values_size_mb'])
     env.assertGreater(sortable_size1, 0)


### PR DESCRIPTION
# Description
Backport of #9293 to `8.6`.

## Describe the changes in the pull request

Three perf improvements to the expiration feature, ported and adapted from the 8.4 investigation branches (originally redislabsdev PRs #225 and #226).

### 1. Redesign the TTL table for cache-friendly iterator lookups
Replace the dict-backed `TimeToLiveTable` with a direct-modulo bucket array whose collision chains are contiguous-vec blocks. docIds are allocated monotonically via `++maxDocId` in `DocTable`, so iterator-time `VerifyDocAndField*` lookups see them in ascending, mostly-sequential order; direct modulo keeps sequential docIds in sequential slots, letting the hardware prefetcher pull upcoming bucket headers into L1 ahead of demand. Primarily benefits the "miss" hot path - docs without TTL, the common case at query time. `DocTable_UpdateExpiration` now passes `t->maxSize` through to `TimeToLiveTable_VerifyInit` so the slot formula cannot drift from `DocTable`'s own modulus.

### 2. Gate per-posting TTL lookup on the presence of HFE entries
The TTL table now holds field-level (HEXPIRE) entries only and is destroyed by `DocTable_Pop` when the last one leaves the index, so a non-NULL `docs.ttl` is a sufficient and tight gate by itself. Iterators (`HybridIterator`, geometry `CPPQueryIterator`, Rust `FieldExpirationChecker`) bypass the TTL lookup entirely on indexes that have no field-level TTL right now, with no extra latch to maintain.

### 3. Inline doc-level expiration on DMD to bypass TTL lookup
Inline the doc-level expiration timestamp directly on the DMD as an `int64_t` nanoseconds-since-epoch (8 B per DMD, after `nextInChain` and before `payload` so `DocTable_Put`'s lean-allocation path is preserved). The new `DocTable_IsDocExpired` check is a single scalar compare on a cache line we are already touching (the caller has just read `dmd->flags`), eliminating the per-result table lookup on the result-processor hot path. The `Document_HasExpiration` flag is no longer set or read on the in-memory DMD path - the result processor fetches the DMD on every hit anyway, so a flag-gated branch buys nothing there.

#### Which additional issues this PR fixes
1. MOD-14916

#### Main objects this PR modified
1. `TimeToLiveTable` (`src/ttl_table/`): direct-modulo bucket array; HFE-only payload
2. `DocTable` / `RSDocumentMetadata` (`src/doc_table.*`, `src/redisearch.h`): inlined `expirationTimeNs`; HFE gate via `docs.ttl`
3. Iterators (`src/iterators/hybrid_reader.c`, `src/geometry/query_iterator.cpp`, `src/redisearch_rs/rqe_iterators/src/expiration_checker.rs`): hoisted gate

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

### Conflicts resolved

- `src/redisearch.h` — kept 8.6's inline `struct RSSortingVector sortVector;` and inserted `expirationTimeNs` after `ref_count`.
- `tests/cpptests/test_cpp_llapi.cpp` — kept `sortablesSize == 48`; dropped master-only `get_trie_entry_extra_overhead`, `RSGlobalConfig.gcConfigParams.gcSettings`, and `periodicCallback(... , false)` artifacts; kept the +8 / +16 byte deltas from inlining `expirationTimeNs`.
- Dropped two new files added by the cherry-pick that don't exist on 8.6: `src/redisearch_rs/rqe_iterators/src/expiration_checker.rs`, `src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs`.

### Post-cherry-pick fix-ups

Amended on top of the cherry-pick after CI revealed that several tests don't exist on master and were therefore not updated by the original PR:

- **`tests/cpptests/test_cpp_index.cpp`** — applied the +8-per-live-DMD delta to the `DocTable_MemUsage` assertions in `testDocTable` (9380→10180, 63→71, 132→148). This file is not present on master, so it was missed by the cherry-pick.
- **`tests/cpptests/test_cpp_iterator_index.cpp`** — replaced the 1-arg `q_mock.TTL_Add(resultSet[i])` call with `q_mock.TTL_Add(resultSet[i], t_fieldIndex{0})`. The 1-arg overload was removed by the PR (TTL table no longer stores doc-level TTL); master's only caller was already 2-arg, but this 8.6-only test was not updated.
- **`src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs`** — adapted to the new TTL FFI signatures: dropped the now-irrelevant `doc_expiration_time` argument from `TimeToLiveTable_Add` (doc-level TTL is now inlined on the DMD), passed `self.spec.docs.maxSize` as the new `maxSize` argument to `TimeToLiveTable_VerifyInit`, and initialized `spec.docs.maxSize` in `MockContext::new` so the lazy-init bucket modulus is non-zero (avoids `% 0` SIGSEGV in expiration tests). Master's equivalent file uses a `MockExpirationChecker` abstraction instead of raw FFI, so this update has no master counterpart. Final `cargo fmt` pass to wrap the multi-arg `TimeToLiveTable_VerifyInit` call across lines so it satisfies `make fmt CHECK=1`.
