### PR TITLE
tests(benchmarks): expire/persist coverage + group metadata

### DIFF
--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -7,6 +7,8 @@ description: |
 
 metadata:
   component: "search"
+  group: "expire-persist"
+  use_case: "PEXPIRE fast path on indexed hashes (5/95 write ratio, lazy expiration)"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -8,7 +8,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "PEXPIRE fast path on indexed hashes (5/95 write ratio, lazy expiration)"
+  use_case: "PEXPIRE fast path on indexed hashes 5-95 write ratio lazy expiration"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-doc-1000-seconds.yml
@@ -8,7 +8,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "EXPIRE fast path on indexed hashes (10/90 write ratio, long TTL — keys never actually expire)"
+  use_case: "EXPIRE fast path on indexed hashes 10-90 write ratio long TTL keys never actually expire"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-doc-1000-seconds.yml
@@ -7,6 +7,8 @@ description: |
 
 metadata:
   component: "search"
+  group: "expire-persist"
+  use_case: "EXPIRE fast path on indexed hashes (10/90 write ratio, long TTL — keys never actually expire)"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-doc-50-50-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-50-50-10-milliseconds.yml
@@ -1,0 +1,39 @@
+version: 0.2
+name: "search-expire-doc-50-50-10-milliseconds"
+description: |
+  High write-ratio variant of search-expire-doc-10-milliseconds. Splits load
+  50/50 between FT.SEARCH and PEXPIRE so the doc-expiration fast path
+  dominates the workload — any throughput delta from
+  Indexes_UpdateMatchingDocExpiration (or any regression in the
+  notification-routing branch in OnKeySpaceNotification) shows up well above
+  the variance floor.
+
+  Active expiration is disabled so keys stay in the dataset and every PEXPIRE
+  is a pure TTL-only metadata update. Search side is a deterministic
+  catch-all to keep latency tight and re-triggers stable (>1000 QPS).
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "PEXPIRE fast path under high write ratio (50/50) — signal amplification for regression detection"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-50-50-10ms"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 * NOCONTENT LIMIT 0 1' --command-ratio 50 --command 'PEXPIRE __key__ 10' --command-ratio 50"

--- a/tests/benchmarks/search-expire-doc-50-50-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-50-50-10-milliseconds.yml
@@ -15,7 +15,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "PEXPIRE fast path under high write ratio (50/50) — signal amplification for regression detection"
+  use_case: "PEXPIRE fast path under high write ratio 50-50 signal amplification for regression detection"
 setups:
   - oss-standalone
 

--- a/tests/benchmarks/search-expire-doc-json-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-json-10-milliseconds.yml
@@ -15,7 +15,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "PEXPIRE fast path on JSON documents — covers Document_LoadSchemaFieldJson side of GetKeyExpirationTime"
+  use_case: "PEXPIRE fast path on JSON documents covers Document_LoadSchemaFieldJson side of GetKeyExpirationTime"
 setups:
   - oss-standalone
 

