### PR TITLE
[MOD-15369] Trie - Clean up existing interface in C

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
@@ -63,24 +63,6 @@ pub extern "C" fn TrieMapResultBuf_Free(buf: TrieMapResultBuf) {
     drop(buf);
 }
 
-/// Get the data from the TrieMapResultBuf as an array of values.
-///
-/// # Safety
-///
-/// The following invariants must be upheld when calling this function:
-/// - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn TrieMapResultBuf_Data(buf: *mut TrieMapResultBuf) -> *mut *mut c_void {
-    debug_assert!(!buf.is_null(), "buf cannot be NULL");
-
-    // SAFETY:
-    // As per the safety invariants of this function:
-    // - `buf` is not NULL
-    // - `buf` points to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`]
-    let TrieMapResultBuf(data) = unsafe { &mut *buf };
-    data.as_mut_ptr()
-}
-
 /// Retrieve an element from the buffer, via a 0-initialized index.
 ///
 /// It returns `NULL` if the index is out of bounds.

--- a/src/redisearch_rs/headers/triemap.h
+++ b/src/redisearch_rs/headers/triemap.h
@@ -215,16 +215,6 @@ TrieMapResultBuf TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len)
 void TrieMapResultBuf_Free(TrieMapResultBuf buf);
 
 /**
- * Get the data from the TrieMapResultBuf as an array of values.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
- */
-void **TrieMapResultBuf_Data(TrieMapResultBuf *buf);
-
-/**
  * Retrieve an element from the buffer, via a 0-initialized index.
  *
  * It returns `NULL` if the index is out of bounds.

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -47,11 +47,9 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   TrieNode *trienode = TrieNode_Get(trie->root, runes, rlen, 1, NULL);
   suffixData *data = NULL;
   if (trienode) {
-    // suffixData *node = TrieNode_GetValue(trie->root, runes, rlen, 1);
     data = Suffix_GetData(trienode);
     // if string was added in the past, skip
     if (data && data->term) {
-      //rm_free(runes);
       runeBufFree(&buf);
       return;
     }
@@ -96,13 +94,8 @@ static void removeSuffix(const char *str, size_t rlen, arrayof(char*) array) {
 
 void deleteSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   size_t rlen = 0;
-  //rune *runes = strToRunesN(str, len, &rlen);
-
   runeBuf buf;
   rune *runes = runeBufFill(str, len, &buf, &rlen);
-
-  //rune runes[len];
-  //size_t rlen = strToRunesN(str, len, &runes);
   char *oldTerm = NULL;
 
   // iterate all matching terms and remove word
@@ -113,8 +106,6 @@ void deleteSuffixTrie(Trie *trie, const char *str, uint32_t len) {
     // if the trie is owned by other fields and not any one containing this suffix,
     // then failure to find the suffix is not an error. just move along.
     if (!data) continue;
-    // RS_LOG_ASSERT(data, "all suffixes must exist");
-    // suffixData *data = TrieMap_Find(trie, str + j, len - j);
     if (j == 0) {
       // keep pointer to word string to free after it was found in al sub tokens.
       oldTerm = data->term;

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -15,11 +15,11 @@
 #include "rmalloc.h"
 
 static rune runeLower(rune r) {
-  uint32_t lowered = 0;
   const char *map = nu_tolower((uint32_t)r);
   if (!map) {
     return r;
   }
+  uint32_t lowered;
   nu_casemap_read(map, &lowered);
   return (rune)lowered;
 }

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -14,6 +14,16 @@
 #include "rune_util.h"
 #include "rmalloc.h"
 
+static rune runeLower(rune r) {
+  uint32_t lowered = 0;
+  const char *map = nu_tolower((uint32_t)r);
+  if (!map) {
+    return r;
+  }
+  nu_casemap_read(map, &lowered);
+  return (rune)lowered;
+}
+
 // NewSparseAutomaton creates a new automaton for the string s, with a given max
 // edit distance check
 SparseAutomaton NewSparseAutomaton(const rune *s, size_t len, int maxEdits) {

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -15,11 +15,12 @@
 #include "rmalloc.h"
 
 static rune runeLower(rune r) {
-  const char *map = nu_tolower((uint32_t)r);
+  uint32_t lowered = 0;
+  const char *map = 0;
+  map = nu_tolower((uint32_t)r);
   if (!map) {
     return r;
   }
-  uint32_t lowered;
   nu_casemap_read(map, &lowered);
   return (rune)lowered;
 }

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -29,21 +29,6 @@ rune runeFold(rune r) {
   return __fold((uint32_t)r);
 }
 
-static uint32_t __lower(uint32_t runelike) {
-  uint32_t lowered = 0;
-  const char *map = 0;
-  map = nu_tolower(runelike);
-  if (!map) {
-    return runelike;
-  }
-  nu_casemap_read(map, &lowered);
-  return lowered;
-}
-
-rune runeLower(rune r) {
-  return __lower((uint32_t)r);
-}
-
 char *runesToStr(const rune *in, size_t len, size_t *utflen) {
   if (len > MAX_RUNESTR_LEN) {
     if (utflen) *utflen = 0;
@@ -183,14 +168,4 @@ size_t strToRunesN(const char *src, size_t slen, rune *out) {
     out[nout++] = (rune)cp;
   }
   return nout;
-}
-
-const rune *runenchr(const rune *r, size_t len, rune c) {
-  size_t i = 0;
-  for (; i < len; ++i) {
-    if (r[i] == (rune)c) {
-      break;
-    }
-  }
-  return i == len ? NULL : r + i;
 }

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -44,9 +44,6 @@ typedef rune (*runeTransform)(rune r);
 /* fold rune: assumes rune is of the correct size */
 rune runeFold(rune r);
 
