### PR TITLE
[8.2] MOD-14916 MOD-15104 Expiration perf improvements

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -222,47 +222,77 @@ void DocTable_SetByteOffsets(RSDocumentMetadata *dmd, RSByteOffsets *v) {
   dmd->flags |= Document_HasOffsetVector;
 }
 
+// Pack a t_expirationTimePoint into nanoseconds since the epoch, preserving
+// the {0,0} "no expiration" sentinel as 0 so callers can use a single scalar
+// compare on the result-processor hot path.
+//
+// `t_expirationTimePoint` is a POSIX `struct timespec` (IEEE Std 1003.1), which
+// is the OS-level resolution ceiling: `tv_nsec` is in [0, 999999999], and any
+// finer-grained clock would require a different type. `int64_t` of nanoseconds
+// covers ~292 years from the epoch (year 2262), far beyond any TTL Redis can
+// produce — `RM_GetAbsExpire` and `RM_HashFieldMinExpire` both return an
+// `mstime_t` (signed milliseconds since epoch), which we expand into a
+// `timespec` in `document_basic.c::timespecFromMilliseconds` before reaching
+// here. The debug assert traps any future caller that violates the timespec
+// invariant.
+static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
+  RS_LOG_ASSERT(t.tv_nsec >= 0 && t.tv_nsec < 1000000000L,
+                "tv_nsec out of POSIX timespec range");
+  return (int64_t)t.tv_sec * 1000000000LL + (int64_t)t.tv_nsec;
+}
+
+// Inlines the doc-level TTL on the DMD unconditionally so the result-processor
+// can drop the TTL-table lookup, and only routes field-level expirations into
+// the TTL table. This keeps the table strictly an HFE store, which lets
+// iterators use `t->ttl == NULL` as their per-spec gate. Takes ownership of
+// `sortedFieldWithExpiration` either by handing it to the table or freeing it
+// when there are no field-level entries to register.
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
-  if (hasExpirationTimeInformation(dmd->flags)) {
-    TimeToLiveTable_VerifyInit(&t->ttl);
-    TimeToLiveTable_Add(t->ttl, dmd->id, ttl, sortedFieldWithExpiration);
+  dmd->expirationTimeNs = expirationTimePointToNs(ttl);
+  if (array_len(sortedFieldWithExpiration) > 0) {
+    TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
+    TimeToLiveTable_Add(t->ttl, dmd->id, sortedFieldWithExpiration);
+  } else {
+    array_free(sortedFieldWithExpiration);
   }
 }
 
 bool DocTable_HasExpiration(DocTable *t, t_docId docId)
 {
-  return t->ttl && TimeToLiveTable_HasExpiration(t->ttl, docId);
+  // After the inline doc-level TTL change, this only reflects whether the
+  // spec has any field-level expirations registered; that is sufficient for
+  // its callers (early-exit optimization for field-mask checks).
+  return t->ttl != NULL;
 }
 
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint) {
-  if (!hasExpirationTimeInformation(dmd->flags)) {
-      return false;
+  if (dmd->expirationTimeNs == 0) {
+    return false;
   }
-  RS_LOG_ASSERT(t->ttl, "Document has expiration time information but no TTL table");
-  return TimeToLiveTable_HasDocExpired(t->ttl, dmd->id, expirationPoint);
+  return dmd->expirationTimeNs <= expirationTimePointToNs(*expirationPoint);
 }
 
 void DocTable_ClearExpirationData(DocTable *t) {
-  if (t->ttl) {
-    dictIterator *ttlIter = dictGetIterator(t->ttl);
-    dictEntry *ttlEntry;
-    while ((ttlEntry = dictNext(ttlIter))) {
-      t_docId docId = (t_docId)dictGetKey(ttlEntry);
-      RSDocumentMetadata *dmd = DocTable_GetOwn(t, docId);
-      if (dmd) {
-        dmd->flags &= ~Document_HasExpiration;
-      }
-    }
-    dictReleaseIterator(ttlIter);
-    TimeToLiveTable_Destroy(&t->ttl);
-  }
+  // Walk every DMD: doc-level TTL lives inline on the DMD (not in the TTL
+  // table), and field-level TTL is only present for docs that are also in
+  // the table. Either may be set, so a single sweep over all DMDs is the
+  // simplest correct path.
+  DOCTABLE_FOREACH(t, dmd->expirationTimeNs = 0);
+  TimeToLiveTable_Destroy(&t->ttl);
 }
 
 bool DocTable_VerifyFieldExpirationPredicate(const DocTable *t, t_docId docId, const t_fieldIndex* fieldIndices, size_t fieldCount, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
   if (!t->ttl || !fieldIndices || fieldCount == 0) {
     return true;
   }
-  return TimeToLiveTable_VerifyDocAndFields(t->ttl, docId, fieldIndices, fieldCount, predicate, expirationPoint);
+  // The new TTL table exposes a per-field check; the array variant keeps the
+  // original "at least one field satisfies predicate" semantics.
+  for (size_t i = 0; i < fieldCount; ++i) {
+    if (TimeToLiveTable_VerifyDocAndField(t->ttl, docId, fieldIndices[i], predicate, expirationPoint)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /* Put a new document into the table, assign it an incremental id and store the metadata in the
@@ -395,7 +425,11 @@ RSDocumentMetadata *DocTable_Pop(DocTable *t, const char *s, size_t n) {
       return NULL;
     }
 
-    if (t->ttl && hasExpirationTimeInformation(md->flags)) {
+    // The TTL table holds field-level (HEXPIRE) entries only. Remove is a
+    // no-op if this doc never had one, and the IsEmpty check destroys the
+    // table once the last HFE doc leaves the index, restoring the iterator
+    // gate to its NULL "no HFE in this spec" state.
+    if (t->ttl) {
       TimeToLiveTable_Remove(t->ttl, md->id);
       if (TimeToLiveTable_IsEmpty(t->ttl)) {
         TimeToLiveTable_Destroy(&t->ttl);

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -75,6 +75,10 @@ typedef struct {
 
   DMDChain *buckets;
   DocIdMap dim;             // Mapping between document name to internal id
+  // Holds field-level expirations only; created lazily on the first HEXPIRE
+  // and destroyed when the last entry is removed. Iterators use a NULL check
+  // on this pointer as their HFE gate, so a NULL `ttl` means no doc in this
+  // index has ever had (or still has) a field-level expiration.
   TimeToLiveTable* ttl;
 } DocTable;
 
@@ -143,7 +147,7 @@ bool DocTable_HasExpiration(DocTable *t, t_docId docId);
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint);
 
 // Clear all expiration data from this doc table.
-// Clears Document_HasExpiration flags from all documents and destroys the TTL table.
+// Resets `expirationTimeNs` on every DMD and destroys the TTL table.
 // Must be called with the index write lock held.
 void DocTable_ClearExpirationData(DocTable *t);
 

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -324,6 +324,9 @@ static int HR_ReadHybridUnsortedSingle(HybridIterator *hr, RSIndexResult **hit) 
   const t_fieldIndex fieldIndex = hr->filterCtx.field.value.index;
   if (hr->sctx && fieldIndex != RS_INVALID_FIELD_INDEX
       && !DocTable_VerifyFieldExpirationPredicate(&hr->sctx->spec->docs, (*hit)->docId, &fieldIndex, 1, hr->filterCtx.predicate, &hr->sctx->time.current)) {
+    // The popped hit is no longer owned by topResults and is not appended to
+    // returnedResults, so free it here to avoid leaking on NOTFOUND.
+    IndexResult_Free(*hit);
     return INDEXREAD_NOTFOUND;
   }
   array_append(hr->returnedResults, *hit);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -217,7 +217,10 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
     Document* doc = cur->doc;
     const bool hasExpiration = doc->docExpirationTime.tv_sec || doc->docExpirationTime.tv_nsec || doc->fieldExpirations;
     if (hasExpiration) {
-      md->flags |= Document_HasExpiration;
+      // No need to mark the DMD with Document_HasExpiration: the result
+      // processor already fetches the DMD from the doc table on every hit,
+      // so it can read `expirationTimeNs` directly without going through
+      // a flag-gated branch.
       DocTable_UpdateExpiration(&ctx->spec->docs, md, doc->docExpirationTime, doc->fieldExpirations);
     }
     DMD_Return(md);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -205,13 +205,9 @@ void RedisSearchCtx_LockSpecRead(RedisSearchCtx *ctx) {
   // pause rehashing while we're using the dict for reads only
   // Assert that the pause value before we pause is valid.
   RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->keysDict));
-  // Also pause rehashing on the TTL table if it exists, to avoid concurrent
-  // rehash steps from multiple query threads corrupting the dict during reads.
-  if (ctx->spec->docs.ttl) {
-    RS_ASSERT_ALWAYS(dictPauseRehashing(ctx->spec->docs.ttl));
-  }
   ctx->flags = RS_CTX_READONLY;
 }
+
 
 void RedisSearchCtx_LockSpecWrite(RedisSearchCtx *ctx) {
   RS_ASSERT(ctx->flags == RS_CTX_UNSET);
@@ -246,10 +242,6 @@ void RedisSearchCtx_UnlockSpec(RedisSearchCtx *sctx) {
     // We paused rehashing when we locked the spec for read. Now we can resume it.
     // Assert that it was actually previously paused
     RS_ASSERT_ALWAYS(dictResumeRehashing(sctx->spec->keysDict));
-    // Also resume rehashing on the TTL table if it exists
-    if (sctx->spec->docs.ttl) {
-      RS_ASSERT_ALWAYS(dictResumeRehashing(sctx->spec->docs.ttl));
-    }
   }
   pthread_rwlock_unlock(&sctx->spec->rwlock);
   sctx->flags = RS_CTX_UNSET;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -148,12 +148,16 @@ typedef struct RSDocumentMetadata_s {
 
   uint16_t ref_count;
 
+  /* Document-level expiration time in nanoseconds since the epoch (0 = none).
+   * Inlined to avoid a TTL-table lookup on the result-processor hot path. */
+  int64_t expirationTimeNs;
+
   struct RSSortingVector *sortVector;
   /* Offsets of all terms in the document (in bytes). Used by highlighter */
   struct RSByteOffsets *byteOffsets;
   DLLIST2_node llnode;
 
-  /* Optional user payload */
+  /* Optional user payload. Must remain last for DocTable_Put's lean alloc. */
   RSPayload *payload;
 
 } RSDocumentMetadata;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -609,10 +609,6 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
   /* We might have multiple readers that reads from the index,
    * Avoid rehashing the terms dictionary */
   dictPauseRehashing(sp->keysDict);
-  /* Also pause rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictPauseRehashing(sp->docs.ttl);
-  }
 
   RSSearchOptions options = {0};
   QueryError status = {0};
@@ -665,9 +661,6 @@ end:
      * If iter->sp is set, RediSearch_ResultsIteratorFree will handle cleanup. */
     if (!it->sp) {
       dictResumeRehashing(sp->keysDict);
-      if (sp->docs.ttl) {
-        dictResumeRehashing(sp->docs.ttl);
-      }
       pthread_rwlock_unlock(&sp->rwlock);
     }
     RediSearch_ResultsIteratorFree(it);
@@ -745,9 +738,6 @@ void RediSearch_ResultsIteratorFree(RS_ApiIter* iter) {
   if (iter->sp) {
     if (iter->sp->keysDict) {
       dictResumeRehashing(iter->sp->keysDict);
-    }
-    if (iter->sp->docs.ttl) {
-      dictResumeRehashing(iter->sp->docs.ttl);
     }
     pthread_rwlock_unlock(&iter->sp->rwlock);
   }
@@ -903,10 +893,6 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   /* We might have multiple readers that reads from the index,
    * Avoid rehashing the terms dictionary */
   dictPauseRehashing(sp->keysDict);
-  /* Also pause rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictPauseRehashing(sp->docs.ttl);
-  }
 
   info->gcPolicy = sp->gc ? GC_POLICY_FORK : GC_POLICY_NONE;
   if (sp->rule) {
@@ -950,10 +936,6 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   }
 
   dictResumeRehashing(sp->keysDict);
-  /* Also resume rehashing on the TTL table if it exists */
-  if (sp->docs.ttl) {
-    dictResumeRehashing(sp->docs.ttl);
-  }
   /* Release spec read lock */
   pthread_rwlock_unlock(&sp->rwlock);
   RWLOCK_RELEASE();

--- a/src/ttl_table.c
+++ b/src/ttl_table.c
@@ -13,57 +13,190 @@
 #include "util/misc.h"
 #include "rmutil/rm_assert.h"
 
+// Direct-modulo bucket array with contiguous-vec collision chains.
+//
+// Rationale:
+//  - docIds are allocated monotonically via ++maxDocId in DocTable, so the
+//    iterator-time lookups of `VerifyDocAndField*` see them in ascending,
+//    mostly-sequential order. Hashing would scatter that locality; direct
+//    modulo keeps sequential docIds in sequential slots so the CPU hardware
+//    prefetcher can pull upcoming bucket headers into L1 ahead of demand.
+//    This primarily benefits the "miss" hot path — docs without TTL, the
+//    common case at query time — where each `ttl_find_entry` probes a
+//    bucket pointer (8 B), sees NULL, and returns. Eight such probes fit in
+//    one 64-byte cache line, and the stride-1 access pattern matches the
+//    hardware prefetcher's sequential detector so it streams the next lines
+//    in without demand-miss stalls as long as the iterator walks docIds in
+//    ascending order.
+//  - When maxDocId exceeds `maxSize`, multiple docIds collide on the same
+//    slot. A per-bucket contiguous-vec chain keeps walks cache-line
+//    sequential and bounds worst-case behavior (Poisson tail at load factor
+//    1 gives chain length ≤ ~5) — unlike linear probing, which degrades to
+//    O(cap) once deletes create probe-gaps in a near-full table.
+//  - Each non-empty bucket is an arr.h fat pointer: len/cap live in the
+//    `array_hdr_t` immediately preceding the elements, so the slot itself
+//    is just an 8 B pointer. Writes go through arr.h's geometric growth
+//    rather than a +1 realloc per insert.
+//  - Lazy growth mirrors DocTable_Set: `maxSize` (the modulus used by the
+//    slot formula) is captured once at init and never changes, while `cap`
+//    (the number of buckets actually allocated) starts at 0 and grows on
+//    demand via rm_realloc up to `maxSize`. Because the slot formula depends
+//    only on `maxSize`, growing `cap` never relocates an existing entry —
+//    it only extends the tail of the bucket array. Reads for docIds whose
+//    slot lies in the still-unallocated tail treat the entry as absent,
+//    which is correct because Add always grows `cap` to cover the slot
+//    before writing. This keeps the per-index footprint proportional to the
+//    number of TTL docs ever inserted rather than to maxDocTableSize, which
+//    matters in deployments with many indexes that sparsely use TTL.
+
 typedef struct {
-  t_expirationTimePoint documentExpirationPoint;
-  FieldExpiration* fieldExpirations;
+  t_docId docId;                              // 0 is reserved / unused
+  arrayof(FieldExpiration) fieldExpirations;  // owned, sorted by field index, never empty
 } TimeToLiveEntry;
 
-static uint64_t hashFunction_DocId(const void *key) {
-  return (t_docId)key;
-}
-static void destructor_TimeToLiveEntry(void *privdata, void *val) {
-    TimeToLiveEntry* entry = (TimeToLiveEntry*)val;
-    array_free(entry->fieldExpirations);
-    rm_free(entry);
-}
+// A bucket is a NULL-or-arr.h-managed chain of entries. NULL means empty.
+typedef arrayof(TimeToLiveEntry) TTLBucket;
 
-static dictType dictTimeToLive = {
-  .hashFunction = hashFunction_DocId,
-  .keyDup = NULL,
-  .valDup = NULL,
-  .keyCompare = NULL,
-  .keyDestructor = NULL,
-  .valDestructor = destructor_TimeToLiveEntry,
+struct TimeToLiveTable {
+  TTLBucket *buckets;                   // allocated for the first `cap` slots
+  size_t cap;                           // number of bucket slots physically allocated
+  size_t maxSize;                       // modulus for slot calculation, fixed at init
+  size_t count;                         // total live entries
 };
 
-void TimeToLiveTable_VerifyInit(TimeToLiveTable **table) {
-    if (!*table) {
-      *table = dictCreate(&dictTimeToLive, NULL);
-    }
+static inline size_t ttl_slot(const TimeToLiveTable *t, t_docId docId) {
+  return docId < t->maxSize ? (size_t)docId : (size_t)(docId % t->maxSize);
+}
+
+// Initial bucket-array size the first time we grow from zero. Chosen so an
+// index that only ever holds a handful of TTL docs pays one small allocation
+// and no reallocs. Must be ≥ 1.
+#define TTL_BUCKET_INITIAL_CAP ((size_t)64)
+
+// Upper bound on the geometric +1.5x step once the bucket array is non-empty,
+// mirroring DocTable_Set's cap so huge tables don't take a single multi-MB
+// realloc hit and so the two allocators scale in lockstep.
+#define TTL_BUCKET_MAX_GROW_STEP ((size_t)(1 << 20))  // 1 Mi buckets
+
+// Ensure buckets[slot] is allocated. Called from Add only; reads treat
+// slot >= cap as "not present" and never grow. Growth curve matches
+// DocTable_Set: +1.5x geometric up to TTL_BUCKET_MAX_GROW_STEP, clamped to
+// maxSize, with TTL_BUCKET_INITIAL_CAP as the first-grow seed.
+static void ttl_grow(TimeToLiveTable *t, size_t slot) {
+  RS_ASSERT(slot < t->maxSize);    // ttl_slot's contract; tightens the call boundary
+  if (slot < t->cap) return;
+  RS_ASSERT(t->cap < t->maxSize);  // slot is always < maxSize, so room must exist
+  const size_t oldcap = t->cap;
+  size_t newcap = t->cap == 0
+      ? TTL_BUCKET_INITIAL_CAP
+      : t->cap + 1 + MIN(t->cap / 2, TTL_BUCKET_MAX_GROW_STEP);
+  if (newcap > t->maxSize) newcap = t->maxSize;
+  if (newcap < slot + 1) newcap = slot + 1;
+  t->buckets = rm_realloc(t->buckets, newcap * sizeof(*t->buckets));
+  memset(t->buckets + oldcap, 0, (newcap - oldcap) * sizeof(*t->buckets));
+  t->cap = newcap;
+}
+
+static inline TimeToLiveEntry *ttl_find_entry(const TimeToLiveTable *t, t_docId docId) {
+  const size_t slot = ttl_slot(t, docId);
+  if (slot >= t->cap) return NULL;  // bucket unallocated => entry cannot exist
+  TTLBucket bucket = t->buckets[slot];
+  if (!bucket) return NULL;
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId == docId) return &bucket[i];
+  }
+  return NULL;
+}
+
+// Debug-only duplicate probe for the monotonic-docId invariant. Extracted to
+// keep the Add call site readable (`assert(!ttl_bucket_contains(...))`); the
+// invariant itself is enforced upstream by the spec write lock in
+// DocTable_Put, so eliding the scan in release is intentional.
+static bool ttl_bucket_contains(TTLBucket bucket, t_docId docId) {
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId == docId) return true;
+  }
+  return false;
+}
+
+// Release the owned allocations of a single entry. The entry slot itself is
+// owned by the bucket's `entries` block and is freed with it.
+static inline void ttl_entry_release(TimeToLiveEntry *e) {
+  array_free(e->fieldExpirations);
+}
+
+void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize) {
+  if (*table) return;
+  // maxSize == 0 would make ttl_slot divide by zero; the caller (DocTable)
+  // floors its own maxSize to 1 on load, so treat this as a hard invariant.
+  RS_LOG_ASSERT_ALWAYS(maxSize >= 1, "TTL table maxSize must be >= 1");
+  TimeToLiveTable *t = rm_malloc(sizeof(*t));
+  t->buckets = NULL;
+  t->cap = 0;
+  t->maxSize = maxSize;
+  t->count = 0;
+  *table = t;
 }
 
 void TimeToLiveTable_Destroy(TimeToLiveTable **table) {
-    if (*table) {
-      dictRelease(*table);
-      *table = NULL;
+  if (!*table) return;
+  TimeToLiveTable *t = *table;
+  for (size_t s = 0; s < t->cap; s++) {
+    TTLBucket bucket = t->buckets[s];
+    if (!bucket) continue;
+    const uint32_t n = array_len(bucket);
+    for (uint32_t i = 0; i < n; i++) {
+      ttl_entry_release(&bucket[i]);
     }
+    array_free(bucket);
+  }
+  rm_free(t->buckets);
+  rm_free(t);
+  *table = NULL;
 }
 
-void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpirationTime, arrayof(FieldExpiration) sortedById) {
-  TimeToLiveEntry* entry = (TimeToLiveEntry*)rm_malloc(sizeof(TimeToLiveEntry));
-  entry->documentExpirationPoint = docExpirationTime;
-  entry->fieldExpirations = sortedById;
-  // we don't want the operation to fail so we use dictReplace
-  const bool added = dictAdd(table, (void*)docId, entry) == DICT_OK;
-  RS_LOG_ASSERT(added, "Failed to add document to ttl table");
+void TimeToLiveTable_Add(TimeToLiveTable *t, t_docId docId, arrayof(FieldExpiration) sortedById) {
+  RS_ASSERT(sortedById && array_len(sortedById) > 0);
+  const size_t slot = ttl_slot(t, docId);
+  ttl_grow(t, slot);
+  // docIds are monotonically assigned in DocTable_Put under the spec write
+  // lock, so duplicates should not reach here; the assert catches a broken
+  // locking discipline during development before it corrupts the table.
+  RS_LOG_ASSERT(!ttl_bucket_contains(t->buckets[slot], docId), "duplicate docId in TTL table");
+  TimeToLiveEntry entry = { .docId = docId, .fieldExpirations = sortedById };
+  t->buckets[slot] = array_ensure_append_1(t->buckets[slot], entry);
+  t->count++;
 }
 
-void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId) {
-  dictDelete(table, (void*)docId);
+void TimeToLiveTable_Remove(TimeToLiveTable *t, t_docId docId) {
+  const size_t slot = ttl_slot(t, docId);
+  if (slot >= t->cap) return;  // bucket unallocated => nothing to remove
+  TTLBucket bucket = t->buckets[slot];
+  if (!bucket) return;
+  const uint32_t n = array_len(bucket);
+  for (uint32_t i = 0; i < n; i++) {
+    if (bucket[i].docId != docId) continue;
+    ttl_entry_release(&bucket[i]);
+    array_del_fast(bucket, i);  // swap-last + dec len; in-place, no realloc
+    t->count--;
+    if (array_len(bucket) == 0) {
+      array_free(bucket);
+      t->buckets[slot] = NULL;
+    }
+    // No-shrink-on-delete: arr.h keeps the allocation at its high-water
+    // mark via remain_cap, avoiding realloc churn for buckets that churn.
+    return;
+  }
 }
 
-bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table) {
-  return dictSize(table) == 0;
+bool TimeToLiveTable_IsEmpty(TimeToLiveTable *t) {
+  return t->count == 0;
+}
+
+size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *t) {
+  return t ? t->cap : 0;
 }
 
 static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirationTimePoint* now) {
@@ -74,61 +207,170 @@ static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirat
   return !((field->tv_sec > now->tv_sec) || (field->tv_sec == now->tv_sec && field->tv_nsec > now->tv_nsec));
 }
 
