### PR TITLE
[MOD-15008] ForkGC: Add recv_fixed support

### DIFF
--- a/src/fork_gc/pipe.c
+++ b/src/fork_gc/pipe.c
@@ -29,28 +29,6 @@ void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
   gc->stats.gcBlocksDenied += ignoredLastBlock ? 1 : 0;
 }
 
-int __attribute__((warn_unused_result)) FGC_recvFixed(ForkGC *fgc, void *buf, size_t len) {
-  // poll the pipe, so that we don't block while read, with timeout of 3 minutes
-  int poll_rc;
-  while ((poll_rc = poll(fgc->pollfd_read, 1, 180000)) == 1) {
-    ssize_t nrecvd = read(fgc->pipe_read_fd, buf, len);
-    if (nrecvd > 0) {
-      buf += nrecvd;
-      len -= nrecvd;
-    } else if (nrecvd <= 0 && errno != EINTR) {
-      break;
-    }
-    if (len == 0) {
-      return REDISMODULE_OK;
-    }
-  }
-  short revents = fgc->pollfd_read[0].revents;
-  const char *what = (poll_rc == 0) ? "timeout" : "error";
-  RedisModule_Log(fgc->ctx, "warning", "ForkGC - got %s while reading from pipe. errno: %s, revents: 0x%x (POLLIN=%x POLLERR=%x POLLHUP=%x POLLNVAL=%x)",
-                  what, strerror(errno), revents, (revents & POLLIN), (revents & POLLERR), (revents & POLLHUP), (revents & POLLNVAL));
-  return REDISMODULE_ERR;
-}
-
 int __attribute__((warn_unused_result))
 FGC_recvBuffer(ForkGC *fgc, void **buf, size_t *len) {
   size_t temp_len;

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -43,8 +43,6 @@ extern void *RECV_BUFFER_EMPTY;
 
 #define FGC_SEND_VAR(fgc, v) FGC_sendFixed(fgc, &v, sizeof v)
 
-int __attribute__((warn_unused_result)) FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
-
 int __attribute__((warn_unused_result)) FGC_recvBuffer(ForkGC *fgc, void **buf, size_t *len);
 
 //------------------------------------------------------------------------------

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -696,6 +696,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "libc",
+ "nix",
  "redis-module",
  "tracing",
  "workspace_hack",
@@ -1293,6 +1294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics_ffi"
 version = "0.0.1"
 dependencies = [
@@ -1348,6 +1358,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1518,6 +1530,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
  "ffi",
  "fork_gc",
  "tracing",
+ "tracing_log_error",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -695,6 +695,7 @@ name = "fork_gc"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "libc",
  "redis-module",
  "tracing",
  "workspace_hack",
@@ -707,6 +708,7 @@ dependencies = [
  "cheadergen",
  "ffi",
  "fork_gc",
+ "tracing",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3436,6 +3436,7 @@ dependencies = [
  "libc",
  "memchr",
  "miniz_oxide",
+ "nix",
  "num-traits 0.2.19",
  "ppv-lite86",
  "proc-macro2",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -165,6 +165,7 @@ insta = "1.46.1"
 itertools = "0.14.0"
 lending-iterator = "0.1.7"
 libc = "0.2.180"
+nix = { version = "0.26", features = ["poll"] }
 memchr = "2.7.6"
 pin-project = "1.1.10"
 pretty_assertions = "1.4.1"

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/Cargo.toml
@@ -19,4 +19,5 @@ cheadergen.workspace = true
 ffi = { workspace = true }
 fork_gc = { workspace = true }
 tracing.workspace = true
+tracing_log_error.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/Cargo.toml
@@ -18,4 +18,5 @@ workspace = true
 cheadergen.workspace = true
 ffi = { workspace = true }
 fork_gc = { workspace = true }
+tracing.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -15,7 +15,7 @@
 //! delegates everything else — including Redis-specific failure
 //! handling — to the `fork_gc` crate.
 
-use std::ffi::c_void;
+use std::ffi::{c_int, c_void};
 
 use fork_gc::{ForkGC, io_result_ext::IoResultExt};
 
@@ -86,4 +86,35 @@ pub unsafe extern "C" fn FGC_sendTerminator(fgc: *mut ffi::ForkGC) {
     let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
 
     fgc.writer().send_terminator().unwrap_or_exit();
+}
+
+/// Read exactly `len` bytes from the FGC pipe into `buf`.
+///
+/// Polls the pipe fd with a 3-minute timeout and retries on `EINTR`. On
+/// timeout, read error, or unexpected EOF, logs a detailed warning
+/// (matching the original C format) and returns `REDISMODULE_ERR`.
+///
+/// # Safety
+///
+/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+///    readable file descriptor.
+/// 2. `buf` must point to a writable region of at least `len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn FGC_recvFixed(
+    fgc: *mut ffi::ForkGC,
+    buf: *mut c_void,
+    len: usize,
+) -> c_int {
+    // SAFETY: caller guarantees (1).
+    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    // SAFETY: caller guarantees (2).
+    let slice = unsafe { std::slice::from_raw_parts_mut(buf.cast::<u8>(), len) };
+
+    match fgc.reader().recv_fixed(slice) {
+        Ok(()) => ffi::REDISMODULE_OK as c_int,
+        Err(err) => {
+            tracing::warn!("ForkGC pipe read error: {err}");
+            ffi::REDISMODULE_ERR as c_int
+        }
+    }
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -19,6 +19,9 @@ use std::ffi::{c_int, c_void};
 
 use fork_gc::{ForkGC, io_result_ext::IoResultExt};
 
+use tracing::Level;
+use tracing_log_error::log_error;
+
 /// Write exactly `len` bytes from `buff` to the FGC pipe.
 ///
 /// On error, logs the failure and terminates the child process via
@@ -112,8 +115,8 @@ pub unsafe extern "C" fn FGC_recvFixed(
 
     match fgc.reader().recv_fixed(slice) {
         Ok(()) => ffi::REDISMODULE_OK as c_int,
-        Err(err) => {
-            tracing::warn!("ForkGC pipe read error: {err}");
+        Err(e) => {
+            log_error!(e, level: Level::WARN, "ForkGC pipe read error");
             ffi::REDISMODULE_ERR as c_int
         }
     }

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 ffi = { workspace = true }
+libc = { workspace = true }
 redis-module = { workspace = true }
 tracing.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 ffi = { workspace = true }
 libc = { workspace = true }
+nix = { workspace = true }
 redis-module = { workspace = true }
 tracing.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -14,3 +14,6 @@ libc = { workspace = true }
 redis-module = { workspace = true }
 tracing.workspace = true
 workspace_hack.workspace = true
+
+[dev-dependencies]
+ffi = { workspace = true }

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -43,31 +43,12 @@ impl ForkGC {
 
     /// Return a writable handle to the GC pipe.
     ///
-    /// The returned [`Writer`] wraps an internal `ForkGCPipeWriter` that
-    /// holds a `PhantomData<&'a mut ForkGC>`, so it statically borrows
-    /// `self` — preventing two concurrent writers and ensuring the
-    /// writer cannot outlive the `ForkGC` it came from. The concrete
-    /// inner writer type is hidden behind `impl Write + '_`.
+    /// The returned [`Writer`] wraps a [`ForkGCPipeWriter`] that holds a
+    /// `PhantomData<&'a mut ForkGC>`, so it statically borrows `self` —
+    /// preventing two concurrent writers and ensuring the writer cannot
+    /// outlive the `ForkGC` it came from. The concrete inner writer type is
+    /// hidden behind `impl Write + '_`.
     pub fn writer(&mut self) -> Writer<impl Write + '_> {
-        // Local [`Write`] adapter over the pipe fd. Holds a
-        // `ManuallyDrop<io::PipeWriter>` so dropping the writer does not
-        // close the caller's fd, and a `PhantomData<&'a mut ForkGC>` so
-        // the writer borrows the `ForkGC` for its entire lifetime.
-        struct ForkGCPipeWriter<'a> {
-            pipe_writer: ManuallyDrop<io::PipeWriter>,
-            _borrow: PhantomData<&'a mut ForkGC>,
-        }
-
-        impl Write for ForkGCPipeWriter<'_> {
-            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                self.pipe_writer.write(buf)
-            }
-
-            fn flush(&mut self) -> io::Result<()> {
-                self.pipe_writer.flush()
-            }
-        }
-
         Writer::from_writer(ForkGCPipeWriter {
             // SAFETY: `pipe_write_fd` is an open writable fd maintained by
             // the C side's Fork GC state machine.
@@ -81,36 +62,21 @@ impl ForkGC {
     /// Return a readable handle to the GC pipe.
     ///
     /// Each call to [`Reader::recv_fixed`] delegates to
-    /// [`read_with_timeout`] (3-minute poll) and retries on `EINTR`.
-    /// On timeout or pipe error the error is logged and surfaced.
+    /// [`read_with_timeout`] with a 3-minute poll timeout and retries on
+    /// `EINTR`. On timeout or pipe error the error is surfaced.
     ///
     /// When `pipe_read_fd` is negative — tests deliberately set it to
     /// `-1` to simulate pipe failure — the returned reader yields
     /// `EBADF` on every read instead of constructing an `io::PipeReader`,
     /// which would otherwise trip a std-internal `fd != -1` precondition.
     pub fn reader(&mut self) -> Reader<impl Read + '_> {
-        // Local [`Read`] adapter over the pipe fd. Holds an
-        // `Option<ManuallyDrop<io::PipeReader>>`: `Some` for a live pipe
-        // (the `ManuallyDrop` keeps `Drop` from closing the caller's
-        // fd), `None` to surface `EBADF` on each read. The
-        // `PhantomData<&'a mut ForkGC>` makes the type system behave
-        // as if the reader borrows `ForkGC` for its entire lifetime.
-        struct ForkGCPipeReader<'a> {
-            pipe_reader: Option<ManuallyDrop<io::PipeReader>>,
-            _borrow: PhantomData<&'a mut ForkGC>,
-        }
+        self.reader_with_timeout(POLL_TIMEOUT)
+    }
 
-        impl Read for ForkGCPipeReader<'_> {
-            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-                match &mut self.pipe_reader {
-                    Some(pr) => {
-                        read_with_timeout(&mut **pr, buf, POLL_TIMEOUT)
-                    }
-                    None => Err(io::Error::from_raw_os_error(libc::EBADF)),
-                }
-            }
-        }
-
+    /// Like [`reader`] but with a caller-supplied poll timeout.
+    ///
+    /// Intended for tests where the 3-minute default would be impractical.
+    pub fn reader_with_timeout(&mut self, timeout: Duration) -> Reader<impl Read + '_> {
         // Existing C++ unit tests (`FGCTestTag.testPipeErrorDuringGC` and
         // `FGCTestTag.testPipeErrorDuringApply`) set `pipe_read_fd` to `-1`
         // to simulate pipe failure. `io::PipeReader` doesn't allow an fd of
@@ -127,7 +93,48 @@ impl ForkGC {
 
         Reader::from_reader(ForkGCPipeReader {
             pipe_reader,
+            timeout,
             _borrow: PhantomData,
         })
+    }
+}
+
+/// [`Write`] adapter over `pipe_write_fd`. Holds a
+/// `ManuallyDrop<io::PipeWriter>` so dropping the writer does not close
+/// the caller's fd, and a `PhantomData<&'a mut ForkGC>` makes the type
+/// system behave as if the writer borrows the `ForkGC` for its entire lifetime.
+struct ForkGCPipeWriter<'a> {
+    pipe_writer: ManuallyDrop<io::PipeWriter>,
+    _borrow: PhantomData<&'a mut ForkGC>,
+}
+
+impl Write for ForkGCPipeWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.pipe_writer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.pipe_writer.flush()
+    }
+}
+
+/// [`Read`] adapter over `pipe_read_fd`. Holds an
+/// `Option<ManuallyDrop<io::PipeReader>>`: `Some` for a live pipe (the
+/// `ManuallyDrop` keeps `Drop` from closing the caller's fd), `None` to
+/// surface `EBADF` on each read. The `PhantomData<&'a mut ForkGC>` makes
+/// the type system behave as if the reader borrows `ForkGC` for its entire
+/// lifetime.
+struct ForkGCPipeReader<'a> {
+    pipe_reader: Option<ManuallyDrop<io::PipeReader>>,
+    timeout: Duration,
+    _borrow: PhantomData<&'a mut ForkGC>,
+}
+
+impl Read for ForkGCPipeReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.pipe_reader {
+            Some(pr) => read_with_timeout(&mut **pr, buf, self.timeout),
+            None => Err(io::Error::from_raw_os_error(libc::EBADF)),
+        }
     }
 }

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -82,29 +82,47 @@ impl ForkGC {
     /// Each call to [`Reader::recv_fixed`] delegates to
     /// [`read_with_timeout`] (3-minute poll) and retries on `EINTR`.
     /// On timeout or pipe error the error is logged and surfaced.
+    ///
+    /// When `pipe_read_fd` is negative — tests deliberately set it to
+    /// `-1` to simulate pipe failure — the returned reader yields
+    /// `EBADF` on every read instead of constructing an `io::PipeReader`,
+    /// which would otherwise trip a std-internal `fd != -1` precondition.
     pub fn reader(&mut self) -> Reader<impl Read + '_> {
-        // Local [`Read`] adapter over the pipe fd. Holds a
-        // `ManuallyDrop<io::PipeWriter>` so dropping the writer does not
-        // close the caller's fd, and a `PhantomData<&'a mut ForkGC>` so
-        // the writer borrows the `ForkGC` for its entire lifetime.
+        // Local [`Read`] adapter over the pipe fd. Holds an
+        // `Option<ManuallyDrop<io::PipeReader>>`: `Some` for a live pipe
+        // (the `ManuallyDrop` keeps `Drop` from closing the caller's
+        // fd), `None` to surface `EBADF` on each read. The
+        // `PhantomData<&'a mut ForkGC>` makes the reader borrow the
+        // `ForkGC` for its entire lifetime.
         struct ForkGCPipeReader<'a> {
-            pipe_reader: ManuallyDrop<io::PipeReader>,
+            pipe_reader: Option<ManuallyDrop<io::PipeReader>>,
             _borrow: PhantomData<&'a mut ForkGC>,
         }
 
         impl Read for ForkGCPipeReader<'_> {
             fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-                read_with_timeout(&mut *self.pipe_reader, buf, POLL_TIMEOUT_MS)
