### PR TITLE
[8.2] MOD-12831 MOD-15023 MOD-15103: improve diagnostics for flaky test_pending_jobs_metrics (#9344)

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1141,7 +1141,10 @@ def launch_cmds_in_bg_with_exception_check(env, command, num_triggers, exception
         exception_timeout: Seconds to wait for exception detection (default: 1).
 
     Returns:
-        list[Thread]: Started thread objects if no exceptions occur, None if any thread fails.
+        tuple[list[Thread] | None, list[Exception]]: (threads, exceptions). `threads` is the
+        list of started thread objects, or None if any thread raised within `exception_timeout`.
+        `exceptions` is the live list that background threads append to on failure; callers may
+        re-inspect it after a later wait to surface errors that arrive past the fast-fail window.
     """
     threads = []
     exceptions = []
@@ -1163,9 +1166,9 @@ def launch_cmds_in_bg_with_exception_check(env, command, num_triggers, exception
     if exception_event.wait(timeout=exception_timeout):
         error_msg = f"Background command {command} failed with {len(exceptions)} error(s): {exceptions}"
         env.assertTrue(False, message=error_msg)
-        return None
+        return None, exceptions
 
-    return threads
+    return threads, exceptions
 
 def get_shards_profile(env, res):
   """Extract shard profiles from FT.PROFILE AGGREGATE response."""

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1501,7 +1501,7 @@ def _test_pending_jobs_metrics(env, command_type):
     # Launch num_queries queries in background threads
     # Queries will be queued as high-priority jobs but not executed (workers paused)
 
-    query_threads = launch_cmds_in_bg_with_exception_check(env, [f'FT.{command_type}', index_name, '*'], num_queries)
+    query_threads, query_excs = launch_cmds_in_bg_with_exception_check(env, [f'FT.{command_type}', index_name, '*'], num_queries)
     if query_threads is None:
         run_command_on_all_shards(env, debug_cmd(), 'WORKERS', 'RESUME')
         return
@@ -1529,7 +1529,18 @@ def _test_pending_jobs_metrics(env, command_type):
           state['workers_stats'][i] = {f'shard {i}': to_dict(con.execute_command(debug_cmd(), 'WORKERS', 'stats'))}
         return all(all_shards_ready), state
 
-    wait_for_condition(check_queries_jobs_pending, "wait_for_high_priority_jobs_pending")
+    try:
+        wait_for_condition(check_queries_jobs_pending, "wait_for_high_priority_jobs_pending")
+    except Exception:
+        # MOD-13322: on timeout, surface late-arriving background-thread exceptions
+        # (raised after the 1s fast-fail window in launch_cmds_in_bg_with_exception_check)
+        # and log how many query threads are still hung in `env.cmd()`.
+        # 1+ alive => one or more client threads never delivered their command to the coord.
+        if query_excs:
+            env.debugPrint(f"background thread errors after timeout: {query_excs}", force=True)
+        alive = sum(t.is_alive() for t in query_threads)
+        env.debugPrint(f"alive query threads after timeout: {alive}/{len(query_threads)}", force=True)
+        raise
 
     # --- STEP 7: RESUME WORKERS AND DRAIN ---
     # Resume workers:
@@ -1632,7 +1643,7 @@ class TestCoordHighPriorityPendingJobs(object):
 
     env.expect(debug_cmd(), 'COORD_THREADS', 'PAUSE').ok()
 
-    search_threads = launch_cmds_in_bg_with_exception_check(self.env, [f'FT.{command_type}', DEFAULT_INDEX_NAME, '*'], num_commands_per_type)
+    search_threads, _ = launch_cmds_in_bg_with_exception_check(self.env, [f'FT.{command_type}', DEFAULT_INDEX_NAME, '*'], num_commands_per_type)
     if search_threads is None:
       env.expect(debug_cmd(), 'COORD_THREADS', 'RESUME').ok()
       return
@@ -1652,7 +1663,7 @@ class TestCoordHighPriorityPendingJobs(object):
     num_commands_per_type = 1  # Number of commands to execute for each command type
 
     self.env.expect(debug_cmd(), 'COORD_THREADS', 'PAUSE').ok()
-    search_threads = launch_cmds_in_bg_with_exception_check(self.env, ['FT.CURSOR', 'READ', DEFAULT_INDEX_NAME, cursor_id], num_commands_per_type)
+    search_threads, _ = launch_cmds_in_bg_with_exception_check(self.env, ['FT.CURSOR', 'READ', DEFAULT_INDEX_NAME, cursor_id], num_commands_per_type)
     if search_threads is None:
       self.env.expect(debug_cmd(), 'COORD_THREADS', 'RESUME').ok()
       return
@@ -1667,7 +1678,7 @@ class TestCoordHighPriorityPendingJobs(object):
 
     self.env.expect(debug_cmd(), 'COORD_THREADS', 'PAUSE').ok()
 
-    hybrid_threads = launch_cmds_in_bg_with_exception_check(self.env, ['FT.HYBRID', DEFAULT_INDEX_NAME, 'SEARCH', 'hello',
+    hybrid_threads, _ = launch_cmds_in_bg_with_exception_check(self.env, ['FT.HYBRID', DEFAULT_INDEX_NAME, 'SEARCH', 'hello',
                                  'VSIM', f'@{DEFAULT_FIELD_NAME}', query_vector], num_commands_per_type)
     if hybrid_threads is None:
       self.env.expect(debug_cmd(), 'COORD_THREADS', 'RESUME').ok()


### PR DESCRIPTION
# Description
Backport of #9344 to `8.2`.

## Context

`test_pending_jobs_metrics_search` / `_aggregate` flake on macOS (MOD-12831, MOD-15023, MOD-15103) with `[2, 2, 2]` pending jobs instead of `[3, 3, 3]` and a 60 s `wait_for_condition` timeout — but no client-side exception is surfaced. The symmetric loss across all 3 shards points to a single query going missing *before* fanout (client-side hang or coord-side drop).

This PR adds diagnostics so the next CI failure tells us which side of the wire dropped the query.

## Changes

- **`tests/pytests/common.py`** — `launch_cmds_in_bg_with_exception_check` now returns `(threads, exceptions)`. The 1 s fast-fail behaviour is unchanged; the second slot exposes the live exceptions list (background threads keep appending to it for their full lifetime, not just within the 1 s window).
- **`tests/pytests/test_info_modules.py`** — on `wait_for_condition` timeout in `_test_pending_jobs_metrics`:
  - log any late-arriving background-thread exceptions (raised after the 1 s fast-fail window),
  - log how many query threads are still hung in `env.cmd()`,
  - then re-raise.
  - Other 3 call sites in `TestCoordHighPriorityPendingJobs` updated to `_, _` unpacking (no polling-timeout path).
  - Removed `@skip_until` so the test runs in CI.
- **`.github/workflows/task-test.yml`** — `TEST: test_info_modules` to focus the diagnostic CI run. **Must be reverted before merging.**

## How to read the next failure

1. `background thread errors after timeout: [...]` — if present, that exception is the real failure; `[2,2,2]` is a downstream consequence.
2. `alive query threads after timeout: N/3`:
   - `N ≥ 1` → client thread stuck in `env.cmd()`, never delivered its command. Loss is client-side.
   - `N == 0` (and no late exceptions) → coord received 3 commands but only fanned out 2. Loss is coord-side.

## Notes

- No production-code change — diagnostics only.
- Revert the workflow filter and decide whether to re-add `@skip_until` before merging.
#### Mark if applicable

- [X] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; main risk is minor breakage in other pytests if any call sites weren’t updated for the new helper return type.
> 
> **Overview**
> Improves CI failure diagnostics for the flaky `test_pending_jobs_metrics_*` tests by preserving and surfacing background-thread exceptions that occur after the initial fast-fail window, and by logging how many query threads remain hung when `wait_for_condition` times out.
> 
> Updates the `launch_cmds_in_bg_with_exception_check` helper to return `(threads, exceptions)` (a live exception list) and adjusts call sites to unpack the new return value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a74f9c77aecc6703400c888555d3d8fc8fc9a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->