-/* Convert rune to lowercase */
-rune runeLower(rune r);
-
 /* Convert a rune string to utf-8 characters */
 char *runesToStr(const rune *in, size_t len, size_t *utflen);
 
@@ -73,9 +70,6 @@ rune *strToRunes(const char *str, size_t *len);
 
 /* Decode a string to a rune in-place */
 size_t strToRunesN(const char *s, size_t slen, rune *outbuf);
-
-/* similar to strchr */
-const rune *runenchr(const rune *r, size_t len, rune c);
 
 static inline rune *runeBufFill(const char *s, size_t n, runeBuf *buf, size_t *len) {
   /**

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -108,7 +108,7 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
   return n;
 }
 
-TrieNode *__trieNode_resizeChildren(TrieNode *n, int offset) {
+static TrieNode *__trieNode_resizeChildren(TrieNode *n, int offset) {
   n = rm_realloc(n, __trieNode_Sizeof(n->numChildren + offset, n->len));
   TrieNode **children = __trieNode_children(n);
 
@@ -118,8 +118,8 @@ TrieNode *__trieNode_resizeChildren(TrieNode *n, int offset) {
   return n;
 }
 
-TrieNode *__trie_AddChildIdx(TrieNode *n, const rune *str, t_len offset, t_len len, RSPayload *payload,
-                             float score, int idx, size_t numDocs) {
+static TrieNode *__trie_AddChildIdx(TrieNode *n, const rune *str, t_len offset, t_len len, RSPayload *payload,
+                                    float score, int idx, size_t numDocs) {
   n = __trieNode_resizeChildren(n, 1);
 
   // a newly added child must be a terminal node
@@ -169,7 +169,7 @@ static TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
 
 /* If a node has a single child after delete, we can merged them. This deletes
  * the node and returns a newly allocated node */
-TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback freecb) {
+static TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback freecb) {
 
   if (__trieNode_isTerminal(n) || n->numChildren != 1) {
     return n;
@@ -375,7 +375,7 @@ TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int 
  *   2. If a child has a single child - merge them
  *   3. recalculate the max child score
  */
-int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
+static int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
   int rc = 0;
   int i = 0;
   TrieNode **nodes = __trieNode_children(n);

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -18,12 +18,13 @@
 #include "trie/levenshtein.h"
 
 static const rune *runenchr(const rune *r, size_t len, rune c) {
-  for (size_t i = 0; i < len; ++i) {
-    if (r[i] == c) {
-      return r + i;
+  size_t i = 0;
+  for (; i < len; ++i) {
+    if (r[i] == (rune)c) {
+      break;
     }
   }
-  return NULL;
+  return i == len ? NULL : r + i;
 }
 
 typedef struct {

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -68,7 +68,9 @@ do {                                                      \
   }                                                       \
 } while(0)
 
-size_t __trieNode_Sizeof(t_len numChildren, t_len slen) {
+/* The byte size of a node, based on its internal string length and number of
+ * children */
+static size_t __trieNode_Sizeof(t_len numChildren, t_len slen) {
   return sizeof(TrieNode) + numChildren * (sizeof(rune) + sizeof(TrieNode *)) + sizeof(rune) * (slen + 1);
 }
 
@@ -133,7 +135,10 @@ TrieNode *__trie_AddChildIdx(TrieNode *n, const rune *str, t_len offset, t_len l
   return n;
 }
 
-TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
+/* Split node n at string offset n. This returns a new node which has a string
+ * up until offset, and
+ * a single child holding The old score of n, and its score */
+static TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
   // Copy the current node's data and children to a new child node
   TrieNode *newChild = __newTrieNode(n->str, offset, n->len, NULL, 0, n->numChildren, n->score,
                                      __trieNode_isTerminal(n), n->sortMode, n->numDocs);

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -633,7 +633,6 @@ inline int __ti_step(TrieIterator *it, void *matchCtx) {
           __ti_Push(it, ch, 0);
           it->nodesConsumed++;
         } else {
-          //__ti_Push(it, ch, 1);
           it->nodesSkipped++;
         }
       } else {
@@ -754,7 +753,6 @@ TrieNode *TrieNode_RandomWalk(TrieNode *n, int minSteps, rune **str, t_len *len)
 
   *str = buf;
   *len = bufSize;
-  //(*str)[bufSize] = '\0';
   rm_free(stack);
   return n;
 }

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -366,11 +366,6 @@ TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int 
   return NULL;
 }
 
-void *TrieNode_GetValue(TrieNode *n, const rune *str, t_len len, bool exact) {
-  TrieNode *res = TrieNode_Get(n, str, len, exact, NULL);
-  return (res && res->payload) ? res->payload->data : NULL;
-}
-
 /* Optimize the node and its children:
  *   1. If a child should be deleted - delete it and reduce the child count
  *   2. If a child has a single child - merge them

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -357,13 +357,6 @@ TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int 
   return NULL;
 }
 
-//TrieNode *TrieNode_Get(TrieNode *n, rune *str, t_len len);
-float TrieNode_Find(TrieNode *n, rune *str, t_len len) {
-  TrieNode *res = TrieNode_Get(n, str, len, true, NULL);
-  return res ? res->score : 0;
-}
-
-//TrieNode *TrieNode_Get(TrieNode *n, rune *str, t_len len);
 void *TrieNode_GetValue(TrieNode *n, const rune *str, t_len len, bool exact) {
   TrieNode *res = TrieNode_Get(n, str, len, exact, NULL);
   return (res && res->payload) ? res->payload->data : NULL;

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -167,7 +167,7 @@ static TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
   return n;
 }
 
-/* If a node has a single child after delete, we can merged them. This deletes
+/* If a node has a single child after delete, we can merge them. This deletes
  * the node and returns a newly allocated node */
 static TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback freecb) {
 

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -18,6 +18,15 @@
 #include "wildcard.h"
 #include "trie/levenshtein.h"
 
+static const rune *runenchr(const rune *r, size_t len, rune c) {
+  for (size_t i = 0; i < len; ++i) {
+    if (r[i] == c) {
+      return r + i;
+    }
+  }
+  return NULL;
+}
+
 typedef struct {
   rune * buf;
   TrieRangeCallback *callback;

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -13,7 +13,6 @@
 #include "redisearch.h"
 #include "rmutil/rm_assert.h"
 #include "util/arr.h"
-#include "config.h"
 #include "util/timeout.h"
 #include "wildcard.h"
 #include "trie/levenshtein.h"

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -69,6 +69,10 @@ do {                                                      \
   }                                                       \
 } while(0)
 
+#define __trieNode_childKey(n, c) (rune *)((void *)n + sizeof(TrieNode) + (n->len + 1 + c) * sizeof(rune))
+
+#define __trieNode_isDeleted(n) (n->flags & TRIENODE_DELETED)
+
 /* The byte size of a node, based on its internal string length and number of
  * children */
 static size_t __trieNode_Sizeof(t_len numChildren, t_len slen) {

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -120,8 +120,6 @@ int TrieNode_Add(TrieNode **n, const rune *str, t_len len, RSPayload *payload,
 
 /* Find the entry with a given string and length, and return it. */
 TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int *offsetOut);
-/* Returns the payload of the node. */
-void *TrieNode_GetValue(TrieNode *n, const rune *str, t_len len, bool exact);
 
 /* Mark a node as deleted. For simplicity for now we don't actually delete
  * anything,

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -26,10 +26,6 @@ typedef uint16_t t_len;
 #define TRIENODE_TERMINAL 0x1
 #define TRIENODE_DELETED 0x2
 
-#define TRIENODE_SORTED_NONE 0
-#define TRIENODE_SORTED_SCORE 1
-#define TRIENODE_SORTED_LEX 2
-
 typedef enum {
   Trie_Sort_Lex = 0,
   Trie_Sort_Score = 1,

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -90,11 +90,7 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
 #define __trieNode_children(n) \
   ((TrieNode **)((void *)n + sizeof(TrieNode) + ((n->len + 1) + (n->numChildren)) * sizeof(rune)))
 
-#define __trieNode_childKey(n, c) (rune *)((void *)n + sizeof(TrieNode) + (n->len + 1 + c) * sizeof(rune))
-
 #define __trieNode_isTerminal(n) (n->flags & TRIENODE_TERMINAL)
-
-#define __trieNode_isDeleted(n) (n->flags & TRIENODE_DELETED)
 
 typedef enum {
   ADD_REPLACE,

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -78,10 +78,6 @@ typedef struct {
 } TrieNode;
 #pragma pack()
 
-/* The byte size of a node, based on its internal string length and number of
- * children */
-size_t __trieNode_Sizeof(t_len numChildren, t_len slen);
-
 /* Create a new trie node. str is a string to be copied into the node, starting
  * from offset up until
  * len. numChildren is the initial number of allocated child nodes */
@@ -99,11 +95,6 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
 #define __trieNode_isTerminal(n) (n->flags & TRIENODE_TERMINAL)
 
 #define __trieNode_isDeleted(n) (n->flags & TRIENODE_DELETED)
-
-/* Split node n at string offset n. This returns a new node which has a string
- * up until offset, and
- * a single child holding The old score of n, and its score */
-TrieNode *__trie_SplitNode(TrieNode *n, t_len offset);
 
 typedef enum {
   ADD_REPLACE,

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -45,9 +45,6 @@ typedef struct {
 } TriePayload;
 #pragma pack()
 
-/* The byte size of a TriePayload, based on its internal data length */
-size_t __triePayload_Sizeof(uint32_t len);
-
 #pragma pack(1)
 /* TrieNode represents a single node in a trie. The actual size of it is bigger,
  * as the children are
@@ -107,12 +104,6 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
 
 #define __trieNode_isDeleted(n) (n->flags & TRIENODE_DELETED)
 
-/* Add a child node to the parent node n, with a string str starting at offset
-up until len, and a
-given score */
-TrieNode *__trie_AddChild(TrieNode *n, const rune *str, t_len offset, t_len len, RSPayload *payload,
-                          float score);
-
 /* Split node n at string offset n. This returns a new node which has a string
  * up until offset, and
  * a single child holding The old score of n, and its score */
@@ -130,12 +121,6 @@ typedef enum {
 int TrieNode_Add(TrieNode **n, const rune *str, t_len len, RSPayload *payload,
                  float score, TrieAddOp op, TrieFreeCallback freecb,
                  size_t numDocs);
-
-/* Find the entry with a given string and length, and return its score. Returns
- * 0 if the entry was
- * not found.
- * Note that you cannot put entries with zero score */
-float TrieNode_Find(TrieNode *n, rune *str, t_len len);
 
 /* Find the entry with a given string and length, and return it. */
 TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int *offsetOut);

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -65,21 +65,6 @@ int Trie_InsertRune(Trie *t, const rune *runes, size_t len, double score, int in
   return rc;
 }
 
-static void *Trie_GetValueRune(Trie *t, const rune *runes, size_t len, bool exact) {
-  return TrieNode_GetValue(t->root, runes, len, exact);
-}
-
-void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact) {
-  if (len > TRIE_INITIAL_STRING_LEN * sizeof(rune)) {
-    return 0;
-  }
-  runeBuf buf;
-  rune *runes = runeBufFill(s, len, &buf, &len);
-  void *val = Trie_GetValueRune(t, runes, len, exact);
-  runeBufFree(&buf);
-  return val;
-}
-
 int Trie_Delete(Trie *t, const char *s, size_t len) {
   runeBuf buf;
   rune *runes = runeBufFill(s, len, &buf, &len);

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -65,6 +65,10 @@ int Trie_InsertRune(Trie *t, const rune *runes, size_t len, double score, int in
   return rc;
 }
 
+static void *Trie_GetValueRune(Trie *t, const rune *runes, size_t len, bool exact) {
+  return TrieNode_GetValue(t->root, runes, len, exact);
+}
+
 void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact) {
   if (len > TRIE_INITIAL_STRING_LEN * sizeof(rune)) {
     return 0;
@@ -74,10 +78,6 @@ void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact) 
   void *val = Trie_GetValueRune(t, runes, len, exact);
   runeBufFree(&buf);
   return val;
-}
-
-void *Trie_GetValueRune(Trie *t, const rune *runes, size_t len, bool exact) {
-  return TrieNode_GetValue(t->root, runes, len, exact);
 }
 
 int Trie_Delete(Trie *t, const char *s, size_t len) {

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -53,10 +53,6 @@ int Trie_InsertStringBuffer(Trie *t, const char *s, size_t len, double score, in
 int Trie_InsertRune(Trie *t, const rune *s, size_t len, double score, int incr,
                     RSPayload *payload, size_t numDocs);
 
-/* Get the payload from the node. if `exact` is 0, the payload is return even if local offset!=len
-   Use for debug only! */
-void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact);
-
 /* Delete the string from the trie. Return 1 if the node was found and deleted, 0 otherwise */
 int Trie_Delete(Trie *t, const char *s, size_t len);
 int Trie_DeleteRunes(Trie *t, const rune *runes, size_t len);

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -56,7 +56,6 @@ int Trie_InsertRune(Trie *t, const rune *s, size_t len, double score, int incr,
 /* Get the payload from the node. if `exact` is 0, the payload is return even if local offset!=len
    Use for debug only! */
 void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact);
-void *Trie_GetValueRune(Trie *t, const rune *runes, size_t len, bool exact);
 
 /* Delete the string from the trie. Return 1 if the node was found and deleted, 0 otherwise */
 int Trie_Delete(Trie *t, const char *s, size_t len);

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -32,6 +32,17 @@ static bool trieInsert(Trie *t, const std::string &s) {
   return trieInsert(t, s.c_str(), s.size());
 }
 
+static void *triePayload(Trie *t, const char *s, size_t len, bool exact) {
+  if (len > TRIE_INITIAL_STRING_LEN * sizeof(rune)) {
+    return nullptr;
+  }
+  runeBuf buf;
+  rune *runes = runeBufFill(s, len, &buf, &len);
+  TrieNode *node = TrieNode_Get(t->root, runes, len, exact, NULL);
+  runeBufFree(&buf);
+  return (node && node->payload) ? node->payload->data : nullptr;
+}
+
 static int rangeFunc(const rune *u16, size_t nrune, void *ctx, void *payload, size_t numDocsInTerm) {
   size_t n;
   char *s = runesToStr(u16, nrune, &n);
@@ -203,35 +214,35 @@ TEST_F(TrieTest, testPayload) {
 
   // check for prefix of existing term
   // with exact returns null, w/o return load of next term
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 1, 0), "wo", 2), 0);
-  ASSERT_TRUE((char*)Trie_GetValueStringBuffer(t, buf1, 1, 1) == NULL);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 1, 0), "wo", 2), 0);
+  ASSERT_TRUE((char*)triePayload(t, buf1, 1, 1) == NULL);
 
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 2, 1), "wo", 2), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 3, 1), "wor", 3), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 4, 1), "worl", 4), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 5, 1), "world", 5), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf2, 4, 1), "work", 4), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 2, 1), "wo", 2), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 3, 1), "wor", 3), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 4, 1), "worl", 4), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 5, 1), "world", 5), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf2, 4, 1), "work", 4), 0);
 
   ASSERT_EQ(Trie_Delete(t, buf1, 3), 1);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 2, 1), "wo", 2), 0);
