### PR TITLE
refactor(cmake): convert arr and wildcard to OBJECT libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,10 +61,8 @@ endif()
 add_subdirectory(geometry)
 add_subdirectory(buffer)
 add_subdirectory(iterators)
-add_subdirectory(wildcard)
 add_subdirectory(index_result)
 add_subdirectory(util/mempool)
-add_subdirectory(util/arr)
 add_subdirectory(util/dict)
 add_subdirectory(util/hash)
 add_subdirectory(coord)
@@ -88,6 +86,8 @@ file(GLOB SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/query_parser/v1/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/query_parser/v2/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/util/*.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/util/arr/*.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/wildcard/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/trie/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/info/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/info/info_redis/*.c"
@@ -114,11 +114,9 @@ endif()
 
 # Collect all object files
 set(FINAL_OBJECTS
-    $<TARGET_OBJECTS:arr>
     $<TARGET_OBJECTS:buffer>
     $<TARGET_OBJECTS:dict>
     $<TARGET_OBJECTS:iterators>
-    $<TARGET_OBJECTS:wildcard>
     $<TARGET_OBJECTS:index_result>
     $<TARGET_OBJECTS:mempool>
     $<TARGET_OBJECTS:rscore>

--- a/src/util/arr/CMakeLists.txt
+++ b/src/util/arr/CMakeLists.txt
@@ -1,6 +1,0 @@
-# Build the `arr` module as a CMake OBJECT library so its objects can be
-# pulled into `redisearch_c` via `$<TARGET_OBJECTS:arr>` without producing an
-# unused `libarr.a` archive.
-file(GLOB ARR_SOURCES "arr.c")
-add_library(arr OBJECT ${ARR_SOURCES})
-target_include_directories(arr PRIVATE . ../..)

--- a/src/util/arr/CMakeLists.txt
+++ b/src/util/arr/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Build the `arr` module as a standalone static library
-# This is a temporary requirement to allow us to benchmark the
-# Rust implementation of the triemap against the original C implementation.
+# Build the `arr` module as a CMake OBJECT library so its objects can be
+# pulled into `redisearch_c` via `$<TARGET_OBJECTS:arr>` without producing an
+# unused `libarr.a` archive.
 file(GLOB ARR_SOURCES "arr.c")
-add_library(arr STATIC ${ARR_SOURCES})
+add_library(arr OBJECT ${ARR_SOURCES})
 target_include_directories(arr PRIVATE . ../..)

--- a/src/wildcard/CMakeLists.txt
+++ b/src/wildcard/CMakeLists.txt
@@ -1,6 +1,0 @@
-# Build the `wildcard` module as a CMake OBJECT library so its objects can be
-# pulled into `redisearch_c` via `$<TARGET_OBJECTS:wildcard>` without producing
-# an unused `libwildcard.a` archive.
-file(GLOB WILDCARD_SOURCES "wildcard.c")
-add_library(wildcard OBJECT ${WILDCARD_SOURCES})
-target_include_directories(wildcard PRIVATE . ..)

--- a/src/wildcard/CMakeLists.txt
+++ b/src/wildcard/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Build the `wildcard` module as a standalone static library
-# This is a temporary requirement to allow us to benchmark the
-# Rust implementation of the triemap against the original C implementation.
-file(GLOB ARR_SOURCES "wildcard.c")
-add_library(wildcard STATIC ${ARR_SOURCES})
+# Build the `wildcard` module as a CMake OBJECT library so its objects can be
+# pulled into `redisearch_c` via `$<TARGET_OBJECTS:wildcard>` without producing
+# an unused `libwildcard.a` archive.
+file(GLOB WILDCARD_SOURCES "wildcard.c")
+add_library(wildcard OBJECT ${WILDCARD_SOURCES})
 target_include_directories(wildcard PRIVATE . ..)


### PR DESCRIPTION
As mentioned here
https://github.com/RediSearch/RediSearch/pull/9432#pullrequestreview-4226135926

## Describe the changes in the pull request

1. **Current:** `src/util/arr/CMakeLists.txt` and `src/wildcard/CMakeLists.txt` declare their modules as `STATIC` libraries with comments stating this is "a temporary requirement to allow us to benchmark the Rust implementation of the triemap against the original C implementation". The original C triemap is gone, the dedicated `trie_bencher` `build.rs` that linked these archives directly no longer exists, and nothing in the build graph references `libarr.a` or `libwildcard.a` by name. They are only consumed via `$<TARGET_OBJECTS:>` into `redisearch_c` (`src/CMakeLists.txt:117,121`), which then flows into the unified `libredisearch_all.a`.

2. **Change:** Convert both targets from `STATIC` to `OBJECT` libraries — the proper CMake idiom for "compile sources into a bag of objects for another target to splice in". Update the rationale comments. Rename the wildcard sources variable from `ARR_SOURCES` (copy-paste artifact) to `WILDCARD_SOURCES`.

3. **Outcome:** Two stale archive files (`libarr.a`, `libwildcard.a`) stop being produced. The actual usage pattern is now reflected in the target type. No symbol-level or link-graph change for downstream consumers — `redisearch_c`, `libredisearch_all.a`, and `redisearch.so` all link identically. Locally verified with `./build.sh`.

#### Which additional issues this PR fixes
_None._

#### Main objects this PR modified
1. `src/util/arr/CMakeLists.txt`
2. `src/wildcard/CMakeLists.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system-only change, but it can affect compilation/link order and object inclusion if any target relied on the removed `arr`/`wildcard` libraries.
> 
> **Overview**
> Removes the separate `arr` and `wildcard` subdirectory targets from `src/CMakeLists.txt` and stops collecting `$<TARGET_OBJECTS:arr>`/`$<TARGET_OBJECTS:wildcard>` into the final archive.
> 
> Instead, `util/arr/*.c` and `wildcard/*.c` are globbed directly into the core `rscore` object library, and the now-unused `src/util/arr/CMakeLists.txt` and `src/wildcard/CMakeLists.txt` are deleted so `libarr.a`/`libwildcard.a` are no longer produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686063b38583e056efe4e6da6726387059a400df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->