### PR TITLE
MOD-15383 feat: RLookup Iter & IterMut types

### DIFF
--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -20,8 +20,8 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 pub use bindings::{IndexSpec, IndexSpecCache, SchemaRule};
 pub use lookup::{
-    Cursor, CursorMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, RLookupOption,
-    RLookupOptions, opaque::OpaqueRLookup,
+    Cursor, CursorMut, Iter, IterMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags,
+    RLookupOption, RLookupOptions, opaque::OpaqueRLookup,
 };
 pub use row::RLookupRow;
 pub use row::opaque::OpaqueRLookupRow;

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -13,6 +13,7 @@ mod key_list;
 use crate::{
     IndexSpec, RLookupRow,
     bindings::{FieldSpec, FieldSpecOption, FieldSpecOptions, IndexSpecCache},
+    lookup::key_list::{Iter, IterMut},
 };
 use enumflags2::{BitFlags, bitflags};
 use key_list::KeyList;
@@ -152,19 +153,27 @@ impl<'a> RLookup<'a> {
     }
 
     /// Returns a [`Cursor`] starting at the first key.
-    ///
-    /// The [`Cursor`] type can be used as Iterator over the keys in this lookup.
     #[inline(always)]
     pub fn cursor(&self) -> Cursor<'_, 'a> {
         self.keys.cursor_front()
     }
 
     /// Returns a [`Cursor`] starting at the first key.
-    ///
-    /// The [`Cursor`] type can be used as Iterator over the keys in this lookup.
     #[inline(always)]
     pub fn cursor_mut(&mut self) -> CursorMut<'_, 'a> {
         self.keys.cursor_front_mut()
+    }
+
+    /// Returns an [`Iter`] starting at the first key.
+    #[inline(always)]
+    pub fn iter(&self) -> Iter<'_, 'a> {
+        self.keys.iter()
+    }
+
+    /// Returns an [`IterMut`] starting at the first key.
+    #[inline(always)]
+    pub fn iter_mut(&mut self) -> IterMut<'_, 'a> {
+        self.keys.iter_mut()
     }
 
     // ===== Get key for reading (create only if in schema and sortable) =====

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -164,13 +164,15 @@ impl<'a> RLookup<'a> {
         self.keys.cursor_front_mut()
     }
 
-    /// Returns an [`Iter`] starting at the first key.
+    /// Returns an iterator over immutable references to keys.
     #[inline(always)]
     pub fn iter(&self) -> Iter<'_, 'a> {
         self.keys.iter()
     }
 
