### PR TITLE
MOD-16530: Relax HIGHLIGHT/SUMMARIZE restriction for single-value JSON fields

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1139,7 +1139,7 @@
             "optional": true
           }
         ],
-        "summary": "Splits a field into contextual fragments surrounding the found terms, Note that summarize for JSON documents is not currently supported."
+        "summary": "Splits a field into contextual fragments surrounding the found terms. Note: SUMMARIZE is not supported for JSON fields with multi-value JSONPath."
       },
       {
         "name": "highlight",
@@ -1191,7 +1191,7 @@
             ]
           }
         ],
-        "summary": "Highlights terms in the search results, with customizable tags for emphasis. Note that highlight for JSON documents is not currently supported."
+        "summary": "Highlights terms in the search results, with customizable tags for emphasis. Note: HIGHLIGHT is not supported for JSON fields with multi-value JSONPath."
       },
       {
         "name": "slop",

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -31,6 +31,7 @@
 #include "coord/rmr/command.h"
 #include "coord/rmr/chan.h"
 #include "coord/rpnet.h"
+#include "json.h"
 #include "search_disk.h"
 #include "search_disk_utils.h"
 #include "doc_id_meta.h"
@@ -1543,6 +1544,56 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   return REDISMODULE_OK;
 }
 
+// Check if a single FieldSpec has a multi-value JSONPath.
+// Returns true if the field is a TEXT field with a multi-value JSONPath.
+static bool fieldSpecIsMultiValueText(const FieldSpec *fs) {
+  if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !fs->fieldPath) {
+    return false;
+  }
+  RedisModuleString *err_msg = NULL;
+  JSONPath path = pathParse(fs->fieldPath, &err_msg);
+  if (err_msg) {
+    RedisModule_FreeString(RSDummyContext, err_msg);
+  }
+  if (!path) {
+    return false;
+  }
+  bool isSingle = japi->pathIsSingle(path);
+  japi->pathFree(path);
+  return !isSingle;
+}
+
+// Validate that HIGHLIGHT/SUMMARIZE fields on a JSON index all use single-value JSONPaths.
+// Returns REDISMODULE_OK if all fields are single-value, REDISMODULE_ERR otherwise.
+static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *index,
+                                             QueryError *status) {
+  const FieldList *fields = &req->outFields;
+  bool hasMultiValue = false;
+
+  // outFields contains fields from both RETURN and HIGHLIGHT/SUMMARIZE FIELDS.
+  // Since we require explicitReturn for JSON, numFields is always > 0 here.
+  for (size_t ii = 0; ii < fields->numFields; ++ii) {
+    const ReturnedField *rf = &fields->fields[ii];
+    // Skip fields that are only in RETURN (no highlight/summarize mode).
+    if (rf->mode == SummarizeMode_None && fields->defaultField.mode == SummarizeMode_None) {
+      continue;
+    }
+    const FieldSpec *fs = IndexSpec_GetFieldWithLength(index, rf->name, strlen(rf->name));
+    if (fieldSpecIsMultiValueText(fs)) {
+      hasMultiValue = true;
+      break;
+    }
+  }
+
+  if (hasMultiValue) {
+    QueryError_SetError(
+        status, QUERY_ERROR_CODE_INVAL,
+        "HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath");
+    return REDISMODULE_ERR;
+  }
+  return REDISMODULE_OK;
+}
+
 int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   // Sort through the applicable options:
   IndexSpec *index = sctx->spec;