+                match &mut self.pipe_reader {
+                    Some(pr) => read_with_timeout(&mut **pr, buf, POLL_TIMEOUT_MS),
+                    None => Err(io::Error::from_raw_os_error(libc::EBADF)),
+                }
             }
         }
 
+        // Snapshot the fd: tests close the pipe and assign `-1` from
+        // another thread to simulate pipe failure. Reading once and
+        // validating before constructing `io::PipeReader` avoids an
+        // `fd != -1` panic.
+        let fd = self.0.pipe_read_fd;
+        let pipe_reader = (fd >= 0).then(|| {
+            // SAFETY: `fd` is non-negative (checked above) and refers to
+            // an open readable fd maintained by the C side's Fork GC
+            // state machine; `ManuallyDrop` prevents `File::drop` from
+            // closing it.
+            ManuallyDrop::new(unsafe { io::PipeReader::from_raw_fd(fd) })
+        });
+
         Reader::from_reader(ForkGCPipeReader {
-            // SAFETY: `pipe_read_fd` is an open readable fd maintained
-            // by the C side's Fork GC state machine; `ManuallyDrop`
-            // prevents `File::drop` from closing it.
-            pipe_reader: ManuallyDrop::new(unsafe {
-                io::PipeReader::from_raw_fd(self.0.pipe_read_fd)
-            }),
+            pipe_reader,
             _borrow: PhantomData,
         })
     }

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -73,7 +73,7 @@ impl ForkGC {
         self.reader_with_timeout(POLL_TIMEOUT)
     }
 
