### PR TITLE
[MOD-15278] fix: Read Saved bytes when persistence in progress

### DIFF
--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -128,12 +128,16 @@ static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
 static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   RS_LOG_ASSERT(encver == 1, "DocIdMeta: unexpected encver in RDB load");
 
-  // Even when PersistenceInProgress is set we must consume exactly the bytes
+  // Cache the flag locally to ensure all decisions in this callback observe a
+  // consistent value, although it cannot really happen, this gives certanty to static analyzers.
+  const bool persistenceInProgress = PersistenceInProgress;
+
+  // Even when persistenceInProgress is set we must consume exactly the bytes
   // that docIdMetaRDBSave wrote: the key-meta framework reads a trailing EOF
   // marker right after this callback returns and expects the stream to be
   // positioned at it. Discarding the parsed entries is fine; skipping the
   // reads would desynchronize the stream and fail the EOF check.
-  dict *specIdToDocId = PersistenceInProgress ? NULL : dictCreate(&dictTypeUint64, NULL);
+  dict *specIdToDocId = persistenceInProgress ? NULL : dictCreate(&dictTypeUint64, NULL);
   size_t numEntries;
 
   // Load the number of entries
@@ -145,7 +149,7 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
     uint64_t docId = LoadUnsigned_IOError(rdb, goto cleanup);
 
     // While persistence is in progress, drain the bytes but do not attach.
-    if (PersistenceInProgress) continue;
+    if (persistenceInProgress) continue;
 
     // Skip entries belonging to indexes that are no longer in specIdDict_g (O(1) lookup).
     if (!isSpecValid(specId)) {
@@ -155,7 +159,7 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
     dictAdd(specIdToDocId, SPECID_TO_KEY(specId), DOCID_TO_VAL(docId));
   }
 
