### PR TITLE
CI: Fix - Persist Redis on PATH for login shells

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -117,3 +117,13 @@ runs:
       run: |
         echo "$PREFIX/bin" >> "$GITHUB_PATH"
         echo "REDIS_SERVER=$PREFIX/bin/redis-server" >> "$GITHUB_ENV"
+        # Some container images (debian via gcc:*-bookworm/trixie, alpine)
+        # ship an /etc/profile that unconditionally rewrites PATH for root,
+        # wiping the GITHUB_PATH addition above when downstream steps run
+        # under `bash -l` (see task-build-artifacts.yml `defaults.run.shell`).
+        # Drop a profile.d snippet so login shells re-prepend the
+        # redis-install bin directory after /etc/profile has been sourced.
+        if [[ -d /etc/profile.d && ( -w /etc/profile.d || $(id -u) -eq 0 ) ]]; then
+          printf 'export PATH="%s:$PATH"\n' "$PREFIX/bin" > /etc/profile.d/redis-prefix.sh
+          chmod 0644 /etc/profile.d/redis-prefix.sh
+        fi


### PR DESCRIPTION
### Description

1. **Current**:
   `task-build-artifacts.yml` has long used `defaults.run.shell: bash -l -eo pipefail {0}`, so every step in those jobs runs as a login shell and sources `/etc/profile`. On `debian:bookworm`, `debian:trixie` (`gcc:12-bookworm` / `gcc:14-trixie`) and `alpine:3.23`, `/etc/profile` contains:

   ```sh
   if [ "$(id -u)" -eq 0 ]; then
     PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   ...
   export PATH
   ```

   This unconditional reset wipes any addition made via `$GITHUB_PATH`. The behaviour was latent until #9123 (`Cache Redis build in task-test workflow`) replaced the `make install` step (which installed Redis to the default `/usr/local/bin` — part of the PATH that `/etc/profile` resets to) with `build-redis`, which installs to a workspace-relative `redis-install/` and exposes it only via `$GITHUB_PATH`. From that point on, `Build and Pack RediSearch OSS` cannot find `redis-server` on those distributions and `sbin/pack.sh` aborts with `Cannot find redis-server`.

   #9345 then made the `Build Redis (cache miss)` step itself use `bash -leo pipefail {0}` to expose `cc`/`gcc` via `/etc/profile.d/*` on Rocky Linux runners; that change is unrelated to this failure but is what surfaced PATH-reset semantics during recent investigation.

   Failing job: https://github.com/RediSearch/RediSearch/actions/runs/25130081583/job/73653761527

   Other distributions (`ubuntu`, `rocky`, `amazonlinux`, `azurelinux`) ship an `/etc/profile` that appends rather than resets `PATH`, which is why only debian and alpine fail. The failure is deterministic per-platform; it appears flaky only because the affected cells are a minority of the matrix.

2. **Change**:
   In `Expose Redis on PATH`, in addition to writing to `$GITHUB_PATH` / `$GITHUB_ENV`, drop a `/etc/profile.d/redis-prefix.sh` snippet so login shells re-prepend `$PREFIX/bin` after `/etc/profile` runs.

   The cache-restore / build / cache-save steps are untouched: caching still keys on the same `$PREFIX` and runs on every cache miss exactly as before. The `profile.d` snippet is regenerated unconditionally on every run from the (deterministic) `$PREFIX` value, so it does not need to be cached.

3. **Outcome**:
   `redis-server` remains discoverable in subsequent steps regardless of whether the calling workflow uses a login shell.

Verified locally that the snippet survives the `/etc/profile` PATH reset on `gcc:12-bookworm`, `gcc:14-trixie` and `alpine:3.23`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it modifies shell environment setup in containers by writing a guarded `/etc/profile.d` snippet, which could affect PATH ordering but is limited to the runner/container context.
> 
> **Overview**
> Ensures `redis-server` remains discoverable in workflows that run steps as `bash -l` by supplementing the `build-redis` composite action’s `$GITHUB_PATH` update with a `/etc/profile.d/redis-prefix.sh` snippet.
> 
> On images where `/etc/profile` resets `PATH` (e.g., Debian bookworm/trixie and Alpine), the added snippet re-prepends the Redis install prefix for subsequent login-shell steps while still exporting `REDIS_SERVER` via `$GITHUB_ENV`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808f0a267ab9c62a5cd50514f79a8c5fed7ee196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->