### PR TITLE
[MOD-14980] Fix use-after-move in Indexer_Process

### DIFF
--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -158,6 +158,15 @@ static inline bool DocTable_CheckWideFieldMaskExpirationPredicate(const DocTable
   return TimeToLiveTable_VerifyDocAndWideFieldMask(t->ttl, docId, fieldMask, predicate, expirationPoint, ftIdToFieldIndex);
 }
 
+// Borrowed read of the field-expiration array for `docId`. Returns NULL if
+// this index has never registered any field-level TTLs (`t->ttl == NULL`)
+// or if `docId` has no field-level entry. See
+// TimeToLiveTable_GetFieldExpirations for lifetime / aliasing rules.
+static inline const arrayof(FieldExpiration) DocTable_GetFieldExpirations(const DocTable *t, t_docId docId) {
+  if (!t->ttl) return NULL;
+  return TimeToLiveTable_GetFieldExpirations(t->ttl, docId);
+}
+
 
 /** Get the docId of a key if it exists in the table, or 0 if it doesn't */
 t_docId DocTable_GetId(const DocTable *dt, const char *s, size_t n);

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -461,6 +461,8 @@ void Document_Clear(Document *d) {
 
 void Document_Free(Document *doc) {
   Document_Clear(doc);
+  array_free(doc->fieldExpirations);
+  doc->fieldExpirations = NULL;
   if (doc->flags & (DOCUMENT_F_OWNREFS | DOCUMENT_F_OWNSTRINGS)) {
     RedisModule_FreeString(RSDummyContext, doc->docKey);
   }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -286,6 +286,8 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
         // so it can read `expirationTimeNs` directly without going through
         // a flag-gated branch.
         DocTable_UpdateExpiration(&ctx->spec->docs, md, doc->docExpirationTime, doc->fieldExpirations);
+
+        doc->fieldExpirations = NULL; // Moved to DocTable (TTL table actually)
       }
       DMD_Return(md);
     }
