### PR TITLE
MOD-14805: `FIELDS *` support for shard-side reducer

### DIFF
--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -392,13 +392,6 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
     data.input_key = options->input_key;
   }
 
-  if (data.load_all) {
-    QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS,
-      "COLLECT does not yet support `*` in FIELDS");
-    CollectParseData_Free(&data);
-    return NULL;
-  }
-
   // Rust copies the mode-specific parsed data and wires the vtable.
   Reducer *rbase;
   if (options->is_local) {
@@ -418,7 +411,7 @@ Reducer *RDCRCollect_New(const ReducerOptions *options) {
     rbase = CollectReducer_CreateRemote(
       data.field_keys,
       data.field_keys ? array_len(data.field_keys) : 0,
-      data.load_all,
+      data.load_all ? options->srclookup : NULL,
       data.sort_keys,
       data.sort_keys ? array_len(data.sort_keys) : 0,
       data.sortAscMap,

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "build_utils",
  "bumpalo",
  "ffi",
+ "itertools 0.14.0",
  "query_error",
  "redis_mock",
  "redisearch_rs",

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -30,7 +30,7 @@ use std::{
 ///    `sort_keys_len` [valid] `*const RLookupKey` pointers.
 /// 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
 ///    lifetime of the returned reducer.
-/// 4. `srclookup` is either null (no wildcard) or a [valid] pointer to a
+/// 4. `srclookup` is either null (no load-all) or a [valid] pointer to a
 ///    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the
 ///    returned reducer.
 ///
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn CollectReducer_CreateRemote(
 
     // SAFETY: ensured by caller (4.) — when non-null, `srclookup` outlives
     // the returned reducer. `from_opaque_ptr` maps null to `None`, so the
-    // pointer's nullness is the wildcard-mode signal. The cbindgen rename
+    // pointer's nullness is the load-all-mode signal. The cbindgen rename
     // `OpaqueRLookup → RLookup` makes `*const ffi::RLookup` and
     // `*const OpaqueRLookup` interchangeable at the layout level.
     let srclookup: Option<&RLookup> =
@@ -215,10 +215,10 @@ pub const unsafe extern "C" fn CollectReducer_GetFieldKeysLen(r: *const ffi::Red
 /// `r` must point to a valid [`RemoteCollectReducer`] originally created by
 /// `CollectReducer_CreateRemote`.
 #[unsafe(no_mangle)]
-pub const unsafe extern "C" fn CollectReducer_HasLoadAll(r: *const ffi::Reducer) -> bool {
+pub const unsafe extern "C" fn CollectReducer_IsLoadAll(r: *const ffi::Reducer) -> bool {
     // SAFETY: ensured by caller.
     let r = unsafe { r.cast::<RemoteCollectReducer>().as_ref().unwrap() };
-    r.has_wildcard()
+    r.is_load_all()
 }
 
 /// # Safety

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -10,7 +10,7 @@
 //! Remote COLLECT reducer FFI.
 
 use reducers::collect::{RemoteCollectCtx, RemoteCollectReducer};
-use rlookup::{OpaqueRLookup, RLookup, RLookupKey, RLookupRow};
+use rlookup::{RLookup, RLookupKey, RLookupRow};
 use std::{
     ffi::{c_int, c_void},
     ptr, slice,
@@ -30,7 +30,7 @@ use std::{
 ///    `sort_keys_len` [valid] `*const RLookupKey` pointers.
 /// 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
 ///    lifetime of the returned reducer.
-/// 4. `srclookup` is either null (no load-all) or a [valid] pointer to a
+/// 4. `srclookup` is either null or a [valid] pointer to a
 ///    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the
 ///    returned reducer.
 ///
@@ -64,13 +64,8 @@ pub unsafe extern "C" fn CollectReducer_CreateRemote(
         Box::new([])
     };
 
-    // SAFETY: ensured by caller (4.) — when non-null, `srclookup` outlives
-    // the returned reducer. `from_opaque_ptr` maps null to `None`, so the
-    // pointer's nullness is the load-all-mode signal. The cbindgen rename
-    // `OpaqueRLookup → RLookup` makes `*const ffi::RLookup` and
-    // `*const OpaqueRLookup` interchangeable at the layout level.
-    let srclookup: Option<&RLookup> =
-        unsafe { RLookup::from_opaque_ptr(srclookup.cast::<OpaqueRLookup>()) };
+    // SAFETY: ensured by caller (4.)
+    let srclookup: Option<&RLookup> = unsafe { srclookup.cast::<RLookup>().as_ref() };
 
     let limit = has_limit.then_some((limit_offset, limit_count));
 
@@ -117,10 +112,7 @@ pub unsafe extern "C" fn collectRemoteNewInstance(r: *mut ffi::Reducer) -> *mut 
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn collectRemoteFreeInstance(_r: *mut ffi::Reducer, ctx: *mut c_void) {
-    // SAFETY: ensured by caller (1.) — `ctx` points to a valid, initialized
-    // `RemoteCollectCtx`. After this call the pointee is logically uninitialized,
-    // but the arena memory is freed later when `RemoteCollectReducer` (and its
-    // `Bump`) is dropped.
+    // SAFETY: ensured by caller (1.)
     unsafe { ptr::drop_in_place(ctx.cast::<RemoteCollectCtx>()) }
 }
 
@@ -184,8 +176,7 @@ pub unsafe extern "C" fn collectRemoteFinalize(
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn collectRemoteFree(r: *mut ffi::Reducer) {
-    // SAFETY: ensured by caller (1.); `r` originates from `Box::into_raw` of a
-    // `Box<RemoteCollectReducer>` and is still owned by C, so we can reclaim it here.
+    // SAFETY: ensured by caller (1.)
     drop(unsafe { Box::from_raw(r.cast::<RemoteCollectReducer>()) });
 }
 

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -10,7 +10,7 @@
 //! Remote COLLECT reducer FFI.
 
 use reducers::collect::{RemoteCollectCtx, RemoteCollectReducer};
-use rlookup::{RLookupKey, RLookupRow};
+use rlookup::{OpaqueRLookup, RLookup, RLookupKey, RLookupRow};
 use std::{
     ffi::{c_int, c_void},
     ptr, slice,
@@ -30,13 +30,16 @@ use std::{
 ///    `sort_keys_len` [valid] `*const RLookupKey` pointers.
 /// 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
 ///    lifetime of the returned reducer.
+/// 4. `srclookup` is either null (no wildcard) or a [valid] pointer to a
+///    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the
+///    returned reducer.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn CollectReducer_CreateRemote(
     field_keys: *const *const ffi::RLookupKey,
     field_keys_len: usize,
-    load_all: bool,
+    srclookup: *const ffi::RLookup,
     sort_keys: *const *const ffi::RLookupKey,
     sort_keys_len: usize,
     sort_asc_map: u64,
@@ -61,11 +64,19 @@ pub unsafe extern "C" fn CollectReducer_CreateRemote(
         Box::new([])
     };
 
+    // SAFETY: ensured by caller (4.) — when non-null, `srclookup` outlives
+    // the returned reducer. `from_opaque_ptr` maps null to `None`, so the
+    // pointer's nullness is the wildcard-mode signal. The cbindgen rename
+    // `OpaqueRLookup → RLookup` makes `*const ffi::RLookup` and
+    // `*const OpaqueRLookup` interchangeable at the layout level.
+    let srclookup: Option<&RLookup> =
+        unsafe { RLookup::from_opaque_ptr(srclookup.cast::<OpaqueRLookup>()) };
+
     let limit = has_limit.then_some((limit_offset, limit_count));
 
     let mut cr = Box::new(RemoteCollectReducer::new(
         field_keys,
-        load_all,
+        srclookup,
         sort_keys,
         sort_asc_map,
         limit,
@@ -207,7 +218,7 @@ pub const unsafe extern "C" fn CollectReducer_GetFieldKeysLen(r: *const ffi::Red
 pub const unsafe extern "C" fn CollectReducer_HasLoadAll(r: *const ffi::Reducer) -> bool {
     // SAFETY: ensured by caller.
     let r = unsafe { r.cast::<RemoteCollectReducer>().as_ref().unwrap() };
-    r.load_all()
+    r.has_wildcard()
 }
 
 /// # Safety

--- a/src/redisearch_rs/headers/reducers_rs.h
+++ b/src/redisearch_rs/headers/reducers_rs.h
@@ -100,7 +100,7 @@ void collectLocalFree(Reducer *r);
  *    `sort_keys_len` [valid] `*const RLookupKey` pointers.
  * 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
  *    lifetime of the returned reducer.
- * 4. `srclookup` is either null (no wildcard) or a [valid] pointer to a
+ * 4. `srclookup` is either null (no load-all) or a [valid] pointer to a
  *    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the
  *    returned reducer.
  *
@@ -192,7 +192,7 @@ uintptr_t CollectReducer_GetFieldKeysLen(const Reducer *r);
  * `r` must point to a valid [`RemoteCollectReducer`] originally created by
  * `CollectReducer_CreateRemote`.
  */
-bool CollectReducer_HasLoadAll(const Reducer *r);
+bool CollectReducer_IsLoadAll(const Reducer *r);
 
 /**
  * # Safety

--- a/src/redisearch_rs/headers/reducers_rs.h
+++ b/src/redisearch_rs/headers/reducers_rs.h
@@ -100,7 +100,7 @@ void collectLocalFree(Reducer *r);
  *    `sort_keys_len` [valid] `*const RLookupKey` pointers.
  * 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
  *    lifetime of the returned reducer.
- * 4. `srclookup` is either null (no load-all) or a [valid] pointer to a
+ * 4. `srclookup` is either null or a [valid] pointer to a
  *    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the
  *    returned reducer.
  *

--- a/src/redisearch_rs/headers/reducers_rs.h
+++ b/src/redisearch_rs/headers/reducers_rs.h
@@ -100,12 +100,15 @@ void collectLocalFree(Reducer *r);
  *    `sort_keys_len` [valid] `*const RLookupKey` pointers.
  * 3. All [`RLookupKey`][ffi::RLookupKey] pointers must remain valid for the
  *    lifetime of the returned reducer.
+ * 4. `srclookup` is either null (no wildcard) or a [valid] pointer to a
+ *    [`RLookup`][ffi::RLookup] that remains alive for the lifetime of the
+ *    returned reducer.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 Reducer *CollectReducer_CreateRemote(const RLookupKey *const *field_keys,
                                      uintptr_t field_keys_len,
-                                     bool load_all,
+                                     const RLookup *srclookup,
                                      const RLookupKey *const *sort_keys,
                                      uintptr_t sort_keys_len,
                                      uint64_t sort_asc_map,

--- a/src/redisearch_rs/reducers/Cargo.toml
+++ b/src/redisearch_rs/reducers/Cargo.toml
@@ -11,6 +11,7 @@ unittest = []
 [dependencies]
 bumpalo.workspace = true
 ffi.workspace = true
+itertools.workspace = true
 query_error.workspace = true
 rlookup.workspace = true
 value.workspace = true

--- a/src/redisearch_rs/reducers/src/collect/common.rs
+++ b/src/redisearch_rs/reducers/src/collect/common.rs
@@ -10,8 +10,7 @@
 //! Shared COLLECT reducer state and utilities.
 
 use bumpalo::Bump;
-use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
-use value::SharedValue;
+use rlookup::{RLookup, RLookupKey, RLookupKeyFlag};
 
 use crate::Reducer;
 
@@ -42,24 +41,15 @@ impl CollectCommon {
     }
 }
 
-/// Walk `lookup` in insertion order, invoking `f` for every *visible* key
-/// that has a value in `row`.
+/// Walk `lookup` in insertion order, yielding every *visible* key.
 ///
-/// "Visible" means [`RLookupKey::is_tombstone`] is `false` and the key
-/// is not flagged [`RLookupKeyFlag::Hidden`] — the `FIELDS *` projection
-/// rule.
-pub(super) fn for_each_visible_value<'a, F>(lookup: &RLookup<'a>, row: &RLookupRow<'_>, mut f: F)
-where
-    F: FnMut(&RLookupKey<'a>, &SharedValue),
-{
-    let mut cursor = lookup.cursor();
-    while let Some(key) = cursor.current() {
-        if !key.is_tombstone()
-            && !key.flags.contains(RLookupKeyFlag::Hidden)
-            && let Some(v) = row.get(key)
-        {
-            f(key, v);
-        }
-        cursor.move_next();
-    }
+/// "Visible" means the key is not flagged [`RLookupKeyFlag::Hidden`] —
+/// the `FIELDS *` projection rule. Tombstones are already skipped by
+/// [`RLookup::iter`].
+pub(super) fn visible_keys<'l, 'a>(
+    lookup: &'l RLookup<'a>,
+) -> impl Iterator<Item = &'l RLookupKey<'a>> {
+    lookup
+        .iter()
+        .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden))
 }

--- a/src/redisearch_rs/reducers/src/collect/common.rs
+++ b/src/redisearch_rs/reducers/src/collect/common.rs
@@ -10,7 +10,6 @@
 //! Shared COLLECT reducer state and utilities.
 
 use bumpalo::Bump;
-use rlookup::{RLookup, RLookupKey, RLookupKeyFlag};
 
 use crate::Reducer;
 
@@ -41,15 +40,3 @@ impl CollectCommon {
     }
 }
 
-/// Walk `lookup` in insertion order, yielding every *visible* key.
-///
-/// "Visible" means the key is not flagged [`RLookupKeyFlag::Hidden`] —
-/// the `FIELDS *` projection rule. Tombstones are already skipped by
-/// [`RLookup::iter`].
-pub(super) fn visible_keys<'l, 'a>(
-    lookup: &'l RLookup<'a>,
-) -> impl Iterator<Item = &'l RLookupKey<'a>> {
-    lookup
-        .iter()
-        .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden))
-}

--- a/src/redisearch_rs/reducers/src/collect/common.rs
+++ b/src/redisearch_rs/reducers/src/collect/common.rs
@@ -39,4 +39,3 @@ impl CollectCommon {
         }
     }
 }
-

--- a/src/redisearch_rs/reducers/src/collect/common.rs
+++ b/src/redisearch_rs/reducers/src/collect/common.rs
@@ -7,9 +7,11 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Shared COLLECT reducer state.
+//! Shared COLLECT reducer state and utilities.
 
 use bumpalo::Bump;
+use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
+use value::SharedValue;
 
 use crate::Reducer;
 
@@ -37,5 +39,27 @@ impl CollectCommon {
             sort_asc_map,
             limit,
         }
+    }
+}
+
+/// Walk `lookup` in insertion order, invoking `f` for every *visible* key
+/// that has a value in `row`.
+///
+/// "Visible" means [`RLookupKey::is_tombstone`] is `false` and the key
+/// is not flagged [`RLookupKeyFlag::Hidden`] — the `FIELDS *` projection
+/// rule.
+pub(super) fn for_each_visible_value<'a, F>(lookup: &RLookup<'a>, row: &RLookupRow<'_>, mut f: F)
+where
+    F: FnMut(&RLookupKey<'a>, &SharedValue),
+{
+    let mut cursor = lookup.cursor();
+    while let Some(key) = cursor.current() {
+        if !key.is_tombstone()
+            && !key.flags.contains(RLookupKeyFlag::Hidden)
+            && let Some(v) = row.get(key)
+        {
+            f(key, v);
+        }
+        cursor.move_next();
     }
 }

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -119,20 +119,15 @@ impl LocalCollectCtx {
                     .field_names
                     .iter()
                     .map(|name| {
-                        // Missing field → null. `finalize` is infallible by contract
-                        // (the C caller passes the result straight to `RLookup_WriteOwnKey`
-                        // with no error branch), matching the C convention of
+                        // Missing field → null, matching the C convention of
                         // `RSValue_NullStatic()` for absent fields.
                         let val = match &*entry {
-                            Value::Map(m) => {
-                                m.get(name).cloned().unwrap_or_else(SharedValue::null_static)
-                            }
-                            Value::Array(a) => {
-                                a.map_get(name).cloned().unwrap_or_else(SharedValue::null_static)
-                            }
+                            Value::Map(m) => m.get(name).cloned(),
+                            Value::Array(a) => a.map_get(name).cloned(),
                             // Filtered above; only `Map` and `Array` reach here.
                             _ => unreachable!(),
-                        };
+                        }
+                        .unwrap_or_else(SharedValue::null_static);
                         (SharedValue::new_string(name.to_vec()), val)
                     })
                     .collect();

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -23,7 +23,7 @@
 //!
 //! Remote reducers emit each row as `Map` (RESP3) or flat `[k, v, ...]` `Array`
 //! (RESP2). The local reducer projects only requested field names; extra
-//! internal sort-key values are ignored, and missing fields become nulls.
+//! internal sort-key values are ignored, and missing fields are omitted.
 
 use std::mem;
 
@@ -118,17 +118,14 @@ impl LocalCollectCtx {
                 let row_entries: Vec<_> = r
                     .field_names
                     .iter()
-                    .map(|name| {
-                        // Missing field → null, matching the C convention of
-                        // `RSValue_NullStatic()` for absent fields.
+                    .filter_map(|name| {
                         let val = match &*entry {
                             Value::Map(m) => m.get(name).cloned(),
                             Value::Array(a) => a.map_get(name).cloned(),
                             // Filtered above; only `Map` and `Array` reach here.
                             _ => unreachable!(),
-                        }
-                        .unwrap_or_else(SharedValue::null_static);
-                        (SharedValue::new_string(name.to_vec()), val)
+                        }?;
+                        Some((SharedValue::new_string(name.to_vec()), val))
                     })
                     .collect();
                 SharedValue::new_map(row_entries)

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -119,13 +119,20 @@ impl LocalCollectCtx {
                     .field_names
                     .iter()
                     .map(|name| {
+                        // Missing field → null. `finalize` is infallible by contract
+                        // (the C caller passes the result straight to `RLookup_WriteOwnKey`
+                        // with no error branch), matching the C convention of
+                        // `RSValue_NullStatic()` for absent fields.
                         let val = match &*entry {
-                            Value::Map(m) => m.get(name).cloned(),
-                            Value::Array(a) => a.map_get(name).cloned(),
+                            Value::Map(m) => {
+                                m.get(name).cloned().unwrap_or_else(SharedValue::null_static)
+                            }
+                            Value::Array(a) => {
+                                a.map_get(name).cloned().unwrap_or_else(SharedValue::null_static)
+                            }
                             // Filtered above; only `Map` and `Array` reach here.
                             _ => unreachable!(),
-                        }
-                        .unwrap_or_else(SharedValue::null_static);
+                        };
                         (SharedValue::new_string(name.to_vec()), val)
                     })
                     .collect();

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -38,14 +38,14 @@ pub struct RemoteCollectReducer<'a> {
     field_keys: Box<[&'a RLookupKey<'a>]>,
     /// [`Some`] when `FIELDS *` was specified at parse time.
     ///
-    /// In wildcard mode both [`RemoteCollectCtx::add`] and
+    /// In load-all mode both [`RemoteCollectCtx::add`] and
     /// [`RemoteCollectCtx::finalize`] walk this lookup *live* on every
     /// invocation, filtering tombstones and keys flagged
     /// [`RLookupKeyFlag::Hidden`]. The
     /// per-call walk is required because an upstream `LOAD *` may append
     /// keys mid-pipeline; caching the iteration result would silently lose
     /// them. This mirrors the per-row `RLOOKUP_FOREACH` pattern in
-    /// `aggregate_exec.c`'s wildcard reply path.
+    /// `aggregate_exec.c`'s load-all reply path.
     ///
     /// The borrow lives for the reducer's full lifetime; both the source
     /// [`RLookup`] and the reducer outlive every per-group
@@ -56,7 +56,7 @@ pub struct RemoteCollectReducer<'a> {
     /// `true` for shard replies dispatched by the coordinator: extra sort-key
     /// columns are emitted alongside the requested fields so the coordinator
     /// can re-order shard rows during merge. `false` for direct execution.
-    /// No-op in wildcard mode — the [`srclookup`][Self::srclookup] live walk
+    /// No-op in load-all mode — the [`srclookup`][Self::srclookup] live walk
     /// emits whatever is currently in the lookup regardless of this flag,
     /// since sort keys are always registered in the source lookup at parse
     /// time.
@@ -85,7 +85,7 @@ impl<'a> RemoteCollectReducer<'a> {
     /// Create a reducer from C-parsed configuration.
     ///
     /// `srclookup` is [`Some`] when the user wrote `FIELDS *`;
-    /// see [`Self::srclookup`] for the wildcard-mode policy. The borrow ties
+    /// see [`Self::srclookup`] for the load-all-mode policy. The borrow ties
     /// the reducer to the request's source lookup, whose stable address is
     /// guaranteed by the parser holding `options->srclookup` for the
     /// reducer's entire lifetime.
@@ -124,7 +124,7 @@ impl<'a> RemoteCollectReducer<'a> {
         self.field_keys.len()
     }
 
-    pub const fn has_wildcard(&self) -> bool {
+    pub const fn is_load_all(&self) -> bool {
         self.srclookup.is_some()
     }
 
@@ -199,7 +199,7 @@ impl<'a> RemoteCollectCtx<'a> {
             // references borrowed from itself, so the explicit-fields path's
             // pre-built template (with hoisted name allocations) cannot be
             // expressed without unsafe — and hoisting matters less here
-            // anyway, since the wildcard key set varies per row (a hoisted
+            // anyway, since the load-all key set varies per row (a hoisted
             // name might not even be emitted for some rows).
             SharedValue::new_array(rows.into_iter().map(|row| {
                 let mut entries: Vec<(SharedValue, SharedValue)> = Vec::new();

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -14,9 +14,6 @@
 //! execution it is used for the shard-side half of the innermost split
 //! `GROUPBY`, where it serializes collected items into a payload for the
 //! coordinator-side COLLECT reducer.
-//!
-//! Coordinator-side outer `GROUPBY` steps also see ordinary rows/items; they are
-//! not this reducer's special merge input.
 
 use std::collections::HashSet;
 use std::mem;
@@ -36,29 +33,21 @@ use crate::collect::common::{CollectCommon, for_each_visible_value};
 pub struct RemoteCollectReducer<'a> {
     common: CollectCommon,
     field_keys: Box<[&'a RLookupKey<'a>]>,
-    /// [`Some`] when `FIELDS *` was specified at parse time.
+    /// Source lookup for `FIELDS *` mode (a.k.a. *load-all*).
     ///
-    /// In load-all mode both [`RemoteCollectCtx::add`] and
-    /// [`RemoteCollectCtx::finalize`] walk this lookup *live* on every
-    /// invocation via [`for_each_visible_value`]. The per-call walk is
-    /// required because an upstream `LOAD *` may append keys
-    /// mid-pipeline; caching the iteration result would silently lose
-    /// them. This mirrors the per-row `RLOOKUP_FOREACH` pattern in
-    /// `aggregate_exec.c`'s load-all reply path.
+    /// `Some` when the user wrote `FIELDS *`; the projection then emits
+    /// every visible key present on the row (see
+    /// [`for_each_visible_value`]), walked per call.
     ///
-    /// The borrow lives for the reducer's full lifetime; both the source
-    /// [`RLookup`] and the reducer outlive every per-group
-    /// [`RemoteCollectCtx`].
+    /// The walk runs per `add()` call rather than once at construction because an
+    /// upstream `LOAD *` may append keys mid-pipeline.
     srclookup: Option<&'a RLookup<'a>>,
     /// Raw sort-key references, including keys not present in `FIELDS`.
     sort_keys: Box<[&'a RLookupKey<'a>]>,
     /// `true` for shard replies dispatched by the coordinator: extra sort-key
     /// columns are emitted alongside the requested fields so the coordinator
     /// can re-order shard rows during merge. `false` for direct execution.
-    /// No-op in load-all mode — the [`srclookup`][Self::srclookup] live walk
-    /// emits whatever is currently in the lookup regardless of this flag,
-    /// since sort keys are always registered in the source lookup at parse
-    /// time.
+    /// No-op when [`srclookup`][Self::srclookup] is `Some`.
     include_sort_keys: bool,
 }
 
@@ -83,14 +72,11 @@ pub struct RemoteCollectCtx<'a> {
 impl<'a> RemoteCollectReducer<'a> {
     /// Create a reducer from C-parsed configuration.
     ///
-    /// `srclookup` is [`Some`] when the user wrote `FIELDS *`;
-    /// see [`Self::srclookup`] for the load-all-mode policy. The borrow ties
-    /// the reducer to the request's source lookup, whose stable address is
-    /// guaranteed by the parser holding `options->srclookup` for the
-    /// reducer's entire lifetime.
+    /// `srclookup` is `Some` when the user wrote `FIELDS *`; see
+    /// [`Self::srclookup`] for the load-all-mode policy.
     #[expect(
         rustdoc::private_intra_doc_links,
-        reason = "links to the private srclookup field per docs guidelines"
+        reason = "links to the private srclookup field"
     )]
     pub fn new(
         field_keys: Box<[&'a RLookupKey<'a>]>,
@@ -187,12 +173,6 @@ impl<'a> RemoteCollectCtx<'a> {
         let rows = mem::take(&mut self.rows);
 
         if let Some(lookup) = r.srclookup {
-            // Each row walks the lookup freshly. The cursor hands out
-            // references borrowed from itself, so the explicit-fields path's
-            // pre-built template (with hoisted name allocations) cannot be
-            // expressed without unsafe — and hoisting matters less here
-            // anyway, since the load-all key set varies per row (a hoisted
-            // name might not even be emitted for some rows).
             SharedValue::new_array(rows.into_iter().map(|row| {
                 let mut entries: Vec<(SharedValue, SharedValue)> = Vec::new();
                 for_each_visible_value(lookup, &row, |key, v| {

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -22,7 +22,7 @@ use rlookup::{RLookup, RLookupKey, RLookupRow};
 use value::SharedValue;
 
 use crate::Reducer;
-use crate::collect::common::{CollectCommon, for_each_visible_value};
+use crate::collect::common::{CollectCommon, visible_keys};
 
 /// Remote COLLECT reducer.
 ///
@@ -36,8 +36,8 @@ pub struct RemoteCollectReducer<'a> {
     /// Source lookup for `FIELDS *` mode (a.k.a. *load-all*).
     ///
     /// `Some` when the user wrote `FIELDS *`; the projection then emits
-    /// every visible key present on the row (see
-    /// [`for_each_visible_value`]), walked per call.
+    /// every visible key present on the row (see [`visible_keys`]), walked
+    /// per call.
     ///
     /// The walk runs per `add()` call rather than once at construction because an
     /// upstream `LOAD *` may append keys mid-pipeline.
@@ -140,6 +140,33 @@ impl<'a> RemoteCollectReducer<'a> {
     }
 }
 
+/// Deduplicate `field_keys ++ sort_extras` by [`RLookupKey::dstidx`],
+/// preserving the chained order. A field referenced by `SORTBY` lands in
+/// both inputs but must be emitted only once.
+fn dedup_by_dstidx<'a>(
+    field_keys: &[&'a RLookupKey<'a>],
+    sort_extras: &[&'a RLookupKey<'a>],
+) -> Vec<&'a RLookupKey<'a>> {
+    let mut seen: HashSet<u16> = HashSet::with_capacity(field_keys.len() + sort_extras.len());
+    field_keys
+        .iter()
+        .copied()
+        .chain(sort_extras.iter().copied())
+        .filter(|k| seen.insert(k.dstidx))
+        .collect()
+}
+
+/// Pair each `key` with its name as a reusable [`SharedValue`], hoisting the
+/// allocation out of the per-row loop in [`RemoteCollectCtx::finalize`].
+fn build_template_for_finalize<'a, I>(keys: I) -> Vec<(&'a RLookupKey<'a>, SharedValue)>
+where
+    I: IntoIterator<Item = &'a RLookupKey<'a>>,
+{
+    keys.into_iter()
+        .map(|k| (k, SharedValue::new_string(k.name().to_bytes().to_vec())))
+        .collect()
+}
+
 impl<'a> RemoteCollectCtx<'a> {
     pub const fn new(_r: &RemoteCollectReducer<'a>) -> Self {
         Self { rows: Vec::new() }
@@ -149,74 +176,47 @@ impl<'a> RemoteCollectCtx<'a> {
     /// [`RLookupRow`].
     pub fn add(&mut self, r: &RemoteCollectReducer<'a>, row: &RLookupRow<'_>) {
         let mut dst = RLookupRow::new();
-        if let Some(lookup) = r.srclookup {
-            for_each_visible_value(lookup, row, |key, v| {
+        let mut write_if_present = |key: &RLookupKey<'a>| {
+            if let Some(v) = row.get(key) {
                 dst.write_key(key, v.clone());
-            });
+            }
+        };
+        if let Some(lookup) = r.srclookup {
+            visible_keys(lookup).for_each(&mut write_if_present);
         } else {
-            for key in r.field_keys.iter() {
-                if let Some(v) = row.get(key) {
-                    dst.write_key(key, v.clone());
-                }
-            }
-            for key in r.sort_keys.iter() {
-                if let Some(v) = row.get(key) {
-                    dst.write_key(key, v.clone());
-                }
-            }
+            r.field_keys
+                .iter()
+                .copied()
+                .chain(r.sort_keys.iter().copied())
+                .for_each(&mut write_if_present);
         }
         self.rows.push(dst);
     }
 
-    /// Serialize the buffered rows into a Map.
+    /// Serialize the buffered rows into an array of maps. Keys absent from a
+    /// row are omitted; on the cluster path
+    /// [`LocalCollectCtx::finalize`][crate::collect::local::LocalCollectCtx::finalize]
+    /// null-fills missing requested fields when reconstructing the
+    /// client-facing result.
     pub fn finalize(&mut self, r: &RemoteCollectReducer<'a>) -> SharedValue {
         let rows = mem::take(&mut self.rows);
-
-        if let Some(lookup) = r.srclookup {
-            SharedValue::new_array(rows.into_iter().map(|row| {
-                let mut entries: Vec<(SharedValue, SharedValue)> = Vec::new();
-                for_each_visible_value(lookup, &row, |key, v| {
-                    entries.push((
-                        SharedValue::new_string(key.name().to_bytes().to_vec()),
-                        v.clone(),
-                    ));
-                });
-                SharedValue::new_map(entries)
-            }))
+        let keys: Vec<&RLookupKey<'a>> = if let Some(lookup) = r.srclookup {
+            visible_keys(lookup).collect()
         } else {
             let sort_extras: &[&RLookupKey<'a>] = if r.include_sort_keys {
                 &r.sort_keys
             } else {
                 &[]
             };
-            let mut seen: HashSet<u16> =
-                HashSet::with_capacity(r.field_keys.len() + sort_extras.len());
-            let template: Vec<(&RLookupKey<'a>, SharedValue)> = r
-                .field_keys
+            dedup_by_dstidx(&r.field_keys, sort_extras)
+        };
+        let template = build_template_for_finalize(keys);
+        SharedValue::new_array(rows.into_iter().map(|row| {
+            let entries: Vec<_> = template
                 .iter()
-                .chain(sort_extras)
-                .filter(|key| seen.insert(key.dstidx))
-                .map(|key| {
-                    (
-                        *key,
-                        SharedValue::new_string(key.name().to_bytes().to_vec()),
-                    )
-                })
+                .filter_map(|(key, name)| row.get(key).map(|v| (name.clone(), v.clone())))
                 .collect();
-
-            SharedValue::new_array(rows.into_iter().map(|row| {
-                let entries: Vec<_> = template
-                    .iter()
-                    .map(|(key, name)| {
-                        let val = row
-                            .get(key)
-                            .cloned()
-                            .unwrap_or_else(SharedValue::null_static);
-                        (name.clone(), val)
-                    })
-                    .collect();
-                SharedValue::new_map(entries)
-            }))
-        }
+            SharedValue::new_map(entries)
+        }))
     }
 }

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -21,7 +21,7 @@
 use std::collections::HashSet;
 use std::mem;
 
-use rlookup::{RLookupKey, RLookupRow};
+use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
 use value::SharedValue;
 
 use crate::Reducer;
@@ -31,16 +31,35 @@ use crate::collect::common::CollectCommon;
 ///
 /// Must remain `#[repr(C)]` with [`CollectCommon`] at offset 0 so the C layer
 /// can downcast this struct to `ffi::Reducer*` and read the vtable directly.
+#[expect(rustdoc::private_intra_doc_links)]
 #[repr(C)]
 pub struct RemoteCollectReducer<'a> {
     common: CollectCommon,
     field_keys: Box<[&'a RLookupKey<'a>]>,
-    load_all: bool,
+    /// [`Some`] when `FIELDS *` was specified at parse time.
+    ///
+    /// In wildcard mode both [`RemoteCollectCtx::add`] and
+    /// [`RemoteCollectCtx::finalize`] walk this lookup *live* on every
+    /// invocation, filtering tombstones and keys flagged
+    /// [`RLookupKeyFlag::Hidden`]. The
+    /// per-call walk is required because an upstream `LOAD *` may append
+    /// keys mid-pipeline; caching the iteration result would silently lose
+    /// them. This mirrors the per-row `RLOOKUP_FOREACH` pattern in
+    /// `aggregate_exec.c`'s wildcard reply path.
+    ///
+    /// The borrow lives for the reducer's full lifetime; both the source
+    /// [`RLookup`] and the reducer outlive every per-group
+    /// [`RemoteCollectCtx`].
+    srclookup: Option<&'a RLookup<'a>>,
     /// Raw sort-key references, including keys not present in `FIELDS`.
     sort_keys: Box<[&'a RLookupKey<'a>]>,
     /// `true` for shard replies dispatched by the coordinator: extra sort-key
     /// columns are emitted alongside the requested fields so the coordinator
     /// can re-order shard rows during merge. `false` for direct execution.
+    /// No-op in wildcard mode — the [`srclookup`][Self::srclookup] live walk
+    /// emits whatever is currently in the lookup regardless of this flag,
+    /// since sort keys are always registered in the source lookup at parse
+    /// time.
     include_sort_keys: bool,
 }
 
@@ -64,9 +83,19 @@ pub struct RemoteCollectCtx<'a> {
 
 impl<'a> RemoteCollectReducer<'a> {
     /// Create a reducer from C-parsed configuration.
+    ///
+    /// `srclookup` is [`Some`] when the user wrote `FIELDS *`;
+    /// see [`Self::srclookup`] for the wildcard-mode policy. The borrow ties
+    /// the reducer to the request's source lookup, whose stable address is
+    /// guaranteed by the parser holding `options->srclookup` for the
+    /// reducer's entire lifetime.
+    #[expect(
+        rustdoc::private_intra_doc_links,
+        reason = "links to the private srclookup field per docs guidelines"
+    )]
     pub fn new(
         field_keys: Box<[&'a RLookupKey<'a>]>,
-        load_all: bool,
+        srclookup: Option<&'a RLookup<'a>>,
         sort_keys: Box<[&'a RLookupKey<'a>]>,
         sort_asc_map: u64,
         limit: Option<(u64, u64)>,
@@ -75,7 +104,7 @@ impl<'a> RemoteCollectReducer<'a> {
         Self {
             common: CollectCommon::new(sort_asc_map, limit),
             field_keys,
-            load_all,
+            srclookup,
             sort_keys,
             include_sort_keys,
         }
@@ -95,8 +124,8 @@ impl<'a> RemoteCollectReducer<'a> {
         self.field_keys.len()
     }
 
-    pub const fn load_all(&self) -> bool {
-        self.load_all
+    pub const fn has_wildcard(&self) -> bool {
+        self.srclookup.is_some()
     }
 
     pub const fn sort_keys_len(&self) -> usize {
@@ -135,14 +164,27 @@ impl<'a> RemoteCollectCtx<'a> {
     /// [`RLookupRow`].
     pub fn add(&mut self, r: &RemoteCollectReducer<'a>, row: &RLookupRow<'_>) {
         let mut dst = RLookupRow::new();
-        for key in r.field_keys.iter() {
-            if let Some(v) = row.get(key) {
-                dst.write_key(key, v.clone());
+        if let Some(lookup) = r.srclookup {
+            let mut cursor = lookup.cursor();
+            while let Some(key) = cursor.current() {
+                if !key.is_tombstone()
+                    && !key.flags.contains(RLookupKeyFlag::Hidden)
+                    && let Some(v) = row.get(key)
+                {
+                    dst.write_key(key, v.clone());
+                }
+                cursor.move_next();
             }
-        }
-        for key in r.sort_keys.iter() {
-            if let Some(v) = row.get(key) {
-                dst.write_key(key, v.clone());
+        } else {
+            for key in r.field_keys.iter() {
+                if let Some(v) = row.get(key) {
+                    dst.write_key(key, v.clone());
+                }
+            }
+            for key in r.sort_keys.iter() {
+                if let Some(v) = row.get(key) {
+                    dst.write_key(key, v.clone());
+                }
             }
         }
         self.rows.push(dst);
@@ -152,37 +194,64 @@ impl<'a> RemoteCollectCtx<'a> {
     pub fn finalize(&mut self, r: &RemoteCollectReducer<'a>) -> SharedValue {
         let rows = mem::take(&mut self.rows);
 
-        let sort_extras: &[&RLookupKey<'a>] = if r.include_sort_keys {
-            &r.sort_keys
+        if let Some(lookup) = r.srclookup {
+            // Each row walks the lookup freshly. The cursor hands out
+            // references borrowed from itself, so the explicit-fields path's
+            // pre-built template (with hoisted name allocations) cannot be
+            // expressed without unsafe — and hoisting matters less here
+            // anyway, since the wildcard key set varies per row (a hoisted
+            // name might not even be emitted for some rows).
+            SharedValue::new_array(rows.into_iter().map(|row| {
+                let mut entries: Vec<(SharedValue, SharedValue)> = Vec::new();
+                let mut cursor = lookup.cursor();
+                while let Some(key) = cursor.current() {
+                    if !key.is_tombstone()
+                        && !key.flags.contains(RLookupKeyFlag::Hidden)
+                        && let Some(v) = row.get(key)
+                    {
+                        entries.push((
+                            SharedValue::new_string(key.name().to_bytes().to_vec()),
+                            v.clone(),
+                        ));
+                    }
+                    cursor.move_next();
+                }
+                SharedValue::new_map(entries)
+            }))
         } else {
-            &[]
-        };
-        let mut seen: HashSet<u16> = HashSet::with_capacity(r.field_keys.len() + sort_extras.len());
-        let template: Vec<(&RLookupKey<'a>, SharedValue)> = r
-            .field_keys
-            .iter()
-            .chain(sort_extras)
-            .filter(|key| seen.insert(key.dstidx))
-            .map(|key| {
-                (
-                    *key,
-                    SharedValue::new_string(key.name().to_bytes().to_vec()),
-                )
-            })
-            .collect();
-
-        SharedValue::new_array(rows.into_iter().map(|row| {
-            let entries: Vec<_> = template
+            let sort_extras: &[&RLookupKey<'a>] = if r.include_sort_keys {
+                &r.sort_keys
+            } else {
+                &[]
+            };
+            let mut seen: HashSet<u16> =
+                HashSet::with_capacity(r.field_keys.len() + sort_extras.len());
+            let template: Vec<(&RLookupKey<'a>, SharedValue)> = r
+                .field_keys
                 .iter()
-                .map(|(key, name)| {
-                    let val = row
-                        .get(key)
-                        .cloned()
-                        .unwrap_or_else(SharedValue::null_static);
-                    (name.clone(), val)
+                .chain(sort_extras)
+                .filter(|key| seen.insert(key.dstidx))
+                .map(|key| {
+                    (
+                        *key,
+                        SharedValue::new_string(key.name().to_bytes().to_vec()),
+                    )
                 })
                 .collect();
-            SharedValue::new_map(entries)
-        }))
+
+            SharedValue::new_array(rows.into_iter().map(|row| {
+                let entries: Vec<_> = template
+                    .iter()
+                    .map(|(key, name)| {
+                        let val = row
+                            .get(key)
+                            .cloned()
+                            .unwrap_or_else(SharedValue::null_static);
+                        (name.clone(), val)
+                    })
+                    .collect();
+                SharedValue::new_map(entries)
+            }))
+        }
     }
 }

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -18,36 +18,33 @@
 use std::collections::HashSet;
 use std::mem;
 
-use rlookup::{RLookup, RLookupKey, RLookupRow};
+use itertools::Either;
+use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
 use value::SharedValue;
 
 use crate::Reducer;
-use crate::collect::common::{CollectCommon, visible_keys};
+use crate::collect::common::CollectCommon;
 
 /// Remote COLLECT reducer.
 ///
 /// Must remain `#[repr(C)]` with [`CollectCommon`] at offset 0 so the C layer
 /// can downcast this struct to `ffi::Reducer*` and read the vtable directly.
-#[expect(rustdoc::private_intra_doc_links)]
 #[repr(C)]
 pub struct RemoteCollectReducer<'a> {
     common: CollectCommon,
     field_keys: Box<[&'a RLookupKey<'a>]>,
-    /// Source lookup for `FIELDS *` mode (a.k.a. *load-all*).
+    /// Source lookup for `FIELDS *` mode.
     ///
-    /// `Some` when the user wrote `FIELDS *`; the projection then emits
-    /// every visible key present on the row (see [`visible_keys`]), walked
-    /// per call.
-    ///
-    /// The walk runs per `add()` call rather than once at construction because an
-    /// upstream `LOAD *` may append keys mid-pipeline.
+    /// `Some` when the user wrote `FIELDS *`; every key not flagged
+    /// [`RLookupKeyFlag::Hidden`] is emitted. Walked per [`RemoteCollectCtx::add`]
+    /// call rather than once at construction so that keys appended by an
+    /// upstream `LOAD *` mid-pipeline are included.
     srclookup: Option<&'a RLookup<'a>>,
     /// Raw sort-key references, including keys not present in `FIELDS`.
     sort_keys: Box<[&'a RLookupKey<'a>]>,
     /// `true` for shard replies dispatched by the coordinator: extra sort-key
     /// columns are emitted alongside the requested fields so the coordinator
     /// can re-order shard rows during merge. `false` for direct execution.
-    /// No-op when [`srclookup`][Self::srclookup] is `Some`.
     include_sort_keys: bool,
 }
 
@@ -72,12 +69,7 @@ pub struct RemoteCollectCtx<'a> {
 impl<'a> RemoteCollectReducer<'a> {
     /// Create a reducer from C-parsed configuration.
     ///
-    /// `srclookup` is `Some` when the user wrote `FIELDS *`; see
-    /// [`Self::srclookup`] for the load-all-mode policy.
-    #[expect(
-        rustdoc::private_intra_doc_links,
-        reason = "links to the private srclookup field"
-    )]
+    /// `srclookup` is `Some` when the user wrote `FIELDS *`.
     pub fn new(
         field_keys: Box<[&'a RLookupKey<'a>]>,
         srclookup: Option<&'a RLookup<'a>>,
@@ -156,12 +148,21 @@ fn dedup_by_dstidx<'a>(
         .collect()
 }
 
-/// Pair each `key` with its name as a reusable [`SharedValue`], hoisting the
-/// allocation out of the per-row loop in [`RemoteCollectCtx::finalize`].
-fn build_template_for_finalize<'a, I>(keys: I) -> Vec<(&'a RLookupKey<'a>, SharedValue)>
-where
-    I: IntoIterator<Item = &'a RLookupKey<'a>>,
-{
+/// Builds the key→name template once per group so [`RemoteCollectCtx::finalize`]
+/// can clone pre-allocated name [`SharedValue`]s per row rather than re-allocating.
+fn build_finalize_template<'a>(
+    r: &RemoteCollectReducer<'a>,
+) -> Vec<(&'a RLookupKey<'a>, SharedValue)> {
+    let keys: Vec<&RLookupKey<'a>> = if let Some(lookup) = r.srclookup {
+        lookup
+            .iter()
+            .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden))
+            .collect()
+    } else if r.include_sort_keys {
+        dedup_by_dstidx(&r.field_keys, &r.sort_keys)
+    } else {
+        r.field_keys.to_vec()
+    };
     keys.into_iter()
         .map(|k| (k, SharedValue::new_string(k.name().to_bytes().to_vec())))
         .collect()
@@ -172,23 +173,28 @@ impl<'a> RemoteCollectCtx<'a> {
         Self { rows: Vec::new() }
     }
 
-    /// Project the source row's field-key and sort-key values into a stored
-    /// [`RLookupRow`].
+    /// Project the relevant fields from `row` for later serialization by
+    /// [`Self::finalize`].
     pub fn add(&mut self, r: &RemoteCollectReducer<'a>, row: &RLookupRow<'_>) {
         let mut dst = RLookupRow::new();
-        let mut write_if_present = |key: &RLookupKey<'a>| {
+        let keys = if let Some(lookup) = r.srclookup {
+            Either::Left(
+                lookup
+                    .iter()
+                    .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden)),
+            )
+        } else {
+            Either::Right(
+                r.field_keys
+                    .iter()
+                    .copied()
+                    .chain(r.sort_keys.iter().copied()),
+            )
+        };
+        for key in keys {
             if let Some(v) = row.get(key) {
                 dst.write_key(key, v.clone());
             }
-        };
-        if let Some(lookup) = r.srclookup {
-            visible_keys(lookup).for_each(&mut write_if_present);
-        } else {
-            r.field_keys
-                .iter()
-                .copied()
-                .chain(r.sort_keys.iter().copied())
-                .for_each(&mut write_if_present);
         }
         self.rows.push(dst);
     }
@@ -200,17 +206,7 @@ impl<'a> RemoteCollectCtx<'a> {
     /// client-facing result.
     pub fn finalize(&mut self, r: &RemoteCollectReducer<'a>) -> SharedValue {
         let rows = mem::take(&mut self.rows);
-        let keys: Vec<&RLookupKey<'a>> = if let Some(lookup) = r.srclookup {
-            visible_keys(lookup).collect()
-        } else {
-            let sort_extras: &[&RLookupKey<'a>] = if r.include_sort_keys {
-                &r.sort_keys
-            } else {
-                &[]
-            };
-            dedup_by_dstidx(&r.field_keys, sort_extras)
-        };
-        let template = build_template_for_finalize(keys);
+        let template = build_finalize_template(r);
         SharedValue::new_array(rows.into_iter().map(|row| {
             let entries: Vec<_> = template
                 .iter()

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -158,7 +158,7 @@ fn build_finalize_template<'a>(
             .iter()
             .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden))
             .collect()
-    } else if r.include_sort_keys {
+    } else if r.include_sort_keys && !r.sort_keys.is_empty() {
         dedup_by_dstidx(&r.field_keys, &r.sort_keys)
     } else {
         r.field_keys.to_vec()

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -21,11 +21,11 @@
 use std::collections::HashSet;
 use std::mem;
 
-use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
+use rlookup::{RLookup, RLookupKey, RLookupRow};
 use value::SharedValue;
 
 use crate::Reducer;
-use crate::collect::common::CollectCommon;
+use crate::collect::common::{CollectCommon, for_each_visible_value};
 
 /// Remote COLLECT reducer.
 ///
@@ -40,10 +40,9 @@ pub struct RemoteCollectReducer<'a> {
     ///
     /// In load-all mode both [`RemoteCollectCtx::add`] and
     /// [`RemoteCollectCtx::finalize`] walk this lookup *live* on every
-    /// invocation, filtering tombstones and keys flagged
-    /// [`RLookupKeyFlag::Hidden`]. The
-    /// per-call walk is required because an upstream `LOAD *` may append
-    /// keys mid-pipeline; caching the iteration result would silently lose
+    /// invocation via [`for_each_visible_value`]. The per-call walk is
+    /// required because an upstream `LOAD *` may append keys
+    /// mid-pipeline; caching the iteration result would silently lose
     /// them. This mirrors the per-row `RLOOKUP_FOREACH` pattern in
     /// `aggregate_exec.c`'s load-all reply path.
     ///
@@ -165,16 +164,9 @@ impl<'a> RemoteCollectCtx<'a> {
     pub fn add(&mut self, r: &RemoteCollectReducer<'a>, row: &RLookupRow<'_>) {
         let mut dst = RLookupRow::new();
         if let Some(lookup) = r.srclookup {
-            let mut cursor = lookup.cursor();
-            while let Some(key) = cursor.current() {
-                if !key.is_tombstone()
-                    && !key.flags.contains(RLookupKeyFlag::Hidden)
-                    && let Some(v) = row.get(key)
-                {
-                    dst.write_key(key, v.clone());
-                }
-                cursor.move_next();
-            }
+            for_each_visible_value(lookup, row, |key, v| {
+                dst.write_key(key, v.clone());
+            });
         } else {
             for key in r.field_keys.iter() {
                 if let Some(v) = row.get(key) {
@@ -203,19 +195,12 @@ impl<'a> RemoteCollectCtx<'a> {
             // name might not even be emitted for some rows).
             SharedValue::new_array(rows.into_iter().map(|row| {
                 let mut entries: Vec<(SharedValue, SharedValue)> = Vec::new();
-                let mut cursor = lookup.cursor();
-                while let Some(key) = cursor.current() {
-                    if !key.is_tombstone()
-                        && !key.flags.contains(RLookupKeyFlag::Hidden)
-                        && let Some(v) = row.get(key)
-                    {
-                        entries.push((
-                            SharedValue::new_string(key.name().to_bytes().to_vec()),
-                            v.clone(),
-                        ));
-                    }
-                    cursor.move_next();
-                }
+                for_each_visible_value(lookup, &row, |key, v| {
+                    entries.push((
+                        SharedValue::new_string(key.name().to_bytes().to_vec()),
+                        v.clone(),
+                    ));
+                });
                 SharedValue::new_map(entries)
             }))
         } else {

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -132,7 +132,7 @@ impl<'a> RemoteCollectReducer<'a> {
     }
 }
 
-/// Deduplicate `field_keys ++ sort_extras` by [`RLookupKey::dstidx`],
+/// Deduplicate `field_keys ++ sort_extras` by `dstidx`,
 /// preserving the chained order. A field referenced by `SORTBY` lands in
 /// both inputs but must be emitted only once.
 fn dedup_by_dstidx<'a>(

--- a/src/redisearch_rs/reducers/tests/collect.rs
+++ b/src/redisearch_rs/reducers/tests/collect.rs
@@ -154,6 +154,47 @@ fn remote_finalize_dedupes_overlapping_field_and_sort_key() {
 }
 
 #[test]
+fn remote_external_omits_keys_missing_on_row() {
+    let fixture = RemoteCollectFixture::new();
+    let reducer = RemoteCollectReducer::new(
+        Box::new([&fixture.name_key, &fixture.sweetness_key]),
+        None,
+        Box::new([]),
+        0,
+        None,
+        false,
+    );
+    let mut ctx = RemoteCollectCtx::new(&reducer);
+
+    let row_a = fixture.row("apple", 4.0);
+    let mut row_b = RLookupRow::new();
+    row_b.write_key(&fixture.name_key, string_value("lemon"));
+
+    ctx.add(&reducer, &row_a);
+    ctx.add(&reducer, &row_b);
+    let output = ctx.finalize(&reducer);
+    let rows = array_entries(&output);
+    assert_eq!(rows.len(), 2);
+
+    let map_a = map_entries(&rows[0]);
+    assert_eq!(
+        map_a.get(b"name").and_then(|v| v.as_str_bytes()),
+        Some(b"apple".as_slice()),
+    );
+    assert_eq!(map_a.get(b"sweetness").and_then(|v| v.as_num()), Some(4.0));
+
+    let map_b = map_entries(&rows[1]);
+    assert_eq!(
+        map_b.get(b"name").and_then(|v| v.as_str_bytes()),
+        Some(b"lemon".as_slice()),
+    );
+    assert!(
+        map_b.get(b"sweetness").is_none(),
+        "row B was missing `sweetness`; the requested-fields map must omit the entry entirely"
+    );
+}
+
+#[test]
 fn remote_finalize_hoists_name_allocations() {
     let fixture = RemoteCollectFixture::new();
     let reducer = fixture.reducer(false);

--- a/src/redisearch_rs/reducers/tests/collect.rs
+++ b/src/redisearch_rs/reducers/tests/collect.rs
@@ -222,7 +222,7 @@ fn remote_finalize_hoists_name_allocations() {
 }
 
 #[test]
-fn local_collect_projects_remote_maps_and_fills_missing_fields_with_null() {
+fn local_collect_projects_remote_maps_and_omits_missing_fields() {
     let input_key = key(c"generatedalias", 0);
     let reducer = LocalCollectReducer::new(
         &input_key,
@@ -255,7 +255,7 @@ fn local_collect_projects_remote_maps_and_fills_missing_fields_with_null() {
         Some(b"apple".as_slice())
     );
     assert!(row.get(b"sweetness").is_none());
-    assert!(row.get(b"missing").unwrap().is_null_static());
+    assert!(row.get(b"missing").is_none());
 }
 
 #[test]

--- a/src/redisearch_rs/reducers/tests/collect.rs
+++ b/src/redisearch_rs/reducers/tests/collect.rs
@@ -252,15 +252,15 @@ fn local_collect_accepts_resp2_flat_array_payloads() {
     assert!(row.get(b"sweetness").is_none());
 }
 
-/// Fixture for wildcard (`FIELDS *`) tests. Owns a real [`RLookup`] so the
+/// Fixture for load-all (`FIELDS *`) tests. Owns a real [`RLookup`] so the
 /// reducer's live walk has something to iterate. Pre-registers three visible
 /// keys (`name`, `color`, `sweetness`) plus one [`RLookupKeyFlag::Hidden`]
 /// key (`__hidden`) so the "skip hidden" assertion has a target.
-struct RemoteCollectWildcardFixture {
+struct RemoteCollectLoadAllFixture {
     lookup: RLookup<'static>,
 }
 
-impl RemoteCollectWildcardFixture {
+impl RemoteCollectLoadAllFixture {
     fn new() -> Self {
         let mut lookup = RLookup::new();
         let _ = lookup
@@ -279,7 +279,7 @@ impl RemoteCollectWildcardFixture {
     }
 
     /// Build a reducer with `srclookup = Some(&self.lookup)` and no explicit
-    /// field/sort keys (matching the parser's "wildcard alone" assumption).
+    /// field/sort keys (matching the parser's "load-all alone" assumption).
     fn reducer(&self) -> RemoteCollectReducer<'_> {
         RemoteCollectReducer::new(
             Box::new([]),
@@ -293,8 +293,8 @@ impl RemoteCollectWildcardFixture {
 }
 
 #[test]
-fn remote_wildcard_emits_all_lookup_keys_present_on_row() {
-    let mut fixture = RemoteCollectWildcardFixture::new();
+fn remote_load_all_emits_all_lookup_keys_present_on_row() {
+    let mut fixture = RemoteCollectLoadAllFixture::new();
     let mut row = RLookupRow::new();
     row.write_key_by_name(&mut fixture.lookup, c"name", string_value("apple"));
     row.write_key_by_name(&mut fixture.lookup, c"color", string_value("red"));
@@ -325,15 +325,15 @@ fn remote_wildcard_emits_all_lookup_keys_present_on_row() {
 }
 
 #[test]
-fn remote_wildcard_omits_keys_missing_on_row() {
-    let mut fixture = RemoteCollectWildcardFixture::new();
+fn remote_load_all_omits_keys_missing_on_row() {
+    let mut fixture = RemoteCollectLoadAllFixture::new();
 
     let mut row_a = RLookupRow::new();
     row_a.write_key_by_name(&mut fixture.lookup, c"name", string_value("apple"));
     row_a.write_key_by_name(&mut fixture.lookup, c"color", string_value("red"));
     row_a.write_key_by_name(&mut fixture.lookup, c"sweetness", SharedValue::new_num(4.0));
 
-    // Row B is missing `color` entirely — the wildcard map must drop the
+    // Row B is missing `color` entirely — the load-all map must drop the
     // entry instead of padding with `null_static`.
     let mut row_b = RLookupRow::new();
     row_b.write_key_by_name(&mut fixture.lookup, c"name", string_value("lemon"));
@@ -352,13 +352,13 @@ fn remote_wildcard_omits_keys_missing_on_row() {
     assert_eq!(
         map_a.get(b"color").and_then(|v| v.as_str_bytes()),
         Some(b"red".as_slice()),
-        "row A had `color`; the wildcard map must include it"
+        "row A had `color`; the load-all map must include it"
     );
 
     let map_b = map_entries(&rows[1]);
     assert!(
         map_b.get(b"color").is_none(),
-        "row B was missing `color`; the wildcard map must omit the entry entirely (no null_static padding)"
+        "row B was missing `color`; the load-all map must omit the entry entirely (no null_static padding)"
     );
     assert_eq!(
         map_b.get(b"name").and_then(|v| v.as_str_bytes()),
@@ -368,8 +368,8 @@ fn remote_wildcard_omits_keys_missing_on_row() {
 }
 
 #[test]
-fn remote_wildcard_skips_hidden_keys_even_when_row_has_value() {
-    let mut fixture = RemoteCollectWildcardFixture::new();
+fn remote_load_all_skips_hidden_keys_even_when_row_has_value() {
+    let mut fixture = RemoteCollectLoadAllFixture::new();
     let mut row = RLookupRow::new();
     row.write_key_by_name(&mut fixture.lookup, c"name", string_value("apple"));
     // Populate the Hidden key on the row to prove the filter happens at the
@@ -391,6 +391,6 @@ fn remote_wildcard_skips_hidden_keys_even_when_row_has_value() {
     );
     assert!(
         map.get(b"__hidden").is_none(),
-        "Hidden keys must be excluded from the wildcard emission template"
+        "Hidden keys must be excluded from the load-all emission template"
     );
 }

--- a/src/redisearch_rs/reducers/tests/collect.rs
+++ b/src/redisearch_rs/reducers/tests/collect.rs
@@ -12,7 +12,7 @@ extern crate redisearch_rs;
 use reducers::collect::{
     LocalCollectCtx, LocalCollectReducer, RemoteCollectCtx, RemoteCollectReducer,
 };
-use rlookup::{RLookupKey, RLookupKeyFlags, RLookupRow};
+use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, RLookupRow};
 use value::{Map, SharedValue, Value};
 
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
@@ -62,7 +62,7 @@ impl RemoteCollectFixture {
     fn reducer(&self, include_sort_keys: bool) -> RemoteCollectReducer<'_> {
         RemoteCollectReducer::new(
             Box::new([&self.name_key]),
-            false,
+            None,
             Box::new([&self.sweetness_key]),
             0,
             None,
@@ -127,7 +127,7 @@ fn remote_finalize_dedupes_overlapping_field_and_sort_key() {
     // emission.
     let reducer = RemoteCollectReducer::new(
         Box::new([&fixture.name_key]),
-        false,
+        None,
         Box::new([&fixture.name_key]),
         0,
         None,
@@ -250,4 +250,147 @@ fn local_collect_accepts_resp2_flat_array_payloads() {
         Some(b"apple".as_slice())
     );
     assert!(row.get(b"sweetness").is_none());
+}
+
+/// Fixture for wildcard (`FIELDS *`) tests. Owns a real [`RLookup`] so the
+/// reducer's live walk has something to iterate. Pre-registers three visible
+/// keys (`name`, `color`, `sweetness`) plus one [`RLookupKeyFlag::Hidden`]
+/// key (`__hidden`) so the "skip hidden" assertion has a target.
+struct RemoteCollectWildcardFixture {
+    lookup: RLookup<'static>,
+}
+
+impl RemoteCollectWildcardFixture {
+    fn new() -> Self {
+        let mut lookup = RLookup::new();
+        let _ = lookup
+            .get_key_write(c"name", RLookupKeyFlags::empty())
+            .expect("`name` is a fresh key");
+        let _ = lookup
+            .get_key_write(c"color", RLookupKeyFlags::empty())
+            .expect("`color` is a fresh key");
+        let _ = lookup
+            .get_key_write(c"sweetness", RLookupKeyFlags::empty())
+            .expect("`sweetness` is a fresh key");
+        let _ = lookup
+            .get_key_write(c"__hidden", RLookupKeyFlag::Hidden.into())
+            .expect("`__hidden` is a fresh key");
+        Self { lookup }
+    }
+
+    /// Build a reducer with `srclookup = Some(&self.lookup)` and no explicit
+    /// field/sort keys (matching the parser's "wildcard alone" assumption).
+    fn reducer(&self) -> RemoteCollectReducer<'_> {
+        RemoteCollectReducer::new(
+            Box::new([]),
+            Some(&self.lookup),
+            Box::new([]),
+            0,
+            None,
+            false,
+        )
+    }
+}
+
+#[test]
+fn remote_wildcard_emits_all_lookup_keys_present_on_row() {
+    let mut fixture = RemoteCollectWildcardFixture::new();
+    let mut row = RLookupRow::new();
+    row.write_key_by_name(&mut fixture.lookup, c"name", string_value("apple"));
+    row.write_key_by_name(&mut fixture.lookup, c"color", string_value("red"));
+    row.write_key_by_name(&mut fixture.lookup, c"sweetness", SharedValue::new_num(4.0));
+
+    let reducer = fixture.reducer();
+    let mut ctx = RemoteCollectCtx::new(&reducer);
+
+    ctx.add(&reducer, &row);
+    let output = ctx.finalize(&reducer);
+    let rows = array_entries(&output);
+    assert_eq!(rows.len(), 1);
+
+    let map = map_entries(&rows[0]);
+    assert_eq!(
+        map.get(b"name").and_then(|v| v.as_str_bytes()),
+        Some(b"apple".as_slice())
+    );
+    assert_eq!(
+        map.get(b"color").and_then(|v| v.as_str_bytes()),
+        Some(b"red".as_slice())
+    );
+    assert_eq!(map.get(b"sweetness").and_then(|v| v.as_num()), Some(4.0));
+    assert!(
+        map.get(b"__hidden").is_none(),
+        "Hidden keys must never be emitted"
+    );
+}
+
+#[test]
+fn remote_wildcard_omits_keys_missing_on_row() {
+    let mut fixture = RemoteCollectWildcardFixture::new();
+
+    let mut row_a = RLookupRow::new();
+    row_a.write_key_by_name(&mut fixture.lookup, c"name", string_value("apple"));
+    row_a.write_key_by_name(&mut fixture.lookup, c"color", string_value("red"));
+    row_a.write_key_by_name(&mut fixture.lookup, c"sweetness", SharedValue::new_num(4.0));
+
+    // Row B is missing `color` entirely — the wildcard map must drop the
+    // entry instead of padding with `null_static`.
+    let mut row_b = RLookupRow::new();
+    row_b.write_key_by_name(&mut fixture.lookup, c"name", string_value("lemon"));
+    row_b.write_key_by_name(&mut fixture.lookup, c"sweetness", SharedValue::new_num(2.0));
+
+    let reducer = fixture.reducer();
+    let mut ctx = RemoteCollectCtx::new(&reducer);
+
+    ctx.add(&reducer, &row_a);
+    ctx.add(&reducer, &row_b);
+    let output = ctx.finalize(&reducer);
+    let rows = array_entries(&output);
+    assert_eq!(rows.len(), 2);
+
+    let map_a = map_entries(&rows[0]);
+    assert_eq!(
+        map_a.get(b"color").and_then(|v| v.as_str_bytes()),
+        Some(b"red".as_slice()),
+        "row A had `color`; the wildcard map must include it"
+    );
+
+    let map_b = map_entries(&rows[1]);
+    assert!(
+        map_b.get(b"color").is_none(),
+        "row B was missing `color`; the wildcard map must omit the entry entirely (no null_static padding)"
+    );
+    assert_eq!(
+        map_b.get(b"name").and_then(|v| v.as_str_bytes()),
+        Some(b"lemon".as_slice())
+    );
+    assert_eq!(map_b.get(b"sweetness").and_then(|v| v.as_num()), Some(2.0));
+}
+
+#[test]
+fn remote_wildcard_skips_hidden_keys_even_when_row_has_value() {
+    let mut fixture = RemoteCollectWildcardFixture::new();
+    let mut row = RLookupRow::new();
+    row.write_key_by_name(&mut fixture.lookup, c"name", string_value("apple"));
+    // Populate the Hidden key on the row to prove the filter happens at the
+    // lookup-walk level, not at "no value" — the value is present.
+    row.write_key_by_name(&mut fixture.lookup, c"__hidden", string_value("internal"));
+
+    let reducer = fixture.reducer();
+    let mut ctx = RemoteCollectCtx::new(&reducer);
+
+    ctx.add(&reducer, &row);
+    let output = ctx.finalize(&reducer);
+    let rows = array_entries(&output);
+    assert_eq!(rows.len(), 1);
+
+    let map = map_entries(&rows[0]);
+    assert_eq!(
+        map.get(b"name").and_then(|v| v.as_str_bytes()),
+        Some(b"apple".as_slice())
+    );
+    assert!(
+        map.get(b"__hidden").is_none(),
+        "Hidden keys must be excluded from the wildcard emission template"
+    );
 }

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -129,13 +129,6 @@ TEST_F(CollectParserTest, DISABLED_FieldsLoadAll) {
   parseOkLocal({"FIELDS", "*"});
 }
 
-// Documents the current behavior: `*` in FIELDS is rejected by the parser in
-// both remote and local modes with the same message. Remove once LoadAll
-// support lands and `DISABLED_FieldsLoadAll` is re-enabled.
-TEST_F(CollectParserTest, FieldsLoadAllRejected) {
-  expectError({"FIELDS", "*"}, "COLLECT does not yet support `*` in FIELDS");
-}
-
 TEST_F(CollectParserTest, FieldsWithCount) {
   registerKeys({"a", "b"});
   Reducer *r = parseCollectOk({"FIELDS", "2", "@a", "@b"});

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -123,7 +123,7 @@ protected:
 // `if (data.load_all)` branch).
 TEST_F(CollectParserTest, DISABLED_FieldsLoadAll) {
   parseOkRemote({"FIELDS", "*"}, [](Reducer *r) {
-    EXPECT_TRUE(CollectReducer_HasLoadAll(r));
+    EXPECT_TRUE(CollectReducer_IsLoadAll(r));
     EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 0u);
   });
   parseOkLocal({"FIELDS", "*"});
@@ -140,7 +140,7 @@ TEST_F(CollectParserTest, FieldsWithCount) {
   registerKeys({"a", "b"});
   Reducer *r = parseCollectOk({"FIELDS", "2", "@a", "@b"});
   ASSERT_NE(r, nullptr);
-  EXPECT_FALSE(CollectReducer_HasLoadAll(r));
+  EXPECT_FALSE(CollectReducer_IsLoadAll(r));
   EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 2u);
   r->Free(r);
 }
@@ -154,7 +154,7 @@ TEST_F(CollectParserTest, DISABLED_FieldsLoadAllWithSortBy) {
       "SORTBY", "1", "@price",
   });
   ASSERT_NE(r, nullptr);
-  EXPECT_TRUE(CollectReducer_HasLoadAll(r));
+  EXPECT_TRUE(CollectReducer_IsLoadAll(r));
   EXPECT_EQ(CollectReducer_GetSortKeysLen(r), 1u);
   r->Free(r);
 }
@@ -339,7 +339,7 @@ TEST_F(CollectParserTest, JsonPathField) {
   Reducer *r = parseCollectOk({"FIELDS", "1", "$..price"});
   ASSERT_NE(r, nullptr);
   EXPECT_EQ(CollectReducer_GetFieldKeysLen(r), 1u);
-  EXPECT_FALSE(CollectReducer_HasLoadAll(r));
+  EXPECT_FALSE(CollectReducer_IsLoadAll(r));
   r->Free(r);
 }
 

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -946,3 +946,43 @@ def test_collect_resp2_sanity():
         collected = row[names_idx]
         env.assertTrue(isinstance(collected, list))
         env.assertEqual(len(collected), 2)
+
+
+# ---------------------------------------------------------------------------
+# APPLY interactions with COLLECT
+#
+# The four tests below pin how APPLY-derived aliases flow through COLLECT:
+#   1. APPLY alias as the GROUPBY key             (upstream rlookup -> grouping)
+#   2. APPLY alias projected by COLLECT FIELDS    (upstream rlookup -> reducer)
+#   3. APPLY over a reducer alias, outer COLLECT  (reducer->APPLY->outer COLLECT)
+#   4. APPLY + outer COLLECT FIELDS *             (wildcard walk picks up APPLY)
+# ---------------------------------------------------------------------------
+def test_collect_apply_alias_as_groupby_key():
+    """APPLY before GROUPBY writes `upper(@color)` into the upstream
+    rlookup; ``GROUPBY @COLOR_UP`` then partitions by the derived alias.
+    COLLECT sees the APPLY alias as a regular group key and projects
+    ``@name`` per row unaffected.
+
+    This pins that APPLY-produced keys are first-class GROUPBY inputs:
+    the grouping step reads them out of the rlookup like any loaded
+    field.
+    """
+    env = Env(protocol=3)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'APPLY', 'upper(@color)', 'AS', 'COLOR_UP',
+        'GROUPBY', '1', '@COLOR_UP',
+        'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name',
+        'AS', 'names')
+
+    groups = _sort_by(res['results'], 'COLOR_UP')
+    env.assertEqual([g['extra_attributes']['COLOR_UP'] for g in groups],
+                    ['GREEN', 'RED', 'YELLOW'])
+    env.assertEqual(_sort_collected(groups[0]['extra_attributes']['names'], 'name'),
+                    [{'name': 'kiwi'}, {'name': 'lime'}])
+    env.assertEqual(_sort_collected(groups[1]['extra_attributes']['names'], 'name'),
+                    [{'name': 'apple'}, {'name': 'strawberry'}])
+    env.assertEqual(_sort_collected(groups[2]['extra_attributes']['names'], 'name'),
+                    [{'name': 'banana'}, {'name': 'lemon'}])

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -533,11 +533,11 @@ def test_collect_internal_duplicate_field_and_sort():
 
 
 @skip(cluster=True)
-def test_collect_internal_wildcard_emits_all_fields():
+def test_collect_internal_load_all_emits_all_fields():
     """`COLLECT FIELDS *` projects every non-hidden lookup key on each row.
 
     `LOAD` populates the source lookup with the schema fields before
-    `GROUPBY`; the reducer's wildcard walk then sees those keys live and
+    `GROUPBY`; the reducer's load-all walk then sees those keys live and
     emits them per row.
 
     Uses RESP2 because RESP3 maps are parsed into Python dicts that silently
@@ -572,17 +572,17 @@ def test_collect_internal_wildcard_emits_all_fields():
             row_keys = set(row[0::2])
             env.assertTrue(
                 always_present.issubset(row_keys),
-                message=f'wildcard row missing always-present schema fields: {row_keys}')
+                message=f'load-all row missing always-present schema fields: {row_keys}')
 
 
 @skip(cluster=True)
-def test_collect_internal_wildcard_omits_missing_fields():
+def test_collect_internal_load_all_omits_missing_fields():
     """When a row has no value for a key, `FIELDS *` drops it from the map.
 
     `lemon` and `kiwi` in the FRUITS fixture have no `origin` field; their
     rows must NOT contain an `origin` entry on the wire. Other fruits with
     `origin` set must still emit it. The `LOAD` step pulls every schema
-    field (including `origin`) into the lookup so the wildcard walk has a
+    field (including `origin`) into the lookup so the load-all walk has a
     chance to project it — the omit-if-missing rule is what makes the
     fruits with no `origin` value drop it.
     """

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -752,6 +752,143 @@ def test_collect_internal_load_all_omits_missing_fields():
 
 
 # ---------------------------------------------------------------------------
+# `COLLECT FIELDS *` on JSON indexes
+#
+# JSON's `LOAD *` does not fan out into per-field rlookup keys (as `HGETALL`
+# does for HASH). Instead `RLookup_JSON_GetAll` adds a single key named
+# ``$`` (`JSON_ROOT`) carrying the whole serialized document. The wildcard
+# walk picks this up unchanged: each emitted row is a singleton map keyed
+# on ``$``. The "rlookup drives projection" rule holds without any
+# JSON-specific code path on the COLLECT side.
+#
+# The two tests below pin the rule by varying whether `LOAD *` runs:
+#   1. With LOAD *  -> rlookup contains `$`; wildcard emits {$: <doc>}.
+#   2. Without LOAD -> rlookup contains only what the GROUPBY key
+#                      registered (`color`); wildcard emits {color: ...}
+#                      and `$` is absent.
+# ---------------------------------------------------------------------------
+@skip(cluster=True, no_json=True)
+def test_collect_internal_load_all_emits_dollar_on_json():
+    """`LOAD *` on JSON adds a single ``$`` key to the rlookup carrying
+    the whole serialized doc; `COLLECT FIELDS *` emits it alongside
+    whatever else the request stages registered (here: ``color`` from
+    the GROUPBY).
+
+    This is the JSON counterpart of
+    ``test_collect_internal_load_all_with_load_star_emits_full_schema``:
+    both lock in that the rlookup at row time is what drives the
+    wildcard's projection. The HASH side fans out into many keys, the
+    JSON side keeps a single ``$`` carrying the serialized doc — and
+    that asymmetry is intentional, mirroring the runtime behaviour of
+    `LOAD *` itself (HGETALL fans out fields, JSON_GetAll does not).
+    """
+    env = Env(protocol=2)
+    _setup_json(env)
+
+    _, slots_data = get_shard_slot_ranges(env)[0]
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    internal = env.cmd(
+        '_FT.AGGREGATE', 'idx', '*',
+        'LOAD', '*',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COLLECT', '3',
+            'FIELDS', '1', '*',
+        'AS', 'info',
+        '_SLOTS_INFO', slots_data,
+    )
+
+    fixture_by_name = {f['name']: f for f in FRUITS}
+    seen_names = set()
+    for group_row in internal[1:]:
+        info_idx = group_row.index('info') + 1
+        rows = group_row[info_idx]
+        for row in rows:
+            row_dict = dict(zip(row[0::2], row[1::2]))
+            env.assertEqual(
+                set(row_dict.keys()), {'color', '$'},
+                message=f'LOAD * + FIELDS * on JSON must emit exactly the lookup keys ({{color, $}}), got {set(row_dict.keys())}')
+
+            doc_str = row_dict['$']
+            doc = json.loads(doc_str)
+            env.assertIn(
+                doc.get('name'), fixture_by_name,
+                message=f'`$` value must be a serialized fixture doc, got {doc_str!r}')
+            seen_names.add(doc['name'])
+            # The `$` doc must be self-consistent with the GROUPBY key
+            # that the same row also carries.
+            env.assertEqual(
+                doc['color'], row_dict['color'],
+                message=f"row's `color` and `$.color` must agree, got color={row_dict['color']!r}, $.color={doc['color']!r}")
+            # And it must match the original fixture exactly (both for
+            # set fields and for absent-`origin` rows).
+            env.assertEqual(
+                doc, fixture_by_name[doc['name']],
+                message=f"`$` value for {doc['name']!r} must round-trip the fixture exactly, got {doc!r}")
+
+    env.assertEqual(
+        seen_names, set(fixture_by_name),
+        message=f'every fruit must appear in some collected group, saw {seen_names}')
+
+
+@skip(cluster=True, no_json=True)
+def test_collect_internal_no_load_emits_only_groupby_key_on_json():
+    """Without `LOAD *`, only fields the request itself registered in the
+    source rlookup are emitted by `COLLECT FIELDS *`.
+
+    With ``GROUPBY 1 @color REDUCE COLLECT FIELDS 1 *`` and no upstream
+    `LOAD`, the only key registered in the source rlookup is ``color``
+    (resolved by the GROUPBY against the schema cache). ``color`` is
+    sortable, so its value is supplied via the per-row sorting vector
+    even without an explicit loader. ``$`` is absent because no
+    `LOAD *` ever ran; ``name``/``sweetness``/``origin`` are absent
+    because nothing in the request resolved them.
+
+    This documents that the wildcard is rlookup-driven, not
+    schema-driven — calling `COLLECT FIELDS *` on JSON without an
+    explicit `LOAD` is a footgun that emits less than users may expect.
+    """
+    env = Env(protocol=2)
+    _setup_json(env)
+
+    _, slots_data = get_shard_slot_ranges(env)[0]
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    internal = env.cmd(
+        '_FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COLLECT', '3',
+            'FIELDS', '1', '*',
+        'AS', 'info',
+        '_SLOTS_INFO', slots_data,
+    )
+
+    expected_colors = {f['color'] for f in FRUITS}
+    seen_colors = set()
+    seen_doc_count = 0
+    for group_row in internal[1:]:
+        info_idx = group_row.index('info') + 1
+        rows = group_row[info_idx]
+        for row in rows:
+            seen_doc_count += 1
+            row_keys = row[0::2]
+            env.assertEqual(
+                row_keys, ['color'],
+                message=f'no-LOAD wildcard row must contain exactly [\'color\', <val>], got keys {row_keys}')
+            env.assertEqual(
+                len(row), 2,
+                message=f'no-LOAD wildcard row must contain exactly one (key, value) pair, got {row}')
+            seen_colors.add(row[1])
+
+    env.assertEqual(
+        seen_colors, expected_colors,
+        message=f'every fixture color must appear, expected {expected_colors}, got {seen_colors}')
+    env.assertEqual(
+        seen_doc_count, len(FRUITS),
+        message=f'every fruit must appear in some collected group, saw {seen_doc_count}/{len(FRUITS)}')
+
+
+# ---------------------------------------------------------------------------
 # Chained GROUPBY: outer COLLECT FIELDS * projects every key the inner
 # reducers placed in the lookup
 # ---------------------------------------------------------------------------

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -190,7 +190,7 @@ def test_collect_3_fields_hash():
     groups = _sort_by(res['results'], 'color')
     green = _sort_collected(groups[0]['extra_attributes']['info'], 'name')
     env.assertEqual(green, [
-        {'name': 'kiwi', 'sweetness': '3', 'origin': None},
+        {'name': 'kiwi', 'sweetness': '3'},
         {'name': 'lime', 'sweetness': '2', 'origin': 'mexico'},
     ])
 
@@ -203,7 +203,7 @@ def test_collect_3_fields_hash():
     yellow = _sort_collected(groups[2]['extra_attributes']['info'], 'name')
     env.assertEqual(yellow, [
         {'name': 'banana', 'sweetness': '4', 'origin': 'ecuador'},
-        {'name': 'lemon',  'sweetness': '2', 'origin': None},
+        {'name': 'lemon',  'sweetness': '2'},
     ])
 
 
@@ -247,7 +247,7 @@ def test_collect_3_fields_json():
     groups = _sort_by(res['results'], 'color')
     green = _sort_collected(groups[0]['extra_attributes']['info'], 'name')
     env.assertEqual(green, [
-        {'name': 'kiwi', 'sweetness': '3', 'origin': None},
+        {'name': 'kiwi', 'sweetness': '3'},
         {'name': 'lime', 'sweetness': '2', 'origin': 'Mexico'},
     ])
 
@@ -303,13 +303,13 @@ def test_collect_missing_values():
 
     items2 = _sort_collected(groups[0]['extra_attributes']['items'], 'name')
     env.assertEqual(items2, [
-        {'name': 'lemon', 'origin': None},
+        {'name': 'lemon'},
         {'name': 'lime',  'origin': 'mexico'},
     ])
 
     items3 = _sort_collected(groups[1]['extra_attributes']['items'], 'name')
     env.assertEqual(items3, [
-        {'name': 'kiwi',       'origin': None},
+        {'name': 'kiwi'},
         {'name': 'strawberry', 'origin': 'spain'},
     ])
 

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1020,3 +1020,43 @@ def test_collect_apply_alias_as_field():
         for entry in g['extra_attributes']['shouted']:
             env.assertNotContains('name', entry)
             env.assertEqual(set(entry.keys()), {'NAME_UP'})
+
+
+def test_chained_groupby_collect_apply_on_reducer_alias():
+    """APPLY between two GROUPBYs consumes two reducer aliases
+    (``@cnt`` and ``@avg_sweet``) and writes ``@weighted`` into the
+    pipeline rlookup. The outer GROUPBY's COLLECT then projects
+    ``@color`` and ``@weighted`` per inner-group row.
+
+    The multiplication is chosen so every color group produces a
+    distinct post-APPLY value -- a passing test can only be explained
+    by per-group APPLY evaluation against that group's reducer output.
+
+    Fixture math:
+        green:  cnt=2, avg_sweet=2.5 -> weighted = 5
+        yellow: cnt=2, avg_sweet=3.0 -> weighted = 6
+        red:    cnt=2, avg_sweet=3.5 -> weighted = 7
+    """
+    env = Env(protocol=3)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COUNT', '0', 'AS', 'cnt',
+        'REDUCE', 'AVG', '1', '@sweetness', 'AS', 'avg_sweet',
+        'APPLY', '@cnt * @avg_sweet', 'AS', 'weighted',
+        'GROUPBY', '0',
+        'REDUCE', 'COLLECT', '4', 'FIELDS', '2', '@color', '@weighted',
+        'AS', 'per_color')
+
+    results = res['results']
+    env.assertEqual(len(results), 1)
+
+    entries = sorted(results[0]['extra_attributes']['per_color'],
+                     key=lambda e: float(e['weighted']))
+    env.assertEqual(entries, [
+        {'color': 'green',  'weighted': '5'},
+        {'color': 'yellow', 'weighted': '6'},
+        {'color': 'red',    'weighted': '7'},
+    ])

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -532,78 +532,203 @@ def test_collect_internal_duplicate_field_and_sort():
                 message='internal row must contain exactly one (key, value) pair')
 
 
+# ---------------------------------------------------------------------------
+# `COLLECT FIELDS *` rule: emits exactly the keys present in the source
+# rlookup at row time — neither the schema, nor whatever happens to be in
+# the underlying Redis hash, drives the projection.
+#
+# The three tests below pin this rule by varying what `LOAD` puts into the
+# lookup while keeping the schema and hash contents constant:
+#   1. Partial LOAD             → only the loaded subset is emitted.
+#   2. LOAD with `@__key`       → derived keys ride along like any field.
+#   3. LOAD *                   → the full schema is emitted.
+#
+# All three use RESP2 so each emitted row arrives as a flat
+# ``[k, v, k, v, ...]`` list whose keys can be inspected directly without
+# RESP3's silent duplicate-key collapse.
+# ---------------------------------------------------------------------------
+def _collect_load_all_index_with_three_fields(env):
+    """Create a 3-field schema and two docs in the same group.
+
+    Both docs populate every schema field, so any field absent from a
+    collected row's wire payload comes from the rlookup not having that
+    key — never from the row missing a value.
+    """
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA',
+               'name', 'TEXT', 'SORTABLE',
+               'team', 'TAG', 'SORTABLE',
+               'score', 'NUMERIC', 'SORTABLE').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:alpha', 'name', 'alice', 'team', 't', 'score', '7')
+    conn.execute_command('HSET', 'doc:bravo', 'name', 'bob',   'team', 't', 'score', '5')
+    enable_unstable_features(env)
+
+
+def _collect_load_all_extract_rows(internal_resp2):
+    """Iterate every collected row across every group from a RESP2 reply.
+
+    RESP2 shape: ``[num_groups, group_row, group_row, ...]`` where each
+    ``group_row`` is a flat ``[k, v, k, v, ...]`` list and the ``info``
+    entry is itself a list of flat rows.
+    """
+    for group_row in internal_resp2[1:]:
+        info_idx = group_row.index('info') + 1
+        for row in group_row[info_idx]:
+            yield row
+
+
 @skip(cluster=True)
-def test_collect_internal_load_all_emits_all_fields():
-    """`COLLECT FIELDS *` projects every non-hidden lookup key on each row.
+def test_collect_internal_load_all_partial_load_emits_only_loaded_fields():
+    """Loading a strict subset of the schema produces a strict subset on the
+    wire — even though the underlying hash holds all three fields.
 
-    `LOAD` populates the source lookup with the schema fields before
-    `GROUPBY`; the reducer's load-all walk then sees those keys live and
-    emits them per row.
-
-    Uses RESP2 because RESP3 maps are parsed into Python dicts that silently
-    collapse duplicate keys, hiding any wire-level duplication. Under RESP2
-    each row arrives as a flat ``[k, v, k, v, ...]`` list where keys can be
-    counted directly.
+    The schema has ``name``, ``team``, ``score``; ``LOAD`` pulls in only
+    ``name`` and ``team``. Every emitted row therefore carries exactly
+    ``{name, team}`` and ``score`` is absent. This is the canonical
+    counter-example to "FIELDS * mirrors the schema": the rlookup, not the
+    schema, drives the load-all walk.
     """
     env = Env(protocol=2)
-    _setup_hash(env)
+    _collect_load_all_index_with_three_fields(env)
 
     _, slots_data = get_shard_slot_ranges(env)[0]
     env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
 
     internal = env.cmd(
         '_FT.AGGREGATE', 'idx', '*',
-        'LOAD', '3', '@name', '@sweetness', '@origin',
-        'GROUPBY', '1', '@color',
+        'LOAD', '2', '@name', '@team',
+        'GROUPBY', '1', '@team',
         'REDUCE', 'COLLECT', '3',
             'FIELDS', '1', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
 
-    # RESP2 shape: [num_groups, group_row, group_row, ...] where each
-    # group_row is a flat [key, val, key, val, ...] list. The 'info' value
-    # is a list of rows, each itself a flat [key, val, ...] list.
-    always_present = {'name', 'color', 'sweetness'}
-    for group_row in internal[1:]:
-        info_idx = group_row.index('info') + 1
-        rows = group_row[info_idx]
-        for row in rows:
-            row_keys = set(row[0::2])
-            env.assertTrue(
-                always_present.issubset(row_keys),
-                message=f'load-all row missing always-present schema fields: {row_keys}')
+    expected_keys = {'name', 'team'}
+    for row in _collect_load_all_extract_rows(internal):
+        row_keys = set(row[0::2])
+        env.assertEqual(
+            row_keys, expected_keys,
+            message=f'partial-load row must emit only the loaded subset, got {row_keys}')
+
+
+@skip(cluster=True)
+def test_collect_internal_load_all_emits_dunder_key_when_loaded():
+    """``@__key`` rides through `FIELDS *` like any other loaded field.
+
+    The schema has ``name``, ``team``, ``score``; ``LOAD`` pulls in
+    ``name``, ``team`` and the special derived ``@__key``, but not
+    ``score``. Every emitted row therefore carries exactly
+    ``{name, team, __key}``, and the ``__key`` value matches the doc's
+    Redis key. This documents that the load-all walk does not
+    discriminate against derived keys: anything sitting in the rlookup at
+    row time (modulo hidden flags and tombstones, neither of which apply
+    to ``@__key``) is emitted.
+    """
+    env = Env(protocol=2)
+    _collect_load_all_index_with_three_fields(env)
+
+    _, slots_data = get_shard_slot_ranges(env)[0]
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    internal = env.cmd(
+        '_FT.AGGREGATE', 'idx', '*',
+        'LOAD', '3', '@name', '@team', '@__key',
+        'GROUPBY', '1', '@team',
+        'REDUCE', 'COLLECT', '3',
+            'FIELDS', '1', '*',
+        'AS', 'info',
+        '_SLOTS_INFO', slots_data,
+    )
+
+    expected_keys = {'name', 'team', '__key'}
+    expected_dunder_values = {'doc:alpha', 'doc:bravo'}
+    seen_dunder = set()
+    for row in _collect_load_all_extract_rows(internal):
+        row_dict = dict(zip(row[0::2], row[1::2]))
+        env.assertEqual(
+            set(row_dict.keys()), expected_keys,
+            message=f'expected exactly {expected_keys}, got {set(row_dict.keys())}')
+        seen_dunder.add(row_dict['__key'])
+
+    env.assertEqual(
+        seen_dunder, expected_dunder_values,
+        message='each doc must emit its own @__key value through FIELDS *')
+
+
+@skip(cluster=True)
+def test_collect_internal_load_all_with_load_star_emits_full_schema():
+    """``LOAD *`` populates the rlookup with every schema field, so
+    ``COLLECT FIELDS *`` emits all of them per row.
+
+    With ``LOAD *`` the rlookup at COLLECT-time mirrors the schema
+    exactly. This is the case the previous single test conflated — it now
+    sits as one of three points on the rule curve, alongside the partial
+    and `@__key` cases above.
+    """
+    env = Env(protocol=2)
+    _collect_load_all_index_with_three_fields(env)
+
+    _, slots_data = get_shard_slot_ranges(env)[0]
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    internal = env.cmd(
+        '_FT.AGGREGATE', 'idx', '*',
+        'LOAD', '*',
+        'GROUPBY', '1', '@team',
+        'REDUCE', 'COLLECT', '3',
+            'FIELDS', '1', '*',
+        'AS', 'info',
+        '_SLOTS_INFO', slots_data,
+    )
+
+    expected_keys = {'name', 'team', 'score'}
+    for row in _collect_load_all_extract_rows(internal):
+        row_keys = set(row[0::2])
+        env.assertEqual(
+            row_keys, expected_keys,
+            message=f'LOAD * row must emit the full schema, got {row_keys}')
 
 
 @skip(cluster=True)
 def test_collect_internal_load_all_omits_missing_fields():
     """When a row has no value for a key, `FIELDS *` drops it from the map.
 
-    `lemon` and `kiwi` in the FRUITS fixture have no `origin` field; their
-    rows must NOT contain an `origin` entry on the wire. Other fruits with
-    `origin` set must still emit it. The `LOAD` step pulls every schema
-    field (including `origin`) into the lookup so the load-all walk has a
+    Two docs share the same group: ``full`` has every schema field set,
+    ``partial`` is missing ``extra``. The `LOAD` step pulls every schema
+    field (including ``extra``) into the lookup so the load-all walk has a
     chance to project it — the omit-if-missing rule is what makes the
-    fruits with no `origin` value drop it.
+    ``partial`` row drop ``extra`` while ``full`` still emits it.
+
+    Uses RESP2 to inspect each row as a flat ``[k, v, k, v, ...]`` list
+    without RESP3's silent duplicate-key collapse.
     """
     env = Env(protocol=2)
-    _setup_hash(env)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA',
+               'name', 'TEXT', 'SORTABLE',
+               'team', 'TAG', 'SORTABLE',
+               'extra', 'TEXT', 'SORTABLE').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:full',    'name', 'full',    'team', 'g', 'extra', 'set')
+    conn.execute_command('HSET', 'doc:partial', 'name', 'partial', 'team', 'g')
+    enable_unstable_features(env)
 
     _, slots_data = get_shard_slot_ranges(env)[0]
     env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
 
     internal = env.cmd(
         '_FT.AGGREGATE', 'idx', '*',
-        'LOAD', '3', '@name', '@sweetness', '@origin',
-        'GROUPBY', '1', '@color',
+        'LOAD', '3', '@name', '@team', '@extra',
+        'GROUPBY', '1', '@team',
         'REDUCE', 'COLLECT', '3',
             'FIELDS', '1', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
 
-    expected_has_origin = {f['name']: 'origin' in f for f in FRUITS}
-
+    expected_has_extra = {'full': True, 'partial': False}
     seen_names = set()
     for group_row in internal[1:]:
         info_idx = group_row.index('info') + 1
@@ -612,20 +737,52 @@ def test_collect_internal_load_all_omits_missing_fields():
             row_dict = dict(zip(row[0::2], row[1::2]))
 
             name = row_dict.get('name')
-            env.assertIsNotNone(
-                name,
-                message='every fruit row must carry its `name`')
+            env.assertIsNotNone(name, message='every row must carry its `name`')
             seen_names.add(name)
 
-            should_have_origin = expected_has_origin.get(name, False)
-            has_origin = 'origin' in row_dict
+            should_have_extra = expected_has_extra[name]
+            has_extra = 'extra' in row_dict
             env.assertEqual(
-                has_origin, should_have_origin,
-                message=f'fruit {name!r}: expected origin present={should_have_origin}, got {has_origin}')
+                has_extra, should_have_extra,
+                message=f'doc {name!r}: expected extra present={should_have_extra}, got {has_extra}')
 
     env.assertEqual(
-        seen_names, set(expected_has_origin),
-        message='every fruit must appear in some collected group')
+        seen_names, set(expected_has_extra),
+        message='every doc must appear in the collected group')
+
+
+# ---------------------------------------------------------------------------
+# Chained GROUPBY: outer COLLECT FIELDS * projects every key the inner
+# reducers placed in the lookup
+# ---------------------------------------------------------------------------
+def test_chained_groupby_collect_load_all():
+    """Outer ``COLLECT FIELDS *`` after a chained GROUPBY projects every
+    key surfaced by the inner reducers (``@color``, ``@cnt``,
+    ``@avg_sweet``), none of which are explicit fields on the outer
+    reducer.
+    """
+    env = Env(protocol=3)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COUNT', '0', 'AS', 'cnt',
+        'REDUCE', 'AVG', '1', '@sweetness', 'AS', 'avg_sweet',
+        'GROUPBY', '0',
+        'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '*',
+        'AS', 'stats')
+
+    results = res['results']
+    env.assertEqual(len(results), 1)
+
+    stats = sorted(results[0]['extra_attributes']['stats'],
+                   key=lambda e: e['avg_sweet'])
+    env.assertEqual(stats, [
+        {'color': 'green',  'cnt': '2', 'avg_sweet': '2.5'},
+        {'color': 'yellow', 'cnt': '2', 'avg_sweet': '3'},
+        {'color': 'red',    'cnt': '2', 'avg_sweet': '3.5'},
+    ])
 
 
 # RESP2 sanity: basic COLLECT works under RESP2

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1060,3 +1060,46 @@ def test_chained_groupby_collect_apply_on_reducer_alias():
         {'color': 'yellow', 'weighted': '6'},
         {'color': 'red',    'weighted': '7'},
     ])
+
+
+def test_chained_groupby_collect_apply_load_all():
+    """Outer ``COLLECT FIELDS *`` after a chained GROUPBY + APPLY
+    projects every key the inner stages placed in the source rlookup:
+    ``@color`` (inner group key), ``@cnt`` and ``@avg_sweet`` (inner
+    reducers), and ``@weighted`` (APPLY).
+
+    This is the APPLY-aware sibling of
+    ``test_chained_groupby_collect_load_all``: the additional APPLY
+    alias must appear in the wildcard projection alongside the reducer
+    aliases, pinning that APPLY-derived keys participate in the
+    rlookup-driven wildcard walk the same way reducer-produced keys
+    do -- the wildcard does not discriminate by producer.
+
+    Fixture math matches the sibling reducer-alias test:
+        green:  cnt=2, avg_sweet=2.5 -> weighted = 5
+        yellow: cnt=2, avg_sweet=3.0 -> weighted = 6
+        red:    cnt=2, avg_sweet=3.5 -> weighted = 7
+    """
+    env = Env(protocol=3)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COUNT', '0', 'AS', 'cnt',
+        'REDUCE', 'AVG', '1', '@sweetness', 'AS', 'avg_sweet',
+        'APPLY', '@cnt * @avg_sweet', 'AS', 'weighted',
+        'GROUPBY', '0',
+        'REDUCE', 'COLLECT', '2', 'FIELDS', '*',
+        'AS', 'stats')
+
+    results = res['results']
+    env.assertEqual(len(results), 1)
+
+    stats = sorted(results[0]['extra_attributes']['stats'],
+                   key=lambda e: float(e['weighted']))
+    env.assertEqual(stats, [
+        {'color': 'green',  'cnt': '2', 'avg_sweet': '2.5', 'weighted': '5'},
+        {'color': 'yellow', 'cnt': '2', 'avg_sweet': '3',   'weighted': '6'},
+        {'color': 'red',    'cnt': '2', 'avg_sweet': '3.5', 'weighted': '7'},
+    ])

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -986,3 +986,37 @@ def test_collect_apply_alias_as_groupby_key():
                     [{'name': 'apple'}, {'name': 'strawberry'}])
     env.assertEqual(_sort_collected(groups[2]['extra_attributes']['names'], 'name'),
                     [{'name': 'banana'}, {'name': 'lemon'}])
+
+
+def test_collect_apply_alias_as_field():
+    """APPLY-derived alias flows through the upstream rlookup into
+    COLLECT's per-row projection. Each collected map carries exactly
+    the derived key (``@NAME_UP``), not the raw source (``@name``).
+
+    The negative assertion is the real pin here: a COLLECT with a
+    specific ``FIELDS`` list is name-driven, so any hypothetical path
+    that silently rode the raw source through to the wire would be
+    caught.
+    """
+    env = Env(protocol=3)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'APPLY', 'upper(@name)', 'AS', 'NAME_UP',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@NAME_UP',
+        'AS', 'shouted')
+
+    groups = _sort_by(res['results'], 'color')
+    env.assertEqual(_sort_collected(groups[0]['extra_attributes']['shouted'], 'NAME_UP'),
+                    [{'NAME_UP': 'KIWI'}, {'NAME_UP': 'LIME'}])
+    env.assertEqual(_sort_collected(groups[1]['extra_attributes']['shouted'], 'NAME_UP'),
+                    [{'NAME_UP': 'APPLE'}, {'NAME_UP': 'STRAWBERRY'}])
+    env.assertEqual(_sort_collected(groups[2]['extra_attributes']['shouted'], 'NAME_UP'),
+                    [{'NAME_UP': 'BANANA'}, {'NAME_UP': 'LEMON'}])
+
+    for g in groups:
+        for entry in g['extra_attributes']['shouted']:
+            env.assertNotContains('name', entry)
+            env.assertEqual(set(entry.keys()), {'NAME_UP'})

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -532,6 +532,102 @@ def test_collect_internal_duplicate_field_and_sort():
                 message='internal row must contain exactly one (key, value) pair')
 
 
+@skip(cluster=True)
+def test_collect_internal_wildcard_emits_all_fields():
+    """`COLLECT FIELDS *` projects every non-hidden lookup key on each row.
+
+    `LOAD` populates the source lookup with the schema fields before
+    `GROUPBY`; the reducer's wildcard walk then sees those keys live and
+    emits them per row.
+
+    Uses RESP2 because RESP3 maps are parsed into Python dicts that silently
+    collapse duplicate keys, hiding any wire-level duplication. Under RESP2
+    each row arrives as a flat ``[k, v, k, v, ...]`` list where keys can be
+    counted directly.
+    """
+    env = Env(protocol=2)
+    _setup_hash(env)
+
+    _, slots_data = get_shard_slot_ranges(env)[0]
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    internal = env.cmd(
+        '_FT.AGGREGATE', 'idx', '*',
+        'LOAD', '3', '@name', '@sweetness', '@origin',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COLLECT', '3',
+            'FIELDS', '1', '*',
+        'AS', 'info',
+        '_SLOTS_INFO', slots_data,
+    )
+
+    # RESP2 shape: [num_groups, group_row, group_row, ...] where each
+    # group_row is a flat [key, val, key, val, ...] list. The 'info' value
+    # is a list of rows, each itself a flat [key, val, ...] list.
+    always_present = {'name', 'color', 'sweetness'}
+    for group_row in internal[1:]:
+        info_idx = group_row.index('info') + 1
+        rows = group_row[info_idx]
+        for row in rows:
+            row_keys = set(row[0::2])
+            env.assertTrue(
+                always_present.issubset(row_keys),
+                message=f'wildcard row missing always-present schema fields: {row_keys}')
+
+
+@skip(cluster=True)
+def test_collect_internal_wildcard_omits_missing_fields():
+    """When a row has no value for a key, `FIELDS *` drops it from the map.
+
+    `lemon` and `kiwi` in the FRUITS fixture have no `origin` field; their
+    rows must NOT contain an `origin` entry on the wire. Other fruits with
+    `origin` set must still emit it. The `LOAD` step pulls every schema
+    field (including `origin`) into the lookup so the wildcard walk has a
+    chance to project it — the omit-if-missing rule is what makes the
+    fruits with no `origin` value drop it.
+    """
+    env = Env(protocol=2)
+    _setup_hash(env)
+
+    _, slots_data = get_shard_slot_ranges(env)[0]
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    internal = env.cmd(
+        '_FT.AGGREGATE', 'idx', '*',
+        'LOAD', '3', '@name', '@sweetness', '@origin',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COLLECT', '3',
+            'FIELDS', '1', '*',
+        'AS', 'info',
+        '_SLOTS_INFO', slots_data,
+    )
+
+    expected_has_origin = {f['name']: 'origin' in f for f in FRUITS}
+
+    seen_names = set()
+    for group_row in internal[1:]:
+        info_idx = group_row.index('info') + 1
+        rows = group_row[info_idx]
+        for row in rows:
+            row_dict = dict(zip(row[0::2], row[1::2]))
+
+            name = row_dict.get('name')
+            env.assertIsNotNone(
+                name,
+                message='every fruit row must carry its `name`')
+            seen_names.add(name)
+
+            should_have_origin = expected_has_origin.get(name, False)
+            has_origin = 'origin' in row_dict
+            env.assertEqual(
+                has_origin, should_have_origin,
+                message=f'fruit {name!r}: expected origin present={should_have_origin}, got {has_origin}')
+
+    env.assertEqual(
+        seen_names, set(expected_has_origin),
+        message='every fruit must appear in some collected group')
+
+
 # RESP2 sanity: basic COLLECT works under RESP2
 # ---------------------------------------------------------------------------
 def test_collect_resp2_sanity():

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -599,8 +599,8 @@ def test_collect_internal_load_all_partial_load_emits_only_loaded_fields():
         '_FT.AGGREGATE', 'idx', '*',
         'LOAD', '2', '@name', '@team',
         'GROUPBY', '1', '@team',
-        'REDUCE', 'COLLECT', '3',
-            'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2',
+            'FIELDS', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
@@ -636,8 +636,8 @@ def test_collect_internal_load_all_emits_dunder_key_when_loaded():
         '_FT.AGGREGATE', 'idx', '*',
         'LOAD', '3', '@name', '@team', '@__key',
         'GROUPBY', '1', '@team',
-        'REDUCE', 'COLLECT', '3',
-            'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2',
+            'FIELDS', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
@@ -677,8 +677,8 @@ def test_collect_internal_load_all_with_load_star_emits_full_schema():
         '_FT.AGGREGATE', 'idx', '*',
         'LOAD', '*',
         'GROUPBY', '1', '@team',
-        'REDUCE', 'COLLECT', '3',
-            'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2',
+            'FIELDS', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
@@ -722,8 +722,8 @@ def test_collect_internal_load_all_omits_missing_fields():
         '_FT.AGGREGATE', 'idx', '*',
         'LOAD', '3', '@name', '@team', '@extra',
         'GROUPBY', '1', '@team',
-        'REDUCE', 'COLLECT', '3',
-            'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2',
+            'FIELDS', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
@@ -792,8 +792,8 @@ def test_collect_internal_load_all_emits_dollar_on_json():
         '_FT.AGGREGATE', 'idx', '*',
         'LOAD', '*',
         'GROUPBY', '1', '@color',
-        'REDUCE', 'COLLECT', '3',
-            'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2',
+            'FIELDS', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
@@ -857,8 +857,8 @@ def test_collect_internal_no_load_emits_only_groupby_key_on_json():
     internal = env.cmd(
         '_FT.AGGREGATE', 'idx', '*',
         'GROUPBY', '1', '@color',
-        'REDUCE', 'COLLECT', '3',
-            'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2',
+            'FIELDS', '*',
         'AS', 'info',
         '_SLOTS_INFO', slots_data,
     )
@@ -907,7 +907,7 @@ def test_chained_groupby_collect_load_all():
         'REDUCE', 'COUNT', '0', 'AS', 'cnt',
         'REDUCE', 'AVG', '1', '@sweetness', 'AS', 'avg_sweet',
         'GROUPBY', '0',
-        'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '*',
+        'REDUCE', 'COLLECT', '2', 'FIELDS', '*',
         'AS', 'stats')
 
     results = res['results']


### PR DESCRIPTION

## Summary

Wires `FIELDS *` (load-all) end-to-end through the shard-side (Remote) `COLLECT` reducer, so an inner `GROUPBY ... REDUCE COLLECT FIELDS *` projects every visible non-deleted key per row.
The local/coordinator parser still rejects `*` and is left as a follow-up.

## Key design points

- **Typed-row storage with lazy lookup interning** - `LocalCollectCtx` now holds a private `RLookup` plus `Vec<RLookupRow>` instead of a `Vec<SharedValue>` of opaque maps. `add` interns each shard-payload field name into the context's lookup and writes its value into a typed `RLookupRow`, so `add` and `finalize` agree on the key-slot mapping with no out-of-band channel.
- **Wire-shape sanitization at the boundary** - all RESP3 `Map` / RESP2 flat-array decoding, non-string-key skipping, and odd-length guarding lives in `add`. Downstream (`finalize`) sees only typed rows.
- **Per-row omission, not padding** - absent keys are dropped in all paths. Two rows in the same group may emit different key sets, matching shard-side `LOAD *` semantics.
- **FFI signal split** - load-all/explicit-list selection is internal to `LocalCollectReducer::new` (driven by the `load_all` flag); `field_names` is ignored when `load_all` is `true`. The unused `sort_key_names` parameter is dropped from the constructor. A new `CollectReducer_IsLocalLoadAll` accessor mirrors the remote-side `CollectReducer_IsLoadAll` (different struct offset, kept as a temporary C++ parser-test hook).

## Files

- `src/aggregate/reducers/collect.c` - drop the "not yet supported" rejection; thread `options->srclookup` to FFI.
- `src/redisearch_rs/reducers/src/collect/common.rs` - new `visible_keys` iterator helper.
- `src/redisearch_rs/reducers/src/collect/remote.rs` - `srclookup: Option<&RLookup>` field, load-all `add`/`finalize` paths, `dedup_by_dstidx`, `build_template_for_finalize`.
- `src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs` + `headers/reducers_rs.h` - FFI signature change and `IsLoadAll` rename.
- `src/redisearch_rs/reducers/tests/collect.rs` - new unit tests covering load-all and the unified omission rule.
- `tests/cpptests/test_cpp_collect.cpp` - drop the deprecated `FieldsLoadAllRejected` test; rename accessors to `IsLoadAll`.
- `tests/pytests/test_groupby_collect.py` - new flow tests covering load-all and APPLY interactions.

## Test coverage

**Rust unit** (`reducers/tests/collect.rs`, +190): 4 new tests
- `remote_external_omits_keys_missing_on_row` (locks the unified omission rule for explicit `FIELDS`)
- `remote_load_all_emits_all_lookup_keys_present_on_row`
- `remote_load_all_omits_keys_missing_on_row` (no null padding)
- `remote_load_all_skips_hidden_keys_even_when_row_has_value`

**Python flow** (`tests/pytests/test_groupby_collect.py`, +557): 11 new tests
- Load-all matrix: partial `LOAD`, dunder keys, `LOAD *`, missing fields, JSON `$`, JSON without `LOAD`, chained GROUPBY.
- APPLY interactions: APPLY alias as GROUPBY key, APPLY alias projected by `FIELDS`, APPLY on reducer alias picked up by outer COLLECT, `FIELDS *` picking up APPLY alias after chained GROUPBY.


## Follow-ups

- Coordinator-side (`LocalCollectReducer`) `FIELDS *` support - parser still rejects `*` for local mode.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes COLLECT wire/output semantics (missing fields are now omitted rather than null-filled) and adds shard-side `FIELDS *` behavior, which can affect client expectations and distributed merge behavior despite added test coverage.
> 
> **Overview**
> Shard-side (remote) `COLLECT` now supports `FIELDS *` by passing the source `RLookup` through the C→Rust FFI and having the reducer iterate visible (non-`Hidden`) lookup keys per row when `*` is requested.
> 
> Serialization for both remote and local COLLECT was tightened to **omit absent keys** (instead of emitting `null` placeholders), while still de-duping overlaps between `FIELDS` and internal `SORTBY` keys; FFI was updated accordingly (`CollectReducer_CreateRemote` signature change and `CollectReducer_IsLoadAll` rename), and unit/flow tests were expanded to cover wildcard projection, missing-field omission, JSON behavior, and APPLY/chained-GROUPBY interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24ed84bcfa6f292227ebae812ce7a30359d3454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->