### PR TITLE
[MOD-15246] Port C geohash library to pure Rust as geo::hash module

### DIFF
--- a/src/redisearch_rs/geo/src/hash/bits.rs
+++ b/src/redisearch_rs/geo/src/hash/bits.rs
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Bit interleaving (Morton code) and neighbor movement operations.
+//!
+//! The interleaving places latitude bits in even positions and longitude bits
+//! in odd positions, producing a Z-order curve over the coordinate space.
+
+use super::types::GeoHashBits;
+
+/// Interleave the lower bits of `x` (latitude) and `y` (longitude) so that
+/// x-bits occupy even positions and y-bits occupy odd positions.
+///
+/// Reference: <https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN>
+pub(crate) const fn interleave64(xlo: u32, ylo: u32) -> u64 {
+    const B: [u64; 5] = [
+        0x5555_5555_5555_5555,
+        0x3333_3333_3333_3333,
+        0x0F0F_0F0F_0F0F_0F0F,
+        0x00FF_00FF_00FF_00FF,
+        0x0000_FFFF_0000_FFFF,
+    ];
+    const S: [u32; 5] = [1, 2, 4, 8, 16];
+
+    let mut x = xlo as u64;
+    let mut y = ylo as u64;
+
+    x = (x | (x << S[4])) & B[4];
+    y = (y | (y << S[4])) & B[4];
+
+    x = (x | (x << S[3])) & B[3];
+    y = (y | (y << S[3])) & B[3];
+
+    x = (x | (x << S[2])) & B[2];
+    y = (y | (y << S[2])) & B[2];
+
+    x = (x | (x << S[1])) & B[1];
+    y = (y | (y << S[1])) & B[1];
+
+    x = (x | (x << S[0])) & B[0];
+    y = (y | (y << S[0])) & B[0];
+
+    x | (y << 1)
+}
+
+/// Reverse the interleave: extract the x (latitude) and y (longitude)
+/// components from an interleaved 64-bit value.
+///
+/// Reference: <http://stackoverflow.com/questions/4909263>
+pub(crate) const fn deinterleave64(interleaved: u64) -> (u32, u32) {
+    const B: [u64; 6] = [
+        0x5555_5555_5555_5555,
+        0x3333_3333_3333_3333,
+        0x0F0F_0F0F_0F0F_0F0F,
+        0x00FF_00FF_00FF_00FF,
+        0x0000_FFFF_0000_FFFF,
+        0x0000_0000_FFFF_FFFF,
+    ];
+    const S: [u32; 6] = [0, 1, 2, 4, 8, 16];
+
+    let mut x = interleaved;
+    let mut y = interleaved >> 1;
+
+    x = (x | (x >> S[0])) & B[0];
+    y = (y | (y >> S[0])) & B[0];
+
+    x = (x | (x >> S[1])) & B[1];
+    y = (y | (y >> S[1])) & B[1];
+
+    x = (x | (x >> S[2])) & B[2];
+    y = (y | (y >> S[2])) & B[2];
+
+    x = (x | (x >> S[3])) & B[3];
+    y = (y | (y >> S[3])) & B[3];
+
+    x = (x | (x >> S[4])) & B[4];
+    y = (y | (y >> S[4])) & B[4];
+
+    x = (x | (x >> S[5])) & B[5];
+    y = (y | (y >> S[5])) & B[5];
+
+    (x as u32, y as u32)
+}
+
+/// Move a geohash along the x-axis (longitude) by `d` steps (+1 = east,
+/// -1 = west).
+pub(crate) const fn move_x(hash: &mut GeoHashBits, d: i8) {
+    if d == 0 {
+        return;
+    }
+
+    let step = hash.step.as_u8() as u32;
+    let x = hash.bits & 0xAAAA_AAAA_AAAA_AAAA;
+    let y = hash.bits & 0x5555_5555_5555_5555;
+    let zz = 0x5555_5555_5555_5555u64 >> (64 - step * 2);
+    let mask = 0xAAAA_AAAA_AAAA_AAAAu64 >> (64 - step * 2);
+
+    let x = if d > 0 {
+        x.wrapping_add(zz.wrapping_add(1)) & mask
+    } else {
+        (x | zz).wrapping_sub(zz.wrapping_add(1)) & mask
+    };
+
+    hash.bits = x | y;
+}
+
+/// Move a geohash along the y-axis (latitude) by `d` steps (+1 = north,
+/// -1 = south).
+pub(crate) const fn move_y(hash: &mut GeoHashBits, d: i8) {
+    if d == 0 {
+        return;
+    }
+
+    let step = hash.step.as_u8() as u32;
+    let x = hash.bits & 0xAAAA_AAAA_AAAA_AAAA;
+    let y = hash.bits & 0x5555_5555_5555_5555;
+    let zz = 0xAAAA_AAAA_AAAA_AAAAu64 >> (64 - step * 2);
+    let mask = 0x5555_5555_5555_5555u64 >> (64 - step * 2);
+
+    let y = if d > 0 {
+        y.wrapping_add(zz.wrapping_add(1)) & mask
+    } else {
+        (y | zz).wrapping_sub(zz.wrapping_add(1)) & mask
+    };
+
+    hash.bits = x | y;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::types::PrecisionStep;
+
+    #[test]
+    fn interleave_roundtrip() {
+        for (x, y) in [(0, 0), (1, 0), (0, 1), (0xFFFF, 0xFFFF), (12345, 67890)] {
+            let interleaved = interleave64(x, y);
+            let (dx, dy) = deinterleave64(interleaved);
+            assert_eq!(dx, x, "x mismatch for ({x}, {y})");
+            assert_eq!(dy, y, "y mismatch for ({x}, {y})");
+        }
+    }
+
+    #[test]
+    fn interleave_known_values() {
+        // All bits set: interleave(0xFFFFFFFF, 0xFFFFFFFF) should be all bits set
+        assert_eq!(interleave64(0xFFFF_FFFF, 0xFFFF_FFFF), u64::MAX);
+        // Only x bits: interleave(0xFFFFFFFF, 0) should be 0x5555...
+        assert_eq!(interleave64(0xFFFF_FFFF, 0), 0x5555_5555_5555_5555);
+        // Only y bits: interleave(0, 0xFFFFFFFF) should be 0xAAAA...
+        assert_eq!(interleave64(0, 0xFFFF_FFFF), 0xAAAA_AAAA_AAAA_AAAA);
+    }
+
+    #[test]
+    fn move_x_zero_is_noop() {
+        let mut hash = GeoHashBits {
+            bits: 0xABCD,
+            step: PrecisionStep::new(10).unwrap(),
+        };
+        let original = hash;
+        move_x(&mut hash, 0);
+        assert_eq!(hash, original);
+    }
+
+    #[test]
+    fn move_y_zero_is_noop() {
+        let mut hash = GeoHashBits {
+            bits: 0xABCD,
+            step: PrecisionStep::new(10).unwrap(),
+        };
+        let original = hash;
+        move_y(&mut hash, 0);
+        assert_eq!(hash, original);
+    }
+
+    #[test]
+    fn move_x_east_then_west_roundtrips() {
+        let original = GeoHashBits {
+            bits: interleave64(100, 200),
+            step: PrecisionStep::new(16).unwrap(),
+        };
+        let mut hash = original;
+        move_x(&mut hash, 1);
+        assert_ne!(hash, original, "moving east should change the hash");
+        move_x(&mut hash, -1);
+        assert_eq!(hash, original, "moving east then west should roundtrip");
+    }
+
+    #[test]
+    fn move_y_north_then_south_roundtrips() {
+        let original = GeoHashBits {
+            bits: interleave64(100, 200),
+            step: PrecisionStep::new(16).unwrap(),
+        };
+        let mut hash = original;
+        move_y(&mut hash, 1);
+        assert_ne!(hash, original, "moving north should change the hash");
+        move_y(&mut hash, -1);
+        assert_eq!(hash, original, "moving north then south should roundtrip");
+    }
+
+    #[test]
+    fn move_x_and_y_are_independent() {
+        let original = GeoHashBits {
+            bits: interleave64(50, 75),
+            step: PrecisionStep::new(10).unwrap(),
+        };
+
+        let mut moved_x = original;
+        move_x(&mut moved_x, 1);
+
+        let mut moved_y = original;
+        move_y(&mut moved_y, 1);
+
+        // X movement should only change odd-position bits (longitude).
+        // Y movement should only change even-position bits (latitude).
+        // The y-bits of an x-move should be unchanged, and vice versa.
+        let y_mask = 0x5555_5555_5555_5555u64;
+        let x_mask = 0xAAAA_AAAA_AAAA_AAAAu64;
+        assert_eq!(
+            moved_x.bits & y_mask,
+            original.bits & y_mask,
+            "move_x should not change y (latitude) bits"
+        );
+        assert_eq!(
+            moved_y.bits & x_mask,
+            original.bits & x_mask,
+            "move_y should not change x (longitude) bits"
+        );
+    }
+}

--- a/src/redisearch_rs/geo/src/hash/distance.rs
+++ b/src/redisearch_rs/geo/src/hash/distance.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Haversine great-circle distance calculation.
+
+use decorum::R64;
+
+use super::EARTH_RADIUS_IN_METERS;
+
+/// Calculate the great-circle distance between two WGS-84 points using the
+/// haversine formula.
+///
+/// All coordinates are in degrees. Returns distance in meters.
+pub fn haversine_distance(lon1: R64, lat1: R64, lon2: R64, lat2: R64) -> f64 {
+    let lat1r = lat1.into_inner().to_radians();
+    let lon1r = lon1.into_inner().to_radians();
+    let lat2r = lat2.into_inner().to_radians();
+    let lon2r = lon2.into_inner().to_radians();
+
+    let u = ((lat2r - lat1r) / 2.0).sin();
+    let v = ((lon2r - lon1r) / 2.0).sin();
+
+    // Clamp before asin: floating-point rounding can push the sqrt result
+    // slightly above 1.0 for near-antipodal points, which would yield NaN.
+    2.0 * EARTH_RADIUS_IN_METERS
+        * (u * u + lat1r.cos() * lat2r.cos() * v * v)
+            .sqrt()
+            .min(1.0)
+            .asin()
+}

--- a/src/redisearch_rs/geo/src/hash/distance.rs
+++ b/src/redisearch_rs/geo/src/hash/distance.rs
@@ -34,3 +34,22 @@ pub fn haversine_distance(lon1: R64, lat1: R64, lon2: R64, lat2: R64) -> f64 {
             .min(1.0)
             .asin()
 }
