### PR TITLE
Support lexicographic range queries (>, <, >=, <=) on TAG and TEXT indices

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -337,6 +337,20 @@ QueryNode *NewMissingNode(const FieldSpec *field) {
   return ret;
 }
 
+QueryNode *NewLexRangeNode(const char *begin, size_t beginLen, bool includeBegin,
+                           const char *end, size_t endLen, bool includeEnd) {
+  QueryNode *ret = NewQueryNode(QN_LEXRANGE);
+  if (begin) {
+    ret->lxrng.begin = rm_strndup(begin, beginLen);
+    ret->lxrng.includeBegin = includeBegin;
+  }
+  if (end) {
+    ret->lxrng.end = rm_strndup(end, endLen);
+    ret->lxrng.includeEnd = includeEnd;
+  }
+  return ret;
+}
+
 static enum QueryType parseGeometryPredicate(const char *predicate, size_t len) {
   enum QueryType query_type;
   // length is insufficient to uniquely identify predicates. CONTAINS, DISJOINT, and DISTANCE all have 8 chars.

--- a/src/query_internal.h
+++ b/src/query_internal.h
@@ -77,6 +77,9 @@ QueryNode *NewTagNode(const FieldSpec *fs);
 QueryNode *NewWildcardNode_WithParams(QueryParseCtx *q, QueryToken *qt);
 QueryNode *NewMissingNode(const FieldSpec *fs);
 
+QueryNode *NewLexRangeNode(const char *begin, size_t beginLen, bool includeBegin,
+                           const char *end, size_t endLen, bool includeEnd);
+
 QueryNode *NewTokenNode_WithParams(QueryParseCtx *q, QueryToken *qt);
 void QueryNode_InitParams(QueryNode *n, size_t num);
 bool QueryNode_SetParam(QueryParseCtx *q, Param *target_param, void *target_value,

--- a/src/query_parser/v2/lexer.rl
+++ b/src/query_parser/v2/lexer.rl
@@ -84,9 +84,15 @@ int RSQuery_ParseNumericOp_v2(void* pParser, int OperatorType, QueryToken tok,
       }
       RSQuery_Parse_v2(pParser, ATTRIBUTE, tok, q);
     } else {
-      char *ne = (char*)te;
+      char *ne = (char*)tok.s;
       tok.numval = fast_float_strtod(tok.s, &ne);
-      RSQuery_Parse_v2(pParser, NUMBER, tok, q);
+      if (ne > tok.s) {
+        RSQuery_Parse_v2(pParser, NUMBER, tok, q);
+      } else {
+        tok.numval = 0;
+        tok.len = te - tok.s;
+        RSQuery_Parse_v2(pParser, TERM, tok, q);
+      }
     }
     if (!QPCTX_ISOK(q)) {
         return 0;
@@ -125,12 +131,12 @@ term = (((any - (punct | cntrl | space | escape)) | escaped_character) | '_')+  
 empty_string = quote.quote | squote.squote;
 mod = '@'.term $ 1;
 attr = '$'.term $ 1;
-mod_not_equal = '@'.term.(space*).'!='.(space*).(number|inf|size|('+'|'-')?.attr) $ 1;
-mod_equal = '@'.term.(space*).'=='.(space*).(number|inf|size|('+'|'-')?.attr) $ 1;
-mod_gt = '@'.term.(space*).'>'.(space*).(number|inf|size|('+'|'-')?.attr) $ 1;
-mod_ge = '@'.term.(space*).'>='.(space*).(number|inf|size|('+'|'-')?.attr) $ 1;
-mod_lt = '@'.term.(space*).'<'.(space*).(number|inf|size|('+'|'-')?.attr) $ 1;
-mod_le = '@'.term.(space*).'<='.(space*).(number|inf|size|('+'|'-')?.attr) $ 1;
+mod_not_equal = '@'.term.(space*).'!='.(space*).(number|inf|size|('+'|'-')?.attr|term) $ 1;
+mod_equal = '@'.term.(space*).'=='.(space*).(number|inf|size|('+'|'-')?.attr|term) $ 1;
+mod_gt = '@'.term.(space*).'>'.(space*).(number|inf|size|('+'|'-')?.attr|term) $ 1;
+mod_ge = '@'.term.(space*).'>='.(space*).(number|inf|size|('+'|'-')?.attr|term) $ 1;
+mod_lt = '@'.term.(space*).'<'.(space*).(number|inf|size|('+'|'-')?.attr|term) $ 1;
+mod_le = '@'.term.(space*).'<='.(space*).(number|inf|size|('+'|'-')?.attr|term) $ 1;
 contains = (star.term.star | star.number.star | star.attr.star) $1;
 contains_exact = (star.exact.star) $1;
 prefix = (term.star | number.star | attr.star) $1;

--- a/src/query_parser/v2/lexer.rl
+++ b/src/query_parser/v2/lexer.rl
@@ -86,7 +86,13 @@ int RSQuery_ParseNumericOp_v2(void* pParser, int OperatorType, QueryToken tok,
     } else {
       char *ne = (char*)tok.s;
       tok.numval = fast_float_strtod(tok.s, &ne);
-      if (ne > tok.s) {
+      /* Require full consumption of the RHS as a number: partial parses like
+       * "5stars" or "1st" must become TERM for TAG/TEXT lex ranges. */
+      const char *p = ne;
+      while (p < te && isspace((unsigned char)*p)) {
+        ++p;
+      }
+      if (ne > tok.s && p == te) {
         RSQuery_Parse_v2(pParser, NUMBER, tok, q);
       } else {
         tok.numval = 0;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -864,6 +864,40 @@ expr(A) ::= modifier(B) EQUALS param_num(C) . {
   }
 }
 
+expr(A) ::= modifier(B) NOT_EQUAL TERM(C) . {
+  A = NULL;
+  if (ctx->sctx->spec) {
+    if (FIELD_IS(B.fs, INDEXFLD_T_TAG)) {
+      QueryNode *lxrng = NewLexRangeNode(C.s, C.len, true, C.s, C.len, true);
+      QueryNode *tagNode = NewTagNode(B.fs);
+      QueryNode_AddChild(tagNode, lxrng);
+      A = not_step(tagNode);
+    } else if (FIELD_IS(B.fs, INDEXFLD_T_FULLTEXT)) {
+      QueryNode *lxrng = NewLexRangeNode(C.s, C.len, true, C.s, C.len, true);
+      QueryNode_SetFieldMask(lxrng, FIELD_BIT(B.fs));
+      A = not_step(lxrng);
+    } else {
+      REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR " or " SPEC_TAG_STR " or " SPEC_TEXT_STR);
+    }
+  }
+}
+
+expr(A) ::= modifier(B) EQUALS TERM(C) . {
+  A = NULL;
+  if (ctx->sctx->spec) {
+    if (FIELD_IS(B.fs, INDEXFLD_T_TAG)) {
+      QueryNode *lxrng = NewLexRangeNode(C.s, C.len, true, C.s, C.len, true);
+      A = NewTagNode(B.fs);
+      QueryNode_AddChild(A, lxrng);
+    } else if (FIELD_IS(B.fs, INDEXFLD_T_FULLTEXT)) {
+      A = NewLexRangeNode(C.s, C.len, true, C.s, C.len, true);
+      QueryNode_SetFieldMask(A, FIELD_BIT(B.fs));
+    } else {
+      REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR " or " SPEC_TAG_STR " or " SPEC_TEXT_STR);
+    }
+  }
+}
+
 expr(A) ::= modifier(B) GT param_num(C) . {
   if (ctx->sctx->spec && !FIELD_IS(B.fs, INDEXFLD_T_NUMERIC)) {
     REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR);
@@ -901,6 +935,74 @@ expr(A) ::= modifier(B) LE param_num(C) . {
   } else {
     QueryParam *qp = NewNumericFilterQueryParam_WithParams(ctx, NULL, &C, 1, 1);
     A = NewNumericNode(qp, B.fs);
+  }
+}
+
+/////////////////////////////////////////////////////////////////
+// Lexicographic Range Queries (TAG/TEXT fields)
+/////////////////////////////////////////////////////////////////
+
+expr(A) ::= modifier(B) GT TERM(C) . {
+  A = NULL;
+  if (ctx->sctx->spec) {
+    if (FIELD_IS(B.fs, INDEXFLD_T_TAG)) {
+      QueryNode *lxrng = NewLexRangeNode(C.s, C.len, false, NULL, 0, false);
+      A = NewTagNode(B.fs);
+      QueryNode_AddChild(A, lxrng);
+    } else if (FIELD_IS(B.fs, INDEXFLD_T_FULLTEXT)) {
+      A = NewLexRangeNode(C.s, C.len, false, NULL, 0, false);
+      QueryNode_SetFieldMask(A, FIELD_BIT(B.fs));
+    } else {
+      REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR " or " SPEC_TAG_STR " or " SPEC_TEXT_STR);
+    }
+  }
+}
+
+expr(A) ::= modifier(B) GE TERM(C) . {
+  A = NULL;
+  if (ctx->sctx->spec) {
+    if (FIELD_IS(B.fs, INDEXFLD_T_TAG)) {
+      QueryNode *lxrng = NewLexRangeNode(C.s, C.len, true, NULL, 0, false);
+      A = NewTagNode(B.fs);
+      QueryNode_AddChild(A, lxrng);
+    } else if (FIELD_IS(B.fs, INDEXFLD_T_FULLTEXT)) {
+      A = NewLexRangeNode(C.s, C.len, true, NULL, 0, false);
+      QueryNode_SetFieldMask(A, FIELD_BIT(B.fs));
+    } else {
+      REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR " or " SPEC_TAG_STR " or " SPEC_TEXT_STR);
+    }
+  }
+}
+
+expr(A) ::= modifier(B) LT TERM(C) . {
+  A = NULL;
+  if (ctx->sctx->spec) {
+    if (FIELD_IS(B.fs, INDEXFLD_T_TAG)) {
+      QueryNode *lxrng = NewLexRangeNode(NULL, 0, false, C.s, C.len, false);
+      A = NewTagNode(B.fs);
+      QueryNode_AddChild(A, lxrng);
+    } else if (FIELD_IS(B.fs, INDEXFLD_T_FULLTEXT)) {
+      A = NewLexRangeNode(NULL, 0, false, C.s, C.len, false);
+      QueryNode_SetFieldMask(A, FIELD_BIT(B.fs));
+    } else {
+      REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR " or " SPEC_TAG_STR " or " SPEC_TEXT_STR);
+    }
+  }
+}
+
+expr(A) ::= modifier(B) LE TERM(C) . {
+  A = NULL;
+  if (ctx->sctx->spec) {
+    if (FIELD_IS(B.fs, INDEXFLD_T_TAG)) {
+      QueryNode *lxrng = NewLexRangeNode(NULL, 0, false, C.s, C.len, true);
+      A = NewTagNode(B.fs);
+      QueryNode_AddChild(A, lxrng);
+    } else if (FIELD_IS(B.fs, INDEXFLD_T_FULLTEXT)) {
+      A = NewLexRangeNode(NULL, 0, false, C.s, C.len, true);
+      QueryNode_SetFieldMask(A, FIELD_BIT(B.fs));
+    } else {
+      REPORT_WRONG_FIELD_TYPE(B, SPEC_NUMERIC_STR " or " SPEC_TAG_STR " or " SPEC_TEXT_STR);
+    }
   }
 }
 

