### PR TITLE
[8.4] MOD-14916 perf(rp): inline SearchResult_Clear to recover ~5-6% CPU on FT.SEARCH

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -69,7 +69,8 @@ fn main() {
         root.join("src").join("rlookup.h"),
     ];
 
-    let mut bindings = bindgen::Builder::default();
+    let mut bindings = bindgen::Builder::default()
+        .clang_arg("-DRS_BINDGEN_GENERATION=1");
 
     for header in headers {
         bindings = bindings

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -69,8 +69,7 @@ fn main() {
         root.join("src").join("rlookup.h"),
     ];
 
-    let mut bindings = bindgen::Builder::default()
-        .clang_arg("-DRS_BINDGEN_GENERATION=1");
+    let mut bindings = bindgen::Builder::default().clang_arg("-DRS_BINDGEN_GENERATION=1");
 
     for header in headers {
         bindings = bindings

--- a/src/search_result.c
+++ b/src/search_result.c
@@ -21,31 +21,7 @@ SearchResult *SearchResult_AllocateMove(SearchResult *r) {
   return ret;
 }
 
-void SearchResult_Clear(SearchResult *r) {
-  // This won't affect anything if the result is null
-
-  SearchResult_SetScore(r, 0.0);
-
-  RSScoreExplain *score_explain = SearchResult_GetScoreExplainMut(r);
-  if (score_explain) {
-    SEDestroy(score_explain);
-    SearchResult_SetScoreExplain(r, NULL);
-  }
-
-  const RSIndexResult* index_result = SearchResult_GetIndexResult(r);
-  if (index_result) {
-    SearchResult_SetIndexResult(r, NULL);
-  }
-
-  SearchResult_SetFlags(r, 0);
-  RLookupRow_Wipe(SearchResult_GetRowDataMut(r));
-
-  const RSDocumentMetadata* dmd = SearchResult_GetDocumentMetadata(r);
-  if (dmd) {
-    DMD_Return(dmd);
-    SearchResult_SetDocumentMetadata(r, NULL);
-  }
-}
+extern inline void SearchResult_Clear(SearchResult *r);
 
 void SearchResult_Destroy(SearchResult *r) {
   SearchResult_Clear(r);

--- a/src/search_result.h
+++ b/src/search_result.h
@@ -14,6 +14,7 @@
 #include "types_rs.h"
 #include "rlookup.h"
 #include "index_result.h"
+#include "doc_table.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,7 +59,32 @@ SearchResult* SearchResult_AllocateMove(SearchResult* r);
  * This function resets the search result, so that it may be reused again.
  * Internal caches are reset but not freed
  */
+#ifdef RS_BINDGEN_GENERATION
 void SearchResult_Clear(SearchResult* r);
+#else
+inline void SearchResult_Clear(SearchResult *r) {
+  // This won't affect anything if the result is null
+
+  r->score = 0.0;
+
+  if (r->scoreExplain) {
+    SEDestroy(r->scoreExplain);
+    r->scoreExplain = NULL;
+  }
+
+  if (r->indexResult) {
+    r->indexResult = NULL;
+  }
+
+  r->flags = 0;
+  RLookupRow_Wipe(&r->rowdata);
+
+  if (r->dmd) {
+    DMD_Return(r->dmd);
+    r->dmd = NULL;
+  }
+}
+#endif
 
 /**
  * This function clears the search result, also freeing its internals. Internal


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: After PR #7089 (commit `f8ec8361e`) extracted `SearchResult_Clear` into its own translation unit, with our build profile (`RelWithDebInfo`, `-O2`, no LTO) the compiler can no longer inline it across TUs. Customer pprof on LTK (7.4 → 8.4 regression, MOD-14916) shows `SearchResult_Clear` at ~31 s flat / **5.89 % of total CPU**, almost entirely from `rpsortNext_Accum → rpsortNext_innerLoop` on the heap-full sort path (called once per upstream result above the heap size, billions of times per run).
2. **Change**: Restore inlining via the C99 `inline` / `extern inline` idiom while still emitting one externally-linkable copy of the symbol for FFI and tests:
   - `src/search_result.h`: add the body under `inline … { … }` accessing struct members directly. Hidden behind `#ifndef RS_BINDGEN_GENERATION` so that bindgen sees only the plain prototype and still emits the FFI binding.
   - `src/search_result.c`: replace the body with a single `extern inline void SearchResult_Clear(SearchResult *r);` line so the compiler emits exactly one externally-visible definition.
   - `src/redisearch_rs/ffi/build.rs`: add `.clang_arg("-DRS_BINDGEN_GENERATION=1")` so bindgen still sees the non-inline declaration.
3. **Outcome**: `SearchResult_Clear` is inlined back into its hot caller (`rpsortNext_innerLoop`), eliminating the call/return overhead that accounts for ~5-6 % of FT.SEARCH CPU on the customer profile, while behavior is unchanged. The inline body is functionally identical to the prior out-of-line definition — it just goes through the C struct members directly instead of through the `SearchResult_Get*` / `SearchResult_Set*` static-inline accessor wrappers, which fold to the same accesses.

#### Which additional issues this PR fixes
1. MOD-14916

#### Main objects this PR modified
1. `src/search_result.h`
2. `src/search_result.c`
3. `src/redisearch_rs/ffi/build.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

### Build / inlining verification (macos-aarch64-release)

Symbol is still exported (one definition emitted by the `extern inline` line in `search_result.c`):

```
$ nm bin/.../CMakeFiles/rscore.dir/src/search_result.c.o | grep SearchResult_Clear
0000000000000050 T _SearchResult_Clear

$ nm bin/.../redisearch.so | grep SearchResult_Clear
00000000000a02ec T _SearchResult_Clear
```

Every reference inside `result_processor.c` (the hot-path TU containing `rpsortNext_Accum` / `rpsortNext_innerLoop` / `rpsortNext_Yield`) is now inlined — zero call sites remain:

```
$ otool -tvV bin/.../CMakeFiles/rscore.dir/src/result_processor.c.o | grep -c '_SearchResult_Clear'
0
```

### Tests

- All **101** C/C++ unit tests pass (`./build.sh FORCE BUILD_TESTS=1 RUN_UNIT_TESTS`).
- All **479** Rust tests pass (`cd src/redisearch_rs && cargo nextest run`).
- No behavioral change expected; tests are unmodified.

### Reference

Landed earlier as commit `d8d6434fc` on the customer branch `perf/MOD-14916-hfe-observed-gate-8.4` (`RediSearch-private`); this PR ports the same 3-file diff to the public 8.4 branch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving performance change that primarily affects how `SearchResult_Clear` is compiled/inlined; main risk is subtle build/FFI edge cases across compilers.
> 
> **Overview**
> Improves `FT.SEARCH` performance by restoring inlining of `SearchResult_Clear`, avoiding a hot call overhead on tight result-processing loops.
> 
> To keep the symbol available for FFI/tests while enabling inlining, `SearchResult_Clear` is moved back to an inline definition in `search_result.h` with an `extern inline` out-of-line definition in `search_result.c`, and Rust bindgen generation now defines `RS_BINDGEN_GENERATION` to see a plain function prototype.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2adf36e47c96e8747d8db081138e52d2754fa28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->