-    /// Returns an [`IterMut`] starting at the first key.
+    /// Returns an iterator over pinned mutable references to keys.
+    ///
+    /// Use [`RLookup::cursor_mut`] to override a key during traversal.
     #[inline(always)]
     pub fn iter_mut(&mut self) -> IterMut<'_, 'a> {
         self.keys.iter_mut()

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -13,14 +13,13 @@ mod key_list;
 use crate::{
     IndexSpec, RLookupRow,
     bindings::{FieldSpec, FieldSpecOption, FieldSpecOptions, IndexSpecCache},
-    lookup::key_list::{Iter, IterMut},
 };
 use enumflags2::{BitFlags, bitflags};
 use key_list::KeyList;
 use std::{borrow::Cow, ffi::CStr, pin::Pin, ptr};
 
 pub use key::{GET_KEY_FLAGS, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, TRANSIENT_FLAGS};
-pub use key_list::{Cursor, CursorMut};
+pub use key_list::{Cursor, CursorMut, Iter, IterMut};
 
 #[bitflags]
 #[repr(u32)]

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -133,21 +133,15 @@ impl<'a> RLookup<'a> {
             "The NameAlloc flag should have been handled in the FFI function. This is a bug."
         );
 
-        // Manually iterate through all keys including hidden ones
-        let mut c = src.cursor();
-        while let Some(src_key) = c.current() {
-            if !src_key.is_tombstone() {
-                // Combine caller's control flags with source key's persistent properties
-                // Only preserve non-transient flags from source (F_SVSRC, F_HIDDEN, etc.)
-                // while respecting caller's control flags (F_OVERRIDE, F_FORCE_LOAD, etc.)
-                let combined_flags = flags | src_key.flags & !TRANSIENT_FLAGS;
+        for src_key in src.iter() {
+            // Combine caller's control flags with source key's persistent properties
+            // Only preserve non-transient flags from source (F_SVSRC, F_HIDDEN, etc.)
+            // while respecting caller's control flags (F_OVERRIDE, F_FORCE_LOAD, etc.)
+            let combined_flags = flags | src_key.flags & !TRANSIENT_FLAGS;
 
-                // NB: get_key_write returns none if the key already exists and `flags` don't contain `Override`.
-                // In this case, we just want to move on to the next key
-                let _ = self.get_key_write(src_key.name().clone(), combined_flags);
-            }
-
-            c.move_next();
+            // NB: get_key_write returns none if the key already exists and `flags` don't contain `Override`.
+            // In this case, we just want to move on to the next key
+            let _ = self.get_key_write(src_key.name().clone(), combined_flags);
         }
     }
 

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -523,6 +523,36 @@ mod tests {
     #[cfg(not(miri))]
     use proptest::prelude::*;
 
+    // Assert that RLookup::iter and iter_mut yield the keys written via get_key_write,
+    // and that mutations through iter_mut are observable on a subsequent iter pass.
+    #[test]
+    fn rlookup_iter_round_trip() {
+        let mut rlookup = RLookup::new();
+
+        for name in [c"a", c"b", c"c"] {
+            rlookup
+                .get_key_write(name, RLookupKeyFlags::empty())
+                .unwrap();
+        }
+
+        let names: Vec<_> = rlookup
+            .iter()
+            .map(|k| k.name().as_ref().to_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![c"a".to_owned(), c"b".to_owned(), c"c".to_owned()]
+        );
+
+        for key in rlookup.iter_mut() {
+            key.project().header.flags |= RLookupKeyFlag::ExplicitReturn;
+        }
+
+        for key in rlookup.iter() {
+            assert!(key.flags.contains(RLookupKeyFlag::ExplicitReturn));
+        }
+    }
+
     // Assert that we can successfully write keys to the rlookup
     #[test]
     fn rlookup_write_new_key() {

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -8,7 +8,7 @@
 */
 
 use crate::{RLookupKey, RLookupKeyFlags};
-use std::{ffi::CStr, marker::PhantomData, pin::Pin, ptr::NonNull};
+use std::{ffi::CStr, iter::FusedIterator, marker::PhantomData, pin::Pin, ptr::NonNull};
 
 #[cfg(any(debug_assertions, test))]
 use std::ptr;
@@ -457,6 +457,12 @@ impl<'list, 'a> Iterator for IterMut<'list, 'a> {
         Some(unsafe { Pin::new_unchecked(next) })
     }
 }
+
+// Once `IterRaw::next` returns `None`, `self.current` is `None` and stays that way, so all three
+// iterators are naturally fused.
+impl FusedIterator for IterRaw<'_> {}
+impl FusedIterator for Iter<'_, '_> {}
+impl FusedIterator for IterMut<'_, '_> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -754,6 +754,43 @@ mod tests {
         assert_eq!(names, vec![c"foo".to_owned(), c"bar".to_owned()]);
     }
 
+    // Assert that mutations performed through IterMut are observable on a subsequent iter() pass.
+    #[test]
+    fn iter_mut_mutation_visible() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"a", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"b", RLookupKeyFlags::empty()));
+
+        for key in keylist.iter_mut() {
+            key.project().header.flags |= RLookupKeyFlag::ExplicitReturn;
+        }
+
+        for key in keylist.iter() {
+            assert!(key.flags.contains(RLookupKeyFlag::ExplicitReturn));
+        }
+    }
+
+    // Assert that Iter handles a tombstone at the tail with no successor (returns None instead of dereferencing past the end).
+    #[test]
+    fn iter_skips_tail_tombstone() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+
+        // Tombstone the tail without inserting a replacement.
+        let mut cursor = keylist.cursor_front_mut();
+        cursor.move_next(); // now at "bar"
+        cursor.current().unwrap().make_tombstone();
+
+        let names: Vec<_> = keylist
+            .iter()
+            .map(|k| k.name().as_ref().to_owned())
+            .collect();
+        assert_eq!(names, vec![c"foo".to_owned()]);
+    }
+
     #[test]
     fn keylist_override_key_tail_handling() {
         let mut keylist = KeyList::new();

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -418,17 +418,16 @@ impl<'a> Iterator for IterRaw<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut curr = self.current.take()?;
-
-        // Safety: The `KeyList` ensures the linked list pointers are valid.
-        while unsafe { curr.as_ref() }.is_tombstone() {
-            // Safety: The `KeyList` ensures the linked list pointers are valid.
-            curr = unsafe { curr.as_ref() }.next()?;
+        loop {
+            // Safety: The `KeyList` ensures the linked list pointers are valid for as long as the
+            // wrapping iterator's borrow lives.
+            let curr_ref = unsafe { curr.as_ref() };
+            if !curr_ref.is_tombstone() {
+                self.current = curr_ref.next();
+                return Some(curr);
+            }
+            curr = curr_ref.next()?;
         }
-
-        // Safety: The `KeyList` ensures the linked list pointers are valid.
-        self.current = unsafe { curr.as_ref() }.next();
-
-        Some(curr)
     }
 }
 

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -38,24 +38,20 @@ pub struct CursorMut<'list, 'a> {
     current: Option<NonNull<RLookupKey<'a>>>,
 }
 