-    /// Like [`reader`] but with a caller-supplied poll timeout.
+    /// Like [`Self::reader`] but with a caller-supplied poll timeout.
     ///
     /// Intended for tests where the 3-minute default would be impractical.
     pub fn reader_with_timeout(&mut self, timeout: Duration) -> Reader<impl Read + '_> {

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -8,10 +8,12 @@
 */
 
 use std::{
+    ffi::c_int,
     io::{self, Read, Write},
     marker::PhantomData,
     mem::ManuallyDrop,
     os::fd::FromRawFd,
+    time::Duration,
 };
 
 use crate::reader::Reader;
@@ -19,7 +21,7 @@ use crate::util::read_with_timeout;
 use crate::writer::Writer;
 
 /// Poll timeout used by the parent-side pipe reader (3 minutes).
-const POLL_TIMEOUT_MS: i32 = 1_000 * 60 * 3;
+const POLL_TIMEOUT: Duration = Duration::from_mins(3);
 
 /// Safe wrapper around [`ffi::ForkGC`].
 #[repr(transparent)]
@@ -92,8 +94,8 @@ impl ForkGC {
         // `Option<ManuallyDrop<io::PipeReader>>`: `Some` for a live pipe
         // (the `ManuallyDrop` keeps `Drop` from closing the caller's
         // fd), `None` to surface `EBADF` on each read. The
-        // `PhantomData<&'a mut ForkGC>` makes the reader borrow the
-        // `ForkGC` for its entire lifetime.
+        // `PhantomData<&'a mut ForkGC>` makes the type system behave
+        // as if the reader borrows `ForkGC` for its entire lifetime.
         struct ForkGCPipeReader<'a> {
             pipe_reader: Option<ManuallyDrop<io::PipeReader>>,
             _borrow: PhantomData<&'a mut ForkGC>,
@@ -102,22 +104,25 @@ impl ForkGC {
         impl Read for ForkGCPipeReader<'_> {
             fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
                 match &mut self.pipe_reader {
-                    Some(pr) => read_with_timeout(&mut **pr, buf, POLL_TIMEOUT_MS),
+                    Some(pr) => {
+                        read_with_timeout(&mut **pr, buf, POLL_TIMEOUT.as_millis() as c_int)
+                    }
                     None => Err(io::Error::from_raw_os_error(libc::EBADF)),
                 }
             }
         }
 