+
+/// Great-circle distance along a meridian (constant longitude).
+///
+/// This is a specialization of [`haversine_distance`] where `lon1 == lon2`,
+/// eliminating the longitude sine/cosine terms.
+pub(crate) fn meridian_distance(lat1: R64, lat2: R64) -> f64 {
+    let u = ((lat2.into_inner().to_radians() - lat1.into_inner().to_radians()) / 2.0).sin();
+    2.0 * EARTH_RADIUS_IN_METERS * u.abs().min(1.0).asin()
+}
+
+/// Great-circle distance along a parallel (constant latitude).
+///
+/// This is a specialization of [`haversine_distance`] where `lat1 == lat2`,
+/// eliminating the latitude-difference term and needing only one cosine.
+pub(crate) fn parallel_distance(lat: R64, lon1: R64, lon2: R64) -> f64 {
+    let lat_r = lat.into_inner().to_radians();
+    let v = ((lon2.into_inner().to_radians() - lon1.into_inner().to_radians()) / 2.0).sin();
+    2.0 * EARTH_RADIUS_IN_METERS * (lat_r.cos() * v.abs()).min(1.0).asin()
+}

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -55,16 +55,16 @@ pub fn encode_wgs84(coords: WGS84Coordinates, step: PrecisionStep) -> GeoHashBit
     let lon = coords.longitude().into_inner();
     let lat = coords.latitude().into_inner();
 
-    let step_val = step.as_u8();
     let lon_offset = (lon - GEO_LONG_MIN) / (GEO_LONG_MAX - GEO_LONG_MIN);
     let lat_offset = (lat - GEO_LAT_MIN) / (GEO_LAT_MAX - GEO_LAT_MIN);
 
     // Clamp to the maximum valid fixed-point value. At exact boundary
     // coordinates (e.g. lon=180, lat=85.05112878) the offset is exactly 1.0,
     // producing `1 << step` which overflows the `step*2`-bit hash range.