-/// A iterator over an [`RLookup`][crate::RLookup]'s key list.
-///
-/// Skips overriden keys.
+/// Internal iterator yielding raw pointers to keys.
 struct IterRaw<'a> {
     current: Option<NonNull<RLookupKey<'a>>>,
 }
 
-/// A iterator over an [`RLookup`][crate::RLookup]'s key list.
-///
-/// Skips overriden keys.
+/// Iterator over an [`RLookup`][crate::RLookup]'s key list, yielding immutable references to keys.
 pub struct Iter<'list, 'a> {
     _list: PhantomData<&'list KeyList<'a>>,
     raw: IterRaw<'a>,
 }
 
-/// A iterator over an [`RLookup`][crate::RLookup]'s key list with editing operations.
+/// Iterator over an [`RLookup`][crate::RLookup]'s key list, yielding pinned mutable references to keys.
 ///
-/// Skips overriden keys.
+/// Use [`CursorMut`] to override a key during traversal.
 pub struct IterMut<'list, 'a> {
     _list: PhantomData<&'list mut KeyList<'a>>,
     raw: IterRaw<'a>,
@@ -149,7 +145,7 @@ impl<'a> KeyList<'a> {
         }
     }
 
-    /// Return a iterator over an [`crate::RLookup`]'s key list.
+    /// Returns an iterator over immutable references to keys.
     #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn iter(&self) -> Iter<'_, 'a> {
         #[cfg(debug_assertions)]
@@ -161,7 +157,7 @@ impl<'a> KeyList<'a> {
         }
     }
 
-    /// Return a iterator over an [`crate::RLookup`]'s key list with editing operations.
+    /// Returns an iterator over pinned mutable references to keys.
     #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn iter_mut(&mut self) -> IterMut<'_, 'a> {
         #[cfg(debug_assertions)]

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -8,7 +8,7 @@
 */
 
 use crate::{RLookupKey, RLookupKeyFlags};
-use std::{ffi::CStr, pin::Pin, ptr::NonNull};
+use std::{ffi::CStr, marker::PhantomData, pin::Pin, ptr::NonNull};
 
 #[cfg(any(debug_assertions, test))]
 use std::ptr;
@@ -28,14 +28,37 @@ pub struct KeyList<'a> {
 
 /// A cursor over an [`RLookup`][crate::RLookup]'s key list.
 pub struct Cursor<'list, 'a> {
-    _rlookup: &'list KeyList<'a>,
+    _list: PhantomData<&'list KeyList<'a>>,
     current: Option<NonNull<RLookupKey<'a>>>,
 }
 
 /// A cursor over an [`RLookup`][crate::RLookup]'s key list with editing operations.
 pub struct CursorMut<'list, 'a> {
-    _rlookup: &'list mut KeyList<'a>,
+    list: &'list mut KeyList<'a>,
     current: Option<NonNull<RLookupKey<'a>>>,
+}
+
+/// A iterator over an [`RLookup`][crate::RLookup]'s key list.
+///
+/// Skips overriden keys.
+struct IterRaw<'a> {
+    current: Option<NonNull<RLookupKey<'a>>>,
+}
+
+/// A iterator over an [`RLookup`][crate::RLookup]'s key list.
+///
+/// Skips overriden keys.
+pub struct Iter<'list, 'a> {
+    _list: PhantomData<&'list KeyList<'a>>,
+    raw: IterRaw<'a>,
+}
+
+/// A iterator over an [`RLookup`][crate::RLookup]'s key list with editing operations.
+///
+/// Skips overriden keys.
+pub struct IterMut<'list, 'a> {
+    _list: PhantomData<&'list mut KeyList<'a>>,
+    raw: IterRaw<'a>,
 }
 
 // ===== impl KeyList =====
