### PR TITLE
[2.6] [MOD-15112] take actions on Node20 deprecation (#9361)

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup specific

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -34,7 +34,7 @@ jobs:
       expected_sha: ${{ steps.get_sha.outputs.sha }}
       release_branch: ${{ steps.verify.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.checkout_target }}
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Update version for next patch
@@ -294,7 +294,7 @@ jobs:
           group_print("Excluded Files", exclude_list)
           group_print("Included Files", include_list)
           group_print("Unexpected SHAs", set([sha for _, sha in exclude_list]))
-          
+
           # Copy included files to new location
           for src, dst in zip(include_list, dest_files):
               client.copy_object(Bucket=bucket, Key=dst, CopySource={"Bucket": bucket, "Key": src}, ACL="public-read")

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -51,7 +51,7 @@ jobs:
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       version-suffix: ${{ steps.set-version.outputs.VERSION_SUFFIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Generate Version Suffix

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -70,7 +70,7 @@ jobs:
           echo "supported=true" >> $GITHUB_OUTPUT
       - name: checkout (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ env.REF }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -79,7 +79,7 @@ jobs:
           echo "supported=true" >> $GITHUB_OUTPUT
       - name: Full checkout (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Full checkout (node20 not supported)
@@ -279,7 +279,7 @@ jobs:
 
       - name: Upload flow coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
@@ -288,7 +288,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit_standalone.info,bin/unit_coordinator.info
           disable_search: true


### PR DESCRIPTION
Manual backport of #9361 to `2.6` (auto-backport failed: https://github.com/RediSearch/RediSearch/pull/9361#issuecomment-4354027786).

Cherry-picked `ee1ee66f929810403dfb9d639c327082340a065b` and resolved conflicts by applying only the changes that map to files existing on `2.6` (Option A).

### Applied to `2.6`

| File | Change |
|---|---|
| `.github/workflows/benchmark-flow.yml` | `actions/checkout@v4` → `@v6` |
| `.github/workflows/event-release.yml` | 2× `actions/checkout@v4` → `@v6` (+1 trailing-whitespace fix) |
| `.github/workflows/flow-build-artifacts.yml` | `actions/checkout@v4` → `@v6` |
| `.github/workflows/task-backport_pr.yml` | `actions/checkout@v4` → `@v6` |
| `.github/workflows/task-build-artifacts.yml` | `actions/checkout@v4` → `@v6` (node20-supported path) |
| `.github/workflows/task-test.yml` | `actions/checkout@v4` → `@v6` (node20-supported path); 2× `codecov/codecov-action@v5` → `@v6 # NOSONAR` |

### Skipped (file does not exist on `2.6`)

Composite actions: `build-redis`, `get-redis`, `setup-sccache`.
Workflows: `daily-ci-report`, `flow-build-benchmark-binary`, `flow-micro-benchmarks*`, `flow-rust-micro-benchmarks`, `link-check`, `pr_label_size`, `task-build-cached-container`, `task-check-changes`, `task-lint`, `task-release-notes-check`, `task-spellcheck`.

Also skipped from existing files:
- `event-weekly.yml`: master-only `link-check` job add (target workflow doesn't exist on `2.6`).
- `task-test.yml`: master-only restructure of codecov uploads that depends on a non-existent `inputs.unit-tests`. The existing v5 uses are bumped to v6 in place instead.

### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible impact.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes updating third-party GitHub Actions versions; low risk beyond potential CI behavior changes/regressions in the updated actions.
> 
> **Overview**
> Updates multiple GitHub Actions workflows to use `actions/checkout@v6` (from `@v4`) to address Node 20 deprecation across benchmark, release, artifact build, backport, and test pipelines.
> 
> Also bumps coverage uploads in `task-test.yml` from `codecov/codecov-action@v5` to `@v6` and includes a minor whitespace cleanup in `event-release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcee4b203c0bfb2ae0a0082ae50ea341aed25a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->