-bool TimeToLiveTable_HasExpiration(TimeToLiveTable *table, t_docId docId) {
-  return dictFind(table, (void*)docId) != NULL;
-}
-
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const struct timespec* expirationPoint) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
-    return false;
-  }
-
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  return DidExpire(&ttlEntry->documentExpirationPoint, expirationPoint);
-}
-
-bool TimeToLiveTable_VerifyDocAndFields(TimeToLiveTable *table, t_docId docId, const t_fieldIndex* sortedFieldIndices, size_t fieldCount, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
-  dictEntry *entry = dictFind(table, (void*)docId);
-  if (!entry) {
+bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *t, t_docId docId, t_fieldIndex field, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
     // the document did not have a ttl for itself or its fields
     // if predicate is default then we know at least one field is valid
     // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
     return true;
   }
 
-  TimeToLiveEntry* ttlEntry = (TimeToLiveEntry*)dictGetVal(entry);
-  if (ttlEntry->fieldExpirations == NULL) {
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
+  if (fieldWithExpirationCount == 0) {
     // the document has no fields with expiration times, there exists at least one valid field
     return true;
   }
 
-  const size_t fieldWithExpirationCount = array_len(ttlEntry->fieldExpirations);
-  if (fieldWithExpirationCount < fieldCount && predicate == FIELD_EXPIRATION_DEFAULT) {
+  for (size_t currentFieldIndex = 0; currentFieldIndex < fieldWithExpirationCount; currentFieldIndex++) {
+    FieldExpiration* fieldExpiration = &e->fieldExpirations[currentFieldIndex];
+    if (field == fieldExpiration->index) {
+      // the field has an expiration time
+      const bool expired = DidExpire(&fieldExpiration->point, expirationPoint);
+      if (expired) {
+        // the document is invalid (should return `false`), unless we look for missing fields
+        return (predicate == FIELD_EXPIRATION_MISSING);
+      } else {
+        // the document is valid (should return `true`), unless we look for missing fields
+        return (predicate != FIELD_EXPIRATION_MISSING);
+      }
+    }
+  }
+  // the field was not found in the document's field expirations,
+  // which means it is valid unless the predicate is FIELD_EXPIRATION_MISSING
+  return (predicate != FIELD_EXPIRATION_MISSING);
+}
+
+bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *t, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
+    // the document did not have a ttl for itself or its fields
+    // if predicate is default then we know at least one field is valid
+    // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
+    return true;
+  }
+
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
+  const size_t fieldCount = __builtin_popcount(fieldMask);
+  if (fieldWithExpirationCount == 0) {
+    // the document has no fields with expiration times, there exists at least one valid field
+    return true;
+  } else if (fieldWithExpirationCount < fieldCount && predicate == FIELD_EXPIRATION_DEFAULT) {
     // the document has less fields with expiration times than the fields we are checking
     // at least one field is valid
     return true;
   }
 
+  size_t predicateMisses = 0;
   size_t currentFieldIndex = 0;
-  for (size_t runningFieldIndex = 0; runningFieldIndex < fieldCount && currentFieldIndex < fieldWithExpirationCount; ) {
-    t_fieldIndex fieldIndexToCheck = sortedFieldIndices[runningFieldIndex];
-    FieldExpiration* fieldExpiration = &ttlEntry->fieldExpirations[currentFieldIndex];
-    if (fieldIndexToCheck > fieldExpiration->index) {
-      ++currentFieldIndex;
-    } else if (fieldIndexToCheck < fieldExpiration->index) {
-      ++runningFieldIndex;
-    } else {
-      // the field has an expiration time
-      const bool expired = DidExpire(&fieldExpiration->point, expirationPoint);
+  int bitIndex;
+  while ((bitIndex = ffs(fieldMask))) {
+    bitIndex--;  // ffs returns 1-based index, we need 0-based
+    fieldMask &= ~(1U << bitIndex);  // Clear the bit we just processed
+    t_fieldIndex fieldIndexToCheck = ftIdToFieldIndex[bitIndex];
+
+    // Attempt to find the next field expiration that matches the current field index
+    while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > e->fieldExpirations[currentFieldIndex].index) {
+      currentFieldIndex++;
+    }
+    if (currentFieldIndex >= fieldWithExpirationCount) {
+      // No more fields with expiration times to check
+      break;
+    } else if (fieldIndexToCheck < e->fieldExpirations[currentFieldIndex].index) {
+      // The field we are checking is not present in the current field expiration
+      continue;
+    }
+
+    RS_ASSERT(fieldIndexToCheck == e->fieldExpirations[currentFieldIndex].index);
+    // Match found - we need to check if it has an expiration time
+    const bool expired = DidExpire(&e->fieldExpirations[currentFieldIndex].point, expirationPoint);
+    if (!expired && predicate == FIELD_EXPIRATION_DEFAULT) {
+      return true;
+    } else if (expired && predicate == FIELD_EXPIRATION_MISSING) {
+      return true;
+    }
+    predicateMisses++; // Count the predicate misses for the current match
+  }
+  if (predicate == FIELD_EXPIRATION_DEFAULT) {
+    // If we are checking for the default predicate, we need at least one valid field
+    return predicateMisses < fieldCount;
+  } else { // if (predicate == FIELD_EXPIRATION_MISSING)
+    // If we are checking for the missing predicate, we need at least one expired field
+    // If we reached here, it means we did not find any expired fields
+    return false;
+  }
+}
+
+
+// TODO: Rust - unify with the implementation above using generic field mask
+bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *t, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  if (!e) {
+    // the document did not have a ttl for itself or its fields
+    // if predicate is default then we know at least one field is valid
+    // if predicate is missing then we know the field is indeed missing since the document has no expiration for it
+    return true;
+  }
+
+  uint64_t fieldMask64[2];
+  if (sizeof(fieldMask) == sizeof(uint64_t)) {
+    fieldMask64[0] = fieldMask;
+    fieldMask64[1] = 0;
+  } else {
+    fieldMask64[0] = (uint64_t)fieldMask;
+    fieldMask64[1] = fieldMask >> 64;
+  }
+
+  const size_t fieldWithExpirationCount = array_len(e->fieldExpirations);
+  const size_t fieldCount = __builtin_popcountll(fieldMask64[0]) + __builtin_popcountll(fieldMask64[1]);
+  if (fieldWithExpirationCount == 0) {
+    // the document has no fields with expiration times, there exists at least one valid field
+    return true;
+  } else if (fieldWithExpirationCount < fieldCount && predicate == FIELD_EXPIRATION_DEFAULT) {
+    // the document has less fields with expiration times than the fields we are checking
+    // at least one field is valid
+    return true;
+  }
+
+  size_t predicateMisses = 0;
+  size_t currentFieldIndex = 0;
+  int bitIndex;
+  for (int i = 0; i < 2; i++) {
+    while ((bitIndex = ffsll(fieldMask64[i]))) {
+      bitIndex--;  // ffsll returns 1-based index, we need 0-based
+      fieldMask64[i] &= ~(1ULL << bitIndex);  // Clear the bit we just processed
+      t_fieldIndex fieldIndexToCheck = ftIdToFieldIndex[bitIndex + (i * 64)];
+
+      // Attempt to find the next field expiration that matches the current field index
+      while (currentFieldIndex < fieldWithExpirationCount && fieldIndexToCheck > e->fieldExpirations[currentFieldIndex].index) {
+        currentFieldIndex++;
+      }
+      if (currentFieldIndex >= fieldWithExpirationCount) {
+        // No more fields with expiration times to check
+        goto end; // Break out of all loops
+      } else if (fieldIndexToCheck < e->fieldExpirations[currentFieldIndex].index) {
+        // The field we are checking is not present in the current field expiration
+        continue;
+      }
+
+      RS_ASSERT(fieldIndexToCheck == e->fieldExpirations[currentFieldIndex].index);
+      // Match found - we need to check if it has an expiration time
+      const bool expired = DidExpire(&e->fieldExpirations[currentFieldIndex].point, expirationPoint);
       if (!expired && predicate == FIELD_EXPIRATION_DEFAULT) {
         return true;
       } else if (expired && predicate == FIELD_EXPIRATION_MISSING) {
         return true;
       }
-      ++currentFieldIndex;
-      ++runningFieldIndex;
+      predicateMisses++; // Count the predicate misses for the current match
     }
   }
-  return false;
+end:
+  if (predicate == FIELD_EXPIRATION_DEFAULT) {
+    // If we are checking for the default predicate, we need at least one valid field
+    return predicateMisses < fieldCount;
+  } else { // if (predicate == FIELD_EXPIRATION_MISSING)
+    // If we are checking for the missing predicate, we need at least one expired field
+    // If we reached here, it means we did not find any expired fields
+    return false;
+  }
 }

