### PR TITLE
Forward symbolic link flags to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ function(setup_shared_object_target target)
     else()
         # We are building a shared library and want to verify that any reference to a symbol within the library will resolve to
         # the library's own definition, rather than to a definition in another shared library or the main executable.
-        set_target_properties(${target} PROPERTIES LINK_FLAGS "-pthread -shared -Bsymbolic -Bsymbolic-functions")
+        set_target_properties(${target} PROPERTIES LINK_FLAGS "-pthread -shared -Wl,-Bsymbolic,-Bsymbolic-functions")
     endif()
     set_target_properties(${target} PROPERTIES PREFIX "")
 endfunction()


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: #6017 moved the module build into CMake and added `-Bsymbolic -Bsymbolic-functions` to the Linux shared-object `LINK_FLAGS`. The final module link is driven through the compiler driver (`cc`/`c++`), not by invoking `ld` directly, so those raw flags are not forwarded to the linker. As a result, references to global symbols defined inside `redisearch.so` can remain dynamically interposable by Redis or other loaded objects.

2. Change: Pass the existing symbolic binding flags through to the linker:

   ```cmake
   -Bsymbolic -Bsymbolic-functions
   ```

   becomes:

   ```cmake
   -Wl,-Bsymbolic,-Bsymbolic-functions
   ```

3. Outcome: The actual `ld` invocation receives both `-Bsymbolic` and `-Bsymbolic-functions`, so references to symbols defined inside `redisearch.so` bind locally as originally intended.

#### Which additional issues does this PR fix

1. MOD-15034
2. Follow-up to #6017

#### Main objects this PR modified

1. `CMakeLists.txt`: Linux shared-object linker flags for `redisearch.so`

#### Backports

Backport labels were added for the affected relevant version branches:

1. `backport 8.6`
2. `backport 8.6-rse`
3. `backport 8.4`
4. `backport 8.2`

The remaining relevant version branches already have the correct `-Wl,-Bsymbolic,-Bsymbolic-functions` form and do not need code changes:

1. `2.10`
2. `2.8`
3. `2.6`

#### Validation

Checked that the old raw flags are not forwarded to `ld`:

```bash
c++ -### -shared -Bsymbolic -Bsymbolic-functions -o /tmp/probe-old.so /dev/null 2>&1 | grep -E -- '-Bsymbolic|-Bsymbolic-functions'
```

Expected/observed: no linker flags in the `ld` invocation.

Checked that the new form is forwarded:

```bash
c++ -### -shared -Wl,-Bsymbolic,-Bsymbolic-functions -o /tmp/probe-new.so /dev/null 2>&1 | grep -E -- '-Bsymbolic|-Bsymbolic-functions'
```

Observed in the `ld` invocation:

```text
-Bsymbolic
-Bsymbolic-functions
```

Also ran:

```bash
git diff --check -- CMakeLists.txt
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system-only change that affects Linux shared library link flags; main risk is unintended linker incompatibility on some toolchains.
> 
> **Overview**
> Ensures Linux shared-object builds actually apply symbolic binding by changing the `redisearch` shared library `LINK_FLAGS` from raw `-Bsymbolic -Bsymbolic-functions` to the linker-forwarded `-Wl,-Bsymbolic,-Bsymbolic-functions`, preventing those flags from being dropped when linking via the compiler driver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4820418ca3b05e787f605011441246077f5dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->