### PR TITLE
redis_reply: add string buffer and raw APIs

### DIFF
--- a/src/redisearch_rs/redis_mock/src/lib.rs
+++ b/src/redisearch_rs/redis_mock/src/lib.rs
@@ -228,6 +228,10 @@ pub fn init_redis_module_mock() {
             Some(RedisModule_ReplyWithSimpleString)
     };
     unsafe {
+        redis_module::raw::RedisModule_ReplyWithStringBuffer =
+            Some(RedisModule_ReplyWithStringBuffer)
+    };
+    unsafe {
         redis_module::raw::RedisModule_ReplyWithEmptyArray = Some(RedisModule_ReplyWithEmptyArray)
     };
     unsafe { redis_module::raw::RedisModule_ReplyWithArray = Some(RedisModule_ReplyWithArray) };

--- a/src/redisearch_rs/redis_mock/src/reply/c_functions.rs
+++ b/src/redisearch_rs/redis_mock/src/reply/c_functions.rs
@@ -65,6 +65,26 @@ pub unsafe extern "C" fn RedisModule_ReplyWithSimpleString(
     ffi::REDISMODULE_OK as c_int
 }
 
+/// Mock implementation of `RedisModule_ReplyWithStringBuffer`.
+///
+/// # Safety
+///
+/// The `buf` pointer must be valid for `len` bytes.
+#[expect(non_snake_case)]
+pub unsafe extern "C" fn RedisModule_ReplyWithStringBuffer(
+    _ctx: *mut RedisModuleCtx,
+    buf: *const c_char,
+    len: usize,
+) -> c_int {
+    // SAFETY: Caller guarantees buf is valid for len bytes.
+    let bytes = unsafe { std::slice::from_raw_parts(buf.cast::<u8>(), len) };
+    let s = String::from_utf8_lossy(bytes).into_owned();
+    CAPTURE_STATE.with(|state| {
+        state.borrow_mut().push_value(ReplyValue::StringBuffer(s));
+    });
+    ffi::REDISMODULE_OK as c_int
+}
+
 /// Mock implementation of `RedisModule_ReplyWithEmptyArray`.
 ///
 /// # Safety