--- a/tests/benchmarks/search-expire-doc-json-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-json-10-milliseconds.yml
@@ -1,0 +1,38 @@
+version: 0.2
+name: "search-expire-doc-json-10-milliseconds"
+description: |
+  TTL table benchmark for document expiration on JSON documents. Mirrors
+  search-expire-doc-10-milliseconds but stores docs as JSON so the JSON
+  branch of the doc-expiration fast path is exercised
+  (Document_LoadSchemaFieldJson uses the same GetKeyExpirationTime helper
+  as the hash branch after PR #9356).
+
+  Active expiration is disabled so every PEXPIRE is a TTL-only metadata
+  update on the matching DMD; the 10K-doc dataset keeps memory pressure low
+  and re-trigger variance tight. Higher per-thread concurrency (-c 32) is
+  used to drive throughput well above 1000 QPS on the smaller dataset.
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "PEXPIRE fast path on JSON documents — covers Document_LoadSchemaFieldJson side of GetKeyExpirationTime"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "10K-singlevalue-numeric-json-expire-doc-10ms"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/10K-singlevalue-numeric-json/10K-singlevalue-numeric-json.redisjson.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - 'FT.CREATE idx:single ON JSON PREFIX 1 doc:single SCHEMA $.numericInt1 AS numericInt1 NUMERIC $.numericFloat1 AS numericFloat1 NUMERIC $.numericInt2 AS numericInt2 NUMERIC $.numericFloat2 AS numericFloat2 NUMERIC $.numericInt3 AS numericInt3 NUMERIC $.numericFloat3 AS numericFloat3 NUMERIC $.numericInt4 AS numericInt4 NUMERIC $.numericFloat4 AS numericFloat4 NUMERIC $.numericInt5 AS numericInt5 NUMERIC $.numericFloat5 AS numericFloat5 NUMERIC $.numericInt6 AS numericInt6 NUMERIC $.numericFloat6 AS numericFloat6 NUMERIC $.numericInt7 AS numericInt7 NUMERIC $.numericFloat7 AS numericFloat7 NUMERIC $.numericInt8 AS numericInt8 NUMERIC $.numericFloat8 AS numericFloat8 NUMERIC $.numericInt9 AS numericInt9 NUMERIC $.numericFloat9 AS numericFloat9 NUMERIC $.numericInt10 AS numericInt10 NUMERIC $.numericFloat10 AS numericFloat10 NUMERIC'
+  - check:
+      keyspacelen: 10000
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 4 --hide-histogram --key-prefix 'doc:single' --key-minimum 1 --key-maximum 10000 --command 'FT.SEARCH idx:single * NOCONTENT LIMIT 0 1' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"

--- a/tests/benchmarks/search-expire-doc-multi-index-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-multi-index-10-milliseconds.yml
@@ -1,0 +1,46 @@
+version: 0.2
+name: "search-expire-doc-multi-index-10-milliseconds"
+description: |
+  TTL table benchmark for document expiration when multiple indexes share the
+  same key prefix. Three FT indexes on the idx10: prefix all monitor doc-level
+  expiration, so every PEXPIRE notification is fanned out across all three
+  specs.
+
+  Under the old reindex path this means N (=3) full re-tokenizations and
+  inverted-index rewrites per PEXPIRE; under the fast path
+  (Indexes_UpdateMatchingDocExpiration) this collapses to N short
+  DocTable_UpdateExpiration calls. Active expiration is disabled so docs
+  remain in the dataset and the per-spec write-lock fan-out is the dominant
+  observable.
+
+  Search side uses a deterministic catch-all on idx10_a so re-triggers on the
+  same branch produce stable throughput (>1000 QPS); the optimization signal
+  comes from the PEXPIRE × 3-index fan-out.
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "EXPIRE/PEXPIRE fast path with N>1 matching indexes — amplifies the per-spec metadata-update vs full-reindex delta"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-multi-index-10ms"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - '"FT.CREATE" "idx10_a" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+      - '"FT.CREATE" "idx10_b" "PREFIX" "1" "idx10:" "SCHEMA" "field2" "TEXT" "field3" "TEXT"'
+      - '"FT.CREATE" "idx10_c" "PREFIX" "1" "idx10:" "SCHEMA" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC"'
+  - dataset_load_timeout_secs: 240
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10_a * NOCONTENT LIMIT 0 1' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"

--- a/tests/benchmarks/search-expire-doc-multi-index-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-multi-index-10-milliseconds.yml
@@ -20,7 +20,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "EXPIRE/PEXPIRE fast path with N>1 matching indexes — amplifies the per-spec metadata-update vs full-reindex delta"
+  use_case: "EXPIRE PEXPIRE fast path with N greater than 1 matching indexes amplifies the per-spec metadata-update vs full-reindex delta"
 setups:
   - oss-standalone
 

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -8,7 +8,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "Field-level HPEXPIRE (HEXPIRE_CMD path) — negative control for the doc-expiration fast-path PR"
+  use_case: "Field-level HPEXPIRE HEXPIRE_CMD path negative control for the doc-expiration fast-path PR"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -7,6 +7,8 @@ description: |
 
 metadata:
   component: "search"
+  group: "expire-persist"
+  use_case: "Field-level HPEXPIRE (HEXPIRE_CMD path) — negative control for the doc-expiration fast-path PR"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -8,7 +8,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "Field-level HEXPIRE (HEXPIRE_CMD path, long TTL) — negative control for the doc-expiration fast-path PR"
+  use_case: "Field-level HEXPIRE HEXPIRE_CMD path long TTL negative control for the doc-expiration fast-path PR"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -7,6 +7,8 @@ description: |
 
 metadata:
   component: "search"
+  group: "expire-persist"
+  use_case: "Field-level HEXPIRE (HEXPIRE_CMD path, long TTL) — negative control for the doc-expiration fast-path PR"
 setups:
   - oss-standalone
   - oss-cluster-02-primaries

--- a/tests/benchmarks/search-persist-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-persist-doc-1000-seconds.yml
@@ -19,7 +19,7 @@ description: |
 metadata:
   component: "search"
   group: "expire-persist"
-  use_case: "PERSIST keyspace-notification fast path on indexed hashes (in-memory flow)"
+  use_case: "PERSIST keyspace-notification fast path on indexed hashes in-memory flow"
 setups:
   - oss-standalone
 

--- a/tests/benchmarks/search-persist-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-persist-doc-1000-seconds.yml
@@ -1,0 +1,43 @@
+version: 0.2
+name: "search-persist-doc-1000-seconds"
+description: |
+  TTL table benchmark exercising the PERSIST keyspace-notification path on
+  indexed hash documents. Each PERSIST clears the key's absolute expiration;
+  in the in-memory flow this is routed through the doc-expiration fast path
+  (Indexes_UpdateMatchingDocExpiration) instead of a full reindex.
+
+  Keeps both the SET-TTL (EXPIRE) and CLEAR-TTL (PERSIST) branches busy with
+  symmetric ratios (5%/5%) on top of a search-dominant load. Active expiration
+  is disabled and TTL=1000s so the dataset never evicts during the 180s test;
+  every notification is a pure metadata update on the matching DMD, which is
+  the property we want to keep stable across re-triggers.
+
+  Search side uses a deterministic catch-all (`FT.SEARCH idx10 * NOCONTENT
+  LIMIT 0 1`) to keep query latency tight (low variance) and push throughput
+  well above 1000 QPS.
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "PERSIST keyspace-notification fast path on indexed hashes (in-memory flow)"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-persist-doc-1000s"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 * NOCONTENT LIMIT 0 1' --command-ratio 90 --command 'EXPIRE __key__ 1000' --command-ratio 5 --command 'PERSIST __key__' --command-ratio 5"


### PR DESCRIPTION
## Summary

Extend the expire/persist benchmark group so PR #9356 (doc-expiration fast path) — and any future change to the `expire_cmd` / `persist_cmd` notification branches — can be evaluated for both improvements and regressions on the existing on-the-fly EC2 infrastructure.

### Adds 4 new specs (all `oss-standalone` only)

| Spec | Why it exists |
|------|---------------|
| `search-persist-doc-1000-seconds.yml` | `PERSIST` was previously unbenched; this exercises the PERSIST branch of `OnKeySpaceNotification` and the matching fast path. |
| `search-expire-doc-multi-index-10-milliseconds.yml` | Three FT indexes on the same prefix — amplifies the per-spec fan-out delta between full reindex and the metadata-only path. |
| `search-expire-doc-50-50-10-milliseconds.yml` | 50/50 write/read ratio so PEXPIRE-driven work dominates the workload — clean signal well above the variance floor. |
| `search-expire-doc-json-10-milliseconds.yml` | JSON path coverage for `Document_LoadSchemaFieldJson` and the shared `GetKeyExpirationTime` helper. |

All four:
- use a deterministic catch-all `FT.SEARCH * NOCONTENT LIMIT 0 1` so query latency is tight and re-triggers on the same branch produce stable throughput,
- run with `DEBUG SET-ACTIVE-EXPIRE 0` so the dataset never evicts during the test (the fast path is exercised purely as a metadata update),
- use `-c 16 -t 4` (or `-c 32 -t 4` for the 10K JSON dataset) to sustain ≥1000 QPS.

### Adds metadata grouping (8 files)

Adds `metadata.group: "expire-persist"` and a per-spec `use_case` string to all eight expire/persist specs (the four new ones plus the four existing `search-expire-{doc,numeric-field}-{10-milliseconds,1000-seconds}.yml`). No behavioral changes to the existing specs — only metadata. The numeric-field specs serve as **negative controls** for the doc-expiration fast path (they exercise `hexpire_cmd`, which is not on the changed code path).

### Why a separate PR from #9356

These specs are evaluation infrastructure — they need to land independently of the optimization being measured so baseline numbers can be produced from `master` before #9356 merges.

## Test plan

- [ ] `redisbench-admin run-remote` against this branch on `oss-standalone` for each new spec — confirm ≥1000 QPS and <5% CV across 3 datapoints.
- [ ] `redisbench-admin compare` master-baseline vs PR #9356 head on the four doc-level specs (existing + new) — should show improvement on the doc-expiration fast path.
- [ ] Same comparison on the two numeric-field specs — should stay flat (negative-control sanity check).
- [ ] `--enable-profilers PROFILE=1` on `search-expire-doc-multi-index-10-milliseconds` to verify the per-spec write-lock pattern in `Indexes_UpdateMatchingDocExpiration` is not contended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to benchmark YAML specs (metadata and new workloads) with no production code impact.
> 
> **Overview**
> Adds `metadata.group: "expire-persist"` and a descriptive `use_case` field to the existing expire benchmarks so they can be consistently grouped and understood in reporting.
> 
> Introduces four new `oss-standalone` benchmark specs to broaden expire/persist coverage: a `PERSIST` notification workload, a high write-ratio `PEXPIRE` workload, a multi-index fan-out `PEXPIRE` workload, and a JSON document `PEXPIRE` workload (all using deterministic `FT.SEARCH` patterns and disabled active expiration for stable signal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d14d1a2f51eeca56c350f7eba61c2883b16539d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->