### PR TITLE
MOD-14818: Array/Map Equality Functions 

### DIFF
--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -190,33 +190,33 @@ fn string_keyed<'a>(
     pairs: impl Iterator<Item = (&'a Value, &'a Value)>,
 ) -> Vec<(&'a [u8], &'a Value)> {
     pairs
-        .filter_map(|(key, value)| Some((key.as_str_bytes()?, value)))
+        .filter_map(|(key, value)| {
+            let bytes = key.as_str_bytes();
+            debug_assert_warn!(bytes.is_some(), "non-string key in map comparison; pair skipped");
+            Some((bytes?, value))
+        })
         .collect()
 }
 
 fn entries_equal(entries1: &[(&[u8], &Value)], entries2: &[(&[u8], &Value)]) -> bool {
-    entries1.len() == entries2.len()
-        && entries1
-            .iter()
-            .zip(entries2)
-            .all(|((k1, v1), (k2, v2))| k1 == k2 && compare_on_equality_only(v1, v2))
+    debug_assert_eq!(entries1.len(), entries2.len());
+    entries1
+        .iter()
+        .zip(entries2)
+        .all(|((k1, v1), (k2, v2))| k1 == k2 && compare_on_equality_only(v1, v2))
 }
 
-fn prepare_array(array: &Array) -> Vec<(&[u8], &Value)> {
+fn collect_array(array: &Array) -> Vec<(&[u8], &Value)> {
     let (pairs, remainder) = array.as_chunks::<2>();
     debug_assert_warn!(
         remainder.is_empty(),
         "arrays_equal_as_maps called on an odd-length array;"
     );
-    let mut entries = string_keyed(pairs.iter().map(|[key, value]| (&**key, &**value)));
-    entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
-    entries
+    string_keyed(pairs.iter().map(|[key, value]| (&**key, &**value)))
 }
 
-fn prepare_map(map: &Map) -> Vec<(&[u8], &Value)> {
-    let mut entries = string_keyed(map.iter().map(|(key, value)| (&**key, &**value)));
-    entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
-    entries
+fn collect_map(map: &Map) -> Vec<(&[u8], &Value)> {
+    string_keyed(map.iter().map(|(key, value)| (&**key, &**value)))
 }
 
 /// Check whether two flat key-value arrays are equal when interpreted as maps.
@@ -231,7 +231,14 @@ fn prepare_map(map: &Map) -> Vec<(&[u8], &Value)> {
 /// Asserts in debug builds and warns in release builds if either array has an
 /// odd number of elements.
 pub fn arrays_equal_as_maps(a1: &Array, a2: &Array) -> bool {
-    entries_equal(&prepare_array(a1), &prepare_array(a2))
+    let mut e1 = collect_array(a1);
+    let mut e2 = collect_array(a2);
+    if e1.len() != e2.len() {
+        return false;
+    }
+    e1.sort_unstable_by_key(|k| k.0);
+    e2.sort_unstable_by_key(|k| k.0);
+    entries_equal(&e1, &e2)
 }
 
 /// Check whether two maps are equal by their string keys and corresponding values.
@@ -239,7 +246,14 @@ pub fn arrays_equal_as_maps(a1: &Array, a2: &Array) -> bool {
 /// This is an explicit map equality helper. It does not change the default
 /// [`compare`] behavior for [`Value::Map`], which remains unsupported.
 pub fn maps_equal(m1: &Map, m2: &Map) -> bool {
-    entries_equal(&prepare_map(m1), &prepare_map(m2))
+    let mut e1 = collect_map(m1);
+    let mut e2 = collect_map(m2);
+    if e1.len() != e2.len() {
+        return false;
+    }
+    e1.sort_unstable_by_key(|k| k.0);
+    e2.sort_unstable_by_key(|k| k.0);
+    entries_equal(&e1, &e2)
 }
 
 /// Compare a number to a byte-string.

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::Value;
-use crate::util::{num_to_str, str_to_float};
+use crate::util::{debug_assert_warn, num_to_str, str_to_float};
+use crate::{Array, Map, Value};
 use query_error::{QueryError, QueryErrorCode};
 use std::cmp::Ordering;
 use std::ops::Deref;
@@ -184,6 +184,104 @@ pub fn compare(
         )),
         _ => Err(CompareError::IncompatibleTypes),
     }
+}
+
+fn sorted_map_like_entries<'a>(
+    pairs: impl Iterator<Item = (&'a Value, &'a Value)>,
+) -> Vec<(&'a [u8], &'a Value)> {
+    let mut entries: Vec<_> = pairs
+        .filter_map(|(key, value)| Some((key.as_str_bytes()?, value)))
+        .collect();
+
+    entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+
+    // Sorting groups equal keys together, so duplicate map keys can be detected
+    // with a single adjacent-pair scan. Duplicate keys are a caller contract
+    // violation, not a runtime comparison error.
+    debug_assert_warn!(
+        !entries.windows(2).any(|window| window[0].0 == window[1].0),
+        "map-like comparison called with duplicate map keys;"
+    );
+
+    entries
+}
+
+fn sorted_array_map_entries(array: &Array) -> Vec<(&[u8], &Value)> {
+    let (pairs, remainder) = array.as_chunks::<2>();
+    debug_assert_warn!(
+        remainder.is_empty(),
+        "compare_arrays_as_maps called on an odd-length array;"
+    );
+
+    sorted_map_like_entries(pairs.iter().map(|[key, value]| (&**key, &**value)))
+}
+
+fn sorted_map_entries(map: &Map) -> Vec<(&[u8], &Value)> {
+    sorted_map_like_entries(map.iter().map(|(key, value)| (&**key, &**value)))
+}
+
+fn compare_sorted_map_entries(
+    entries1: &[(&[u8], &Value)],
+    entries2: &[(&[u8], &Value)],
+    num_to_str_cmp_fallback: bool,
+) -> Result<Ordering, CompareError> {
+    for ((key1, value1), (key2, value2)) in entries1.iter().copied().zip(entries2.iter().copied()) {
+        match key1.cmp(key2) {
+            Ordering::Equal => {}
+            ordering => return Ok(ordering),
+        }
+
+        match compare(value1, value2, num_to_str_cmp_fallback)? {
+            Ordering::Equal => {}
+            ordering => return Ok(ordering),
+        }
+    }
+
+    Ok(entries1.len().cmp(&entries2.len()))
+}
+
+/// Compare two flat key-value arrays as maps.
+///
+/// The arrays are interpreted as RESP2 map fallbacks: `[k1, v1, k2, v2, ...]`.
+/// String and Redis string keys participate in the map; non-string keys are
+/// skipped. Odd trailing elements are ignored with the same warning behavior as
+/// [`Array::map_get`].
+///
+/// # Panics
+///
+/// Asserts in debug builds and warns in release builds if a string key appears
+/// more than once after non-string keys and odd trailing entries are ignored.
+/// Duplicate keys are a caller contract violation.
+pub fn compare_arrays_as_maps(
+    a1: &Array,
+    a2: &Array,
+    num_to_str_cmp_fallback: bool,
+) -> Result<Ordering, CompareError> {
+    let entries1 = sorted_array_map_entries(a1);
+    let entries2 = sorted_array_map_entries(a2);
+
+    compare_sorted_map_entries(&entries1, &entries2, num_to_str_cmp_fallback)
+}
+
+/// Compare two maps by string keys.
+///
+/// This is an explicit map comparison helper. It does not change the default
+/// [`compare`] behavior for [`Value::Map`], which remains unsupported.
+///
+/// # Panics
+///
+/// Asserts in debug builds and warns in release builds if a string key appears
+/// more than once after non-string keys are ignored. Duplicate keys are a caller
+/// contract violation.
+pub fn compare_maps(
+    m1: &Map,
+    m2: &Map,
+    num_to_str_cmp_fallback: bool,
+) -> Result<Ordering, CompareError> {
+    let entries1 = sorted_map_entries(m1);
+    let entries2 = sorted_map_entries(m2);
+
+    compare_sorted_map_entries(&entries1, &entries2, num_to_str_cmp_fallback)
 }
 
 /// Compare a number to a byte-string.

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -186,41 +186,15 @@ pub fn compare(
     }
 }
 