-  ASSERT_TRUE((char*)Trie_GetValueStringBuffer(t, buf1, 3, 1) == NULL);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 4, 1), "worl", 4), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 5, 1), "world", 5), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf2, 4, 1), "work", 4), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 2, 1), "wo", 2), 0);
+  ASSERT_TRUE((char*)triePayload(t, buf1, 3, 1) == NULL);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 4, 1), "worl", 4), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 5, 1), "world", 5), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf2, 4, 1), "work", 4), 0);
 
   ASSERT_EQ(Trie_Delete(t, buf1, 4), 1);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 2, 1), "wo", 2), 0);
-  ASSERT_TRUE((char*)Trie_GetValueStringBuffer(t, buf1, 3, 1) == NULL);
-  ASSERT_TRUE((char*)Trie_GetValueStringBuffer(t, buf1, 4, 1) == NULL);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 5, 1), "world", 5), 0);
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf2, 4, 1), "work", 4), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 2, 1), "wo", 2), 0);
+  ASSERT_TRUE((char*)triePayload(t, buf1, 3, 1) == NULL);
+  ASSERT_TRUE((char*)triePayload(t, buf1, 4, 1) == NULL);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 5, 1), "world", 5), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf2, 4, 1), "work", 4), 0);
 
   // testing with exact = 0
   // "wor" node exists with NULL payload.
