### PR TITLE
[RED-176581] Skip flaky test_with_tls_and_non_tls_ports until 2026-07-29

### DIFF
--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4573,6 +4573,7 @@ def test_with_tls():
     common_with_auth(env)
 
 # TODO: enable macos+san once https://redislabs.atlassian.net/browse/RED-176581 is fixed
+@skip_until("2026-07-29", reason="Flaky test, see RED-176581")
 @skip(cluster=False, macos=True, asan=True)
 def test_with_tls_and_non_tls_ports():
     """Tests that the coordinator-shard connections are using the correct


### PR DESCRIPTION
## Describe the changes in the pull request

Adds a `@skip_until("2026-07-29", ...)` decorator to `test_with_tls_and_non_tls_ports` to suppress its consistent flakiness while [RED-176581] is investigated. The existing `@skip(cluster=False, macos=True, asan=True)` is preserved underneath, so once the date passes the test resumes its previous skip semantics automatically.

1. **Current**: `test_with_tls_and_non_tls_ports` flakes intermittently — the cluster occasionally fails to recover after `CONFIG SET tls-cluster no` (one shard ends up attempting an AUTH on the non-TLS port and the connection never advances), per [RED-176581].
2. **Change**: Stack a `@skip_until("2026-07-29", reason="Flaky test, see RED-176581")` on top of the existing `@skip(...)`. Three months gives enough room to root-cause the cluster-recovery issue without the test being forgotten — `skip_until` re-enables it automatically once the date passes.
3. **Outcome**: CI stops being interrupted by this flake; the test is guaranteed to be reconsidered on or before 2026-07-29.

#### Which additional issues this PR fixes
1. RED-176581

#### Main objects this PR modified
1. `tests/pytests/test.py` — `test_with_tls_and_non_tls_ports`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

[RED-176581]: https://redislabs.atlassian.net/browse/RED-176581

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that only affects CI coverage by skipping a known-flaky test until a fixed date.
> 
> **Overview**
> Temporarily disables the flaky `test_with_tls_and_non_tls_ports` by adding a time-bounded `@skip_until("2026-07-29", reason="Flaky test, see RED-176581")` decorator on top of the existing platform/config `@skip(...)` conditions.
> 
> This reduces CI noise while the underlying TLS cluster recovery issue is investigated, and automatically re-enables the test after the specified date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03fc7a629c2755f5b3846ad150848aa4db6d31df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->