### PR TITLE
[8.6] MOD-14916 perf(rp): inline SearchResult_Clear to recover ~5-6% CPU on FT.SEARCH

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -81,7 +81,7 @@ fn main() {
         src.join("value").join("value.h"),
     ];
 
-    let mut bindings = bindgen::Builder::default();
+    let mut bindings = bindgen::Builder::default().clang_arg("-DRS_BINDGEN_GENERATION=1");
 
     for header in headers {
         bindings = bindings

--- a/src/search_result.c
+++ b/src/search_result.c
@@ -21,31 +21,11 @@ SearchResult *SearchResult_AllocateMove(SearchResult *r) {
   return ret;
 }
 
-void SearchResult_Clear(SearchResult *r) {
-  // This won't affect anything if the result is null
-
-  SearchResult_SetScore(r, 0.0);
-
-  RSScoreExplain *score_explain = SearchResult_GetScoreExplainMut(r);
-  if (score_explain) {
-    SEDestroy(score_explain);
-    SearchResult_SetScoreExplain(r, NULL);
-  }
-
-  const RSIndexResult* index_result = SearchResult_GetIndexResult(r);
-  if (index_result) {
-    SearchResult_SetIndexResult(r, NULL);
-  }
-
-  SearchResult_SetFlags(r, 0);
-  RLookupRow_Wipe(SearchResult_GetRowDataMut(r));
-
-  const RSDocumentMetadata* dmd = SearchResult_GetDocumentMetadata(r);
-  if (dmd) {
-    DMD_Return(dmd);
-    SearchResult_SetDocumentMetadata(r, NULL);
-  }
-}
+// Definition lives in `search_result.h` as `inline`.
+// This `extern inline` declaration emits the externally-visible symbol so
+// that callers without inlining (and FFI consumers via bindgen) can still
+// link to it.
+extern inline void SearchResult_Clear(SearchResult *r);
 
 void SearchResult_Destroy(SearchResult *r) {
   SearchResult_Clear(r);

--- a/src/search_result.h
+++ b/src/search_result.h
@@ -14,6 +14,7 @@
 #include "types_rs.h"
 #include "rlookup.h"
 #include "index_result.h"
+#include "doc_table.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,9 +57,16 @@ SearchResult* SearchResult_AllocateMove(SearchResult* r);
 
 /**
  * This function resets the search result, so that it may be reused again.
- * Internal caches are reset but not freed
+ * Internal caches are reset but not freed.
+ *
+ * Defined as `inline` (with an `extern inline` definition emitted in
+ * `search_result.c`) so that hot callers in the result-processor pipeline
+ * can inline it. Hidden from `bindgen` to keep the FFI surface stable;
+ * bindgen still sees the plain prototype below.
  */
+#ifdef RS_BINDGEN_GENERATION
 void SearchResult_Clear(SearchResult* r);
+#endif
 
 /**
  * This function clears the search result, also freeing its internals. Internal
@@ -196,6 +204,36 @@ static inline void SearchResult_MergeFlags(SearchResult* res, const SearchResult
   RS_ASSERT(res && other);
   res->flags |= other->flags;
 }
+
+#ifndef RS_BINDGEN_GENERATION
+// Inline definition; the externally-visible symbol is emitted in
+// `search_result.c` via `extern inline`.
+inline void SearchResult_Clear(SearchResult* r) {
+  // This won't affect anything if the result is null
+
+  SearchResult_SetScore(r, 0.0);
+
+  RSScoreExplain *score_explain = SearchResult_GetScoreExplainMut(r);
+  if (score_explain) {
+    SEDestroy(score_explain);
+    SearchResult_SetScoreExplain(r, NULL);
+  }
+
+  const RSIndexResult* index_result = SearchResult_GetIndexResult(r);
+  if (index_result) {
+    SearchResult_SetIndexResult(r, NULL);
+  }
+
+  SearchResult_SetFlags(r, 0);
+  RLookupRow_Wipe(SearchResult_GetRowDataMut(r));
+
+  const RSDocumentMetadata* dmd = SearchResult_GetDocumentMetadata(r);
+  if (dmd) {
+    DMD_Return(dmd);
+    SearchResult_SetDocumentMetadata(r, NULL);
+  }
+}
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `SearchResult_Clear` is defined out-of-line in `src/search_result.c`. It's called once per result by every result processor in the chain (notably `rpsortNext_Accum`, `rpsortNext_innerLoop`, `rpsortNext_Yield`). Each call burns a function-call frame plus several more for the small accessor wrappers it invokes (`SearchResult_SetScore`, `SearchResult_GetScoreExplainMut`, `RLookupRow_Wipe`, `DMD_Return`, …). On the customer benchmark this accounts for ~5–6% of CPU on `FT.SEARCH`.
2. **Change**: Move the body of `SearchResult_Clear` into `src/search_result.h` as a C99 `inline` definition. Emit the external symbol from `src/search_result.c` via `extern inline void SearchResult_Clear(SearchResult *r);`. The inline body is gated by `#ifndef RS_BINDGEN_GENERATION` and the plain prototype is gated by `#ifdef RS_BINDGEN_GENERATION`, so:
   - **Normal compiles** see only the inline definition (and the single `extern inline` definition in `search_result.c`). Hot callers inline the body and the small accessors collapse with it.
   - **Bindgen** sees only the prototype, so the FFI surface is unchanged and bindgen doesn't need to chase additional transitive headers.

   Required wiring:
   - `src/search_result.h`: add `#include "doc_table.h"` (for `DMD_Return`); place the `inline` definition after the static-inline accessors it calls.
   - `src/search_result.c`: replace body with `extern inline void SearchResult_Clear(SearchResult *r);`.
   - `src/redisearch_rs/ffi/build.rs`: pass `-DRS_BINDGEN_GENERATION=1` to bindgen.
3. **Outcome**: `SearchResult_Clear` is fully inlined into the hot result-processor loop. ~5–6% CPU recovered on `FT.SEARCH` per the customer perf workload (MOD-14916). Same fix already shipped to the customer and being ported to upstream public branches; the `8.4` port is #9330.

#### Which additional issues this PR fixes
1. MOD-14916

#### Main objects this PR modified
1. `src/search_result.h` — `inline SearchResult_Clear` (gated)
2. `src/search_result.c` — `extern inline SearchResult_Clear` declaration in place of the previous body
3. `src/redisearch_rs/ffi/build.rs` — `clang_arg("-DRS_BINDGEN_GENERATION=1")`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Pure perf/inlining change, no behavioral impact.

---

### Verification (release build, macOS aarch64)

```text
$ nm bin/.../search_result.c.o | grep SearchResult_Clear
0000000000000050 T _SearchResult_Clear

$ nm bin/.../redisearch.so | grep SearchResult_Clear
00000000000a0fd0 T _SearchResult_Clear

$ otool -tvV bin/.../result_processor.c.o | grep "bl.*_SearchResult_Clear" | wc -l
       0          # fully inlined into rpsortNext_*

$ grep "fn SearchResult_Clear" bindings.rs
    pub fn SearchResult_Clear(r: *mut SearchResult);
```

Only `aggregate_exec.c.o` still references `_SearchResult_Clear` externally (cold cleanup path); the hot `result_processor.c.o` loop has zero external calls.

### Tests

- `./build.sh FORCE TESTS RUN_UNIT_TESTS` → 101/101 unit tests pass
- `cd src/redisearch_rs && cargo nextest run` → 674/674 Rust tests pass
- `make fmt CHECK=1` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a hot-path C function and changes how it is emitted/linked (`inline` + `extern inline`), which can cause subtle compiler/linkage issues if miscompiled. Also adjusts bindgen compilation flags, which could affect Rust FFI generation if the macro gating is wrong.
> 
> **Overview**
> **Improves `FT.SEARCH` CPU performance** by inlining `SearchResult_Clear` into the result-processing hot path.
> 
> `SearchResult_Clear` is moved from an out-of-line C implementation to an `inline` definition in `search_result.h`, with `search_result.c` now emitting the external symbol via `extern inline` for non-inlined callers. Rust bindgen generation is updated to define `RS_BINDGEN_GENERATION=1` so the C header exposes a stable prototype to FFI while keeping the inline body out of generated bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4242ed6e9aa016c6c7aa0658cd848ae3ca866e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->