--- a/tests/pytests/test_lexrange.py
+++ b/tests/pytests/test_lexrange.py
@@ -1,0 +1,242 @@
+
+from RLTest import Env
+from includes import *
+from common import *
+
+
+def testTagLexRangeGT(env):
+    """Test > operator on TAG fields returns tags lexicographically greater."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice')
+    conn.execute_command('hset', 'doc2', 'name', 'bob')
+    conn.execute_command('hset', 'doc3', 'name', 'charlie')
+    conn.execute_command('hset', 'doc4', 'name', 'dave')
+    conn.execute_command('hset', 'doc5', 'name', 'eve')
+
+    waitForIndex(env, 'idx')
+
+    # @name > charlie -> dave, eve
+    res = env.cmd('ft.search', 'idx', '@name > charlie', 'nocontent')
+    env.assertEqual(res[0], 2)
+    results = py2sorted(res[1:])
+    env.assertContains('doc4', results)
+    env.assertContains('doc5', results)
+
+
+def testTagLexRangeGE(env):
+    """Test >= operator on TAG fields returns tags lexicographically greater or equal."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice')
+    conn.execute_command('hset', 'doc2', 'name', 'bob')
+    conn.execute_command('hset', 'doc3', 'name', 'charlie')
+    conn.execute_command('hset', 'doc4', 'name', 'dave')
+    conn.execute_command('hset', 'doc5', 'name', 'eve')
+
+    waitForIndex(env, 'idx')
+
+    # @name >= charlie -> charlie, dave, eve
+    res = env.cmd('ft.search', 'idx', '@name >= charlie', 'nocontent')
+    env.assertEqual(res[0], 3)
+    results = py2sorted(res[1:])
+    env.assertContains('doc3', results)
+    env.assertContains('doc4', results)
+    env.assertContains('doc5', results)
+
+
+def testTagLexRangeLT(env):
+    """Test < operator on TAG fields returns tags lexicographically less."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice')
+    conn.execute_command('hset', 'doc2', 'name', 'bob')
+    conn.execute_command('hset', 'doc3', 'name', 'charlie')
+    conn.execute_command('hset', 'doc4', 'name', 'dave')
+    conn.execute_command('hset', 'doc5', 'name', 'eve')
+
+    waitForIndex(env, 'idx')
+
+    # @name < charlie -> alice, bob
+    res = env.cmd('ft.search', 'idx', '@name < charlie', 'nocontent')
+    env.assertEqual(res[0], 2)
+    results = py2sorted(res[1:])
+    env.assertContains('doc1', results)
+    env.assertContains('doc2', results)
+
+
+def testTagLexRangeLE(env):
+    """Test <= operator on TAG fields returns tags lexicographically less or equal."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice')
+    conn.execute_command('hset', 'doc2', 'name', 'bob')
+    conn.execute_command('hset', 'doc3', 'name', 'charlie')
+    conn.execute_command('hset', 'doc4', 'name', 'dave')
+    conn.execute_command('hset', 'doc5', 'name', 'eve')
+
+    waitForIndex(env, 'idx')
+
+    # @name <= charlie -> alice, bob, charlie
+    res = env.cmd('ft.search', 'idx', '@name <= charlie', 'nocontent')
+    env.assertEqual(res[0], 3)
+    results = py2sorted(res[1:])
+    env.assertContains('doc1', results)
+    env.assertContains('doc2', results)
+    env.assertContains('doc3', results)
+
+
+def testTagLexRangeCombined(env):
+    """Test combining lex range operators for between-style queries on TAG fields."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice')
+    conn.execute_command('hset', 'doc2', 'name', 'bob')
+    conn.execute_command('hset', 'doc3', 'name', 'charlie')
+    conn.execute_command('hset', 'doc4', 'name', 'dave')
+    conn.execute_command('hset', 'doc5', 'name', 'eve')
+
+    waitForIndex(env, 'idx')
+
+    # @name >= bob @name <= dave -> bob, charlie, dave
+    res = env.cmd('ft.search', 'idx', '@name >= bob @name <= dave', 'nocontent')
+    env.assertEqual(res[0], 3)
+    results = py2sorted(res[1:])
+    env.assertContains('doc2', results)
+    env.assertContains('doc3', results)
+    env.assertContains('doc4', results)
+
+
+def testTagLexRangeNoResults(env):
+    """Test lex range returns empty when no matches exist."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice')
+    conn.execute_command('hset', 'doc2', 'name', 'bob')
+
+    waitForIndex(env, 'idx')
+
+    # @name > zzz -> nothing
+    res = env.cmd('ft.search', 'idx', '@name > zzz', 'nocontent')
+    env.assertEqual(res[0], 0)
+
+    # @name < aaa -> nothing
+    res = env.cmd('ft.search', 'idx', '@name < aaa', 'nocontent')
+    env.assertEqual(res[0], 0)
+
+
+def testTextLexRangeGT(env):
+    """Test > operator on TEXT NOSTEM fields returns terms lexicographically greater."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'city', 'text', 'NOSTEM').ok()
+    conn.execute_command('hset', 'doc1', 'city', 'atlanta')
+    conn.execute_command('hset', 'doc2', 'city', 'boston')
+    conn.execute_command('hset', 'doc3', 'city', 'chicago')
+    conn.execute_command('hset', 'doc4', 'city', 'denver')
+    conn.execute_command('hset', 'doc5', 'city', 'erie')
+
+    waitForIndex(env, 'idx')
+
+    # @city > chicago -> denver, erie
+    res = env.cmd('ft.search', 'idx', '@city > chicago', 'nocontent')
+    env.assertEqual(res[0], 2)
+    results = py2sorted(res[1:])
+    env.assertContains('doc4', results)
+    env.assertContains('doc5', results)
+
+
+def testTextLexRangeLE(env):
+    """Test <= operator on TEXT NOSTEM fields."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'city', 'text', 'NOSTEM').ok()
+    conn.execute_command('hset', 'doc1', 'city', 'atlanta')
+    conn.execute_command('hset', 'doc2', 'city', 'boston')
+    conn.execute_command('hset', 'doc3', 'city', 'chicago')
+    conn.execute_command('hset', 'doc4', 'city', 'denver')
+    conn.execute_command('hset', 'doc5', 'city', 'erie')
+
+    waitForIndex(env, 'idx')
+
+    # @city <= chicago -> atlanta, boston, chicago
+    res = env.cmd('ft.search', 'idx', '@city <= chicago', 'nocontent')
+    env.assertEqual(res[0], 3)
+    results = py2sorted(res[1:])
+    env.assertContains('doc1', results)
+    env.assertContains('doc2', results)
+    env.assertContains('doc3', results)
+
+
+def testNumericStillWorksWithOperators(env):
+    """Verify that numeric comparison operators still work correctly."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'price', 'numeric').ok()
+    conn.execute_command('hset', 'doc1', 'price', '10')
+    conn.execute_command('hset', 'doc2', 'price', '20')
+    conn.execute_command('hset', 'doc3', 'price', '30')
+
+    waitForIndex(env, 'idx')
+
+    res = env.cmd('ft.search', 'idx', '@price > 15', 'nocontent')
+    env.assertEqual(res[0], 2)
+
+    res = env.cmd('ft.search', 'idx', '@price >= 20', 'nocontent')
+    env.assertEqual(res[0], 2)
+
+    res = env.cmd('ft.search', 'idx', '@price < 25', 'nocontent')
+    env.assertEqual(res[0], 2)
+
+    res = env.cmd('ft.search', 'idx', '@price <= 20', 'nocontent')
+    env.assertEqual(res[0], 2)
+
+
+def testTagLexRangeKeysetPagination(env):
+    """Demonstrate keyset-based pagination using lex range on TAG fields."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'username', 'tag', 'SORTABLE').ok()
+
+    users = ['anna', 'beth', 'carl', 'dana', 'emma', 'finn', 'gina', 'hans']
+    for i, u in enumerate(users):
+        conn.execute_command('hset', 'user:%s' % u, 'username', u)
+
+    waitForIndex(env, 'idx')
+
+    # Page 1: first 3 (sorted by tag): anna, beth, carl
+    res = env.cmd('ft.search', 'idx', '*', 'SORTBY', 'username', 'ASC',
+                  'LIMIT', '0', '3', 'nocontent')
+    env.assertEqual(res[0], 8)
+
+    # Page 2: keyset pagination with @username > carl
+    res = env.cmd('ft.search', 'idx', '@username > carl',
+                  'SORTBY', 'username', 'ASC', 'LIMIT', '0', '3', 'nocontent')
+    env.assertEqual(res[0], 5)
+
+
+def testTagLexRangeWithIntersection(env):
+    """Test lex range combined with other filter conditions."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'name', 'tag', 'score', 'numeric').ok()
+    conn.execute_command('hset', 'doc1', 'name', 'alice', 'score', '90')
+    conn.execute_command('hset', 'doc2', 'name', 'bob', 'score', '80')
+    conn.execute_command('hset', 'doc3', 'name', 'charlie', 'score', '70')
+    conn.execute_command('hset', 'doc4', 'name', 'dave', 'score', '85')
+    conn.execute_command('hset', 'doc5', 'name', 'eve', 'score', '95')
+
+    waitForIndex(env, 'idx')
+
+    # @name >= charlie AND @score > 75 -> dave(85), eve(95)
+    res = env.cmd('ft.search', 'idx', '@name >= charlie @score:[75 +inf]', 'nocontent')
+    env.assertEqual(res[0], 2)
+    results = py2sorted(res[1:])
+    env.assertContains('doc4', results)
+    env.assertContains('doc5', results)

--- a/tests/pytests/test_lexrange.py
+++ b/tests/pytests/test_lexrange.py
@@ -25,6 +25,23 @@ def testTagLexRangeGT(env):
     env.assertContains('doc5', results)
 
 
+def testTagLexRangeLeadingDigitNotParsedAsNumber(env):
+    """RHS like 5stars must be a full TERM, not a partial numeric parse (issue #14996)."""
+    conn = getConnectionByEnv(env)
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'id', 'tag').ok()
+    conn.execute_command('hset', 'a', 'id', '1st')
+    conn.execute_command('hset', 'b', 'id', '5stars')
+    conn.execute_command('hset', 'c', 'id', '5zzz')
+
+    waitForIndex(env, 'idx')
+
+    # Strictly greater than "5stars" -> only "5zzz"
+    res = env.cmd('ft.search', 'idx', '@id > 5stars', 'nocontent')
+    env.assertEqual(res[0], 1)
+    env.assertContains('c', res[1:])
+
+
 def testTagLexRangeGE(env):
     """Test >= operator on TAG fields returns tags lexicographically greater or equal."""
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
## Describe the changes in the pull request
Addresses the needs of this particular request: https://github.com/redis/redis/issues/14996

A clear and concise description of what the PR is solving, including:
1. Current: The Redis Query Engine supports comparison operators (`>, >=, <, <=, ==, !=`) only on `NUMERIC` fields. `TAG` and `TEXT` fields can only be queried via exact match `(@tag:{value})`, prefix/suffix patterns, or lexicographic ranges using the bracket syntax `([begin (end)`. There is no way to express lexicographic comparisons using the familiar operator syntax, which blocks patterns like keyset-based pagination on string-indexed fields.

2. Change: Extended the query parser (lexer + grammar) to accept string `TERM` values as operands to comparison operators. When the field is `TAG` or `TEXT`, the parser now creates `QN_LEXRANGE` nodes (which already had full evaluation support internally via `Query_EvalTagLexRangeNode` and `Query_EvalLexRangeNode`). Numeric fields continue to work exactly as before — the lexer uses `fast_float_strtod` to distinguish numbers from strings at tokenization time, and the parser dispatches to separate grammar rules (`param_num` vs `TERM`) with zero conflicts.

3. Outcome: Users can now write queries like `@name > Marsh`, `@city <= bangalore`, `@username >= shubham` `@username < aish` on `TAG` and `TEXT` indices. This directly enables keyset-based pagination and other lexicographic filtering patterns that were previously impossible without workarounds.