@@ -453,8 +455,15 @@ static void Indexer_Process(RSAddDocumentCtx *aCtx) {
   // Index the document in the `existing docs` inverted index
   writeExistingDocs(aCtx, &ctx);
 
-  // Handle missing values indexing
-  writeMissingFieldDocs(aCtx, &ctx, doc->fieldExpirations);
+  // On the non-disk path, `doc->fieldExpirations` ownership is moved
+  arrayof(FieldExpiration) fes;
+  if (SearchDisk_IsEnabled()) {
+    fes = doc->fieldExpirations;
+  } else {
+    fes = (arrayof(FieldExpiration))DocTable_GetFieldExpirations(&ctx.spec->docs, doc->docId);
+    doc->fieldExpirations = NULL;
+  }
+  writeMissingFieldDocs(aCtx, &ctx, fes);
 
   // Handle FULLTEXT indexes
   if ((aCtx->fwIdx && (aCtx->stateFlags & ACTX_F_ERRORED) == 0)) {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -455,13 +455,15 @@ static void Indexer_Process(RSAddDocumentCtx *aCtx) {
   // Index the document in the `existing docs` inverted index
   writeExistingDocs(aCtx, &ctx);
 
-  // On the non-disk path, `doc->fieldExpirations` ownership is moved
+  // On the non-disk path, `doc->fieldExpirations` ownership has already been
+  // moved into the TTL table by `doAssignIds` on success. On failure (e.g.
+  // `makeDocumentId` returned NULL), the array stays attached to `doc` so
+  // `Document_Free` can release it.
   arrayof(FieldExpiration) fes;
   if (SearchDisk_IsEnabled()) {
     fes = doc->fieldExpirations;
   } else {
     fes = (arrayof(FieldExpiration))DocTable_GetFieldExpirations(&ctx.spec->docs, doc->docId);
-    doc->fieldExpirations = NULL;
   }
   writeMissingFieldDocs(aCtx, &ctx, fes);
 

--- a/src/ttl_table/ttl_table.c
+++ b/src/ttl_table/ttl_table.c
@@ -199,6 +199,11 @@ size_t TimeToLiveTable_DebugAllocatedBuckets(const TimeToLiveTable *t) {
   return t ? t->cap : 0;
 }
 
+const arrayof(FieldExpiration) TimeToLiveTable_GetFieldExpirations(const TimeToLiveTable *t, t_docId docId) {
+  const TimeToLiveEntry *e = ttl_find_entry(t, docId);
+  return e ? e->fieldExpirations : NULL;
+}
+
 static inline bool DidExpire(const t_expirationTimePoint* field, const t_expirationTimePoint* now) {
   if (!field->tv_sec && !field->tv_nsec) {
     return false;

--- a/src/ttl_table/ttl_table.h
+++ b/src/ttl_table/ttl_table.h
@@ -41,6 +41,14 @@ void TimeToLiveTable_Add(TimeToLiveTable *table, t_docId docId, arrayof(FieldExp
 void TimeToLiveTable_Remove(TimeToLiveTable *table, t_docId docId);
 bool TimeToLiveTable_IsEmpty(TimeToLiveTable *table);
 
+// Returns a borrowed, read-only handle to the field-expiration array stored
+// for `docId`, or NULL if the table holds no entry for it. The returned
+// pointer aliases storage owned by the table — it is invalidated by any
+// subsequent `TimeToLiveTable_Add` / `_Remove` / `_Destroy` for this table,
+// and must not be freed by the caller. The array is sorted by field index
+// and is guaranteed to be non-empty.
+const arrayof(FieldExpiration) TimeToLiveTable_GetFieldExpirations(const TimeToLiveTable *table, t_docId docId);
+
 bool TimeToLiveTable_VerifyDocAndField(TimeToLiveTable *table, t_docId docId, t_fieldIndex fieldIndex, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint);
 bool TimeToLiveTable_VerifyDocAndFieldMask(TimeToLiveTable *table, t_docId docId, uint32_t fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);
 bool TimeToLiveTable_VerifyDocAndWideFieldMask(TimeToLiveTable *table, t_docId docId, t_fieldMask fieldMask, enum FieldExpirationPredicate predicate, const struct timespec* expirationPoint, const t_fieldIndex* ftIdToFieldIndex);

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -264,3 +264,40 @@ TEST_F(ExpireTest, testTTLLazyGrowth) {
   RSGlobalConfig.maxDocTableSize = savedMax;
 }
 
+// Exercises TimeToLiveTable_GetFieldExpirations, the borrowed read used by
+// the indexer to recover ownership-transferred FieldExpiration arrays after
+// DocTable_UpdateExpiration has consumed the original Document pointer.
+TEST_F(ExpireTest, testTTLGetFieldExpirations) {
+  TimeToLiveTable *ttl = nullptr;
+  TimeToLiveTable_VerifyInit(&ttl, 32);
+
+  // Empty table: any docId returns NULL.
+  ASSERT_EQ(TimeToLiveTable_GetFieldExpirations(ttl, 1), nullptr);
+  ASSERT_EQ(TimeToLiveTable_GetFieldExpirations(ttl, 999999), nullptr);
+
+  // Add an entry and confirm Get returns the same pointer that was inserted,
+  // with the expected length and content. (Add takes ownership; Get returns
+  // a borrowed alias to that same storage.)
+  struct timespec p = {123, 456};
+  arrayof(FieldExpiration) inserted = makeFE(p);
+  const FieldExpiration *insertedPtr = inserted;  // capture before Add transfers
+  TimeToLiveTable_Add(ttl, 7, inserted);
+
+  const arrayof(FieldExpiration) got = TimeToLiveTable_GetFieldExpirations(ttl, 7);
+  ASSERT_EQ(got, insertedPtr);
+  // array_len takes void*; the const-qualified return needs the cast.
+  ASSERT_EQ(array_len((arrayof(FieldExpiration))got), 1u);
+  ASSERT_EQ(got[0].index, 0);
+  ASSERT_EQ(got[0].point.tv_sec, p.tv_sec);
+  ASSERT_EQ(got[0].point.tv_nsec, p.tv_nsec);
+
+  // A docId that was never added must report NULL even when other entries exist.
+  ASSERT_EQ(TimeToLiveTable_GetFieldExpirations(ttl, 8), nullptr);
+
+  // After Remove, Get for that docId returns NULL.
+  TimeToLiveTable_Remove(ttl, 7);
+  ASSERT_EQ(TimeToLiveTable_GetFieldExpirations(ttl, 7), nullptr);
+
+  TimeToLiveTable_Destroy(&ttl);
+}
+


### PR DESCRIPTION
## Describe the changes in the pull request

Avoid use-after-moved variable during the indexing.

On the non-disk path, `Indexer_Process` was reading `doc->fieldExpirations` *after* `doAssignIds` had already moved the array into the spec's `TimeToLiveTable` via `DocTable_UpdateExpiration`.
This PR adds `TimeToLiveTable_GetFieldExpirations` (with an inline `DocTable_GetFieldExpirations` mirror of the existing TTL accessors), and rewrites the indexer call site to fetch a borrowed, read-only view from the TTL table on the non-disk path.

The disk path keeps reading `doc->fieldExpirations` directly because it never moves it.

The pointer is explicitly nulled at both move sites so any future read hits `NULL` instead of dangling memory. `writeMissingFieldDocs` already tolerates `NULL`, so its signature is unchanged.

I also added a new unit test in `tests/cpptests/test_cpp_expire.cpp` to cover the new getter.                

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indexing/TTL ownership and lifetime semantics; mistakes could cause memory leaks or incorrect missing-field indexing, though changes are localized and covered by a new unit test.
> 
> **Overview**
> Fixes an ownership/use-after-move bug for field-level TTLs during indexing by **treating `Document::fieldExpirations` as transferred** into the DocTable/TTL table after `DocTable_UpdateExpiration`, nulling the pointer and ensuring `Document_Free` releases it only on failure paths.
> 
> Adds a borrowed-read API (`TimeToLiveTable_GetFieldExpirations` + `DocTable_GetFieldExpirations`) and updates `Indexer_Process` to re-fetch field expirations from the TTL table (non-disk path) when indexing missing-field docs. Includes a new C++ unit test covering the TTL getter’s aliasing/NULL semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dbf8e59fdc41c48cb9361333b6bd3700dd65d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->