### PR TITLE
[8.0] [MOD-15112] take actions on Node20 deprecation (#9361)

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup specific  # assuming node20 supported

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -33,7 +33,7 @@ jobs:
       expected_sha: ${{ steps.get_sha.outputs.sha }}
       release_branch: ${{ steps.verify.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.checkout_target }}
       - name: Get SHA
@@ -76,7 +76,7 @@ jobs:
     env:
       BRANCH: bump-version-${{ needs.validate-tag.outputs.next_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-tag.outputs.release_branch }}
       - name: Update version for next patch

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
       redis-ref: ${{ steps.get-redis.outputs.tag }}
       version-suffix: ${{ steps.set-version.outputs.VERSION_SUFFIX }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - id: get-redis

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -76,7 +76,7 @@ jobs:
           echo "supported=true" >> $GITHUB_OUTPUT
       - name: checkout (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ env.REF }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -83,7 +83,7 @@ jobs:
           echo "supported=true" >> $GITHUB_OUTPUT
       - name: Full checkout (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Full checkout (node20 not supported)
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload flow coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
@@ -275,7 +275,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit.info
           disable_search: true


### PR DESCRIPTION
## Describe the changes in the pull request

Manual backport of #9361 to `8.0`. The automated backport (https://github.com/RediSearch/RediSearch/pull/9361#issuecomment-4354029298) failed due to conflicts; resolved manually.

1. **Current**: Several CI workflow actions on `8.0` still use Node 20 versions (`actions/checkout@v4`, `codecov/codecov-action@v5`), which will be deprecated by GitHub in June 2026.
2. **Change**: Bump the affected actions to their latest Node 24-supported versions (`@v6` for `actions/checkout` and `codecov/codecov-action` (with `# NOSONAR`)) wherever the corresponding workflow exists on `8.0`.
3. **Outcome**: `8.0` CI keeps working past Node 20 deprecation without behavioural changes.

### Applied
- `benchmark-flow.yml`: `actions/checkout@v4` → `@v6`
- `event-release.yml`: 2× `actions/checkout@v4` → `@v6`
- `flow-build-artifacts.yml`: `actions/checkout@v4` → `@v6`
- `task-backport_pr.yml`: `actions/checkout@v4` → `@v6`
- `task-build-artifacts.yml`: `actions/checkout@v4` → `@v6` (node20-supported path)
- `task-test.yml`: `actions/checkout@v4` → `@v6` (node20-supported path); 2× `codecov/codecov-action@v5` → `@v6 # NOSONAR`

All modified workflows pass `yaml.safe_load`.

Cherry-picked from commit ee1ee66f929810403dfb9d639c327082340a065b.

#### Which additional issues this PR fixes
1. MOD-15112
2. #9361

#### Main objects this PR modified
1. `.github/workflows/*.yml` (6 files — GitHub Actions version bumps)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions versions in CI workflows; main risk is unexpected behavioral differences in `actions/checkout@v6` or `codecov-action@v6` impacting CI execution.
> 
> **Overview**
> Updates multiple CI workflows to use **Node24-compatible** action versions by bumping `actions/checkout` from `@v4` to `@v6` across benchmark, release, artifact, and test flows.
> 
> Also bumps coverage upload steps in `task-test.yml` from `codecov/codecov-action@v5` to `@v6` (annotated with `# NOSONAR`), with no intended behavioral changes beyond keeping CI working past GitHub’s Node 20 deprecation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fb6867068505c33204099506fbb71efb6e7078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->