### PR TITLE
[MOD-14922] Sync developer.md supported platforms with CI matrix

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -323,39 +323,30 @@ uv redisbench-admin run-local \
 
 ## Supported Platforms
 
-The following operating systems are supported and tested in CI:
+The following operating systems are supported and tested in CI on both `x86_64` and `aarch64` (with the exception of macOS 14, which is ARM64-only):
 
-* Ubuntu 18.04
-* Ubuntu 20.04
-* Ubuntu 22.04
-* Ubuntu 24.04
-* Debian linux 11
-* Debian linux 12
-* Rocky linux 8
-* Rocky linux 9
-* Amazon linux 2
-* Amazon linux 2023
-* Mariner 2.0
-* Azure linux 3
-* macOS
-* Alpine linux 3
+* Ubuntu 20.04 (Focal)
+* Ubuntu 22.04 (Jammy)
+* Ubuntu 24.04 (Noble)
+* Ubuntu 25.10 (Resolute)
+* Debian 12 (Bookworm)
+* Debian 13 (Trixie)
+* Rocky Linux 8
+* Rocky Linux 9
+* Rocky Linux 10
+* Amazon Linux 2023
+* Azure Linux 3
+* Alpine Linux 3.23
+* macOS 14 (ARM64)
+* macOS 15
+* macOS 26
 
-### Platform-specific compiler requirements
+### Platform-specific notes
 
-- Ubuntu 18.04: GCC 10 (not default, installed via PPA)
-- Ubuntu 20.04: GCC 10 (not default, installed via PPA)
-- Ubuntu 22.04: GCC 12 (not default, PPA not required)
-- Ubuntu 24.04: Default GCC is sufficient
-- Debian 11: Default GCC is sufficient
-- Debian 12: Default GCC is sufficient
-- Rocky Linux 8: GCC 13 (not default, installed via gcc-toolset-13-gcc and gcc-toolset-13-gcc-c++)
-- Rocky Linux 9: GCC 14 (not default, installed via gcc-toolset-14-gcc and gcc-toolset-14-gcc-c++)
-- Amazon Linux 2: GCC 11 (not default, installed via Amazon's SCL)
-- Amazon Linux 2023: Default GCC is sufficient
-- Mariner 2.0: Default GCC is sufficient
-- Azure Linux 3: Default GCC is sufficient
-- macOS: Install llvm@21 via homebrew
-- Alpine Linux 3: Default GCC is sufficient
+`./install_script.sh` covers compiler and build-tool installation on every supported platform. The notes below only flag things the script cannot do for you:
+
+- **macOS**: Homebrew must already be installed. The script will fail fast if `brew` is not on `$PATH`. Install it from https://brew.sh first.
+- **Rocky Linux 8 / 9**: The script installs GCC via `gcc-toolset-13` / `gcc-toolset-14` and registers the toolset under `/etc/profile.d/`, which only takes effect in **new** shells. To use the toolset in your current shell, run `source /opt/rh/gcc-toolset-13/enable` (Rocky 8) or `source /opt/rh/gcc-toolset-14/enable` (Rocky 9).
 
 ## Updating Dependencies
 

--- a/developer.md
+++ b/developer.md
@@ -328,7 +328,7 @@ The following operating systems are supported and tested in CI on both `x86_64` 
 * Ubuntu 20.04 (Focal)
 * Ubuntu 22.04 (Jammy)
 * Ubuntu 24.04 (Noble)
-* Ubuntu 25.10 (Resolute)
+* Ubuntu 26.04 (Resolute)
 * Debian 12 (Bookworm)
 * Debian 13 (Trixie)
 * Rocky Linux 8


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `developer.md`'s _Supported Platforms_ section listed several distros that are no longer exercised in CI (Ubuntu 18.04, Debian 11, Amazon Linux 2, Mariner 2.0) and was missing several that are (Ubuntu 25.10, Debian 13, Rocky 10, macOS 14/15/26, Alpine 3.23 pinning). The _Platform-specific compiler requirements_ subsection also held stale per-distro details (e.g. wrong GCC version on Ubuntu 20.04, claim that Ubuntu 22.04 needed a PPA) and largely duplicated what `./install_script.sh` already does.
2. **Change**: Replace the platform list with the set actually defined in `.github/workflows/generate-matrix.yml`, add an upfront note that every platform runs both `x86_64` and `aarch64` (with macOS 14 as the ARM64-only exception), and trim the compiler subsection to the only two caveats `./install_script.sh` cannot handle on its own:
    - **macOS** requires Homebrew to be pre-installed.
    - **Rocky Linux 8 / 9** install the GCC toolset under `/etc/profile.d/`, which only takes effect in new shells, so the current shell needs a manual `source /opt/rh/gcc-toolset-NN/enable`.
3. **Outcome**: Developers landing on `developer.md` see a list that matches what CI actually tests, and only see manual instructions for steps the install script does not cover.

#### Which additional issues this PR fixes
_None — documentation-only change._

#### Main objects this PR modified
1. `developer.md` (Supported Platforms section)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime, build, or CI behavior changes.
> 
> **Overview**
> Updates `developer.md`’s **Supported Platforms** section to match the current CI matrix, including newer Ubuntu/Debian/Rocky/macOS versions, Alpine 3.23 pinning, and noting CI runs on both `x86_64` and `aarch64` (except macOS 14).
> 
> Removes the stale per-distro compiler requirement table and replaces it with a shorter **platform-specific notes** section covering only the manual prerequisites not handled by `./install_script.sh` (preinstalled Homebrew on macOS and needing to `source` the GCC toolset on Rocky 8/9 in the current shell).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1ab50418ec0ab08d2048975f377a866f028196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->