@@ -102,19 +125,19 @@ impl<'a> KeyList<'a> {
         unsafe { Pin::new_unchecked(key) }
     }
 
-    /// Return a cursor over an [`super::RLookup`]'s key list.
+    /// Return a cursor over an [`crate::RLookup`]'s key list.
     #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn cursor_front(&self) -> Cursor<'_, 'a> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::cursor_front");
 
         Cursor {
-            _rlookup: self,
             current: self.head,
+            _list: PhantomData,
         }
     }
 
-    /// Return a cursor over an [`super::RLookup`]'s key list with editing operations.
+    /// Return a cursor over an [`crate::RLookup`]'s key list with editing operations.
     #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
     pub fn cursor_front_mut(&mut self) -> CursorMut<'_, 'a> {
         #[cfg(debug_assertions)]
@@ -122,7 +145,31 @@ impl<'a> KeyList<'a> {
 
         CursorMut {
             current: self.head,
-            _rlookup: self,
+            list: self,
+        }
+    }
+
+    /// Return a iterator over an [`crate::RLookup`]'s key list.
+    #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
+    pub fn iter(&self) -> Iter<'_, 'a> {
+        #[cfg(debug_assertions)]
+        self.assert_valid("KeyList::iter");
+
+        Iter {
+            raw: IterRaw { current: self.head },
+            _list: PhantomData,
+        }
+    }
+
+    /// Return a iterator over an [`crate::RLookup`]'s key list with editing operations.
+    #[cfg_attr(not(debug_assertions), expect(clippy::missing_const_for_fn))]
+    pub fn iter_mut(&mut self) -> IterMut<'_, 'a> {
+        #[cfg(debug_assertions)]
+        self.assert_valid("KeyList::iter_mut");
+
+        IterMut {
+            raw: IterRaw { current: self.head },
+            _list: PhantomData,
         }
     }
 
@@ -362,12 +409,57 @@ impl<'list, 'a> CursorMut<'list, 'a> {
         new.as_mut().set_next(old.next());
         old.set_next(Some(new_ptr));
 
-        // If the old key was the tail, set the new key as the tail
-        if self._rlookup.tail == self.current {
-            self._rlookup.tail = Some(new_ptr);
+        if self.list.tail == self.current {
+            self.list.tail = Some(new_ptr);
         }
 
         Some(new)
+    }
+}
+
+impl<'a> Iterator for IterRaw<'a> {
+    type Item = NonNull<RLookupKey<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut curr = self.current.take()?;
+
+        // Safety: The `KeyList` ensures the linked list pointers are valid.
+        while unsafe { curr.as_ref() }.is_tombstone() {
+            // Safety: The `KeyList` ensures the linked list pointers are valid.
+            curr = unsafe { curr.as_ref() }.next()?;
+        }
+
+        // Safety: The `KeyList` ensures the linked list pointers are valid.
+        self.current = unsafe { curr.as_ref() }.next();
+
+        Some(curr)
+    }
+}
+
+impl<'list, 'a> Iterator for Iter<'list, 'a> {
+    type Item = &'list RLookupKey<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.raw.next()?;
+
+        // Safety: we immutably borrow (through a PhantomData but nonetheless) the `KeyList` ensuring
+        // it cannot be dropped or mutated while we hold the iterator. The returned reference cannot outlive the list.
+        Some(unsafe { next.as_ref() })
+    }
+}
+
+impl<'list, 'a> Iterator for IterMut<'list, 'a> {
+    type Item = Pin<&'list mut RLookupKey<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut next = self.raw.next()?;
+
+        // Safety: we mutably borrow (through a PhantomData but nonetheless) the `KeyList` ensuring
+        // it cannot be dropped or mutated while we hold the iterator. The returned reference cannot outlive the list.
+        let next = unsafe { next.as_mut() };
+
+        // Safety: all keys are treated as pinned by the crate
+        Some(unsafe { Pin::new_unchecked(next) })
     }
 }
 