-        // Snapshot the fd: tests close the pipe and assign `-1` from
-        // another thread to simulate pipe failure. Reading once and
-        // validating before constructing `io::PipeReader` avoids an
-        // `fd != -1` panic.
+        // Existing C++ unit tests (`FGCTestTag.testPipeErrorDuringGC` and
+        // `FGCTestTag.testPipeErrorDuringApply`) set `pipe_read_fd` to `-1`
+        // to simulate pipe failure. `io::PipeReader` doesn't allow an fd of
+        // `-1` to be used and panics instead. Work around this for now. When
+        // all of Fork GC (including the tests) are ported over to Rust, use a
+        // better approach to simulate pipe failure.
         let fd = self.0.pipe_read_fd;
         let pipe_reader = (fd >= 0).then(|| {
             // SAFETY: `fd` is non-negative (checked above) and refers to
             // an open readable fd maintained by the C side's Fork GC
-            // state machine; `ManuallyDrop` prevents `File::drop` from
-            // closing it.
+            // state machine.
             ManuallyDrop::new(unsafe { io::PipeReader::from_raw_fd(fd) })
         });
 

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -19,7 +19,7 @@ use crate::reader::Reader;
 use crate::util::read_with_timeout;
 use crate::writer::Writer;
 
-/// Poll timeout used by the parent-side pipe reader (3 minutes).
+/// Poll timeout used by the parent-side pipe reader.
 const POLL_TIMEOUT: Duration = Duration::from_mins(3);
 
 /// Safe wrapper around [`ffi::ForkGC`].
@@ -62,7 +62,7 @@ impl ForkGC {
     /// Return a readable handle to the GC pipe.
     ///
     /// Each call to [`Reader::recv_fixed`] delegates to
-    /// [`read_with_timeout`] with a 3-minute poll timeout and retries on
+    /// [`read_with_timeout`] with `POLL_TIMEOUT` and retries on
     /// `EINTR`. On timeout or pipe error the error is surfaced.
     ///
     /// When `pipe_read_fd` is negative — tests deliberately set it to

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -8,7 +8,6 @@
 */
 
 use std::{
-    ffi::c_int,
     io::{self, Read, Write},
     marker::PhantomData,
     mem::ManuallyDrop,
@@ -105,7 +104,7 @@ impl ForkGC {
             fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
                 match &mut self.pipe_reader {
                     Some(pr) => {
-                        read_with_timeout(&mut **pr, buf, POLL_TIMEOUT.as_millis() as c_int)
+                        read_with_timeout(&mut **pr, buf, POLL_TIMEOUT)
                     }
                     None => Err(io::Error::from_raw_os_error(libc::EBADF)),
                 }

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -8,13 +8,18 @@
 */
 
 use std::{
-    io::{self, Write},
+    io::{self, Read, Write},
     marker::PhantomData,
     mem::ManuallyDrop,
     os::fd::FromRawFd,
 };
 
+use crate::reader::Reader;
+use crate::util::read_with_timeout;
 use crate::writer::Writer;
+
+/// Poll timeout used by the parent-side pipe reader (3 minutes).
+const POLL_TIMEOUT_MS: i32 = 1_000 * 60 * 3;
 
 /// Safe wrapper around [`ffi::ForkGC`].
 #[repr(transparent)]
@@ -67,6 +72,38 @@ impl ForkGC {
             // the C side's Fork GC state machine.
             pipe_writer: ManuallyDrop::new(unsafe {
                 io::PipeWriter::from_raw_fd(self.0.pipe_write_fd)
+            }),
+            _borrow: PhantomData,
+        })
+    }
+
+    /// Return a readable handle to the GC pipe.
+    ///
+    /// Each call to [`Reader::recv_fixed`] delegates to
+    /// [`read_with_timeout`] (3-minute poll) and retries on `EINTR`.
+    /// On timeout or pipe error the error is logged and surfaced.
+    pub fn reader(&mut self) -> Reader<impl Read + '_> {
+        // Local [`Read`] adapter over the pipe fd. Holds a
+        // `ManuallyDrop<io::PipeWriter>` so dropping the writer does not
+        // close the caller's fd, and a `PhantomData<&'a mut ForkGC>` so
+        // the writer borrows the `ForkGC` for its entire lifetime.
+        struct ForkGCPipeReader<'a> {
+            pipe_reader: ManuallyDrop<io::PipeReader>,
+            _borrow: PhantomData<&'a mut ForkGC>,
+        }
+
+        impl Read for ForkGCPipeReader<'_> {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                read_with_timeout(&mut *self.pipe_reader, buf, POLL_TIMEOUT_MS)
+            }
+        }
+
+        Reader::from_reader(ForkGCPipeReader {
+            // SAFETY: `pipe_read_fd` is an open readable fd maintained
+            // by the C side's Fork GC state machine; `ManuallyDrop`
+            // prevents `File::drop` from closing it.
+            pipe_reader: ManuallyDrop::new(unsafe {
+                io::PipeReader::from_raw_fd(self.0.pipe_read_fd)
             }),
             _borrow: PhantomData,
         })

--- a/src/redisearch_rs/fork_gc/src/lib.rs
+++ b/src/redisearch_rs/fork_gc/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod fork_gc;
 pub mod io_result_ext;
+pub mod reader;
 pub mod util;
 pub mod writer;
 

