### PR TITLE
[MOD-15128] ignore hexpired on disk

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -134,7 +134,11 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
       if (!SearchDisk_IsEnabled()) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
       } else {
-        RedisModule_Log(ctx, "warning", "HEXPIRED event is not supported on Search when Flex is enabled. Ignoring HEXPIRED on Search");
+        static bool hexpired_warned = false;
+        if (!hexpired_warned && Indexes_Count() > 0) {
+          RedisModule_Log(ctx, "warning", "HEXPIRED event is not supported on Search when Flex is enabled. Ignoring HEXPIRED on Search");
+          hexpired_warned = true;
+        }
       }
       break;
 
@@ -174,7 +178,11 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
       if (!SearchDisk_IsEnabled()) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
       } else {
-        RedisModule_Log(ctx, "warning", "Field-level expiration is not supported on Search when Flex is enabled. Ignoring HPEXPIRE/HPERSIST on Search");
+        static bool hpexpire_warned = false;
+        if (!hpexpire_warned && Indexes_Count() > 0) {
+          RedisModule_Log(ctx, "warning", "Field-level expiration is not supported on Search when Flex is enabled. Ignoring HPEXPIRE/HPERSIST on Search");
+          hpexpire_warned = true;
+        }
       }
       break;
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -131,8 +131,10 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
       }
       break;
     case hexpired_cmd:
-      if (!IS_SST_RDB_IN_PROCESS(ctx) && !SearchDisk_IsEnabled()) {
+      if (!SearchDisk_IsEnabled()) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
+      } else {
+        RedisModule_Log(ctx, "warning", "HEXPIRED event is not supported on Search when Flex is enabled. Ignoring HEXPIRED on Search");
       }
       break;
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -174,7 +174,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
       if (!SearchDisk_IsEnabled()) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
       } else {
-        RedisModule_Log(ctx, "warning", "Field-level expiration is not supported on Search when Flex is enabled. Ignoring HPEXPIRE/HEXPIRE on Search");
+        RedisModule_Log(ctx, "warning", "Field-level expiration is not supported on Search when Flex is enabled. Ignoring HPEXPIRE/HPERSIST on Search");
       }
       break;
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -126,8 +126,12 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
     case hincrby_cmd:
     case hincrbyfloat_cmd:
     case hdel_cmd:
-    case hexpired_cmd:
       if (!IS_SST_RDB_IN_PROCESS(ctx)) {
+        Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
+      }
+      break;
+    case hexpired_cmd:
+      if (!IS_SST_RDB_IN_PROCESS(ctx) && !SearchDisk_IsEnabled()) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
       }
       break;
@@ -167,6 +171,8 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
       // We do not support field-TTL metadata changes in the disk flow.
       if (!SearchDisk_IsEnabled()) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
+      } else {
+        RedisModule_Log(ctx, "warning", "Field-level expiration is not supported on Search when Flex is enabled. Ignoring HPEXPIRE/HEXPIRE on Search");
       }
       break;
 


### PR DESCRIPTION
## Describe the changes in the pull request

HEXPIRE commands were properly ignored for SearchDIsk but we did not ignore properly the HEXPIRED effect side.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to keyspace-notification handling that only affects Flex/SearchDisk mode and adds warning logs; main risk is missed index updates for these unsupported events (by design).
> 
> **Overview**
> Prevents SearchDisk/Flex mode from processing hash field-expiration notifications that aren’t supported.
> 
> `HEXPIRED` is now handled separately: in RAM mode it still triggers `Indexes_UpdateMatchingWithSchemaRules`, but in Flex it is ignored and logs a **one-time** warning when indexes exist. Similarly, `HPEXPIRE`/`HPERSIST` continue to be ignored in Flex, but now also emit a **one-time** warning to make the unsupported behavior explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d972fe2e958e249da0fe5e52244f5019f22e602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->