@@ -550,6 +642,115 @@ mod tests {
         // and the next item to be the new key
         c.move_next();
         assert_eq!(c.current().unwrap().name().as_ref(), c"foo");
+    }
+
+    // Assert that Iter skips tombstones (hidden/overridden keys)
+    #[test]
+    fn iter_skips_tombstones() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"baz", RLookupKeyFlags::empty()));
+
+        // Override "foo" to create a tombstone
+        keylist
+            .cursor_front_mut()
+            .override_current(RLookupKeyFlags::empty());
+
+        let names: Vec<_> = keylist
+            .iter()
+            .map(|k| k.name().as_ref().to_owned())
+            .collect();
+
+        // The tombstone for old "foo" should be skipped; new "foo" replacement + bar + baz remain
+        assert_eq!(
+            names,
+            vec![c"foo".to_owned(), c"bar".to_owned(), c"baz".to_owned()]
+        );
+    }
+
+    // Assert that Iter yields nothing for an empty list
+    #[test]
+    fn iter_empty_list() {
+        let keylist = KeyList::new();
+        assert_eq!(keylist.iter().count(), 0);
+    }
+
+    // Assert that Iter yields all elements when there are no tombstones
+    #[test]
+    fn iter_no_tombstones() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"a", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"b", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"c", RLookupKeyFlags::empty()));
+
+        let names: Vec<_> = keylist
+            .iter()
+            .map(|k| k.name().as_ref().to_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![c"a".to_owned(), c"b".to_owned(), c"c".to_owned()]
+        );
+    }
+
+    // Assert that IterMut skips tombstones
+    #[test]
+    fn iter_mut_skips_tombstones() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"baz", RLookupKeyFlags::empty()));
+
+        // Override "bar" (middle element) to create a tombstone
+        let mut cursor = keylist.cursor_front_mut();
+        cursor.move_next(); // move to "bar"
+        cursor.override_current(RLookupKeyFlags::empty());
+
+        let names: Vec<_> = keylist
+            .iter_mut()
+            .map(|k| k.name().as_ref().to_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![c"foo".to_owned(), c"bar".to_owned(), c"baz".to_owned()]
+        );
+    }
+
+    // Assert that IterMut yields nothing for an empty list
+    #[test]
+    fn iter_mut_empty_list() {
+        let mut keylist = KeyList::new();
+        assert_eq!(keylist.iter_mut().count(), 0);
+    }
+
+    // Assert that Iter skips multiple consecutive tombstones
+    #[test]
+    fn iter_skips_consecutive_tombstones() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+
+        // Override both keys to create consecutive tombstones with their replacements
+        keylist
+            .cursor_front_mut()
+            .override_current(RLookupKeyFlags::empty());
+
+        let mut cursor = keylist.cursor_front_mut(); // at foo tombstone
+        cursor.move_next(); // at foo
+        cursor.move_next(); // at bar
+        cursor.override_current(RLookupKeyFlags::empty());
+
+        // All tombstones should be skipped, only replacement keys should be yielded
+        let names: Vec<_> = keylist
+            .iter()
+            .map(|k| k.name().as_ref().to_owned())
+            .collect();
+        assert_eq!(names, vec![c"foo".to_owned(), c"bar".to_owned()]);
     }
 
     #[test]


### PR DESCRIPTION
Adds a `Iter`/`IterMut` types to `RLookup` that allow more ergonomic iteration over the keys. Overridden keys are skipped automatically, keys logically marked as "hidden" are not. The existing `Cursor`/`CursorMut` APIs are not changed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new public iteration APIs over an internal pointer-based linked list, including a pinned mutable iterator; mistakes here could cause subtle iteration/aliasing bugs despite added tests.
> 
> **Overview**
> Adds new `Iter` and `IterMut` iterator types for `RLookup`/`KeyList`, enabling idiomatic iteration over keys while **skipping tombstone (overridden) entries**.
> 
> Refactors `RLookup::add_keys_from` to use the new iterator, re-exports the iterator types from `lib.rs`, and adds focused unit tests validating ordering, tombstone skipping, and that mutations via `iter_mut` are observable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff07192bed7bf98d555f9d3b427157ad83ce64d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->