### PR TITLE
MOD-15025: Fix COLLECT LOADALL (`*`) parsing logic

### DIFF
--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -12,8 +12,10 @@
 #include "spec.h"
 #include "config.h"
 #include "reducers_rs.h"
-#include <string.h>
+#include <errno.h>
 #include <limits.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define COLLECT_MAX_SORT_KEYS SORTASCMAP_MAXFIELDS
 #define COLLECT_MAX_SORT_TOKENS (COLLECT_MAX_SORT_KEYS * 2)  // each key may have a direction
@@ -29,8 +31,8 @@
 // Exactly one population pattern is used per parse, selected by
 // `options->is_local`:
 //   - is_local == true  : `field_names`, `sort_names`, `input_key` are set;
-//                          `field_keys`, `sort_keys`, `has_wildcard` are not.
-//   - is_local == false : `field_keys`, `sort_keys`, `has_wildcard` are set;
+//                          `field_keys`, `sort_keys`, `load_all` are not.
+//   - is_local == false : `field_keys`, `sort_keys`, `load_all` are set;
 //                          `field_names`, `sort_names`, `input_key` are not.
 // `sortAscMap` and the `limit_*` triple are shared across both modes.
 typedef struct {
@@ -41,7 +43,7 @@ typedef struct {
   arrayof(const char *) sort_names;         // local-only
   const RLookupKey *input_key;              // local-only
 
-  bool load_all;                            // remote-only
+  bool load_all;                            // shared
   uint64_t sortAscMap;                      // shared
 
   bool has_limit;                           // shared
@@ -130,7 +132,7 @@ static void handleCollectFieldsRemote(ArgsCursor *ac, CollectParseData *data,
 //
 // The first token after `FIELDS` is consumed by `ArgParser_AddStringV` and
 // passed in via `value`; the remainder is read directly from the parser's
-// underlying cursor. On wildcard the callback returns immediately; otherwise
+// underlying cursor. On load-all the callback returns immediately; otherwise
 // it slices `<num_fields>` tokens and dispatches to the per-mode drainer.
 static void handleCollectFields(ArgParser *parser, const void *value, void *user_data) {
   CollectParseCtx *pctx = (CollectParseCtx *)user_data;
@@ -139,7 +141,7 @@ static void handleCollectFields(ArgParser *parser, const void *value, void *user
   ArgsCursor *ac = parser->cursor;
   const char *firstArg = *(const char **)value;
 
-  // Wildcard branch: `*` consumes nothing else from FIELDS. If the next token
+  // Load-all branch: `*` consumes nothing else from FIELDS. If the next token
   // begins with `@` or `$` it's a stray field reference and we reject it here;
   // other tokens (SORTBY, LIMIT, ...) are left for the outer parser to dispatch.
   if (strcmp(firstArg, "*") == 0) {
@@ -156,12 +158,11 @@ static void handleCollectFields(ArgParser *parser, const void *value, void *user
 
   // Count branch: validate <num_fields> then carve a slice of that size and
   // hand it off to the mode-specific drain. `firstArg` was already extracted
-  // by `ArgParser_AddStringV`; wrap it in a one-element cursor so we can reuse
-  // `AC_GetLongLong` (which handles `LLONG_MIN/MAX` overflow internally).
-  ArgsCursor numAc;
-  ArgsCursor_InitCString(&numAc, &firstArg, 1);
-  long long count;
-  if (AC_GetLongLong(&numAc, &count, 0) != AC_OK) {
+  // by `ArgParser_AddStringV` and is NUL-terminated, so parse it directly.
+  char *end;
+  errno = 0;
+  long long count = strtoll(firstArg, &end, 10);
+  if (errno != 0 || end == firstArg || *end != '\0') {
     QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
       "Expected number of fields or `*` after FIELDS");
     return;

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -41,7 +41,7 @@ typedef struct {
   arrayof(const char *) sort_names;         // local-only
   const RLookupKey *input_key;              // local-only
 
-  bool has_wildcard;                        // remote-only
+  bool load_all;                            // remote-only
   uint64_t sortAscMap;                      // shared
 
   bool has_limit;                           // shared
@@ -143,7 +143,7 @@ static void handleCollectFields(ArgParser *parser, const void *value, void *user
   // begins with `@` or `$` it's a stray field reference and we reject it here;
   // other tokens (SORTBY, LIMIT, ...) are left for the outer parser to dispatch.
   if (strcmp(firstArg, "*") == 0) {
-    data->has_wildcard = true;
+    data->load_all = true;
     if (!AC_IsAtEnd(ac)) {
       const char *next = AC_StringArg(ac, ac->offset);
       if (next && (next[0] == '@' || next[0] == '$')) {
@@ -407,7 +407,7 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
     data.input_key = options->input_key;
   }
 
-  if (data.has_wildcard && options->is_local) {
+  if (data.load_all && options->is_local) {
     QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS,
       "COLLECT does not yet support `*` in FIELDS for local mode");
     CollectParseData_Free(&data);
@@ -432,7 +432,7 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
     rbase = CollectReducer_CreateRemote(
       data.field_keys,
       data.field_keys ? array_len(data.field_keys) : 0,
-      data.has_wildcard,
+      data.load_all,
       data.sort_keys,
       data.sort_keys ? array_len(data.sort_keys) : 0,
       data.sortAscMap,

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -78,33 +78,21 @@ static const char *parseAtPrefixedName(const char *s, size_t len, QueryError *st
 
 // ----- FIELDS -----
 
-// Parses: FIELDS nargs <@field | *> [<@field | *> ...]
-//   nargs: 1..COLLECT_MAX_FIELD_ARGS
-//
-// The local reducer strips `@` and later matches against map keys carried by the remote payload.
-static void handleCollectFieldsLocal(ArgParser *parser, const void *value, void *user_data) {
-  (void)parser;
-  CollectParseCtx *pctx = (CollectParseCtx *)user_data;
-  CollectParseData *data = pctx->data;
-  const ReducerOptions *opts = pctx->options;
-  ArgsCursor *ac = (ArgsCursor *)value;
-
-  int count = AC_NumRemaining(ac);
-
-  // ArgParser validates nargs is within [1, COLLECT_MAX_FIELD_ARGS] before invoking this callback.
-  RS_ASSERT(count >= 1 && count <= COLLECT_MAX_FIELD_ARGS);
-
-  data->field_names = array_new(const char *, count);
-  for (int i = 0; i < count; i++) {
+// Drains `<num_fields>` `@field` tokens into `data->field_names`.
+// The local reducer strips `@` and later matches against map keys carried by
+// the remote payload.
+static void handleCollectFieldsLocal(ArgsCursor *ac, CollectParseData *data,
+                                     const ReducerOptions *opts) {
+  data->field_names = array_new(const char *, AC_NumRemaining(ac));
+  while (!AC_IsAtEnd(ac)) {
     const char *s;
     size_t len;
     int rv = AC_GetString(ac, &s, &len, 0);
-    // ArgParser already validated `count` and provided a sub-cursor with
-    // exactly `count` so each iteration is guaranteed to succeed.
+    // The slice is sized exactly to `<num_fields>`, so every iteration succeeds.
     RS_ASSERT(rv == AC_OK);
     if (len == 1 && s[0] == '*') {
       QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
-        "COLLECT does not yet support `*` in FIELDS");
+        "COLLECT does not support `*` with a count");
       return;
     }
     // `s` aliases the original argv and is NUL-terminated.
@@ -114,38 +102,86 @@ static void handleCollectFieldsLocal(ArgParser *parser, const void *value, void 
   }
 }
 
-// Shards resolve fields against the source lookup.
-static void handleCollectFieldsRemote(ArgParser *parser, const void *value, void *user_data) {
-  (void)parser;
-  CollectParseCtx *pctx = (CollectParseCtx *)user_data;
-  CollectParseData *data = pctx->data;
-  const ReducerOptions *opts = pctx->options;
-  ArgsCursor *ac = (ArgsCursor *)value;
-
-  int count = AC_NumRemaining(ac);
+// Drains `<num_fields>` `@field` tokens into `data->field_keys`. Remote (shard)
+// mode resolves each field against the source lookup via `ReducerOpts_GetKey`.
+static void handleCollectFieldsRemote(ArgsCursor *ac, CollectParseData *data,
+                                      const ReducerOptions *opts) {
   ReducerOptions sub_opts = *opts;
   sub_opts.args = ac;
   sub_opts.name = "FIELDS";
 
-  // ArgParser validates nargs is within [1, COLLECT_MAX_FIELD_ARGS] before invoking this callback.
-  RS_ASSERT(count >= 1 && count <= COLLECT_MAX_FIELD_ARGS);
-
-  data->field_keys = array_new(const RLookupKey *, count);
-  for (int i = 0; i < count; i++) {
+  data->field_keys = array_new(const RLookupKey *, AC_NumRemaining(ac));
+  while (!AC_IsAtEnd(ac)) {
     if (AC_AdvanceIfMatch(ac, "*")) {
-      if (data->has_wildcard) {
-        QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
-          "`*` can only appear once in FIELDS");
-        return;
-      }
-      data->has_wildcard = true;
-    } else {
-      const RLookupKey *key = NULL;
-      if (!ReducerOpts_GetKey(&sub_opts, &key)) {
-        return;
-      }
-      array_append(data->field_keys, key);
+      QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
+        "COLLECT does not support `*` with a count");
+      return;
     }
+    const RLookupKey *key = NULL;
+    if (!ReducerOpts_GetKey(&sub_opts, &key)) {
+      return;
+    }
+    array_append(data->field_keys, key);
+  }
+}
+
+// Parses: FIELDS ( * | <num_fields> @field [@field ...] )
+//   <num_fields>: 1..COLLECT_MAX_FIELD_ARGS
+//
+// The first token after `FIELDS` is consumed by `ArgParser_AddStringV` and
+// passed in via `value`; the remainder is read directly from the parser's
+// underlying cursor. On wildcard the callback returns immediately; otherwise
+// it slices `<num_fields>` tokens and dispatches to the per-mode drainer.
+static void handleCollectFields(ArgParser *parser, const void *value, void *user_data) {
+  CollectParseCtx *pctx = (CollectParseCtx *)user_data;
+  CollectParseData *data = pctx->data;
+  const ReducerOptions *opts = pctx->options;
+  ArgsCursor *ac = parser->cursor;
+  const char *firstArg = *(const char **)value;
+
+  // Wildcard branch: `*` consumes nothing else from FIELDS. If the next token
+  // begins with `@` or `$` it's a stray field reference and we reject it here;
+  // other tokens (SORTBY, LIMIT, ...) are left for the outer parser to dispatch.
+  if (strcmp(firstArg, "*") == 0) {
+    data->has_wildcard = true;
+    if (!AC_IsAtEnd(ac)) {
+      const char *next = AC_StringArg(ac, ac->offset);
+      if (next && (next[0] == '@' || next[0] == '$')) {
+        QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
+          "Unexpected tokens after `*` in FIELDS");
+      }
+    }
+    return;
+  }
+
+  // Count branch: validate <num_fields> then carve a slice of that size and
+  // hand it off to the mode-specific drain. `firstArg` was already extracted
+  // by `ArgParser_AddStringV`; wrap it in a one-element cursor so we can reuse
+  // `AC_GetLongLong` (which handles `LLONG_MIN/MAX` overflow internally).
+  ArgsCursor numAc;
+  ArgsCursor_InitCString(&numAc, &firstArg, 1);
+  long long count;
+  if (AC_GetLongLong(&numAc, &count, 0) != AC_OK) {
+    QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
+      "Expected number of fields or `*` after FIELDS");
+    return;
+  }
+  if (count < 1 || count > COLLECT_MAX_FIELD_ARGS) {
+    QueryError_SetWithoutUserDataFmt(opts->status, QUERY_ERROR_CODE_LIMIT,
+      "FIELDS count must be in [1, %d]", COLLECT_MAX_FIELD_ARGS);
+    return;
+  }
+  ArgsCursor sub = {0};
+  if (AC_GetSlice(ac, &sub, (size_t)count) != AC_OK) {
+    QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
+      "Not enough arguments were provided based on argument count for FIELDS");
+    return;
+  }
+
+  if (opts->is_local) {
+    handleCollectFieldsLocal(&sub, data, opts);
+  } else {
+    handleCollectFieldsRemote(&sub, data, opts);
   }
 }
 
@@ -317,16 +353,18 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
   }
 
   ArgsCursor subArgs = {0};
-  ArgCallback handleFields =
-    options->is_local ? handleCollectFieldsLocal : handleCollectFieldsRemote;
   ArgCallback handleSortBy =
     options->is_local ? handleCollectSortByLocal : handleCollectSortByRemote;
 
-  ArgParser_AddSubArgsV(parser, "FIELDS", "Projected fields",
-    &subArgs, 1, COLLECT_MAX_FIELD_ARGS,
+  // FIELDS accepts either `*` or `<num_fields> @field [@field ...]`. The first
+  // token is consumed as a string; `handleCollectFields` branches on `*` vs.
+  // count and dispatches to the mode-specific drain.
+  const char *fieldsTarget = NULL;
+  ArgParser_AddStringV(parser, "FIELDS", "Projected fields",
+    &fieldsTarget,
     ARG_OPT_REQUIRED,
     ARG_OPT_POSITION, 1,
-    ARG_OPT_CALLBACK, handleFields, &pctx,
+    ARG_OPT_CALLBACK, handleCollectFields, &pctx,
     ARG_OPT_END);
 
   ArgParser_AddSubArgsV(parser, "SORTBY", "In-group sort keys",
@@ -367,13 +405,6 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
       return NULL;
     }
     data.input_key = options->input_key;
-  }
-
-  if (data.has_wildcard) {
-    QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS,
-      "COLLECT does not yet support `*` in FIELDS");
-    CollectParseData_Free(&data);
-    return NULL;
   }
 
   // Rust copies the mode-specific parsed data and wires the vtable.

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -407,9 +407,9 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
     data.input_key = options->input_key;
   }
 
-  if (data.load_all && options->is_local) {
+  if (data.load_all) {
     QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS,
-      "COLLECT does not yet support `*` in FIELDS for local mode");
+      "COLLECT does not yet support `*` in FIELDS");
     CollectParseData_Free(&data);
     return NULL;
   }

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -407,6 +407,13 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
     data.input_key = options->input_key;
   }
 
+  if (data.has_wildcard && options->is_local) {
+    QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS,
+      "COLLECT does not yet support `*` in FIELDS for local mode");
+    CollectParseData_Free(&data);
+    return NULL;
+  }
+
   // Rust copies the mode-specific parsed data and wires the vtable.
   Reducer *rbase;
   if (options->is_local) {

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -9,6 +9,7 @@
 #include <aggregate/reducer.h>
 #include "util/arg_parser.h"
 #include "util/arr_rm_alloc.h"
+#include "util/misc.h"
 #include "spec.h"
 #include "config.h"
 #include "reducers_rs.h"
@@ -92,13 +93,8 @@ static void handleCollectFieldsLocal(ArgsCursor *ac, CollectParseData *data,
     int rv = AC_GetString(ac, &s, &len, 0);
     // The slice is sized exactly to `<num_fields>`, so every iteration succeeds.
     RS_ASSERT(rv == AC_OK);
-    if (len == 1 && s[0] == '*') {
-      QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
-        "COLLECT does not support `*` with a count");
-      return;
-    }
     // `s` aliases the original argv and is NUL-terminated.
-    const char *name = parseAtPrefixedName(s, len, opts->status);
+    const char *name = ExtractKeyName(s, &len, opts->status, opts->strictPrefix, "FIELDS");
     if (!name) return;
     array_append(data->field_names, name);
   }
@@ -114,11 +110,6 @@ static void handleCollectFieldsRemote(ArgsCursor *ac, CollectParseData *data,
 
   data->field_keys = array_new(const RLookupKey *, AC_NumRemaining(ac));
   while (!AC_IsAtEnd(ac)) {
-    if (AC_AdvanceIfMatch(ac, "*")) {
-      QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
-        "COLLECT does not support `*` with a count");
-      return;
-    }
     const RLookupKey *key = NULL;
     if (!ReducerOpts_GetKey(&sub_opts, &key)) {
       return;
@@ -146,13 +137,6 @@ static void handleCollectFields(ArgParser *parser, const void *value, void *user
   // other tokens (SORTBY, LIMIT, ...) are left for the outer parser to dispatch.
   if (strcmp(firstArg, "*") == 0) {
     data->load_all = true;
-    if (!AC_IsAtEnd(ac)) {
-      const char *next = AC_StringArg(ac, ac->offset);
-      if (next && (next[0] == '@' || next[0] == '$')) {
-        QueryError_SetError(opts->status, QUERY_ERROR_CODE_PARSE_ARGS,
-          "Unexpected tokens after `*` in FIELDS");
-      }
-    }
     return;
   }
 

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -421,6 +421,7 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
       data.input_key,
       (const char *const *)data.field_names,
       data.field_names ? array_len(data.field_names) : 0,
+      data.load_all,
       (const char *const *)data.sort_names,
       data.sort_names ? array_len(data.sort_names) : 0,
       data.sortAscMap,

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
@@ -56,6 +56,7 @@ pub unsafe extern "C" fn CollectReducer_CreateLocal(
     input_key: *const ffi::RLookupKey,
     field_names: *const *const c_char,
     field_names_len: usize,
+    has_wildcard: bool,
     sort_names: *const *const c_char,
     sort_names_len: usize,
     sort_asc_map: u64,
@@ -77,6 +78,7 @@ pub unsafe extern "C" fn CollectReducer_CreateLocal(
     let mut cr = Box::new(LocalCollectReducer::new(
         input_key,
         field_names,
+        has_wildcard,
         sort_key_names,
         sort_asc_map,
         limit,

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/local.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn CollectReducer_CreateLocal(
     input_key: *const ffi::RLookupKey,
     field_names: *const *const c_char,
     field_names_len: usize,
-    has_wildcard: bool,
+    load_all: bool,
     sort_names: *const *const c_char,
     sort_names_len: usize,
     sort_asc_map: u64,
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn CollectReducer_CreateLocal(
     let mut cr = Box::new(LocalCollectReducer::new(
         input_key,
         field_names,
-        has_wildcard,
+        load_all,
         sort_key_names,
         sort_asc_map,
         limit,

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -36,7 +36,7 @@ use std::{
 pub unsafe extern "C" fn CollectReducer_CreateRemote(
     field_keys: *const *const ffi::RLookupKey,
     field_keys_len: usize,
-    has_wildcard: bool,
+    load_all: bool,
     sort_keys: *const *const ffi::RLookupKey,
     sort_keys_len: usize,
     sort_asc_map: u64,
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn CollectReducer_CreateRemote(
 
     let mut cr = Box::new(RemoteCollectReducer::new(
         field_keys,
-        has_wildcard,
+        load_all,
         sort_keys,
         sort_asc_map,
         limit,
@@ -204,10 +204,10 @@ pub const unsafe extern "C" fn CollectReducer_GetFieldKeysLen(r: *const ffi::Red
 /// `r` must point to a valid [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
 #[unsafe(no_mangle)]
-pub const unsafe extern "C" fn CollectReducer_HasWildcard(r: *const ffi::Reducer) -> bool {
+pub const unsafe extern "C" fn CollectReducer_HasLoadAll(r: *const ffi::Reducer) -> bool {
     // SAFETY: ensured by caller.
     let r = unsafe { r.cast::<RemoteCollectReducer>().as_ref().unwrap() };
-    r.has_wildcard()
+    r.load_all()
 }
 
 /// # Safety

--- a/src/redisearch_rs/headers/reducers_rs.h
+++ b/src/redisearch_rs/headers/reducers_rs.h
@@ -28,7 +28,7 @@ extern "C" {
 Reducer *CollectReducer_CreateLocal(const RLookupKey *input_key,
                                     const char *const *field_names,
                                     uintptr_t field_names_len,
-                                    bool has_wildcard,
+                                    bool load_all,
                                     const char *const *sort_names,
                                     uintptr_t sort_names_len,
                                     uint64_t sort_asc_map,
@@ -105,7 +105,7 @@ void collectLocalFree(Reducer *r);
  */
 Reducer *CollectReducer_CreateRemote(const RLookupKey *const *field_keys,
                                      uintptr_t field_keys_len,
-                                     bool has_wildcard,
+                                     bool load_all,
                                      const RLookupKey *const *sort_keys,
                                      uintptr_t sort_keys_len,
                                      uint64_t sort_asc_map,
@@ -189,7 +189,7 @@ uintptr_t CollectReducer_GetFieldKeysLen(const Reducer *r);
  * `r` must point to a valid [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
  */
-bool CollectReducer_HasWildcard(const Reducer *r);
+bool CollectReducer_HasLoadAll(const Reducer *r);
 
 /**
  * # Safety

--- a/src/redisearch_rs/headers/reducers_rs.h
+++ b/src/redisearch_rs/headers/reducers_rs.h
@@ -28,6 +28,7 @@ extern "C" {
 Reducer *CollectReducer_CreateLocal(const RLookupKey *input_key,
                                     const char *const *field_names,
                                     uintptr_t field_names_len,
+                                    bool has_wildcard,
                                     const char *const *sort_names,
                                     uintptr_t sort_names_len,
                                     uint64_t sort_asc_map,

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -43,6 +43,7 @@ pub struct LocalCollectReducer<'a> {
     /// Lookup key for the per-remote payload.
     input_key: &'a RLookupKey<'a>,
     field_names: Box<[Box<[u8]>]>,
+    has_wildcard: bool,
     sort_key_names: Box<[Box<[u8]>]>,
 }
 
@@ -69,6 +70,7 @@ impl<'a> LocalCollectReducer<'a> {
     pub fn new(
         input_key: &'a RLookupKey<'a>,
         field_names: Box<[Box<[u8]>]>,
+        has_wildcard: bool,
         sort_key_names: Box<[Box<[u8]>]>,
         sort_asc_map: u64,
         limit: Option<(u64, u64)>,
@@ -77,6 +79,7 @@ impl<'a> LocalCollectReducer<'a> {
             common: CollectCommon::new(sort_asc_map, limit),
             input_key,
             field_names,
+            has_wildcard,
             sort_key_names,
         }
     }

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -43,7 +43,7 @@ pub struct LocalCollectReducer<'a> {
     /// Lookup key for the per-remote payload.
     input_key: &'a RLookupKey<'a>,
     field_names: Box<[Box<[u8]>]>,
-    has_wildcard: bool,
+    load_all: bool,
     sort_key_names: Box<[Box<[u8]>]>,
 }
 
@@ -70,7 +70,7 @@ impl<'a> LocalCollectReducer<'a> {
     pub fn new(
         input_key: &'a RLookupKey<'a>,
         field_names: Box<[Box<[u8]>]>,
-        has_wildcard: bool,
+        load_all: bool,
         sort_key_names: Box<[Box<[u8]>]>,
         sort_asc_map: u64,
         limit: Option<(u64, u64)>,
@@ -79,7 +79,7 @@ impl<'a> LocalCollectReducer<'a> {
             common: CollectCommon::new(sort_asc_map, limit),
             input_key,
             field_names,
-            has_wildcard,
+            load_all,
             sort_key_names,
         }
     }

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -34,7 +34,7 @@ use crate::collect::common::CollectCommon;
 pub struct RemoteCollectReducer<'a> {
     common: CollectCommon,
     field_keys: Box<[&'a RLookupKey<'a>]>,
-    has_wildcard: bool,
+    load_all: bool,
     /// Raw sort-key references, including keys not present in `FIELDS`.
     sort_keys: Box<[&'a RLookupKey<'a>]>,
     /// `true` for shard replies dispatched by the coordinator: extra sort-key
@@ -69,7 +69,7 @@ impl<'a> RemoteCollectReducer<'a> {
     /// Create a reducer from C-parsed configuration.
     pub fn new(
         field_keys: Box<[&'a RLookupKey<'a>]>,
-        has_wildcard: bool,
+        load_all: bool,
         sort_keys: Box<[&'a RLookupKey<'a>]>,
         sort_asc_map: u64,
         limit: Option<(u64, u64)>,
@@ -78,7 +78,7 @@ impl<'a> RemoteCollectReducer<'a> {
         Self {
             common: CollectCommon::new(sort_asc_map, limit),
             field_keys,
-            has_wildcard,
+            load_all,
             sort_keys,
             include_sort_keys,
         }
@@ -98,8 +98,8 @@ impl<'a> RemoteCollectReducer<'a> {
         self.field_keys.len()
     }
 
-    pub const fn has_wildcard(&self) -> bool {
-        self.has_wildcard
+    pub const fn load_all(&self) -> bool {
+        self.load_all
     }
 
     pub const fn sort_keys_len(&self) -> usize {

--- a/src/redisearch_rs/reducers/tests/collect.rs
+++ b/src/redisearch_rs/reducers/tests/collect.rs
@@ -128,6 +128,7 @@ fn local_collect_projects_remote_maps_and_fills_missing_fields_with_null() {
             b"name".to_vec().into_boxed_slice(),
             b"missing".to_vec().into_boxed_slice(),
         ]),
+        false,
         Box::new([]),
         0,
         None,
@@ -161,6 +162,7 @@ fn local_collect_accepts_resp2_flat_array_payloads() {
     let reducer = LocalCollectReducer::new(
         &input_key,
         Box::new([b"name".to_vec().into_boxed_slice()]),
+        false,
         Box::new([]),
         0,
         None,

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -431,23 +431,23 @@ TEST_F(CollectParserTest, FieldsSecondFieldNotInPipeline) {
 
 TEST_F(CollectParserTest, FieldsLoadAllWithCount) {
   expectError({"FIELDS", "1", "*"},
-      "COLLECT does not support `*` with a count");
+      "Missing prefix: name requires '@' prefix, JSON path require '$' prefix, got: * in FIELDS");
 }
 
 TEST_F(CollectParserTest, FieldsLoadAllAmongFields) {
   registerKeys({"price", "name"});
   expectError({"FIELDS", "3", "@price", "*", "@name"},
-      "COLLECT does not support `*` with a count");
+      "Missing prefix: name requires '@' prefix, JSON path require '$' prefix, got: * in FIELDS");
 }
 
 TEST_F(CollectParserTest, FieldsLoadAllFollowedByField) {
   expectError({"FIELDS", "*", "@a"},
-      "Unexpected tokens after `*` in FIELDS");
+      "Bad arguments for COLLECT: @a: Unknown argument");
 }
 
 TEST_F(CollectParserTest, FieldsLoadAllFollowedByJsonPath) {
   expectError({"FIELDS", "*", "$..a"},
-      "Unexpected tokens after `*` in FIELDS");
+      "Bad arguments for COLLECT: $..a: Unknown argument");
 }
 
 TEST_F(CollectParserTest, FieldsLoadAllFollowedByAsterisk) {

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -64,6 +64,18 @@ protected:
     QueryError_ClearError(&status);
   }
 
+  void expectErrorLocal(std::vector<const char *> args, const RLookupKey *inputKey,
+                        const char *expected_detail) {
+    QueryError status = QueryError_Default();
+    Reducer *r = parseCollect(args, &status, /*isLocal=*/true, inputKey);
+    ASSERT_EQ(r, nullptr) << "Expected parse failure but got success";
+    const char *user_error = QueryError_GetUserError(&status);
+    ASSERT_NE(user_error, nullptr);
+    EXPECT_TRUE(std::string(user_error).find(expected_detail) != std::string::npos)
+        << "Expected error containing: " << expected_detail << ", got: " << user_error;
+    QueryError_ClearError(&status);
+  }
+
   Reducer *parseCollectOk(std::vector<const char *> args) {
     QueryError status = QueryError_Default();
     Reducer *r = parseCollect(args, &status);
@@ -75,15 +87,33 @@ protected:
 
 // ====== Happy path tests ======
 
-TEST_F(CollectParserTest, WildcardOnlyRejected) {
-  expectError({"FIELDS", "1", "*"},
-      "COLLECT does not yet support `*` in FIELDS");
+TEST_F(CollectParserTest, FieldsWildcardOnly) {
+  Reducer *r = parseCollectOk({"FIELDS", "*"});
+  ASSERT_NE(r, nullptr);
+  EXPECT_TRUE(CollectReducer_HasWildcard(r));
+  EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 0u);
+  r->Free(r);
 }
 
-TEST_F(CollectParserTest, WildcardAmongFieldsRejected) {
-  registerKeys({"price", "name"});
-  expectError({"FIELDS", "3", "@price", "*", "@name"},
-      "COLLECT does not yet support `*` in FIELDS");
+TEST_F(CollectParserTest, FieldsWithCount) {
+  registerKeys({"a", "b"});
+  Reducer *r = parseCollectOk({"FIELDS", "2", "@a", "@b"});
+  ASSERT_NE(r, nullptr);
+  EXPECT_FALSE(CollectReducer_HasWildcard(r));
+  EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 2u);
+  r->Free(r);
+}
+
+TEST_F(CollectParserTest, FieldsWildcardWithSortBy) {
+  registerKeys({"price"});
+  Reducer *r = parseCollectOk({
+      "FIELDS", "*",
+      "SORTBY", "1", "@price",
+  });
+  ASSERT_NE(r, nullptr);
+  EXPECT_TRUE(CollectReducer_HasWildcard(r));
+  EXPECT_EQ(CollectReducer_GetSortKeysLen(r), 1u);
+  r->Free(r);
 }
 
 TEST_F(CollectParserTest, FieldsAndSortBy) {
@@ -299,6 +329,12 @@ TEST_F(CollectParserTest, FieldWithoutAtPrefix) {
       "Missing prefix: name requires '@' prefix, JSON path require '$' prefix");
 }
 
+TEST_F(CollectParserTest, LocalFieldWithoutAtPrefix) {
+  const RLookupKey *inputKey = RLookup_GetKey_Write(&lk, "remote_collect", RLOOKUP_F_NOFLAGS);
+  expectErrorLocal({"FIELDS", "1", "price"}, inputKey,
+      "Missing prefix: name requires '@' prefix");
+}
+
 TEST_F(CollectParserTest, FieldEmptyAfterAt) {
   expectError({"FIELDS", "1", "@"}, "Property not loaded nor in pipeline");
 }
@@ -313,9 +349,42 @@ TEST_F(CollectParserTest, FieldsSecondFieldNotInPipeline) {
       "Property not loaded nor in pipeline");
 }
 
-TEST_F(CollectParserTest, DuplicateWildcard) {
-  registerKeys({"price"});
-  expectError({"FIELDS", "3", "*", "@price", "*"}, "`*` can only appear once in FIELDS");
+TEST_F(CollectParserTest, FieldsWildcardWithCount) {
+  expectError({"FIELDS", "1", "*"},
+      "COLLECT does not support `*` with a count");
+}
+
+TEST_F(CollectParserTest, FieldsWildcardAmongFields) {
+  registerKeys({"price", "name"});
+  expectError({"FIELDS", "3", "@price", "*", "@name"},
+      "COLLECT does not support `*` with a count");
+}
+
+TEST_F(CollectParserTest, FieldsWildcardFollowedByField) {
+  expectError({"FIELDS", "*", "@a"},
+      "Unexpected tokens after `*` in FIELDS");
+}
+
+TEST_F(CollectParserTest, FieldsWildcardFollowedByJsonPath) {
+  expectError({"FIELDS", "*", "$..a"},
+      "Unexpected tokens after `*` in FIELDS");
+}
+
+// `*` followed by another `*` is not caught by our wildcard stray-token peek
+// (which only flags `@`/`$`-prefixed tokens); the trailing `*` falls through
+// to the outer ArgParser and is rejected as an unknown argument.
+TEST_F(CollectParserTest, FieldsWildcardFollowedByWildcard) {
+  expectError({"FIELDS", "*", "*"}, "Unknown argument");
+}
+
+TEST_F(CollectParserTest, FieldsBareKeyword) {
+  expectError({"FIELDS"},
+      "Bad arguments for COLLECT: FIELDS: Expected an argument, but none provided");
+}
+
+TEST_F(CollectParserTest, FieldsNonNumericCount) {
+  expectError({"FIELDS", "abc"},
+      "Expected number of fields or `*` after FIELDS");
 }
 
 TEST_F(CollectParserTest, UnknownSubcommand) {
@@ -364,7 +433,7 @@ TEST_F(CollectParserTest, FieldsExceedsMax) {
     field_strs[i] = "@f" + std::to_string(i);
     args.push_back(field_strs[i].c_str());
   }
-  expectError(std::move(args), "Bad arguments for COLLECT: FIELDS: Invalid argument count");
+  expectError(std::move(args), "FIELDS count must be in [1,");
 }
 
 TEST_F(CollectParserTest, SortByInvalidTokenBetweenFields) {
@@ -404,7 +473,7 @@ TEST_F(CollectParserTest, LimitNonNumericOffset) {
 }
 
 TEST_F(CollectParserTest, FieldsZeroCountRequiresAtLeastOne) {
-  expectError({"FIELDS", "0"}, "Bad arguments for COLLECT: FIELDS: Invalid argument count");
+  expectError({"FIELDS", "0"}, "FIELDS count must be in [1,");
 }
 
 TEST_F(CollectParserTest, SortByOnlyDirectionsNoFields) {

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -20,6 +20,7 @@
 #include "result_processor.h"
 #include "redismock/redismock.h"
 
+#include <functional>
 #include <initializer_list>
 #include <string>
 #include <vector>
@@ -27,10 +28,14 @@
 class CollectParserTest : public ::testing::Test {
 protected:
   RLookup lk;
+  // Synthetic planner-input key used by `expectErrorBoth` to drive local-mode
+  // parses. Named so it does not collide with any user-registered key.
+  const RLookupKey *plannerInputKey = nullptr;
 
   void SetUp() override {
     RSGlobalConfig.enableUnstableFeatures = true;
     lk = RLookup_New();
+    plannerInputKey = RLookup_GetKey_Write(&lk, "__collect_planner_input__", RLOOKUP_F_NOFLAGS);
   }
 
   void TearDown() override {
@@ -53,7 +58,7 @@ protected:
     return RDCRCollect_New(&opts);
   }
 
-  void expectError(std::vector<const char *> args, const char *expected_detail) {
+  void expectErrorRemote(std::vector<const char *> args, const char *expected_detail) {
     QueryError status = QueryError_Default();
     Reducer *r = parseCollect(args, &status);
     ASSERT_EQ(r, nullptr) << "Expected parse failure but got success";
@@ -76,6 +81,11 @@ protected:
     QueryError_ClearError(&status);
   }
 
+  void expectError(std::vector<const char *> args, const char *expected_detail) {
+    expectErrorRemote(args, expected_detail);
+    expectErrorLocal(args, plannerInputKey, expected_detail);
+  }
+
   Reducer *parseCollectOk(std::vector<const char *> args) {
     QueryError status = QueryError_Default();
     Reducer *r = parseCollect(args, &status);
@@ -83,16 +93,44 @@ protected:
     QueryError_ClearError(&status);
     return r;
   }
+
+  void parseOk(std::vector<const char *> args,
+               std::function<void(Reducer *)> check = {}) {
+    QueryError status = QueryError_Default();
+    Reducer *remote = parseCollect(args, &status);
+    ASSERT_NE(remote, nullptr) << QueryError_GetUserError(&status);
+    if (check) check(remote);
+    remote->Free(remote);
+    QueryError_ClearError(&status);
+
+    status = QueryError_Default();
+    Reducer *local = parseCollect(args, &status, /*isLocal=*/true, plannerInputKey);
+    ASSERT_NE(local, nullptr) << QueryError_GetUserError(&status);
+    if (check) check(local);
+    local->Free(local);
+    QueryError_ClearError(&status);
+  }
 };
 
 // ====== Happy path tests ======
 
-TEST_F(CollectParserTest, FieldsWildcardOnly) {
-  Reducer *r = parseCollectOk({"FIELDS", "*"});
-  ASSERT_NE(r, nullptr);
-  EXPECT_TRUE(CollectReducer_HasWildcard(r));
-  EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 0u);
-  r->Free(r);
+// TODO: Re-enable (drop the `DISABLED_` prefix) and remove the companion
+// `FieldsWildcardRejected` test below once `*` in FIELDS is supported by the
+// COLLECT parser. Today the parser unconditionally rejects `*` in FIELDS in
+// both modes (see `src/aggregate/reducers/collect.c`, the
+// `if (data.load_all)` branch).
+TEST_F(CollectParserTest, DISABLED_FieldsWildcard) {
+  parseOk({"FIELDS", "*"}, [](Reducer *r) {
+    EXPECT_TRUE(CollectReducer_HasWildcard(r));
+    EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 0u);
+  });
+}
+
+// Documents the current behavior: `*` in FIELDS is rejected by the parser in
+// both remote and local modes with the same message. Remove once wildcard
+// support lands and `DISABLED_FieldsWildcard` is re-enabled.
+TEST_F(CollectParserTest, FieldsWildcardRejected) {
+  expectError({"FIELDS", "*"}, "COLLECT does not yet support `*` in FIELDS");
 }
 
 TEST_F(CollectParserTest, FieldsWithCount) {
@@ -104,7 +142,9 @@ TEST_F(CollectParserTest, FieldsWithCount) {
   r->Free(r);
 }
 
-TEST_F(CollectParserTest, FieldsWildcardWithSortBy) {
+// TODO: Re-enable (drop the `DISABLED_` prefix) once `*` in FIELDS is supported
+// by the COLLECT parser.
+TEST_F(CollectParserTest, DISABLED_FieldsWildcardWithSortBy) {
   registerKeys({"price"});
   Reducer *r = parseCollectOk({
       "FIELDS", "*",
@@ -155,12 +195,6 @@ TEST_F(CollectParserTest, LocalCollectRequiresPlannerInputKey) {
               std::string::npos)
       << user_error;
   QueryError_ClearError(&status);
-}
-
-TEST_F(CollectParserTest, LocalWildcardRejected) {
-  const RLookupKey *inputKey = RLookup_GetKey_Write(&lk, "remote_collect", RLOOKUP_F_NOFLAGS);
-  expectErrorLocal({"FIELDS", "*"}, inputKey,
-      "COLLECT does not yet support `*` in FIELDS for local mode");
 }
 
 TEST_F(CollectParserTest, FieldsSortByAndLimit) {
@@ -310,6 +344,9 @@ TEST_F(CollectParserTest, JsonPathField) {
 
 TEST_F(CollectParserTest, SortByJsonPathRejected) {
   registerKeys({"$..price"});
+  // Remote: FIELDS resolves `$..price` via lookup, SORTBY rejects it.
+  // Local: FIELDS rejects it directly (no lookup, only `@` is allowed).
+  // Both modes surface the same shared `parseAtPrefixedName` error substring.
   expectError(
       {"FIELDS", "1", "$..price", "SORTBY", "1", "$..price"},
       "Missing prefix: name requires '@' prefix");
@@ -321,7 +358,8 @@ TEST_F(CollectParserTest, EmptyArgs) {
 
 TEST_F(CollectParserTest, MissingFieldsRequired) {
   registerKeys({"price"});
-  expectError({"SORTBY", "1", "@price"}, "FIELDS: Required positional argument missing or out of order");
+  expectError({"SORTBY", "1", "@price"},
+      "FIELDS: Required positional argument missing or out of order");
 }
 
 TEST_F(CollectParserTest, FieldsMustBeFirstParam) {
@@ -331,7 +369,7 @@ TEST_F(CollectParserTest, FieldsMustBeFirstParam) {
 }
 
 TEST_F(CollectParserTest, FieldWithoutAtPrefix) {
-  expectError({"FIELDS", "1", "price"},
+  expectErrorRemote({"FIELDS", "1", "price"},
       "Missing prefix: name requires '@' prefix, JSON path require '$' prefix");
 }
 
@@ -342,16 +380,16 @@ TEST_F(CollectParserTest, LocalFieldWithoutAtPrefix) {
 }
 
 TEST_F(CollectParserTest, FieldEmptyAfterAt) {
-  expectError({"FIELDS", "1", "@"}, "Property not loaded nor in pipeline");
+  expectErrorRemote({"FIELDS", "1", "@"}, "Property not loaded nor in pipeline");
 }
 
 TEST_F(CollectParserTest, FieldNotInPipeline) {
-  expectError({"FIELDS", "1", "@nonexistent"}, "Property not loaded nor in pipeline");
+  expectErrorRemote({"FIELDS", "1", "@nonexistent"}, "Property not loaded nor in pipeline");
 }
 
 TEST_F(CollectParserTest, FieldsSecondFieldNotInPipeline) {
   registerKeys({"price"});
-  expectError({"FIELDS", "2", "@price", "@unknown"},
+  expectErrorRemote({"FIELDS", "2", "@price", "@unknown"},
       "Property not loaded nor in pipeline");
 }
 
@@ -395,12 +433,13 @@ TEST_F(CollectParserTest, FieldsNonNumericCount) {
 
 TEST_F(CollectParserTest, UnknownSubcommand) {
   registerKeys({"x"});
-  expectError({"FIELDS", "1", "@x", "FOO", "1", "2"}, "Bad arguments for COLLECT: FOO: Unknown argument");
+  expectError({"FIELDS", "1", "@x", "FOO", "1", "2"},
+      "Bad arguments for COLLECT: FOO: Unknown argument");
 }
 
 TEST_F(CollectParserTest, SortByFieldNotInPipeline) {
   registerKeys({"x"});
-  expectError(
+  expectErrorRemote(
       {"FIELDS", "1", "@x", "SORTBY", "1", "@unknown"},
       "Property not loaded nor in pipeline");
 }
@@ -419,14 +458,15 @@ TEST_F(CollectParserTest, SortByFieldWithoutAtPrefix) {
 
 TEST_F(CollectParserTest, SortByTooManyFields) {
   registerKeys({"x", "a", "b", "c", "d", "e", "f", "g", "h", "i"});
-  expectError({"FIELDS", "1", "@x", "SORTBY", "9", "@a", "@b", "@c", "@d", "@e", "@f", "@g", "@h", "@i"},
+  expectError(
+      {"FIELDS", "1", "@x", "SORTBY", "9", "@a", "@b", "@c", "@d", "@e", "@f", "@g", "@h", "@i"},
       "SORTBY exceeds maximum of 8 fields");
 }
 
 TEST_F(CollectParserTest, SortByExceedsMaxTokens) {
   registerKeys({"x", "a", "b", "c", "d", "e", "f", "g", "h", "i"});
-  expectError({"FIELDS", "1", "@x", "SORTBY", "17", "@a", "ASC", "@b", "ASC", "@c", "ASC", "@d", "ASC",
-                  "@e", "ASC", "@f", "ASC", "@g", "ASC", "@h", "ASC", "@i"},
+  expectError({"FIELDS", "1", "@x", "SORTBY", "17", "@a", "ASC", "@b", "ASC", "@c", "ASC",
+                      "@d", "ASC", "@e", "ASC", "@f", "ASC", "@g", "ASC", "@h", "ASC", "@i"},
       "Bad arguments for COLLECT: SORTBY: Invalid argument count");
 }
 

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -115,21 +115,21 @@ protected:
 // ====== Happy path tests ======
 
 // TODO: Re-enable (drop the `DISABLED_` prefix) and remove the companion
-// `FieldsWildcardRejected` test below once `*` in FIELDS is supported by the
+// `FieldsLoadAllRejected` test below once `*` in FIELDS is supported by the
 // COLLECT parser. Today the parser unconditionally rejects `*` in FIELDS in
 // both modes (see `src/aggregate/reducers/collect.c`, the
 // `if (data.load_all)` branch).
-TEST_F(CollectParserTest, DISABLED_FieldsWildcard) {
+TEST_F(CollectParserTest, DISABLED_FieldsLoadAll) {
   parseOk({"FIELDS", "*"}, [](Reducer *r) {
-    EXPECT_TRUE(CollectReducer_HasWildcard(r));
+    EXPECT_TRUE(CollectReducer_HasLoadAll(r));
     EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 0u);
   });
 }
 
 // Documents the current behavior: `*` in FIELDS is rejected by the parser in
-// both remote and local modes with the same message. Remove once wildcard
-// support lands and `DISABLED_FieldsWildcard` is re-enabled.
-TEST_F(CollectParserTest, FieldsWildcardRejected) {
+// both remote and local modes with the same message. Remove once LoadAll
+// support lands and `DISABLED_FieldsLoadAll` is re-enabled.
+TEST_F(CollectParserTest, FieldsLoadAllRejected) {
   expectError({"FIELDS", "*"}, "COLLECT does not yet support `*` in FIELDS");
 }
 
@@ -137,21 +137,21 @@ TEST_F(CollectParserTest, FieldsWithCount) {
   registerKeys({"a", "b"});
   Reducer *r = parseCollectOk({"FIELDS", "2", "@a", "@b"});
   ASSERT_NE(r, nullptr);
-  EXPECT_FALSE(CollectReducer_HasWildcard(r));
+  EXPECT_FALSE(CollectReducer_HasLoadAll(r));
   EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 2u);
   r->Free(r);
 }
 
 // TODO: Re-enable (drop the `DISABLED_` prefix) once `*` in FIELDS is supported
 // by the COLLECT parser.
-TEST_F(CollectParserTest, DISABLED_FieldsWildcardWithSortBy) {
+TEST_F(CollectParserTest, DISABLED_FieldsLoadAllWithSortBy) {
   registerKeys({"price"});
   Reducer *r = parseCollectOk({
       "FIELDS", "*",
       "SORTBY", "1", "@price",
   });
   ASSERT_NE(r, nullptr);
-  EXPECT_TRUE(CollectReducer_HasWildcard(r));
+  EXPECT_TRUE(CollectReducer_HasLoadAll(r));
   EXPECT_EQ(CollectReducer_GetSortKeysLen(r), 1u);
   r->Free(r);
 }
@@ -336,7 +336,7 @@ TEST_F(CollectParserTest, JsonPathField) {
   Reducer *r = parseCollectOk({"FIELDS", "1", "$..price"});
   ASSERT_NE(r, nullptr);
   EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 1u);
-  EXPECT_FALSE(CollectReducer_HasWildcard(r));
+  EXPECT_FALSE(CollectReducer_HasLoadAll(r));
   r->Free(r);
 }
 
@@ -393,31 +393,31 @@ TEST_F(CollectParserTest, FieldsSecondFieldNotInPipeline) {
       "Property not loaded nor in pipeline");
 }
 
-TEST_F(CollectParserTest, FieldsWildcardWithCount) {
+TEST_F(CollectParserTest, FieldsLoadAllWithCount) {
   expectError({"FIELDS", "1", "*"},
       "COLLECT does not support `*` with a count");
 }
 
-TEST_F(CollectParserTest, FieldsWildcardAmongFields) {
+TEST_F(CollectParserTest, FieldsLoadAllAmongFields) {
   registerKeys({"price", "name"});
   expectError({"FIELDS", "3", "@price", "*", "@name"},
       "COLLECT does not support `*` with a count");
 }
 
-TEST_F(CollectParserTest, FieldsWildcardFollowedByField) {
+TEST_F(CollectParserTest, FieldsLoadAllFollowedByField) {
   expectError({"FIELDS", "*", "@a"},
       "Unexpected tokens after `*` in FIELDS");
 }
 
-TEST_F(CollectParserTest, FieldsWildcardFollowedByJsonPath) {
+TEST_F(CollectParserTest, FieldsLoadAllFollowedByJsonPath) {
   expectError({"FIELDS", "*", "$..a"},
       "Unexpected tokens after `*` in FIELDS");
 }
 
-// `*` followed by another `*` is not caught by our wildcard stray-token peek
+// `*` followed by another `*` is not caught by our loadall stray-token peek
 // (which only flags `@`/`$`-prefixed tokens); the trailing `*` falls through
 // to the outer ArgParser and is rejected as an unknown argument.
-TEST_F(CollectParserTest, FieldsWildcardFollowedByWildcard) {
+TEST_F(CollectParserTest, FieldsLoadAllFollowedByAsterisk) {
   expectError({"FIELDS", "*", "*"}, "Unknown argument");
 }
 

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -157,6 +157,12 @@ TEST_F(CollectParserTest, LocalCollectRequiresPlannerInputKey) {
   QueryError_ClearError(&status);
 }
 
+TEST_F(CollectParserTest, LocalWildcardRejected) {
+  const RLookupKey *inputKey = RLookup_GetKey_Write(&lk, "remote_collect", RLOOKUP_F_NOFLAGS);
+  expectErrorLocal({"FIELDS", "*"}, inputKey,
+      "COLLECT does not yet support `*` in FIELDS for local mode");
+}
+
 TEST_F(CollectParserTest, FieldsSortByAndLimit) {
   registerKeys({"price"});
   Reducer *r = parseCollectOk({

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -340,16 +340,49 @@ TEST_F(CollectParserTest, JsonPathField) {
   r->Free(r);
 }
 
+TEST_F(CollectParserTest, SortByJsonPathAccepted) {
+  registerKeys({"$..price"});
+  Reducer *r = parseCollectOk({"FIELDS", "1", "$..price", "SORTBY", "1", "@$..price"});
+  ASSERT_NE(r, nullptr);
+  EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 1u);
+  EXPECT_EQ(CollectReducer_GetSortKeysLen(r), 1u);
+  EXPECT_TRUE(SORTASCMAP_GETASC(CollectReducer_GetSortAscMap(r), 0));
+  r->Free(r);
+}
+
+TEST_F(CollectParserTest, LocalSortByJsonPathAccepted) {
+  std::vector<const char *> args = {"FIELDS", "1", "@$..price", "SORTBY", "1", "@$..price"};
+  QueryError status = QueryError_Default();
+  Reducer *r = parseCollect(args, &status, /*isLocal=*/true, plannerInputKey);
+  ASSERT_NE(r, nullptr) << QueryError_GetUserError(&status);
+  r->Free(r);
+  QueryError_ClearError(&status);
+}
+
 // ====== Validation / error tests ======
 
 TEST_F(CollectParserTest, SortByJsonPathRejected) {
   registerKeys({"$..price"});
-  // Remote: FIELDS resolves `$..price` via lookup, SORTBY rejects it.
-  // Local: FIELDS rejects it directly (no lookup, only `@` is allowed).
-  // Both modes surface the same shared `parseAtPrefixedName` error substring.
-  expectError(
-      {"FIELDS", "1", "$..price", "SORTBY", "1", "$..price"},
-      "Missing prefix: name requires '@' prefix");
+  std::vector<const char *> args = {"FIELDS", "1", "$..price", "SORTBY", "1", "$..price"};
+  const char *expected =
+      "SEARCH_PARSE_ARGS Missing prefix: name requires '@' prefix ($..price)";
+
+  // Remote parse
+  {
+    QueryError status = QueryError_Default();
+    Reducer *r = parseCollect(args, &status);
+    ASSERT_EQ(r, nullptr) << "Expected parse failure but got success";
+    EXPECT_STREQ(QueryError_GetUserError(&status), expected);
+    QueryError_ClearError(&status);
+  }
+  // Local parse
+  {
+    QueryError status = QueryError_Default();
+    Reducer *r = parseCollect(args, &status, /*isLocal=*/true, plannerInputKey);
+    ASSERT_EQ(r, nullptr) << "Expected parse failure but got success";
+    EXPECT_STREQ(QueryError_GetUserError(&status), expected);
+    QueryError_ClearError(&status);
+  }
 }
 
 TEST_F(CollectParserTest, EmptyArgs) {

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -94,20 +94,22 @@ protected:
     return r;
   }
 
-  void parseOk(std::vector<const char *> args,
-               std::function<void(Reducer *)> check = {}) {
+  void parseOkRemote(std::vector<const char *> args,
+                     std::function<void(Reducer *)> check = {}) {
     QueryError status = QueryError_Default();
-    Reducer *remote = parseCollect(args, &status);
-    ASSERT_NE(remote, nullptr) << QueryError_GetUserError(&status);
-    if (check) check(remote);
-    remote->Free(remote);
+    Reducer *r = parseCollect(args, &status);
+    ASSERT_NE(r, nullptr) << QueryError_GetUserError(&status);
+    if (check) check(r);
+    r->Free(r);
     QueryError_ClearError(&status);
+  }
 
-    status = QueryError_Default();
-    Reducer *local = parseCollect(args, &status, /*isLocal=*/true, plannerInputKey);
-    ASSERT_NE(local, nullptr) << QueryError_GetUserError(&status);
-    if (check) check(local);
-    local->Free(local);
+  // No check callback: CollectReducer_* accessors are remote-only.
+  void parseOkLocal(std::vector<const char *> args) {
+    QueryError status = QueryError_Default();
+    Reducer *r = parseCollect(args, &status, /*isLocal=*/true, plannerInputKey);
+    ASSERT_NE(r, nullptr) << QueryError_GetUserError(&status);
+    r->Free(r);
     QueryError_ClearError(&status);
   }
 };
@@ -120,10 +122,11 @@ protected:
 // both modes (see `src/aggregate/reducers/collect.c`, the
 // `if (data.load_all)` branch).
 TEST_F(CollectParserTest, DISABLED_FieldsLoadAll) {
-  parseOk({"FIELDS", "*"}, [](Reducer *r) {
+  parseOkRemote({"FIELDS", "*"}, [](Reducer *r) {
     EXPECT_TRUE(CollectReducer_HasLoadAll(r));
     EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 0u);
   });
+  parseOkLocal({"FIELDS", "*"});
 }
 
 // Documents the current behavior: `*` in FIELDS is rejected by the parser in
@@ -447,9 +450,6 @@ TEST_F(CollectParserTest, FieldsLoadAllFollowedByJsonPath) {
       "Unexpected tokens after `*` in FIELDS");
 }
 
-// `*` followed by another `*` is not caught by our loadall stray-token peek
-// (which only flags `@`/`$`-prefixed tokens); the trailing `*` falls through
-// to the outer ArgParser and is rejected as an unknown argument.
 TEST_F(CollectParserTest, FieldsLoadAllFollowedByAsterisk) {
   expectError({"FIELDS", "*", "*"}, "Unknown argument");
 }
@@ -462,6 +462,11 @@ TEST_F(CollectParserTest, FieldsBareKeyword) {
 TEST_F(CollectParserTest, FieldsNonNumericCount) {
   expectError({"FIELDS", "abc"},
       "Expected number of fields or `*` after FIELDS");
+}
+
+TEST_F(CollectParserTest, NotEnoughFieldNames) {
+  expectError({"FIELDS", "2", "@a"},
+      "Not enough arguments were provided based on argument count for FIELDS");
 }
 
 TEST_F(CollectParserTest, UnknownSubcommand) {


### PR DESCRIPTION
This PR replaces: #9346

## Description
Fix the parsing logic to match the new syntax: 

Current:
```sh
REDUCE COLLECT <narg>
    FIELDS <num_fields> <field_1> [<field_2> ...]
    [DISTINCT]
    [SORTBY <narg> <@field> [ASC|DESC] [<@field> [ASC|DESC] ...]]
    [LIMIT <offset> <count>]
  [AS <alias>]
```

New:
```sh
REDUCE COLLECT <narg>
    FIELDS ( * | <num_fields> <field_1> [<field_2> ...] )
    [DISTINCT]
    [SORTBY <narg> <@field> [ASC|DESC] [<@field> [ASC|DESC] ...]]
    [LIMIT <offset> <count>]
  [AS <alias>]
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core aggregation argument parsing and C↔Rust FFI function signatures, which could break callers or subtly change validation/error behavior if not updated everywhere.
> 
> **Overview**
> Updates `COLLECT`’s `FIELDS` argument parsing to match the new syntax `FIELDS ( * | <num_fields> @field... )`, splitting the logic into a `*` “load all” branch vs. an explicit-count branch with stricter numeric/count validation and clearer error messages (including better handling of missing args / insufficient field tokens).
> 
> Plumbs a new `load_all` flag through the C→Rust reducer factories (FFI signature changes, `has_wildcard` renamed/removed in favor of `load_all`) and updates the Rust reducer structs/constructors and C++/Rust tests accordingly; `*` is still ultimately rejected by the parser for now, but is now detected and validated consistently in both local and remote modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ad873550937dc12b5d69edac667d054e025c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->