### PR TITLE
refactor(triemap_ffi): drop unused TrieMapResultBuf_Data accessor

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
@@ -63,24 +63,6 @@ pub extern "C" fn TrieMapResultBuf_Free(buf: TrieMapResultBuf) {
     drop(buf);
 }
 
-/// Get the data from the TrieMapResultBuf as an array of values.
-///
-/// # Safety
-///
-/// The following invariants must be upheld when calling this function:
-/// - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn TrieMapResultBuf_Data(buf: *mut TrieMapResultBuf) -> *mut *mut c_void {
-    debug_assert!(!buf.is_null(), "buf cannot be NULL");
-
-    // SAFETY:
-    // As per the safety invariants of this function:
-    // - `buf` is not NULL
-    // - `buf` points to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`]
-    let TrieMapResultBuf(data) = unsafe { &mut *buf };
-    data.as_mut_ptr()
-}
-
 /// Retrieve an element from the buffer, via a 0-initialized index.
 ///
 /// It returns `NULL` if the index is out of bounds.

--- a/src/redisearch_rs/headers/triemap.h
+++ b/src/redisearch_rs/headers/triemap.h
@@ -215,16 +215,6 @@ TrieMapResultBuf TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len)
 void TrieMapResultBuf_Free(TrieMapResultBuf buf);
 
 /**
- * Get the data from the TrieMapResultBuf as an array of values.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
- */
-void **TrieMapResultBuf_Data(TrieMapResultBuf *buf);
-
-/**
  * Retrieve an element from the buffer, via a 0-initialized index.
  *
  * It returns `NULL` if the index is out of bounds.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `TrieMapResultBuf_Data` is exported from `triemap_ffi` and declared in the autogenerated `triemap.h`. It returns the raw `void**` backing the `SmallThinVec` inside `TrieMapResultBuf`, leaking the buffer's pointer layout through what is otherwise an opaque type.
2. **Change**: Delete the function from `src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs`. `cbindgen` regenerates `headers/triemap.h` without the declaration.
3. **Outcome**: One less symbol in the C surface; `TrieMapResultBuf` becomes truly opaque. The sibling accessors `TrieMapResultBuf_GetByIndex` and `TrieMapResultBuf_Len` (each used by exactly one C caller) cover the access pattern the C side actually relies on. Verified by `./build.sh`: the linker is happy, so no translation unit referenced the removed symbol.

#### Which additional issues this PR fixes
- N/A — opportunistic cleanup spotted while auditing the `triemap.h` public surface for transitional/deprecated wrappers.

#### Main objects this PR modified
1. `src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs` — removed `TrieMapResultBuf_Data`
2. `src/redisearch_rs/headers/triemap.h` — autogenerated, regenerated by build

#### Mark if applicable

- [x] This PR introduces API changes (removes an unused C-exported symbol from `triemap.h`)
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)