--- a/src/ttl_table.h
+++ b/src/ttl_table.h
@@ -10,25 +10,47 @@
 #ifndef TTL_TABLE_H
 #define TTL_TABLE_H
 #include "redisearch.h"
-#include "util/dict.h"
 #include "stdbool.h"
 #include "util/arr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct {
   t_fieldIndex index;
   t_expirationTimePoint point;
 } FieldExpiration;
 
-typedef dict TimeToLiveTable;
+typedef struct TimeToLiveTable TimeToLiveTable;
 
-void TimeToLiveTable_VerifyInit(TimeToLiveTable **table);
+// Lazy-init: allocates the table on first use with `maxSize` as the fixed
+// modulus for the slot formula. Caller (DocTable) passes its own
+// `t->maxSize` so the two tables' slot formulas are identical by
+// construction and cannot drift if `search-max-doctablesize` is later
+// mutated. No-op if the table is already initialized.
+//
+// The table only holds field-level (HEXPIRE) expirations: doc-level TTL is
+// inlined directly on `RSDocumentMetadata::expirationTimeNs` so the
+// result-processor hot path can avoid this lookup entirely.
+void TimeToLiveTable_VerifyInit(TimeToLiveTable **table, size_t maxSize);
 void TimeToLiveTable_Destroy(TimeToLiveTable **table);