-  ASSERT_TRUE((char*)Trie_GetValueStringBuffer(t, buf1, 3, 0) == NULL);
+  ASSERT_TRUE((char*)triePayload(t, buf1, 3, 0) == NULL);
   // "worl" does not exist but is partial offset of =>`wor`+`ld`.
   // payload of `ld` is returned.
-  ASSERT_EQ(strncmp((char*)Trie_GetValueStringBuffer(t, buf1, 4, 0), "world", 5), 0);
+  ASSERT_EQ(strncmp((char*)triePayload(t, buf1, 4, 0), "world", 5), 0);
 
   TrieType_Free(t);
 }
@@ -544,9 +555,9 @@ TEST_F(TrieTest, testRdbSaveLoadWithPayloads) {
   EXPECT_TRUE(trieContains(loadedTrie, "runner"));
 
   // Verify specific payloads are preserved
-  void *loadedPayload1 = Trie_GetValueStringBuffer(loadedTrie, "run", 3, true);
-  void *loadedPayload2 = Trie_GetValueStringBuffer(loadedTrie, "running", 7, true);
-  void *loadedPayload3 = Trie_GetValueStringBuffer(loadedTrie, "runner", 6, true);
+  void *loadedPayload1 = triePayload(loadedTrie, "run", 3, true);
+  void *loadedPayload2 = triePayload(loadedTrie, "running", 7, true);
+  void *loadedPayload3 = triePayload(loadedTrie, "runner", 6, true);
 
   ASSERT_TRUE(loadedPayload1 != nullptr);
   ASSERT_TRUE(loadedPayload2 != nullptr);
@@ -610,9 +621,9 @@ TEST_F(TrieTest, testRdbSaveLoadPayloadsNotSerialized) {
   EXPECT_TRUE(trieContains(loadedTrie, "careful"));
 
   // Verify that payloads are NOT preserved (should be null)
-  void *loadedPayload1 = Trie_GetValueStringBuffer(loadedTrie, "car", 3, true);
-  void *loadedPayload2 = Trie_GetValueStringBuffer(loadedTrie, "care", 4, true);
-  void *loadedPayload3 = Trie_GetValueStringBuffer(loadedTrie, "careful", 7, true);
+  void *loadedPayload1 = triePayload(loadedTrie, "car", 3, true);
+  void *loadedPayload2 = triePayload(loadedTrie, "care", 4, true);
+  void *loadedPayload3 = triePayload(loadedTrie, "careful", 7, true);
 
   EXPECT_TRUE(loadedPayload1 == nullptr);  // Payload should not be preserved
   EXPECT_TRUE(loadedPayload2 == nullptr);  // Payload should not be preserved
@@ -672,10 +683,10 @@ TEST_F(TrieTest, testRdbSaveLoadWithoutPayloads) {
   EXPECT_TRUE(trieContains(loadedTrie, "helper"));
 
   // Verify that payloads remain NULL (since none were inserted)
-  void *loadedPayload1 = Trie_GetValueStringBuffer(loadedTrie, "hello", 5, true);
-  void *loadedPayload2 = Trie_GetValueStringBuffer(loadedTrie, "hell", 4, true);
-  void *loadedPayload3 = Trie_GetValueStringBuffer(loadedTrie, "help", 4, true);
-  void *loadedPayload4 = Trie_GetValueStringBuffer(loadedTrie, "helper", 6, true);
+  void *loadedPayload1 = triePayload(loadedTrie, "hello", 5, true);
+  void *loadedPayload2 = triePayload(loadedTrie, "hell", 4, true);
+  void *loadedPayload3 = triePayload(loadedTrie, "help", 4, true);
+  void *loadedPayload4 = triePayload(loadedTrie, "helper", 6, true);
 
   EXPECT_TRUE(loadedPayload1 == nullptr);  // No payload was inserted
   EXPECT_TRUE(loadedPayload2 == nullptr);  // No payload was inserted

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -25,6 +25,11 @@
 
 int count = 0;
 
+static float trie_exact_score(TrieNode *n, rune *str, t_len len) {
+  TrieNode *res = TrieNode_Get(n, str, len, true, NULL);
+  return res ? res->score : 0;
+}
+
 FilterCode stepFilter(unsigned char b, void *ctx, int *matched, void *matchCtx) {
   return F_CONTINUE;
 }
@@ -172,7 +177,7 @@ int testTrie() {
   __trie_add(&root, "helter skelter", NULL, 3, ADD_REPLACE);
   size_t rlen;
   rune *runes = strToRunes("helter skelter", &rlen);
-  float sc = TrieNode_Find(root, runes, rlen);
+  float sc = trie_exact_score(root, runes, rlen);
   ASSERT(sc == 3);
 
   __trie_add(&root, "heltar skelter", NULL, 4, ADD_REPLACE);
@@ -181,12 +186,12 @@ int testTrie() {
   // replace the score
   __trie_add(&root, "helter skelter", NULL, 6, ADD_REPLACE);
 
-  sc = TrieNode_Find(root, runes, rlen);
+  sc = trie_exact_score(root, runes, rlen);
   ASSERT(sc == 6);
 
   /// add with increment
   __trie_add(&root, "helter skelter", NULL, 6, ADD_INCR);
-  sc = TrieNode_Find(root, runes, rlen);
+  sc = trie_exact_score(root, runes, rlen);
   ASSERT(sc == 12);
 
   TrieNode_Free(root, NULL);
@@ -210,7 +215,7 @@ int testUnicode() {
   ASSERT_EQUAL(0, rc);
   size_t rlen;
   rune *runes = strToRunes(str, &rlen);
-  float sc = TrieNode_Find(root, runes, rlen);
+  float sc = trie_exact_score(root, runes, rlen);
   free(runes);
   ASSERT(sc == 1);
   TrieNode_Free(root, NULL);

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -25,7 +25,7 @@
 
 int count = 0;
 
-static float trie_exact_score(TrieNode *n, rune *str, t_len len) {
+static float trieExactScore(TrieNode *n, rune *str, t_len len) {
   TrieNode *res = TrieNode_Get(n, str, len, true, NULL);
   return res ? res->score : 0;
 }
@@ -177,7 +177,7 @@ int testTrie() {
   __trie_add(&root, "helter skelter", NULL, 3, ADD_REPLACE);
   size_t rlen;
   rune *runes = strToRunes("helter skelter", &rlen);
-  float sc = trie_exact_score(root, runes, rlen);
+  float sc = trieExactScore(root, runes, rlen);
   ASSERT(sc == 3);
 
   __trie_add(&root, "heltar skelter", NULL, 4, ADD_REPLACE);
@@ -186,12 +186,12 @@ int testTrie() {
   // replace the score
   __trie_add(&root, "helter skelter", NULL, 6, ADD_REPLACE);
 
-  sc = trie_exact_score(root, runes, rlen);
+  sc = trieExactScore(root, runes, rlen);
   ASSERT(sc == 6);
 
   /// add with increment
   __trie_add(&root, "helter skelter", NULL, 6, ADD_INCR);
-  sc = trie_exact_score(root, runes, rlen);
+  sc = trieExactScore(root, runes, rlen);
   ASSERT(sc == 12);
 
   TrieNode_Free(root, NULL);
@@ -215,7 +215,7 @@ int testUnicode() {
   ASSERT_EQUAL(0, rc);
   size_t rlen;
   rune *runes = strToRunes(str, &rlen);
-  float sc = trie_exact_score(root, runes, rlen);
+  float sc = trieExactScore(root, runes, rlen);
   free(runes);
   ASSERT(sc == 1);
   TrieNode_Free(root, NULL);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The C trie / triemap modules expose several debug-only or single-caller symbols through their public headers (`trie.h`, `trie_type.h`, `rune_util.h`, generated `triemap.h`). A handful of internal helpers are declared but unused, and a few stale commented-out breadcrumbs reference long-removed APIs.
2. **Change**: Trim the public surface of the trie module without changing runtime behavior. Concretely:
   - Remove dead public symbols: `TrieMapResultBuf_Data`, `TrieNode_Find`, `__triePayload_Sizeof`, `__trie_AddChild`, `Trie_GetValueStringBuffer`, `Trie_GetValueRune`, `TrieNode_GetValue`, and the unused `TRIENODE_SORTED_NONE/SCORE/LEX` macros.
   - Privatize single-caller helpers: `runeLower` moves into `levenshtein.c`, `runenchr` into `trie.c`, and `__trieNode_Sizeof` / `__trie_SplitNode` are made `static`. Four already-undeclared `__trie*` helpers (`__trieNode_resizeChildren`, `__trie_AddChildIdx`, `__trieNode_MergeWithSingleChild`, `__trieNode_optimizeChildren`) gain `static`.
   - Migrate the 31 `Trie_GetValueStringBuffer` test call sites in `test_cpp_trie.cpp` and the `TrieNode_Find` test sites in `test_trie.c` to local static `triePayload` helpers built directly on `TrieNode_Get`.
   - Drop stale commented-out code in `suffix.c` and `trie.c` referencing removed APIs, plus an unused `config.h` include.
3. **Outcome**: Smaller external API for the trie module, fewer leaky abstractions (e.g. the bulk-pointer accessor that exposed `TrieMapResultBuf`'s pointer layout), and no behavior change. All trie unit tests, cpp tests, and Rust tests pass.

#### Which additional issues this PR fixes

1. MOD-15369

#### Main objects this PR modified

1. `src/trie/trie.{c,h}` — removed/privatized public symbols, dropped stale comments
2. `src/trie/trie_type.{c,h}` — removed `Trie_GetValue*` debug API
3. `src/trie/rune_util.{c,h}` — privatized `runeLower` / `runenchr`, dropped `__lower`
4. `src/trie/levenshtein.c` — absorbed `runeLower` as local static
5. `src/suffix.c` — dropped stale commented-out breadcrumbs
6. `src/redisearch_rs/c_entrypoint/triemap_ffi/` (+ generated `headers/triemap.h`) — removed unused `TrieMapResultBuf_Data` FFI export
7. `tests/cpptests/test_cpp_trie.cpp` and `tests/ctests/test_trie.c` — migrated to local `triePayload` helpers

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

API changes are limited to internal C/Rust FFI symbols of the trie module. No changes to the Redis command surface, RDB format, or replication payloads.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to removal/privatization of exported C and Rust FFI symbols, which can break any downstream code depending on these debug-only APIs; runtime trie behavior is intended to remain unchanged.
> 
> **Overview**
> Reduces the trie/triemap public C/FFI surface by removing several debug-only/unused exported APIs (notably `TrieMapResultBuf_Data` and various trie payload/score accessors) and moving single-caller utilities into file-local `static` functions.
> 
> Also cleans up internal linkage (marking multiple trie helpers `static`, dropping unused macros/includes and stale commented code) and updates C/C++ unit tests to use local helpers built on `TrieNode_Get` for payload/score assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f6c051b2ae1e55ebcd6ac66a0f70c627d7e31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->