### PR TITLE
[MOD-15244] Add test and proper type to geo shape iterator

### DIFF
--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -130,7 +130,7 @@ ValidateStatus QIter_Revalidate(QueryIterator *ctx) {
 
 QueryIterator CPPQueryIterator::init_base() {
   return QueryIterator{
-      .type = ID_LIST_SORTED_ITERATOR,
+      .type = IteratorType_GeoShape,
       .atEOF = false,
       .lastDocId = 0,
       .current = NewVirtualResult(0, RS_FIELDMASK_ALL),

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -549,6 +549,7 @@ PRINT_PROFILE_SINGLE_NO_CHILD(printWildcardIt,                  "WILDCARD");
 PRINT_PROFILE_SINGLE_NO_CHILD(printIdListSortedIt,              "ID-LIST-SORTED");
 PRINT_PROFILE_SINGLE_NO_CHILD(printIdListUnsortedIt,            "ID-LIST-UNSORTED");
 PRINT_PROFILE_SINGLE_NO_CHILD(printEmptyIt,                     "EMPTY");
+PRINT_PROFILE_SINGLE_NO_CHILD(printGeoShapeIt,                  "GEO-SHAPE");
 PRINT_PROFILE_SINGLE(printHybridIt, HybridIterator,             "VECTOR");
 PRINT_PROFILE_SINGLE(printOptimusIt, OptimizerIterator,         "OPTIMIZER");
 
@@ -598,6 +599,7 @@ void printIteratorProfile(RedisModule_Reply *reply, const QueryIterator *root, c
     case METRIC_SORTED_BY_ID_ITERATOR:      { printMetricSortedByIdIt(reply, root, counters, cpuTime, depth, limited, config);      break; }
     case METRIC_SORTED_BY_SCORE_ITERATOR:   { printMetricSortedByScoreIt(reply, root, counters, cpuTime, depth, limited, config);   break; }
     case OPTIMUS_ITERATOR:                  { printOptimusIt(reply, root, counters, cpuTime, depth, limited, config);               break; }
+    case IteratorType_GeoShape:             { printGeoShapeIt(reply, root, counters, cpuTime, depth, limited, config);              break; }
     case IteratorType_Mock:                 { RS_ABORT("mock iterator cannot be profiled");                                         break; } // LCOV_EXCL_LINE
     case MAX_ITERATOR:                      { RS_ABORT("nope");                                                                     break; } // LCOV_EXCL_LINE
   }

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -598,6 +598,7 @@ void printIteratorProfile(RedisModule_Reply *reply, const QueryIterator *root, c
     case METRIC_SORTED_BY_ID_ITERATOR:      { printMetricSortedByIdIt(reply, root, counters, cpuTime, depth, limited, config);      break; }
     case METRIC_SORTED_BY_SCORE_ITERATOR:   { printMetricSortedByScoreIt(reply, root, counters, cpuTime, depth, limited, config);   break; }
     case OPTIMUS_ITERATOR:                  { printOptimusIt(reply, root, counters, cpuTime, depth, limited, config);               break; }
+    case IteratorType_Mock:                 { RS_ABORT("mock iterator cannot be profiled");                                         break; } // LCOV_EXCL_LINE
     case MAX_ITERATOR:                      { RS_ABORT("nope");                                                                     break; } // LCOV_EXCL_LINE
   }
 }

--- a/src/redisearch_rs/headers/iterator_type.h
+++ b/src/redisearch_rs/headers/iterator_type.h
@@ -39,11 +39,12 @@ enum IteratorType
   IteratorType_MetricSortedByScore = 17,
   IteratorType_Profile = 18,
   IteratorType_Optimus = 19,
+  IteratorType_GeoShape = 20,
   /**
    * Used only in tests.
    */
-  IteratorType_Mock = 20,
-  IteratorType_Max = 21,
+  IteratorType_Mock = 21,
+  IteratorType_Max = 22,
 };
 #ifndef __cplusplus
 typedef uint32_t IteratorType;

--- a/src/redisearch_rs/rqe_iterator_type/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterator_type/src/lib.rs
@@ -54,9 +54,10 @@ pub enum IteratorType {
     MetricSortedByScore = 17,
     Profile = 18,
     Optimus = 19,
+    GeoShape = 20,
     /// Used only in tests.
-    Mock = 20,
-    Max = 21,
+    Mock = 21,
+    Max = 22,
 }
 
 impl IteratorType {
@@ -78,6 +79,7 @@ impl IteratorType {
             | Self::MetricSortedById
             | Self::MetricSortedByScore
             | Self::Profile
+            | Self::GeoShape
             | Self::Mock => true,
 
             Self::Hybrid
@@ -116,6 +118,7 @@ impl IteratorType {
             Self::MetricSortedByScore => "METRIC_SORTED_BY_SCORE",
             Self::Profile => "PROFILE",
             Self::Optimus => "OPTIMUS",
+            Self::GeoShape => "GEO_SHAPE",
             Self::Mock => "MOCK",
             Self::Max => "MAX",
         }
@@ -153,8 +156,9 @@ impl TryFrom<u32> for IteratorType {
             17 => Ok(Self::MetricSortedByScore),
             18 => Ok(Self::Profile),
             19 => Ok(Self::Optimus),
-            20 => Ok(Self::Mock),
-            21 => Ok(Self::Max),
+            20 => Ok(Self::GeoShape),
+            21 => Ok(Self::Mock),
+            22 => Ok(Self::Max),
             other => Err(other),
         }
     }

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -377,6 +377,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
             IteratorType::MetricSortedByScore => 1.0,
             IteratorType::Profile => 1.0,
             IteratorType::Optimus => 1.0,
+            IteratorType::GeoShape => 1.0,
             IteratorType::Mock => 1.0,
             IteratorType::Max => 1.0,
         }

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -372,3 +372,92 @@ def testFtInfo(env):
   else:
     # TODO: in cluster - be able to wait for cleaning of the index (would wait for freeing the geoshape index memory)
     env.assertLess(cur_usage, usage)
+
+@skip(cluster=True)
+def testGeometryShapeIteratorSkipTo(env):
+  '''Test skip_to paths in the geometry shape query iterator.
+  Combined geometry+numeric queries cause the intersection engine to call
+  skip_to on the geometry iterator when numeric has fewer estimated results.'''
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'geom', 'GEOSHAPE', 'FLAT', 'n', 'NUMERIC').ok()
+
+  inside = 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))'
+  outside = 'POLYGON((200 200, 200 300, 300 300, 300 200, 200 200))'
+  query_poly = 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))'
+
+  # Geometry iterator matches [doc1,doc2,doc4,doc5,doc6], misses [doc3,doc7]
+  conn.execute_command('HSET', 'doc1', 'geom', inside, 'n', 1)
+  conn.execute_command('HSET', 'doc2', 'geom', inside, 'n', 2)
+  conn.execute_command('HSET', 'doc3', 'geom', outside, 'n', 3)
+  conn.execute_command('HSET', 'doc4', 'geom', inside, 'n', 4)
+  conn.execute_command('HSET', 'doc5', 'geom', inside, 'n', 5)
+  conn.execute_command('HSET', 'doc6', 'geom', inside, 'n', 6)
+  conn.execute_command('HSET', 'doc7', 'geom', outside, 'n', 7)
+
+  # skip_to with non-matching docId: numeric drives with doc3 (outside geom),
+  # geometry skips to doc4 != doc3 → NOTFOUND
+  res = env.cmd('FT.SEARCH', 'idx', '@n:[3 3] @geom:[within $poly]',
+                'PARAMS', 2, 'poly', query_poly, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(res, [0])
+
+  # skip_to beyond last geometry doc: numeric drives with doc7, which exceeds
+  # last geometry match (doc6) → EOF with atEOF
+  res = env.cmd('FT.SEARCH', 'idx', '@n:[7 7] @geom:[within $poly]',
+                'PARAMS', 2, 'poly', query_poly, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(res, [0])
+
+  # skip_to to last element (exhausting iterator) then skip_to on exhausted:
+  # numeric returns doc6 (last geometry match, sets atEOF) then doc7 (already EOF)
+  res = env.cmd('FT.SEARCH', 'idx', '@n:[6 7] @geom:[within $poly]',
+                'PARAMS', 2, 'poly', query_poly, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(res, [1, 'doc6'])
+
+@skip(cluster=True)
+def testGeometryShapeIteratorRewind(env):
+  '''Test rewind path in geometry shape iterator via HIGHLIGHT.
+  The highlight processor rewinds the root iterator tree (including geometry
+  child) to locate index results for each highlighted document.'''
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'geom', 'GEOSHAPE', 'FLAT', 't', 'TEXT').ok()
+
+  conn.execute_command('HSET', 'doc1', 'geom', 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))',
+                       't', 'hello world')
+  conn.execute_command('HSET', 'doc2', 'geom', 'POLYGON((1 1, 1 50, 50 50, 50 1, 1 1))',
+                       't', 'hello there')
+
+  query_poly = 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))'
+  res = env.cmd('FT.SEARCH', 'idx', '@t:(hello) @geom:[within $poly]',
+                'PARAMS', 2, 'poly', query_poly,
+                'HIGHLIGHT', 'FIELDS', 1, 't',
+                'DIALECT', 3)
+  env.assertEqual(res[0], 2)
+  # Verify highlighting was applied, confirming rewind was called
+  env.assertContains('<b>hello</b>', str(res))
+
+@skip(cluster=True)
+def testGeometryShapeIteratorRevalidate(env):
+  '''Test revalidate path in geometry shape iterator via cursor query.
+  In cursor mode the spec lock is released between reads; re-acquiring it
+  calls Revalidate on the root iterator (geometry) on each cursor resume.'''
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'geom', 'GEOSHAPE', 'FLAT').ok()
+
+  inside = 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))'
+  for i in range(5):
+    conn.execute_command('HSET', f'doc{i}', 'geom', inside)
+
+  query_poly = 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))'
+  res = env.cmd('FT.AGGREGATE', 'idx', '@geom:[within $poly]',
+                'PARAMS', 2, 'poly', query_poly,
+                'WITHCURSOR', 'COUNT', 1, 'DIALECT', 3)
+  cursor_id = res[1]
+  env.assertNotEqual(cursor_id, 0)
+
+  # Read remaining results via cursor — each resume re-acquires the spec lock,
+  # triggering Revalidate on the geometry iterator
+  results = len(res[0]) - 1
+  while cursor_id != 0:
+    res = env.cmd('FT.CURSOR', 'READ', 'idx', cursor_id)
+    cursor_id = res[1]
+    results += len(res[0]) - 1
+  env.assertEqual(results, 5)

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -306,6 +306,25 @@ def testProfileGeo(env):
   env.assertContains('GEO', profile_data[3])
 
 @skip(cluster=True)