--- a/src/redisearch_rs/redis_mock/src/reply/value.rs
+++ b/src/redisearch_rs/redis_mock/src/reply/value.rs
@@ -20,6 +20,8 @@ pub enum ReplyValue {
     Double(f64),
     /// A simple string reply.
     SimpleString(String),
+    /// A string buffer (bulk string) reply.
+    StringBuffer(String),
     /// An array reply containing zero or more values.
     Array(Vec<ReplyValue>),
     /// A map reply containing key-value pairs.
@@ -36,6 +38,7 @@ impl ReplyValue {
             ReplyValue::LongLong(n) => format!("{n}"),
             ReplyValue::Double(d) => format!("{d}"),
             ReplyValue::SimpleString(s) => format!("{s:?}"),
+            ReplyValue::StringBuffer(s) => format!("b{s:?}"),
             ReplyValue::Array(elements) => {
                 let inner: Vec<String> = elements.iter().map(|e| e.format_compact()).collect();
                 format!("[{}]", inner.join(", "))
@@ -72,6 +75,7 @@ impl fmt::Debug for ReplyValue {
                     ReplyValue::LongLong(n) => write!(self.f, "{n}"),
                     ReplyValue::Double(d) => write!(self.f, "{d}"),
                     ReplyValue::SimpleString(s) => write!(self.f, "{s:?}"),
+                    ReplyValue::StringBuffer(s) => write!(self.f, "b{s:?}"),
                     ReplyValue::Array(elements) => {
                         if elements.is_empty() {
                             write!(self.f, "[]")

--- a/src/redisearch_rs/redis_reply/src/array.rs
+++ b/src/redisearch_rs/redis_reply/src/array.rs
@@ -51,6 +51,12 @@ impl ArrayBuilder<'_> {
         self.len += 1;
     }
 
+    /// Add a string buffer (bulk string) to the array.
+    pub fn string_buffer(&mut self, buf: &[u8]) {
+        self.replier.string_buffer(buf);
+        self.len += 1;
+    }
+
     /// Add an empty array to the array.
     pub fn empty_array(&mut self) {
         self.replier.empty_array();

--- a/src/redisearch_rs/redis_reply/src/map.rs
+++ b/src/redisearch_rs/redis_reply/src/map.rs
@@ -35,6 +35,20 @@ pub struct MapBuilder<'a> {
 }
 
 impl MapBuilder<'_> {
+    /// Add a key-value pair where the value is a simple string.
+    pub fn kv_simple_string(&mut self, key: &CStr, value: &CStr) {
+        self.replier.simple_string(key);
+        self.replier.simple_string(value);
+        self.len += 1;
+    }
+
+    /// Add a key-value pair where the value is a string buffer (bulk string).
+    pub fn kv_string_buffer(&mut self, key: &CStr, value: &[u8]) {
+        self.replier.simple_string(key);
+        self.replier.string_buffer(value);
+        self.len += 1;
+    }
+
     /// Add a key-value pair where the value is a 64-bit signed integer.
     pub fn kv_long_long(&mut self, key: &CStr, value: i64) {
         self.replier.simple_string(key);

--- a/src/redisearch_rs/redis_reply/src/replier.rs
+++ b/src/redisearch_rs/redis_reply/src/replier.rs
@@ -12,7 +12,7 @@ use std::ffi::CStr;
 use ffi::{
     REDISMODULE_POSTPONED_ARRAY_LEN, REDISMODULE_POSTPONED_LEN, RedisModule_ReplyWithArray,
     RedisModule_ReplyWithDouble, RedisModule_ReplyWithEmptyArray, RedisModule_ReplyWithLongLong,
-    RedisModule_ReplyWithMap, RedisModule_ReplyWithSimpleString,
+    RedisModule_ReplyWithMap, RedisModule_ReplyWithSimpleString, RedisModule_ReplyWithStringBuffer,
 };
 
 pub use ffi::RedisModuleCtx;
@@ -62,6 +62,18 @@ impl Replier {
             RedisModule_ReplyWithSimpleString.expect("RedisModule_ReplyWithSimpleString")(
                 self.ctx,
                 s.as_ptr(),
+            );
+        }
+    }
+
+    /// Reply with a string buffer (bulk string).
+    pub fn string_buffer(&mut self, buf: &[u8]) {
+        // SAFETY: ctx is validated at construction
+        unsafe {
+            RedisModule_ReplyWithStringBuffer.expect("RedisModule_ReplyWithStringBuffer")(
+                self.ctx,
+                buf.as_ptr().cast(),
+                buf.len(),
             );
         }
     }

--- a/src/redisearch_rs/redis_reply/tests/integration/array.rs
+++ b/src/redisearch_rs/redis_reply/tests/integration/array.rs
@@ -46,6 +46,29 @@ fn test_array_builder_mixed_types() {
 }
 
 #[test]
+fn test_array_builder_string_buffer() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        let mut arr = replier.array();
+        arr.string_buffer(b"hello");
+        arr.string_buffer(b"world");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"[b"hello", b"world"]"#);
+}
+
+#[test]
+fn test_array_builder_string_buffer_mixed() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        let mut arr = replier.array();
+        arr.long_long(1);
+        arr.string_buffer(b"text");
+        arr.simple_string(c"simple");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"[1, b"text", "simple"]"#);
+}
+
+#[test]
 fn test_array_builder_empty_array_element() {
     let mut replier = init();
     let reply = capture_single_reply(|| {

--- a/src/redisearch_rs/redis_reply/tests/integration/map.rs
+++ b/src/redisearch_rs/redis_reply/tests/integration/map.rs
@@ -33,6 +33,38 @@ fn test_map_builder_empty() {
 }
 
 #[test]
+fn test_map_kv_simple_string() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        let mut map = replier.map();
+        map.kv_simple_string(c"Type", c"NUMERIC");
+        map.kv_simple_string(c"Term", c"0 - 100");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"{"Type": "NUMERIC", "Term": "0 - 100"}"#);
+}
+
+#[test]
+fn test_map_kv_string_buffer() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        let mut map = replier.map();
+        map.kv_string_buffer(c"Field", b"my_field");
+        map.kv_long_long(c"count", 5);
+    });
+    insta::assert_debug_snapshot!(reply, @r#"{"Field": b"my_field", "count": 5}"#);
+}
+
+#[test]
+fn test_map_kv_string_buffer_empty() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        let mut map = replier.map();
+        map.kv_string_buffer(c"data", b"");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"{"data": b""}"#);
+}
+
+#[test]
 fn test_map_with_nested_array() {
     let mut replier = init();
     let reply = capture_single_reply(|| {

--- a/src/redisearch_rs/redis_reply/tests/integration/replier.rs
+++ b/src/redisearch_rs/redis_reply/tests/integration/replier.rs
@@ -103,6 +103,33 @@ fn test_replier_simple_string_empty() {
 }
 
 #[test]
+fn test_replier_string_buffer() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        replier.string_buffer(b"hello world");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"b"hello world""#);
+}
+
+#[test]
+fn test_replier_string_buffer_empty() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        replier.string_buffer(b"");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"b"""#);
+}
+
+#[test]
+fn test_replier_string_buffer_binary() {
+    let mut replier = init();
+    let reply = capture_single_reply(|| {
+        replier.string_buffer(b"\x00\x01\x02");
+    });
+    insta::assert_debug_snapshot!(reply, @r#"b"\0\u{1}\u{2}""#);
+}
+
+#[test]
 fn test_replier_empty_array() {
     let mut replier = init();
     let reply = capture_single_reply(|| {


### PR DESCRIPTION
Extending `redis_reply` crate with extra API which will be used to produce `Profile` debug output from Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new reply type and API surface (`string_buffer`, new map/array helpers) that can change reply formatting/behavior and requires correct FFI wiring in the mock and runtime.
> 
> **Overview**
> Adds first-class support for Redis bulk strings via `RedisModule_ReplyWithStringBuffer`, including a new `Replier::string_buffer(&[u8])` API and convenience helpers on `ArrayBuilder` and `MapBuilder` (`string_buffer`, `kv_simple_string`, `kv_string_buffer`).
> 
> Extends the `redis_mock` capture system with a `ReplyValue::StringBuffer` variant plus a mock C implementation/registration, and updates integration snapshots to cover bulk-string replies (including empty and binary data) and new map/array builder helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6f338e45929a979173c3521a0c73f4c6dd9979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->