### PR TITLE
Skip flaky test_return_strict_timeout_one_shard_paused_aggregate

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -1738,6 +1738,7 @@ class TestCoordinatorTimeout:
         env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
         env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
 
+    @skip_until("2026-05-14", reason="Flaky test, see MOD-15335")
     def test_return_strict_timeout_one_shard_paused_aggregate(self):
         """RETURN_STRICT timeout while one shard process is suspended.
 


### PR DESCRIPTION

## Describe the changes in the pull request

1. Current: `test_return_strict_timeout_one_shard_paused_aggregate` in `tests/pytests/test_blocked_client_timeout.py` is flaky in CI.
2. Change: Decorate the test with `@skip_until("2026-05-14")` so it is skipped for ~2 weeks while the flakiness is investigated.
3. Outcome: CI no longer fails on this test in the meantime; the test will automatically resume running after 2026-05-14 so it is not forgotten.

#### Which additional issues this PR fixes
1. MOD-...

#### Main objects this PR modified
1. `tests/pytests/test_blocked_client_timeout.py` — added `@skip_until("2026-05-14")` decorator on `test_return_strict_timeout_one_shard_paused_aggregate`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