+def testProfileGeoshape(env):
+  """GEOSHAPE query profile: a geometry query shows GEOSHAPE iterator type."""
+  conn = getConnectionByEnv(env)
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 'g', 'GEOSHAPE', 'FLAT')
+  conn.execute_command('hset', '1', 'g', 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')
+  waitForIndex(env, 'idx')
+
+  actual_res = conn.execute_command(
+    'ft.profile', 'idx', 'search', 'query',
+    '@g:[WITHIN $poly]', 'PARAMS', 2, 'poly', 'POLYGON((-1 -1, 2 -1, 2 2, -1 2, -1 -1))',
+    'nocontent', 'DIALECT', 3)
+  env.assertEqual(actual_res[0], [1, '1'])
+  profile_data = actual_res[1][1][0][3]
+  env.assertEqual(profile_data[0], 'Type')
+  env.assertEqual(profile_data[1], 'ID-LIST-SORTED')
+
+@skip(cluster=True)
 def testProfileMissingFieldQuery(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -322,7 +322,7 @@ def testProfileGeoshape(env):
   env.assertEqual(actual_res[0], [1, '1'])
   profile_data = actual_res[1][1][0][3]
   env.assertEqual(profile_data[0], 'Type')
-  env.assertEqual(profile_data[1], 'ID-LIST-SORTED')
+  env.assertEqual(profile_data[1], 'GEO-SHAPE')
 
 @skip(cluster=True)
 def testProfileMissingFieldQuery(env):


### PR DESCRIPTION
- Improve flow coverage of  `src/geometry/query_iterator.cpp`
- Test its profile output
- Assign it its own `IteratorType`

This would help preventing regressions when moving the debug profile print logic to Rust (`MOD-14895`) and porting the iterator itself (`MOD-15115`).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `IteratorType_GeoShape` discriminant across C/Rust FFI and updates profiling dispatch, which can impact iterator ABI/diagnostics if any code assumes prior numeric values. Functional risk is mitigated by added integration tests covering `SkipTo`, `Rewind`, `Revalidate`, and profile output.
> 
> **Overview**
> Adds a dedicated `IteratorType_GeoShape` for the GEOSHAPE query iterator (replacing the previous placeholder type) and wires it through the shared C/Rust iterator-type enum, including updated discriminant values for `Mock`/`Max`.
> 
> Updates `FT.PROFILE` iterator printing to recognize and label GEOSHAPE iterators as `GEO-SHAPE`, and adds pytests that exercise GEOSHAPE iterator `SkipTo`, `Rewind` (via `HIGHLIGHT`), `Revalidate` (via cursor reads), plus a profile assertion for the new iterator type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92adc6f18710ec7ecc07a587eb8ee3276e6a2046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->