### PR TITLE
[MOD-15245] Add geo crate re-implementing parsing from rs_geo.c

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -737,6 +737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.0.1"
+dependencies = [
+ "proptest",
+ "thiserror",
+ "workspace_hack",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -112,6 +112,15 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "approx"
 version = "0.6.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fbdd65cc59dcc820bfb0fd01315963d4f9898bf3399a47134c9836698c47df"
@@ -493,6 +502,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "decorum"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcc6bb0c903f3f815b48365bb9182092866f54a132d8ebe906f0b66952936e3"
+dependencies = [
+ "approx 0.5.1",
+ "num-traits 0.2.19",
+ "rustversion",
+ "serde",
+ "serde_derive",
+ "thiserror",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +763,7 @@ dependencies = [
 name = "geo"
 version = "0.0.1"
 dependencies = [
+ "decorum",
  "proptest",
  "thiserror",
  "workspace_hack",
@@ -979,7 +1003,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 name = "idf"
 version = "0.0.1"
 dependencies = [
- "approx",
+ "approx 0.6.0-rc2",
  "rstest",
  "workspace_hack",
 ]
@@ -2105,7 +2129,7 @@ dependencies = [
 name = "rqe_iterators"
 version = "0.0.1"
 dependencies = [
- "approx",
+ "approx 0.6.0-rc2",
  "build_utils",
  "ffi",
  "field",
@@ -3428,6 +3452,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_core",
+ "serde_derive",
  "serde_json",
  "stable_deref_trait",
  "syn 1.0.109",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -148,6 +148,7 @@ cc = "1.2.53"
 crc32fast = "1.5.0"
 criterion = { version = "0.8.1", features = ["html_reports"] }
 csv = "1.4.0"
+decorum = "0.4"
 enumflags2 = "0.7.12"
 fs-err = "3.2.2"
 hash32 = "1"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "field",
     "fnv",
     "generational_slab",
+    "geo",
     "hyperloglog",
     "inverted_index",
     "inverted_index_bencher",
@@ -98,6 +99,7 @@ field = { path = "./field" }
 field_spec = { path = "./c_wrappers/field_spec" }
 fnv = { path = "./fnv" }
 generational_slab = { path = "./generational_slab" }
+geo = { path = "./geo" }
 hidden_string = { path = "./c_wrappers/hidden_string" }
 hyperloglog = { path = "./hyperloglog" }
 idf = { path = "./idf" }

--- a/src/redisearch_rs/geo/Cargo.toml
+++ b/src/redisearch_rs/geo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "geo"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror.workspace = true
+workspace_hack.workspace = true
+
+[dev-dependencies]
+proptest = { workspace = true, features = ["std"] }

--- a/src/redisearch_rs/geo/Cargo.toml
+++ b/src/redisearch_rs/geo/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+decorum.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/geo/src/lib.rs
+++ b/src/redisearch_rs/geo/src/lib.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Geographic utilities for RediSearch.
+//!
+//! This crate provides geo coordinate parsing and validation.
+
+mod parse;
+
+pub use parse::{Coordinates, ParseGeoError};

--- a/src/redisearch_rs/geo/src/parse.rs
+++ b/src/redisearch_rs/geo/src/parse.rs
@@ -11,6 +11,8 @@
 
 use std::{num::ParseFloatError, str::FromStr};
 
+use decorum::R64;
+
 /// Maximum length of a geo string input (in bytes).
 const MAX_GEO_STRING_LEN: usize = 128;
 
@@ -38,6 +40,10 @@ pub enum ParseGeoError {
 
 /// A longitude/latitude coordinate pair.
 ///
+/// Coordinates are stored as [`R64`] values, which are guaranteed to be real
+/// (finite and not NaN). This enforces at the type level that invalid
+/// floating-point values like `NaN`, `inf`, and `-inf` cannot be represented.
+///
 /// Created by parsing a `"lon,lat"` or `"lon lat"` string via [`Coordinates::parse_geo`]:
 ///
 /// ```
@@ -50,9 +56,9 @@ pub enum ParseGeoError {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Coordinates {
     /// Longitude value.
-    pub lon: f64,
+    pub lon: R64,
     /// Latitude value.
-    pub lat: f64,
+    pub lat: R64,
 }
 
 impl Coordinates {
@@ -90,24 +96,20 @@ impl FromStr for Coordinates {
         let lon_trimmed = lon_str.trim();
         let lat_trimmed = lat_str.trim();
 
-        let lon: f64 = lon_trimmed
-            .parse()
+        let lon: R64 = lon_trimmed
+            .parse::<f64>()
             .map_err(|source| ParseGeoError::Invalid {
                 input: lon_trimmed.to_owned(),
                 source,
-            })?;
-        let lat: f64 = lat_trimmed
-            .parse()
+            })
+            .and_then(|v| R64::try_new(v).map_err(|_| ParseGeoError::NotFinite))?;
+        let lat: R64 = lat_trimmed
+            .parse::<f64>()
             .map_err(|source| ParseGeoError::Invalid {
                 input: lat_trimmed.to_owned(),
                 source,
-            })?;
-
-        // Reject non-finite values (NaN, inf, -inf) that Rust's f64 parser
-        // accepts but the original fast_float_strtod did not.
-        if !lon.is_finite() || !lat.is_finite() {
-            return Err(ParseGeoError::NotFinite);
-        }
+            })
+            .and_then(|v| R64::try_new(v).map_err(|_| ParseGeoError::NotFinite))?;
 
         Ok(Self { lon, lat })
     }

--- a/src/redisearch_rs/geo/src/parse.rs
+++ b/src/redisearch_rs/geo/src/parse.rs
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Parsing of geo coordinate strings.
+
+use std::{num::ParseFloatError, str::FromStr};
+
+/// Maximum length of a geo string input (in bytes).
+const MAX_GEO_STRING_LEN: usize = 128;
+
+/// Error type for geo string parsing.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseGeoError {
+    /// The input string exceeds 128 bytes.
+    #[error("Geo string cannot be longer than {MAX_GEO_STRING_LEN} bytes")]
+    TooLong,
+    /// The input string does not contain a comma or space separator.
+    #[error("Invalid geo string: missing separator")]
+    MissingSeparator,
+    /// A coordinate value could not be parsed as a floating-point number.
+    #[error("Invalid geo string {input:?}: {source}")]
+    Invalid {
+        /// The substring that failed to parse.
+        input: String,
+        /// The underlying parse error.
+        source: ParseFloatError,
+    },
+    /// A coordinate value is not finite (NaN or infinity).
+    #[error("Geo coordinates must be finite")]
+    NotFinite,
+}
+
+/// A longitude/latitude coordinate pair.
+///
+/// Created by parsing a `"lon,lat"` or `"lon lat"` string via [`Coordinates::parse_geo`]:
+///
+/// ```
+/// use geo::Coordinates;
+///
+/// let coords = Coordinates::parse_geo("29.69465, 34.95126").unwrap();
+/// assert_eq!(coords.lon, 29.69465);
+/// assert_eq!(coords.lat, 34.95126);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Coordinates {
+    /// Longitude value.
+    pub lon: f64,
+    /// Latitude value.
+    pub lat: f64,
+}
+
+impl Coordinates {
+    /// Convenience wrapper around [`str::parse`].
+    pub fn parse_geo(s: &str) -> Result<Self, ParseGeoError> {
+        s.parse()
+    }
+}
+
+impl FromStr for Coordinates {
+    type Err = ParseGeoError;
+
+    /// Parse a string representing a `"lon,lat"` or `"lon lat"` pair.
+    ///
+    /// The separator can be either a comma (`,`) or a space (` `).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseGeoError::TooLong`] if `s` is longer than 128 bytes.
+    /// Returns [`ParseGeoError::MissingSeparator`] if the string does not
+    /// contain a comma or space.
+    /// Returns [`ParseGeoError::Invalid`] if a coordinate cannot be parsed as a
+    /// floating-point number.
+    /// Returns [`ParseGeoError::NotFinite`] if a parsed coordinate is NaN or
+    /// infinity.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > MAX_GEO_STRING_LEN {
+            return Err(ParseGeoError::TooLong);
+        }
+
+        let (lon_str, lat_str) = s
+            .split_once([',', ' '])
+            .ok_or(ParseGeoError::MissingSeparator)?;
+
+        let lon_trimmed = lon_str.trim();
+        let lat_trimmed = lat_str.trim();
+
+        let lon: f64 = lon_trimmed
+            .parse()
+            .map_err(|source| ParseGeoError::Invalid {
+                input: lon_trimmed.to_owned(),
+                source,
+            })?;
+        let lat: f64 = lat_trimmed
+            .parse()
+            .map_err(|source| ParseGeoError::Invalid {
+                input: lat_trimmed.to_owned(),
+                source,
+            })?;
+
+        // Reject non-finite values (NaN, inf, -inf) that Rust's f64 parser
+        // accepts but the original fast_float_strtod did not.
+        if !lon.is_finite() || !lat.is_finite() {
+            return Err(ParseGeoError::NotFinite);
+        }
+
+        Ok(Self { lon, lat })
+    }
+}

--- a/src/redisearch_rs/geo/tests/integration/main.rs
+++ b/src/redisearch_rs/geo/tests/integration/main.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+mod parse_geo;

--- a/src/redisearch_rs/geo/tests/integration/parse_geo.rs
+++ b/src/redisearch_rs/geo/tests/integration/parse_geo.rs
@@ -67,8 +67,8 @@ fn exactly_max_length_valid() {
     let s = format!("{lon_part},1.0");
     assert!(s.len() == MAX_GEO_STRING_LEN);
     let result = Coordinates::parse_geo(&s);
-    // Should parse successfully (though the number may be huge)
-    assert!(result.is_ok() || matches!(result, Err(ParseGeoError::Invalid { .. })));
+    // The 124-digit number is finite (~1.11e+123), so parsing succeeds.
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
 }
 
 #[test]

--- a/src/redisearch_rs/geo/tests/integration/parse_geo.rs
+++ b/src/redisearch_rs/geo/tests/integration/parse_geo.rs
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use geo::{Coordinates, ParseGeoError};
+
+/// Mirror of the private `MAX_GEO_STRING_LEN` constant in the `geo` crate.
+const MAX_GEO_STRING_LEN: usize = 128;
+
+#[test]
+fn valid_comma_separated() {
+    let coords = Coordinates::parse_geo("1.5,2.5").unwrap();
+    assert_eq!(coords.lon, 1.5);
+    assert_eq!(coords.lat, 2.5);
+}
+
+#[test]
+fn valid_space_separated() {
+    let coords = Coordinates::parse_geo("1.5 2.5").unwrap();
+    assert_eq!(coords.lon, 1.5);
+    assert_eq!(coords.lat, 2.5);
+}
+
+#[test]
+fn comma_space_separated() {
+    let coords = Coordinates::parse_geo("1.23, 4.56").unwrap();
+    assert_eq!(coords.lon, 1.23);
+    assert_eq!(coords.lat, 4.56);
+}
+
+#[test]
+fn comma_space_separated_geo_coords() {
+    let coords = Coordinates::parse_geo("29.69465, 34.95126").unwrap();
+    assert_eq!(coords.lon, 29.69465);
+    assert_eq!(coords.lat, 34.95126);
+}
+
+#[test]
+fn negative_coordinates() {
+    let coords = Coordinates::parse_geo("-122.4194,37.7749").unwrap();
+    assert_eq!(coords.lon, -122.4194);
+    assert_eq!(coords.lat, 37.7749);
+}
+
+#[test]
+fn integer_coordinates() {
+    let coords = Coordinates::parse_geo("10,20").unwrap();
+    assert_eq!(coords.lon, 10.0);
+    assert_eq!(coords.lat, 20.0);
+}
+
+#[test]
+fn too_long() {
+    let s = "1".repeat(MAX_GEO_STRING_LEN + 1);
+    assert_eq!(Coordinates::parse_geo(&s), Err(ParseGeoError::TooLong));
+}
+
+#[test]
+fn exactly_max_length_valid() {
+    // "1.0," is 4 chars, pad lon part to fill up to MAX_GEO_STRING_LEN
+    let lon_part = "1".repeat(MAX_GEO_STRING_LEN - 4);
+    let s = format!("{lon_part},1.0");
+    assert!(s.len() == MAX_GEO_STRING_LEN);
+    let result = Coordinates::parse_geo(&s);
+    // Should parse successfully (though the number may be huge)
+    assert!(result.is_ok() || matches!(result, Err(ParseGeoError::Invalid { .. })));
+}
+
+#[test]
+fn no_separator() {
+    assert_eq!(
+        Coordinates::parse_geo("aaaa"),
+        Err(ParseGeoError::MissingSeparator)
+    );
+}
+
+#[test]
+fn non_numeric() {
+    assert!(matches!(
+        Coordinates::parse_geo("abc,def"),
+        Err(ParseGeoError::Invalid { .. })
+    ));
+}
+
+#[test]
+fn partial_non_numeric() {
+    assert!(matches!(
+        Coordinates::parse_geo("1.0,abc"),
+        Err(ParseGeoError::Invalid { .. })
+    ));
+    assert!(matches!(
+        Coordinates::parse_geo("abc,1.0"),
+        Err(ParseGeoError::Invalid { .. })
+    ));
+}
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        Coordinates::parse_geo(""),
+        Err(ParseGeoError::MissingSeparator)
+    );
+}
+
+#[test]
+fn trailing_text() {
+    assert!(matches!(
+        Coordinates::parse_geo("1.0,2.0abc"),
+        Err(ParseGeoError::Invalid { .. })
+    ));
+}
+
+#[test]
+fn leading_text() {
+    assert!(matches!(
+        Coordinates::parse_geo("abc1.0,2.0"),
+        Err(ParseGeoError::Invalid { .. })
+    ));
+}
+
+#[test]
+fn scientific_notation() {
+    let coords = Coordinates::parse_geo("1e2,2e3").unwrap();
+    assert_eq!(coords.lon, 100.0);
+    assert_eq!(coords.lat, 2000.0);
+}
+
+#[test]
+fn nan_rejected() {
+    assert_eq!(
+        Coordinates::parse_geo("NaN,1.0"),
+        Err(ParseGeoError::NotFinite)
+    );
+    assert_eq!(
+        Coordinates::parse_geo("1.0,NaN"),
+        Err(ParseGeoError::NotFinite)
+    );
+    assert_eq!(
+        Coordinates::parse_geo("NaN,NaN"),
+        Err(ParseGeoError::NotFinite)
+    );
+}
+
+#[test]
+fn infinity_rejected() {
+    assert_eq!(
+        Coordinates::parse_geo("inf,1.0"),
+        Err(ParseGeoError::NotFinite)
+    );
+    assert_eq!(
+        Coordinates::parse_geo("1.0,inf"),
+        Err(ParseGeoError::NotFinite)
+    );
+    assert_eq!(
+        Coordinates::parse_geo("-inf,1.0"),
+        Err(ParseGeoError::NotFinite)
+    );
+    assert_eq!(
+        Coordinates::parse_geo("infinity,1.0"),
+        Err(ParseGeoError::NotFinite)
+    );
+}
+
+#[cfg(not(miri))] // proptest calls getcwd() which is not supported on Miri
+mod proptests {
+    use geo::Coordinates;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn roundtrip_comma(lon in -180.0f64..=180.0, lat in -90.0f64..=90.0) {
+            let s = format!("{lon},{lat}");
+            let result = Coordinates::parse_geo(&s);
+            prop_assert!(result.is_ok(), "failed to parse: {s}");
+            let coords = result.unwrap();
+            prop_assert_eq!(coords.lon, lon);
+            prop_assert_eq!(coords.lat, lat);
+        }
+
+        #[test]
+        fn roundtrip_space(lon in -180.0f64..=180.0, lat in -90.0f64..=90.0) {
+            let s = format!("{lon} {lat}");
+            let result = Coordinates::parse_geo(&s);
+            prop_assert!(result.is_ok(), "failed to parse: {s}");
+            let coords = result.unwrap();
+            prop_assert_eq!(coords.lon, lon);
+            prop_assert_eq!(coords.lat, lat);
+        }
+    }
+}

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -70,6 +70,7 @@ regex-syntax = { version = "0.8" }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_core = { version = "1", features = ["alloc"] }
+serde_derive = { version = "1" }
 serde_json = { version = "1", features = ["unbounded_depth"] }
 stable_deref_trait = { version = "1", default-features = false, features = ["alloc"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "full", "visit-mut"] }