-void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, t_expirationTimePoint docExpiration, arrayof(FieldExpiration) sortedById);
+// Adds a field-level expiration entry. `sortedById` must be non-empty;
+// ownership of the array transfers to the table.
+void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, arrayof(FieldExpiration) sortedById);
 void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId);
 bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table);
 
-bool TimeToLiveTable_HasExpiration(TimeToLiveTable *table, t_docId docId);
-bool TimeToLiveTable_HasDocExpired(TimeToLiveTable *table, t_docId docId, const struct timespec* expirationPoint);
-bool TimeToLiveTable_VerifyDocAndFields(TimeToLiveTable *table, t_docId docId, const t_fieldIndex* sortedFieldIndices, size_t fieldCount, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint);
+bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex fieldIndex, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint);
+bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
+bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
+
+// Test-only: number of buckets currently allocated (lazy-growth high-water
+// mark). Not exposed for runtime use.
+size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *table);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //TTL_TABLE_H

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -15,9 +15,11 @@
 #include "redismock/internal.h"
 #include "spec.h"
 #include "common.h"
+#include "config.h"
 #include "module.h"
 #include "version.h"
 #include "tag_index.h"
+#include "ttl_table.h"
 #include "info/info_redis/threads/current_thread.h"
 
 #include <vector>