-fn sorted_map_like_entries<'a>(
+fn string_keyed<'a>(
     pairs: impl Iterator<Item = (&'a Value, &'a Value)>,
 ) -> Vec<(&'a [u8], &'a Value)> {
-    let mut entries: Vec<_> = pairs
+    pairs
         .filter_map(|(key, value)| Some((key.as_str_bytes()?, value)))
-        .collect();
-
-    entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
-
-    // Sorting groups equal keys together, so duplicate map keys can be detected
-    // with a single adjacent-pair scan. Duplicate keys are a caller contract
-    // violation, not a runtime comparison error.
-    debug_assert_warn!(
-        !entries.windows(2).any(|window| window[0].0 == window[1].0),
-        "map-like comparison called with duplicate map keys;"
-    );
-
-    entries
+        .collect()
 }
 
-fn sorted_array_map_entries(array: &Array) -> Vec<(&[u8], &Value)> {
-    let (pairs, remainder) = array.as_chunks::<2>();
-    debug_assert_warn!(
-        remainder.is_empty(),
-        "compare_arrays_as_maps called on an odd-length array;"
-    );
-
-    sorted_map_like_entries(pairs.iter().map(|[key, value]| (&**key, &**value)))
-}
-
-fn sorted_map_entries(map: &Map) -> Vec<(&[u8], &Value)> {
-    sorted_map_like_entries(map.iter().map(|(key, value)| (&**key, &**value)))
-}
-
-fn compare_sorted_map_entries(
+fn compare_entries(
     entries1: &[(&[u8], &Value)],
     entries2: &[(&[u8], &Value)],
     num_to_str_cmp_fallback: bool,
@@ -249,39 +223,41 @@ fn compare_sorted_map_entries(
 ///
 /// # Panics
 ///
-/// Asserts in debug builds and warns in release builds if a string key appears
-/// more than once after non-string keys and odd trailing entries are ignored.
-/// Duplicate keys are a caller contract violation.
+/// Asserts in debug builds and warns in release builds if either array has an
+/// odd number of elements.
 pub fn compare_arrays_as_maps(
     a1: &Array,
     a2: &Array,
     num_to_str_cmp_fallback: bool,
 ) -> Result<Ordering, CompareError> {
-    let entries1 = sorted_array_map_entries(a1);
-    let entries2 = sorted_array_map_entries(a2);
-
-    compare_sorted_map_entries(&entries1, &entries2, num_to_str_cmp_fallback)
+    let prepare = |array: &Array| {
+        let (pairs, remainder) = array.as_chunks::<2>();
+        debug_assert_warn!(
+            remainder.is_empty(),
+            "compare_arrays_as_maps called on an odd-length array;"
+        );
+        let mut entries = string_keyed(pairs.iter().map(|[key, value]| (&**key, &**value)));
+        entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        entries
+    };
+    compare_entries(&prepare(a1), &prepare(a2), num_to_str_cmp_fallback)
 }
 
 /// Compare two maps by string keys.
 ///
 /// This is an explicit map comparison helper. It does not change the default
 /// [`compare`] behavior for [`Value::Map`], which remains unsupported.
-///
-/// # Panics
-///
-/// Asserts in debug builds and warns in release builds if a string key appears
-/// more than once after non-string keys are ignored. Duplicate keys are a caller
-/// contract violation.
 pub fn compare_maps(
     m1: &Map,
     m2: &Map,
     num_to_str_cmp_fallback: bool,
 ) -> Result<Ordering, CompareError> {
-    let entries1 = sorted_map_entries(m1);
-    let entries2 = sorted_map_entries(m2);
-
-    compare_sorted_map_entries(&entries1, &entries2, num_to_str_cmp_fallback)
+    let prepare = |map: &Map| {
+        let mut entries = string_keyed(map.iter().map(|(key, value)| (&**key, &**value)));
+        entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        entries
+    };
+    compare_entries(&prepare(m1), &prepare(m2), num_to_str_cmp_fallback)
 }
 
 /// Compare a number to a byte-string.

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -203,7 +203,19 @@ fn entries_equal(entries1: &[(&[u8], &Value)], entries2: &[(&[u8], &Value)]) -> 
     entries1
         .iter()
         .zip(entries2)
-        .all(|((k1, v1), (k2, v2))| k1 == k2 && compare_on_equality_only(v1, v2))
+        .all(|((k1, v1), (k2, v2))| {
+            // Nested maps/arrays are not supported: `compare_on_equality_only` treats them as
+            // equal regardless of content. This function is intended for flat hash results only.
+            debug_assert_warn!(
+                !matches!(v1, Value::Map(_) | Value::Array(_)),
+                "nested map/array value in map equality comparison; result may be incorrect"
+            );
+            debug_assert_warn!(
+                !matches!(v2, Value::Map(_) | Value::Array(_)),
+                "nested map/array value in map equality comparison; result may be incorrect"
+            );
+            k1 == k2 && compare_on_equality_only(v1, v2)
+        })
 }
 
 fn collect_array(array: &Array) -> Vec<(&[u8], &Value)> {

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -194,27 +194,32 @@ fn string_keyed<'a>(
         .collect()
 }
 
-fn compare_entries(
-    entries1: &[(&[u8], &Value)],
-    entries2: &[(&[u8], &Value)],
-    num_to_str_cmp_fallback: bool,
-) -> Result<Ordering, CompareError> {
-    for ((key1, value1), (key2, value2)) in entries1.iter().copied().zip(entries2.iter().copied()) {
-        match key1.cmp(key2) {
-            Ordering::Equal => {}
-            ordering => return Ok(ordering),
-        }
-
-        match compare(value1, value2, num_to_str_cmp_fallback)? {
-            Ordering::Equal => {}
-            ordering => return Ok(ordering),
-        }
-    }
-
-    Ok(entries1.len().cmp(&entries2.len()))
+fn entries_equal(entries1: &[(&[u8], &Value)], entries2: &[(&[u8], &Value)]) -> bool {
+    entries1.len() == entries2.len()
+        && entries1
+            .iter()
+            .zip(entries2)
+            .all(|((k1, v1), (k2, v2))| k1 == k2 && compare_on_equality_only(v1, v2))
 }
 
-/// Compare two flat key-value arrays as maps.
+fn prepare_array(array: &Array) -> Vec<(&[u8], &Value)> {
+    let (pairs, remainder) = array.as_chunks::<2>();
+    debug_assert_warn!(
+        remainder.is_empty(),
+        "arrays_equal_as_maps called on an odd-length array;"
+    );
+    let mut entries = string_keyed(pairs.iter().map(|[key, value]| (&**key, &**value)));
+    entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+    entries
+}
+
+fn prepare_map(map: &Map) -> Vec<(&[u8], &Value)> {
+    let mut entries = string_keyed(map.iter().map(|(key, value)| (&**key, &**value)));
+    entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+    entries
+}
+
+/// Check whether two flat key-value arrays are equal when interpreted as maps.
 ///
 /// The arrays are interpreted as RESP2 map fallbacks: `[k1, v1, k2, v2, ...]`.
 /// String and Redis string keys participate in the map; non-string keys are
@@ -225,39 +230,16 @@ fn compare_entries(
 ///
 /// Asserts in debug builds and warns in release builds if either array has an
 /// odd number of elements.
-pub fn compare_arrays_as_maps(
-    a1: &Array,
-    a2: &Array,
-    num_to_str_cmp_fallback: bool,
-) -> Result<Ordering, CompareError> {
-    let prepare = |array: &Array| {
-        let (pairs, remainder) = array.as_chunks::<2>();
-        debug_assert_warn!(
-            remainder.is_empty(),
-            "compare_arrays_as_maps called on an odd-length array;"
-        );
-        let mut entries = string_keyed(pairs.iter().map(|[key, value]| (&**key, &**value)));
-        entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
-        entries
-    };
-    compare_entries(&prepare(a1), &prepare(a2), num_to_str_cmp_fallback)
+pub fn arrays_equal_as_maps(a1: &Array, a2: &Array) -> bool {
+    entries_equal(&prepare_array(a1), &prepare_array(a2))
 }
 
-/// Compare two maps by string keys.
+/// Check whether two maps are equal by their string keys and corresponding values.
 ///
-/// This is an explicit map comparison helper. It does not change the default
+/// This is an explicit map equality helper. It does not change the default
 /// [`compare`] behavior for [`Value::Map`], which remains unsupported.
-pub fn compare_maps(
-    m1: &Map,
-    m2: &Map,
-    num_to_str_cmp_fallback: bool,
-) -> Result<Ordering, CompareError> {
-    let prepare = |map: &Map| {
-        let mut entries = string_keyed(map.iter().map(|(key, value)| (&**key, &**value)));
-        entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
-        entries
-    };
-    compare_entries(&prepare(m1), &prepare(m2), num_to_str_cmp_fallback)
+pub fn maps_equal(m1: &Map, m2: &Map) -> bool {
+    entries_equal(&prepare_map(m1), &prepare_map(m2))
 }
 
 /// Compare a number to a byte-string.

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -192,7 +192,10 @@ fn string_keyed<'a>(
     pairs
         .filter_map(|(key, value)| {
             let bytes = key.as_str_bytes();
-            debug_assert_warn!(bytes.is_some(), "non-string key in map comparison; pair skipped");
+            debug_assert_warn!(
+                bytes.is_some(),
+                "non-string key in map comparison; pair skipped"
+            );
             Some((bytes?, value))
         })
         .collect()
@@ -200,22 +203,19 @@ fn string_keyed<'a>(
 
 fn entries_equal(entries1: &[(&[u8], &Value)], entries2: &[(&[u8], &Value)]) -> bool {
     debug_assert_eq!(entries1.len(), entries2.len());
-    entries1
-        .iter()
-        .zip(entries2)
-        .all(|((k1, v1), (k2, v2))| {
-            // Nested maps/arrays are not supported: `compare_on_equality_only` treats them as
-            // equal regardless of content. This function is intended for flat hash results only.
-            debug_assert_warn!(
-                !matches!(v1, Value::Map(_) | Value::Array(_)),
-                "nested map/array value in map equality comparison; result may be incorrect"
-            );
-            debug_assert_warn!(
-                !matches!(v2, Value::Map(_) | Value::Array(_)),
-                "nested map/array value in map equality comparison; result may be incorrect"
-            );
-            k1 == k2 && compare_on_equality_only(v1, v2)
-        })
+    entries1.iter().zip(entries2).all(|((k1, v1), (k2, v2))| {
+        // Nested maps/arrays are not supported: `compare_on_equality_only` treats them as
+        // equal regardless of content. This function is intended for flat hash results only.
+        debug_assert_warn!(
+            !matches!(v1, Value::Map(_) | Value::Array(_)),
+            "nested map/array value in map equality comparison; result may be incorrect"
+        );
+        debug_assert_warn!(
+            !matches!(v2, Value::Map(_) | Value::Array(_)),
+            "nested map/array value in map equality comparison; result may be incorrect"
+        );
+        k1 == k2 && compare_on_equality_only(v1, v2)
+    })
 }
 
 fn collect_array(array: &Array) -> Vec<(&[u8], &Value)> {

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -273,6 +273,22 @@ fn array_as_map_ignores_odd_trailing_entry() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "non-string key in map comparison")]
+fn array_as_map_non_string_key_trips_debug_assertion() {
+    let a1 = raw_array([
+        Value::Number(100.0),
+        Value::Number(999.0),
+        string("a"),
+        Value::Number(1.0),
+    ]);
+    let a2 = raw_array([string("a"), Value::Number(1.0)]);
+
+    let _ = arrays_equal_as_maps(&a1, &a2);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
 fn array_as_map_skips_non_string_keys() {
     let a1 = raw_array([
         Value::Number(100.0),
@@ -286,12 +302,120 @@ fn array_as_map_skips_non_string_keys() {
 }
 
 #[test]
+fn array_as_map_not_equal_different_values() {
+    let a1 = raw_array([string("a"), Value::Number(1.0)]);
+    let a2 = raw_array([string("a"), Value::Number(2.0)]);
+
+    assert!(!arrays_equal_as_maps(&a1, &a2));
+}
+
+#[test]
+fn array_as_map_not_equal_extra_key() {
+    let a1 = raw_array([
+        string("a"),
+        Value::Number(1.0),
+        string("b"),
+        Value::Number(2.0),
+    ]);
+    let a2 = raw_array([string("a"), Value::Number(1.0)]);
+
+    assert!(!arrays_equal_as_maps(&a1, &a2));
+}
+
+#[test]
+fn explicit_map_not_equal_different_values() {
+    let m1 = map([(string("a"), Value::Number(1.0))]);
+    let m2 = map([(string("a"), Value::Number(2.0))]);
+
+    assert!(!maps_equal(&m1, &m2));
+}
+
+#[test]
+fn explicit_map_not_equal_extra_key() {
+    let m1 = map([
+        (string("a"), Value::Number(1.0)),
+        (string("b"), Value::Number(2.0)),
+    ]);
+    let m2 = map([(string("a"), Value::Number(1.0))]);
+
+    assert!(!maps_equal(&m1, &m2));
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "non-string key in map comparison")]
+fn explicit_map_non_string_key_trips_debug_assertion() {
+    let m1 = map([
+        (Value::Number(100.0), Value::Number(999.0)),
+        (string("a"), Value::Number(1.0)),
+    ]);
+    let m2 = map([(string("a"), Value::Number(1.0))]);
+
+    let _ = maps_equal(&m1, &m2);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
 fn explicit_map_skips_non_string_keys() {
     let m1 = map([
         (Value::Number(100.0), Value::Number(999.0)),
         (string("a"), Value::Number(1.0)),
     ]);
     let m2 = map([(string("a"), Value::Number(1.0))]);
+
+    assert!(maps_equal(&m1, &m2));
+}
+
+#[test]
+fn array_as_map_both_empty() {
+    let a1 = raw_array([]);
+    let a2 = raw_array([]);
+
+    assert!(arrays_equal_as_maps(&a1, &a2));
+}
+
+#[test]
+fn explicit_map_both_empty() {
+    let m1 = map([]);
+    let m2 = map([]);
+
+    assert!(maps_equal(&m1, &m2));
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "non-string key in map comparison")]
+fn array_as_map_all_non_string_keys_trips_debug_assertion() {
+    let a1 = raw_array([Value::Number(100.0), Value::Number(999.0)]);
+    let a2 = raw_array([]);
+
+    let _ = arrays_equal_as_maps(&a1, &a2);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn array_as_map_all_non_string_keys_equal_to_empty() {
+    let a1 = raw_array([Value::Number(100.0), Value::Number(999.0)]);
+    let a2 = raw_array([]);
+
+    assert!(arrays_equal_as_maps(&a1, &a2));
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "non-string key in map comparison")]
+fn explicit_map_all_non_string_keys_trips_debug_assertion() {
+    let m1 = map([(Value::Number(100.0), Value::Number(999.0))]);
+    let m2 = map([]);
+
+    let _ = maps_equal(&m1, &m2);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn explicit_map_all_non_string_keys_equal_to_empty() {
+    let m1 = map([(Value::Number(100.0), Value::Number(999.0))]);
+    let m2 = map([]);
 
     assert!(maps_equal(&m1, &m2));
 }

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -318,6 +318,17 @@ fn array_as_map_orders_by_key_bytes() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "compare_arrays_as_maps called on an odd-length array")]
+fn array_as_map_odd_trailing_entry_trips_debug_assertion() {
+    let a1 = raw_array([string("a"), Value::Number(1.0), string("ignored")]);
+    let a2 = raw_array([string("a"), Value::Number(1.0)]);
+
+    let _ = compare_arrays_as_maps(&a1, &a2, false);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
 fn array_as_map_ignores_odd_trailing_entry() {
     let a1 = raw_array([string("a"), Value::Number(1.0), string("ignored")]);
     let a2 = raw_array([string("a"), Value::Number(1.0)]);

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -11,13 +11,30 @@
 
 use query_error::QueryError;
 use std::cmp::Ordering;
-use value::comparison::{CompareError, cmp_fields, compare};
+use value::comparison::{CompareError, cmp_fields, compare, compare_arrays_as_maps, compare_maps};
 use value::{Array, Map, SharedValue, String, Trio, Value};
 
 fn array(values: impl IntoIterator<Item = Value>) -> Value {
     Value::Array(Array::new(
         values.into_iter().map(SharedValue::new).collect(),
     ))
+}
+
+fn raw_array(values: impl IntoIterator<Item = Value>) -> Array {
+    Array::new(values.into_iter().map(SharedValue::new).collect())
+}
+
+fn string(value: impl AsRef<[u8]>) -> Value {
+    Value::String(String::from_vec(value.as_ref().to_vec()))
+}
+
+fn map(entries: impl IntoIterator<Item = (Value, Value)>) -> Map {
+    Map::new(
+        entries
+            .into_iter()
+            .map(|(key, value)| (SharedValue::new(key), SharedValue::new(value)))
+            .collect(),
+    )
 }
 
 fn trio(left: Value, middle: Value, right: Value) -> Value {
@@ -184,6 +201,212 @@ fn array_longer_is_greater_when_prefix_matches() {
     let a2 = array([Value::Number(1.0)]);
     let result = compare(&a1, &a2, false).unwrap();
     assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn array_as_map_equal_same_order() {
+    let a1 = raw_array([
+        string("a"),
+        Value::Number(1.0),
+        string("b"),
+        Value::Number(2.0),
+    ]);
+    let a2 = raw_array([
+        string("a"),
+        Value::Number(1.0),
+        string("b"),
+        Value::Number(2.0),
+    ]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+fn array_as_map_equal_different_order() {
+    let a1 = raw_array([
+        string("a"),
+        Value::Number(1.0),
+        string("b"),
+        Value::Number(2.0),
+    ]);
+    let a2 = raw_array([
+        string("b"),
+        Value::Number(2.0),
+        string("a"),
+        Value::Number(1.0),
+    ]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+fn explicit_map_equal_different_order() {
+    let m1 = map([
+        (string("a"), Value::Number(1.0)),
+        (string("b"), Value::Number(2.0)),
+    ]);
+    let m2 = map([
+        (string("b"), Value::Number(2.0)),
+        (string("a"), Value::Number(1.0)),
+    ]);
+
+    let result = compare_maps(&m1, &m2, false).unwrap();
+
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+fn explicit_map_compares_values_for_matching_keys() {
+    let m1 = map([(string("a"), Value::Number(1.0))]);
+    let m2 = map([(string("a"), Value::Number(2.0))]);
+
+    let result = compare_maps(&m1, &m2, false).unwrap();
+
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn explicit_map_orders_by_missing_or_extra_key() {
+    let m1 = map([(string("a"), Value::Number(1.0))]);
+    let m2 = map([
+        (string("a"), Value::Number(1.0)),
+        (string("b"), Value::Number(2.0)),
+    ]);
+
+    let result = compare_maps(&m1, &m2, false).unwrap();
+
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn array_as_map_compares_values_for_matching_keys() {
+    let a1 = raw_array([string("a"), Value::Number(1.0)]);
+    let a2 = raw_array([string("a"), Value::Number(2.0)]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn array_as_map_orders_by_missing_or_extra_key() {
+    let a1 = raw_array([string("a"), Value::Number(1.0)]);
+    let a2 = raw_array([
+        string("a"),
+        Value::Number(1.0),
+        string("b"),
+        Value::Number(2.0),
+    ]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn array_as_map_orders_by_key_bytes() {
+    let a1 = raw_array([string("a"), Value::Number(1.0)]);
+    let a2 = raw_array([string("b"), Value::Number(1.0)]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn array_as_map_ignores_odd_trailing_entry() {
+    let a1 = raw_array([string("a"), Value::Number(1.0), string("ignored")]);
+    let a2 = raw_array([string("a"), Value::Number(1.0)]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+fn array_as_map_skips_non_string_keys() {
+    let a1 = raw_array([
+        Value::Number(100.0),
+        Value::Number(999.0),
+        string("a"),
+        Value::Number(1.0),
+    ]);
+    let a2 = raw_array([string("a"), Value::Number(1.0)]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
+
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+fn explicit_map_skips_non_string_keys() {
+    let m1 = map([
+        (Value::Number(100.0), Value::Number(999.0)),
+        (string("a"), Value::Number(1.0)),
+    ]);
+    let m2 = map([(string("a"), Value::Number(1.0))]);
+
+    let result = compare_maps(&m1, &m2, false).unwrap();
+
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "map-like comparison called with duplicate map keys")]
+fn array_as_map_duplicate_string_keys_trip_debug_assertion() {
+    let a1 = raw_array([
+        string("a"),
+        Value::Number(1.0),
+        string("a"),
+        Value::Number(2.0),
+    ]);
+    let a2 = raw_array([string("a"), Value::Number(1.0)]);
+
+    let _ = compare_arrays_as_maps(&a1, &a2, false);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "map-like comparison called with duplicate map keys")]
+fn explicit_map_duplicate_string_keys_trip_debug_assertion() {
+    let m1 = map([
+        (string("a"), Value::Number(1.0)),
+        (string("a"), Value::Number(2.0)),
+    ]);
+    let m2 = map([(string("a"), Value::Number(1.0))]);
+
+    let _ = compare_maps(&m1, &m2, false);
+}
+
+#[test]
+fn array_as_map_propagates_value_comparison_errors() {
+    let a1 = raw_array([string("a"), trio(Value::Null, Value::Null, Value::Null)]);
+    let a2 = raw_array([string("a"), array([Value::Number(1.0)])]);
+
+    let result = compare_arrays_as_maps(&a1, &a2, false);
+
+    assert_eq!(result, Err(CompareError::IncompatibleTypes));
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Calls FFI function `snprintf`")]
+fn array_as_map_uses_number_to_string_fallback_flag() {
+    let a1 = raw_array([string("a"), Value::Number(5.0)]);
+    let a2 = raw_array([string("a"), string("hello")]);
+
+    let result_without_fallback = compare_arrays_as_maps(&a1, &a2, false);
+    assert_eq!(
+        result_without_fallback,
+        Err(CompareError::NoNumberToStringFallback)
+    );
+
+    let result_with_fallback = compare_arrays_as_maps(&a1, &a2, true).unwrap();
+    assert_eq!(result_with_fallback, Ordering::Less);
 }
 
 #[test]

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -11,7 +11,7 @@
 
 use query_error::QueryError;
 use std::cmp::Ordering;
-use value::comparison::{CompareError, cmp_fields, compare, compare_arrays_as_maps, compare_maps};
+use value::comparison::{CompareError, arrays_equal_as_maps, cmp_fields, compare, maps_equal};
 use value::{Array, Map, SharedValue, String, Trio, Value};
 
 fn array(values: impl IntoIterator<Item = Value>) -> Value {
@@ -218,9 +218,7 @@ fn array_as_map_equal_same_order() {
         Value::Number(2.0),
     ]);
 
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Equal);
+    assert!(arrays_equal_as_maps(&a1, &a2));
 }
 
 #[test]
@@ -238,9 +236,7 @@ fn array_as_map_equal_different_order() {
         Value::Number(1.0),
     ]);
 
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Equal);
+    assert!(arrays_equal_as_maps(&a1, &a2));
 }
 
 #[test]
@@ -254,77 +250,17 @@ fn explicit_map_equal_different_order() {
         (string("a"), Value::Number(1.0)),
     ]);
 
-    let result = compare_maps(&m1, &m2, false).unwrap();
-
-    assert_eq!(result, Ordering::Equal);
-}
-
-#[test]
-fn explicit_map_compares_values_for_matching_keys() {
-    let m1 = map([(string("a"), Value::Number(1.0))]);
-    let m2 = map([(string("a"), Value::Number(2.0))]);
-
-    let result = compare_maps(&m1, &m2, false).unwrap();
-
-    assert_eq!(result, Ordering::Less);
-}
-
-#[test]
-fn explicit_map_orders_by_missing_or_extra_key() {
-    let m1 = map([(string("a"), Value::Number(1.0))]);
-    let m2 = map([
-        (string("a"), Value::Number(1.0)),
-        (string("b"), Value::Number(2.0)),
-    ]);
-
-    let result = compare_maps(&m1, &m2, false).unwrap();
-
-    assert_eq!(result, Ordering::Less);
-}
-
-#[test]
-fn array_as_map_compares_values_for_matching_keys() {
-    let a1 = raw_array([string("a"), Value::Number(1.0)]);
-    let a2 = raw_array([string("a"), Value::Number(2.0)]);
-
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Less);
-}
-
-#[test]
-fn array_as_map_orders_by_missing_or_extra_key() {
-    let a1 = raw_array([string("a"), Value::Number(1.0)]);
-    let a2 = raw_array([
-        string("a"),
-        Value::Number(1.0),
-        string("b"),
-        Value::Number(2.0),
-    ]);
-
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Less);
-}
-
-#[test]
-fn array_as_map_orders_by_key_bytes() {
-    let a1 = raw_array([string("a"), Value::Number(1.0)]);
-    let a2 = raw_array([string("b"), Value::Number(1.0)]);
-
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Less);
+    assert!(maps_equal(&m1, &m2));
 }
 
 #[test]
 #[cfg(debug_assertions)]
-#[should_panic(expected = "compare_arrays_as_maps called on an odd-length array")]
+#[should_panic(expected = "arrays_equal_as_maps called on an odd-length array")]
 fn array_as_map_odd_trailing_entry_trips_debug_assertion() {
     let a1 = raw_array([string("a"), Value::Number(1.0), string("ignored")]);
     let a2 = raw_array([string("a"), Value::Number(1.0)]);
 
-    let _ = compare_arrays_as_maps(&a1, &a2, false);
+    let _ = arrays_equal_as_maps(&a1, &a2);
 }
 
 #[test]
@@ -333,9 +269,7 @@ fn array_as_map_ignores_odd_trailing_entry() {
     let a1 = raw_array([string("a"), Value::Number(1.0), string("ignored")]);
     let a2 = raw_array([string("a"), Value::Number(1.0)]);
 
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Equal);
+    assert!(arrays_equal_as_maps(&a1, &a2));
 }
 
 #[test]
@@ -348,9 +282,7 @@ fn array_as_map_skips_non_string_keys() {
     ]);
     let a2 = raw_array([string("a"), Value::Number(1.0)]);
 
-    let result = compare_arrays_as_maps(&a1, &a2, false).unwrap();
-
-    assert_eq!(result, Ordering::Equal);
+    assert!(arrays_equal_as_maps(&a1, &a2));
 }
 
 #[test]
@@ -361,36 +293,7 @@ fn explicit_map_skips_non_string_keys() {
     ]);
     let m2 = map([(string("a"), Value::Number(1.0))]);
 
-    let result = compare_maps(&m1, &m2, false).unwrap();
-
-    assert_eq!(result, Ordering::Equal);
-}
-
-
-#[test]
-fn array_as_map_propagates_value_comparison_errors() {
-    let a1 = raw_array([string("a"), trio(Value::Null, Value::Null, Value::Null)]);
-    let a2 = raw_array([string("a"), array([Value::Number(1.0)])]);
-
-    let result = compare_arrays_as_maps(&a1, &a2, false);
-
-    assert_eq!(result, Err(CompareError::IncompatibleTypes));
-}
-
-#[test]
-#[cfg_attr(miri, ignore = "Calls FFI function `snprintf`")]
-fn array_as_map_uses_number_to_string_fallback_flag() {
-    let a1 = raw_array([string("a"), Value::Number(5.0)]);
-    let a2 = raw_array([string("a"), string("hello")]);
-
-    let result_without_fallback = compare_arrays_as_maps(&a1, &a2, false);
-    assert_eq!(
-        result_without_fallback,
-        Err(CompareError::NoNumberToStringFallback)
-    );
-
-    let result_with_fallback = compare_arrays_as_maps(&a1, &a2, true).unwrap();
-    assert_eq!(result_with_fallback, Ordering::Less);
+    assert!(maps_equal(&m1, &m2));
 }
 
 #[test]

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -366,33 +366,6 @@ fn explicit_map_skips_non_string_keys() {
     assert_eq!(result, Ordering::Equal);
 }
 
-#[test]
-#[cfg(debug_assertions)]
-#[should_panic(expected = "map-like comparison called with duplicate map keys")]
-fn array_as_map_duplicate_string_keys_trip_debug_assertion() {
-    let a1 = raw_array([
-        string("a"),
-        Value::Number(1.0),
-        string("a"),
-        Value::Number(2.0),
-    ]);
-    let a2 = raw_array([string("a"), Value::Number(1.0)]);
-
-    let _ = compare_arrays_as_maps(&a1, &a2, false);
-}
-
-#[test]
-#[cfg(debug_assertions)]
-#[should_panic(expected = "map-like comparison called with duplicate map keys")]
-fn explicit_map_duplicate_string_keys_trip_debug_assertion() {
-    let m1 = map([
-        (string("a"), Value::Number(1.0)),
-        (string("a"), Value::Number(2.0)),
-    ]);
-    let m2 = map([(string("a"), Value::Number(1.0))]);
-
-    let _ = compare_maps(&m1, &m2, false);
-}
 
 #[test]
 fn array_as_map_propagates_value_comparison_errors() {


### PR DESCRIPTION
## Add `arrays_equal_as_maps` and `maps_equal` to `value::comparison`

Adds two new public functions to the `value` crate's comparison module:

- `arrays_equal_as_maps(a1: &Array, a2: &Array) -> bool` - checks equality between two flat RESP2-style key-value arrays (`[k1, v1, k2, v2, ...]`) interpreted as maps, matching by string keys regardless of insertion order
- `maps_equal(m1: &Map, m2: &Map) -> bool` - same semantics for proper `Map` values

Both functions skip non-string keys, sort entries by key before comparing, and use `compare_on_equality_only` for value equality. Odd trailing elements in array inputs trigger a debug-build assertion.

These are needed for the `DISTINCT` option in `COLLECT`, which must deduplicate collected values including objects represented as flat key-value arrays.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new public equality helpers with sorting and key filtering; risk is mainly around semantic expectations (skipping non-string keys, treating nested arrays/maps as equal via existing equality-only comparison).
> 
> **Overview**
> Adds two new public helpers in `value::comparison`: `arrays_equal_as_maps` (treats flat `[k, v, ...]` arrays as maps) and `maps_equal` (explicit `Map` equality), comparing by *string/redis-string keys* regardless of insertion order.
> 
> Both helpers **skip non-string keys**, **warn/assert on odd-length arrays**, sort entries by key before comparing, and use `compare_on_equality_only` for value equality (with debug warnings for nested `Array`/`Map` values). Integration tests are extended to cover ordering, mismatches, empty inputs, and debug-vs-release assertion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787c2f8567506019fce62b0f9ae9ec2b737c9bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->