@@ -1560,10 +1611,19 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
 
   QEFlags reqFlags = AREQ_RequestFlags(req);
   if (isSpecJson(index) && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {
-    QueryError_SetError(
-        status, QUERY_ERROR_CODE_INVAL,
-        "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes");
-    return REDISMODULE_ERR;
+    // JSON requires RETURN so that fields are loaded individually. Without RETURN,
+    // JSON "LOAD ALL" produces a single serialized blob and individual fields are
+    // not available for highlighting.
+    if (!req->outFields.explicitReturn) {
+      QueryError_SetError(
+          status, QUERY_ERROR_CODE_INVAL,
+          "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names");
+      return REDISMODULE_ERR;
+    }
+    // Multi-value JSONPaths are rejected regardless of dialect.
+    if (AREQ_HasMultiValueHighlightFields(req, index, status) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
+    }
   }
 
   if ((index->flags & Index_StoreByteOffsets) == 0 && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -97,6 +97,10 @@ ReturnedField *FieldList_GetCreateField(FieldList *fields, const char *name, con
   size_t foundIndex = -1;
   for (size_t ii = 0; ii < fields->numFields; ++ii) {
     if (!strcmp(fields->fields[ii].name, name)) {
+      if (path && fields->fields[ii].explicitReturn == 0 &&
+          fields->fields[ii].mode != SummarizeMode_None) {
+        fields->fields[ii].path = path;
+      }
       return fields->fields + ii;
     }
   }
@@ -1563,6 +1567,33 @@ static bool fieldSpecIsMultiValueText(const FieldSpec *fs) {
   return !isSingle;
 }
 
+static bool jsonPathIsMultiValue(const char *pathStr) {
+  if (!pathStr || *pathStr != '$') {
+    return false;
+  }
+
+  RedisModuleString *err_msg = NULL;
+  JSONPath path = japi->pathParse(pathStr, RSDummyContext, &err_msg);
+  if (err_msg) {
+    RedisModule_FreeString(RSDummyContext, err_msg);
+  }
+  if (!path) {
+    return false;
+  }
+
+  bool isSingle = japi->pathIsSingle(path);
+  japi->pathFree(path);
+  return !isSingle;
+}
+
+static const FieldSpec *getHighlightFieldSpec(const IndexSpec *index, const ReturnedField *rf) {
+  const FieldSpec *fs = IndexSpec_GetFieldWithLength(index, rf->name, strlen(rf->name));
+  if (!fs && rf->path && strcmp(rf->path, rf->name) != 0) {
+    fs = IndexSpec_GetFieldWithLength(index, rf->path, strlen(rf->path));
+  }
+  return fs;
+}
+
 // Validate that HIGHLIGHT/SUMMARIZE fields on a JSON index all use single-value JSONPaths.
 // Returns REDISMODULE_OK if all fields are single-value, REDISMODULE_ERR otherwise.
 static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *index,
@@ -1571,15 +1602,14 @@ static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *i
   bool hasMultiValue = false;
 
   // outFields contains fields from both RETURN and HIGHLIGHT/SUMMARIZE FIELDS.
-  // Since we require explicitReturn for JSON, numFields is always > 0 here.
   for (size_t ii = 0; ii < fields->numFields; ++ii) {
     const ReturnedField *rf = &fields->fields[ii];
     // Skip fields that are only in RETURN (no highlight/summarize mode).
     if (rf->mode == SummarizeMode_None && fields->defaultField.mode == SummarizeMode_None) {
       continue;
     }
-    const FieldSpec *fs = IndexSpec_GetFieldWithLength(index, rf->name, strlen(rf->name));
-    if (fieldSpecIsMultiValueText(fs)) {
+    const FieldSpec *fs = getHighlightFieldSpec(index, rf);
+    if (jsonPathIsMultiValue(rf->path) || (fs && fieldSpecIsMultiValueText(fs))) {
       hasMultiValue = true;
       break;
     }
@@ -1614,7 +1644,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
     // JSON requires RETURN so that fields are loaded individually. Without RETURN,
     // JSON "LOAD ALL" produces a single serialized blob and individual fields are
     // not available for highlighting.
-    if (!req->outFields.explicitReturn) {
+    if (!req->outFields.explicitReturn || req->outFields.numFields == 0) {
       QueryError_SetError(
           status, QUERY_ERROR_CODE_INVAL,
           "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names");

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -136,10 +136,11 @@ void FieldList_Free(FieldList *fields) {
   rm_free(fields->fields);
 }
 
+// Gets or creates the returned-field entry for `path AS name`; NULL `path` means `name`.
 ReturnedField *FieldList_GetCreateField(FieldList *fields, const char *name, const char *path) {
   for (size_t ii = 0; ii < fields->numFields; ++ii) {
     if (!strcmp(fields->fields[ii].name, name)) {
-      if (path && fields->fields[ii].explicitReturn == 0 &&
+      if (path && !fields->fields[ii].explicitReturn &&
           fields->fields[ii].mode != SummarizeMode_None) {
         fields->fields[ii].path = path;
       }
@@ -1587,6 +1588,7 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
 }
 
 // Check if a single FieldSpec has a multi-value JSONPath.
+// This request-time validation is used only for JSON HIGHLIGHT/SUMMARIZE fields.
 // Returns true if the field is a TEXT field with a multi-value JSONPath.
 static bool fieldSpecIsMultiValueText(const FieldSpec *fs) {
   if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !fs->fieldPath) {
@@ -1633,7 +1635,8 @@ static const FieldSpec *getHighlightFieldSpec(const IndexSpec *index, const Retu
 }
 
 // Validate that HIGHLIGHT/SUMMARIZE fields on a JSON index all use single-value JSONPaths.
-// Returns REDISMODULE_OK if all fields are single-value, REDISMODULE_ERR otherwise.
+// Returns REDISMODULE_OK if all fields are single-value, REDISMODULE_ERR and sets `status`
+// otherwise.
 static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *index,
                                              QueryError *status) {
   const FieldList *fields = &req->outFields;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -140,6 +140,10 @@ ReturnedField *FieldList_GetCreateField(FieldList *fields, const char *name, con
   size_t foundIndex = -1;
   for (size_t ii = 0; ii < fields->numFields; ++ii) {
     if (!strcmp(fields->fields[ii].name, name)) {
+      if (path && fields->fields[ii].explicitReturn == 0 &&
+          fields->fields[ii].mode != SummarizeMode_None) {
+        fields->fields[ii].path = path;
+      }
       return fields->fields + ii;
     }
   }
@@ -1602,6 +1606,33 @@ static bool fieldSpecIsMultiValueText(const FieldSpec *fs) {
   return !isSingle;
 }
 
+static bool jsonPathIsMultiValue(const char *pathStr) {
+  if (!pathStr || *pathStr != '$') {
+    return false;
+  }
+
+  RedisModuleString *err_msg = NULL;
+  JSONPath path = japi->pathParse(pathStr, RSDummyContext, &err_msg);
+  if (err_msg) {
+    RedisModule_FreeString(RSDummyContext, err_msg);
+  }
+  if (!path) {
+    return false;
+  }
+
+  bool isSingle = japi->pathIsSingle(path);
+  japi->pathFree(path);
+  return !isSingle;
+}
+
+static const FieldSpec *getHighlightFieldSpec(const IndexSpec *index, const ReturnedField *rf) {
+  const FieldSpec *fs = IndexSpec_GetFieldWithLength(index, rf->name, strlen(rf->name));
+  if (!fs && rf->path && strcmp(rf->path, rf->name) != 0) {
+    fs = IndexSpec_GetFieldWithLength(index, rf->path, strlen(rf->path));
+  }
+  return fs;
+}
+
 // Validate that HIGHLIGHT/SUMMARIZE fields on a JSON index all use single-value JSONPaths.
 // Returns REDISMODULE_OK if all fields are single-value, REDISMODULE_ERR otherwise.
 static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *index,
@@ -1610,15 +1641,14 @@ static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *i
   bool hasMultiValue = false;
 
   // outFields contains fields from both RETURN and HIGHLIGHT/SUMMARIZE FIELDS.
-  // Since we require explicitReturn for JSON, numFields is always > 0 here.
   for (size_t ii = 0; ii < fields->numFields; ++ii) {
     const ReturnedField *rf = &fields->fields[ii];
     // Skip fields that are only in RETURN (no highlight/summarize mode).
     if (rf->mode == SummarizeMode_None && fields->defaultField.mode == SummarizeMode_None) {
       continue;
     }
-    const FieldSpec *fs = IndexSpec_GetFieldWithLength(index, rf->name, strlen(rf->name));
-    if (fieldSpecIsMultiValueText(fs)) {
+    const FieldSpec *fs = getHighlightFieldSpec(index, rf);
+    if (jsonPathIsMultiValue(rf->path) || (fs && fieldSpecIsMultiValueText(fs))) {
       hasMultiValue = true;
       break;
     }
@@ -1653,7 +1683,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
     // JSON requires RETURN so that fields are loaded individually. Without RETURN,
     // JSON "LOAD ALL" produces a single serialized blob and individual fields are
     // not available for highlighting.
-    if (!req->outFields.explicitReturn) {
+    if (!req->outFields.explicitReturn || req->outFields.numFields == 0) {
       QueryError_SetError(
           status, QUERY_ERROR_CODE_INVAL,
           "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names");

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -34,6 +34,7 @@
 #include "coord/rmr/command.h"
 #include "coord/rmr/chan.h"
 #include "coord/rpnet.h"
+#include "json.h"
 #include "search_disk.h"
 #include "search_disk_utils.h"
 #include "doc_id_meta.h"
@@ -1582,6 +1583,56 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   return REDISMODULE_OK;
 }
 
+// Check if a single FieldSpec has a multi-value JSONPath.
+// Returns true if the field is a TEXT field with a multi-value JSONPath.
+static bool fieldSpecIsMultiValueText(const FieldSpec *fs) {
+  if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !fs->fieldPath) {
+    return false;
+  }
+  RedisModuleString *err_msg = NULL;
+  JSONPath path = pathParse(fs->fieldPath, &err_msg);
+  if (err_msg) {
+    RedisModule_FreeString(RSDummyContext, err_msg);
+  }
+  if (!path) {
+    return false;
+  }
+  bool isSingle = japi->pathIsSingle(path);
+  japi->pathFree(path);
+  return !isSingle;
+}
+
+// Validate that HIGHLIGHT/SUMMARIZE fields on a JSON index all use single-value JSONPaths.
+// Returns REDISMODULE_OK if all fields are single-value, REDISMODULE_ERR otherwise.
+static int AREQ_HasMultiValueHighlightFields(const AREQ *req, const IndexSpec *index,
+                                             QueryError *status) {
+  const FieldList *fields = &req->outFields;
+  bool hasMultiValue = false;
+
+  // outFields contains fields from both RETURN and HIGHLIGHT/SUMMARIZE FIELDS.
+  // Since we require explicitReturn for JSON, numFields is always > 0 here.
+  for (size_t ii = 0; ii < fields->numFields; ++ii) {
+    const ReturnedField *rf = &fields->fields[ii];
+    // Skip fields that are only in RETURN (no highlight/summarize mode).
+    if (rf->mode == SummarizeMode_None && fields->defaultField.mode == SummarizeMode_None) {
+      continue;
+    }
+    const FieldSpec *fs = IndexSpec_GetFieldWithLength(index, rf->name, strlen(rf->name));
+    if (fieldSpecIsMultiValueText(fs)) {
+      hasMultiValue = true;
+      break;
+    }
+  }
+
+  if (hasMultiValue) {
+    QueryError_SetError(
+        status, QUERY_ERROR_CODE_INVAL,
+        "HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath");
+    return REDISMODULE_ERR;
+  }
+  return REDISMODULE_OK;
+}
+
 int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   // Sort through the applicable options:
   IndexSpec *index = sctx->spec;
@@ -1599,10 +1650,19 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
 
   QEFlags reqFlags = AREQ_RequestFlags(req);
   if (isSpecJson(index) && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {
-    QueryError_SetError(
-        status, QUERY_ERROR_CODE_INVAL,
-        "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes");
-    return REDISMODULE_ERR;
+    // JSON requires RETURN so that fields are loaded individually. Without RETURN,
+    // JSON "LOAD ALL" produces a single serialized blob and individual fields are
+    // not available for highlighting.
+    if (!req->outFields.explicitReturn) {
+      QueryError_SetError(
+          status, QUERY_ERROR_CODE_INVAL,
+          "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names");
+      return REDISMODULE_ERR;
+    }
+    // Multi-value JSONPaths are rejected regardless of dialect.
+    if (AREQ_HasMultiValueHighlightFields(req, index, status) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
+    }
   }
 
   if ((index->flags & Index_StoreByteOffsets) == 0 && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -137,7 +137,6 @@ void FieldList_Free(FieldList *fields) {
 }
 
 ReturnedField *FieldList_GetCreateField(FieldList *fields, const char *name, const char *path) {
-  size_t foundIndex = -1;
   for (size_t ii = 0; ii < fields->numFields; ++ii) {
     if (!strcmp(fields->fields[ii].name, name)) {
       if (path && fields->fields[ii].explicitReturn == 0 &&

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1229,7 +1229,7 @@ int SetFtSearchInfo(RedisModuleCommand *cmd) {
       },
       {
         .name = "summarize",
-        .summary = "Splits a field into contextual fragments surrounding the found terms, Note that summarize for JSON documents is not currently supported.",
+        .summary = "Splits a field into contextual fragments surrounding the found terms. Note: SUMMARIZE is not supported for JSON fields with multi-value JSONPath.",
         .type = REDISMODULE_ARG_TYPE_BLOCK,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,
         .subargs = (RedisModuleCommandArg[]){
@@ -1280,7 +1280,7 @@ int SetFtSearchInfo(RedisModuleCommand *cmd) {
       },
       {
         .name = "highlight",
-        .summary = "Highlights terms in the search results, with customizable tags for emphasis. Note that highlight for JSON documents is not currently supported.",
+        .summary = "Highlights terms in the search results, with customizable tags for emphasis. Note: HIGHLIGHT is not supported for JSON fields with multi-value JSONPath.",
         .type = REDISMODULE_ARG_TYPE_BLOCK,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,
         .subargs = (RedisModuleCommandArg[]){

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -259,6 +259,36 @@ static void resetIovsArr(Array **iovsArrp, size_t *curSize, size_t newSize) {
   *curSize = newSize;
 }
 
+static bool shouldSkipJsonFieldValue(const RSValue *fieldValue) {
+  // A single-value JSONPath (e.g., $.colors) can point to a JSON array.
+  // Array elements are indexed as separate values with independent byte offsets, so
+  // highlighting against a single loaded string would be incorrect.
+  //
+  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
+  //   (serialized JSON). We reject RedisString only for JSON.
+  // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
+  //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
+  //   array-at-path. We reject the latter.
+  RSValueType type = RSValue_Type(fieldValue);
+  if (type == RSValueType_RedisString) {
+    return true;
+  }
+  if (type != RSValueType_Trio) {
+    return false;
+  }
+
+  const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
+  if (RSValue_Type(expanded) != RSValueType_Array) {
+    return false;
+  }
+  if (RSValue_ArrayLen(expanded) == 0) {
+    return true;
+  }
+
+  const RSValue *first = RSValue_ArrayItem(expanded, 0);
+  return RSValue_Type(first) != RSValueType_String;
+}
+
 static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, ReturnedField *spec) {
   const char *fName = spec->name;
   const RSValue *fieldValue = RLookupRow_Get(spec->lookupKey, docParams->row);
@@ -267,32 +297,8 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
     return;
   }
 
-  if (hlpCtx->isJson) {
-    // A single-value JSONPath (e.g., $.colors) can point to a JSON array.
-    // Array elements are indexed as separate values with independent byte offsets, so
-    // highlighting against a single loaded string would be incorrect.
-    //
-    // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
-    //   (serialized JSON). We reject RedisString only for JSON.
-    // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
-    //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
-    //   array-at-path. We reject the latter.
-    RSValueType type = RSValue_Type(fieldValue);
-    if (type == RSValueType_RedisString) {
-      return;
-    }
-    if (type == RSValueType_Trio) {
-      const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
-      if (RSValue_Type(expanded) == RSValueType_Array) {
-        if (RSValue_ArrayLen(expanded) == 0) {
-          return;
-        }
-        const RSValue *first = RSValue_ArrayItem(expanded, 0);
-        if (RSValue_Type(first) != RSValueType_String) {
-          return;
-        }
-      }
-    }
+  if (hlpCtx->isJson && shouldSkipJsonFieldValue(fieldValue)) {
+    return;
   }
 
   size_t fieldLen;

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -19,6 +19,7 @@ typedef struct {
   int fragmentizeOptions;
   const FieldList *fields;
   const RLookup *lookup;
+  bool isJson;
 } HlpProcessor;
 
 /**
@@ -266,25 +267,30 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
     return;
   }
 
-  // For JSON documents, a single-value JSONPath (e.g., $.colors) can point to a JSON array.
-  // Array elements are indexed as separate values with independent byte offsets, so
-  // highlighting against a single loaded string would be incorrect.
-  //
-  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
-  //   (serialized JSON). We reject RedisString.
-  // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
-  //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
-  //   array-at-path. We reject the latter.
-  RSValueType type = RSValue_Type(fieldValue);
-  if (type == RSValueType_RedisString) {
-    return;
-  }
-  if (type == RSValueType_Trio) {
-    const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
-    if (RSValue_Type(expanded) == RSValueType_Array) {
-      const RSValue *first = RSValue_ArrayItem(expanded, 0);
-      if (RSValue_Type(first) != RSValueType_String) {
-        return;
+  if (hlpCtx->isJson) {
+    // A single-value JSONPath (e.g., $.colors) can point to a JSON array.
+    // Array elements are indexed as separate values with independent byte offsets, so
+    // highlighting against a single loaded string would be incorrect.
+    //
+    // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
+    //   (serialized JSON). We reject RedisString only for JSON.
+    // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
+    //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
+    //   array-at-path. We reject the latter.
+    RSValueType type = RSValue_Type(fieldValue);
+    if (type == RSValueType_RedisString) {
+      return;
+    }
+    if (type == RSValueType_Trio) {
+      const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
+      if (RSValue_Type(expanded) == RSValueType_Array) {
+        if (RSValue_ArrayLen(expanded) == 0) {
+          return;
+        }
+        const RSValue *first = RSValue_ArrayItem(expanded, 0);
+        if (RSValue_Type(first) != RSValueType_String) {
+          return;
+        }
       }
     }
   }
@@ -388,7 +394,7 @@ static void hlpFree(ResultProcessor *p) {
 }
 
 ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
-                                   const RLookup *lookup) {
+                                   const RLookup *lookup, bool isJson) {
   HlpProcessor *hlp = rm_calloc(1, sizeof(*hlp));
   if (language == RS_LANG_CHINESE) {
     hlp->fragmentizeOptions = FRAGMENTIZE_TOKLEN_EXACT;
@@ -397,6 +403,7 @@ ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
   hlp->base.Free = hlpFree;
   hlp->fields = fields;
   hlp->lookup = lookup;
+  hlp->isJson = isJson;
   hlp->base.type = RP_HIGHLIGHTER;
   return &hlp->base;
 }

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -171,7 +171,7 @@ static char *trimField(const ReturnedField *fieldInfo, const char *docStr, size_
 }
 
 static RSValue *summarizeField(const RLookup *lookup, const ReturnedField *fieldInfo,
-                               const char *fieldName, const RSValue *returnedField,
+                               const char *fieldName, const char *docStr, size_t docLen,
                                hlpDocContext *docParams, int options) {
 
   FragmentList frags;
@@ -180,10 +180,6 @@ static RSValue *summarizeField(const RLookup *lookup, const ReturnedField *field
   // Start gathering the terms
   HighlightTags tags = {.openTag = fieldInfo->highlightSettings.openTag,
                         .closeTag = fieldInfo->highlightSettings.closeTag};
-
-  // First actually generate the fragments
-  size_t docLen;
-  const char *docStr = RSValue_StringPtrLen(returnedField, &docLen);
   if (docParams->byteOffsets == NULL ||
       !fragmentizeOffsets(lookup, fieldName, docStr, docLen, docParams->indexResult,
                           docParams->byteOffsets, &frags, options)) {
@@ -266,10 +262,39 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
   const char *fName = spec->name;
   const RSValue *fieldValue = RLookupRow_Get(spec->lookupKey, docParams->row);
 
-  if (fieldValue == NULL || !RSValue_IsString(fieldValue)) {
+  if (fieldValue == NULL) {
     return;
   }
-  RSValue *v = summarizeField(hlpCtx->lookup, spec, fName, fieldValue, docParams,
+
+  // For JSON documents, a single-value JSONPath (e.g., $.colors) can point to a JSON array.
+  // Array elements are indexed as separate values with independent byte offsets, so
+  // highlighting against a single loaded string would be incorrect.
+  //
+  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
+  //   (serialized JSON). We reject RedisString.
+  // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
+  //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
+  //   array-at-path. We reject the latter.
+  RSValueType type = RSValue_Type(fieldValue);
+  if (type == RSValueType_RedisString) {
+    return;
+  }
+  if (type == RSValueType_Trio) {
+    const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
+    if (RSValue_Type(expanded) == RSValueType_Array) {
+      const RSValue *first = RSValue_ArrayItem(expanded, 0);
+      if (RSValue_Type(first) != RSValueType_String) {
+        return;
+      }
+    }
+  }
+
+  size_t fieldLen;
+  const char *fieldStr = RSValue_StringPtrLen(fieldValue, &fieldLen);
+  if (!fieldStr) {
+    return;
+  }
+  RSValue *v = summarizeField(hlpCtx->lookup, spec, fName, fieldStr, fieldLen, docParams,
                               hlpCtx->fragmentizeOptions);
   if (v) {
     RLookup_WriteOwnKey(spec->lookupKey, docParams->row, v);

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -35,6 +35,7 @@ typedef struct {
   int fragmentizeOptions;
   const FieldList *fields;
   const RLookup *lookup;
+  bool isJson;
 } HlpProcessor;
 
 /**
@@ -282,25 +283,30 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
     return;
   }
 
-  // For JSON documents, a single-value JSONPath (e.g., $.colors) can point to a JSON array.
-  // Array elements are indexed as separate values with independent byte offsets, so
-  // highlighting against a single loaded string would be incorrect.
-  //
-  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
-  //   (serialized JSON). We reject RedisString.
-  // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
-  //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
-  //   array-at-path. We reject the latter.
-  RSValueType type = RSValue_Type(fieldValue);
-  if (type == RSValueType_RedisString) {
-    return;
-  }
-  if (type == RSValueType_Trio) {
-    const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
-    if (RSValue_Type(expanded) == RSValueType_Array) {
-      const RSValue *first = RSValue_ArrayItem(expanded, 0);
-      if (RSValue_Type(first) != RSValueType_String) {
-        return;
+  if (hlpCtx->isJson) {
+    // A single-value JSONPath (e.g., $.colors) can point to a JSON array.
+    // Array elements are indexed as separate values with independent byte offsets, so
+    // highlighting against a single loaded string would be incorrect.
+    //
+    // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
+    //   (serialized JSON). We reject RedisString only for JSON.
+    // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
+    //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
+    //   array-at-path. We reject the latter.
+    RSValueType type = RSValue_Type(fieldValue);
+    if (type == RSValueType_RedisString) {
+      return;
+    }
+    if (type == RSValueType_Trio) {
+      const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
+      if (RSValue_Type(expanded) == RSValueType_Array) {
+        if (RSValue_ArrayLen(expanded) == 0) {
+          return;
+        }
+        const RSValue *first = RSValue_ArrayItem(expanded, 0);
+        if (RSValue_Type(first) != RSValueType_String) {
+          return;
+        }
       }
     }
   }
@@ -404,7 +410,7 @@ static void hlpFree(ResultProcessor *p) {
 }
 
 ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
-                                   const RLookup *lookup) {
+                                   const RLookup *lookup, bool isJson) {
   HlpProcessor *hlp = rm_calloc(1, sizeof(*hlp));
   if (language == RS_LANG_CHINESE) {
     hlp->fragmentizeOptions = FRAGMENTIZE_TOKLEN_EXACT;
@@ -413,6 +419,7 @@ ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
   hlp->base.Free = hlpFree;
   hlp->fields = fields;
   hlp->lookup = lookup;
+  hlp->isJson = isJson;
   hlp->base.type = RP_HIGHLIGHTER;
   return &hlp->base;
 }

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -275,6 +275,36 @@ static void resetIovsArr(Array **iovsArrp, size_t *curSize, size_t newSize) {
   *curSize = newSize;
 }
 
+static bool shouldSkipJsonFieldValue(const RSValue *fieldValue) {
+  // A single-value JSONPath (e.g., $.colors) can point to a JSON array.
+  // Array elements are indexed as separate values with independent byte offsets, so
+  // highlighting against a single loaded string would be incorrect.
+  //
+  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
+  //   (serialized JSON). We reject RedisString only for JSON.
+  // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
+  //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
+  //   array-at-path. We reject the latter.
+  RSValueType type = RSValue_Type(fieldValue);
+  if (type == RSValueType_RedisString) {
+    return true;
+  }
+  if (type != RSValueType_Trio) {
+    return false;
+  }
+
+  const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
+  if (RSValue_Type(expanded) != RSValueType_Array) {
+    return false;
+  }
+  if (RSValue_ArrayLen(expanded) == 0) {
+    return true;
+  }
+
+  const RSValue *first = RSValue_ArrayItem(expanded, 0);
+  return RSValue_Type(first) != RSValueType_String;
+}
+
 static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, ReturnedField *spec) {
   const char *fName = spec->name;
   const RSValue *fieldValue = RLookupRow_Get(spec->lookupKey, docParams->row);
@@ -283,32 +313,8 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
     return;
   }
 
-  if (hlpCtx->isJson) {
-    // A single-value JSONPath (e.g., $.colors) can point to a JSON array.
-    // Array elements are indexed as separate values with independent byte offsets, so
-    // highlighting against a single loaded string would be incorrect.
-    //
-    // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
-    //   (serialized JSON). We reject RedisString only for JSON.
-    // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
-    //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
-    //   array-at-path. We reject the latter.
-    RSValueType type = RSValue_Type(fieldValue);
-    if (type == RSValueType_RedisString) {
-      return;
-    }
-    if (type == RSValueType_Trio) {
-      const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
-      if (RSValue_Type(expanded) == RSValueType_Array) {
-        if (RSValue_ArrayLen(expanded) == 0) {
-          return;
-        }
-        const RSValue *first = RSValue_ArrayItem(expanded, 0);
-        if (RSValue_Type(first) != RSValueType_String) {
-          return;
-        }
-      }
-    }
+  if (hlpCtx->isJson && shouldSkipJsonFieldValue(fieldValue)) {
+    return;
   }
 
   size_t fieldLen;

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -280,8 +280,10 @@ static bool shouldSkipJsonFieldValue(const RSValue *fieldValue) {
   // Array elements are indexed as separate values with independent byte offsets, so
   // highlighting against a single loaded string would be incorrect.
   //
-  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
-  //   (serialized JSON). We reject RedisString only for JSON.
+  // DIALECT 1-2: scalar JSON strings are RSValueType_String and fall through without
+  //   skipping; JSON arrays/objects without usable scalar offsets are serialized as
+  //   RSValueType_RedisString and are skipped. The caller gates this helper on
+  //   hlpCtx->isJson, so HASH RedisString values are not affected.
   // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
   //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
   //   array-at-path. We reject the latter.

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -187,7 +187,7 @@ static char *trimField(const ReturnedField *fieldInfo, const char *docStr, size_
 }
 
 static RSValue *summarizeField(const RLookup *lookup, const ReturnedField *fieldInfo,
-                               const char *fieldName, const RSValue *returnedField,
+                               const char *fieldName, const char *docStr, size_t docLen,
                                hlpDocContext *docParams, int options) {
 
   FragmentList frags;
@@ -196,10 +196,6 @@ static RSValue *summarizeField(const RLookup *lookup, const ReturnedField *field
   // Start gathering the terms
   HighlightTags tags = {.openTag = fieldInfo->highlightSettings.openTag,
                         .closeTag = fieldInfo->highlightSettings.closeTag};
-
-  // First actually generate the fragments
-  size_t docLen;
-  const char *docStr = RSValue_StringPtrLen(returnedField, &docLen);
   if (docParams->byteOffsets == NULL ||
       !fragmentizeOffsets(lookup, fieldName, docStr, docLen, docParams->indexResult,
                           docParams->byteOffsets, &frags, options)) {
@@ -282,10 +278,39 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
   const char *fName = spec->name;
   const RSValue *fieldValue = RLookupRow_Get(spec->lookupKey, docParams->row);
 
-  if (fieldValue == NULL || !RSValue_IsString(fieldValue)) {
+  if (fieldValue == NULL) {
     return;
   }
-  RSValue *v = summarizeField(hlpCtx->lookup, spec, fName, fieldValue, docParams,
+
+  // For JSON documents, a single-value JSONPath (e.g., $.colors) can point to a JSON array.
+  // Array elements are indexed as separate values with independent byte offsets, so
+  // highlighting against a single loaded string would be incorrect.
+  //
+  // DIALECT 1-2: scalars are RSValueType_String, arrays are RSValueType_RedisString
+  //   (serialized JSON). We reject RedisString.
+  // DIALECT 3+: values are wrapped in a Trio. The Trio's right (expanded) array reveals
+  //   the origin: expanded[0] is RSValueType_String for scalars, RSValueType_Array for
+  //   array-at-path. We reject the latter.
+  RSValueType type = RSValue_Type(fieldValue);
+  if (type == RSValueType_RedisString) {
+    return;
+  }
+  if (type == RSValueType_Trio) {
+    const RSValue *expanded = RSValue_Trio_GetRight(fieldValue);
+    if (RSValue_Type(expanded) == RSValueType_Array) {
+      const RSValue *first = RSValue_ArrayItem(expanded, 0);
+      if (RSValue_Type(first) != RSValueType_String) {
+        return;
+      }
+    }
+  }
+
+  size_t fieldLen;
+  const char *fieldStr = RSValue_StringPtrLen(fieldValue, &fieldLen);
+  if (!fieldStr) {
+    return;
+  }
+  RSValue *v = summarizeField(hlpCtx->lookup, spec, fName, fieldStr, fieldLen, docParams,
                               hlpCtx->fragmentizeOptions);
   if (v) {
     RLookup_WriteOwnKey(spec->lookupKey, docParams->row, v);

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -543,7 +543,8 @@ int buildOutputPipeline(Pipeline *pipeline, const AggregationPipelineParams* par
       }
       ff->lookupKey = kk;
     }
-    rp = RPHighlighter_New(params->language, params->outFields, lookup);
+    rp = RPHighlighter_New(params->language, params->outFields, lookup,
+                           isSpecJson(params->common.sctx->spec));
     PUSH_RP();
   }
 

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -608,7 +608,8 @@ int buildOutputPipeline(Pipeline *pipeline, const AggregationPipelineParams* par
       }
       ff->lookupKey = kk;
     }
-    rp = RPHighlighter_New(params->language, params->outFields, lookup);
+    rp = RPHighlighter_New(params->language, params->outFields, lookup,
+                           isSpecJson(params->common.sctx->spec));
     PUSH_RP();
   }
 

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -19,7 +19,7 @@ use redis_json_api::{JsonType, JsonValueRef, RedisJsonApi, SerializeError};
 use redis_module::RedisString;
 use std::ffi::CStr;
 use std::ptr::{self, NonNull};
-use value::SharedValue;
+use value::{SharedValue, Value};
 
 const JSON_ROOT: &CStr = c"$";
 
@@ -301,7 +301,11 @@ fn json_val_to_value(
         JsonType::Object | JsonType::Array => {
             // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
             let v = unsafe { json.serialize(ctx.cast().as_ptr()).unwrap() };
-            SharedValue::new_string(v.to_vec())
+            redis_module::raw::string_retain_string(ptr::null_mut(), v.inner);
+            // SAFETY: `v` is a valid Redis string and we retained it above to
+            // transfer one owned reference into the RSValue.
+            let v = unsafe { value::RedisString::from_raw(v.inner.cast()) };
+            SharedValue::new(Value::RedisString(v))
         }
         JsonType::Null => SharedValue::null_static(),
     }

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -112,6 +112,10 @@ fn assert_value_matches(actual: &SharedValue, expected: &serde_json::Value) {
         serde_json::Value::Number(n) => assert_eq!(actual.as_num(), n.as_f64()),
         serde_json::Value::String(s) => assert_eq!(actual.as_str_bytes(), Some(s.as_bytes())),
         serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            assert!(
+                matches!(&**actual, Value::RedisString(_)),
+                "expected serialized RedisString, got {actual:?}"
+            );
             let expected = serde_json::to_string(expected).unwrap();
             assert_eq!(actual.as_str_bytes(), Some(expected.as_bytes()));
         }
@@ -211,6 +215,16 @@ fn load_all_reports_missing_root_values() {
         load_all_dollar(Some(json!([])), MULTI),
         Err(LoadAllError::JsonRootMissing),
     ));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn pre_multi_non_scalar_values_are_redis_strings() {
+    for value in [json!(["red", "blue"]), json!({ "name": "alice" })] {
+        let val = load_field_value(json!({ "x": value.clone() }), PRE_MULTI, c"$.x")
+            .expect("value should be loaded");
+        assert_value_matches(&val, &value);
+    }
 }
 
 proptest! {

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -205,7 +205,7 @@ void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct RequestSyncCtx *sy
 
 /** Creates a new Highlight processor */
 ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
-                                   const RLookup *lookup);
+                                   const RLookup *lookup, bool isJson);
 
 /*******************************************************************************************************************
  *  Profiling Processor

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -220,7 +220,7 @@ void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct QueryRequest *requ
 
 /** Creates a new Highlight processor */
 ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,
-                                   const RLookup *lookup);
+                                   const RLookup *lookup, bool isJson);
 
 /*******************************************************************************************************************
  *  Profiling Processor

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -44,7 +44,9 @@ typedef struct {
 } HighlightSettings;
 
 typedef struct {
-  // path AS name
+  // The requested document path and its returned field name (`path AS name`).
+  // For HASH they are usually identical. For JSON, `path` may be a JSONPath
+  // such as `$.name` while `name` is the schema alias returned to the client.
   const char *path;
   const char *name;
 
@@ -69,8 +71,8 @@ typedef struct {
   uint16_t explicitReturn;
 } FieldList;
 
-// "path AS name"
-// If `path` is NULL then `path` = `name`
+// Gets or creates the returned-field entry for `path AS name`.
+// If `path` is NULL then `path` = `name`.
 ReturnedField *FieldList_GetCreateField(FieldList *fields, const char *name, const char *path);
 void FieldList_Free(FieldList *fields);
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1169,44 +1169,6 @@ def test_mod_6541(env: Env):
 
 
 @skip(cluster=True)
-def test_mod_14921(env: Env):
-  """Test that FT.SEARCH, FT.AGGREGATE, and FT.PROFILE work inside MULTI/EXEC
-  in standalone mode (MOD-14921). When search-workers > 0, the module falls
-  back to main-thread execution instead of calling RedisModule_BlockClient."""
-  env = Env(moduleArgs='WORKERS 1')
-  conn = getConnectionByEnv(env)
-
-  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC').ok()
-  conn.execute_command('HSET', 'doc1', 't', 'hello world', 'n', '1')
-  conn.execute_command('HSET', 'doc2', 't', 'foo bar', 'n', '2')
-
-  # FT.SEARCH inside MULTI/EXEC
-  env.expect('MULTI').ok()
-  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '10').equal('QUEUED')
-  res = env.cmd('EXEC')
-  env.assertEqual(len(res), 1)
-  env.assertTrue(not isinstance(res[0], redis_exceptions.ResponseError),
-                 message=f'FT.SEARCH in MULTI failed: {res[0]}')
-  env.assertGreaterEqual(res[0][0], 1)
-
-  # FT.AGGREGATE inside MULTI/EXEC
-  env.expect('MULTI').ok()
-  env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n').equal('QUEUED')
-  res = env.cmd('EXEC')
-  env.assertEqual(len(res), 1)
-  env.assertTrue(not isinstance(res[0], redis_exceptions.ResponseError),
-                 message=f'FT.AGGREGATE in MULTI failed: {res[0]}')
-
-  # FT.PROFILE inside MULTI/EXEC
-  env.expect('MULTI').ok()
-  env.expect('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*').equal('QUEUED')
-  res = env.cmd('EXEC')
-  env.assertEqual(len(res), 1)
-  env.assertTrue(not isinstance(res[0], redis_exceptions.ResponseError),
-                 message=f'FT.PROFILE in MULTI failed: {res[0]}')
-
-
-@skip(cluster=True)
 def test_4732(env):
   '''
   Test tokenizing text with an escaped backslash followed by a delimiter

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -425,18 +425,14 @@ def test_MOD_1517(env):
 
 @skip(msan=True, no_json=True)
 def test_MOD1544(env):
-  # Test parsing failure
   conn = getConnectionByEnv(env)
   env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT')
   conn.execute_command('JSON.SET', '1', '.', '{"name": "John Smith"}')
-  # res = [1, '1', ['name', '<b>John</b> Smith']]
-
-  # Highlight/summarize is not supported with JSON indexes
-  error_msg = "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes"
+  res = [1, '1', ['name', '<b>John</b> Smith']]
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
-             'HIGHLIGHT').error().contains(error_msg)
+             'HIGHLIGHT', 'DIALECT', '2').equal(res)
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
-             'HIGHLIGHT', 'FIELDS', '1', 'name').error().contains(error_msg)
+             'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', '2').equal(res)
 
 def test_MOD_1808(env):
   conn = getConnectionByEnv(env)
@@ -1170,6 +1166,44 @@ def test_mod_6541(env: Env):
   # Test Lua
   for cmd in cmds:
     env.expect('EVAL', f'return redis.call{cmd}', '0').error().contains(expect_error(cmd))
+
+
+@skip(cluster=True)
+def test_mod_14921(env: Env):
+  """Test that FT.SEARCH, FT.AGGREGATE, and FT.PROFILE work inside MULTI/EXEC
+  in standalone mode (MOD-14921). When search-workers > 0, the module falls
+  back to main-thread execution instead of calling RedisModule_BlockClient."""
+  env = Env(moduleArgs='WORKERS 1')
+  conn = getConnectionByEnv(env)
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC').ok()
+  conn.execute_command('HSET', 'doc1', 't', 'hello world', 'n', '1')
+  conn.execute_command('HSET', 'doc2', 't', 'foo bar', 'n', '2')
+
+  # FT.SEARCH inside MULTI/EXEC
+  env.expect('MULTI').ok()
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '10').equal('QUEUED')
+  res = env.cmd('EXEC')
+  env.assertEqual(len(res), 1)
+  env.assertTrue(not isinstance(res[0], redis_exceptions.ResponseError),
+                 message=f'FT.SEARCH in MULTI failed: {res[0]}')
+  env.assertGreaterEqual(res[0][0], 1)
+
+  # FT.AGGREGATE inside MULTI/EXEC
+  env.expect('MULTI').ok()
+  env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n').equal('QUEUED')
+  res = env.cmd('EXEC')
+  env.assertEqual(len(res), 1)
+  env.assertTrue(not isinstance(res[0], redis_exceptions.ResponseError),
+                 message=f'FT.AGGREGATE in MULTI failed: {res[0]}')
+
+  # FT.PROFILE inside MULTI/EXEC
+  env.expect('MULTI').ok()
+  env.expect('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*').equal('QUEUED')
+  res = env.cmd('EXEC')
+  env.assertEqual(len(res), 1)
+  env.assertTrue(not isinstance(res[0], redis_exceptions.ResponseError),
+                 message=f'FT.PROFILE in MULTI failed: {res[0]}')
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -426,13 +426,21 @@ def test_MOD_1517(env):
 @skip(msan=True, no_json=True)
 def test_MOD1544(env):
   conn = getConnectionByEnv(env)
+  MAX_DIALECT = set_max_dialect(env)
   env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT')
   conn.execute_command('JSON.SET', '1', '.', '{"name": "John Smith"}')
   res = [1, '1', ['name', '<b>John</b> Smith']]
+
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
-             'HIGHLIGHT', 'DIALECT', '2').equal(res)
+             'HIGHLIGHT').equal(res)
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
-             'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', '2').equal(res)
+             'HIGHLIGHT', 'FIELDS', '1', 'name').equal(res)
+
+  for dialect in range(1, MAX_DIALECT + 1):
+    env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
+               'HIGHLIGHT', 'DIALECT', dialect).equal(res)
+    env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
+               'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect).equal(res)
 
 def test_MOD_1808(env):
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1437,7 +1437,7 @@ def testTagAutoescaping(env):
     env.assertEqual(res, expected_result)
 
 @skip(no_json=True)
-def testHighlightSingleValueJson(env):
+def test_highlight_single_value_json(env):
     """ highlight/summarize works for JSON fields with single-value JSONPath across all dialects """
     conn = getConnectionByEnv(env)
     MAX_DIALECT = set_max_dialect(env)
@@ -1515,7 +1515,7 @@ def testHighlightSingleValueJson(env):
         env.assertEqual(res, expected, message=f'array summarize guard DIALECT {dialect}')
 
 @skip(no_json=True)
-def testHighlightMultiValueJsonRejected(env):
+def test_highlight_multi_value_json_rejected(env):
     """ highlight/summarize is not supported for JSON fields with multi-value JSONPath """
     MAX_DIALECT = set_max_dialect(env)
 

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1437,19 +1437,110 @@ def testTagAutoescaping(env):
     env.assertEqual(res, expected_result)
 
 @skip(no_json=True)
-def testLimitations(env):
-    """ highlight/summarize is not supported with JSON indexes """
+def testHighlightSingleValueJson(env):
+    """ highlight/summarize works for JSON fields with single-value JSONPath across all dialects """
+    conn = getConnectionByEnv(env)
+    MAX_DIALECT = set_max_dialect(env)
 
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
-               'SCHEMA',  '$.txt', 'AS', 'txt', 'TEXT').ok()
+               'SCHEMA', '$.name', 'AS', 'name', 'TEXT',
+               '$.description', 'AS', 'description', 'TEXT').ok()
+    conn.execute_command('JSON.SET', 'doc:1', '$',
+                         '{"name": "Noise-cancelling Bluetooth headphones",'
+                         ' "description": "Wireless Bluetooth headphones with noise-cancelling technology"}')
+    conn.execute_command('JSON.SET', 'doc:2', '$',
+                         '{"name": "Wireless earbuds",'
+                         ' "description": "Wireless Bluetooth in-ear headphones"}')
 
-    error_msg = "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes"
+    for dialect in range(1, MAX_DIALECT + 1):
+        # HIGHLIGHT FIELDS on a specific field -- only 'name' is highlighted, not 'description'
+        res = env.cmd('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '2', 'name', 'description',
+                      'HIGHLIGHT', 'FIELDS', '1', 'name', 'TAGS', '<b>', '</b>', 'DIALECT', dialect)
+        env.assertEqual(res[0], 1, message=f'DIALECT {dialect}')
+        env.assertEqual(res[1], 'doc:1', message=f'DIALECT {dialect}')
+        fields = dict(zip(res[2][0::2], res[2][1::2]))
+        env.assertEqual(fields['name'], 'Noise-cancelling <b>Bluetooth</b> headphones', message=f'DIALECT {dialect}')
+        env.assertNotContains('<b>', fields['description'], message=f'DIALECT {dialect}')
 
-    env.expect('FT.SEARCH', 'idx', 'jacob', 'HIGHLIGHT').error()\
-        .contains(error_msg)
+        # HIGHLIGHT without FIELDS -- all returned TEXT fields are highlighted
+        res = env.cmd('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '2', 'name', 'description',
+                      'HIGHLIGHT', 'TAGS', '<b>', '</b>', 'DIALECT', dialect)
+        env.assertEqual(res[0], 1, message=f'DIALECT {dialect}')
+        fields = dict(zip(res[2][0::2], res[2][1::2]))
+        env.assertContains('<b>Bluetooth</b>', fields['name'], message=f'DIALECT {dialect}')
+        env.assertContains('<b>Bluetooth</b>', fields['description'], message=f'DIALECT {dialect}')
 
-    env.expect('FT.SEARCH', 'idx', 'abraham', 'SUMMARIZE').error()\
-        .contains(error_msg)
+        # HIGHLIGHT on a query matching both docs -- verify highlighted terms per doc
+        res = env.cmd('FT.SEARCH', 'idx', '@description:(Bluetooth headphones)', 'RETURN', '1', 'description',
+                      'HIGHLIGHT', 'TAGS', '<b>', '</b>', 'DIALECT', dialect)
+        env.assertEqual(res[0], 2, message=f'DIALECT {dialect}')
+        results = {res[i]: dict(zip(res[i+1][0::2], res[i+1][1::2])) for i in range(1, len(res), 2)}
+        env.assertContains('<b>Bluetooth</b>', results['doc:1']['description'], message=f'DIALECT {dialect}')
+        env.assertContains('<b>headphones</b>', results['doc:1']['description'], message=f'DIALECT {dialect}')
+        env.assertContains('<b>Bluetooth</b>', results['doc:2']['description'], message=f'DIALECT {dialect}')
+        env.assertContains('<b>headphones</b>', results['doc:2']['description'], message=f'DIALECT {dialect}')
+
+        # SUMMARIZE -- verify fragments contain the matched term
+        res = env.cmd('FT.SEARCH', 'idx', '@description:(technology)', 'RETURN', '1', 'description',
+                      'SUMMARIZE', 'LEN', '3', 'FRAGS', '1', 'DIALECT', dialect)
+        env.assertEqual(res[0], 1, message=f'DIALECT {dialect}')
+        env.assertEqual(res[1], 'doc:1', message=f'DIALECT {dialect}')
+        env.assertContains('technology', res[2][1], message=f'DIALECT {dialect}')
+
+    # HIGHLIGHT without RETURN is rejected for JSON (any dialect)
+    no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"
+    env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)',
+               'HIGHLIGHT', 'DIALECT', '2').error().contains(no_return_error)
+
+    # Guard: single-value JSONPath pointing to a JSON array value.
+    # The highlighter detects arrays and skips them (via RSValueType in DIALECT 1-2,
+    # and via Trio expanded array inspection in DIALECT 3+). If this test breaks
+    # (highlights appear), the array detection logic must be updated.
+    env.expect('FT.CREATE', 'idx_arr', 'ON', 'JSON',
+               'SCHEMA', '$.colors', 'AS', 'colors', 'TEXT').ok()
+    conn.execute_command('JSON.SET', 'doc:3', '$',
+                         '{"colors": ["red", "blue"]}')
+    for dialect in range(1, MAX_DIALECT + 1):
+        res = env.cmd('FT.SEARCH', 'idx_arr', '@colors:(red)', 'RETURN', '1', 'colors',
+                      'HIGHLIGHT', 'TAGS', '<b>', '</b>', 'DIALECT', dialect)
+        env.assertEqual(res[0], 1, message=f'array guard DIALECT {dialect}')
+        env.assertNotContains('<b>', str(res[2]), message=f'array guard DIALECT {dialect}')
+
+@skip(no_json=True)
+def testHighlightMultiValueJsonRejected(env):
+    """ highlight/summarize is not supported for JSON fields with multi-value JSONPath """
+    MAX_DIALECT = set_max_dialect(env)
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
+               'SCHEMA', '$.tags[*]', 'AS', 'tags', 'TEXT',
+               '$.name', 'AS', 'name', 'TEXT').ok()
+    waitForIndex(env, 'idx')
+
+    multi_value_error = "HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath"
+    no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"
+
+    for dialect in range(2, MAX_DIALECT + 1):
+        # Without RETURN, the RETURN requirement error fires first
+        env.expect('FT.SEARCH', 'idx', 'hello', 'HIGHLIGHT', 'FIELDS', '1', 'tags',
+                   'DIALECT', dialect).error().contains(no_return_error)
+
+        # With RETURN, multi-value HIGHLIGHT FIELDS are rejected
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '1', 'tags',
+                   'HIGHLIGHT', 'FIELDS', '1', 'tags', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '1', 'tags',
+                   'SUMMARIZE', 'FIELDS', '1', 'tags', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        # HIGHLIGHT without FIELDS when any returned TEXT field has multi-value JSONPath
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '2', 'tags', 'name',
+                   'HIGHLIGHT', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        # But HIGHLIGHT on single-value fields only should still work
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '1', 'name',
+                   'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect).noError()
 
 # For MOD-13904
 @skip(no_json=True)

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1491,20 +1491,28 @@ def testHighlightSingleValueJson(env):
     no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"
     env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)',
                'HIGHLIGHT', 'DIALECT', '2').error().contains(no_return_error)
+    env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '0',
+               'HIGHLIGHT', 'DIALECT', '2').error().contains(no_return_error)
 
     # Guard: single-value JSONPath pointing to a JSON array value.
-    # The highlighter detects arrays and skips them (via RSValueType in DIALECT 1-2,
-    # and via Trio expanded array inspection in DIALECT 3+). If this test breaks
-    # (highlights appear), the array detection logic must be updated.
+    # The highlighter detects arrays and skips HIGHLIGHT/SUMMARIZE transformations
+    # (via RSValueType in DIALECT 1-2, and via Trio expanded array inspection in
+    # DIALECT 3+). The original loaded value should still be returned.
     env.expect('FT.CREATE', 'idx_arr', 'ON', 'JSON',
                'SCHEMA', '$.colors', 'AS', 'colors', 'TEXT').ok()
     conn.execute_command('JSON.SET', 'doc:3', '$',
                          '{"colors": ["red", "blue"]}')
     for dialect in range(1, MAX_DIALECT + 1):
+        expected = env.cmd('FT.SEARCH', 'idx_arr', '@colors:(red)', 'RETURN', '1', 'colors',
+                           'DIALECT', dialect)
+
         res = env.cmd('FT.SEARCH', 'idx_arr', '@colors:(red)', 'RETURN', '1', 'colors',
                       'HIGHLIGHT', 'TAGS', '<b>', '</b>', 'DIALECT', dialect)
-        env.assertEqual(res[0], 1, message=f'array guard DIALECT {dialect}')
-        env.assertNotContains('<b>', str(res[2]), message=f'array guard DIALECT {dialect}')
+        env.assertEqual(res, expected, message=f'array highlight guard DIALECT {dialect}')
+
+        res = env.cmd('FT.SEARCH', 'idx_arr', '@colors:(red)', 'RETURN', '1', 'colors',
+                      'SUMMARIZE', 'LEN', '1', 'FRAGS', '1', 'DIALECT', dialect)
+        env.assertEqual(res, expected, message=f'array summarize guard DIALECT {dialect}')
 
 @skip(no_json=True)
 def testHighlightMultiValueJsonRejected(env):
@@ -1536,6 +1544,21 @@ def testHighlightMultiValueJsonRejected(env):
         # HIGHLIGHT without FIELDS when any returned TEXT field has multi-value JSONPath
         env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '2', 'tags', 'name',
                    'HIGHLIGHT', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        # RETURN aliases are validated against the schema field named by the original return path
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '3', 'tags', 'AS', 'tag_alias',
+                   'HIGHLIGHT', 'FIELDS', '1', 'tag_alias', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        # Raw JSONPath returns are validated directly when they do not resolve to a schema field
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '3', '$.tags[*]', 'AS', 'tag_path',
+                   'HIGHLIGHT', 'FIELDS', '1', 'tag_path', 'DIALECT', dialect).error()\
+            .contains(multi_value_error)
+
+        # Raw JSONPath validation still applies if the alias collides with a schema field name
+        env.expect('FT.SEARCH', 'idx', 'hello', 'RETURN', '3', '$.tags[*]', 'AS', 'name',
+                   'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect).error()\
             .contains(multi_value_error)
 
         # But HIGHLIGHT on single-value fields only should still work

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1487,12 +1487,33 @@ def test_highlight_single_value_json(env):
         env.assertEqual(res[1], 'doc:1', message=f'DIALECT {dialect}')
         env.assertContains('technology', res[2][1], message=f'DIALECT {dialect}')
 
-    # HIGHLIGHT without RETURN is rejected for JSON (any dialect)
+    # HIGHLIGHT/SUMMARIZE without RETURN is rejected for JSON (any dialect).
     no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"
-    env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)',
-               'HIGHLIGHT', 'DIALECT', '2').error().contains(no_return_error)
-    env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '0',
-               'HIGHLIGHT', 'DIALECT', '2').error().contains(no_return_error)
+    for dialect in range(1, MAX_DIALECT + 1):
+        env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)',
+                   'HIGHLIGHT', 'DIALECT', dialect).error().contains(no_return_error)
+        env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '0',
+                   'HIGHLIGHT', 'DIALECT', dialect).error().contains(no_return_error)
+        env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)',
+                   'SUMMARIZE', 'DIALECT', dialect).error().contains(no_return_error)
+        env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '0',
+                   'SUMMARIZE', 'DIALECT', dialect).error().contains(no_return_error)
+
+    # Raw JSONPath projection aliases are not added in MOD-16530. HASH projection
+    # aliases are not fully compatible with HIGHLIGHT/SUMMARIZE either; adding
+    # support for both index types is tracked separately by MOD-17663.
+    alias_error = "Property `alias` is not in schema"
+    for dialect in range(1, MAX_DIALECT + 1):
+        env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '3', '$.name', 'AS', 'alias',
+                   'HIGHLIGHT', 'FIELDS', '1', 'alias', 'DIALECT', dialect).error()\
+            .contains(alias_error)
+        env.expect('FT.SEARCH', 'idx', '@description:(technology)',
+                   'RETURN', '3', '$.description', 'AS', 'alias',
+                   'SUMMARIZE', 'FIELDS', '1', 'alias', 'DIALECT', dialect).error()\
+            .contains(alias_error)
+        env.expect('FT.SEARCH', 'idx', '@name:(Bluetooth)', 'RETURN', '3', '$.unindexed', 'AS', 'alias',
+                   'HIGHLIGHT', 'FIELDS', '1', 'alias', 'DIALECT', dialect).error()\
+            .contains(alias_error)
 
     # Guard: single-value JSONPath pointing to a JSON array value.
     # The highlighter detects arrays and skips HIGHLIGHT/SUMMARIZE transformations
@@ -1515,6 +1536,79 @@ def test_highlight_single_value_json(env):
         env.assertEqual(res, expected, message=f'array summarize guard DIALECT {dialect}')
 
 @skip(no_json=True)
+def test_highlight_single_value_json_matches_hash_explicit_return(env):
+    """JSON explicit-return highlight/summarize matches HASH for scalar TEXT fields."""
+    conn = getConnectionByEnv(env)
+    MAX_DIALECT = set_max_dialect(env)
+
+    env.expect('FT.CREATE', 'idx_hash', 'ON', 'HASH',
+               'SCHEMA', 'name', 'TEXT', 'body', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc:hash',
+                         'name', 'hello world',
+                         'body', 'alpha beta hello gamma delta epsilon')
+
+    env.expect('FT.CREATE', 'idx_json', 'ON', 'JSON',
+               'SCHEMA', '$.name', 'AS', 'name', 'TEXT',
+               '$.body', 'AS', 'body', 'TEXT').ok()
+    conn.execute_command('JSON.SET', 'doc:json', '$',
+                         '{"name": "hello world",'
+                         ' "body": "alpha beta hello gamma delta epsilon"}')
+
+    for dialect in range(1, MAX_DIALECT + 1):
+        hash_res = env.cmd('FT.SEARCH', 'idx_hash', '@name:(hello)', 'RETURN', '1', 'name',
+                           'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect)
+        json_res = env.cmd('FT.SEARCH', 'idx_json', '@name:(hello)', 'RETURN', '1', 'name',
+                           'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect)
+        hash_fields = dict(zip(hash_res[2][0::2], hash_res[2][1::2]))
+        json_fields = dict(zip(json_res[2][0::2], json_res[2][1::2]))
+        env.assertEqual(hash_fields['name'], '<b>hello</b> world', message=f'DIALECT {dialect}')
+        env.assertEqual(json_fields['name'], hash_fields['name'], message=f'DIALECT {dialect}')
+
+        hash_res = env.cmd('FT.SEARCH', 'idx_hash', '@body:(hello)', 'RETURN', '1', 'body',
+                           'SUMMARIZE', 'FIELDS', '1', 'body', 'LEN', '3', 'FRAGS', '1',
+                           'DIALECT', dialect)
+        json_res = env.cmd('FT.SEARCH', 'idx_json', '@body:(hello)', 'RETURN', '1', 'body',
+                           'SUMMARIZE', 'FIELDS', '1', 'body', 'LEN', '3', 'FRAGS', '1',
+                           'DIALECT', dialect)
+        hash_fields = dict(zip(hash_res[2][0::2], hash_res[2][1::2]))
+        json_fields = dict(zip(json_res[2][0::2], json_res[2][1::2]))
+        env.assertContains('hello', hash_fields['body'], message=f'DIALECT {dialect}')
+        env.assertEqual(json_fields['body'], hash_fields['body'], message=f'DIALECT {dialect}')
+
+@skip(no_json=True)
+def test_highlight_json_requires_explicit_return_unlike_hash(env):
+    """HASH supports implicit return; JSON requires explicit RETURN fields."""
+    conn = getConnectionByEnv(env)
+    MAX_DIALECT = set_max_dialect(env)
+
+    env.expect('FT.CREATE', 'idx_hash', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc:hash', 'name', 'hello world')
+
+    env.expect('FT.CREATE', 'idx_json', 'ON', 'JSON',
+               'SCHEMA', '$.name', 'AS', 'name', 'TEXT').ok()
+    conn.execute_command('JSON.SET', 'doc:json', '$', '{"name": "hello world"}')
+
+    no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"
+    for dialect in range(1, MAX_DIALECT + 1):
+        res = env.cmd('FT.SEARCH', 'idx_hash', '@name:(hello)',
+                      'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect)
+        fields = dict(zip(res[2][0::2], res[2][1::2]))
+        env.assertEqual(fields['name'], '<b>hello</b> world', message=f'DIALECT {dialect}')
+
+        env.expect('FT.SEARCH', 'idx_json', '@name:(hello)',
+                   'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect).error()\
+            .contains(no_return_error)
+        env.expect('FT.SEARCH', 'idx_json', '@name:(hello)', 'RETURN', '0',
+                   'HIGHLIGHT', 'FIELDS', '1', 'name', 'DIALECT', dialect).error()\
+            .contains(no_return_error)
+        env.expect('FT.SEARCH', 'idx_json', '@name:(hello)',
+                   'SUMMARIZE', 'FIELDS', '1', 'name', 'DIALECT', dialect).error()\
+            .contains(no_return_error)
+        env.expect('FT.SEARCH', 'idx_json', '@name:(hello)', 'RETURN', '0',
+                   'SUMMARIZE', 'FIELDS', '1', 'name', 'DIALECT', dialect).error()\
+            .contains(no_return_error)
+
+@skip(no_json=True)
 def test_highlight_multi_value_json_rejected(env):
     """ highlight/summarize is not supported for JSON fields with multi-value JSONPath """
     MAX_DIALECT = set_max_dialect(env)
@@ -1527,7 +1621,7 @@ def test_highlight_multi_value_json_rejected(env):
     multi_value_error = "HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath"
     no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"
 
-    for dialect in range(2, MAX_DIALECT + 1):
+    for dialect in range(1, MAX_DIALECT + 1):
         # Without RETURN, the RETURN requirement error fires first
         env.expect('FT.SEARCH', 'idx', 'hello', 'HIGHLIGHT', 'FIELDS', '1', 'tags',
                    'DIALECT', dialect).error().contains(no_return_error)

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1616,7 +1616,6 @@ def test_highlight_multi_value_json_rejected(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
                'SCHEMA', '$.tags[*]', 'AS', 'tags', 'TEXT',
                '$.name', 'AS', 'name', 'TEXT').ok()
-    waitForIndex(env, 'idx')
 
     multi_value_error = "HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath"
     no_return_error = "HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names"


### PR DESCRIPTION
## Summary

Previously, `HIGHLIGHT` and `SUMMARIZE` were blanket-rejected for all JSON indexes (added in MOD-7551, Oct 2024). This PR relaxes the restriction to allow highlighting for JSON fields with single-value scalar JSONPaths, across all dialects.

### What changed

**`aggregate_request.c`** — replaced the blanket `isSpecJson` rejection with targeted checks:
1. **Require `RETURN`** — JSON "LOAD ALL" doesn't populate individual fields; only explicit `RETURN` triggers per-field loading needed by the highlighter.
2. **Reject multi-value JSONPaths** — paths like `$.tags[*]` or `$..name` are blocked via `pathIsSingle()` (same API already used in `spec.c`).

**`highlight_processor.c`** — changed `processField` to:
- Use `RSValue_StringPtrLen` instead of `RSValue_IsString` for the guard check (handles Trio values from JSON loading, removes a redundant call in `summarizeField`).
- **DIALECT 1-2**: skip `RSValueType_RedisString` values (serialized JSON arrays at a single-value path like `$.colors` -> `["red","blue"]`).
- **DIALECT 3+**: inspect the Trio's expanded array (`RSValue_Trio_GetRight`) — if `expanded[0]` is `RSValueType_Array` (array-at-path), skip highlighting. If it's `RSValueType_String` (scalar), proceed.

**`command_info.c`** — updated help text to reflect multi-value-only limitation.

### Behavior matrix

All JSON cases below are tested across all supported dialects (`DIALECT 1..MAX`) unless stated otherwise.

| # | Scenario | HASH behavior | JSON behavior in this PR | Coverage / decision |
|---:|----------|---------------|--------------------------|---------------------|
| 1 | Single-value scalar `TEXT` with explicit `RETURN` and `HIGHLIGHT FIELDS field` | Works | Works | `test_highlight_single_value_json`, `test_highlight_single_value_json_matches_hash_explicit_return` |
| 2 | Single-value scalar `TEXT` with explicit `RETURN` and `HIGHLIGHT` without `FIELDS` | Works on returned text fields | Works on returned text fields | `test_highlight_single_value_json` |
| 3 | Single-value scalar `TEXT` with explicit `RETURN` and `SUMMARIZE` | Works | Works | `test_highlight_single_value_json`, `test_highlight_single_value_json_matches_hash_explicit_return` |
| 4 | No `RETURN` with `HIGHLIGHT`/`SUMMARIZE` | Works via implicit HASH field loading | Rejected: explicit `RETURN` required | `test_highlight_json_requires_explicit_return_unlike_hash`, `test_highlight_single_value_json` |
| 5 | `RETURN 0` with `HIGHLIGHT`/`SUMMARIZE` | No fields are returned | Rejected: explicit `RETURN` fields required | `test_highlight_json_requires_explicit_return_unlike_hash`, `test_highlight_single_value_json` |
| 6 | Single-value JSONPath to JSON array value, e.g. `$.colors` | N/A | Allowed, but transformation is skipped and the original loaded value is returned | `test_highlight_single_value_json` |
| 7 | Multi-value schema JSONPath, e.g. `$.tags[*] AS tags TEXT` | N/A | Rejected: multi-value JSONPath | `test_highlight_multi_value_json_rejected` |
| 8 | Raw multi-value JSONPath return, e.g. `RETURN $.tags[*] AS tag_path` | N/A | Rejected: multi-value JSONPath | `test_highlight_multi_value_json_rejected` |
| 9 | Raw JSONPath projection alias matching an indexed field, e.g. `RETURN $.name AS alias` then `HIGHLIGHT FIELDS alias` | No JSONPath equivalent; see row 11 for the closest HASH projection-alias behavior | Rejected: alias is not a schema field | Negative coverage in `test_highlight_single_value_json`; alias support is tracked separately by [MOD-17663](https://redislabs.atlassian.net/browse/MOD-17663) |
| 10 | Raw JSONPath projection alias not matching an indexed field, e.g. `RETURN $.other AS alias` | No JSONPath equivalent; see row 11 for the closest HASH projection-alias behavior | Rejected: alias is not a schema field | Negative coverage in `test_highlight_single_value_json` |
| 11 | Projection alias, e.g. `RETURN name AS alias` then `HIGHLIGHT FIELDS alias` | Accepted today, but not transformed for this form | Accepted for schema-name return, but not transformed; raw-path alias is rejected | Out of scope for this PR because HASH does not fully support it either; tracked by [MOD-17663](https://redislabs.atlassian.net/browse/MOD-17663) |
| 12 | Non-`TEXT` / no full-text offsets fields, e.g. `TAG` or `NUMERIC` | Not rejected; falls back to unchanged or summarized value | Not changed by this PR | No new JSON rejection; left aligned with existing HASH behavior |

### Array-at-path detection

A single-value JSONPath like `$.colors` can point to a JSON array. The indexer treats array elements as separate values with independent byte offsets, so highlighting against a single loaded string would be incorrect. Detection differs by dialect:

- **DIALECT 1-2**: `jsonValToValue` returns `RSValueType_String` for scalars and `RSValueType_RedisString` for arrays. The highlighter checks `RSValue_Type`.
- **DIALECT 3+**: values are wrapped in a Trio. The Trio's expanded array (`RSValue_Trio_GetRight`) contains `RSValueType_String` for scalars or `RSValueType_Array` for array-at-path. The highlighter inspects `expanded[0]` via `RSValue_ArrayItem`.

A guard test asserts both detection paths work across all dialects. If `jsonValToValue` or `jsonIterToValueExpanded` change how arrays are represented, these tests will break.

### Tests

All new and updated MOD-16530 tests loop across all supported dialects (`range(1, MAX_DIALECT + 1)`):

- `test_highlight_single_value_json` — HIGHLIGHT and SUMMARIZE produce correct output for single-value scalar JSON fields; no-RETURN / `RETURN 0` are rejected; raw JSONPath projection aliases are rejected; array-at-path is skipped.
- `test_highlight_single_value_json_matches_hash_explicit_return` — JSON explicit-return HIGHLIGHT/SUMMARIZE matches HASH explicit-return behavior for the same scalar text field.
- `test_highlight_json_requires_explicit_return_unlike_hash` — documents the intentional difference: HASH works with implicit return, JSON requires `RETURN` with explicit field names.
- `test_highlight_multi_value_json_rejected` — multi-value JSONPaths are rejected across dialects; single-value paths are still allowed.
- `test_MOD1544` — original regression test now expects success.

## Proposed docs changes (separate PR)

The [indexing docs](https://redis.io/docs/latest/develop/ai/search-and-query/indexing/) should clarify:

1. **"arrays indexed as TEXT" ambiguity**: The current note says _"not supported when the JSONPath leads to multiple values (such as arrays indexed as TEXT)"_. This covers both:
   - Multi-value JSONPaths like `$.tags[*]` (rejected with error)
   - Single-value JSONPaths where the value at the path is a JSON array, e.g., `$.colors` -> `["red","blue"]` (silently skipped)

2. **RETURN requirement**: Already documented: _"For JSON documents, you must use the RETURN parameter"_.

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


[MOD-17663]: https://redislabs.atlassian.net/browse/MOD-17663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