@@ -89,3 +91,176 @@ TEST_F(ExpireTest, testSkipTo) {
   args.clear();
   RedisModule_FreeThreadSafeContext(ctx);
 }
+
+// Helper: build a one-entry FieldExpiration array on field index 0. Ownership
+// transfers to the table on TimeToLiveTable_Add.
+static arrayof(FieldExpiration) makeFE(t_expirationTimePoint p) {
+  arrayof(FieldExpiration) fe = array_new(FieldExpiration, 1);
+  FieldExpiration entry = {0, p};
+  array_append(fe, entry);
+  return fe;
+}
+
+// Returns true if field 0 is expired for the given docId. Mirrors what the
+// VerifyDocAndField slow path observes during query iteration.
+static bool fieldExpired(TimeToLiveTable *ttl, t_docId d, const struct timespec *now) {
+  return !TimeToLiveTable_VerifyDocAndField(ttl, d, 0, FIELD_EXPIRATION_DEFAULT, now);
+}
+
+// Exercises the direct-modulo + contiguous-vec chain implementation of
+// TimeToLiveTable: seed it with more docIds than the bucket cap so every slot
+// carries multiple entries, then verify each docId's expiration state is
+// observed correctly. Also exercises removal from the middle of a chain via
+// the swap-last path.
+TEST_F(ExpireTest, testTTLCollisionChain) {
+  // Force a small cap so the chain path is actually exercised at this size.
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const size_t cap = 32;
+  RSGlobalConfig.maxDocTableSize = cap;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, cap);
+
+  // Insert 4x the cap so every slot has ~4 entries on average. Alternate
+  // expired/fresh so we can assert the chain walk returns the right entry.
+  const t_docId N = (t_docId)cap * 4;
+  struct timespec past = {1, 0};
+  struct timespec future = {LONG_MAX, LONG_MAX};
+  for (t_docId d = 1; d <= N; ++d) {
+    TimeToLiveTable_Add(ttl, d, makeFE((d & 1) ? past : future));
+  }
+
+  struct timespec now = {2, 0};
+  for (t_docId d = 1; d <= N; ++d) {
+    const bool expected = (d & 1) != 0;
+    ASSERT_EQ(fieldExpired(ttl, d, &now), expected) << "docId=" << d;
+  }
+
+  // Remove every third docId and re-verify. This deletes from arbitrary chain
+  // positions and triggers the swap-last codepath repeatedly.
+  for (t_docId d = 3; d <= N; d += 3) {
+    TimeToLiveTable_Remove(ttl, d);
+  }
+  for (t_docId d = 1; d <= N; ++d) {
+    if (d % 3 == 0) {
+      // Removed entries are absent => VerifyDocAndField treats the field as
+      // valid, i.e. fieldExpired returns false.
+      ASSERT_FALSE(fieldExpired(ttl, d, &now)) << "docId=" << d;
+    } else {
+      const bool expected = (d & 1) != 0;
+      ASSERT_EQ(fieldExpired(ttl, d, &now), expected) << "docId=" << d;
+    }
+  }
+
+  // Drain the rest and verify the table reports empty so the lifecycle
+  // mechanism in DocTable_Pop can destroy it.
+  for (t_docId d = 1; d <= N; ++d) {
+    if (d % 3 != 0) {
+      TimeToLiveTable_Remove(ttl, d);
+    }
+  }
+  ASSERT_TRUE(TimeToLiveTable_IsEmpty(ttl));
+
+  TimeToLiveTable_Destroy(&ttl);
+  ASSERT_EQ(ttl, nullptr);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+
+// Exercises the docId wrap at the cap boundary: docId < cap uses slot = docId,
+// while docId >= cap uses slot = docId % cap. The two branches must land on
+// the same bucket and stay distinguishable from each other.
+TEST_F(ExpireTest, testTTLDocIdWrap) {
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const t_docId CAP = 32;
+  RSGlobalConfig.maxDocTableSize = CAP;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, CAP);
+  // Collide docId X (fast path) with docId X + CAP and X + 2*CAP (modulo path).
+  struct timespec past = {1, 0};
+  struct timespec future = {LONG_MAX, LONG_MAX};
+  struct timespec now = {2, 0};
+  for (t_docId x = 1; x < 8; ++x) {
+    TimeToLiveTable_Add(ttl, x, makeFE(past));
+    TimeToLiveTable_Add(ttl, x + CAP, makeFE(future));
+    TimeToLiveTable_Add(ttl, x + 2 * CAP, makeFE(past));
+  }
+  for (t_docId x = 1; x < 8; ++x) {
+    ASSERT_TRUE(fieldExpired(ttl, x, &now));
+    ASSERT_FALSE(fieldExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x + 2 * CAP, &now));
+    // A docId that hashes to the same slot but was never inserted must report
+    // "no TTL" => fieldExpired returns false without matching another entry.
+    ASSERT_FALSE(fieldExpired(ttl, x + 3 * CAP, &now));
+  }
+
+  // Remove the "middle" entries and confirm the remaining two are still
+  // found in both directions (the swap-last must not corrupt the chain).
+  for (t_docId x = 1; x < 8; ++x) {
+    TimeToLiveTable_Remove(ttl, x + CAP);
+  }
+  for (t_docId x = 1; x < 8; ++x) {
+    ASSERT_TRUE(fieldExpired(ttl, x, &now));
+    ASSERT_FALSE(fieldExpired(ttl, x + CAP, &now));
+    ASSERT_TRUE(fieldExpired(ttl, x + 2 * CAP, &now));
+  }
+
+  TimeToLiveTable_Destroy(&ttl);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+
+// Exercises lazy bucket-array growth: with a large configured maxSize, a
+// table that only ever holds a handful of entries must not allocate the
+// full maxSize worth of buckets. Also verifies that the grown `cap` covers
+// every slot that has been written, and that wrap-around docIds are still
+// routed to their correct (already-allocated) slot after growth.
+TEST_F(ExpireTest, testTTLLazyGrowth) {
+  const size_t savedMax = RSGlobalConfig.maxDocTableSize;
+  const size_t MAX = 1000000;  // matches production default
+  RSGlobalConfig.maxDocTableSize = MAX;
+
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, MAX);
+  // Init alone must not allocate any buckets.
+  ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), 0u);
+
+  struct timespec past = {1, 0};
+  struct timespec now = {2, 0};
+
+  // Insert a small, sparse set of low docIds. Growth should stop well below
+  // MAX; concretely, the high-water slot is 100, so cap is bounded by the
+  // geometric growth curve's next step above that, which is a small factor
+  // of 100 — nowhere near MAX.
+  const t_docId small_ids[] = {1, 5, 42, 100};
+  for (t_docId d : small_ids) {
+    TimeToLiveTable_Add(ttl, d, makeFE(past));
+  }
+  const size_t cap_after_small = TimeToLiveTable_DebugAllocatedBuckets(ttl);
+  ASSERT_GE(cap_after_small, 101u);   // must cover slot 100
+  ASSERT_LT(cap_after_small, MAX / 10);  // must be far below maxSize
+
+  // Reads for docIds whose slot is still unallocated must report not-found.
+  ASSERT_FALSE(fieldExpired(ttl, 999999, &now));
+  // Writes must still work for those, and bump cap to cover them.
+  TimeToLiveTable_Add(ttl, 999999, makeFE(past));
+  ASSERT_GE(TimeToLiveTable_DebugAllocatedBuckets(ttl), 999999u + 1);
+  ASSERT_TRUE(fieldExpired(ttl, 999999, &now));
+
+  // Previously-inserted entries must not have moved during the grow.
+  for (t_docId d : small_ids) {
+    ASSERT_TRUE(fieldExpired(ttl, d, &now)) << "docId=" << d;
+  }
+
+  // A wrap-around docId (>= maxSize) routes via modulo into an already-
+  // allocated slot, so it works without further growth.
+  const size_t cap_before_wrap = TimeToLiveTable_DebugAllocatedBuckets(ttl);
+  TimeToLiveTable_Add(ttl, MAX + 5, makeFE(past));  // slot = 5, already in range
+  ASSERT_EQ(TimeToLiveTable_DebugAllocatedBuckets(ttl), cap_before_wrap);
+  ASSERT_TRUE(fieldExpired(ttl, MAX + 5, &now));
+  // The original docId=5 entry must still be distinct from the wrapped one.
+  ASSERT_TRUE(fieldExpired(ttl, 5, &now));
+
+  TimeToLiveTable_Destroy(&ttl);
+  RSGlobalConfig.maxDocTableSize = savedMax;
+}
+

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1493,7 +1493,7 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_EQ(N + 1, dt.size);
   ASSERT_EQ(N, dt.maxDocId);
 #ifdef __x86_64__
