### PR TITLE
[8.2][codex] Forward symbolic link flags to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ function(setup_shared_object_target target)
     else()
         # We are building a shared library and want to verify that any reference to a symbol within the library will resolve to
         # the library's own definition, rather than to a definition in another shared library or the main executable.
-        set_target_properties(${target} PROPERTIES LINK_FLAGS "-pthread -shared -Bsymbolic -Bsymbolic-functions")
+        set_target_properties(${target} PROPERTIES LINK_FLAGS "-pthread -shared -Wl,-Bsymbolic,-Bsymbolic-functions")
     endif()
     set_target_properties(${target} PROPERTIES PREFIX "")
 endfunction()


### PR DESCRIPTION
## Summary

Backport of #9405 to `8.2`.

Forward the existing symbolic binding flags to the linker:

```cmake
-Bsymbolic -Bsymbolic-functions
```

becomes:

```cmake
-Wl,-Bsymbolic,-Bsymbolic-functions
```

## Why

The module link is driven through the compiler driver. Raw `-Bsymbolic` / `-Bsymbolic-functions` do not reach `ld`, so the intended local binding was ineffective. This can leave internal `redisearch.so` symbols interposable by Redis or other loaded objects. MOD-15034 exposed this via the geohash helper collision, but the underlying issue is the ineffective linker flags.

## Validation

```bash
git diff --check HEAD~1..HEAD -- CMakeLists.txt
```

Also validated on master that the old raw flags are not forwarded by `c++ -###`, while the `-Wl,` form reaches `/usr/bin/ld`.