### PR TITLE
top core iterator: fix CI coverage for top_k

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -852,7 +852,7 @@ run_rust_tests() {
       --doctests
       $EXCLUDE_RUST_BENCHING_CRATES_LINKING_C
       --codecov
-      --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*"
+      --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*,top_k_bencher/*"
       --output-path=$BINROOT/rust_cov.info
     "
   elif [[ "$RUN_MIRI" == "1" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ RUST_TOOLCHAIN_MODIFIER="" # Rust toolchain to use (e.g., +nightly)
 
 # Rust code is built first, so exclude benchmarking crates that link C code,
 # since the static libraries they depend on haven't been built yet.
-EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi"
+EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher"
 
 # Retrieve our pinned nightly version.
 NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2713,7 +2713,30 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 name = "top_k"
 version = "0.0.1"
 dependencies = [
+ "build_utils",
  "ffi",
+ "inverted_index",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_iterator_type",
+ "rqe_iterators",
+ "rqe_iterators_test_utils",
+ "top_k",
+ "workspace_hack",
+]
+
+[[package]]
+name = "top_k_bencher"
+version = "0.0.1"
+dependencies = [
+ "bindgen",
+ "build_utils",
+ "criterion",
+ "rand 0.9.3",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_iterators",
+ "top_k",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "tracing_redismodule",
     "trie_bencher",
     "top_k",
+    "top_k_bencher",
     "trie_rs",
     "value",
     "varint",

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -8,6 +8,32 @@ publish.workspace = true
 [lib]
 bench = false
 
+[features]
+# Exposes MockScoreSource and MockScoreBatch for use in tests and benchmarks.
+test-utils = []
+# Links C static libraries at test time (see build.rs).
+# https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+unittest = []
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }
+
 [dependencies]
 ffi.workspace = true
+inverted_index.workspace = true
+rqe_iterator_type.workspace = true
+rqe_iterators.workspace = true
 workspace_hack.workspace = true
+
+[dev-dependencies]
+top_k = { path = ".", features = ["unittest", "test-utils"] }
+redis_mock.workspace = true
+# `unittest` feature triggers rqe_iterators' build.rs to link libredisearch_all.a,
+# providing the C symbols (RedisModule_Free, ResultMetrics_Free, etc.) needed at
+# link time by rqe_iterators and inverted_index.
+# Same pattern used by rqe_iterators for its own integration tests.
+rqe_iterators = { workspace = true, features = ["unittest"] }
+rqe_iterators_test_utils.workspace = true
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 
 [lib]
 bench = false
+doctest = false
 
 [features]
 # Exposes MockScoreSource and MockScoreBatch for use in tests and benchmarks.

--- a/src/redisearch_rs/top_k/build.rs
+++ b/src/redisearch_rs/top_k/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`TopKIterator`] — the generic top-k state machine.
+
+use std::{cmp::Ordering, num::NonZeroUsize};
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+
+use crate::{
+    heap::{ScoredResult, TopKHeap},
+    traits::{ScoreBatch, ScoreSource},
+};
+
+// ── Public enums ─────────────────────────────────────────────────────────────
+
+/// Determines which collection algorithm [`TopKIterator`] uses.
+///
+/// Selected at construction based on whether a child filter is present,
+/// and may be switched mid-execution when the source decides a different
+/// strategy is more efficient.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopKMode {
+    /// No child filter — stream directly from the source's single batch.
+    /// The heap is bypassed entirely.
+    Unfiltered,
+}
+
+/// Diagnostic counters collected during a single evaluation.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TopKMetrics {
+    /// Number of batches fetched from the source (Batches mode only).
+    pub num_batches: usize,
+    /// Number of times the collection strategy was switched.
+    pub strategy_switches: usize,
+    /// Number of (batch_doc, child_doc) comparisons performed during
+    /// merge-join intersection (Batches mode only).
+    pub total_comparisons: usize,
+}
+
+// ── Private phase enum ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Collection has not started; the first call to [`read`](TopKIterator::read)
+    /// will trigger it.
+    NotStarted,
+    /// Actively collecting results (transient; only visible inside collection methods).
+    Collecting,
+    /// Collection is done; yielding results from `results` in order.
+    #[expect(
+        dead_code,
+        reason = "TopKMode::Unfiltered is without child so no yielding necessary"
+    )]
+    Yielding,
+    /// Unfiltered path: yielding directly from `direct_batch` without a heap.
+    YieldingDirect,
+}
+
+// ── TopKIterator ──────────────────────────────────────────────────────────────
+
+/// A generic top-k iterator parameterized over a [`ScoreSource`].
+///
+/// Implements the execution mode described in the design doc:
+/// [`Unfiltered`](TopKMode::Unfiltered).
+pub struct TopKIterator<'index, S: ScoreSource<'index>> {
+    source: S,
+    child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+    mode: TopKMode,
+    /// Preserved so [`rewind`](Self::rewind) can restore the original mode.
+    initial_mode: TopKMode,
+    heap: TopKHeap,
+    /// Holds the in-progress batch for the Unfiltered path.
+    direct_batch: Option<S::Batch>,
+    k: NonZeroUsize,
+    compare: fn(f64, f64) -> Ordering,
+    phase: Phase,
+    /// Heap contents drained into score order for yielding.
+    results: Vec<ScoredResult>,
+    yield_pos: usize,
+    current: Option<RSIndexResult<'index>>,
+    last_doc_id: t_docId,
+    at_eof: bool,
+    /// Diagnostic counters — not reset on [`rewind`](Self::rewind).
+    pub metrics: TopKMetrics,
+}
+
+impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
+    /// Create a new [`TopKIterator`].
+    ///
+    /// The execution mode is inferred from `child`.
+    ///
+    /// For now, only [`TopKMode::Unfiltered`] exists.
+    pub fn new(
+        source: S,
+        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        k: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
+    ) -> Self {
+        let mode = TopKMode::Unfiltered;
+        Self::new_with_mode(source, child, k, compare, mode)
+    }
+
+    /// Create a new [`TopKIterator`] with an explicit initial mode.
+    pub fn new_with_mode(
+        source: S,
+        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        k: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
+        mode: TopKMode,
+    ) -> Self {
+        Self {
+            heap: TopKHeap::new(k, compare),
+            source,
+            child,
+            mode,
+            initial_mode: mode,
+            direct_batch: None,
+            k,
+            compare,
+            phase: Phase::NotStarted,
+            results: Vec::new(),
+            yield_pos: 0,
+            current: None,
+            last_doc_id: 0,
+            at_eof: false,
+            metrics: TopKMetrics::default(),
+        }
+    }
+
+    /// Returns a reference to the diagnostic counters accumulated so far.
+    pub const fn metrics(&self) -> &TopKMetrics {
+        &self.metrics
+    }
+
+    // ── Collection dispatch ───────────────────────────────────────────────────
+
+    /// Drive collection based on the current mode.
+    fn collect(&mut self) -> Result<(), RQEIteratorError> {
+        self.phase = Phase::Collecting;
+        let result = match self.mode {
+            TopKMode::Unfiltered => self.prepare_unfiltered_direct(),
+        };
+        if result.is_err() {
+            // Restore a stable phase so that a subsequent read() call can retry.
+            // Phase::Collecting is only valid transiently inside this method.
+            // TODO: MOD-14209: bubble up errors
+            self.phase = Phase::NotStarted;
+        }
+        result
+    }
+
+    // ── Unfiltered path ───────────────────────────────────────────────────────
+
+    /// Set up the unfiltered direct-yield path.
+    ///
+    /// Calls [`ScoreSource::next_batch`] exactly once.  Results are streamed
+    /// directly from the batch cursor — no heap is involved.
+    fn prepare_unfiltered_direct(&mut self) -> Result<(), RQEIteratorError> {
+        self.direct_batch = self.source.next_batch()?;
+        if self.direct_batch.is_none() {
+            self.at_eof = true;
+        }
+        self.phase = Phase::YieldingDirect;
+        Ok(())
+    }
+
+    // ── Yielding helpers ─────────────────────────────────────────────────────
+
+    /// Yield the next result from the unfiltered direct batch.
+    fn advance_unfiltered_direct(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        let item = if let Some(batch) = &mut self.direct_batch {
+            batch.next()
+        } else {
+            None
+        };
+
+        match item {
+            Some((doc_id, score)) => {
+                let result = self.source.build_result(doc_id, score);
+                self.current = Some(result);
+                self.last_doc_id = doc_id;
+                Ok(self.current.as_mut())
+            }
+            None => {
+                self.at_eof = true;
+                Ok(None)
+            }
+        }
+    }
+}
+
+// ── RQEIterator impl ──────────────────────────────────────────────────────────
+
+impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index, S> {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.current.as_mut()
+    }
+
+    #[inline(always)]
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if self.at_eof {
+            return Ok(None);
+        }
+
+        if self.phase == Phase::NotStarted {
+            self.collect()?;
+        }
+
+        match self.phase {
+            Phase::YieldingDirect => self.advance_unfiltered_direct(),
+            Phase::Yielding => {
+                unreachable!("collect() must set phase to YieldingDirect or Yielding")
+            }
+            Phase::NotStarted | Phase::Collecting => {
+                unreachable!("collect() must set phase to YieldingDirect or Yielding")
+            }
+        }
+    }
+
+    fn skip_to(
+        &mut self,
+        _doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        // TopKIterator is a root-only iterator that yields results sorted by
+        // score, not by doc_id.  It cannot be used as a child in a larger
+        // iterator tree, so skip_to is unsupported.
+        unimplemented!("TopKIterator is a root-only iterator; skip_to is not supported")
+    }
+
+    #[inline(always)]
+    unsafe fn revalidate(
+        &mut self,
+        spec: std::ptr::NonNull<ffi::IndexSpec>,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        if let Some(child) = &mut self.child {
+            // SAFETY: Delegating to child with the same `spec` passed by our caller.
+            return unsafe { child.revalidate(spec) };
+        }
+        Ok(RQEValidateStatus::Ok)
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        self.source.rewind();
+        if let Some(child) = &mut self.child {
+            child.rewind();
+        }
+        self.mode = self.initial_mode;
+        self.heap = TopKHeap::new(self.k, self.compare);
+        self.direct_batch = None;
+        self.results.clear();
+        self.yield_pos = 0;
+        self.current = None;
+        self.last_doc_id = 0;
+        self.at_eof = false;
+        self.phase = Phase::NotStarted;
+        // We explicitly do NOT reset self.metrics because they're used for diagnostics.
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        self.k.get().min(self.source.num_estimated())
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        self.last_doc_id
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        self.at_eof
+    }
+
+    #[inline(always)]
+    fn type_(&self) -> IteratorType {
+        self.source.iterator_type()
+    }
+
+    #[inline(always)]
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -8,7 +8,27 @@
 */
 
 //! A fixed-capacity heap that retains the top-k scored documents.
+//! Generic top-k iterator shared by the vector (hybrid) and numeric (optimizer)
+//! query iterators.
+//!
+//! # Architecture
+//!
+//! The core abstraction is [`TopKIterator<S>`], a state machine that drives
+//! top-k collection in three modes:
+//!
+//! - **Unfiltered** — no child filter; stream results directly from the source's batch.
+//!   for each document.
+//!
+//! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
+//! traits.
 
 pub mod heap;
+pub mod iterator;
+pub mod traits;
+
+#[cfg(feature = "test-utils")]
+pub mod mock;
 
 pub use heap::{ScoredResult, TopKHeap};
+pub use iterator::{TopKIterator, TopKMetrics, TopKMode};
+pub use traits::{ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -26,6 +26,11 @@ pub mod heap;
 pub mod iterator;
 pub mod traits;
 
+#[cfg(test)]
+extern crate redisearch_rs;
+#[cfg(test)]
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 #[cfg(feature = "test-utils")]
 pub mod mock;
 

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Mock implementations of [`ScoreBatch`] and [`ScoreSource`] for use in unit
+//! tests and benchmarks.
+//!
+//! Gated behind the `test-utils` feature.
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+use rqe_iterators::RQEIteratorError;
+
+use crate::traits::{ScoreBatch, ScoreSource};
+
+// ── MockScoreBatch ────────────────────────────────────────────────────────────
+
+/// A [`ScoreBatch`] backed by a pre-sorted `Vec<(t_docId, f64)>`.
+///
+/// Doc IDs must be strictly increasing; this is not validated at runtime.
+pub struct MockScoreBatch {
+    items: Vec<(t_docId, f64)>,
+    pos: usize,
+}
+
+impl MockScoreBatch {
+    /// Creates a batch from a vector of `(doc_id, score)` pairs.
+    ///
+    /// The pairs must be sorted by `doc_id` in strictly ascending order.
+    pub fn new(items: Vec<(t_docId, f64)>) -> Self {
+        Self { items, pos: 0 }
+    }
+}
+
+impl ScoreBatch for MockScoreBatch {
+    fn next(&mut self) -> Option<(t_docId, f64)> {
+        let item = self.items.get(self.pos).copied();
+        if item.is_some() {
+            self.pos += 1;
+        }
+        item
+    }
+}
+
+// ── MockScoreSource ───────────────────────────────────────────────────────────
+
+/// A [`ScoreSource`] backed by fixed data for use in tests and benchmarks.
+///
+/// # Usage
+///
+/// ```rust
+/// # use top_k::mock::MockScoreSource;
+/// let source = MockScoreSource::new(
+///     // Two batches: each is a Vec<(doc_id, score)>
+///     vec![
+///         vec![(1, 0.5), (3, 0.8)],
+///         vec![(5, 0.2), (7, 0.9)],
+///     ],
+/// );
+/// ```
+pub struct MockScoreSource {
+    batches: Vec<Vec<(t_docId, f64)>>,
+    batch_pos: usize,
+    num_estimated: usize,
+}
+
+impl MockScoreSource {
+    /// Creates a new `MockScoreSource`.
+    ///
+    /// - `batches` — sequence of batches; each inner `Vec` is one [`MockScoreBatch`].
+    /// - `strategy` — function called after each batch.
+    ///
+    /// `num_estimated` defaults to the total number of entries across all batches.
+    pub fn new(batches: Vec<Vec<(t_docId, f64)>>) -> Self {
+        let num_estimated = batches.iter().map(Vec::len).sum();
+        Self {
+            batches,
+            batch_pos: 0,
+            num_estimated,
+        }
+    }
+
+    /// Override the `num_estimated` value.
+    pub fn with_num_estimated(mut self, n: usize) -> Self {
+        self.num_estimated = n;
+        self
+    }
+}
+
+impl<'index> ScoreSource<'index> for MockScoreSource {
+    type Batch = MockScoreBatch;
+
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        let batch = self
+            .batches
+            .get(self.batch_pos)
+            .cloned()
+            .map(MockScoreBatch::new);
+        if batch.is_some() {
+            self.batch_pos += 1;
+        }
+        Ok(batch)
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
+    }
+
+    fn rewind(&mut self) {
+        self.batch_pos = 0;
+    }
+
+    fn build_result(&self, doc_id: t_docId, _score: f64) -> RSIndexResult<'index> {
+        RSIndexResult::build_virt().doc_id(doc_id).build()
+    }
+
+    fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+}

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Core traits that score sources must implement to plug into [`TopKIterator`].
+//!
+//! [`TopKIterator`]: crate::TopKIterator
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::RQEIteratorError;
+
+// ── ScoreBatch ────────────────────────────────────────────────────────────────
+
+/// A cursor over a single score-ordered batch of `(doc_id, score)` pairs.
+///
+/// Produced by [`ScoreSource::next_batch`] and streamed by [`TopKIterator`].
+/// Doc IDs within a batch must be **strictly increasing**.
+///
+/// [`TopKIterator`]: crate::TopKIterator
+pub trait ScoreBatch {
+    /// Advance to the next `(doc_id, score)` pair.
+    ///
+    /// Returns `None` when the batch is exhausted.
+    fn next(&mut self) -> Option<(t_docId, f64)>;
+}
+
+// ── ScoreSource ───────────────────────────────────────────────────────────────
+
+/// The score-producing half of a [`TopKIterator`].
+///
+/// A [`ScoreSource`] knows how to:
+/// 1. Produce score-ordered batches ([`next_batch`]).
+/// 2. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
+///
+/// [`TopKIterator`]: crate::TopKIterator
+/// [`next_batch`]: ScoreSource::next_batch
+/// [`build_result`]: ScoreSource::build_result
+pub trait ScoreSource<'index> {
+    /// The type of batch cursor this source produces.
+    type Batch: ScoreBatch;
+
+    /// Fetch the next score-ordered batch.
+    ///
+    /// Returns:
+    /// - `Ok(Some(batch))` — a new batch is available.
+    /// - `Ok(None)` — the source is exhausted; no more batches.
+    /// - `Err(RQEIteratorError::TimedOut)` — the query time limit was reached.
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError>;
+
+    /// Return an upper-bound estimate for the number of documents this source
+    /// can produce.
+    fn num_estimated(&self) -> usize;
+
+    /// Rewind the source to its initial state so batch iteration can restart.
+    fn rewind(&mut self);
+
+    /// Build the [`RSIndexResult`] that the [`TopKIterator`] will yield for a
+    /// given `(doc_id, score)` pair.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn build_result(&self, doc_id: t_docId, score: f64) -> RSIndexResult<'index>;
+
+    /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn iterator_type(&self) -> IteratorType;
+}

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Integration tests for [`TopKIterator`].
+
+use std::{cmp::Ordering, num::NonZeroUsize};
+
+use rqe_iterators::RQEIterator;
+use top_k::{TopKIterator, mock::MockScoreSource};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Ascending comparator: lower score is better (e.g. vector distance).
+fn asc(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+// ── State machine ─────────────────────────────────────────────────────────────
+
+#[test]
+fn read_triggers_collection_on_first_call() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    assert!(!it.at_eof());
+    let result = it.read().unwrap().expect("should have a result");
+    assert_eq!(result.doc_id, 1);
+}
+
+#[test]
+fn rewind_resets_to_not_started() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    it.read().unwrap();
+    it.read().unwrap();
+    it.read().unwrap(); // EOF
+
+    assert!(it.at_eof());
+    it.rewind();
+    assert!(!it.at_eof());
+
+    let result = it
+        .read()
+        .unwrap()
+        .expect("should have a result after rewind");
+    assert_eq!(result.doc_id, 1);
+}
+
+#[test]
+fn eof_set_after_results_exhausted() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    it.read().unwrap();
+    let eof = it.read().unwrap();
+    assert!(eof.is_none());
+    assert!(it.at_eof());
+}
+
+#[test]
+fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+
+    assert_eq!(it.last_doc_id(), 0);
+
+    it.read().unwrap();
+    assert_eq!(it.last_doc_id(), 1);
+    it.read().unwrap();
+    assert_eq!(it.last_doc_id(), 2);
+
+    it.rewind();
+    assert_eq!(it.last_doc_id(), 0);
+}
+
+#[test]
+fn num_estimated_capped_at_k() {
+    let source =
+        MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]]).with_num_estimated(100);
+    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc);
+    assert_eq!(it.num_estimated(), 3);
+}
+
+// ── Unfiltered path ───────────────────────────────────────────────────────────
+
+#[test]
+fn unfiltered_yields_batch_in_source_order() {
+    // Unfiltered mode streams directly from the batch without sorting.
+    let source = MockScoreSource::new(vec![vec![(3, 0.1), (1, 0.5), (2, 0.9)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc);
+    let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(ids, vec![3, 1, 2]);
+}
+
+#[test]
+fn unfiltered_empty_source_is_immediate_eof() {
+    let source = MockScoreSource::new(vec![]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    assert!(it.read().unwrap().is_none());
+    assert!(it.at_eof());
+}
+
+// ── Revalidation ──────────────────────────────────────────────────────────────
+
+/// Child iterator whose `revalidate` unconditionally returns `Aborted`.
+///
+/// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
+/// already returns `Ok` from `revalidate`.  This stub only exists for the
+/// case that cannot be expressed with any existing public iterator type.
+struct AbortOnRevalidate;
+
+impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
+    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+        None
+    }
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
+    {
+        Ok(None)
+    }
+    fn skip_to(
+        &mut self,
+        _doc_id: ffi::t_docId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        unimplemented!()
+    }
+    unsafe fn revalidate(
+        &mut self,
+        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError>
+    {
+        Ok(rqe_iterators::RQEValidateStatus::Aborted)
+    }
+    fn rewind(&mut self) {}
+    fn num_estimated(&self) -> usize { 0 }
+    fn last_doc_id(&self) -> ffi::t_docId { 0 }
+    fn at_eof(&self) -> bool { true }
+    fn type_(&self) -> rqe_iterator_type::IteratorType { rqe_iterator_type::IteratorType::Mock }
+    fn intersection_sort_weight(&self, _: bool) -> f64 { 1.0 }
+}
+
+#[test]
+fn revalidate_without_child_returns_ok() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    // SAFETY: child-less path returns Ok unconditionally; spec is never read.
+    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
+}
+
+#[test]
+fn revalidate_with_child_delegates_ok() {
+    // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
+    // for any child iterator that leaves the parent in a valid state.
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
+    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
+    // SAFETY: Empty::revalidate ignores spec; nothing is dereferenced.
+    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
+}
+
+#[test]
+fn revalidate_with_child_delegates_aborted() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
+    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
+    // SAFETY: AbortOnRevalidate::revalidate ignores spec; nothing is dereferenced.
+    let status = unsafe { it.revalidate(mock_ctx.spec()) }.unwrap();
+    assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
+}
+
+#[test]
+fn unfiltered_timeout_propagated() {
+    use rqe_iterators::RQEIteratorError;
+    use top_k::{ScoreSource, mock::MockScoreBatch};
+
+    struct TimingOutSource;
+    impl<'index> ScoreSource<'index> for TimingOutSource {
+        type Batch = MockScoreBatch;
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            Err(RQEIteratorError::TimedOut)
+        }
+        fn num_estimated(&self) -> usize {
+            0
+        }
+        fn rewind(&mut self) {}
+        fn build_result(
+            &self,
+            doc_id: ffi::t_docId,
+            _: f64,
+        ) -> inverted_index::RSIndexResult<'index> {
+            inverted_index::RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .build()
+        }
+
+        fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
+            rqe_iterator_type::IteratorType::Mock
+        }
+    }
+
+    let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap(), asc);
+    assert!(matches!(
+        it.read().unwrap_err(),
+        rqe_iterators::RQEIteratorError::TimedOut
+    ));
+}

