### PR TITLE
[8.2] MOD-13617: Skip redundant depleter yield on FT.AGGREGATE timeout under FAIL policy

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1657,6 +1657,15 @@ static int RPDepleter_Next_Accumulate(ResultProcessor *base, SearchResult *r) {
   // Call the sync depletion function directly
   RPDepleter_Deplete(self);
 
+  // Only TimeoutPolicy_Return yields buffered results on timeout; FAIL
+  // propagates TIMEDOUT immediately since the buffer will be discarded by
+  // the serializer anyway.
+  if (self->last_rc == RS_RESULT_TIMEDOUT &&
+      base->parent->timeoutPolicy != TimeoutPolicy_Return) {
+    self->base.Next = RPDepleter_Next_Yield;
+    return RS_RESULT_TIMEDOUT;
+  }
+
   // Switch to yield mode
   self->base.Next = RPDepleter_Next_Yield;
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: When the coordinator pipeline contains an `RPDepleter` (e.g. `FT.AGGREGATE WITHCOUNT`) and the upstream returns `RS_RESULT_TIMEDOUT`, `RPDepleter_Next_Accumulate` unconditionally switches to yield mode and emits every buffered `SearchResult` one at a time, even when the active timeout policy is `FAIL`. Under `FAIL` the buffered results are guaranteed to be discarded by `handleSendChunkError` before any reply is sent, so the yield + serialize + free loop is pure overhead during an already-degraded request.
2. **Change**: Detect the `RS_RESULT_TIMEDOUT + policy != TimeoutPolicy_Return` case in `RPDepleter_Next_Accumulate` and short-circuit by propagating `RS_RESULT_TIMEDOUT` immediately. The yield-mode transition is still installed so any subsequent `Next()` calls drain the buffered results in O(1). This mirrors the existing precedent in `RPSorter`, `RPMaxScoreNormalizer`, and `RPSafeLoader`.
3. **Outcome**: `FT.AGGREGATE` queries that hit the timeout under `FAIL` policy no longer pay the per-result yield cost on the depleter when the response will be discarded anyway. Behavior under `RETURN` is unchanged — buffered results are still drained.

#### Which additional issues this PR fixes
1. MOD-13617

#### Main objects this PR modified
1. `RPDepleter_Next_Accumulate` in `src/result_processor.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes