### PR TITLE
[8.8] [MOD-15112] take actions on Node20 deprecation (#9361)

### DIFF
--- a/.github/actions/get-redis/action.yml
+++ b/.github/actions/get-redis/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Get Redis
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis/redis
         ref: ${{ inputs.ref }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.10
       with:
         # Disable the post-run stats annotation as it runs outside the
         # container and reports nothing. We show stats ourselves.

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Compute effective benchmark filter
         id: benchmark-filter
         working-directory: tests/benchmarks

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -34,7 +34,7 @@ jobs:
       expected_sha: ${{ steps.get_sha.outputs.sha }}
       release_branch: ${{ steps.verify.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.checkout_target }}
           fetch-depth: 0
@@ -107,7 +107,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-tag.outputs.release_branch }}
       - name: Update version for next patch
@@ -257,7 +257,7 @@ jobs:
           with ThreadPoolExecutor() as executor:
               sha_list = executor.map(extract_sha, files)
           sha_list = list(sha_list)
-          
+
           # Include only files that match the expected SHA
           exclude_list = [(f, sha) for f, sha in zip(files, sha_list) if sha != expected_sha]
           include_list = [f for f in files if f not in [x for x, _ in exclude_list]]
@@ -287,7 +287,7 @@ jobs:
           group_print("Excluded Files", exclude_list)
           group_print("Included Files", include_list)
           group_print("Unexpected SHAs", set([sha for _, sha in exclude_list]))
-          
+
           # Copy included files to new location
           for src, dst in zip(include_list, dest_files):
               client.copy_object(Bucket=bucket, Key=dst, CopySource={"Bucket": bucket, "Key": src}, ACL="public-read")

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'pip'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -59,7 +59,7 @@ jobs:
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - id: get-redis

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -27,7 +27,7 @@ jobs:
       BUILD_DIR: ${{ inputs.profile_env == 1 && 'bin/linux-x64-release-profile/search-community' || 'bin/linux-x64-release/search-community' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup specific

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get -y --no-install-recommends install git
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Print runner info
@@ -68,7 +68,7 @@ jobs:
           printf "Runner uname:\n$(uname -a)\n"
           printf "Runner arch:\n$(arch)\n"
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Setup sccache

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -84,7 +84,7 @@ jobs:
       PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install benchmark dependencies
         run: |
           # Then install Python dependencies

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -10,7 +10,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup specific

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -22,17 +22,17 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.action != 'labeled' ||
       contains(github.event.label.name, 'check-links')
-    
+
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-      
+      uses: actions/checkout@v6
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'pip'
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip uv
@@ -44,7 +44,7 @@ jobs:
           --timeout 15 \
           --max-workers 5 \
           --delay 0.2
-      
+
     - name: Upload results on failure
       if: failure()
       uses: actions/upload-artifact@v4
@@ -53,10 +53,10 @@ jobs:
         path: |
           link-check-*.log
         retention-days: 7
-        
+
     - name: Comment on PR
       if: failure()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: |
           github.rest.issues.createComment({

--- a/.github/workflows/pr_label_size.yml
+++ b/.github/workflows/pr_label_size.yml
@@ -29,4 +29,3 @@ jobs:
             github_api_url: 'https://api.github.com'
             files_to_ignore: '*.md .gitignore'
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -128,7 +128,7 @@ jobs:
         run: ${{ needs.get-config.outputs.post_setup_script }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ env.REF }}

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -40,11 +40,11 @@ jobs:
     steps:
       - name: Checkout
         if: inputs.checkout-ref == ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Checkout (custom ref)
         if: inputs.checkout-ref != ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout-ref }}
       - name: Set image name

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -24,20 +24,20 @@ jobs:
       TESTS_CHANGED: ${{ steps.check-tests.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # required for changed-files action to work
 
       - name: Check if any workflows were changed
         id: check-workflows
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
         with: # Only run on changes to these paths (workflows)
           files: |
                 .github/workflows/**
                 .github/actions/**
       - name: Check if code were changed
         id: check-code
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
         with: # Only run on changes to these paths (code, deps)
           files: |
                 src/**
@@ -47,7 +47,7 @@ jobs:
           fetch_additional_submodule_history: true
       - name: Check if benchmarks or code were changed
         id: check-benchmarks
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
         with: # Only run on changes to these paths (code, deps, and benchmarks related changes)
           files: |
                 src/**
@@ -59,7 +59,7 @@ jobs:
           fetch_additional_submodule_history: true
       - name: Check if tests were changed
         id: check-tests
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
         with: # Only run on changes to these paths (tests related changes)
           files: |
                 tests/**
@@ -67,7 +67,7 @@ jobs:
           fetch_additional_submodule_history: true
       - name: Check if rust micro-benchmarks were changed
         id: check-micro-benchmarks
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
         with: # Only run on changes to these paths (redisearch_rs)
           files: |
               src/redisearch_rs/**

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Fix HOME Directory

--- a/.github/workflows/task-release-notes-check.yml
+++ b/.github/workflows/task-release-notes-check.yml
@@ -47,4 +47,3 @@ jobs:
           else:
               print('✅ Release notes not required - checkbox is checked.')
           EOF
-

--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -16,7 +16,7 @@ jobs:
         run: git fetch origin master
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -235,7 +235,7 @@ jobs:
           ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Print CPU information
@@ -520,7 +520,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (combined)
         if: inputs.coverage && inputs.standalone && inputs.coordinator
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
@@ -529,7 +529,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.standalone && !inputs.coordinator
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
@@ -538,7 +538,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && !inputs.standalone && inputs.coordinator
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true
@@ -547,7 +547,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage && inputs.unit-tests
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true


### PR DESCRIPTION
## Describe the changes in the pull request

Manual backport of #9361 to `8.8`. The automated backport (https://github.com/RediSearch/RediSearch/pull/9361#issuecomment-4354029100) failed because `8.8` no longer contains `.github/actions/build-redis/action.yml`; resolved by dropping that one file from the cherry-pick. All other files merged cleanly.

1. **Current**: Several CI workflow actions on `8.8` still use Node 20 versions (`actions/checkout@v4/v5`, `actions/setup-python@v4`, `actions/github-script@v6`, `tj-actions/changed-files@v46.0.5`), which will be deprecated by GitHub in June 2026.
2. **Change**: Bump the affected actions to their latest Node 24-supported versions (`@v6` for `actions/checkout`, `actions/setup-python`, `codecov/codecov-action` (with `# NOSONAR`), `@v8` for `actions/github-script`, `@v47.0.6` for `tj-actions/changed-files`).
3. **Outcome**: `8.8` CI keeps working past Node 20 deprecation without behavioural changes.

All modified workflows pass `yaml.safe_load`.

Cherry-picked from commit ee1ee66f929810403dfb9d639c327082340a065b.

#### Which additional issues this PR fixes
1. MOD-15112
2. #9361

#### Main objects this PR modified
1. `.github/workflows/*.yml`, `.github/actions/**/action.yml` (21 files — GitHub Actions version bumps)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates multiple CI workflows and composite actions to newer third-party action versions; primary risk is CI breakage due to upstream behavior changes or new defaults in the bumped actions.
> 
> **Overview**
> Modernizes the CI configuration to avoid upcoming Node 20 deprecations by bumping GitHub Actions dependencies across workflows and composite actions (notably `actions/checkout@v6`, `actions/setup-python@v6`, `actions/github-script@v8`, `tj-actions/changed-files@v47.0.6`, and `codecov/codecov-action@v6`).
> 
> Also updates the sccache setup action to `mozilla-actions/sccache-action@v0.0.10` and includes minor YAML whitespace/format cleanup in a couple of workflow files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcddd9dc837091f61636a7ea37e8facd96e15d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->