### PR TITLE
Report vector index memory in FT.INFO under Flex/ROF [MOD-14840]

### DIFF
--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -260,7 +260,9 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   const bool isDisk = SearchDisk_IsEnabledForValidation();
   size_t num_records = isDisk ? 0 : sp->stats.numRecords;
   size_t inverted_size = isDisk ? 0 : sp->stats.invertedSize;
-  size_t vector_indexes_size = isDisk ? 0 : IndexSpec_VectorIndexesSize(specForOpeningIndexes);
+  // Vector indexes (e.g. HNSW) remain in memory even when the rest of the
+  // index is stored on disk, so their memory must always be reported.
+  size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
   size_t total_ii_blocks = isDisk ? 0 : TotalIIBlocks();
   size_t offset_vecs_size = isDisk ? 0 : sp->stats.offsetVecsSize;
   size_t doc_table_size = isDisk ? 0 : sp->docs.memsize;

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -487,6 +487,45 @@ def test_disk_vector_query_validation(env: Env):
 
 @skip(cluster=True)
 @with_simulate_in_flex(True)
+def test_flex_ft_info_reports_vector_index_memory(env):
+    """Regression test for MOD-14840.
+
+    HNSW vector indexes are kept in memory even in Flex/ROF mode, so
+    FT.INFO must report a non-zero `vector_index_sz_mb` and the vector
+    memory must be included in `total_index_memory_sz_mb`.
+    """
+    dim = 4
+    env.expect(
+        'FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
+        't', 'TEXT',
+        'tag', 'TAG',
+        'v', 'VECTOR', 'HNSW', '14',
+        'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2',
+        'M', '16', 'EF_CONSTRUCTION', '100', 'EF_RUNTIME', '10', 'RERANK', 'TRUE',
+    ).ok()
+
+    n_docs = 100
+    with env.getClusterConnectionIfNeeded() as conn:
+        for i in range(n_docs):
+            vector = create_np_array_typed([float(i)] * dim, 'FLOAT32').tobytes()
+            conn.execute_command('HSET', f'doc:{i}', 't', f'hello{i}',
+                                 'tag', f'tag{i}', 'v', vector)
+
+    info = index_info(env, 'idx')
+    vector_size_mb = float(info['vector_index_sz_mb'])
+    total_size_mb = float(info['total_index_memory_sz_mb'])
+
+    env.assertGreater(vector_size_mb, 0,
+                      message=f'Expected vector_index_sz_mb > 0 for HNSW index, got {vector_size_mb}')
+    env.assertGreater(total_size_mb, 0,
+                      message=f'Expected total_index_memory_sz_mb > 0, got {total_size_mb}')
+    env.assertGreaterEqual(total_size_mb, vector_size_mb,
+                           message=f'total_index_memory_sz_mb ({total_size_mb}) must include '
+                                   f'vector_index_sz_mb ({vector_size_mb})')
+
+
+@skip(cluster=True)
+@with_simulate_in_flex(True)
 def test_flex_blocks_alter_command(env):
     _create_flex_search(env)
 


### PR DESCRIPTION
HNSW vector indexes remain in RAM even when the rest of the index is stored on disk in Flex/ROF mode, so FT.INFO's vector_index_sz_mb (and the vector portion of total_index_memory_sz_mb) must always reflect their real memory usage. Previously these values were unconditionally zeroed when isDisk was true, causing test_rof_disk_metrics_info to fail with 'Expected vector_index_sz_mb > 0 for HNSW index, got 0'.



## Describe the changes in the pull request

1. **Current**: In Flex/ROF mode, `FT.INFO` reports `vector_index_sz_mb` as `0` and under-reports `total_index_memory_sz_mb`, even though HNSW vector indexes remain entirely in RAM. Introduced by #8935 (MOD-13832), which uniformly gated all stat fields behind `isDisk ? 0 : ...`.
2. **Change**: Always call `IndexSpec_VectorIndexesSize(...)` regardless of `isDisk`, so the vector contribution to `vector_index_sz_mb` and `total_index_memory_sz_mb` is reported correctly in Flex/ROF.
3. **Outcome**: `FT.INFO` now correctly reflects vector index memory in Flex/ROF deployments. The RLEC integration test `test_rof_disk_metrics_info` (and the new OSS regression test below) pass.

#### Which additional issues this PR fixes
1. MOD-14840

#### Main objects this PR modified
1. `src/info/info_command.c` — `fillReplyWithIndexInfo`
2. `tests/pytests/test_flex_validation.py` — new regression test `test_flex_ft_info_reports_vector_index_memory`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

**Suggested release note:**
> Fix `FT.INFO` reporting `0` for `vector_index_sz_mb` and under-reporting `total_index_memory_sz_mb` in Flex/ROF mode. HNSW vector index memory is now always reported correctly.
