### PR TITLE
[2.10] [MOD-15112] take actions on Node20 deprecation (#9361)

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup specific  # assuming node20 supported

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -34,7 +34,7 @@ jobs:
       expected_sha: ${{ steps.get_sha.outputs.sha }}
       release_branch: ${{ steps.verify.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.checkout_target }}
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Update version for next patch
@@ -260,7 +260,7 @@ jobs:
           with ThreadPoolExecutor() as executor:
               sha_list = executor.map(extract_sha, files)
           sha_list = list(sha_list)
-          
+
           # Include only files that match the expected SHA
           exclude_list = [(f, sha) for f, sha in zip(files, sha_list) if sha != expected_sha]
           include_list = [f for f in files if f not in [x for x, _ in exclude_list]]
@@ -290,7 +290,7 @@ jobs:
           group_print("Excluded Files", exclude_list)
           group_print("Included Files", include_list)
           group_print("Unexpected SHAs", set([sha for _, sha in exclude_list]))
-          
+
           # Copy included files to new location
           for src, dst in zip(include_list, dest_files):
               client.copy_object(Bucket=bucket, Key=dst, CopySource={"Bucket": bucket, "Key": src}, ACL="public-read")

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -52,7 +52,7 @@ jobs:
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       version-suffix: ${{ steps.set-version.outputs.VERSION_SUFFIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Generate Version Suffix

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -81,7 +81,7 @@ jobs:
           echo "supported=true" >> $GITHUB_OUTPUT
       - name: checkout (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ env.REF }}

--- a/.github/workflows/task-release-notes-check.yml
+++ b/.github/workflows/task-release-notes-check.yml
@@ -47,4 +47,3 @@ jobs:
           else:
               print('✅ Release notes not required - checkbox is checked.')
           EOF
-

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -93,7 +93,7 @@ jobs:
           echo "supported=true" >> $GITHUB_OUTPUT
       - name: Full checkout (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Full checkout (node20 not supported)
@@ -318,7 +318,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
@@ -327,7 +327,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit_standalone.info,bin/unit_coordinator.info
           disable_search: true


### PR DESCRIPTION
Manual backport of #9361 to `2.10`.

The automated backport (https://github.com/RediSearch/RediSearch/pull/9361#issuecomment-4354028000) failed due to conflicts. Resolved manually using **Option A**: apply the version bumps only to files/sections that exist on `2.10`; skip new files and chunks that depend on `master`-only structure.

### Applied
- `benchmark-flow.yml`: `actions/checkout@v4` → `@v6`
- `event-release.yml`: 2× `actions/checkout@v4` → `@v6` (+ trailing-whitespace cleanup)
- `flow-build-artifacts.yml`: `actions/checkout@v4` → `@v6`
- `task-backport_pr.yml`: `actions/checkout@v4` → `@v6`
- `task-build-artifacts.yml`: `actions/checkout@v4` → `@v6` (node20-supported path)
- `task-release-notes-check.yml`: trailing newline cleanup
- `task-test.yml`: `actions/checkout@v4` → `@v6` (node20-supported path); 2× `codecov/codecov-action@v5` → `@v6 # NOSONAR`

### Skipped 
- Files not present on `2.10`: `actions/build-redis`, `actions/get-redis`, `actions/setup-sccache`, workflows `daily-ci-report`, `flow-build-benchmark-binary`, `flow-micro-benchmarks*`, `flow-rust-micro-benchmarks`, `link-check`, `pr_label_size`, `task-build-cached-container`, `task-check-changes`, `task-lint`, `task-spellcheck`.
- `event-weekly.yml` link-check job (depends on `link-check` workflow not present here).
- `task-build-artifacts.yml` / `task-test.yml` restructuring chunks that introduce new HOME/cleanup logic and a non-existent `inputs.unit-tests` (the `master`-side codecov-upload split). Existing single uploads are bumped to v6 instead.

All 4 modified workflows pass `yaml.safe_load`.

Cherry-picked from commit ee1ee66f929810403dfb9d639c327082340a065b.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CI and release workflows; while changes are mostly action version bumps, they can still affect checkout/coverage/upload behavior and should be validated in the pipeline.
> 
> **Overview**
> Updates CI workflows to use Node 20-compatible action versions by bumping `actions/checkout` to `v6` across benchmark, build, release, backport, and test workflows, and upgrading `codecov/codecov-action` to `v6` for coverage uploads.
> 
> Includes minor whitespace/formatting cleanups in workflow scripts with no intended behavior change beyond the action version upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ced13650fd02da69eab48a5e0a90c039f7b9c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->