### PR TITLE
CI: Fix - Use login shell when building Redis

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -86,7 +86,7 @@ runs:
 
     - name: Build Redis (cache miss)
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-      shell: bash
+      shell: bash -leo pipefail {0}
       working-directory: redis
       env:
         PREFIX: ${{ steps.resolve.outputs.prefix }}


### PR DESCRIPTION
### Description

1. Current:
   PR #9123 extracted the Redis build into a composite action (`.github/actions/build-redis/action.yml`). 
   Composite action steps **do not inherit `defaults.run` from the calling workflow**, so the new `Build Redis (cache miss)` step ran under `bash --noprofile --norc -e -o pipefail {0}` instead of the workflow's `bash -l -eo pipefail {0}`.

   On platforms where the C toolchain is exposed through `/etc/profile.d/*` (e.g. Rocky Linux 9 / 8 with `gcc-toolset-14`), the non-login shell never sources those scripts, so `cc`/`gcc` are not on `PATH`. The Redis Makefile then fails:

   ```sh
   sh: line 1: cc: command not found
   ```
   Failing job:
   https://github.com/RediSearch/RediSearch/actions/runs/25039234079/job/73339808605#step:20:395

2. Change:
Run the `Build Redis (cache miss)` step under a login shell (`bash -leo pipefail {0}`) so `/etc/profile.d/*.sh` is sourced and the platform's compiler is on `PATH`, matching the behavior of the pre-#9123 inline step.

3. Outcome:
Build on platforms without errors:
https://github.com/RediSearch/RediSearch/actions/runs/25067965744/job/73440278741

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts the shell used for the Redis build step; main risk is altered environment sourcing affecting build behavior on some runners.
> 
> **Overview**
> Updates the `Build Redis (cache miss)` step in the `build-redis` composite GitHub Action to run under a *login* bash shell (`bash -leo pipefail {0}`) instead of plain `bash`.
> 
> This aligns the action’s environment setup with workflows that rely on login-shell profile scripts (e.g., toolchains added via `/etc/profile.d`) so Redis builds don’t fail on cache misses due to missing compilers on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ec001a8a7eea5f04aa8f474f5d26f6a5100a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->