### PR TITLE
conn.c: fix timer casting

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -396,7 +396,7 @@ static void MRConn_SwitchState(MRConn *conn, MRConnState nextState) {
   // Freeing (explicit stop) and Reconnecting (from an unexpected disconnect callback).
   // They are the only states that has to handle a timer stop.
   // We reach any other state linearly from the previous one, so no timer should be active on the transition.
-  RS_ASSERT(!uv_is_active(&conn->timer) || nextState == MRConn_Reconnecting || nextState == MRConn_Freeing);
+  RS_ASSERT(!uv_is_active((uv_handle_t *)&conn->timer) || nextState == MRConn_Reconnecting || nextState == MRConn_Freeing);
 
   conn->state = nextState;
   switch (nextState) {


### PR DESCRIPTION
Fix `-Wincompatible-pointer-types` warning.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line type-cast change to an assertion; behavior is unchanged aside from silencing a compiler warning.
> 
> **Overview**
> Adjusts the `MRConn_SwitchState` timer-state invariant assertion to call `uv_is_active` with a `uv_handle_t*` cast of `conn->timer`, resolving `-Wincompatible-pointer-types` warnings while keeping the same runtime check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37bb176f6033a53c56b879a1273454d4c64b27d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->