### PR TITLE
MOD-14858: Add GetNumRecords Disk API 

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -407,6 +407,11 @@ uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
   return disk->metrics.getVectorIndexTotalMemory(disk_db, index);
 }
 
+uint64_t SearchDisk_GetNumRecords(RedisSearchDiskIndexSpec* index) {
+  RS_ASSERT(disk && disk_db && index);
+  return disk->metrics.getNumRecords(disk_db, index);
+}
+
 void SearchDisk_OutputInfoMetrics(RedisModuleInfoCtx* ctx) {
   RS_ASSERT(disk && disk_db && ctx);
   disk->metrics.outputInfoMetrics(disk_db, ctx);

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -515,6 +515,18 @@ uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index)
 uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index);
 
 /**
+ * @brief Get the disk-owned total number of records for a disk index
+ *
+ * Returns the disk-side num_records counter used by FT.INFO.
+ * This wrapper is safe for read-only callers: if SearchDisk is not initialized,
+ * the callback is unavailable, or the index handle is invalid, it returns 0.
+ *
+ * @param index Pointer to the disk index spec
+ * @return Number of records in the index, or 0 if unavailable
+ */
+uint64_t SearchDisk_GetNumRecords(RedisSearchDiskIndexSpec* index);
+
+/**
  * @brief Output aggregated disk metrics to Redis INFO
  *
  * Iterates over all collected index metrics, aggregates them, and outputs

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -518,11 +518,10 @@ uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index);
  * @brief Get the disk-owned total number of records for a disk index
  *
  * Returns the disk-side num_records counter used by FT.INFO.
- * This wrapper is safe for read-only callers: if SearchDisk is not initialized,
- * the callback is unavailable, or the index handle is invalid, it returns 0.
+ * Requires initialized SearchDisk and non-null index (RS_ASSERT).
  *
  * @param index Pointer to the disk index spec
- * @return Number of records in the index, or 0 if unavailable
+ * @return Number of records in the index
  */
 uint64_t SearchDisk_GetNumRecords(RedisSearchDiskIndexSpec* index);
 

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -549,6 +549,17 @@ typedef struct MetricsDiskAPI {
   uint64_t (*getVectorIndexTotalMemory)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
 
   /**
+   * @brief Get the disk-owned total number of records for a specific index
+   *
+   * Returns the disk-side num_records counter used by FT.INFO.
+   *
+   * @param disk Pointer to the disk context
+   * @param index Pointer to the index spec
+   * @return Number of records in the index
+   */
+  uint64_t (*getNumRecords)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
+
+  /**
    * @brief Output aggregated disk metrics to Redis INFO
    *
    * Iterates over all collected index metrics, aggregates them, and outputs


### PR DESCRIPTION
Add disk api for retrieving num records.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a disk API/ABI surface change by extending `MetricsDiskAPI` with `getNumRecords`, requiring all disk backends to implement it to avoid runtime issues. The functional change is small (a new thin wrapper), but mismatched headers/implementations could break builds or metrics reporting.
> 
> **Overview**
> Adds a new disk metrics getter, `SearchDisk_GetNumRecords`, to expose the disk-owned `num_records` counter used by `FT.INFO`.
> 
> Extends the public disk API (`MetricsDiskAPI` in `search_disk_api.h`) with a new `getNumRecords` function pointer and wires it through the C wrapper in `search_disk.c`/`search_disk.h` with basic `RS_ASSERT` validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41406c6e8847bbc880bb4bea392aafb76bf86c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->