-  if (PersistenceInProgress) {
+  if (persistenceInProgress) {
     *meta = 0;
     return DOCID_META_RDB_LOAD_SKIP;
   }

--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -128,13 +128,12 @@ static void docIdMetaUnlink(RedisModuleKeyOptCtx *ctx, uint64_t *meta) {
 static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   RS_LOG_ASSERT(encver == 1, "DocIdMeta: unexpected encver in RDB load");
 
-  if (PersistenceInProgress) {
-    // Skip actual loading during persistence events. We don't store this metadata in the RDB/AOF files.
-    *meta = 0;
-    return DOCID_META_RDB_LOAD_SKIP;
-  }
-
-  dict *specIdToDocId = dictCreate(&dictTypeUint64, NULL);
+  // Even when PersistenceInProgress is set we must consume exactly the bytes
+  // that docIdMetaRDBSave wrote: the key-meta framework reads a trailing EOF
+  // marker right after this callback returns and expects the stream to be
+  // positioned at it. Discarding the parsed entries is fine; skipping the
+  // reads would desynchronize the stream and fail the EOF check.
+  dict *specIdToDocId = PersistenceInProgress ? NULL : dictCreate(&dictTypeUint64, NULL);
   size_t numEntries;
 
   // Load the number of entries
@@ -145,12 +144,20 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
     uint64_t specId = LoadUnsigned_IOError(rdb, goto cleanup);
     uint64_t docId = LoadUnsigned_IOError(rdb, goto cleanup);
 
+    // While persistence is in progress, drain the bytes but do not attach.
+    if (PersistenceInProgress) continue;
+
     // Skip entries belonging to indexes that are no longer in specIdDict_g (O(1) lookup).
     if (!isSpecValid(specId)) {
       continue;
     }
 
     dictAdd(specIdToDocId, SPECID_TO_KEY(specId), DOCID_TO_VAL(docId));
+  }
+
+  if (PersistenceInProgress) {
+    *meta = 0;
+    return DOCID_META_RDB_LOAD_SKIP;
   }
 
   *meta = (uint64_t)(specIdToDocId);

--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -129,7 +129,7 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   RS_LOG_ASSERT(encver == 1, "DocIdMeta: unexpected encver in RDB load");
 
   // Cache the flag locally to ensure all decisions in this callback observe a
-  // consistent value, although it cannot really happen, this gives certanty to static analyzers.
+  // consistent value, although it cannot really happen, this gives certainty to static analyzers.
   const bool persistenceInProgress = PersistenceInProgress;
 
   // Even when persistenceInProgress is set we must consume exactly the bytes

--- a/tests/cpptests/test_cpp_doc_id_meta.cpp
+++ b/tests/cpptests/test_cpp_doc_id_meta.cpp
@@ -522,6 +522,40 @@ TEST_F(DocIdMetaTest, TestRdbSaveSkipsDeletedEntries) {
   RedisModule_FreeString(ctx, newKeyName);
 }
 
+// When persistence is in progress at load time, the load callback must still
+// consume every byte that the save callback wrote, so that the key-meta
+// framework's trailing EOF marker stays aligned. The callback is expected to
+// return SKIP (0) and leave the output meta untouched (0).
+TEST_F(DocIdMetaTest, TestRdbLoadDuringPersistenceConsumesBytesAndSkips) {
+  addTestSpec("spec1", SPEC1_ID);
+  addTestSpec("spec2", SPEC2_ID);
+
+  EXPECT_EQ(DocIdMeta_Set(ctx, testKeyName, SPEC1_ID, 1001), REDISMODULE_OK);
+  EXPECT_EQ(DocIdMeta_Set(ctx, testKeyName, SPEC2_ID, 2002), REDISMODULE_OK);
+
+  // Save while persistence is NOT in progress, so bytes are actually written.
+  rdbSave(getKeyMeta(testKeyName));
+  const size_t bytesWritten = rdbIO->buffer.size();
+  EXPECT_GT(bytesWritten, 0u);
+
+  // Simulate persistence in progress during the load.
+  DocIdMeta_SetPersistenceInProgress(true);
+
+  rdbIO->read_pos = 0;
+  uint64_t loadedMeta = 0xDEADBEEF; // sentinel; load must overwrite to 0
+  int result = RMCK_KeyMetaRdbLoad(getDocIdMetaClassId(), rdbIO, &loadedMeta, 1);
+
+  DocIdMeta_SetPersistenceInProgress(false);
+
+  // Return value is SKIP (0): do not attach the meta to the key.
+  EXPECT_EQ(result, 0);
+  // Meta is not filled.
+  EXPECT_EQ(loadedMeta, 0u);
+  // No I/O error occurred and exactly all the saved bytes were consumed.
+  EXPECT_EQ(RMCK_IsIOError(rdbIO), 0);
+  EXPECT_EQ(rdbIO->read_pos, bytesWritten);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////
 // Unlink callback tests
 //


### PR DESCRIPTION
## Describe the changes in the pull request

### 1. Current

`docIdMetaRDBLoad` short-circuits when `PersistenceInProgress` is true: it sets `*meta = 0`, returns `SKIP`, and never reads anything from the RDB stream.

This is unsafe because `PersistenceInProgress` is **only** consulted at the call site of the callback — it does not control whether bytes were written. In particular, `docIdMetaRDBSave` may have written real bytes (entry count + per-entry `specId`/`docId`) when persistence was *not* in progress, and the load can then run in a context where the flag *is* set (e.g. an AOF replay / RDB load that overlaps with a BGSAVE/BGREWRITEAOF window, or a save snapshot taken before the flag flipped). The save side and load side observe the flag independently.

When that happens, the key-meta framework reads its trailing EOF marker immediately after the load callback returns and expects the stream to be positioned at it. With the early-return, the bytes written by save remain in the stream, the EOF marker check fails, and the whole RDB load aborts.

### 2. Change

In `docIdMetaRDBLoad`, when `PersistenceInProgress` is set, still parse the entry count and every `(specId, docId)` pair from the stream — just discard them instead of attaching anything. The function then returns `SKIP` with `*meta = 0`, exactly as before, but the stream position is now correct.

The save side is unchanged: when `PersistenceInProgress` is set at save time it still writes nothing, which is also fine because the framework will not invoke the load callback for a key that had no meta written.

### 3. Outcome

RDB load no longer fails its EOF check when a `D-ID` meta payload is present in the stream and the load happens to run with `PersistenceInProgress` set. The semantics from the caller's point of view are unchanged (`SKIP`, no meta attached), only the stream stays in sync.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. `src/doc_id_meta.c` — `docIdMetaRDBLoad`
2. `tests/cpptests/test_cpp_doc_id_meta.cpp` — new test `TestRdbLoadDuringPersistenceConsumesBytesAndSkips` that saves real bytes, sets `PersistenceInProgress` before loading, and asserts the load returns `SKIP` (0), leaves `meta` at 0, reports no I/O error, and consumes exactly the number of bytes that `docIdMetaRDBSave` wrote.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB/key-meta deserialization logic; while behavior is intended to be a no-op during persistence, mistakes here can still break RDB/AOF loading or corrupt stream alignment.
> 
> **Overview**
> Prevents RDB/AOF load failures when `PersistenceInProgress` is true by changing `docIdMetaRDBLoad` to **always read and drain** the saved entry count and `(specId, docId)` pairs, but discard them and return `SKIP` instead of early-returning without consuming bytes.
> 
> Adds a regression test `TestRdbLoadDuringPersistenceConsumesBytesAndSkips` asserting the load path returns `SKIP`, leaves `meta` as `0`, and consumes exactly the bytes written by the save callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac2e56dfa614f276a1e425d19fd3447d0fd355e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->