-    let max_fixed = (1u64 << step_val) - 1;
-    let lat_fixed = ((lat_offset * (1u64 << step_val) as f64) as u64).min(max_fixed) as u32;
-    let lon_fixed = ((lon_offset * (1u64 << step_val) as f64) as u64).min(max_fixed) as u32;
+    let step_size = (1u64 << step.as_u8()) as f64;
+    let max_fixed = step_size as u64 - 1;
+    let lat_fixed = ((lat_offset * step_size) as u64).min(max_fixed) as u32;
+    let lon_fixed = ((lon_offset * step_size) as u64).min(max_fixed) as u32;
 
     GeoHashBits {
         bits: bits::interleave64(lat_fixed, lon_fixed),

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -97,13 +97,21 @@ pub fn decode(hash: GeoHashBits) -> GeoHashArea {
 }
 
 /// Decode a [`GeoHashBits`] to the center `(longitude, latitude)` point.
+///
+/// Computes the cell center directly from the interleaved bits, avoiding
+/// a full [`decode`] and bound averaging.
 pub fn decode_to_lon_lat(hash: GeoHashBits) -> (R64, R64) {
-    let area = decode(hash);
-    let lon = ((area.longitude.min + area.longitude.max) / 2.0)
-        .clamp(R64::assert(GEO_LONG_MIN), R64::assert(GEO_LONG_MAX));
-    let lat = ((area.latitude.min + area.latitude.max) / 2.0)
-        .clamp(R64::assert(GEO_LAT_MIN), R64::assert(GEO_LAT_MAX));
-    (lon, lat)
+    let step = hash.step.as_u8();
+    let (ilat, ilon) = bits::deinterleave64(hash.bits);
+    let step_size = (1u64 << step) as f64;
+
+    let lon = (GEO_LONG_MIN + ((ilon as f64 + 0.5) / step_size) * (GEO_LONG_MAX - GEO_LONG_MIN))
+        .clamp(GEO_LONG_MIN, GEO_LONG_MAX);
+    let lat = (GEO_LAT_MIN + ((ilat as f64 + 0.5) / step_size) * (GEO_LAT_MAX - GEO_LAT_MIN))
+        .clamp(GEO_LAT_MIN, GEO_LAT_MAX);
+
+    // Both values are finite: bounded arithmetic on clamped integer inputs.
+    (R64::assert(lon), R64::assert(lat))
 }
 
 /// Left-shift a geohash to fill 52 bits, producing a value suitable for use

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -152,31 +152,28 @@ pub const fn neighbors(hash: GeoHashBits) -> GeoHashNeighbors {
 
 /// Estimate the precision step for a radius query at the given latitude.
 fn estimate_steps_by_radius(range_meters: f64, lat: R64) -> PrecisionStep {
-    if range_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-        // Zero, negative, or NaN radius — use finest precision.
-        // This also avoids an infinite loop: doubling a non-positive value
-        // never reaches MERCATOR_MAX.
-        return GEO_STEP_MAX;
-    }
-    let mut range = range_meters;
-    let mut step: i32 = 1;
-    while range < MERCATOR_MAX {
-        range *= 2.0;
-        step += 1;
-    }
-    step -= 2; // Ensure the range is included in most base cases.
+    // Non-positive, NaN, or infinite radius — use finest/coarsest precision.
+    let step = if range_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        GEO_STEP_MAX.as_u8() as i32
+    } else {
+        // step = 1 + ceil(log2(MERCATOR_MAX / range)) - 2
+        //       = ceil(log2(MERCATOR_MAX / range)) - 1
+        // Clamp the f64 result before converting to i32 to avoid overflow
+        // when range_meters is very large or infinite (log2(0) = -inf).
+        ((MERCATOR_MAX / range_meters).log2().ceil() - 1.0).clamp(1.0, GEO_STEP_MAX.as_u8() as f64)
+            as i32
+    };
 
     // Wider range towards the poles.
     let lat = lat.into_inner();
-    if !(-66.0..=66.0).contains(&lat) {
-        step -= 1;
-        if !(-80.0..=80.0).contains(&lat) {
-            step -= 1;
-        }
-    }
+    let polar_adjust = if !(-66.0..=66.0).contains(&lat) {
+        if !(-80.0..=80.0).contains(&lat) { 2 } else { 1 }
+    } else {
+        0
+    };
 
     // Clamped to 1..=GEO_STEP_MAX, which is always valid for PrecisionStep.
-    PrecisionStep::new(step.clamp(1, GEO_STEP_MAX.as_u8() as i32) as u8).unwrap()
+    PrecisionStep::new((step - polar_adjust).clamp(1, GEO_STEP_MAX.as_u8() as i32) as u8).unwrap()
 }
 
 /// Compute the bounding box `[min_lon, min_lat, max_lon, max_lat]` for a

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -114,31 +114,29 @@ pub const fn align_52bits(hash: GeoHashBits) -> u64 {
 
 /// Compute the 8 neighboring geohash cells.
 pub const fn neighbors(hash: GeoHashBits) -> GeoHashNeighbors {
+    // Cardinal directions.
     let mut east = hash;
     let mut west = hash;
     let mut north = hash;
     let mut south = hash;
-    let mut north_east = hash;
-    let mut north_west = hash;
-    let mut south_east = hash;
-    let mut south_west = hash;
 
     bits::move_x(&mut east, 1);
     bits::move_x(&mut west, -1);
     bits::move_y(&mut north, 1);
     bits::move_y(&mut south, -1);
 
+    // Diagonal neighbors: move_x and move_y operate on disjoint bit
+    // positions, so we can derive corners from the cardinal neighbors
+    // with a single additional move each.
+    let mut north_east = north;
+    let mut north_west = north;
+    let mut south_east = south;
+    let mut south_west = south;
+
     bits::move_x(&mut north_east, 1);
-    bits::move_y(&mut north_east, 1);
-
     bits::move_x(&mut north_west, -1);
-    bits::move_y(&mut north_west, 1);
-
     bits::move_x(&mut south_east, 1);
-    bits::move_y(&mut south_east, -1);
-
     bits::move_x(&mut south_west, -1);
-    bits::move_y(&mut south_west, -1);
 
     GeoHashNeighbors {
         north: Some(north),

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -22,6 +22,7 @@ mod distance;
 mod types;
 
 pub use distance::haversine_distance;
+use distance::{meridian_distance, parallel_distance};
 pub use types::{
     GeoHashArea, GeoHashBits, GeoHashNeighbors, GeoHashRadius, GeoHashRange, InvalidPrecisionStep,
     InvalidWGS84Coordinates, PrecisionStep, WGS84Coordinates,
@@ -223,25 +224,15 @@ pub fn get_areas_by_radius(coords: WGS84Coordinates, radius_meters: f64) -> GeoH
 
     // Check if the step is sufficient at the limits of the covered area.
     // Sometimes a neighboring cell is too near to cover everything.
-    let mut decrease_step = false;
-    if let (Some(n), Some(s), Some(e), Some(w)) = (nbrs.north, nbrs.south, nbrs.east, nbrs.west) {
-        let north = decode(n);
-        let south = decode(s);
-        let east = decode(e);
-        let west = decode(w);
-        if haversine_distance(longitude, latitude, longitude, north.latitude.max) < radius_meters {
-            decrease_step = true;
-        }
-        if haversine_distance(longitude, latitude, longitude, south.latitude.min) < radius_meters {
-            decrease_step = true;
-        }
-        if haversine_distance(longitude, latitude, east.longitude.max, latitude) < radius_meters {
-            decrease_step = true;
-        }
-        if haversine_distance(longitude, latitude, west.longitude.min, latitude) < radius_meters {
-            decrease_step = true;
-        }
-    }
+    // `neighbors()` always returns all `Some`, so unwrap is safe here.
+    let north = decode(nbrs.north.unwrap());
+    let south = decode(nbrs.south.unwrap());
+    let east = decode(nbrs.east.unwrap());
+    let west = decode(nbrs.west.unwrap());
+    let decrease_step = meridian_distance(latitude, north.latitude.max) < radius_meters
+        || meridian_distance(latitude, south.latitude.min) < radius_meters
+        || parallel_distance(latitude, longitude, east.longitude.max) < radius_meters
+        || parallel_distance(latitude, longitude, west.longitude.min) < radius_meters;
 
     if steps.as_u8() > 1 && decrease_step {
         // steps is at least 2 here, so steps - 1 is at least 1 — always valid.

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -96,6 +96,46 @@ pub fn decode(hash: GeoHashBits) -> GeoHashArea {
     }
 }
 
+/// Decode the maximum latitude of a geohash cell.
+///
+/// This is cheaper than a full [`decode`] when only one bound is needed.
+fn decode_lat_max(hash: GeoHashBits) -> R64 {
+    let step = hash.step.as_u8();
+    let (ilat, _) = bits::deinterleave64(hash.bits);
+    let step_size = (1u64 << step) as f64;
+    R64::assert(GEO_LAT_MIN + ((ilat as f64 + 1.0) / step_size) * (GEO_LAT_MAX - GEO_LAT_MIN))
+}
+
+/// Decode the minimum latitude of a geohash cell.
+///
+/// This is cheaper than a full [`decode`] when only one bound is needed.
+fn decode_lat_min(hash: GeoHashBits) -> R64 {
+    let step = hash.step.as_u8();
+    let (ilat, _) = bits::deinterleave64(hash.bits);
+    let step_size = (1u64 << step) as f64;
+    R64::assert(GEO_LAT_MIN + (ilat as f64 / step_size) * (GEO_LAT_MAX - GEO_LAT_MIN))
+}
+
+/// Decode the maximum longitude of a geohash cell.
+///
+/// This is cheaper than a full [`decode`] when only one bound is needed.
+fn decode_lon_max(hash: GeoHashBits) -> R64 {
+    let step = hash.step.as_u8();
+    let (_, ilon) = bits::deinterleave64(hash.bits);
+    let step_size = (1u64 << step) as f64;
+    R64::assert(GEO_LONG_MIN + ((ilon as f64 + 1.0) / step_size) * (GEO_LONG_MAX - GEO_LONG_MIN))
+}
+
+/// Decode the minimum longitude of a geohash cell.
+///
+/// This is cheaper than a full [`decode`] when only one bound is needed.
+fn decode_lon_min(hash: GeoHashBits) -> R64 {
+    let step = hash.step.as_u8();
+    let (_, ilon) = bits::deinterleave64(hash.bits);
+    let step_size = (1u64 << step) as f64;
+    R64::assert(GEO_LONG_MIN + (ilon as f64 / step_size) * (GEO_LONG_MAX - GEO_LONG_MIN))
+}
+
 /// Decode a [`GeoHashBits`] to the center `(longitude, latitude)` point.
 ///
 /// Computes the cell center directly from the interleaved bits, avoiding
@@ -228,14 +268,14 @@ pub fn get_areas_by_radius(coords: WGS84Coordinates, radius_meters: f64) -> GeoH
     // Check if the step is sufficient at the limits of the covered area.
     // Sometimes a neighboring cell is too near to cover everything.
     // `neighbors()` always returns all `Some`, so unwrap is safe here.
-    let north = decode(nbrs.north.unwrap());
-    let south = decode(nbrs.south.unwrap());
-    let east = decode(nbrs.east.unwrap());
-    let west = decode(nbrs.west.unwrap());
-    let decrease_step = meridian_distance(latitude, north.latitude.max) < radius_meters
-        || meridian_distance(latitude, south.latitude.min) < radius_meters
-        || parallel_distance(latitude, longitude, east.longitude.max) < radius_meters
-        || parallel_distance(latitude, longitude, west.longitude.min) < radius_meters;
+    // Only decode the single bound needed per direction to avoid full decode.
+    let decrease_step = meridian_distance(latitude, decode_lat_max(nbrs.north.unwrap()))
+        < radius_meters
+        || meridian_distance(latitude, decode_lat_min(nbrs.south.unwrap())) < radius_meters
+        || parallel_distance(latitude, longitude, decode_lon_max(nbrs.east.unwrap()))
+            < radius_meters
+        || parallel_distance(latitude, longitude, decode_lon_min(nbrs.west.unwrap()))
+            < radius_meters;
 
     if steps.as_u8() > 1 && decrease_step {
         // steps is at least 2 here, so steps - 1 is at least 1 — always valid.

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -200,28 +200,24 @@ pub const fn neighbors(hash: GeoHashBits) -> GeoHashNeighbors {
 
 /// Estimate the precision step for a radius query at the given latitude.
 fn estimate_steps_by_radius(range_meters: f64, lat: R64) -> PrecisionStep {
-    // Non-positive, NaN, or infinite radius — use finest/coarsest precision.
-    let step = if range_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-        GEO_STEP_MAX.as_u8() as i32
-    } else {
-        // step = 1 + ceil(log2(MERCATOR_MAX / range)) - 2
-        //       = ceil(log2(MERCATOR_MAX / range)) - 1
-        // Clamp the f64 result before converting to i32 to avoid overflow
-        // when range_meters is very large or infinite (log2(0) = -inf).
-        ((MERCATOR_MAX / range_meters).log2().ceil() - 1.0).clamp(1.0, GEO_STEP_MAX.as_u8() as f64)
-            as i32
-    };
-
+    if range_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        // Zero, negative, or NaN radius — use finest precision.
+        return GEO_STEP_MAX;
+    }
+    // Smallest n such that range_meters * 2^n >= MERCATOR_MAX, minus 2 to
+    // ensure the range is included in most base cases. Equivalently:
+    //   ceil(log2(MERCATOR_MAX / range_meters)) - 1
+    // The `min` keeps next_power_of_two from overflowing on extreme inputs.
+    let ratio = (MERCATOR_MAX / range_meters).ceil().min(u32::MAX as f64) as u64;
+    let base = ratio.next_power_of_two().ilog2() as i32 - 1;
     // Wider range towards the poles.
-    let lat = lat.into_inner();
-    let polar_adjust = if !(-66.0..=66.0).contains(&lat) {
-        if !(-80.0..=80.0).contains(&lat) { 2 } else { 1 }
-    } else {
-        0
+    let polar_adjust = match lat.into_inner().abs() {
+        a if a > 80.0 => 2,
+        a if a > 66.0 => 1,
+        _ => 0,
     };
-
-    // Clamped to 1..=GEO_STEP_MAX, which is always valid for PrecisionStep.
-    PrecisionStep::new((step - polar_adjust).clamp(1, GEO_STEP_MAX.as_u8() as i32) as u8).unwrap()
+    let step = (base - polar_adjust).clamp(1, GEO_STEP_MAX.as_u8() as i32) as u8;
+    PrecisionStep::new(step).unwrap()
 }
 
 /// Compute the bounding box `[min_lon, min_lat, max_lon, max_lat]` for a

--- a/src/redisearch_rs/geo/src/hash/mod.rs
+++ b/src/redisearch_rs/geo/src/hash/mod.rs
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Redis-compatible geohash encoding/decoding.
+//!
+//! This is a port of the [C geohash library](https://github.com/yinqiwen/ardb/blob/d42503/src/geo/geohash_helper.cpp)
+//! originally by yinqiwen, Matt Stancliff, and Salvatore Sanfilippo (used in Redis and RediSearch).
+//!
+//! Coordinates are encoded as 52-bit interleaved hashes (Morton codes) using
+//! WGS-84 bounds, suitable for storage as sorted-set scores in Redis.
+
+use decorum::R64;
+
+mod bits;
+mod distance;
+mod types;
+
+pub use distance::haversine_distance;
+pub use types::{
+    GeoHashArea, GeoHashBits, GeoHashNeighbors, GeoHashRadius, GeoHashRange, InvalidPrecisionStep,
+    InvalidWGS84Coordinates, PrecisionStep, WGS84Coordinates,
+};
+
+/// Maximum geohash step count. 26 steps × 2 bits = 52 bits of precision.
+pub const GEO_STEP_MAX: PrecisionStep = match PrecisionStep::new(26) {
+    Ok(s) => s,
+    Err(_) => unreachable!(),
+};
+
+/// WGS-84 latitude limits (EPSG:900913).
+pub const GEO_LAT_MIN: f64 = -85.05112878;
+/// WGS-84 latitude limits (EPSG:900913).
+pub const GEO_LAT_MAX: f64 = 85.05112878;
+/// WGS-84 longitude limits.
+pub const GEO_LONG_MIN: f64 = -180.0;
+/// WGS-84 longitude limits.
+pub const GEO_LONG_MAX: f64 = 180.0;
+
+/// Mercator projection maximum (meters).
+const MERCATOR_MAX: f64 = 20037726.37;
+
+/// Earth's quadratic mean radius for WGS-84 (meters).
+const EARTH_RADIUS_IN_METERS: f64 = 6372797.560856;
+
+/// Encode WGS-84 coordinates into a [`GeoHashBits`] with the given step
+/// precision.
+pub fn encode_wgs84(coords: WGS84Coordinates, step: PrecisionStep) -> GeoHashBits {
+    let lon = coords.longitude().into_inner();
+    let lat = coords.latitude().into_inner();
+
+    let step_val = step.as_u8();
+    let lon_offset = (lon - GEO_LONG_MIN) / (GEO_LONG_MAX - GEO_LONG_MIN);
+    let lat_offset = (lat - GEO_LAT_MIN) / (GEO_LAT_MAX - GEO_LAT_MIN);
+
+    // Clamp to the maximum valid fixed-point value. At exact boundary
+    // coordinates (e.g. lon=180, lat=85.05112878) the offset is exactly 1.0,
+    // producing `1 << step` which overflows the `step*2`-bit hash range.
+    let max_fixed = (1u64 << step_val) - 1;
+    let lat_fixed = ((lat_offset * (1u64 << step_val) as f64) as u64).min(max_fixed) as u32;
+    let lon_fixed = ((lon_offset * (1u64 << step_val) as f64) as u64).min(max_fixed) as u32;
+
+    GeoHashBits {
+        bits: bits::interleave64(lat_fixed, lon_fixed),
+        step,
+    }
+}
+
+/// Decode a [`GeoHashBits`] back into the bounding [`GeoHashArea`].
+pub fn decode(hash: GeoHashBits) -> GeoHashArea {
+    let step = hash.step.as_u8();
+    let (ilat, ilon) = bits::deinterleave64(hash.bits);
+
+    let lat_scale = GEO_LAT_MAX - GEO_LAT_MIN;
+    let lon_scale = GEO_LONG_MAX - GEO_LONG_MIN;
+    let step_size = (1u64 << step) as f64;
+
+    // All values below are finite: they are bounded arithmetic on integer
+    // inputs clamped to `step` bits, so `R64::assert` cannot panic.
+    GeoHashArea {
+        hash,
+        latitude: GeoHashRange {
+            min: R64::assert(GEO_LAT_MIN + (ilat as f64 / step_size) * lat_scale),
+            max: R64::assert(GEO_LAT_MIN + ((ilat as f64 + 1.0) / step_size) * lat_scale),
+        },
+        longitude: GeoHashRange {
+            min: R64::assert(GEO_LONG_MIN + (ilon as f64 / step_size) * lon_scale),
+            max: R64::assert(GEO_LONG_MIN + ((ilon as f64 + 1.0) / step_size) * lon_scale),
+        },
+    }
+}
+
+/// Decode a [`GeoHashBits`] to the center `(longitude, latitude)` point.
+pub fn decode_to_lon_lat(hash: GeoHashBits) -> (R64, R64) {
+    let area = decode(hash);
+    let lon = ((area.longitude.min + area.longitude.max) / 2.0)
+        .clamp(R64::assert(GEO_LONG_MIN), R64::assert(GEO_LONG_MAX));
+    let lat = ((area.latitude.min + area.latitude.max) / 2.0)
+        .clamp(R64::assert(GEO_LAT_MIN), R64::assert(GEO_LAT_MAX));
+    (lon, lat)
+}
+
+/// Left-shift a geohash to fill 52 bits, producing a value suitable for use
+/// as a Redis sorted-set score.
+pub const fn align_52bits(hash: GeoHashBits) -> u64 {
+    hash.bits << (52 - hash.step.as_u8() as u32 * 2)
+}
+
+/// Compute the 8 neighboring geohash cells.
+pub const fn neighbors(hash: GeoHashBits) -> GeoHashNeighbors {
+    let mut east = hash;
+    let mut west = hash;
+    let mut north = hash;
+    let mut south = hash;
+    let mut north_east = hash;
+    let mut north_west = hash;
+    let mut south_east = hash;
+    let mut south_west = hash;
+
+    bits::move_x(&mut east, 1);
+    bits::move_x(&mut west, -1);
+    bits::move_y(&mut north, 1);
+    bits::move_y(&mut south, -1);
+
+    bits::move_x(&mut north_east, 1);
+    bits::move_y(&mut north_east, 1);
+
+    bits::move_x(&mut north_west, -1);
+    bits::move_y(&mut north_west, 1);
+
+    bits::move_x(&mut south_east, 1);
+    bits::move_y(&mut south_east, -1);
+
+    bits::move_x(&mut south_west, -1);
+    bits::move_y(&mut south_west, -1);
+
+    GeoHashNeighbors {
+        north: Some(north),
+        south: Some(south),
+        east: Some(east),
+        west: Some(west),
+        north_east: Some(north_east),
+        north_west: Some(north_west),
+        south_east: Some(south_east),
+        south_west: Some(south_west),
+    }
+}
+
+/// Estimate the precision step for a radius query at the given latitude.
+fn estimate_steps_by_radius(range_meters: f64, lat: R64) -> PrecisionStep {
+    if range_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        // Zero, negative, or NaN radius — use finest precision.
+        // This also avoids an infinite loop: doubling a non-positive value
+        // never reaches MERCATOR_MAX.
+        return GEO_STEP_MAX;
+    }
+    let mut range = range_meters;
+    let mut step: i32 = 1;
+    while range < MERCATOR_MAX {
+        range *= 2.0;
+        step += 1;
+    }
+    step -= 2; // Ensure the range is included in most base cases.
+
+    // Wider range towards the poles.
+    let lat = lat.into_inner();
+    if !(-66.0..=66.0).contains(&lat) {
+        step -= 1;
+        if !(-80.0..=80.0).contains(&lat) {
+            step -= 1;
+        }
+    }
+
+    // Clamped to 1..=GEO_STEP_MAX, which is always valid for PrecisionStep.
+    PrecisionStep::new(step.clamp(1, GEO_STEP_MAX.as_u8() as i32) as u8).unwrap()
+}
+
+/// Compute the bounding box `[min_lon, min_lat, max_lon, max_lat]` for a
+/// circle centered at `(longitude, latitude)` with the given radius in meters.
+///
+/// **Known limitation:** the planar approximation does not behave correctly
+/// at very high latitudes with large radii. For example, at coordinates
+/// (81.63, 30.56) with a 7 083 km radius the reported `min_lon` is too
+/// large, missing points that are actually within range. Because the
+/// bounding box is only used as an optimistic filter (candidates are
+/// verified with [`haversine_distance`]), the result is over-pruning of
+/// neighbor cells, not incorrect final results.
+fn bounding_box(coords: WGS84Coordinates, radius_meters: f64) -> [f64; 4] {
+    let lon = coords.longitude().into_inner();
+    let lat = coords.latitude().into_inner();
+    let lat_rad = lat.to_radians();
+    let lon_delta = (radius_meters / EARTH_RADIUS_IN_METERS / lat_rad.cos()).to_degrees();
+    let lat_delta = (radius_meters / EARTH_RADIUS_IN_METERS).to_degrees();
+    [
+        lon - lon_delta,
+        lat - lat_delta,
+        lon + lon_delta,
+        lat + lat_delta,
+    ]
+}
+
+/// Return the center hash, bounding area, and 8 neighbors that cover a
+/// radius query around the given coordinates with `radius_meters`.
+///
+/// Neighbors that fall outside the bounding box are set to [`None`].
+pub fn get_areas_by_radius(coords: WGS84Coordinates, radius_meters: f64) -> GeoHashRadius {
+    let bounds = bounding_box(coords, radius_meters);
+    let [min_lon, min_lat, max_lon, max_lat] = bounds;
+
+    let longitude = coords.longitude();
+    let latitude = coords.latitude();
+
+    let mut steps = estimate_steps_by_radius(radius_meters, latitude);
+
+    let mut hash = encode_wgs84(coords, steps);
+    let mut nbrs = neighbors(hash);
+    let mut area = decode(hash);
+
+    // Check if the step is sufficient at the limits of the covered area.
+    // Sometimes a neighboring cell is too near to cover everything.
+    let mut decrease_step = false;
+    if let (Some(n), Some(s), Some(e), Some(w)) = (nbrs.north, nbrs.south, nbrs.east, nbrs.west) {
+        let north = decode(n);
+        let south = decode(s);
+        let east = decode(e);
+        let west = decode(w);
+        if haversine_distance(longitude, latitude, longitude, north.latitude.max) < radius_meters {
+            decrease_step = true;
+        }
+        if haversine_distance(longitude, latitude, longitude, south.latitude.min) < radius_meters {
+            decrease_step = true;
+        }
+        if haversine_distance(longitude, latitude, east.longitude.max, latitude) < radius_meters {
+            decrease_step = true;
+        }
+        if haversine_distance(longitude, latitude, west.longitude.min, latitude) < radius_meters {
+            decrease_step = true;
+        }
+    }
+
+    if steps.as_u8() > 1 && decrease_step {
+        // steps is at least 2 here, so steps - 1 is at least 1 — always valid.
+        steps = PrecisionStep::new(steps.as_u8() - 1).unwrap();
+        hash = encode_wgs84(coords, steps);
+        nbrs = neighbors(hash);
+        area = decode(hash);
+    }
+
+    // Exclude neighbor cells that are outside the bounding box.
+    if steps.as_u8() >= 2 {
+        if area.latitude.min < min_lat {
+            nbrs.south = None;
+            nbrs.south_west = None;
+            nbrs.south_east = None;
+        }
+        if area.latitude.max > max_lat {
+            nbrs.north = None;
+            nbrs.north_east = None;
+            nbrs.north_west = None;
+        }
+        if area.longitude.min < min_lon {
+            nbrs.west = None;
+            nbrs.south_west = None;
+            nbrs.north_west = None;
+        }
+        if area.longitude.max > max_lon {
+            nbrs.east = None;
+            nbrs.south_east = None;
+            nbrs.north_east = None;
+        }
+    }
+
+    GeoHashRadius {
+        hash,
+        area,
+        neighbors: nbrs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn estimate_steps_zero_radius_returns_max() {
+        assert_eq!(
+            estimate_steps_by_radius(0.0, R64::assert(0.0)),
+            GEO_STEP_MAX
+        );
+    }
+
+    #[test]
+    fn estimate_steps_negative_radius_returns_max() {
+        assert_eq!(
+            estimate_steps_by_radius(-1.0, R64::assert(0.0)),
+            GEO_STEP_MAX
+        );
+        assert_eq!(
+            estimate_steps_by_radius(-1000.0, R64::assert(45.0)),
+            GEO_STEP_MAX
+        );
+        assert_eq!(
+            estimate_steps_by_radius(f64::NEG_INFINITY, R64::assert(0.0)),
+            GEO_STEP_MAX
+        );
+    }
+
+    #[test]
+    fn estimate_steps_positive_infinity_returns_one() {
+        assert_eq!(
+            estimate_steps_by_radius(f64::INFINITY, R64::assert(0.0)).as_u8(),
+            1
+        );
+    }
+
+    #[test]
+    fn estimate_steps_nan_radius_returns_max() {
+        assert_eq!(
+            estimate_steps_by_radius(f64::NAN, R64::assert(0.0)),
+            GEO_STEP_MAX
+        );
+    }
+
+    #[test]
+    fn estimate_steps_small_radius_gives_high_step() {
+        let step = estimate_steps_by_radius(100.0, R64::assert(45.0)).as_u8();
+        // 100m radius should yield a high step count (fine precision).
+        assert!(
+            step >= 15,
+            "expected step >= 15 for 100m radius, got {step}"
+        );
+    }
+
+    #[test]
+    fn estimate_steps_large_radius_gives_low_step() {
+        let step = estimate_steps_by_radius(5_000_000.0, R64::assert(0.0)).as_u8();
+        // 5000 km radius should yield a very low step count.
+        assert!(
+            step <= 5,
+            "expected step <= 5 for 5000km radius, got {step}"
+        );
+    }
+
+    #[test]
+    fn estimate_steps_polar_latitude_decrements() {
+        let step_equator = estimate_steps_by_radius(1000.0, R64::assert(0.0)).as_u8();
+        let step_polar = estimate_steps_by_radius(1000.0, R64::assert(70.0)).as_u8();
+        let step_extreme_polar = estimate_steps_by_radius(1000.0, R64::assert(85.0)).as_u8();
+
+        assert!(
+            step_polar < step_equator,
+            "polar ({step_polar}) should be less than equator ({step_equator})"
+        );
+        assert!(
+            step_extreme_polar < step_polar,
+            "extreme polar ({step_extreme_polar}) should be less than polar ({step_polar})"
+        );
+    }
+
+    #[test]
+    fn estimate_steps_negative_polar_latitude_decrements() {
+        let step_equator = estimate_steps_by_radius(1000.0, R64::assert(0.0)).as_u8();
+        let step_polar = estimate_steps_by_radius(1000.0, R64::assert(-70.0)).as_u8();
+
+        assert!(
+            step_polar < step_equator,
+            "negative polar ({step_polar}) should be less than equator ({step_equator})"
+        );
+    }
+
+    #[test]
+    fn estimate_steps_clamps_to_valid_range() {
+        // Extremely large radius should clamp to 1.
+        let step = estimate_steps_by_radius(f64::MAX, R64::assert(85.0)).as_u8();
+        assert_eq!(step, 1);
+    }
+
+    fn coords(lon: f64, lat: f64) -> WGS84Coordinates {
+        WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap()
+    }
+
+    #[test]
+    fn bounding_box_symmetric_around_center() {
+        let [min_lon, min_lat, max_lon, max_lat] = bounding_box(coords(10.0, 45.0), 1000.0);
+
+        let lon_delta_west = 10.0 - min_lon;
+        let lon_delta_east = max_lon - 10.0;
+        assert!(
+            (lon_delta_west - lon_delta_east).abs() < 1e-10,
+            "longitude deltas should be symmetric"
+        );
+
+        let lat_delta_south = 45.0 - min_lat;
+        let lat_delta_north = max_lat - 45.0;
+        assert!(
+            (lat_delta_south - lat_delta_north).abs() < 1e-10,
+            "latitude deltas should be symmetric"
+        );
+    }
+
+    #[test]
+    fn bounding_box_larger_radius_gives_larger_box() {
+        let small = bounding_box(coords(0.0, 45.0), 100.0);
+        let large = bounding_box(coords(0.0, 45.0), 10_000.0);
+
+        assert!(
+            large[0] < small[0],
+            "larger radius should have smaller min_lon"
+        );
+        assert!(
+            large[1] < small[1],
+            "larger radius should have smaller min_lat"
+        );
+        assert!(
+            large[2] > small[2],
+            "larger radius should have larger max_lon"
+        );
+        assert!(
+            large[3] > small[3],
+            "larger radius should have larger max_lat"
+        );
+    }
+
+    #[test]
+    fn bounding_box_wider_at_high_latitude() {
+        let equator = bounding_box(coords(0.0, 0.0), 1000.0);
+        let high_lat = bounding_box(coords(0.0, 60.0), 1000.0);
+
+        let equator_lon_span = equator[2] - equator[0];
+        let high_lat_lon_span = high_lat[2] - high_lat[0];
+
+        // At higher latitudes, the longitude span should be wider because
+        // meridians converge towards the poles.
+        assert!(
+            high_lat_lon_span > equator_lon_span,
+            "lon span at 60° ({high_lat_lon_span}) should be wider than at equator ({equator_lon_span})"
+        );
+    }
+}

--- a/src/redisearch_rs/geo/src/hash/types.rs
+++ b/src/redisearch_rs/geo/src/hash/types.rs
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Data types for geohash encoding.
+
+use std::num::NonZeroU8;
+
+use decorum::R64;
+
+/// A WGS-84 coordinate pair with longitude and latitude validated to be
+/// within the supported bounds.
+///
+/// Longitude is in [`GEO_LONG_MIN`]`..=`[`GEO_LONG_MAX`] and latitude is in
+/// [`GEO_LAT_MIN`]`..=`[`GEO_LAT_MAX`] (EPSG:900913).
+///
+/// Use [`WGS84Coordinates::new`] to construct, which validates the bounds.
+///
+/// [`GEO_LONG_MIN`]: super::GEO_LONG_MIN
+/// [`GEO_LONG_MAX`]: super::GEO_LONG_MAX
+/// [`GEO_LAT_MIN`]: super::GEO_LAT_MIN
+/// [`GEO_LAT_MAX`]: super::GEO_LAT_MAX
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WGS84Coordinates {
+    /// Longitude in degrees, guaranteed to be in
+    /// [`GEO_LONG_MIN`]`..=`[`GEO_LONG_MAX`].
+    ///
+    /// [`GEO_LONG_MIN`]: super::GEO_LONG_MIN
+    /// [`GEO_LONG_MAX`]: super::GEO_LONG_MAX
+    longitude: R64,
+    /// Latitude in degrees, guaranteed to be in
+    /// [`GEO_LAT_MIN`]`..=`[`GEO_LAT_MAX`].
+    ///
+    /// [`GEO_LAT_MIN`]: super::GEO_LAT_MIN
+    /// [`GEO_LAT_MAX`]: super::GEO_LAT_MAX
+    latitude: R64,
+}
+
+/// Error returned by [`WGS84Coordinates::new`] when a coordinate is outside
+/// WGS-84 bounds.
+///
+/// Contains the out-of-bounds coordinate(s): [`longitude`](Self::longitude)
+/// and/or [`latitude`](Self::latitude) are [`Some`] when outside bounds
+/// (including non-finite values like NaN or infinity).
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
+#[error("coordinates outside WGS-84 bounds{}", format_failing_coords(*.longitude, *.latitude))]
+pub struct InvalidWGS84Coordinates {
+    /// The longitude value, if it was outside bounds.
+    pub longitude: Option<f64>,
+    /// The latitude value, if it was outside bounds.
+    pub latitude: Option<f64>,
+}
+
+fn format_failing_coords(longitude: Option<f64>, latitude: Option<f64>) -> String {
+    match (longitude, latitude) {
+        (Some(lon), Some(lat)) => format!(": longitude={lon}, latitude={lat}"),
+        (Some(lon), None) => format!(": longitude={lon}"),
+        (None, Some(lat)) => format!(": latitude={lat}"),
+        (None, None) => String::new(),
+    }
+}
+
+impl WGS84Coordinates {
+    /// Longitude in degrees, in [`GEO_LONG_MIN`]`..=`[`GEO_LONG_MAX`].
+    ///
+    /// [`GEO_LONG_MIN`]: super::GEO_LONG_MIN
+    /// [`GEO_LONG_MAX`]: super::GEO_LONG_MAX
+    pub const fn longitude(self) -> R64 {
+        self.longitude
+    }
+
+    /// Latitude in degrees, in [`GEO_LAT_MIN`]`..=`[`GEO_LAT_MAX`].
+    ///
+    /// [`GEO_LAT_MIN`]: super::GEO_LAT_MIN
+    /// [`GEO_LAT_MAX`]: super::GEO_LAT_MAX
+    pub const fn latitude(self) -> R64 {
+        self.latitude
+    }
+
+    /// Create validated WGS-84 coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidWGS84Coordinates`] if `longitude` or `latitude` is
+    /// outside the WGS-84 bounds.
+    pub fn new(longitude: R64, latitude: R64) -> Result<Self, InvalidWGS84Coordinates> {
+        let lon = longitude.into_inner();
+        let lat = latitude.into_inner();
+        let bad_lon = !(super::GEO_LONG_MIN..=super::GEO_LONG_MAX).contains(&lon);
+        let bad_lat = !(super::GEO_LAT_MIN..=super::GEO_LAT_MAX).contains(&lat);
+        if bad_lon || bad_lat {
+            return Err(InvalidWGS84Coordinates {
+                longitude: bad_lon.then_some(lon),
+                latitude: bad_lat.then_some(lat),
+            });
+        }
+        Ok(Self {
+            longitude,
+            latitude,
+        })
+    }
+
+    /// Create validated WGS-84 coordinates from raw `f64` values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidWGS84Coordinates`] if `longitude` or `latitude` is
+    /// non-finite (NaN/infinity) or outside the WGS-84 bounds.
+    pub fn from_f64(longitude: f64, latitude: f64) -> Result<Self, InvalidWGS84Coordinates> {
+        let lon = R64::try_new(longitude);
+        let lat = R64::try_new(latitude);
+        match (lon, lat) {
+            (Ok(lon), Ok(lat)) => Self::new(lon, lat),
+            (lon, lat) => Err(InvalidWGS84Coordinates {
+                longitude: lon.err().map(|_| longitude),
+                latitude: lat.err().map(|_| latitude),
+            }),
+        }
+    }
+}
+
+impl TryFrom<(f64, f64)> for WGS84Coordinates {
+    type Error = InvalidWGS84Coordinates;
+
+    /// Convert `(longitude, latitude)` into validated WGS-84 coordinates.
+    fn try_from((longitude, latitude): (f64, f64)) -> Result<Self, Self::Error> {
+        Self::from_f64(longitude, latitude)
+    }
+}
+
+/// A validated geohash precision step in the range `1..=26`.
+///
+/// 26 steps × 2 bits = 52 bits of precision, which is the maximum
+/// that fits in a Redis sorted-set score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PrecisionStep(NonZeroU8);
+
+/// Error returned by [`PrecisionStep::new`] when the value is outside `1..=26`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("precision step must be in 1..=26, got {0}")]
+pub struct InvalidPrecisionStep(u8);
+
+impl PrecisionStep {
+    /// Create a new precision step.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPrecisionStep`] if `step` is outside `1..=26`.
+    pub const fn new(step: u8) -> Result<Self, InvalidPrecisionStep> {
+        if step >= 1 && step <= 26 {
+            Ok(Self(NonZeroU8::new(step).unwrap()))
+        } else {
+            Err(InvalidPrecisionStep(step))
+        }
+    }
+
+    /// Return the raw step value.
+    pub const fn as_u8(self) -> u8 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u8> for PrecisionStep {
+    type Error = InvalidPrecisionStep;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// A geohash value with its precision level.
+///
+/// Always represents a valid hash — use [`Option<GeoHashBits>`] where an
+/// absent/empty cell is needed (e.g. excluded neighbors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GeoHashBits {
+    /// The interleaved hash bits.
+    pub bits: u64,
+    /// The precision step (number of bits per coordinate, `1..=26`).
+    pub step: PrecisionStep,
+}
+
+/// A min/max range for a single coordinate dimension.
+///
+/// Values are guaranteed to be finite ([`R64`]).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeoHashRange {
+    /// Minimum value (inclusive).
+    pub min: R64,
+    /// Maximum value (exclusive for geohash cells, inclusive for coordinate
+    /// bounds).
+    pub max: R64,
+}
+
+/// A decoded geohash area with latitude and longitude bounds.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeoHashArea {
+    /// The original hash that was decoded.
+    pub hash: GeoHashBits,
+    /// Longitude bounds.
+    pub longitude: GeoHashRange,
+    /// Latitude bounds.
+    pub latitude: GeoHashRange,
+}
+
+/// The 8 directional neighbors of a geohash cell.
+///
+/// Each neighbor is [`None`] if it falls outside the search bounding box.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GeoHashNeighbors {
+    /// Northern neighbor.
+    pub north: Option<GeoHashBits>,
+    /// Southern neighbor.
+    pub south: Option<GeoHashBits>,
+    /// Eastern neighbor.
+    pub east: Option<GeoHashBits>,
+    /// Western neighbor.
+    pub west: Option<GeoHashBits>,
+    /// North-eastern neighbor.
+    pub north_east: Option<GeoHashBits>,
+    /// North-western neighbor.
+    pub north_west: Option<GeoHashBits>,
+    /// South-eastern neighbor.
+    pub south_east: Option<GeoHashBits>,
+    /// South-western neighbor.
+    pub south_west: Option<GeoHashBits>,
+}
+
+/// Result of a radius query: the center cell, its area, and its neighbors.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeoHashRadius {
+    /// The geohash of the center point.
+    pub hash: GeoHashBits,
+    /// The decoded area of the center cell.
+    pub area: GeoHashArea,
+    /// The 8 neighboring cells ([`None`] if outside the bounding box).
+    pub neighbors: GeoHashNeighbors,
+}

--- a/src/redisearch_rs/geo/src/lib.rs
+++ b/src/redisearch_rs/geo/src/lib.rs
@@ -9,8 +9,11 @@
 
 //! Geographic utilities for RediSearch.
 //!
-//! This crate provides geo coordinate parsing and validation.
+//! This crate provides geo coordinate parsing, validation, and geohash
+//! encoding/decoding. The lower-level geohash primitives live in the
+//! [`hash`] module.
 
+pub mod hash;
 mod parse;
 
 pub use parse::{Coordinates, ParseGeoError};

--- a/src/redisearch_rs/geo/tests/integration/hash/distance.rs
+++ b/src/redisearch_rs/geo/tests/integration/hash/distance.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use decorum::R64;
+use geo::hash::haversine_distance;
+
+#[test]
+fn same_point_is_zero() {
+    assert_eq!(
+        haversine_distance(
+            R64::assert(0.0),
+            R64::assert(0.0),
+            R64::assert(0.0),
+            R64::assert(0.0)
+        ),
+        0.0
+    );
+    assert_eq!(
+        haversine_distance(
+            R64::assert(10.0),
+            R64::assert(20.0),
+            R64::assert(10.0),
+            R64::assert(20.0)
+        ),
+        0.0
+    );
+}
+
+#[test]
+fn known_distance() {
+    // London (51.5074, -0.1278) to Paris (48.8566, 2.3522)
+    // Expected: ~343 km
+    let dist = haversine_distance(
+        R64::assert(-0.1278),
+        R64::assert(51.5074),
+        R64::assert(2.3522),
+        R64::assert(48.8566),
+    );
+    assert!((dist - 343_556.0).abs() < 500.0, "got {dist}");
+}
+
+#[test]
+fn symmetric() {
+    let d1 = haversine_distance(
+        R64::assert(1.0),
+        R64::assert(2.0),
+        R64::assert(3.0),
+        R64::assert(4.0),
+    );
+    let d2 = haversine_distance(
+        R64::assert(3.0),
+        R64::assert(4.0),
+        R64::assert(1.0),
+        R64::assert(2.0),
+    );
+    assert!((d1 - d2).abs() < 1e-6);
+}

--- a/src/redisearch_rs/geo/tests/integration/hash/encode_decode.rs
+++ b/src/redisearch_rs/geo/tests/integration/hash/encode_decode.rs
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use decorum::R64;
+use geo::hash::{
+    GEO_LAT_MAX, GEO_LAT_MIN, GEO_LONG_MAX, GEO_LONG_MIN, GEO_STEP_MAX, PrecisionStep,
+    WGS84Coordinates, align_52bits, decode_to_lon_lat, encode_wgs84,
+};
+
+#[test]
+fn encode_decode_roundtrip() {
+    let cases = [
+        (0.0, 0.0),
+        (10.0, 20.0),
+        (-122.4194, 37.7749),   // San Francisco
+        (2.3522, 48.8566),      // Paris
+        (139.6917, 35.6895),    // Tokyo
+        (-0.1278, 51.5074),     // London
+        (180.0, 85.05112878),   // max bounds
+        (-180.0, -85.05112878), // min bounds
+    ];
+
+    for (lon, lat) in cases {
+        let coords = WGS84Coordinates::new(R64::assert(lon), R64::assert(lat))
+            .unwrap_or_else(|e| panic!("failed to create coords ({lon}, {lat}): {e:?}"));
+        let hash = encode_wgs84(coords, GEO_STEP_MAX);
+        let (decoded_lon, decoded_lat) = decode_to_lon_lat(hash);
+        let (decoded_lon, decoded_lat) = (decoded_lon.into_inner(), decoded_lat.into_inner());
+        // 52-bit precision gives sub-meter accuracy, so 0.001 degree tolerance is generous
+        assert!(
+            (decoded_lon - lon).abs() < 0.001,
+            "lon mismatch for ({lon}, {lat}): got {decoded_lon}"
+        );
+        assert!(
+            (decoded_lat - lat).abs() < 0.001,
+            "lat mismatch for ({lon}, {lat}): got {decoded_lat}"
+        );
+    }
+}
+
+#[test]
+fn encode_out_of_range_longitude() {
+    let err = WGS84Coordinates::new(R64::assert(181.0), R64::assert(0.0)).unwrap_err();
+    assert_eq!(err.longitude, Some(181.0));
+    assert_eq!(err.latitude, None);
+
+    let err = WGS84Coordinates::new(R64::assert(-181.0), R64::assert(0.0)).unwrap_err();
+    assert_eq!(err.longitude, Some(-181.0));
+    assert_eq!(err.latitude, None);
+}
+
+#[test]
+fn encode_out_of_range_latitude() {
+    let err = WGS84Coordinates::new(R64::assert(0.0), R64::assert(90.0)).unwrap_err();
+    assert_eq!(err.longitude, None);
+    assert_eq!(err.latitude, Some(90.0));
+
+    let err = WGS84Coordinates::new(R64::assert(0.0), R64::assert(-90.0)).unwrap_err();
+    assert_eq!(err.longitude, None);
+    assert_eq!(err.latitude, Some(-90.0));
+}
+
+#[test]
+fn encode_out_of_range_both() {
+    let err = WGS84Coordinates::new(R64::assert(200.0), R64::assert(90.0)).unwrap_err();
+    assert_eq!(err.longitude, Some(200.0));
+    assert_eq!(err.latitude, Some(90.0));
+}
+
+#[test]
+fn from_f64_valid() {
+    let c = WGS84Coordinates::from_f64(10.0, 20.0).unwrap();
+    assert_eq!(c.longitude(), R64::assert(10.0));
+    assert_eq!(c.latitude(), R64::assert(20.0));
+}
+
+#[test]
+fn from_f64_boundary_values() {
+    let c = WGS84Coordinates::from_f64(GEO_LONG_MIN, GEO_LAT_MIN).unwrap();
+    assert_eq!(c.longitude(), R64::assert(GEO_LONG_MIN));
+    assert_eq!(c.latitude(), R64::assert(GEO_LAT_MIN));
+
+    let c = WGS84Coordinates::from_f64(GEO_LONG_MAX, GEO_LAT_MAX).unwrap();
+    assert_eq!(c.longitude(), R64::assert(GEO_LONG_MAX));
+    assert_eq!(c.latitude(), R64::assert(GEO_LAT_MAX));
+}
+
+#[test]
+fn from_f64_out_of_range() {
+    let err = WGS84Coordinates::from_f64(181.0, 0.0).unwrap_err();
+    assert_eq!(err.longitude, Some(181.0));
+    assert_eq!(err.latitude, None);
+
+    let err = WGS84Coordinates::from_f64(0.0, 90.0).unwrap_err();
+    assert_eq!(err.longitude, None);
+    assert_eq!(err.latitude, Some(90.0));
+}
+
+#[test]
+fn from_f64_nan_rejected() {
+    assert!(WGS84Coordinates::from_f64(f64::NAN, 0.0).is_err());
+    assert!(WGS84Coordinates::from_f64(0.0, f64::NAN).is_err());
+    assert!(WGS84Coordinates::from_f64(f64::NAN, f64::NAN).is_err());
+}
+
+#[test]
+fn from_f64_infinity_rejected() {
+    assert!(WGS84Coordinates::from_f64(f64::INFINITY, 0.0).is_err());
+    assert!(WGS84Coordinates::from_f64(0.0, f64::NEG_INFINITY).is_err());
+}
+
+#[test]
+fn try_from_tuple() {
+    let c = WGS84Coordinates::try_from((10.0, 20.0)).unwrap();
+    assert_eq!(c, WGS84Coordinates::from_f64(10.0, 20.0).unwrap());
+    assert!(WGS84Coordinates::try_from((181.0, 0.0)).is_err());
+}
+
+#[test]
+fn precision_step_rejects_invalid_values() {
+    assert!(PrecisionStep::new(0).is_err());
+    assert!(PrecisionStep::new(27).is_err());
+    assert!(PrecisionStep::new(1).is_ok());
+    assert!(PrecisionStep::new(26).is_ok());
+}
+
+#[test]
+fn nearby_points_have_similar_hashes() {
+    let h1 = encode_wgs84(
+        WGS84Coordinates::new(R64::assert(29.69465), R64::assert(34.95126)).unwrap(),
+        GEO_STEP_MAX,
+    );
+    let h2 = encode_wgs84(
+        WGS84Coordinates::new(R64::assert(29.69350), R64::assert(34.94737)).unwrap(),
+        GEO_STEP_MAX,
+    );
+    // Nearby points should share high-order bits
+    let aligned1 = geo::hash::align_52bits(h1);
+    let aligned2 = geo::hash::align_52bits(h2);
+    // Top 30 bits should match for points ~500m apart
+    assert_eq!(aligned1 >> 22, aligned2 >> 22);
+}
+
+#[cfg(not(miri))] // proptest calls getcwd() which is not supported on Miri
+mod proptests {
+    use decorum::R64;
+    use geo::hash::{
+        GEO_LAT_MAX, GEO_LAT_MIN, GEO_LONG_MAX, GEO_LONG_MIN, PrecisionStep, WGS84Coordinates,
+        decode_to_lon_lat, encode_wgs84,
+    };
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn encode_decode_roundtrip(
+            lon in GEO_LONG_MIN..=GEO_LONG_MAX,
+            lat in GEO_LAT_MIN..=GEO_LAT_MAX,
+            step in 1u8..=26,
+        ) {
+            let step = PrecisionStep::new(step).unwrap();
+            let coords = WGS84Coordinates::new(R64::assert(lon), R64::assert(lat))
+                .unwrap_or_else(|e| panic!("failed to create coords ({lon}, {lat}): {e:?}"));
+            let hash = encode_wgs84(coords, step);
+            let (decoded_lon, decoded_lat) = decode_to_lon_lat(hash);
+            let (decoded_lon, decoded_lat) = (decoded_lon.into_inner(), decoded_lat.into_inner());
+            // Lower steps have coarser precision — scale tolerance by cell size.
+            let tolerance = (GEO_LONG_MAX - GEO_LONG_MIN) / (1u64 << step.as_u8()) as f64;
+            prop_assert!(
+                (decoded_lon - lon).abs() < tolerance,
+                "lon mismatch for ({}, {}) step={}: got {}, tolerance={}",
+                lon, lat, step.as_u8(), decoded_lon, tolerance
+            );
+            prop_assert!(
+                (decoded_lat - lat).abs() < tolerance,
+                "lat mismatch for ({}, {}) step={}: got {}, tolerance={}",
+                lon, lat, step.as_u8(), decoded_lat, tolerance
+            );
+        }
+    }
+}
+
+#[test]
+fn align_52bits_fits_in_52_bits() {
+    for step in 1..=26 {
+        let step = PrecisionStep::new(step).unwrap();
+        // Test all four corners + interior point.
+        for (lon, lat) in [
+            (GEO_LONG_MIN, GEO_LAT_MIN),
+            (GEO_LONG_MAX, GEO_LAT_MAX),
+            (GEO_LONG_MIN, GEO_LAT_MAX),
+            (GEO_LONG_MAX, GEO_LAT_MIN),
+            (0.0, 0.0),
+        ] {
+            let coords = WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap();
+            let h = encode_wgs84(coords, step);
+            let aligned = align_52bits(h);
+            assert!(
+                aligned < (1u64 << 52),
+                "step={}, ({lon}, {lat}): aligned 0x{aligned:013x} exceeds 52 bits",
+                step.as_u8()
+            );
+        }
+    }
+}

--- a/src/redisearch_rs/geo/tests/integration/hash/mod.rs
+++ b/src/redisearch_rs/geo/tests/integration/hash/mod.rs
@@ -7,5 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-mod hash;
-mod parse_geo;
+mod distance;
+mod encode_decode;
+mod neighbors;
+mod radius;

--- a/src/redisearch_rs/geo/tests/integration/hash/neighbors.rs
+++ b/src/redisearch_rs/geo/tests/integration/hash/neighbors.rs
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use decorum::{R64, real::UnaryRealFunction};
+use geo::hash::{
+    GeoHashBits, GeoHashNeighbors, PrecisionStep, WGS84Coordinates, decode, encode_wgs84, neighbors,
+};
+
+fn encode(lon: f64, lat: f64) -> GeoHashBits {
+    let coords = WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap();
+    encode_wgs84(coords, PrecisionStep::new(26).unwrap())
+}
+
+#[test]
+fn all_eight_neighbors_are_distinct() {
+    let hash = encode(2.3522, 48.8566); // Paris
+    let nbrs = neighbors(hash);
+
+    let all = [
+        Some(hash),
+        nbrs.north,
+        nbrs.south,
+        nbrs.east,
+        nbrs.west,
+        nbrs.north_east,
+        nbrs.north_west,
+        nbrs.south_east,
+        nbrs.south_west,
+    ];
+
+    // All 9 cells (center + 8 neighbors) should be distinct.
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "cells {i} and {j} should differ");
+            }
+        }
+    }
+}
+
+#[test]
+fn all_neighbors_have_same_step() {
+    let hash = encode(10.0, 20.0);
+    let nbrs = neighbors(hash);
+
+    for (name, cell) in named_neighbors(&nbrs) {
+        let cell = cell.expect("neighbor should be present");
+        assert_eq!(cell.step, hash.step, "{name} step mismatch");
+    }
+}
+
+#[test]
+fn neighbor_of_neighbor_returns_to_original() {
+    let hash = encode(-73.9857, 40.7484); // NYC
+    let nbrs = neighbors(hash);
+
+    // Going north then south should return to the original.
+    let north_nbrs = neighbors(nbrs.north.unwrap());
+    assert_eq!(
+        north_nbrs.south.unwrap(),
+        hash,
+        "south-of-north should be the original"
+    );
+
+    // Going east then west should return to the original.
+    let east_nbrs = neighbors(nbrs.east.unwrap());
+    assert_eq!(
+        east_nbrs.west.unwrap(),
+        hash,
+        "west-of-east should be the original"
+    );
+
+    // Going south then north should return to the original.
+    let south_nbrs = neighbors(nbrs.south.unwrap());
+    assert_eq!(
+        south_nbrs.north.unwrap(),
+        hash,
+        "north-of-south should be the original"
+    );
+
+    // Going west then east should return to the original.
+    let west_nbrs = neighbors(nbrs.west.unwrap());
+    assert_eq!(
+        west_nbrs.east.unwrap(),
+        hash,
+        "east-of-west should be the original"
+    );
+}
+
+#[test]
+fn diagonal_neighbors_are_consistent() {
+    let hash = encode(139.6917, 35.6895); // Tokyo
+    let nbrs = neighbors(hash);
+
+    // north_east should be east-of-north and north-of-east.
+    let north_nbrs = neighbors(nbrs.north.unwrap());
+    let east_nbrs = neighbors(nbrs.east.unwrap());
+    assert_eq!(
+        nbrs.north_east, north_nbrs.east,
+        "north_east should equal east-of-north"
+    );
+    assert_eq!(
+        nbrs.north_east, east_nbrs.north,
+        "north_east should equal north-of-east"
+    );
+}
+
+#[test]
+fn neighbors_decoded_areas_are_adjacent() {
+    let hash = encode(0.0, 0.0);
+    let nbrs = neighbors(hash);
+    let center = decode(hash);
+
+    let north = decode(nbrs.north.unwrap());
+    assert!(
+        (north.latitude.min - center.latitude.max).abs() < 1e-10,
+        "north cell should be adjacent above the center"
+    );
+
+    let south = decode(nbrs.south.unwrap());
+    assert!(
+        (south.latitude.max - center.latitude.min).abs() < 1e-10,
+        "south cell should be adjacent below the center"
+    );
+
+    let east = decode(nbrs.east.unwrap());
+    assert!(
+        (east.longitude.min - center.longitude.max).abs() < 1e-10,
+        "east cell should be adjacent to the right of center"
+    );
+
+    let west = decode(nbrs.west.unwrap());
+    assert!(
+        (west.longitude.max - center.longitude.min).abs() < 1e-10,
+        "west cell should be adjacent to the left of center"
+    );
+}
+
+#[test]
+fn neighbors_at_lower_step_precision() {
+    // Verify neighbors work at a lower precision too.
+    let coords = WGS84Coordinates::new(R64::assert(10.0), R64::assert(20.0)).unwrap();
+    let hash = encode_wgs84(coords, PrecisionStep::new(5).unwrap());
+    let nbrs = neighbors(hash);
+
+    let all = [
+        Some(hash),
+        nbrs.north,
+        nbrs.south,
+        nbrs.east,
+        nbrs.west,
+        nbrs.north_east,
+        nbrs.north_west,
+        nbrs.south_east,
+        nbrs.south_west,
+    ];
+
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "cells {i} and {j} should differ at step=5");
+            }
+        }
+    }
+}
+
+#[cfg(not(miri))] // proptest calls getcwd() which is not supported on Miri
+mod proptests {
+    use decorum::{R64, real::UnaryRealFunction};
+    use geo::hash::{
+        GEO_LAT_MAX, GEO_LAT_MIN, GEO_LONG_MAX, GEO_LONG_MIN, PrecisionStep, WGS84Coordinates,
+        decode, encode_wgs84, neighbors,
+    };
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn all_eight_neighbors_are_distinct(
+            lon in GEO_LONG_MIN..=GEO_LONG_MAX,
+            lat in GEO_LAT_MIN..=GEO_LAT_MAX,
+            // At step=1 the grid is 2×2, so east and west wrap to the same
+            // cell. Step >= 2 gives at least 4 cells per dimension, enough
+            // for a 3×3 neighborhood without aliasing.
+            step in 2u8..=26,
+        ) {
+            let step = PrecisionStep::new(step).unwrap();
+            let hash = encode_wgs84(WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap(), step);
+            let nbrs = neighbors(hash);
+
+            let all = [
+                Some(hash),
+                nbrs.north, nbrs.south, nbrs.east, nbrs.west,
+                nbrs.north_east, nbrs.north_west, nbrs.south_east, nbrs.south_west,
+            ];
+
+            for (i, a) in all.iter().enumerate() {
+                for (j, b) in all.iter().enumerate() {
+                    if i != j {
+                        prop_assert_ne!(a, b, "cells {} and {} should differ at step={}", i, j, step.as_u8());
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn all_neighbors_have_same_step(
+            lon in GEO_LONG_MIN..=GEO_LONG_MAX,
+            lat in GEO_LAT_MIN..=GEO_LAT_MAX,
+            step in 1u8..=26,
+        ) {
+            let step = PrecisionStep::new(step).unwrap();
+            let hash = encode_wgs84(WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap(), step);
+            let nbrs = neighbors(hash);
+
+            for (name, cell) in super::named_neighbors(&nbrs) {
+                let cell = cell.unwrap();
+                prop_assert_eq!(
+                    cell.step, hash.step,
+                    "{} step mismatch at ({}, {}) step={}", name, lon, lat, step.as_u8()
+                );
+            }
+        }
+
+        #[test]
+        fn neighbor_of_neighbor_returns_to_original(
+            lon in GEO_LONG_MIN..=GEO_LONG_MAX,
+            lat in GEO_LAT_MIN..=GEO_LAT_MAX,
+            step in 1u8..=26,
+        ) {
+            let step = PrecisionStep::new(step).unwrap();
+            let hash = encode_wgs84(WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap(), step);
+            let nbrs = neighbors(hash);
+
+            let north_nbrs = neighbors(nbrs.north.unwrap());
+            prop_assert_eq!(
+                north_nbrs.south.unwrap(), hash,
+                "south-of-north should be original at ({}, {}) step={}", lon, lat, step.as_u8()
+            );
+
+            let east_nbrs = neighbors(nbrs.east.unwrap());
+            prop_assert_eq!(
+                east_nbrs.west.unwrap(), hash,
+                "west-of-east should be original at ({}, {}) step={}", lon, lat, step.as_u8()
+            );
+
+            let south_nbrs = neighbors(nbrs.south.unwrap());
+            prop_assert_eq!(
+                south_nbrs.north.unwrap(), hash,
+                "north-of-south should be original at ({}, {}) step={}", lon, lat, step.as_u8()
+            );
+
+            let west_nbrs = neighbors(nbrs.west.unwrap());
+            prop_assert_eq!(
+                west_nbrs.east.unwrap(), hash,
+                "east-of-west should be original at ({}, {}) step={}", lon, lat, step.as_u8()
+            );
+        }
+
+        #[test]
+        fn diagonal_neighbors_are_consistent(
+            lon in GEO_LONG_MIN..=GEO_LONG_MAX,
+            lat in GEO_LAT_MIN..=GEO_LAT_MAX,
+            step in 1u8..=26,
+        ) {
+            let step = PrecisionStep::new(step).unwrap();
+            let hash = encode_wgs84(WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap(), step);
+            let nbrs = neighbors(hash);
+
+            let north_nbrs = neighbors(nbrs.north.unwrap());
+            let east_nbrs = neighbors(nbrs.east.unwrap());
+            prop_assert_eq!(
+                nbrs.north_east, north_nbrs.east,
+                "north_east should equal east-of-north at ({}, {}) step={}", lon, lat, step.as_u8()
+            );
+            prop_assert_eq!(
+                nbrs.north_east, east_nbrs.north,
+                "north_east should equal north-of-east at ({}, {}) step={}", lon, lat, step.as_u8()
+            );
+        }
+
+        #[test]
+        fn neighbors_decoded_areas_are_adjacent(
+            lon in GEO_LONG_MIN..=GEO_LONG_MAX,
+            lat in GEO_LAT_MIN..=GEO_LAT_MAX,
+            step in 1u8..=26,
+        ) {
+            let step = PrecisionStep::new(step).unwrap();
+            let hash = encode_wgs84(WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap(), step);
+            let nbrs = neighbors(hash);
+            let center = decode(hash);
+
+            // At grid edges, move_x/move_y wrap around so the "neighbor"
+            // is on the opposite side of the grid. Only assert geometric
+            // adjacency when the neighbor didn't wrap.
+            let north = decode(nbrs.north.unwrap());
+            if north.latitude.min > center.latitude.min {
+                prop_assert!(
+                    (north.latitude.min - center.latitude.max).abs() < 1e-10,
+                    "north cell should be adjacent above center at ({}, {}) step={}", lon, lat, step.as_u8()
+                );
+            }
+
+            let south = decode(nbrs.south.unwrap());
+            if south.latitude.max < center.latitude.max {
+                prop_assert!(
+                    (south.latitude.max - center.latitude.min).abs() < 1e-10,
+                    "south cell should be adjacent below center at ({}, {}) step={}", lon, lat, step.as_u8()
+                );
+            }
+
+            let east = decode(nbrs.east.unwrap());
+            if east.longitude.min > center.longitude.min {
+                prop_assert!(
+                    (east.longitude.min - center.longitude.max).abs() < 1e-10,
+                    "east cell should be adjacent right of center at ({}, {}) step={}", lon, lat, step.as_u8()
+                );
+            }
+
+            let west = decode(nbrs.west.unwrap());
+            if west.longitude.max < center.longitude.max {
+                prop_assert!(
+                    (west.longitude.max - center.longitude.min).abs() < 1e-10,
+                    "west cell should be adjacent left of center at ({}, {}) step={}", lon, lat, step.as_u8()
+                );
+            }
+        }
+    }
+}
+
+fn named_neighbors(nbrs: &GeoHashNeighbors) -> [(&str, Option<GeoHashBits>); 8] {
+    [
+        ("north", nbrs.north),
+        ("south", nbrs.south),
+        ("east", nbrs.east),
+        ("west", nbrs.west),
+        ("north_east", nbrs.north_east),
+        ("north_west", nbrs.north_west),
+        ("south_east", nbrs.south_east),
+        ("south_west", nbrs.south_west),
+    ]
+}

--- a/src/redisearch_rs/geo/tests/integration/hash/radius.rs
+++ b/src/redisearch_rs/geo/tests/integration/hash/radius.rs
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use decorum::R64;
+use geo::hash::{
+    GEO_LAT_MAX, GEO_LONG_MAX, GEO_LONG_MIN, WGS84Coordinates, decode, decode_to_lon_lat,
+    get_areas_by_radius, haversine_distance,
+};
+
+fn coords(lon: f64, lat: f64) -> WGS84Coordinates {
+    WGS84Coordinates::new(R64::assert(lon), R64::assert(lat)).unwrap()
+}
+
+#[test]
+fn small_radius_returns_valid_center() {
+    let result = get_areas_by_radius(coords(2.3522, 48.8566), 1000.0); // Paris, 1km
+    assert!(
+        result.hash.bits != 0,
+        "center hash should have non-zero bits for valid coordinates"
+    );
+}
+
+#[test]
+fn center_hash_contains_query_point() {
+    let lon = -73.9857;
+    let lat = 40.7484;
+    let result = get_areas_by_radius(coords(lon, lat), 500.0);
+    let area = result.area;
+
+    assert!(
+        area.longitude.min <= lon && area.longitude.max >= lon,
+        "query longitude {lon} should be within center cell [{}, {}]",
+        area.longitude.min,
+        area.longitude.max,
+    );
+    assert!(
+        area.latitude.min <= lat && area.latitude.max >= lat,
+        "query latitude {lat} should be within center cell [{}, {}]",
+        area.latitude.min,
+        area.latitude.max,
+    );
+}
+
+#[test]
+fn radius_covers_nearby_point() {
+    // Two points ~500m apart in Eilat, Israel.
+    let lon = 29.69465;
+    let lat = 34.95126;
+    let nearby_lon = 29.69350;
+    let nearby_lat = 34.94737;
+    let dist = haversine_distance(
+        R64::assert(lon),
+        R64::assert(lat),
+        R64::assert(nearby_lon),
+        R64::assert(nearby_lat),
+    );
+
+    let result = get_areas_by_radius(coords(lon, lat), dist + 100.0);
+
+    // The nearby point should fall within one of the 9 cells.
+    let cells = [
+        Some(result.hash),
+        result.neighbors.north,
+        result.neighbors.south,
+        result.neighbors.east,
+        result.neighbors.west,
+        result.neighbors.north_east,
+        result.neighbors.north_west,
+        result.neighbors.south_east,
+        result.neighbors.south_west,
+    ];
+
+    let in_any_cell = cells.iter().any(|cell| {
+        let Some(cell) = cell else {
+            return false;
+        };
+        let area = decode(*cell);
+        area.longitude.min <= nearby_lon
+            && area.longitude.max >= nearby_lon
+            && area.latitude.min <= nearby_lat
+            && area.latitude.max >= nearby_lat
+    });
+    assert!(in_any_cell, "nearby point should be in one of the 9 cells");
+}
+
+#[test]
+fn some_neighbors_are_zeroed_for_small_radius() {
+    // A small radius at mid-latitudes: some bounding-box exclusion should
+    // zero out neighbors that are outside the search area.
+    let result = get_areas_by_radius(coords(0.0, 0.0), 100.0);
+
+    let cells = [
+        result.neighbors.north,
+        result.neighbors.south,
+        result.neighbors.east,
+        result.neighbors.west,
+        result.neighbors.north_east,
+        result.neighbors.north_west,
+        result.neighbors.south_east,
+        result.neighbors.south_west,
+    ];
+
+    let none_count = cells.iter().filter(|c| c.is_none()).count();
+    // With a very small radius, at least some neighbors should be excluded.
+    assert!(
+        none_count > 0,
+        "expected some None neighbors for a 100m radius"
+    );
+}
+
+#[test]
+fn large_radius_triggers_step_decrease() {
+    // At very high latitude with a large radius, the step should decrease.
+    let result_small = get_areas_by_radius(coords(0.0, 85.0), 100.0);
+    let result_large = get_areas_by_radius(coords(0.0, 85.0), 500_000.0);
+
+    assert!(
+        result_large.hash.step < result_small.hash.step,
+        "large radius at pole should use a coarser step ({}) than small radius ({})",
+        result_large.hash.step.as_u8(),
+        result_small.hash.step.as_u8(),
+    );
+}
+
+#[test]
+fn all_non_zero_neighbors_decode_successfully() {
+    let result = get_areas_by_radius(coords(139.6917, 35.6895), 5000.0); // Tokyo, 5km
+
+    let cells = [
+        ("center", Some(result.hash)),
+        ("north", result.neighbors.north),
+        ("south", result.neighbors.south),
+        ("east", result.neighbors.east),
+        ("west", result.neighbors.west),
+        ("north_east", result.neighbors.north_east),
+        ("north_west", result.neighbors.north_west),
+        ("south_east", result.neighbors.south_east),
+        ("south_west", result.neighbors.south_west),
+    ];
+
+    for (name, cell) in cells {
+        if let Some(cell) = cell {
+            // decode is infallible — just verify the area is sane.
+            let area = decode(cell);
+            assert!(
+                area.latitude.min < area.latitude.max,
+                "{name} cell should have valid latitude range"
+            );
+        }
+    }
+}
+
+#[test]
+fn center_decodes_to_point_near_query() {
+    let lon = 10.0;
+    let lat = 20.0;
+    let result = get_areas_by_radius(coords(lon, lat), 1000.0);
+
+    let (decoded_lon, decoded_lat) = decode_to_lon_lat(result.hash);
+
+    // The decoded center of the hash cell should be close to the query point.
+    let dist = haversine_distance(R64::assert(lon), R64::assert(lat), decoded_lon, decoded_lat);
+    // The cell size at step ~24 is sub-meter; at step ~10 it can be ~km.
+    // With a 1km radius the step is high, so the center should be very close.
+    assert!(
+        dist < 1000.0,
+        "decoded center should be within the search radius, got {dist}m"
+    );
+}
+
+#[test]
+fn very_large_radius_does_not_panic() {
+    // Radius larger than Earth's circumference — should not panic.
+    let _result = get_areas_by_radius(coords(0.0, 0.0), 50_000_000.0);
+}
+
+#[test]
+fn near_antimeridian_does_not_panic() {
+    let _result = get_areas_by_radius(coords(179.9, 0.0), 10_000.0);
+    let _result = get_areas_by_radius(coords(-179.9, 0.0), 10_000.0);
+}
+
+#[test]
+fn near_poles_does_not_panic() {
+    let _result = get_areas_by_radius(coords(0.0, GEO_LAT_MAX - 0.01), 10_000.0);
+    let _result = get_areas_by_radius(coords(0.0, -GEO_LAT_MAX + 0.01), 10_000.0);
+}
+
+#[test]
+fn neighbor_exclusion_respects_bounding_box() {
+    // Use a moderate radius and verify that non-zero neighbors are within
+    // the bounding box (approximately).
+    let lon = 0.0;
+    let lat = 45.0;
+    let radius = 5000.0;
+    let result = get_areas_by_radius(coords(lon, lat), radius);
+
+    let cells = [
+        result.neighbors.north,
+        result.neighbors.south,
+        result.neighbors.east,
+        result.neighbors.west,
+        result.neighbors.north_east,
+        result.neighbors.north_west,
+        result.neighbors.south_east,
+        result.neighbors.south_west,
+    ];
+
+    for cell in cells.into_iter().flatten() {
+        let area = decode(cell);
+        let cell_lon = (area.longitude.min + area.longitude.max) / 2.0;
+        let cell_lat = (area.latitude.min + area.latitude.max) / 2.0;
+        let dist = haversine_distance(R64::assert(lon), R64::assert(lat), cell_lon, cell_lat);
+        // Non-zero neighbors should be reasonably close to the query point.
+        // The cell centers should be within a few multiples of the radius.
+        assert!(
+            dist < radius * 10.0,
+            "non-zero neighbor center at ({cell_lon}, {cell_lat}) is {dist}m away, too far"
+        );
+    }
+}
+
+#[test]
+fn duplicate_neighbor_suppression_with_huge_radius() {
+    // With a very large radius, adjacent neighbors can become the same cell.
+    // `get_areas_by_radius` uses a coarse step, so multiple neighbors may
+    // share the same hash (the FFI layer in `calcRanges` deduplicates them).
+    // Just verify it doesn't panic and returns a valid result.
+    let result = get_areas_by_radius(coords(0.0, 0.0), 10_000_000.0);
+    assert_eq!(result.hash.step, result.area.hash.step);
+}
+
+#[test]
+fn boundary_longitudes() {
+    for lon in [GEO_LONG_MIN + 0.01, GEO_LONG_MAX - 0.01] {
+        let _result = get_areas_by_radius(coords(lon, 0.0), 1000.0);
+    }
+}
+
+#[test]
+fn high_latitude_bounding_box_over_pruning() {
+    // The planar bounding-box approximation used by `get_areas_by_radius`
+    // does not behave correctly at very high latitudes with large radii.
+    // For instance, at lat ≈ 84° with a 50 km radius the longitude delta
+    // computed from `radius / (R * cos(lat))` explodes because cos(84°) is
+    // small, but the *latitude* delta stays modest, so the box is very wide
+    // in longitude yet narrow in latitude. This can cause the south (and
+    // south-east / south-west) neighbors to be incorrectly pruned even
+    // though points within the radius exist in those cells.
+    let result = get_areas_by_radius(coords(0.0, 84.0), 50_000.0);
+    let nbr_count = [
+        result.neighbors.north,
+        result.neighbors.south,
+        result.neighbors.east,
+        result.neighbors.west,
+        result.neighbors.north_east,
+        result.neighbors.north_west,
+        result.neighbors.south_east,
+        result.neighbors.south_west,
+    ]
+    .iter()
+    .filter(|c| c.is_some())
+    .count();
+    // Current behavior: only 1 of 8 neighbors survives pruning.
+    // If the bounding-box logic is improved, update this assertion.
+    assert_eq!(nbr_count, 1);
+}


### PR DESCRIPTION
- Depends of https://github.com/RediSearch/RediSearch/pull/9340

Rust re-implementation of `deps/geohash/`.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new core geospatial hashing/radius implementation (encoding, neighbors, radius selection) where subtle edge-case bugs could impact query coverage and correctness, though changes are largely additive and well-tested.
> 
> **Overview**
> Adds a new `geo::hash` module that ports Redis/RediSearch’s C geohash library to pure Rust, including WGS-84 validated coordinates (`WGS84Coordinates`), precision handling (`PrecisionStep`), geohash encode/decode (`encode_wgs84`, `decode`, `decode_to_lon_lat`), 52-bit score alignment (`align_52bits`), and neighbor computation (`neighbors`).
> 
> Introduces radius-query support via `get_areas_by_radius`, including step estimation by radius/latitude, bounding-box pruning of neighbors, and great-circle distance helpers (`haversine_distance`). The crate API is expanded to publicly expose `hash`, and extensive unit/integration tests are added covering interleave/deinterleave, neighbor consistency, encode/decode roundtrips, and radius edge cases (poles/antimeridian/huge radii).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb96044d935eee9198589df250861ebac83befa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->