--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -194,3 +194,60 @@ def testGeoLargeRadiusDecreaseStep(env):
   res = env.cmd('FT.SEARCH', 'idx', '@g:[30.0 85.0 620 km]', 'NOCONTENT')
   env.assertGreaterEqual(res[0], 2, message=res)
   env.assertNotContains('doc4', res)
+
+@skip(cluster=True)
+def testGeoParseNaN(env):
+  """NaN passes C parseGeo (fast_float v7 parses it) and slips through
+  geohashEncode (NaN comparisons are always false), so the document
+  indexes with garbage geohash data.
+
+  TODO: Once the Rust parseGeo replacement is active, NaN will be
+  rejected at parse time and these documents should fail to index.
+  Flip assertions to expect hash_indexing_failures."""
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
+
+  conn.execute_command('HSET', 'nan_lon', 'g', 'NaN,1.0')
+  conn.execute_command('HSET', 'nan_lat', 'g', '1.0,NaN')
+  conn.execute_command('HSET', 'nan_both', 'g', 'NaN,NaN')
+
+  # Currently no indexing failures — NaN sneaks through the C path.
+  assertInfoField(env, 'idx', 'hash_indexing_failures', 0)
+
+@skip(cluster=True)
+def testGeoParseInfinity(env):
+  """inf/-inf/infinity pass C parseGeo (fast_float v7 parses them) but
+  are caught by geohashEncode bounds checking (inf > 180 is true), so
+  they fail to index with 'Invalid geo coordinates'.
+
+  TODO: Once the Rust parseGeo replacement is active, these will be
+  rejected earlier at parse time. The end-to-end behavior (indexing
+  failure) stays the same, but the error reason changes."""
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
+
+  conn.execute_command('HSET', 'inf_lon', 'g', 'inf,1.0')
+  conn.execute_command('HSET', 'neg_inf_lon', 'g', '-inf,1.0')
+  conn.execute_command('HSET', 'inf_lat', 'g', '1.0,inf')
+  conn.execute_command('HSET', 'infinity_lon', 'g', 'infinity,1.0')
+
+  # All four fail to index (caught by encodeGeo bounds check).
+  assertInfoField(env, 'idx', 'hash_indexing_failures', 4)
+
+@skip(cluster=True)
+def testGeoParseTrailingWhitespace(env):
+  """Trailing whitespace after a coordinate value: fast_float parses the
+  number but leaves the end pointer at the space, so the C check
+  `if (*end1 || *end2)` triggers and parseGeo rejects the input.
+
+  TODO: Once the Rust parseGeo replacement is active, trim() strips
+  trailing whitespace before parsing, so these inputs will index
+  successfully. Flip assertions to expect hash_indexing_failures == 0."""
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
+
+  conn.execute_command('HSET', 'ws1', 'g', '1.23,4.56 ')
+  conn.execute_command('HSET', 'ws2', 'g', '1.23, 4.56 ')
+
+  # Both fail to index under the C path: trailing whitespace in lat.
+  assertInfoField(env, 'idx', 'hash_indexing_failures', 2)


### PR DESCRIPTION
## Describe the changes in the pull request

Starting to move geo specific code to Rust.
Parsing is easy as it does not require any dep.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new `geo` crate plus tests) and don’t yet alter the existing C geo indexing/query path, aside from introducing new workspace dependencies.
> 
> **Overview**
> Adds a new Rust workspace crate, `geo`, that parses/validates `"lon,lat"` or `"lon lat"` coordinate strings with strict input limits (128 bytes) and explicit rejection of non-finite values (NaN/±inf) via `decorum::R64`.
> 
> Wires the crate into the workspace (`Cargo.toml`, `Cargo.lock`, `workspace_hack`) and adds Rust integration tests + new Python tests documenting current C parser edge cases (NaN/infinity/trailing whitespace) with TODOs for expected behavior once the Rust parser is used end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603b1a65333bcfdea0d6044610916bcdd5ef0ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->