-  ASSERT_EQ(10180 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(10980 + doc_table_size, (int)dt.memsize);
 #endif
   for (int i = 0; i < N; i++) {
     snprintf(buf, sizeof(buf), "doc_%d", i);
@@ -1530,7 +1530,7 @@ TEST_F(IndexTest, testDocTable) {
   RSDocumentMetadata *dmd = DocTable_Put(&dt, "Hello", 5, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   t_docId strDocId = dmd->id;
   ASSERT_TRUE(0 != strDocId);
-  ASSERT_EQ(71 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(79 + doc_table_size, (int)dt.memsize);
 
   // Test that binary keys also work here
   static const char binBuf[] = {"Hello\x00World"};
@@ -1539,7 +1539,7 @@ TEST_F(IndexTest, testDocTable) {
   DMD_Return(dmd);
   dmd = DocTable_Put(&dt, binBuf, binBufLen, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   ASSERT_TRUE(dmd);
-  ASSERT_EQ(148 + doc_table_size, (int)dt.memsize);
+  ASSERT_EQ(164 + doc_table_size, (int)dt.memsize);
   ASSERT_NE(dmd->id, strDocId);
   ASSERT_EQ(dmd->id, DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1282,7 +1282,7 @@ TEST_F(LLApiTest, testInfo) {
   // common stats
   ASSERT_EQ(info.numDocuments, 2);
   ASSERT_EQ(info.maxDocId, 2);
-  ASSERT_EQ(info.docTableSize, 140 + doc_table_size);
+  ASSERT_EQ(info.docTableSize, 156 + doc_table_size);
   ASSERT_EQ(info.sortablesSize, 48);
   ASSERT_EQ(info.docTrieSize, 120);
   ASSERT_EQ(info.numTerms, 5);
@@ -1378,23 +1378,23 @@ TEST_F(LLApiTest, testInfoSize) {
   // additional memory so from now on it will be easier to track the expected memory.
   size_t additional_overhead = sizeof(NumericRangeTree) + doc_table_size;
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 330 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 338 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 613 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 629 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 471 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 479 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 327 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 335 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
@@ -1438,23 +1438,23 @@ TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
   // additional memory so from now on it will be easier to track the expected memory.
   size_t additional_overhead = sizeof(NumericRangeTree) + doc_table_size;
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 416 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 424 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 699 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 715 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 557 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 565 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 408 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 416 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -617,3 +617,35 @@ def test_background_index_no_lazy_expiration_json(env):
     # Accessing doc:1 directly should cause lazy expire and its removal from the DB.
     env.expect('JSON.GET', 'doc:1', "$").equal(None)
     env.expect('DBSIZE').equal(1)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_ttl_table_collision_chain():
+    # Regression for the direct-modulo TTL table: seed the index with far more
+    # HEXPIRE-covered docs than the TTL bucket cap, so every slot must carry
+    # a collision chain. Then query for fresh and expired entries and verify
+    # the chain walk returns the right ones.
+    env = Env(moduleArgs='MAXDOCTABLESIZE 4')
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA', 'n', 'NUMERIC', 't', 'TAG').ok()
+
+    # Docs 1..odd are long-lived; docs 1..even get a fast HPEXPIRE so they
+    # will be reported as expired at query time.
+    N = 64  # > 16x the bucket cap => many collisions per slot
+    for d in range(1, N + 1):
+        env.expect('HSET', f'doc:{d}', 'n', str(d), 't', 'tag').equal(2)
+        if d % 2 == 0:
+            env.expect('HPEXPIRE', f'doc:{d}', '1', 'FIELDS', '2', 'n', 't').equal([1, 1])
+
+    time.sleep(0.050)
+
+    # Tag filter should still find every odd doc; evens are all expired.
+    res = env.cmd('FT.SEARCH', 'idx', '@t:{tag}', 'NOCONTENT', 'LIMIT', '0', str(N))
+    returned = sorted(int(d.split(':')[1]) for d in res[1:])
+    expected = list(range(1, N + 1, 2))
+    env.assertEqual(returned, expected)
+
+    # Numeric filter over the full range: same expectation.
+    res = env.cmd('FT.SEARCH', 'idx', f'@n:[1 {N}]', 'NOCONTENT', 'LIMIT', '0', str(N))
+    returned = sorted(int(d.split(':')[1]) for d in res[1:])
+    env.assertEqual(returned, expected)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -348,9 +348,9 @@ def testDocTableInfo(env):
     # = leanSize + sdsAllocSize(keyPtr)
     # = (sizeof(RSDocumentMetadata) - sizeof(RSPayload *))  (No payload)
     #   + (strlen(key) + 2)
-    # = (72 - 8) + 3 = 67
-    # 2 docs * 67 = 134
-    exp_doc_table_size = (n * doc_table_size_mb) + (134 / (1024 * 1024))
+    # = (80 - 8) + 3 = 75
+    # 2 docs * 75 = 150
+    exp_doc_table_size = (n * doc_table_size_mb) + (150 / (1024 * 1024))
     env.assertEqual(doctable_size1, exp_doc_table_size)
     sortable_size1 = float(d['sortable_values_size_mb'])
     env.assertGreater(sortable_size1, 0)


### PR DESCRIPTION
# Description
Backport of #9293 to `8.2`.

## Describe the changes in the pull request

Three perf improvements to the expiration feature, ported and adapted from the 8.4 investigation branches (originally redislabsdev PRs #225 and #226).

### 1. Redesign the TTL table for cache-friendly iterator lookups
Replace the dict-backed `TimeToLiveTable` with a direct-modulo bucket array whose collision chains are contiguous-vec blocks. docIds are allocated monotonically via `++maxDocId` in `DocTable`, so iterator-time `VerifyDocAndField*` lookups see them in ascending, mostly-sequential order; direct modulo keeps sequential docIds in sequential slots, letting the hardware prefetcher pull upcoming bucket headers into L1 ahead of demand. Primarily benefits the "miss" hot path - docs without TTL, the common case at query time. `DocTable_UpdateExpiration` now passes `t->maxSize` through to `TimeToLiveTable_VerifyInit` so the slot formula cannot drift from `DocTable`'s own modulus.

### 2. Gate per-posting TTL lookup on the presence of HFE entries
The TTL table now holds field-level (HEXPIRE) entries only and is destroyed by `DocTable_Pop` when the last one leaves the index, so a non-NULL `docs.ttl` is a sufficient and tight gate by itself. On 8.2's iterator architecture this gate is enforced inside `DocTable_VerifyFieldExpirationPredicate`/`DocTable_HasExpiration` (early-return when `t->ttl == NULL`); the per-iterator `checkFieldExpiration` snapshot from master is not applicable here and was dropped.

### 3. Inline doc-level expiration on DMD to bypass TTL lookup
Inline the doc-level expiration timestamp directly on the DMD as an `int64_t` nanoseconds-since-epoch (8 B per DMD). The new `DocTable_IsDocExpired` check is a single scalar compare on a cache line we are already touching, eliminating the per-result table lookup on the result-processor hot path. The `Document_HasExpiration` flag is no longer set on `RSDocumentMetadata` for fresh entries — the result processor fetches the DMD on every hit anyway, so a flag-gated branch buys nothing there.

#### Which additional issues this PR fixes
1. MOD-14916

#### Main objects this PR modified
1. `TimeToLiveTable` (`src/ttl_table.*`): direct-modulo bucket array; HFE-only payload
2. `DocTable` / `RSDocumentMetadata` (`src/doc_table.*`, `src/redisearch.h`): inlined `expirationTimeNs`; HFE gate via `docs.ttl`
3. `RSAddDocumentCtx` indexer path (`src/indexer.c`): drop the per-DMD `Document_HasExpiration` flag write

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

### Conflicts resolved

- **`src/redisearch.h`**: kept the pointer `struct RSSortingVector *sortVector;` and added `expirationTimeNs` after `ref_count`.
- **`src/indexer.c::doAssignIds`**: 8.2 lacks the `SearchDisk` branch; kept 8.2's flat control flow (single `makeDocumentId` call with `&cur->status`, `md->maxFreq`/`md->len`, `spec->stats.totalDocsLen`, pointer-`cur->sv`). Applied the PR's removal of `md->flags |= Document_HasExpiration;` and updated the comment.
- **`src/redis_index.c`**: dropped the cherry-pick's added `RedisSearchCtx_TryLockSpecRead` — that helper does not exist on 8.2.
- **`src/iterators/hybrid_reader.c` and `src/geometry/query_iterator.{cpp,hpp}`**: 8.2 still uses the `IndexIterator` interface (`LastDocId`, `HasNext`, no `Revalidate`), and master's hoisted-gate snapshot relies on iterator fields and a `Revalidate` callback that don't exist here. Kept HEAD verbatim. The iterator-level hoist is replaced by the `t->ttl == NULL` early-return inside `DocTable_VerifyFieldExpirationPredicate`/`DocTable_HasExpiration`, so the per-spec gating remains. Reverted the unused `checkFieldExpiration` field on `HybridIterator`.
- **`src/doc_table.c`**: bridged the rewritten TTL table API. The new `ttl_table.h` only exposes the singular `TimeToLiveTable_VerifyDocAndField`; rewrote `DocTable_VerifyFieldExpirationPredicate` to iterate fields with the existing "any field satisfies predicate" semantics, and simplified `DocTable_HasExpiration` to `t->ttl != NULL` (matches the per-spec gate the PR establishes).
- **`src/ttl_table.c`** and **`tests/cpptests/test_cpp_expire.cpp`**: kept 8.2's `FIELD_EXPIRATION_DEFAULT`/`_MISSING` enum names (master renamed to `*_PREDICATE_*`).
- **`tests/cpptests/index_utils.h`**: dropped the cherry-pick's `MockQueryEvalCtx` `TTL_Add` helpers — they reference fields/types not present on 8.2 and have no callers.
- **`tests/cpptests/test_cpp_llapi.cpp`**: kept 8.2 baseline byte values; applied the +8-per-live-DMD delta to each `MemUsage` / `docTableSize` assertion (140→156, 330→338, 613→629, 471→479, 327→335, 416→424, 699→715, 557→565, 408→416). Dropped master-only `get_trie_entry_extra_overhead`, `gcConfigParams.gcSettings`, and `periodicCallback(..., false)` artifacts.
- **Dropped Rust files** added by the cherry-pick that don't exist on 8.2: `expiration_checker.rs`, `rqe_iterators_test_utils/src/test_context.rs`.

### Post-cherry-pick fix-ups

Amended on top of the cherry-pick after CI revealed an 8.2-only test that does not exist on master, plus a Python `doc_table_size_mb` assertion that was missed on the test side:

- **`tests/cpptests/test_cpp_index.cpp`** — applied the +8-per-live-DMD delta to the `DocTable_MemUsage` assertions in `testDocTable` (10180→10980, 71→79, 148→164). This file is not present on master, so it was missed by the cherry-pick.
- **`tests/pytests/test_stats.py::testDocTableInfo`**: updated the `doc_table_size_mb` math comment and constant. 8.2's `RSDocumentMetadata` is 80 B post-inline (sortVector is a pointer, not inline), not master's 72 B, so the per-doc lean contribution is `(80 - 8) + 3 = 75` and `2 docs * 75 = 150` (was 67 / 134 baseline, which the cherry-pick did not touch but which assumed the smaller layout).
- **`src/hybrid_reader.c::HR_ReadHybridUnsortedSingle`** — fix a pre-existing leak exposed by this backport. The new per-field TTL semantics (queried field not in the doc's `fieldExpirations` ⇒ "not expired") let docs whose only expired field is unrelated to the query field flow further along the hybrid pipeline than they used to. They now pass the numeric/text child iterator and reach `topResults`, where the existing post-pop field-expiration check on the vector field can flip them to `INDEXREAD_NOTFOUND`. The popped hit was neither freed nor appended to `returnedResults` on that path, so it leaked. Added `IndexResult_Free(*hit)` before the `INDEXREAD_NOTFOUND` return. Surfaced by `tests/pytests/test_expire.py::testLazyVectorFieldExpiration` under ASAN. (8.4/master are unaffected: their `HR_ReadHybridUnsortedSingle` keeps the popped hit in `hr->base.current`, which has single-owner semantics and is freed by the next call or at iterator destruction.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks core expiration/HEXPIRE data structures and query-time validation paths, which could affect correctness of expired vs. visible results and memory behavior despite added coverage.
> 
> **Overview**
> **Improves query-time expiration performance** by eliminating a doc-level TTL lookup on the hot path and tightening when per-field expiration checks run.
> 
> Doc-level expiration is now stored inline on `RSDocumentMetadata` (`expirationTimeNs`) and compared via a single scalar check, while the TTL table is repurposed to store *field-level (HEXPIRE) expirations only* and is lazily created/destroyed based on whether any such entries exist.
> 
> Replaces the dict-backed `TimeToLiveTable` with a cache-friendly direct-modulo bucket array + contiguous collision chains, updates iterator-side field-expiration verification accordingly, and adds new C++/Python tests plus updated memory-usage assertions to match the new metadata layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc7281fb1f44ae082d24d97bca1f480b56b7583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->