### PR TITLE
Skip flaky test_timeout_return_strict_with_profile until 2026-05-05 [MOD-15123]

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -1785,6 +1785,7 @@ class TestCoordinatorReducePause:
         env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
         self._cleanup_pause_state()
 
+    @skip_until("2026-05-05", reason="Flaky test, see MOD-15123")
     def test_timeout_return_strict_with_profile(self):
         """Test return-strict timeout policy with FT.PROFILE command.
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `test_timeout_return_strict_with_profile` in `tests/pytests/test_blocked_client_timeout.py` is flaky in CI.
2. **Change**: Decorate the test with `@skip_until("2026-05-05", reason="Flaky test, see MOD-15123")` so it is temporarily skipped while the flake is investigated, and will automatically resume running after 2026-05-05.
3. **Outcome**: CI noise from this flaky test is eliminated until the underlying issue is resolved, without losing track of the test (it auto-unskips after the date).

#### Which additional issues this PR fixes
1. MOD-15123

#### Main objects this PR modified
1. `tests/pytests/test_blocked_client_timeout.py` — `test_timeout_return_strict_with_profile`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that reduces CI coverage for a single scenario until the skip date; no production code paths are affected.
> 
> **Overview**
> Temporarily skips the flaky `test_timeout_return_strict_with_profile` in `tests/pytests/test_blocked_client_timeout.py` by adding `@skip_until("2026-05-05", reason="Flaky test, see MOD-15123")`, so it auto-resumes after the specified date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82774eb0951005872b4569b53d0ebf942e2f9042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->