### PR TITLE
[MOD-15123] Fix TestCoordinatorReducePause flaky tests

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -1461,8 +1461,6 @@ class TestCoordinatorReducePause:
         # Set pause before first result (N=1 means pause before 1st result)
         setPauseBeforeReduce(env, 1)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         t_query = threading.Thread(
             target=run_cmd_expect_timeout,
             args=(env, ['FT.SEARCH', 'idx', '*']),
@@ -1476,7 +1474,7 @@ class TestCoordinatorReducePause:
             'Timeout while waiting for coordinator to pause during reduce'
         )
 
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
 
         # Trigger timeout - the pause loop in the reducer will detect the timeout
         # and auto-break to avoid deadlock with timeout callback
@@ -1515,8 +1513,6 @@ class TestCoordinatorReducePause:
         # Set pause after last result
         setPauseBeforeReduce(env, PAUSE_AFTER_LAST_RESULT)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         t_query = threading.Thread(
             target=run_cmd_expect_timeout,
             args=(env, ['FT.SEARCH', 'idx', '*']),
@@ -1525,7 +1521,7 @@ class TestCoordinatorReducePause:
         t_query.start()
 
         # First wait for client to be blocked (query is being processed)
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
 
         # Then wait for coordinator to be paused (after all results are reduced)
         wait_for_condition(
@@ -1571,8 +1567,6 @@ class TestCoordinatorReducePause:
 
         setPauseBeforeReduce(env, 1)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         query_result = []
 
         t_query = threading.Thread(
@@ -1587,7 +1581,7 @@ class TestCoordinatorReducePause:
             'Timeout while waiting for coordinator to pause during reduce'
         )
 
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
 
         env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
 
@@ -1626,8 +1620,6 @@ class TestCoordinatorReducePause:
         # will wait for it, then force the reducer to take the timed-out early exit.
         setPauseBeforeReduce(env, PAUSE_BEFORE_REDUCER_INIT)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         query_result = []
 
         t_query = threading.Thread(
@@ -1642,7 +1634,7 @@ class TestCoordinatorReducePause:
             'Timeout while waiting for coordinator to pause before reducer ctx init'
         )
 
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
 
         env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
 
@@ -1678,8 +1670,6 @@ class TestCoordinatorReducePause:
         pause_before_n = 2
         setPauseBeforeReduce(env, pause_before_n)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         query_result = []
 
         t_query = threading.Thread(
@@ -1698,7 +1688,7 @@ class TestCoordinatorReducePause:
         env.assertEqual(reduce_count, pause_before_n - 1,
                         message=f"Expected {pause_before_n - 1} results reduced before pause")
 
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
 
         env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
 
@@ -1742,8 +1732,6 @@ class TestCoordinatorReducePause:
 
         setPauseBeforeReduce(env, PAUSE_AFTER_LAST_RESULT)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         query_result = []
 
         t_query = threading.Thread(
@@ -1753,7 +1741,7 @@ class TestCoordinatorReducePause:
         )
         t_query.start()
 
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
 
         wait_for_condition(
             lambda: (getIsCoordReducePaused(env) == 1, {'paused': getIsCoordReducePaused(env)}),
@@ -1785,7 +1773,6 @@ class TestCoordinatorReducePause:
         env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
         self._cleanup_pause_state()
 
-    @skip_until("2026-05-05", reason="Flaky test, see MOD-15123")
     def test_timeout_return_strict_with_profile(self):
         """Test return-strict timeout policy with FT.PROFILE command.
 
@@ -1804,8 +1791,6 @@ class TestCoordinatorReducePause:
 
         setPauseBeforeReduce(env, 2)
 
-        blocked_client_id = env.cmd('CLIENT', 'ID')
-
         query_result = []
 
         t_query = threading.Thread(
@@ -1820,7 +1805,7 @@ class TestCoordinatorReducePause:
             'Timeout while waiting for coordinator to pause during reduce'
         )
 
-        wait_for_client_blocked(env, blocked_client_id)
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.PROFILE')
 
         env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
 


### PR DESCRIPTION
## Summary

Fixes [MOD-15123](https://redislabs.atlassian.net/browse/MOD-15123) — the `TestCoordinatorReducePause` class in `tests/pytests/test_blocked_client_timeout.py` was flaking on CI with a 30-second timeout in `wait_for_client_blocked`.

## Root cause

Each test captured a "blocked" client id on the **main thread** before launching a worker thread to run `FT.SEARCH` / `FT.PROFILE`:

```python
blocked_client_id = env.cmd('CLIENT', 'ID')   # main-thread connection
t_query = threading.Thread(target=call_and_store, args=(env.cmd, [...], result))
t_query.start()
...
wait_for_client_blocked(env, blocked_client_id)
```

`redis-py`'s connection pool is thread-safe, so the worker thread frequently acquires a **different physical connection** (and therefore a different server-side client id) than the one captured on the main thread. The polling loop then waits for an idle connection's id to become "blocked", which never happens — eventually hitting the 30 s timeout, while the actual blocked query is sitting on a different id.

The flake was reproduced from the failing CI run (commit `3cd4642`, build `689613975`); the worker thread's command was visible in `CLIENT LIST` under a different id than the one being polled.

## Fix

Replace the racy pre-capture with **discovery** via the existing helper `wait_for_blocked_query_client(env, '<COMMAND>')`, which scans `CLIENT LIST` for the command that is actually blocked. The id returned is then the real blocked client and is used for the subsequent `CLIENT UNBLOCK` / `wait_for_client_unblocked` calls.

This matches the pattern already used by the more stable tests in the same file. Applied uniformly to all 7 tests in `TestCoordinatorReducePause`:

- `test_timeout_fail_during_reduce_before_first`
- `test_timeout_fail_during_reduce_after_last`
- `test_timeout_return_strict_before_first_reduce`
- `test_timeout_return_strict_before_reducer_ctx_init`
- `test_timeout_return_strict_mid_reduce`
- `test_timeout_return_strict_after_last_reduce`
- `test_timeout_return_strict_with_profile`

Also drops the `@skip_until("2026-05-05", reason="Flaky test, see MOD-15123")` decorator from `test_timeout_return_strict_with_profile` so the test runs again.

## Verification

Built locally with `ENABLE_ASSERT=1` and ran the full class in cluster mode (`REDIS_STANDALONE=0`) **5 consecutive times** = **35 test executions**, all passing:

```
Total Tests Run: 7, Total Tests Failed: 0, Total Tests Passed: 7
```

## Diff

7 insertions, 22 deletions in `tests/pytests/test_blocked_client_timeout.py`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=github&utm_medium=pr&utm_campaign=mod_15123)


[MOD-15123]: https://redislabs.atlassian.net/browse/MOD-15123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that make client selection deterministic and re-enable an existing test; no production logic is modified.
>
> **Overview**
> Stabilizes `TestCoordinatorReducePause` by **stopping the pre-capture of `CLIENT ID` on the main thread** and instead discovering the *actual* blocked query connection via `wait_for_blocked_query_client(env, ...)` before issuing `CLIENT UNBLOCK ... TIMEOUT`.
>
> Also re-enables `test_timeout_return_strict_with_profile` by removing its flakiness skip, so the profile timeout coverage runs again.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9450c1a5679ff2443d0bfde58341ced25abcbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