#### Which additional issues this PR fixes
None

#### Main objects this PR modified
1.`src/query_parser/v2/lexer.rl` — Extended ragel patterns for comparison operators to accept term operands; modified `RSQuery_ParseNumericOp_v2()` to emit `TERM` tokens when the value is not a valid number.

2. `src/query_parser/v2/parser.y` — Added 8 new grammar rules (`GT/GE/LT/LE/EQUALS/NOT_EQUAL × TERM`) that create `QN_LEXRANGE` nodes for `TAG` and `TEXT` fields.

3.`src/query.c` — Added `NewLexRangeNode()` helper to construct `QN_LEXRANGE AST` nodes from length-delimited strings.

4. `src/query_internal.h` — Declared `NewLexRangeNode()` so parser-generated code can call it.

5. `tests/pytests/test_lexrange.py` — Added 11 integration tests covering all operators on `TAG/TEXT` fields, edge cases, regression for numeric operators, keyset pagination, and combined filters.

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Support lexicographic range queries (`>, >=, <, <=, ==, !=`) on `TAG` and `TEXT` indices using the same operator syntax already available for `NUMERIC` fields. This enables patterns like keyset-based pagination on string-valued fields (e.g., `FT.SEARCH idx "@username > shubham" SORTBY username ASC LIMIT 0 10`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the v2 lexer/parser to reinterpret comparison operators with non-numeric RHS as lexicographic range filters for `TAG`/`TEXT`, which could subtly change how some previously-accepted mixed tokens were tokenized (e.g. leading-digit strings) and impact query behavior.
> 
> **Overview**
> Adds support for lexicographic comparisons on `TAG` and `TEXT` fields using standard operators (`>`, `>=`, `<`, `<=`, plus `==`/`!=` for term equality) by emitting `QN_LEXRANGE` nodes from the v2 parser.
> 
> The lexer now accepts `TERM` operands for modifier comparisons and tightens numeric tokenization to require full RHS consumption (so inputs like `5stars` become `TERM`, not a partially-parsed `NUMBER`). A new `NewLexRangeNode()` constructor is introduced, and a new Python test suite exercises the new operator syntax, regression coverage for numeric operators, and keyset-pagination style queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d32d8ec5cb273112d7e5ea753f2067bcd8c402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->