### PR TITLE
Fix build system for clang 22

### DIFF
--- a/tests/cpptests/micro-benchmarks/CMakeLists.txt
+++ b/tests/cpptests/micro-benchmarks/CMakeLists.txt
@@ -22,6 +22,14 @@ set(BENCHMARK_ENABLE_TESTING OFF)
 FetchContent_MakeAvailable(googlebench)
 include_directories("${googlebench_SOURCE_DIR}/include")
 
+# clang 22+ warns about __COUNTER__ under -Wc2y-extensions: it's a compiler extension
+# being standardized in C2y (the C standard after C23). googlebench uses -pedantic-errors
+# and -Werror, turning this into a fatal error. __COUNTER__ has been a de facto compiler
+# extension so is fine to use it, but we need to suppress the warning now that clang 22+
+# is more strict.
+target_compile_options(benchmark PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>)
+target_compile_options(benchmark_main PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>)
+
 file(GLOB BENCHMARK_ITER_SOURCES "benchmark_*_iterator.cpp")
 foreach(benchmark_file ${BENCHMARK_ITER_SOURCES})
   get_filename_component(benchmark_name ${benchmark_file} NAME_WE)


### PR DESCRIPTION
## Describe the changes in the pull request

clang 22+ warns about __COUNTER__ under -Wc2y-extensions: it's a compiler extension being standardized in C2y (the C standard after C23). googlebench uses -pedantic-errors and -Werror, turning this into a fatal error. __COUNTER__ has been a de facto compiler extension so is fine to use it, but we need to suppress the warning now that clang 22+ is more strict.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-only change that tweaks compiler flags for the micro-benchmark targets to avoid clang 22+ treating a new warning as an error.
> 
> **Overview**
> Fixes micro-benchmark builds on clang 22+ by conditionally adding `-Wno-c2y-extensions` to the upstream `benchmark` and `benchmark_main` targets.
> 
> This suppresses the `__COUNTER__` warning that becomes fatal under googlebench’s `-Werror`/`-pedantic-errors` settings, without affecting non-Clang compilers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7787ff229771092748e9c96ca0ea7a394c1086e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->