### PR TITLE
enable coverage on C++ files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ endif()
 message(STATUS "COV: ${COV}")
 if (COV)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
     add_compile_definitions(COVERAGE=1)
@@ -365,6 +366,11 @@ add_dependencies(redisearch redisearch_rs)
 # Unit tests configuration
 if(BUILD_SEARCH_UNIT_TESTS)
     enable_testing()
+
+    # Disable coverage on C++ tests/benchmarks to avoid geninfo mismatch errors
+    if (COV)
+        string(REPLACE "--coverage" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    endif()
 
     add_subdirectory(tests/cpptests/redismock)
 


### PR DESCRIPTION
Coverage info were not generated for cpp files.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global CMake compiler/linker flags for coverage and conditionally mutates `CMAKE_CXX_FLAGS` for unit-test builds, which can impact build/CI behavior and coverage reporting.
> 
> **Overview**
> Adds `--coverage` to `CMAKE_CXX_FLAGS` when `COV` is enabled so coverage data is produced for C++ sources.
> 
> When `BUILD_SEARCH_UNIT_TESTS` is on, it strips `--coverage` back out of `CMAKE_CXX_FLAGS` to prevent `geninfo` mismatch errors in C++ test/benchmark targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161f0de73c4c99341e01fe7f430f4f2724c060fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->