--- a/src/redisearch_rs/top_k/tests/integration/main.rs
+++ b/src/redisearch_rs/top_k/tests/integration/main.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Provide stubs for C symbols (RedisModule_Free, ResultMetrics_Free, etc.)
+// that rqe_iterators and inverted_index reference at link time.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;
+
+mod iterator;

--- a/src/redisearch_rs/top_k_bencher/Cargo.toml
+++ b/src/redisearch_rs/top_k_bencher/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "top_k_bencher"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[[bench]]
+name = "top_k"
+harness = false
+
+[build-dependencies]
+bindgen.workspace = true
+build_utils = { path = "../build_utils" }
+
+[dependencies]
+criterion.workspace = true
+rand.workspace = true
+redis_mock.workspace = true
+rqe_iterators = { workspace = true }
+top_k = { workspace = true, features = ["test-utils"] }
+workspace_hack.workspace = true
+# Crate required to invoke C symbols and keep Rust-defined FFI symbols alive.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Micro-benchmarks for [`TopKHeap`] and [`TopKIterator`].
+//!
+//! These benchmarks use mock sources and synthetic data.  They are NOT
+//! comparable to the C iterator numbers — their purpose is to provide a
+//! regression guard for the shared skeleton before real sources are plugged in.
+
+// Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
+use top_k_bencher as _;
+
+use std::hint::black_box;
+use std::{cmp::Ordering, num::NonZeroUsize};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand::{SeedableRng as _, seq::SliceRandom as _};
+use top_k::TopKHeap;
+
+// ── Comparators ───────────────────────────────────────────────────────────────
+
+fn asc(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+// ── Heap benchmarks ───────────────────────────────────────────────────────────
+
+fn bench_heap_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("heap");
+    let (n, k) = (100_000, NonZeroUsize::new(1_000).unwrap());
+
+    // Best case: scores arrive worst-first; after the heap fills every
+    // subsequent element is immediately rejected without touching the heap.
+    group.bench_with_input(
+        BenchmarkId::new("insert_asc", format!("{n}→k{k}")),
+        &(n, k),
+        |b, &(n, k)| {
+            b.iter(|| {
+                let mut heap = TopKHeap::new(k, asc);
+                for i in 0..n {
+                    heap.push(i as u64, i as f64);
+                }
+                black_box(heap.len())
+            })
+        },
+    );
+
+    // Worst case: scores arrive best-first; every element after fill is
+    // strictly better than the current worst, forcing a pop + push
+    // (O(log k)) on each of the n-k remaining insertions.
+    group.bench_with_input(
+        BenchmarkId::new("insert_desc", format!("{n}→k{k}")),
+        &(n, k),
+        |b, &(n, k)| {
+            b.iter(|| {
+                let mut heap = TopKHeap::new(k, asc);
+                for i in (0..n).rev() {
+                    heap.push(i as u64, i as f64);
+                }
+                black_box(heap.len())
+            })
+        },
+    );
+
+    // Realistic case: shuffled scores give a mix of evictions and
+    // rejections representative of real query-result streams.
+    // The shuffle is done once outside the timed loop.
+    let scores: Vec<u64> = {
+        let mut v: Vec<u64> = (0..n as u64).collect();
+        v.shuffle(&mut rand::rngs::SmallRng::seed_from_u64(42));
+        v
+    };
+    group.bench_function(
+        BenchmarkId::new("insert_rand", format!("{n}→k{k}")),
+        |b| {
+            b.iter(|| {
+                let mut heap = TopKHeap::new(k, asc);
+                for &i in &scores {
+                    heap.push(i, i as f64);
+                }
+                black_box(heap.len())
+            })
+        },
+    );
+
+    group.finish();
+}
+
+fn bench_heap_pop_all(c: &mut Criterion) {
+    let mut group = c.benchmark_group("heap");
+    let k = NonZeroUsize::new(1_000).unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("drain_sorted", format!("k{k}")),
+        &k,
+        |b, &k| {
+            b.iter_batched(
+                || {
+                    let mut heap = TopKHeap::new(k, asc);
+                    for i in 0..k.get() {
+                        heap.push(i as u64, i as f64);
+                    }
+                    heap
+                },
+                |heap| black_box(heap.drain_sorted()),
+                BatchSize::SmallInput,
+            )
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, bench_heap_insert, bench_heap_pop_all);
+criterion_main!(benches);

--- a/src/redisearch_rs/top_k_bencher/build.rs
+++ b/src/redisearch_rs/top_k_bencher/build.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/top_k_bencher/src/lib.rs
+++ b/src/redisearch_rs/top_k_bencher/src/lib.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Some of the missing C symbols are actually Rust-provided.
+
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;

--- a/src/redisearch_rs/top_k_bencher/src/lib.rs
+++ b/src/redisearch_rs/top_k_bencher/src/lib.rs
@@ -9,5 +9,5 @@
 
 // Some of the missing C symbols are actually Rust-provided.
 
-redis_mock::mock_or_stub_missing_redis_c_symbols!();
 extern crate redisearch_rs;
+redis_mock::mock_or_stub_missing_redis_c_symbols!();


### PR DESCRIPTION
- Based on https://github.com/RediSearch/RediSearch/pull/9276 ; experimental branch to figure out why linking is failing.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Rust workspace crates plus build-script feature gating to bind C symbols during tests/benches, which can affect CI/build/link behavior across platforms. Runtime risk is limited since changes are mainly test/benchmark and coverage configuration, but the new `top_k` iterator API is sizable and newly introduced.
> 
> **Overview**
> Fixes Rust CI coverage/linking issues by excluding the new `top_k_bencher` crate from early Rust builds and from `llvm-cov` filename matching in `build.sh`.
> 
> Adds a new `top_k_bencher` Criterion benchmark crate (with a `build.rs` that binds foreign C symbols) and expands the `top_k` crate from just the heap into a generic `TopKIterator` skeleton with `ScoreSource`/`ScoreBatch` traits, feature-gated test utilities, and integration tests that stub required Redis C symbols for successful linking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981470f1dc78a89b382ded3fdb614ccb9d6cb82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->