--- a/src/redisearch_rs/fork_gc/src/reader.rs
+++ b/src/redisearch_rs/fork_gc/src/reader.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::{self, Read};
+
+/// Reader over a Fork GC pipe endpoint.
+///
+/// Constructed via [`ForkGC::reader`](crate::ForkGC::reader) in
+/// production, or directly via [`from_reader`](Self::from_reader) in
+/// tests. Exposes [`recv_fixed`](Self::recv_fixed) as an inherent method;
+/// callers go through that rather than through [`Read`] directly.
+///
+/// Any borrow-lifetime relationship with the owning `ForkGC` is encoded
+/// in the inner Reader `R`, not in `Reader` itself.
+pub struct Reader<R: Read> {
+    reader: R,
+}
+
+impl<R: Read> Reader<R> {
+    /// Wrap any [`Read`] impl as a `Reader`.
+    pub const fn from_reader(reader: R) -> Self {
+        Self { reader }
+    }
+
+    /// Read exactly `buf.len()` bytes from the reader into `buf`.
+    pub fn recv_fixed(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.reader.read_exact(buf)
+    }
+}

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -71,15 +71,18 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
             }
             0 => return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out")),
             _ => {
-                if pfd.revents & libc::POLLIN == 0 {
+                // Reads from closed empty pipes return only `POLLHUP`, while reads from closed
+                // unix domain sockets return `POLLIN | POLLHUP`. In both cases however, a
+                // subsequent read doesn't block and returns 0, signalling EOF.
+                if pfd.revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+                    match reader.read(buf) {
+                        Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                        result => return result,
+                    }
+                } else {
                     return Err(io::Error::other(format!(
-                        "poll error: revents=0x{:x}{}{}{}",
+                        "poll error: revents=0x{:x}{}{}",
                         pfd.revents,
-                        if pfd.revents & libc::POLLHUP != 0 {
-                            " POLLHUP"
-                        } else {
-                            ""
-                        },
                         if pfd.revents & libc::POLLERR != 0 {
                             " POLLERR"
                         } else {
@@ -91,10 +94,6 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
                             ""
                         },
                     )));
-                }
-                match reader.read(buf) {
-                    Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
-                    result => return result,
                 }
             }
         }

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -70,8 +70,25 @@ pub(crate) fn read_with_timeout<R: Read + AsRawFd>(
             0 => return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out")),
             _ => {
                 if pfd.revents & libc::POLLIN == 0 {
-                    // POLLHUP / POLLERR / POLLNVAL
-                    return Err(io::Error::other("poll error"));
+                    return Err(io::Error::other(format!(
+                        "poll error: revents=0x{:x}{}{}{}",
+                        pfd.revents,
+                        if pfd.revents & libc::POLLHUP != 0 {
+                            " POLLHUP"
+                        } else {
+                            ""
+                        },
+                        if pfd.revents & libc::POLLERR != 0 {
+                            " POLLERR"
+                        } else {
+                            ""
+                        },
+                        if pfd.revents & libc::POLLNVAL != 0 {
+                            " POLLNVAL"
+                        } else {
+                            ""
+                        },
+                    )));
                 }
                 match reader.read(buf) {
                     Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use nix::poll::{PollFd, PollFlags};
 use redis_module::raw::RedisModule_ExitFromChild;
 use std::{
     io::{self, Read},
@@ -49,52 +50,26 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
     buf: &mut [u8],
     timeout: Duration,
 ) -> io::Result<usize> {
-    let timeout_ms = timeout.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
-
-    let mut pfd = libc::pollfd {
-        fd: reader.as_raw_fd(),
-        events: libc::POLLIN,
-        revents: 0,
-    };
+    let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+    let mut pfd = PollFd::new(reader.as_raw_fd(), PollFlags::POLLIN);
 
     loop {
-        // SAFETY: `pfd` is a valid pointer to a single pollfd for the
-        // duration of the call.
-        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
-
-        match ret {
-            -1 => {
-                let err = io::Error::last_os_error();
-                if err.kind() == io::ErrorKind::Interrupted {
-                    continue;
-                }
-                return Err(err);
-            }
-            0 => return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out")),
-            _ => {
+        match nix::poll::poll(std::slice::from_mut(&mut pfd), timeout_ms) {
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(e) => return Err(io::Error::from(e)),
+            Ok(0) => return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out")),
+            Ok(_) => {
+                let revents = pfd.revents().expect("poll returned unknown bits in revents");
                 // Reads from closed empty pipes return only `POLLHUP`, while reads from closed
                 // unix domain sockets return `POLLIN | POLLHUP`. In both cases however, a
                 // subsequent read doesn't block and returns 0, signalling EOF.
-                if pfd.revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+                if revents.intersects(PollFlags::POLLIN | PollFlags::POLLHUP) {
                     match reader.read(buf) {
                         Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
                         result => return result,
                     }
                 } else {
-                    return Err(io::Error::other(format!(
-                        "poll error: revents=0x{:x}{}{}",
-                        pfd.revents,
-                        if pfd.revents & libc::POLLERR != 0 {
-                            " POLLERR"
-                        } else {
-                            ""
-                        },
-                        if pfd.revents & libc::POLLNVAL != 0 {
-                            " POLLNVAL"
-                        } else {
-                            ""
-                        },
-                    )));
+                    return Err(io::Error::other(format!("poll error: revents={revents:?}")));
                 }
             }
         }

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -50,13 +50,14 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
     timeout: Duration,
 ) -> io::Result<usize> {
     let timeout_ms = timeout.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
-    loop {
-        let mut pfd = libc::pollfd {
-            fd: reader.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        };
 
+    let mut pfd = libc::pollfd {
+        fd: reader.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+
+    loop {
         // SAFETY: `pfd` is a valid pointer to a single pollfd for the
         // duration of the call.
         let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -59,7 +59,9 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
             Err(e) => return Err(io::Error::from(e)),
             Ok(0) => return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out")),
             Ok(_) => {
-                let revents = pfd.revents().expect("poll returned unknown bits in revents");
+                let revents = pfd
+                    .revents()
+                    .expect("poll returned unknown bits in revents");
                 // Reads from closed empty pipes return only `POLLHUP`, while reads from closed
                 // unix domain sockets return `POLLIN | POLLHUP`. In both cases however, a
                 // subsequent read doesn't block and returns 0, signalling EOF.

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -11,6 +11,7 @@ use redis_module::raw::RedisModule_ExitFromChild;
 use std::{
     io::{self, Read},
     os::fd::AsRawFd,
+    time::Duration,
 };
 
 /// Log a write error and terminate the current process.
@@ -38,16 +39,17 @@ pub(crate) fn exit_on_write_error(err: io::Error) -> ! {
 /// Read from `reader` with a timeout, returning the number of bytes
 /// actually read.
 ///
-/// Polls the reader's file descriptor for `POLLIN` with `timeout_ms`,
+/// Polls the reader's file descriptor for `POLLIN` with `timeout`,
 /// then delegates to [`Read::read`] when the fd is ready. Surfaces
 /// timeouts as [`io::ErrorKind::TimedOut`] and `POLLHUP` / `POLLERR` /
 /// `POLLNVAL` as [`io::ErrorKind::Other`]. `EINTR` from either `poll`
 /// or the underlying read is handled internally by looping.
-pub(crate) fn read_with_timeout<R: Read + AsRawFd>(
+pub fn read_with_timeout<R: Read + AsRawFd>(
     reader: &mut R,
     buf: &mut [u8],
-    timeout_ms: i32,
+    timeout: Duration,
 ) -> io::Result<usize> {
+    let timeout_ms = timeout.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
     loop {
         let mut pfd = libc::pollfd {
             fd: reader.as_raw_fd(),
@@ -57,7 +59,7 @@ pub(crate) fn read_with_timeout<R: Read + AsRawFd>(
 
         // SAFETY: `pfd` is a valid pointer to a single pollfd for the
         // duration of the call.
-        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms as libc::c_int) };
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
 
         match ret {
             -1 => {

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -8,7 +8,10 @@
 */
 
 use redis_module::raw::RedisModule_ExitFromChild;
-use std::io;
+use std::{
+    io::{self, Read},
+    os::fd::AsRawFd,
+};
 
 /// Log a write error and terminate the current process.
 pub(crate) fn exit_on_write_error(err: io::Error) -> ! {
@@ -30,4 +33,51 @@ pub(crate) fn exit_on_write_error(err: io::Error) -> ! {
     }
 
     unreachable!("RedisModule_ExitFromChild returned")
+}
+
+/// Read from `reader` with a timeout, returning the number of bytes
+/// actually read.
+///
+/// Polls the reader's file descriptor for `POLLIN` with `timeout_ms`,
+/// then delegates to [`Read::read`] when the fd is ready. Surfaces
+/// timeouts as [`io::ErrorKind::TimedOut`] and `POLLHUP` / `POLLERR` /
+/// `POLLNVAL` as [`io::ErrorKind::Other`]. `EINTR` from either `poll`
+/// or the underlying read is handled internally by looping.
+pub(crate) fn read_with_timeout<R: Read + AsRawFd>(
+    reader: &mut R,
+    buf: &mut [u8],
+    timeout_ms: i32,
+) -> io::Result<usize> {
+    loop {
+        let mut pfd = libc::pollfd {
+            fd: reader.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+
+        // SAFETY: `pfd` is a valid pointer to a single pollfd for the
+        // duration of the call.
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms as libc::c_int) };
+
+        match ret {
+            -1 => {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+            0 => return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out")),
+            _ => {
+                if pfd.revents & libc::POLLIN == 0 {
+                    // POLLHUP / POLLERR / POLLNVAL
+                    return Err(io::Error::other("poll error"));
+                }
+                match reader.read(buf) {
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                    result => return result,
+                }
+            }
+        }
+    }
 }

--- a/src/redisearch_rs/fork_gc/tests/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/tests/fork_gc.rs
@@ -7,6 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+// All tests exercise `read_with_timeout`, which relies on the `poll` syscall
+// that miri does not support.
+#![cfg(not(miri))]
+
 use fork_gc::ForkGC;
 use std::{io, mem, os::fd::AsRawFd, time::Duration};
 

--- a/src/redisearch_rs/fork_gc/tests/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/tests/fork_gc.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use fork_gc::ForkGC;
+use std::{io, mem, os::fd::AsRawFd, time::Duration};
+
+/// Construct a zeroed [`ffi::ForkGC`] backed by a real pipe pair.
+///
+/// Returns the raw struct together with the [`io::PipeReader`] and
+/// [`io::PipeWriter`] that own the file descriptors. Both must be kept
+/// alive for as long as the [`ForkGC`] is in use.
+fn make_fork_gc() -> (ffi::ForkGC, io::PipeReader, io::PipeWriter) {
+    let (pipe_reader, pipe_writer) = io::pipe().unwrap();
+    // SAFETY: all pointer fields in ffi::ForkGC are zeroed (null), which is
+    // a valid bit pattern. Only pipe_read_fd / pipe_write_fd are used by the
+    // reader() / writer() methods exercised in these tests.
+    let mut raw: ffi::ForkGC = unsafe { mem::zeroed() };
+    raw.pipe_read_fd = pipe_reader.as_raw_fd();
+    raw.pipe_write_fd = pipe_writer.as_raw_fd();
+    (raw, pipe_reader, pipe_writer)
+}
+
+#[test]
+fn roundtrip_through_fork_gc() {
+    let (mut raw, _pipe_reader, _pipe_writer) = make_fork_gc();
+    // SAFETY: raw is a valid ffi::ForkGC for the duration of the test.
+    let fgc = unsafe { ForkGC::from_ptr_mut(&mut raw) };
+
+    fgc.writer().send_fixed(b"hello").unwrap();
+
+    let mut buf = [0u8; 5];
+    fgc.reader().recv_fixed(&mut buf).unwrap();
+    assert_eq!(&buf, b"hello");
+}
+
+#[test]
+fn times_out_when_no_data_available() {
+    let (mut raw, _pipe_reader, _pipe_writer) = make_fork_gc();
+    // SAFETY: raw is a valid ffi::ForkGC for the duration of the test.
+    let fgc = unsafe { ForkGC::from_ptr_mut(&mut raw) };
+
+    let mut buf = [0u8; 5];
+    let err = fgc
+        .reader_with_timeout(Duration::from_millis(1))
+        .recv_fixed(&mut buf)
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+}

--- a/src/redisearch_rs/fork_gc/tests/reader.rs
+++ b/src/redisearch_rs/fork_gc/tests/reader.rs
@@ -27,3 +27,12 @@ fn recv_fixed_surfaces_unexpected_eof_on_short_stream() {
     let err = pr.recv_fixed(&mut buf).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
+
+#[test]
+fn recv_fixed_reads_less_bytes_than_are_available() {
+    let mut src = Cursor::new(b"hello world".to_vec());
+    let mut pr = Reader::from_reader(&mut src);
+    let mut buf = [0u8; 5];
+    pr.recv_fixed(&mut buf).unwrap();
+    assert_eq!(&buf, b"hello");
+}

--- a/src/redisearch_rs/fork_gc/tests/reader.rs
+++ b/src/redisearch_rs/fork_gc/tests/reader.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use fork_gc::reader::Reader;
+use std::io::{self, Cursor};
+
+#[test]
+fn recv_fixed_reads_exact_bytes() {
+    let mut src = Cursor::new(b"hello world".to_vec());
+    let mut pr = Reader::from_reader(&mut src);
+    let mut buf = [0u8; 11];
+    pr.recv_fixed(&mut buf).unwrap();
+    assert_eq!(&buf, b"hello world");
+}
+
+#[test]
+fn recv_fixed_surfaces_unexpected_eof_on_short_stream() {
+    let mut src = Cursor::new(b"hi".to_vec());
+    let mut pr = Reader::from_reader(&mut src);
+    let mut buf = [0u8; 5];
+    let err = pr.recv_fixed(&mut buf).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+}

--- a/src/redisearch_rs/fork_gc/tests/util.rs
+++ b/src/redisearch_rs/fork_gc/tests/util.rs
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use fork_gc::util::read_with_timeout;
+use std::{
+    io::{self, Read, Write},
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::net::UnixStream,
+    },
+    time::Duration,
+};
+
+#[test]
+fn reads_available_data() {
+    let (mut reader, mut writer) = UnixStream::pair().unwrap();
+    writer.write_all(b"hello").unwrap();
+    let mut buf = [0u8; 5];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+}
+
+#[test]
+fn returns_eof_when_writer_closes() {
+    let (mut reader, writer) = UnixStream::pair().unwrap();
+    drop(writer);
+    let mut buf = [0u8; 4];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap();
+    assert_eq!(n, 0);
+}
+
+#[test]
+fn times_out_when_no_data_available() {
+    let (mut reader, _writer) = UnixStream::pair().unwrap();
+    let mut buf = [0u8; 4];
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+}
+
+/// A reader that returns [`io::ErrorKind::Interrupted`] on the first `read`
+/// call, then delegates to the underlying socket. This exercises the retry
+/// loop that handles `EINTR` from the `read` syscall.
+struct InterruptedOnFirstRead<'a> {
+    inner: &'a mut UnixStream,
+    interrupted: bool,
+}
+
+impl Read for InterruptedOnFirstRead<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !self.interrupted {
+            self.interrupted = true;
+            Err(io::Error::from(io::ErrorKind::Interrupted))
+        } else {
+            self.inner.read(buf)
+        }
+    }
+}
+
+impl AsRawFd for InterruptedOnFirstRead<'_> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[test]
+fn retries_after_interrupted_read() {
+    let (mut reader, mut writer) = UnixStream::pair().unwrap();
+    writer.write_all(b"hi").unwrap();
+    let mut reader = InterruptedOnFirstRead {
+        inner: &mut reader,
+        interrupted: false,
+    };
+    let mut buf = [0u8; 2];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap();
+    assert_eq!(n, 2);
+    assert_eq!(&buf, b"hi");
+}
+
+/// A reader whose `read` always fails with a non-`Interrupted` error, backed
+/// by a real socket fd so that `poll` returns `POLLIN`.
+struct FailingReader<'a> {
+    socket: &'a UnixStream,
+}
+
+impl Read for FailingReader<'_> {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "injected read error",
+        ))
+    }
+}
+
+impl AsRawFd for FailingReader<'_> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+}
+
+#[test]
+fn propagates_non_interrupted_read_error() {
+    let (reader, mut writer) = UnixStream::pair().unwrap();
+    writer.write_all(b"x").unwrap();
+    let mut reader = FailingReader { socket: &reader };
+    let mut buf = [0u8; 1];
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+}
+
+/// A reader backed by an always-invalid fd (`RawFd::MAX`), causing `poll` to
+/// return `POLLNVAL` immediately without setting `POLLIN`. `read` is therefore
+/// unreachable and panics if called.
+struct InvalidFdReader;
+
+impl Read for InvalidFdReader {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        unreachable!("read must not be called when poll reports POLLNVAL")
+    }
+}
+
+impl AsRawFd for InvalidFdReader {
+    fn as_raw_fd(&self) -> RawFd {
+        // i32::MAX is always an invalid fd: the kernel fd limit is
+        // configurable but capped well below i32::MAX.
+        RawFd::MAX
+    }
+}
+
+#[test]
+fn returns_error_on_pollnval() {
+    let mut reader = InvalidFdReader;
+    let mut buf = [0u8; 4];
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(
+        err.to_string(),
+        format!("poll error: revents=0x{:x} POLLNVAL", libc::POLLNVAL)
+    );
+}

--- a/src/redisearch_rs/fork_gc/tests/util.rs
+++ b/src/redisearch_rs/fork_gc/tests/util.rs
@@ -192,8 +192,5 @@ fn returns_error_on_pollnval() {
     let mut buf = [0u8; 4];
     let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Other);
-    assert_eq!(
-        err.to_string(),
-        format!("poll error: revents=0x{:x} POLLNVAL", libc::POLLNVAL)
-    );
+    assert_eq!(err.to_string(), "poll error: revents=POLLNVAL");
 }

--- a/src/redisearch_rs/fork_gc/tests/util.rs
+++ b/src/redisearch_rs/fork_gc/tests/util.rs
@@ -10,45 +10,92 @@
 use fork_gc::util::read_with_timeout;
 use std::{
     io::{self, Read, Write},
-    os::{
-        fd::{AsRawFd, RawFd},
-        unix::net::UnixStream,
-    },
+    os::fd::{AsRawFd, RawFd},
     time::Duration,
 };
 
 #[test]
 fn reads_available_data() {
-    let (mut reader, mut writer) = UnixStream::pair().unwrap();
+    let (mut reader, mut writer) = io::pipe().unwrap();
     writer.write_all(b"hello").unwrap();
     let mut buf = [0u8; 5];
-    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap();
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
     assert_eq!(n, 5);
     assert_eq!(&buf, b"hello");
 }
 
 #[test]
 fn returns_eof_when_writer_closes() {
-    let (mut reader, writer) = UnixStream::pair().unwrap();
+    let (mut reader, writer) = io::pipe().unwrap();
     drop(writer);
     let mut buf = [0u8; 4];
-    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap();
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
     assert_eq!(n, 0);
 }
 
 #[test]
 fn times_out_when_no_data_available() {
-    let (mut reader, _writer) = UnixStream::pair().unwrap();
+    let (mut reader, _writer) = io::pipe().unwrap();
     let mut buf = [0u8; 4];
     let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
 }
 
+#[test]
+fn returns_available_data_then_eof_when_writer_closes_with_pipe() {
+    let (mut reader, mut writer) = io::pipe().unwrap();
+    writer.write_all(b"hello").unwrap();
+    drop(writer);
+    let mut buf = [0u8; 5];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
+    assert_eq!(n, 0);
+}
+
+#[test]
+fn returns_available_data_then_eof_when_writer_closes_with_unix_domain_socket() {
+    let (mut reader, mut writer) = std::os::unix::net::UnixStream::pair().unwrap();
+    writer.write_all(b"hello").unwrap();
+    drop(writer);
+    let mut buf = [0u8; 5];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
+    assert_eq!(n, 0);
+}
+
+#[test]
+fn times_out_when_no_data_available_on_subsequent_read_with_pipe() {
+    let (mut reader, mut writer) = io::pipe().unwrap();
+    writer.write_all(b"hello").unwrap();
+    let mut buf = [0u8; 5];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+}
+
+#[test]
+fn times_out_when_no_data_available_on_subsequent_read_with_unix_domain_socket() {
+    let (mut reader, mut writer) = std::os::unix::net::UnixStream::pair().unwrap();
+    writer.write_all(b"hello").unwrap();
+    let mut buf = [0u8; 5];
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+}
+
 /// A reader that returns [`io::ErrorKind::Interrupted`] on the first `read`
-/// call, then delegates to the underlying socket. This exercises the retry
+/// call, then delegates to the underlying pipe. This exercises the retry
 /// loop that handles `EINTR` from the `read` syscall.
 struct InterruptedOnFirstRead<'a> {
-    inner: &'a mut UnixStream,
+    inner: &'a mut io::PipeReader,
     interrupted: bool,
 }
 
@@ -71,22 +118,22 @@ impl AsRawFd for InterruptedOnFirstRead<'_> {
 
 #[test]
 fn retries_after_interrupted_read() {
-    let (mut reader, mut writer) = UnixStream::pair().unwrap();
+    let (mut reader, mut writer) = io::pipe().unwrap();
     writer.write_all(b"hi").unwrap();
     let mut reader = InterruptedOnFirstRead {
         inner: &mut reader,
         interrupted: false,
     };
     let mut buf = [0u8; 2];
-    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap();
+    let n = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap();
     assert_eq!(n, 2);
     assert_eq!(&buf, b"hi");
 }
 
 /// A reader whose `read` always fails with a non-`Interrupted` error, backed
-/// by a real socket fd so that `poll` returns `POLLIN`.
+/// by a real pipe fd so that `poll` returns `POLLIN`.
 struct FailingReader<'a> {
-    socket: &'a UnixStream,
+    pipe_reader: &'a io::PipeReader,
 }
 
 impl Read for FailingReader<'_> {
@@ -100,17 +147,19 @@ impl Read for FailingReader<'_> {
 
 impl AsRawFd for FailingReader<'_> {
     fn as_raw_fd(&self) -> RawFd {
-        self.socket.as_raw_fd()
+        self.pipe_reader.as_raw_fd()
     }
 }
 
 #[test]
 fn propagates_non_interrupted_read_error() {
-    let (reader, mut writer) = UnixStream::pair().unwrap();
+    let (pipe_reader, mut writer) = io::pipe().unwrap();
     writer.write_all(b"x").unwrap();
-    let mut reader = FailingReader { socket: &reader };
+    let mut reader = FailingReader {
+        pipe_reader: &pipe_reader,
+    };
     let mut buf = [0u8; 1];
-    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap_err();
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
 }
 
@@ -137,7 +186,7 @@ impl AsRawFd for InvalidFdReader {
 fn returns_error_on_pollnval() {
     let mut reader = InvalidFdReader;
     let mut buf = [0u8; 4];
-    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_secs(1)).unwrap_err();
+    let err = read_with_timeout(&mut reader, &mut buf, Duration::from_millis(1)).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Other);
     assert_eq!(
         err.to_string(),

--- a/src/redisearch_rs/fork_gc/tests/util.rs
+++ b/src/redisearch_rs/fork_gc/tests/util.rs
@@ -7,6 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+// All tests exercise `read_with_timeout`, which relies on the `poll` syscall
+// that miri does not support.
+#![cfg(not(miri))]
+
 use fork_gc::util::read_with_timeout;
 use std::{
     io::{self, Read, Write},

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -59,6 +59,21 @@ void FGC_sendBuffer(ForkGC *fgc, const void *buff, size_t len);
  */
 void FGC_sendTerminator(ForkGC *fgc);
 
+/**
+ * Read exactly `len` bytes from the FGC pipe into `buf`.
+ *
+ * Polls the pipe fd with a 3-minute timeout and retries on `EINTR`. On
+ * timeout, read error, or unexpected EOF, logs a detailed warning
+ * (matching the original C format) and returns `REDISMODULE_ERR`.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+ *    readable file descriptor.
+ * 2. `buf` must point to a writable region of at least `len` bytes.
+ */
+int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -22,6 +22,7 @@ insta = { version = "1", features = ["filters"] }
 itertools = { version = "0.13" }
 libc = { version = "0.2", features = ["extra_traits"] }
 memchr = { version = "2" }
+nix = { version = "0.26" }
 num-traits = { version = "0.2" }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
@@ -50,6 +51,7 @@ insta = { version = "1", features = ["filters"] }
 itertools = { version = "0.13" }
 libc = { version = "0.2", features = ["extra_traits"] }
 memchr = { version = "2" }
+nix = { version = "0.26" }
 num-traits = { version = "0.2" }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }


### PR DESCRIPTION
## Describe the changes in the pull request

- Implement `recv_fixed` in Rust with a similar poll based `read_with_timeout` helper function.
- Adds extensive tests to all parts of the existing Rust ForkGC code. 

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the parent/child ForkGC pipe read path by moving `FGC_recvFixed` from C into Rust and introducing poll/timeout behavior via `nix`, which could affect GC stability if edge cases differ. Added unit tests reduce risk but this code runs in a failure-sensitive IPC path.
> 
> **Overview**
> **Moves ForkGC fixed-size pipe reads from C to Rust.** The C implementation of `FGC_recvFixed` is removed from `pipe.c`/`pipe.h` and replaced with a Rust FFI export in `fork_gc_ffi`, with the generated header (`fork_gc_ffi.h`) updated accordingly.
> 
> **Adds a poll-based read helper and reader abstraction in Rust.** The `fork_gc` crate gains `read_with_timeout` (using `nix::poll`) plus a new `Reader` wrapper and `ForkGC::reader()`/`reader_with_timeout()` plumbing, including handling for `pipe_read_fd == -1` in tests.
> 
> **Expands test coverage.** New tests validate `recv_fixed` behavior (exact reads, EOF, timeouts, EINTR retry, poll error cases) and a basic end-to-end pipe roundtrip.
> 
> Dependencies are updated to include `nix`/`libc` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6de5bb0aabe414a093baa818d579ad91caadc85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->