### PR TITLE
[MOD 14980] TTL table Rust implementation

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2871,6 +2871,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttl_table"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "field",
+ "libc",
+ "thin_vec",
+ "ttl_table",
+ "workspace_hack",
+]
+
+[[package]]
 name = "types_ffi"
 version = "0.0.1"
 dependencies = [

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "trie_bencher",
     "top_k",
     "trie_rs",
+    "ttl_table",
     "value",
     "varint",
     "varint_bencher",
@@ -130,6 +131,7 @@ thin_vec = { path = "./thin_vec" }
 top_k = { path = "./top_k" }
 tracing_redismodule = { path = "./tracing_redismodule" }
 trie_rs = { path = "./trie_rs" }
+ttl_table = { path = "./ttl_table" }
 value = { path = "./value" }
 varint = { path = "./varint" }
 wildcard = { path = "./wildcard" }

--- a/src/redisearch_rs/ttl_table/Cargo.toml
+++ b/src/redisearch_rs/ttl_table/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ttl_table"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[features]
+test-utils = []
+
+[lints]
+workspace = true
+
+[dependencies]
+ffi.workspace = true
+field.workspace = true
+libc.workspace = true
+thin_vec.workspace = true
+workspace_hack.workspace = true
+
+[dev-dependencies]
+ttl_table = { path = ".", features = ["test-utils"] }

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -1,0 +1,745 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A per-(document-field) time-to-live table
+//!
+//! Data layout and growth strategy:
+//!
+//! - A direct-modulo bucket array (`slot = doc_id % max_size`) — no hashing,
+//!   so monotonically allocated docIds map to sequential slots and the CPU
+//!   prefetcher can stream upcoming bucket headers into L1.
+//! - Per-bucket contiguous-vec collision chains (a [`ThinVec`] of entries).
+//! - Lazy growth: the bucket array starts empty and grows geometrically
+//!   (+1.5×, capped at `1 << 20` and clamped to `max_size`) only as `add`
+//!   demands more slots.
+//! - No shrink-on-delete: empty buckets are released, but the bucket array
+//!   itself keeps its high-water-mark length so churning indexes don't
+//!   thrash on realloc.
+//!
+//! The table holds only field-level (HEXPIRE) expirations; document-level
+//! TTL lives directly on `RSDocumentMetadata::expirationTimeNs` so the
+//! result-processor hot path avoids a lookup here.
+
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
+
+use std::num::NonZeroUsize;
+
+pub use field::FieldExpirationPredicate;
+use libc::timespec;
+use thin_vec::ThinVec;
+
+use ffi::t_docId;
+
+/// Initial bucket-array length the first time we grow from zero.
+///
+/// Chosen so an index that only ever holds a handful of TTL docs pays a
+/// single small allocation and no further reallocs.
+const TTL_BUCKET_INITIAL_CAP: usize = 64;
+
+/// Upper bound on the geometric +1.5× step once the bucket array is
+/// non-empty.
+///
+/// Very large tables don't take a single
+/// multi-MiB realloc hit and so the two allocators scale in lockstep.
+const TTL_BUCKET_MAX_GROW_STEP: usize = 1 << 20;
+
+/// The expiration time recorded for a single field of a document.
+#[derive(Debug, Clone, Copy)]
+pub struct FieldExpiration {
+    /// The field index this expiration applies to.
+    pub index: u16,
+    /// The point in time at which the field expires.
+    pub point: timespec,
+}
+
+/// A document's record in a [`TimeToLiveTable`] bucket's collision chain.
+#[derive(Debug)]
+pub struct TimeToLiveEntry {
+    /// The document id
+    pub doc_id: t_docId,
+    /// Owned, sorted by field index, never empty.
+    pub field_expirations: ThinVec<FieldExpiration>,
+}
+
+/// Direct-modulo bucket array with contiguous-vec collision chains.
+///
+/// See the module-level documentation for the rationale. The bucket array
+/// length (`buckets.len()`) always satisfies `buckets.len() <= max_size`.
+#[derive(Debug)]
+pub struct TimeToLiveTable {
+    /// The bucket
+    buckets: Vec<ThinVec<TimeToLiveEntry>>,
+    /// Modulus for the slot formula. Captured at construction and never
+    /// changes.
+    max_size: usize,
+    /// Number of stored document
+    count: usize,
+}
+
+impl TimeToLiveTable {
+    /// Creates an empty table with `max_size` as the fixed modulus for
+    /// the slot formula.
+    ///
+    /// The bucket array starts empty and grows on demand.
+    pub fn new(max_size: NonZeroUsize) -> Self {
+        Self {
+            buckets: Vec::new(),
+            max_size: max_size.into(),
+            count: 0,
+        }
+    }
+
+    /// Returns `true` if the table holds no entries.
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Inserts a document's per-field expirations.
+    ///
+    /// `sorted_by_id` must be non-empty and sorted by `index` in ascending
+    /// order. Ownership transfers to the table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sorted_by_id` is empty.
+    /// In debug builds, it panics:
+    /// - if `doc_id` is already present in the table
+    /// - if `sorted_by_id` is not sorted by index
+    pub fn add(&mut self, doc_id: t_docId, sorted_by_id: ThinVec<FieldExpiration>) {
+        debug_assert!(
+            !sorted_by_id.is_empty(),
+            "TTL table add requires at least one field expiration"
+        );
+        debug_assert!(
+            sorted_by_id.is_sorted_by_key(|f| f.index),
+            "sorted_by_id is not sorted by index"
+        );
+
+        let slot = self.slot(doc_id);
+        self.grow_to(slot);
+
+        debug_assert!(
+            !self.buckets[slot].iter().any(|e| e.doc_id == doc_id),
+            "duplicate docId in TTL table"
+        );
+
+        self.buckets[slot].push(TimeToLiveEntry {
+            doc_id,
+            field_expirations: sorted_by_id,
+        });
+        self.count += 1;
+    }
+
+    /// Removes the entry for `doc_id`, if any. No-op if absent.
+    ///
+    /// Uses swap-last deletion (O(1)) and does not shrink the bucket — the
+    /// allocation is kept at its high-water mark to avoid realloc churn.
+    pub fn remove(&mut self, doc_id: t_docId) -> Option<TimeToLiveEntry> {
+        let slot = self.slot(doc_id);
+        if slot >= self.buckets.len() {
+            return None;
+        }
+        let bucket = &mut self.buckets[slot];
+        if let Some(pos) = bucket.iter().position(|e| e.doc_id == doc_id) {
+            let removed = bucket.swap_remove(pos);
+            self.count -= 1;
+
+            Some(removed)
+        } else {
+            None
+        }
+    }
+
+    /// Return the number of buckets currently allocated
+    #[cfg(feature = "test-utils")]
+    pub const fn n_allocated_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Returns the per-field expiration list stored for `doc_id`, or `None`
+    /// if no entry exists.
+    ///
+    /// The slice aliases storage owned by the table and is invalidated by any
+    /// subsequent [`add`](Self::add) / [`remove`](Self::remove) on this table.
+    pub fn field_expirations(&self, doc_id: t_docId) -> Option<&[FieldExpiration]> {
+        self.find_entry(doc_id)
+            .map(|e| e.field_expirations.as_slice())
+    }
+
+    /// Checks the expiration state of a single field of a document under
+    /// `predicate`.
+    ///
+    /// The result then respects `predicate`:
+    /// - [`FieldExpirationPredicate::Default`] returns `true` iff the
+    ///   field is not expired ("valid").
+    /// - [`FieldExpirationPredicate::Missing`] returns `true` iff the
+    ///   field is expired ("considered missing").
+    ///
+    /// A field is considered *expired* when it has a recorded expiration
+    /// point that has elapsed by `expiration_point`.
+    /// `(0, 0)` is a special value that means it never expires.
+    /// Untracked fields are likewise treated as not expired.
+    ///
+    /// As a special case, when no expiration information is recorded for
+    /// the document at all, the function returns `true` regardless of `predicate`,
+    /// because none of the document's fields is expired, so the query trivially passes
+    /// under either predicate.
+    pub fn verify_doc_and_field(
+        &self,
+        doc_id: t_docId,
+        field: u16,
+        predicate: FieldExpirationPredicate,
+        expiration_point: &timespec,
+    ) -> bool {
+        let Some(entry) = self.find_entry(doc_id) else {
+            // the document did not have a ttl for itself or its fields
+            // if predicate is FieldExpirationPredicate::Default, at least one field is valid
+            // if predicate is FieldExpirationPredicate::Missing, the field is indeed missing since the document has no expiration for it
+            return true;
+        };
+
+        debug_assert!(
+            !entry.field_expirations.is_empty(),
+            "field_expirations is guaranteed to not be empty"
+        );
+
+        entry
+            .field_expirations
+            .iter()
+            // Find the field in the chain
+            .find(|fe| fe.index == field)
+            .map(|fe| {
+                let expired = did_expire(&fe.point, expiration_point);
+                if expired {
+                    // the document is invalid (should return `false`), unless we look for missing fields
+                    predicate == FieldExpirationPredicate::Missing
+                } else {
+                    // the document is valid (should return `true`), unless we look for missing fields
+                    predicate != FieldExpirationPredicate::Missing
+                }
+            })
+            // Field not tracked: valid for `Default`, not actually missing for
+            // `Missing`.
+            .unwrap_or(predicate != FieldExpirationPredicate::Missing)
+    }
+
+    /// Checks the expiration state of a set of fields described by a
+    /// 32-bit `field_mask`.
+    ///
+    /// `ft_id_to_field_index[bit]` translates a bit position in the mask
+    /// into the `t_fieldIndex` recorded in the table; it must contain at
+    /// least as many entries as the highest set bit of `field_mask`. The
+    /// translation is required to be monotonic, bits scanned low-to-high
+    /// must produce non-decreasing field indices.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ft_id_to_field_index` is shorter than `highest_set_bit + 1`.
+    pub fn verify_doc_and_field_mask(
+        &self,
+        doc_id: t_docId,
+        field_mask: u32,
+        predicate: FieldExpirationPredicate,
+        expiration_point: &timespec,
+        ft_id_to_field_index: &[u16],
+    ) -> bool {
+        verify_mask::<u32>(
+            self.find_entry(doc_id),
+            field_mask,
+            predicate,
+            expiration_point,
+            ft_id_to_field_index,
+        )
+    }
+
+    /// Checks the expiration state of a set of fields described by a
+    /// 128-bit `field_mask` (the wide-schema variant).
+    /// See also [`TimeToLiveTable::verify_doc_and_field_mask`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ft_id_to_field_index` is shorter than
+    /// `highest_set_bit + 1` of `field_mask`.
+    pub fn verify_doc_and_wide_field_mask(
+        &self,
+        doc_id: t_docId,
+        field_mask: u128,
+        predicate: FieldExpirationPredicate,
+        expiration_point: &timespec,
+        ft_id_to_field_index: &[u16],
+    ) -> bool {
+        verify_mask::<u128>(
+            self.find_entry(doc_id),
+            field_mask,
+            predicate,
+            expiration_point,
+            ft_id_to_field_index,
+        )
+    }
+
+    /// Direct-modulo slot formula
+    const fn slot(&self, doc_id: t_docId) -> usize {
+        // All the casts here are safe because we check the conversion in the constructor
+        if doc_id < self.max_size as u64 {
+            doc_id as usize
+        } else {
+            (doc_id % self.max_size as u64) as usize
+        }
+    }
+
+    /// Ensures `buckets[slot]` is allocated.
+    ///
+    /// The first grow seeds at `TTL_BUCKET_INITIAL_CAP`,
+    /// subsequent grows are `+1 + min(cap/2, TTL_BUCKET_MAX_GROW_STEP)`,
+    /// all clamped to `max_size` and rounded up to cover the requested `slot`.
+    fn grow_to(&mut self, slot: usize) {
+        debug_assert!(slot < self.max_size);
+        let cap = self.buckets.len();
+        if slot < cap {
+            return;
+        }
+        debug_assert!(cap < self.max_size);
+
+        let mut newcap = if cap == 0 {
+            TTL_BUCKET_INITIAL_CAP
+        } else {
+            cap + 1 + std::cmp::min(cap / 2, TTL_BUCKET_MAX_GROW_STEP)
+        };
+        if newcap > self.max_size {
+            newcap = self.max_size;
+        }
+        if newcap < slot + 1 {
+            newcap = slot + 1;
+        }
+
+        self.buckets.resize_with(newcap, ThinVec::new);
+    }
+
+    fn find_entry(&self, doc_id: t_docId) -> Option<&TimeToLiveEntry> {
+        let slot = self.slot(doc_id);
+        let bucket = self.buckets.get(slot)?;
+        bucket.iter().find(|e| e.doc_id == doc_id)
+    }
+}
+
+/// Bit-mask abstraction shared by the 32-bit and wide-mask helpers.
+///
+/// The trait splits the mask into a slice of `u64` halves (low to high)
+/// so [`verify_mask`] can iterate bits with native `u64` ops — single
+/// `rbit`+`clz` for `trailing_zeros`, single `lsl`, single `bic` for the
+/// AND-NOT.
+trait BitMask: Copy {
+    /// Owned array holding the mask split into `u64` halves.
+    type Halves: AsRef<[u64]>;
+
+    /// Splits the mask into a sequence of `u64` halves, low to high.
+    fn halves(self) -> Self::Halves;
+}
+
+impl BitMask for u32 {
+    type Halves = [u64; 1];
+
+    #[inline]
+    fn halves(self) -> Self::Halves {
+        [self as u64]
+    }
+}
+
+impl BitMask for u128 {
+    type Halves = [u64; 2];
+
+    #[inline]
+    fn halves(self) -> Self::Halves {
+        [self as u64, (self >> 64) as u64]
+    }
+}
+
+fn verify_mask<M: BitMask>(
+    entry: Option<&TimeToLiveEntry>,
+    mask: M,
+    predicate: FieldExpirationPredicate,
+    expiration_point: &timespec,
+    ft_id_to_field_index: &[u16],
+) -> bool {
+    let Some(entry) = entry else {
+        // The document did not have a ttl for itself or its fields.
+        // Therefore:
+        // - if predicate is default, then we know at least one field is valid
+        // - if predicate is missing, then we know the field is indeed missing since the document has no expiration for it
+        return true;
+    };
+
+    let field_expirations: &[FieldExpiration] = &entry.field_expirations;
+    debug_assert!(
+        !entry.field_expirations.is_empty(),
+        "field_expirations is guaranteed to not be empty"
+    );
+    let field_with_expiration_length = field_expirations.len();
+
+    let halves = mask.halves();
+    let halves = halves.as_ref();
+    let field_count: usize = halves.iter().map(|h| h.count_ones() as usize).sum();
+    if field_with_expiration_length < field_count && predicate == FieldExpirationPredicate::Default
+    {
+        // The document has less fields with expiration times than the fields we are checking.
+        // So, at least one field is valid
+        return true;
+    }
+
+    // Hoisted bounds check on the translation table. The bit indices
+    // we generate are exactly the set bits of the mask, so we only
+    // need the slice to cover the *highest* set bit. Doing the check
+    // once here lets us drop the per-iteration bounds check on
+    // `ft_id_to_field_index` below.
+    let highest_bit_plus_one: usize = halves
+        .iter()
+        .enumerate()
+        .map(|(i, &h)| {
+            if h == 0 {
+                0
+            } else {
+                i * (u64::BITS as usize) + (u64::BITS as usize) - (h.leading_zeros() as usize)
+            }
+        })
+        .max()
+        .unwrap_or(0);
+    // Hoisted bound. The inner loop derives `bit_index` from
+    // `trailing_zeros` over the same halves used to compute
+    // `highest_bit_plus_one`, but LLVM cannot relate those two
+    // bit-manipulation intrinsics on its own — so the per-iteration
+    // bounds check survives without a hint. This assertion both
+    // gives the caller an actionable error message and underwrites
+    // the `unsafe` proof at the call site of `get_field_index`.
+    debug_assert!(
+        ft_id_to_field_index.len() >= highest_bit_plus_one,
+        "ft_id_to_field_index must cover the highest set bit of the mask"
+    );
+
+    /// Reads `ft_id_to_field_index[bit_index]` while telling LLVM the
+    /// bound holds, so the per-call bounds check on the slice indexing
+    /// is elided.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee `bit_index < ft_id_to_field_index.len()`.
+    #[inline]
+    unsafe fn get_field_index_unchecked(ft_id_to_field_index: &[u16], bit_index: usize) -> u16 {
+        debug_assert!(
+            bit_index < ft_id_to_field_index.len(),
+            "Safety violation: try to access to an out-of-bounds index, {bit_index}. Length {}",
+            ft_id_to_field_index.len(),
+        );
+        // SAFETY: Function safety guarantees
+        unsafe { *ft_id_to_field_index.get_unchecked(bit_index) }
+    }
+
+    /// Reads `&field_expirations[field_index]` while telling LLVM the
+    /// bound holds, so the per-call bounds check is elided.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee `field_index < field_expirations.len()`.
+    #[inline]
+    unsafe fn get_candidate_field_unchecked(
+        field_expirations: &[FieldExpiration],
+        field_index: usize,
+    ) -> &FieldExpiration {
+        debug_assert!(
+            field_index < field_expirations.len(),
+            "Safety violation: try to access to an out-of-bounds index, {field_index}. Length {}",
+            field_expirations.len(),
+        );
+        // SAFETY: Function safety guarantees
+        unsafe { field_expirations.get_unchecked(field_index) }
+    }
+
+    let mut predicate_misses: usize = 0;
+    let mut current_field_index: usize = 0;
+
+    // Outer loop walks halves. This is known at compile time:
+    // u32 -> `[u64; 1]`, u128 -> `[u64; 2]`.
+    // NB: in case of u128, the order  (lower bits, higher bits) is important.
+    // In fact, we can keep track of `current_field_index` and perform a fast check.
+    // NB2: the outer loop is fully unrolled by LLVM.
+    'outer: for (half_idx, &half_init) in halves.iter().enumerate() {
+        let mut half = half_init;
+
+        // 0 for u64, 0 or 64 for u128
+        let bit_offset = (half_idx as u32) * u64::BITS;
+
+        // This loop navigates, from lower to higher, each bit set to 1.
+        // For each of them, check if ft_id_to_field_index contains that index,
+        // and run the expiration logic if found.
+        while half != 0 {
+            // Turn off last 1 bit
+            // `bit_in_half ∈ [0, 64)`, 64 excluded because half != 0.
+            let bit_in_half = half.trailing_zeros();
+            half &= !(1u64 << bit_in_half);
+
+            // This is the index of mask where the lower bit set to 1 is located.
+            // NB: the mask is cleaned up from the lower bit after each iteration.
+            // NB2: `bit_index <= highest_bit_plus_one - 1`.
+            let bit_index = bit_offset + bit_in_half;
+
+            // SAFETY: `bit_index` is the position of a set bit in `mask`.
+            // Because:
+            // - `bit_index <= highest_bit_plus_one - 1`
+            // - `highest_bit_plus_one <= ft_id_to_field_index.len()`
+            // hence `bit_index < ft_id_to_field_index.len()`.
+            let field_index_to_check =
+                unsafe { get_field_index_unchecked(ft_id_to_field_index, bit_index as usize) };
+
+            // Advance the cursor over fields strictly less than the one
+            // we are checking.
+            while current_field_index < field_with_expiration_length {
+                // SAFETY: the `while` condition above proves it
+                let candidate_index = unsafe {
+                    get_candidate_field_unchecked(field_expirations, current_field_index).index
+                };
+                if field_index_to_check <= candidate_index {
+                    break;
+                }
+                current_field_index += 1;
+            }
+            if current_field_index >= field_with_expiration_length {
+                // No more fields with expiration times to check.
+                break 'outer;
+            }
+
+            // SAFETY: the `if … break 'outer` above ensures we only get
+            // here when `current_field_index < field_with_expiration_length`
+            let entry_field =
+                unsafe { get_candidate_field_unchecked(field_expirations, current_field_index) };
+            if field_index_to_check < entry_field.index {
+                // Field not tracked by this entry — treat as absent.
+                continue;
+            }
+            debug_assert_eq!(field_index_to_check, entry_field.index);
+
+            let expired = did_expire(&entry_field.point, expiration_point);
+            if !expired && predicate == FieldExpirationPredicate::Default {
+                return true;
+            }
+            if expired && predicate == FieldExpirationPredicate::Missing {
+                return true;
+            }
+            predicate_misses += 1;
+        }
+    }
+
+    match predicate {
+        FieldExpirationPredicate::Default => {
+            // At least one valid field
+            predicate_misses < field_count
+        }
+        FieldExpirationPredicate::Missing => {
+            // If we are checking for the missing predicate, we need at least one expired field
+            // If we reached here, it means we did not find any expired fields
+            false
+        }
+    }
+}
+
+/// Returns `true` if `field` has elapsed by `now`.
+///
+/// A `field` with both `tv_sec` and `tv_nsec` zero is treated as "no
+/// expiration set" and never expires.
+#[inline]
+const fn did_expire(field: &timespec, now: &timespec) -> bool {
+    if field.tv_sec == 0 && field.tv_nsec == 0 {
+        return false;
+    }
+    !((field.tv_sec > now.tv_sec) || (field.tv_sec == now.tv_sec && field.tv_nsec > now.tv_nsec))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_utils::*;
+    use super::*;
+
+    use thin_vec::thin_vec;
+
+    #[test]
+    fn verify_field_returns_true_for_doc_colliding_with_a_known_doc() {
+        // doc_id 1 is in the table; doc_id 9 also hashes to slot 1 but is
+        // absent. Per docs: if the document has no entry, both predicates
+        // return true.
+        const MAX: usize = 8;
+        let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+        t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+
+        let unknown_collider: u64 = DOC_ID_1 + MAX as u64;
+        // Be sure it is a collider
+        assert_eq!(t.slot(DOC_ID_1), t.slot(unknown_collider));
+
+        assert!(t.verify_doc_and_field(
+            unknown_collider,
+            FIELD_INDEX_1,
+            FieldExpirationPredicate::Default,
+            &NOW,
+        ));
+        assert!(t.verify_doc_and_field(
+            unknown_collider,
+            FIELD_INDEX_1,
+            FieldExpirationPredicate::Missing,
+            &NOW,
+        ));
+    }
+
+    #[test]
+    fn remove_first_of_three_collider_bucket_keeps_others_findable() {
+        const MAX: usize = 8;
+
+        const DOC_ID_1_COLLIDER_1: u64 = DOC_ID_1 + MAX as u64;
+        const DOC_ID_1_COLLIDER_2: u64 = DOC_ID_1 + (MAX as u64) * 2;
+
+        let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+
+        // ensure collisions
+        assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_1));
+        assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_2));
+
+        t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        t.add(DOC_ID_1_COLLIDER_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+        t.add(DOC_ID_1_COLLIDER_2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        t.remove(DOC_ID_1);
+        // Doc 9: PAST ⇒ Default false.
+        assert!(!t.verify_doc_and_field(
+            DOC_ID_1_COLLIDER_1,
+            FIELD_INDEX_1,
+            FieldExpirationPredicate::Default,
+            &NOW,
+        ));
+        // Doc 17: FUTURE ⇒ Default true.
+        assert!(t.verify_doc_and_field(
+            DOC_ID_1_COLLIDER_2,
+            FIELD_INDEX_1,
+            FieldExpirationPredicate::Default,
+            &NOW,
+        ));
+        t.remove(DOC_ID_1_COLLIDER_1);
+        assert!(t.verify_doc_and_field(
+            DOC_ID_1_COLLIDER_2,
+            FIELD_INDEX_1,
+            FieldExpirationPredicate::Default,
+            &NOW,
+        ));
+        assert!(!t.is_empty());
+        t.remove(DOC_ID_1_COLLIDER_2);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn remove_doc_absent_from_existing_bucket_is_noop() {
+        const MAX: usize = 8;
+        const DOC_ID_1_COLLIDER: u64 = DOC_ID_1 + MAX as u64;
+
+        let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+        t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+
+        // Slot collider
+        assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER));
+        t.remove(DOC_ID_1_COLLIDER);
+
+        assert!(!t.is_empty());
+        assert!(t.verify_doc_and_field(
+            DOC_ID_1,
+            FIELD_INDEX_1,
+            FieldExpirationPredicate::Default,
+            &NOW,
+        ));
+    }
+
+    #[test]
+    fn max_size_one_collapses_every_doc_to_slot_zero() {
+        const MAX: usize = 1;
+        let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+        t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        t.add(1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+        t.add(2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        assert_eq!(t.n_allocated_buckets(), 1);
+        assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
+        assert!(
+            !t.verify_doc_and_field(1, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,)
+        );
+        assert!(t.verify_doc_and_field(2, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
+
+        assert_eq!(t.slot(0), t.slot(1));
+        assert_eq!(t.slot(0), t.slot(2));
+    }
+
+    #[test]
+    #[should_panic(expected = "field_expirations is guaranteed to not be empty")]
+    fn verify_mask_returns_true_when_entry_has_no_field_expirations() {
+        let entry = TimeToLiveEntry {
+            doc_id: DOC_ID_1,
+            field_expirations: empty_fields(),
+        };
+        let map = identity_ft_id();
+        verify_mask(
+            Some(&entry),
+            mask_bit(&[0, 1, 2]),
+            FieldExpirationPredicate::Default,
+            &NOW,
+            &map,
+        );
+    }
+
+    #[test]
+    fn fast_path_and_modulo_path_doc_ids_coexist_in_same_bucket() {
+        // docId `x` uses the fast path (`x < max_size`); `x + CAP` and
+        // `x + 2*CAP` take the modulo path (`>= max_size`). All three hash to
+        // the same slot. Verifies the two `slot()` arms route to the same
+        // bucket and stay distinguishable, then removes the middle layer to
+        // confirm swap-last does not corrupt the outer entries.
+        const CAP: u64 = 32;
+        let mut t = TimeToLiveTable::new(NonZeroUsize::new(CAP as usize).unwrap());
+
+        for x in 1u64..8 {
+            assert_eq!(t.slot(x), t.slot(x + CAP));
+            assert_eq!(t.slot(x), t.slot(x + 2 * CAP));
+            t.add(x, thin_vec![fe(0, PAST)]);
+            t.add(x + CAP, thin_vec![fe(0, FUTURE)]);
+            t.add(x + 2 * CAP, thin_vec![fe(0, PAST)]);
+        }
+        for x in 1u64..8 {
+            assert!(!t.verify_doc_and_field(x, 0, FieldExpirationPredicate::Default, &NOW));
+            assert!(t.verify_doc_and_field(x + CAP, 0, FieldExpirationPredicate::Default, &NOW));
+            assert!(!t.verify_doc_and_field(
+                x + 2 * CAP,
+                0,
+                FieldExpirationPredicate::Default,
+                &NOW,
+            ));
+            // A never-inserted docId hashing to the same slot must report "no TTL".
+            assert!(t.verify_doc_and_field(
+                x + 3 * CAP,
+                0,
+                FieldExpirationPredicate::Default,
+                &NOW,
+            ));
+        }
+
+        for x in 1u64..8 {
+            t.remove(x + CAP);
+        }
+        for x in 1u64..8 {
+            assert!(!t.verify_doc_and_field(x, 0, FieldExpirationPredicate::Default, &NOW));
+            // Removed docs report "no TTL" ⇒ Default true.
+            assert!(t.verify_doc_and_field(x + CAP, 0, FieldExpirationPredicate::Default, &NOW));
+            assert!(!t.verify_doc_and_field(
+                x + 2 * CAP,
+                0,
+                FieldExpirationPredicate::Default,
+                &NOW,
+            ));
+        }
+    }
+}

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -29,7 +29,7 @@
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
-use std::num::NonZeroUsize;
+use std::{iter::Chain, num::NonZeroUsize};
 
 pub use field::FieldExpirationPredicate;
 use libc::timespec;
@@ -103,16 +103,26 @@ impl TimeToLiveTable {
 
     /// Inserts a document's per-field expirations.
     ///
-    /// `sorted_by_id` must be non-empty and sorted by `index` in ascending
-    /// order. Ownership transfers to the table.
+    /// Ownership of `sorted_by_id` transfers to the table.
     ///
-    /// # Panics
+    /// # Safety
     ///
-    /// Panics if `sorted_by_id` is empty.
-    /// In debug builds, it panics:
-    /// - if `doc_id` is already present in the table
-    /// - if `sorted_by_id` is not sorted by index
-    pub fn add(&mut self, doc_id: t_docId, sorted_by_id: ThinVec<FieldExpiration>) {
+    /// The caller must guarantee:
+    /// - `sorted_by_id` is non-empty.
+    /// - `sorted_by_id` is sorted in ascending order by `index`.
+    /// - `doc_id` is not already present in the table.
+    ///
+    /// These invariants are load-bearing for the lookup hot paths
+    /// ([`verify_doc_and_field`](Self::verify_doc_and_field),
+    /// [`verify_doc_and_field_mask`](Self::verify_doc_and_field_mask),
+    /// [`verify_doc_and_wide_field_mask`](Self::verify_doc_and_wide_field_mask)),
+    /// which assume them when scanning the per-bucket chain and the
+    /// per-entry field-expiration list.
+    ///
+    /// In debug builds these preconditions are checked via `debug_assert!`
+    /// and will panic on violation; in release builds the checks are
+    /// elided.
+    pub unsafe fn add(&mut self, doc_id: t_docId, sorted_by_id: ThinVec<FieldExpiration>) {
         debug_assert!(
             !sorted_by_id.is_empty(),
             "TTL table add requires at least one field expiration"
@@ -242,6 +252,11 @@ impl TimeToLiveTable {
     /// # Panics
     ///
     /// Panics if `ft_id_to_field_index` is shorter than `highest_set_bit + 1`.
+    ///
+    /// Callers must guarantee that `ft_id_to_field_index.len()` is at
+    /// least `highest_set_bit + 1` of `field_mask`. The bit-walk reads
+    /// the translation slice via `_unchecked` once per set bit;
+    /// violating the bound is undefined behavior in release builds.
     pub fn verify_doc_and_field_mask(
         &self,
         doc_id: t_docId,
@@ -265,8 +280,7 @@ impl TimeToLiveTable {
     ///
     /// # Panics
     ///
-    /// Panics if `ft_id_to_field_index` is shorter than
-    /// `highest_set_bit + 1` of `field_mask`.
+    /// See [`TimeToLiveTable::verify_doc_and_field_mask`].
     pub fn verify_doc_and_wide_field_mask(
         &self,
         doc_id: t_docId,
@@ -286,7 +300,6 @@ impl TimeToLiveTable {
 
     /// Direct-modulo slot formula
     const fn slot(&self, doc_id: t_docId) -> usize {
-        // All the casts here are safe because we check the conversion in the constructor
         if doc_id < self.max_size as u64 {
             doc_id as usize
         } else {
@@ -330,34 +343,53 @@ impl TimeToLiveTable {
 }
 
 /// Bit-mask abstraction shared by the 32-bit and wide-mask helpers.
-///
-/// The trait splits the mask into a slice of `u64` halves (low to high)
-/// so [`verify_mask`] can iterate bits with native `u64` ops — single
-/// `rbit`+`clz` for `trailing_zeros`, single `lsl`, single `bic` for the
-/// AND-NOT.
 trait BitMask: Copy {
-    /// Owned array holding the mask split into `u64` halves.
-    type Halves: AsRef<[u64]>;
+    /// Concrete iterator type returned by [`Self::iter`]; yields the
+    /// positions of set bits as [`u32`] values.
+    type Iter: Iterator<Item = u32>;
 
-    /// Splits the mask into a sequence of `u64` halves, low to high.
-    fn halves(self) -> Self::Halves;
+    /// Returns the number of `1` bits in the mask.
+    fn count_ones(self) -> usize;
+
+    /// Returns the highest set-bit position plus one — i.e. the minimum
+    /// number of bits needed to represent the value, or `0` when the mask
+    /// is zero.
+    fn higher_bit_position(self) -> usize;
+
+    /// Returns an iterator over the positions of the set bits, yielded
+    /// low-to-high.
+    fn iter(self) -> Self::Iter;
 }
 
 impl BitMask for u32 {
-    type Halves = [u64; 1];
+    type Iter = BitU64Iter;
 
-    #[inline]
-    fn halves(self) -> Self::Halves {
-        [self as u64]
+    fn iter(self) -> Self::Iter {
+        BitU64Iter::new(self as u64)
+    }
+
+    fn count_ones(self) -> usize {
+        u32::count_ones(self) as usize
+    }
+
+    fn higher_bit_position(self) -> usize {
+        (Self::BITS - self.leading_zeros()) as usize
     }
 }
 
 impl BitMask for u128 {
-    type Halves = [u64; 2];
+    type Iter = BitU128Iter;
 
-    #[inline]
-    fn halves(self) -> Self::Halves {
-        [self as u64, (self >> 64) as u64]
+    fn iter(self) -> Self::Iter {
+        BitU128Iter::new(self)
+    }
+
+    fn count_ones(self) -> usize {
+        u128::count_ones(self) as usize
+    }
+
+    fn higher_bit_position(self) -> usize {
+        (Self::BITS - self.leading_zeros()) as usize
     }
 }
 
@@ -402,7 +434,7 @@ impl Iterator for BitU64Iter {
         if self.current == 0 {
             return None;
         }
-        // `bit ∈ [0, 64)`, 64 excluded because `self.current != 0`.
+        // `bit ∈ [0, 64)`, 64 excluded because of `self.current != 0`.
         let bit = self.current.trailing_zeros();
         // Clear the lowest set bit.
         self.current &= self.current - 1;
@@ -423,21 +455,20 @@ impl Iterator for BitU64Iter {
 /// assert_eq!(bits, vec![1, 3]);
 /// ```
 pub struct BitU128Iter {
-    first: BitU64Iter,
-    second: BitU64Iter,
+    iter: Chain<BitU64Iter, BitU64Iter>,
 }
 impl BitU128Iter {
     /// Builds an iterator over the set bits of `mask`.
     #[inline]
-    pub const fn new(mask: u128) -> Self {
+    pub fn new(mask: u128) -> Self {
         let first = mask as u64;
         let second = (mask >> 64) as u64;
-        Self {
-            // Yield from [0, 64)
-            first: BitU64Iter::with_base(first, 0),
+
+        let iter = // Yield from [0, 64)
+            BitU64Iter::with_base(first, 0)
             // Yield from [64, 127)
-            second: BitU64Iter::with_base(second, 64),
-        }
+            .chain(BitU64Iter::with_base(second, 64));
+        Self { iter }
     }
 }
 impl Iterator for BitU128Iter {
@@ -445,11 +476,7 @@ impl Iterator for BitU128Iter {
 
     #[inline]
     fn next(&mut self) -> Option<u32> {
-        // LLVM inlines this `or_else` chain into the caller, lowering it to a
-        // single bit-iteration loop with one half-selector branch — no closure
-        // overhead, no `Option` marshalling on the hot path. `verify_mask::<u128>`
-        // depends on this codegen; re-check the asm before changing.
-        self.first.next().or_else(|| self.second.next())
+        self.iter.next()
     }
 }
 
@@ -475,9 +502,7 @@ fn verify_mask<M: BitMask>(
     );
     let field_with_expiration_length = field_expirations.len();
 
-    let halves = mask.halves();
-    let halves = halves.as_ref();
-    let field_count: usize = halves.iter().map(|h| h.count_ones() as usize).sum();
+    let field_count: usize = mask.count_ones();
     if field_with_expiration_length < field_count && predicate == FieldExpirationPredicate::Default
     {
         // The document has less fields with expiration times than the fields we are checking.
@@ -485,138 +510,80 @@ fn verify_mask<M: BitMask>(
         return true;
     }
 
-    // Hoisted bounds check on the translation table. The bit indices
-    // we generate are exactly the set bits of the mask, so we only
-    // need the slice to cover the *highest* set bit. Doing the check
-    // once here lets us drop the per-iteration bounds check on
-    // `ft_id_to_field_index` below.
-    let highest_bit_plus_one: usize = halves
-        .iter()
-        .enumerate()
-        .map(|(i, &h)| {
-            if h == 0 {
-                0
-            } else {
-                i * (u64::BITS as usize) + (u64::BITS as usize) - (h.leading_zeros() as usize)
-            }
-        })
-        .max()
-        .unwrap_or(0);
-    // Hoisted bound. The inner loop derives `bit_index` from
-    // `trailing_zeros` over the same halves used to compute
-    // `highest_bit_plus_one`, but LLVM cannot relate those two
-    // bit-manipulation intrinsics on its own — so the per-iteration
-    // bounds check survives without a hint. This assertion both
-    // gives the caller an actionable error message and underwrites
-    // the `unsafe` proof at the call site of `get_field_index`.
-    debug_assert!(
+    // Hoisted bound, so the loop can use `get_unchecked`.
+    let highest_bit_plus_one: usize = mask.higher_bit_position();
+    assert!(
         ft_id_to_field_index.len() >= highest_bit_plus_one,
         "ft_id_to_field_index must cover the highest set bit of the mask"
     );
 
-    /// Reads `ft_id_to_field_index[bit_index]` while telling LLVM the
-    /// bound holds, so the per-call bounds check on the slice indexing
-    /// is elided.
+    /// Reads `&arr[index]`,
     ///
     /// # Safety
     ///
-    /// The caller must guarantee `bit_index < ft_id_to_field_index.len()`.
+    /// The caller must guarantee `index < arr.len()`.
     #[inline]
-    unsafe fn get_field_index_unchecked(ft_id_to_field_index: &[u16], bit_index: usize) -> u16 {
+    unsafe fn get_unchecked<T>(arr: &[T], index: usize) -> &T {
         debug_assert!(
-            bit_index < ft_id_to_field_index.len(),
-            "Safety violation: try to access to an out-of-bounds index, {bit_index}. Length {}",
-            ft_id_to_field_index.len(),
+            index < arr.len(),
+            "Safety violation: try to access to an out-of-bounds index, {index}. Length {}",
+            arr.len(),
         );
         // SAFETY: Function safety guarantees
-        unsafe { *ft_id_to_field_index.get_unchecked(bit_index) }
-    }
-
-    /// Reads `&field_expirations[field_index]` while telling LLVM the
-    /// bound holds, so the per-call bounds check is elided.
-    ///
-    /// # Safety
-    ///
-    /// The caller must guarantee `field_index < field_expirations.len()`.
-    #[inline]
-    unsafe fn get_candidate_field_unchecked(
-        field_expirations: &[FieldExpiration],
-        field_index: usize,
-    ) -> &FieldExpiration {
-        debug_assert!(
-            field_index < field_expirations.len(),
-            "Safety violation: try to access to an out-of-bounds index, {field_index}. Length {}",
-            field_expirations.len(),
-        );
-        // SAFETY: Function safety guarantees
-        unsafe { field_expirations.get_unchecked(field_index) }
+        unsafe { arr.get_unchecked(index) }
     }
 
     let mut predicate_misses: usize = 0;
     let mut current_field_index: usize = 0;
 
-    // Outer loop walks halves. This is known at compile time:
-    // u32 -> `[u64; 1]`, u128 -> `[u64; 2]`.
-    // NB: in case of u128, the order  (lower bits, higher bits) is important.
-    // In fact, we can keep track of `current_field_index` and perform a fast check.
-    // NB2: the outer loop is fully unrolled by LLVM.
-    'outer: for (half_idx, &half_init) in halves.iter().enumerate() {
-        // 0 for u64, 0 or 64 for u128
-        let bit_offset = (half_idx as u32) * u64::BITS;
+    // Visits set bits low-to-high. Order matters: `current_field_index` only
+    // moves forward, so monotonic field indices amortize the cursor walk
+    // across bits (especially across the u128 halves).
+    for bit_index in mask.iter() {
+        // Load-bearing: `bit_index <= highest_bit_plus_one - 1`, which
+        // underwrites the safety proof of `get_unchecked` below.
 
-        // This loop navigates, from lower to higher, each bit set to 1.
-        // For each of them, check if ft_id_to_field_index contains that index,
-        // and run the expiration logic if found.
-        for bit_in_half in BitU64Iter::new(half_init) {
-            // This is the index of mask where the lower bit set to 1 is located.
-            // NB: the mask is cleaned up from the lower bit after each iteration.
-            // NB2: `bit_index <= highest_bit_plus_one - 1`.
-            let bit_index = bit_offset + bit_in_half;
+        // SAFETY: `bit_index` is the position of a set bit in `mask`.
+        // Because:
+        // - `bit_index <= highest_bit_plus_one - 1`
+        // - `highest_bit_plus_one <= ft_id_to_field_index.len()`
+        // hence `bit_index < ft_id_to_field_index.len()`.
+        let field_index_to_check =
+            unsafe { *get_unchecked(ft_id_to_field_index, bit_index as usize) };
 
-            // SAFETY: `bit_index` is the position of a set bit in `mask`.
-            // Because:
-            // - `bit_index <= highest_bit_plus_one - 1`
-            // - `highest_bit_plus_one <= ft_id_to_field_index.len()`
-            // hence `bit_index < ft_id_to_field_index.len()`.
-            let field_index_to_check =
-                unsafe { get_field_index_unchecked(ft_id_to_field_index, bit_index as usize) };
-
-            // Advance the cursor over fields strictly less than the one
-            // we are checking.
-            while current_field_index < field_with_expiration_length {
-                // SAFETY: the `while` condition above proves it
-                let candidate_index = unsafe {
-                    get_candidate_field_unchecked(field_expirations, current_field_index).index
-                };
-                if field_index_to_check <= candidate_index {
-                    break;
-                }
-                current_field_index += 1;
+        // Advance the cursor over fields strictly less than the one
+        // we are checking.
+        while current_field_index < field_with_expiration_length {
+            // SAFETY: the `while` condition above proves it
+            let candidate_index =
+                unsafe { get_unchecked(field_expirations, current_field_index).index };
+            if field_index_to_check <= candidate_index {
+                break;
             }
-            if current_field_index >= field_with_expiration_length {
-                // No more fields with expiration times to check.
-                break 'outer;
-            }
-
-            // SAFETY: the `if … break 'outer` above ensures we only get
-            // here when `current_field_index < field_with_expiration_length`
-            let entry_field =
-                unsafe { get_candidate_field_unchecked(field_expirations, current_field_index) };
-            if field_index_to_check < entry_field.index {
-                // Field not tracked by this entry — treat as absent.
-                continue;
-            }
-            debug_assert_eq!(field_index_to_check, entry_field.index);
-
-            let expired = did_expire(&entry_field.point, expiration_point);
-            if !expired && predicate == FieldExpirationPredicate::Default {
-                return true;
-            }
-            if expired && predicate == FieldExpirationPredicate::Missing {
-                return true;
-            }
-            predicate_misses += 1;
+            current_field_index += 1;
         }
+        if current_field_index >= field_with_expiration_length {
+            // No more fields with expiration times to check.
+            break;
+        }
+
+        // SAFETY: the `if … break` above ensures we only get
+        // here when `current_field_index < field_with_expiration_length`
+        let entry_field = unsafe { get_unchecked(field_expirations, current_field_index) };
+        if field_index_to_check < entry_field.index {
+            // Field not tracked by this entry — treat as absent.
+            continue;
+        }
+        debug_assert_eq!(field_index_to_check, entry_field.index);
+
+        let expired = did_expire(&entry_field.point, expiration_point);
+        if !expired && predicate == FieldExpirationPredicate::Default {
+            return true;
+        }
+        if expired && predicate == FieldExpirationPredicate::Missing {
+            return true;
+        }
+        predicate_misses += 1;
     }
 
     match predicate {
@@ -658,7 +625,9 @@ mod tests {
         // return true.
         const MAX: usize = 8;
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+        // SAFETY: `DOC_ID_1` is fresh; `[fe(FIELD_INDEX_1, PAST)]` is non-empty
+        // and trivially sorted (single element).
+        unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
 
         let unknown_collider: u64 = DOC_ID_1 + MAX as u64;
         // Be sure it is a collider
@@ -691,9 +660,11 @@ mod tests {
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_1));
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_2));
 
-        t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
-        t.add(DOC_ID_1_COLLIDER_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
-        t.add(DOC_ID_1_COLLIDER_2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        // SAFETY (each call below): the `doc_id` is unique across this test
+        // and each single-element vec is non-empty and trivially sorted.
+        unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+        unsafe { t.add(DOC_ID_1_COLLIDER_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+        unsafe { t.add(DOC_ID_1_COLLIDER_2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
         t.remove(DOC_ID_1);
         // Doc 9: PAST ⇒ Default false.
         assert!(!t.verify_doc_and_field(
@@ -727,7 +698,9 @@ mod tests {
         const DOC_ID_1_COLLIDER: u64 = DOC_ID_1 + MAX as u64;
 
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        // SAFETY: `DOC_ID_1` is fresh; the single-element vec is non-empty
+        // and trivially sorted.
+        unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
 
         // Slot collider
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER));
@@ -746,9 +719,11 @@ mod tests {
     fn max_size_one_collapses_every_doc_to_slot_zero() {
         const MAX: usize = 1;
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
-        t.add(1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
-        t.add(2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+        // SAFETY (each call below): doc_ids 0, 1, 2 are distinct; each
+        // single-element vec is non-empty and trivially sorted.
+        unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+        unsafe { t.add(1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+        unsafe { t.add(2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
         assert_eq!(t.n_allocated_buckets(), 1);
         assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
         assert!(
@@ -762,7 +737,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "field_expirations is guaranteed to not be empty")]
-    fn verify_mask_returns_true_when_entry_has_no_field_expirations() {
+    fn verify_mask_panics_when_entry_has_no_field_expirations() {
         let entry = TimeToLiveEntry {
             doc_id: DOC_ID_1,
             field_expirations: empty_fields(),
@@ -790,9 +765,12 @@ mod tests {
         for x in 1u64..8 {
             assert_eq!(t.slot(x), t.slot(x + CAP));
             assert_eq!(t.slot(x), t.slot(x + 2 * CAP));
-            t.add(x, thin_vec![fe(0, PAST)]);
-            t.add(x + CAP, thin_vec![fe(0, FUTURE)]);
-            t.add(x + 2 * CAP, thin_vec![fe(0, PAST)]);
+            // SAFETY (each call below): `x`, `x + CAP`, `x + 2 * CAP` are
+            // distinct and never repeat across loop iterations; each
+            // single-element vec is non-empty and trivially sorted.
+            unsafe { t.add(x, thin_vec![fe(0, PAST)]) };
+            unsafe { t.add(x + CAP, thin_vec![fe(0, FUTURE)]) };
+            unsafe { t.add(x + 2 * CAP, thin_vec![fe(0, PAST)]) };
         }
         for x in 1u64..8 {
             assert!(!t.verify_doc_and_field(x, 0, FieldExpirationPredicate::Default, &NOW));

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -361,6 +361,98 @@ impl BitMask for u128 {
     }
 }
 
+/// Iterator over the indices of the set bits of a [`u64`], yielded low to high.
+///
+/// Each item is the zero-based position of a `1` bit (`0..64`).
+///
+/// # Example
+///
+/// ```
+/// use ttl_table::BitU64Iter;
+///
+/// let bits: Vec<u32> = BitU64Iter::new(0b1010_u64).collect();
+/// assert_eq!(bits, vec![1, 3]);
+/// ```
+pub struct BitU64Iter {
+    current: u64,
+    base: u32,
+}
+
+impl BitU64Iter {
+    /// Builds an iterator over the set bits of `mask`.
+    #[inline]
+    pub const fn new(mask: u64) -> Self {
+        Self::with_base(mask, 0)
+    }
+
+    #[inline]
+    pub const fn with_base(mask: u64, base: u32) -> Self {
+        Self {
+            current: mask,
+            base,
+        }
+    }
+}
+
+impl Iterator for BitU64Iter {
+    type Item = u32;
+
+    #[inline]
+    fn next(&mut self) -> Option<u32> {
+        if self.current == 0 {
+            return None;
+        }
+        // `bit ∈ [0, 64)`, 64 excluded because `self.current != 0`.
+        let bit = self.current.trailing_zeros();
+        // Clear the lowest set bit.
+        self.current &= self.current - 1;
+        Some(bit + self.base)
+    }
+}
+
+/// Iterator over the indices of the set bits of a [`u128`], yielded low to high.
+///
+/// Each item is the zero-based position of a `1` bit (`0..128`).
+///
+/// # Example
+///
+/// ```
+/// use ttl_table::BitU128Iter;
+///
+/// let bits: Vec<u32> = BitU128Iter::new(0b1010_u128).collect();
+/// assert_eq!(bits, vec![1, 3]);
+/// ```
+pub struct BitU128Iter {
+    first: BitU64Iter,
+    second: BitU64Iter,
+}
+impl BitU128Iter {
+    /// Builds an iterator over the set bits of `mask`.
+    #[inline]
+    pub const fn new(mask: u128) -> Self {
+        let first = mask as u64;
+        let second = (mask >> 64) as u64;
+        Self {
+            // Yield from [0, 64)
+            first: BitU64Iter::with_base(first, 0),
+            // Yield from [64, 127)
+            second: BitU64Iter::with_base(second, 64),
+        }
+    }
+}
+impl Iterator for BitU128Iter {
+    type Item = u32;
+
+    #[inline]
+    fn next(&mut self) -> Option<u32> {
+        // LLVM inlines this `or_else` chain into the caller, lowering it to a
+        // single bit-iteration loop with one half-selector branch — no closure
+        // overhead, no `Option` marshalling on the hot path. `verify_mask::<u128>`
+        // depends on this codegen; re-check the asm before changing.
+        self.first.next().or_else(|| self.second.next())
+    }
+}
+
 fn verify_mask<M: BitMask>(
     entry: Option<&TimeToLiveEntry>,
     mask: M,
@@ -469,20 +561,13 @@ fn verify_mask<M: BitMask>(
     // In fact, we can keep track of `current_field_index` and perform a fast check.
     // NB2: the outer loop is fully unrolled by LLVM.
     'outer: for (half_idx, &half_init) in halves.iter().enumerate() {
-        let mut half = half_init;
-
         // 0 for u64, 0 or 64 for u128
         let bit_offset = (half_idx as u32) * u64::BITS;
 
         // This loop navigates, from lower to higher, each bit set to 1.
         // For each of them, check if ft_id_to_field_index contains that index,
         // and run the expiration logic if found.
-        while half != 0 {
-            // Turn off last 1 bit
-            // `bit_in_half ∈ [0, 64)`, 64 excluded because half != 0.
-            let bit_in_half = half.trailing_zeros();
-            half &= !(1u64 << bit_in_half);
-
+        for bit_in_half in BitU64Iter::new(half_init) {
             // This is the index of mask where the lower bit set to 1 is located.
             // NB: the mask is cleaned up from the lower bit after each iteration.
             // NB2: `bit_index <= highest_bit_plus_one - 1`.

--- a/src/redisearch_rs/ttl_table/src/test_utils.rs
+++ b/src/redisearch_rs/ttl_table/src/test_utils.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use std::num::NonZeroUsize;
 
 use ffi::t_docId;

--- a/src/redisearch_rs/ttl_table/src/test_utils.rs
+++ b/src/redisearch_rs/ttl_table/src/test_utils.rs
@@ -1,0 +1,52 @@
+use std::num::NonZeroUsize;
+
+use ffi::t_docId;
+use libc::timespec;
+use thin_vec::ThinVec;
+
+use crate::FieldExpiration;
+
+pub const fn ts(sec: i64, nsec: i64) -> timespec {
+    timespec {
+        tv_sec: sec as libc::time_t,
+        tv_nsec: nsec as libc::c_long,
+    }
+}
+
+pub const DOC_ID_1: t_docId = 1;
+pub const DOC_ID_2: t_docId = 4;
+pub const FIELD_INDEX_1: u16 = 3;
+pub const FIELD_INDEX_2: u16 = 5;
+pub const FIELD_INDEX_3: u16 = 6;
+pub const FIELD_INDEX_4: u16 = 10;
+
+pub const PAST: timespec = ts(999, 0);
+pub const NOW: timespec = ts(1000, 0);
+pub const FUTURE: timespec = ts(1000, 1);
+pub const FAR_IN_THE_FUTURE: timespec = ts(1001, 0);
+
+// Special value
+pub const NEVER: timespec = ts(0, 0);
+
+pub const TEST_MAX_SIZE: NonZeroUsize = NonZeroUsize::new(1024).unwrap();
+
+pub const fn empty_fields() -> ThinVec<FieldExpiration> {
+    ThinVec::new()
+}
+
+pub const fn fe(index: u16, point: timespec) -> FieldExpiration {
+    FieldExpiration { index, point }
+}
+
+/// Identity mapping from bit position → field index (bit `i` ↔ field `i`).
+pub fn identity_ft_id() -> Vec<u16> {
+    (0u16..128).collect()
+}
+
+pub fn mask_bit(indexes: &[u16]) -> u32 {
+    indexes.iter().map(|index| 1 << index).sum()
+}
+
+pub fn mask_bit_u128(indexes: &[u16]) -> u128 {
+    indexes.iter().map(|index| 1 << index).sum()
+}

--- a/src/redisearch_rs/ttl_table/tests/main.rs
+++ b/src/redisearch_rs/ttl_table/tests/main.rs
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Every test in this file constructs a fresh table and inserts one or more
+// documents whose IDs are obviously distinct, paired with one or more
+// `FieldExpiration`s whose `index`es are obviously sorted ascending and
+// whose vec is non-empty. The safety preconditions of `TimeToLiveTable::add`
+// are therefore met at every call site by inspection — adding per-call
+// `// SAFETY:` comments to ~60 callsites would be more noise than signal.
+#![expect(
+    clippy::undocumented_unsafe_blocks,
+    clippy::multiple_unsafe_ops_per_block
+)]
+
 use std::num::NonZeroUsize;
 
 use thin_vec::thin_vec;
@@ -13,13 +33,15 @@ fn new_table_doesnt_allocate() {
 #[test]
 fn add_then_remove_leaves_table_empty() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![FieldExpiration {
-            index: FIELD_INDEX_1,
-            point: FUTURE,
-        }],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![FieldExpiration {
+                index: FIELD_INDEX_1,
+                point: FUTURE,
+            }],
+        );
+    }
     assert!(!t.is_empty());
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
@@ -44,7 +66,7 @@ fn field_expirations_on_empty_table_is_none() {
 fn field_expirations_returns_inserted_slice() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     let inserted = thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)];
-    t.add(DOC_ID_1, inserted.clone());
+    unsafe { t.add(DOC_ID_1, inserted.clone()) };
 
     let got = t.field_expirations(DOC_ID_1).expect("entry must exist");
     assert_eq!(got.len(), 2);
@@ -62,7 +84,7 @@ fn field_expirations_returns_inserted_slice() {
 #[test]
 fn field_expirations_after_remove_is_none() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert!(t.field_expirations(DOC_ID_1).is_some());
     t.remove(DOC_ID_1);
     assert!(t.field_expirations(DOC_ID_1).is_none());
@@ -72,14 +94,14 @@ fn field_expirations_after_remove_is_none() {
 #[should_panic(expected = "at least one field expiration")]
 fn add_with_empty_fields_panics() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(1, empty_fields());
+    unsafe { t.add(1, empty_fields()) };
 }
 
 #[test]
 fn field_with_zero_expiration_never_expires() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     // Field never expires
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NEVER)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NEVER)]) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -98,7 +120,7 @@ fn field_with_zero_expiration_never_expires() {
 fn field_with_past_expiration_has_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     // Expired field
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -116,7 +138,7 @@ fn field_with_past_expiration_has_expired() {
 #[test]
 fn field_with_equal_expiration_has_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NOW)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NOW)]) };
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -134,7 +156,7 @@ fn field_with_equal_expiration_has_expired() {
 #[test]
 fn nanoseconds_break_seconds_tie() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -152,7 +174,7 @@ fn nanoseconds_break_seconds_tie() {
 #[test]
 fn field_with_future_expiration_has_not_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)]) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -187,7 +209,7 @@ fn verify_field_returns_true_for_unknown_doc() {
 #[test]
 fn verify_field_absent_default_returns_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_2,
@@ -225,10 +247,12 @@ fn verify_mask_returns_true_for_unknown_doc() {
 #[test]
 fn verify_mask_default_short_circuits_when_more_bits_than_field_expirations() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -243,10 +267,12 @@ fn verify_mask_default_short_circuits_when_more_bits_than_field_expirations() {
 #[test]
 fn verify_mask_default_returns_false_when_all_matched_fields_expired_and_no_extras() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     // Mask covers exactly the two expired fields ⇒ no field is valid.
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
@@ -261,10 +287,12 @@ fn verify_mask_default_returns_false_when_all_matched_fields_expired_and_no_extr
 #[test]
 fn verify_mask_missing_returns_true_when_any_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -278,10 +306,12 @@ fn verify_mask_missing_returns_true_when_any_matched_field_expired() {
 #[test]
 fn verify_mask_missing_returns_false_when_no_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+        );
+    }
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -295,10 +325,12 @@ fn verify_mask_missing_returns_false_when_no_matched_field_expired() {
 #[test]
 fn verify_mask_default_returns_true_when_at_least_one_matched_field_valid() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)],
+        );
+    }
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -319,10 +351,12 @@ fn verify_mask_skips_bits_whose_field_index_is_not_tracked() {
     // The doc only tracks FIELD_INDEX_1 and FIELD_INDEX_2; bit
     // UNTRACKED_FIELD_ID translates to FIELD_INDEX_3, which the entry
     // does not record — so the scan should treat it as "field absent".
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
         mask_bit(&[FIELD_ID as u16]),
@@ -345,14 +379,16 @@ fn verify_mask_with_sparse_monotonic_translation_table() {
     // 5 are valid.
     let map: Vec<u16> = vec![FIELD_INDEX_1, FIELD_INDEX_2, FIELD_INDEX_3, 0, 0];
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![
-            fe(FIELD_INDEX_1, FUTURE),
-            fe(FIELD_INDEX_2, PAST),
-            fe(FIELD_INDEX_3, FUTURE)
-        ],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![
+                fe(FIELD_INDEX_1, FUTURE),
+                fe(FIELD_INDEX_2, PAST),
+                fe(FIELD_INDEX_3, FUTURE)
+            ],
+        );
+    }
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
         mask_bit(&[0, 1, 2]),
@@ -383,7 +419,7 @@ fn verify_wide_mask_high_bits_use_correct_field_index() {
     let mut map: Vec<u16> = vec![0; 128];
     map[MAPPING_BIT] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     let mask: u128 = 1u128 << MAPPING_BIT;
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -418,7 +454,7 @@ fn verify_wide_mask_returns_true_for_unknown_doc() {
 fn bucket_array_grows_lazily_from_zero() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     assert_eq!(t.n_allocated_buckets(), 0);
-    t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     // First grow seeds at TTL_BUCKET_INITIAL_CAP = 64.
     assert_eq!(t.n_allocated_buckets(), 64);
 }
@@ -429,7 +465,7 @@ fn bucket_array_grows_to_cover_requested_slot() {
     // doc_id 200 is past the initial-cap of 64, so growth must round up to
     // at least 201. Geometric step from 0 → 64 → 64+1+32 = 97; still not
     // enough for slot 200, so newcap is bumped to slot+1 = 201.
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert!(t.n_allocated_buckets() >= (DOC_ID_1 as usize + 1));
 }
 
@@ -437,7 +473,7 @@ fn bucket_array_grows_to_cover_requested_slot() {
 fn bucket_array_never_exceeds_max_size() {
     const MAX: usize = 16;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-    t.add(0, thin_vec![fe(0, FUTURE)]);
+    unsafe { t.add(0, thin_vec![fe(0, FUTURE)]) };
     // Initial cap of 64 gets clamped down to MAX.
     assert_eq!(t.n_allocated_buckets(), MAX);
 }
@@ -447,8 +483,8 @@ fn slot_collisions_are_handled_via_bucket_chains() {
     const MAX: usize = 8;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
     // doc_id 1 and doc_id 9 both land in slot 1.
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
-    t.add(DOC_ID_2, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_2, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
@@ -475,7 +511,7 @@ fn slot_collisions_are_handled_via_bucket_chains() {
 #[test]
 fn no_shrink_on_delete() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(0, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(0, FUTURE)]) };
     let cap_after_add = t.n_allocated_buckets();
     t.remove(DOC_ID_1);
     assert_eq!(t.n_allocated_buckets(), cap_after_add);
@@ -484,15 +520,17 @@ fn no_shrink_on_delete() {
 #[test]
 fn verify_wide_mask_with_bits_in_both_halves() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![
-            fe(FIELD_INDEX_1, PAST),
-            fe(FIELD_INDEX_2, PAST),
-            fe(FIELD_INDEX_3, FUTURE),
-            fe(FIELD_INDEX_4, PAST),
-        ],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![
+                fe(FIELD_INDEX_1, PAST),
+                fe(FIELD_INDEX_2, PAST),
+                fe(FIELD_INDEX_3, FUTURE),
+                fe(FIELD_INDEX_4, PAST),
+            ],
+        );
+    }
     // NB: 64 and 65 fall in the second half
     let mut map = vec![0u16; 128];
     map[0] = FIELD_INDEX_1;
@@ -524,7 +562,7 @@ fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
     // ("one of the fields need to be valid"/"expired"), an empty query
     // cannot satisfy either ⇒ both predicates return false.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -545,7 +583,7 @@ fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
 #[test]
 fn verify_wide_mask_with_empty_mask_returns_false_for_both_predicates() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -569,7 +607,7 @@ fn verify_mask_panics_when_translation_table_is_too_short() {
     let count = 5;
 
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     let map: Vec<u16> = vec![0u16; count];
     let _ = t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -586,7 +624,7 @@ fn verify_wide_mask_panics_when_translation_table_is_too_short() {
     let count = 70;
 
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     let map: Vec<u16> = vec![0u16; count];
     let _ = t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -604,17 +642,17 @@ fn add_duplicate_doc_id_panics_in_debug() {
     // Per docs: in debug builds, `add` panics if `doc_id` is already
     // present in the table.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]) };
 }
 
 #[test]
 fn add_then_remove_then_add_keeps_count_consistent() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]) };
     assert!(!t.is_empty());
 
     assert!(t.verify_doc_and_field(
@@ -650,7 +688,7 @@ fn add_then_remove_then_add_keeps_count_consistent() {
 #[test]
 fn remove_same_doc_twice_is_idempotent() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     t.remove(DOC_ID_1);
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
@@ -659,10 +697,12 @@ fn remove_same_doc_twice_is_idempotent() {
 #[test]
 fn verify_field_walks_multi_field_entry() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)],
+        );
+    }
     // Field 1: FUTURE.
     assert!(t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Default, &NOW));
     assert!(!t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Missing, &NOW));
@@ -688,16 +728,18 @@ fn verify_mask_interleaved_skip_and_match_pattern() {
     // Entry: 5 fields at indices 1, 3, 5, 7, 9.
     // Identity translation lets us mix tracked and untracked bits.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![
-            fe(1, PAST),
-            fe(3, FUTURE),
-            fe(5, PAST),
-            fe(7, FUTURE),
-            fe(9, PAST),
-        ],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![
+                fe(1, PAST),
+                fe(3, FUTURE),
+                fe(5, PAST),
+                fe(7, FUTURE),
+                fe(9, PAST),
+            ],
+        );
+    }
     let map = identity_ft_id();
 
     // Mask {1, 2, 3, 5, 7}: 5 bits, entry has 5 fields ⇒ no Default
@@ -748,7 +790,7 @@ fn field_with_zero_seconds_but_nonzero_nanos_is_not_the_never_sentinel() {
     // tv_sec == 0 but tv_nsec > 0 is a legitimate time (1ns past
     // epoch), which is in the past relative to NOW ⇒ expired.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, ts(0, 1))]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, ts(0, 1))]) };
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -771,7 +813,7 @@ fn verify_wide_mask_at_bit_64_uses_correct_field_index() {
     let mut map = vec![0u16; 128];
     map[64] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     let mask = mask_bit_u128(&[64]);
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -794,7 +836,7 @@ fn verify_wide_mask_at_bit_127_uses_correct_field_index() {
     let mut map = vec![0u16; 128];
     map[127] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     let mask = mask_bit_u128(&[127]);
     assert!(t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -815,10 +857,12 @@ fn verify_wide_mask_at_bit_127_uses_correct_field_index() {
 #[test]
 fn verify_wide_mask_default_short_circuits_when_more_bits_than_field_expirations() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     assert!(t.verify_doc_and_wide_field_mask(
@@ -833,10 +877,12 @@ fn verify_wide_mask_default_short_circuits_when_more_bits_than_field_expirations
 #[test]
 fn verify_wide_mask_default_returns_false_when_all_matched_fields_expired_and_no_extras() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
     assert!(!t.verify_doc_and_wide_field_mask(
@@ -851,10 +897,12 @@ fn verify_wide_mask_default_returns_false_when_all_matched_fields_expired_and_no
 #[test]
 fn verify_wide_mask_missing_returns_true_when_any_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
     assert!(t.verify_doc_and_wide_field_mask(
@@ -869,10 +917,12 @@ fn verify_wide_mask_missing_returns_true_when_any_matched_field_expired() {
 #[test]
 fn verify_wide_mask_missing_returns_false_when_no_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+        );
+    }
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
     assert!(!t.verify_doc_and_wide_field_mask(
@@ -890,10 +940,12 @@ fn verify_wide_mask_skips_bits_whose_field_index_is_not_tracked() {
     let mut map: Vec<u16> = (0u16..128).collect();
     map[FIELD_ID] = FIELD_INDEX_3;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+        );
+    }
     let mask = mask_bit_u128(&[FIELD_ID as u16]);
     // Untracked field ⇒ Default true, Missing false.
     assert!(t.verify_doc_and_wide_field_mask(
@@ -919,11 +971,11 @@ fn bucket_array_grows_geometrically_across_multiple_steps() {
     //   step 2: 64 → 64+1+32 = 97 (slot 64 forces a grow)
     //   step 3: 97 → 97+1+48 = 146 (slot 97 forces a grow)
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert_eq!(t.n_allocated_buckets(), 64);
-    t.add(64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert_eq!(t.n_allocated_buckets(), 97);
-    t.add(97, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(97, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert_eq!(t.n_allocated_buckets(), 146);
 }
 
@@ -933,7 +985,7 @@ fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
     // First add into slot 500: initial cap of 64 is too small, so the
     // final cap must be `slot + 1 = 501`.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(500, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(500, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert_eq!(t.n_allocated_buckets(), 501);
 }
 
@@ -941,7 +993,7 @@ fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
 fn add_at_max_size_minus_one_works() {
     const MAX: usize = 16;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-    t.add((MAX - 1) as u64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add((MAX - 1) as u64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(
         (MAX - 1) as u64,
@@ -954,11 +1006,11 @@ fn add_at_max_size_minus_one_works() {
 #[test]
 fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
-    t.add(2, thin_vec![fe(FIELD_INDEX_1, PAST)]);
-    t.add(3, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
-    t.add(4, thin_vec![fe(FIELD_INDEX_1, PAST)]);
-    t.add(5, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(2, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(3, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(4, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(5, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     // FUTURE ⇒ Default true; PAST ⇒ Default false.
     assert!(t.verify_doc_and_field(1, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
     assert!(!t.verify_doc_and_field(2, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
@@ -978,11 +1030,13 @@ fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
 #[should_panic(expected = "sorted_by_id is not sorted by index")]
 fn add_unsorted_fields_panics_in_debug() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        // Not sorted
-        thin_vec![fe(FIELD_INDEX_2, FUTURE), fe(FIELD_INDEX_1, FUTURE)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            // Not sorted
+            thin_vec![fe(FIELD_INDEX_2, FUTURE), fe(FIELD_INDEX_1, FUTURE)],
+        );
+    }
 }
 
 #[test]
@@ -991,10 +1045,12 @@ fn verify_mask_with_two_bits_translating_to_same_field_index() {
     map[0] = FIELD_INDEX_1;
     map[1] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(
-        DOC_ID_1,
-        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
-    );
+    unsafe {
+        t.add(
+            DOC_ID_1,
+            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+        );
+    }
     let mask = mask_bit(&[0, 1]);
 
     assert!(t.verify_doc_and_field_mask(
@@ -1017,7 +1073,7 @@ fn verify_mask_with_two_bits_translating_to_same_field_index() {
 #[test]
 fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -1031,7 +1087,7 @@ fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
 #[test]
 fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
     let map = identity_ft_id();
     assert!(t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -1045,7 +1101,7 @@ fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
 #[test]
 fn doc_id_zero_is_a_valid_doc_id() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
     t.remove(0);
@@ -1065,7 +1121,7 @@ fn high_density_chain_alternating_states_with_swap_last_removes() {
 
     for d in 1..=N {
         let point = if d & 1 == 1 { PAST } else { FUTURE };
-        t.add(d, thin_vec![fe(0, point)]);
+        unsafe { t.add(d, thin_vec![fe(0, point)]) };
     }
     for d in 1..=N {
         let valid = t.verify_doc_and_field(d, 0, FieldExpirationPredicate::Default, &NOW);
@@ -1094,6 +1150,10 @@ fn high_density_chain_alternating_states_with_swap_last_removes() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "Too slow to run under miri due to the huge memory allocation"
+)]
 fn production_scale_max_size_keeps_cap_proportional_to_use() {
     // With a million-bucket modulus, a sparse workload must not balloon
     // the bucket allocation, and a wrap-around docId must reuse an
@@ -1104,7 +1164,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
 
     let small_ids: [u64; 4] = [1, 5, 42, 100];
     for d in small_ids {
-        t.add(d, thin_vec![fe(0, PAST)]);
+        unsafe { t.add(d, thin_vec![fe(0, PAST)]) };
     }
     let cap_after_small = t.n_allocated_buckets();
     assert!(
@@ -1118,7 +1178,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
 
     // Reads for docIds whose slot is still unallocated report "no TTL".
     assert!(t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
-    t.add(999_999, thin_vec![fe(0, PAST)]);
+    unsafe { t.add(999_999, thin_vec![fe(0, PAST)]) };
     assert!(t.n_allocated_buckets() >= 1_000_000);
     assert!(!t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
 
@@ -1132,7 +1192,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
     // Wrap-around docId routes via modulo into an already-allocated slot,
     // so cap must NOT change.
     let cap_before_wrap = t.n_allocated_buckets();
-    t.add(MAX as u64 + 5, thin_vec![fe(0, PAST)]);
+    unsafe { t.add(MAX as u64 + 5, thin_vec![fe(0, PAST)]) };
     assert_eq!(t.n_allocated_buckets(), cap_before_wrap);
     assert!(!t.verify_doc_and_field(MAX as u64 + 5, 0, FieldExpirationPredicate::Default, &NOW,));
     // The original docId=5 entry must remain distinct from the wrap.

--- a/src/redisearch_rs/ttl_table/tests/main.rs
+++ b/src/redisearch_rs/ttl_table/tests/main.rs
@@ -1138,3 +1138,29 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
     // The original docId=5 entry must remain distinct from the wrap.
     assert!(!t.verify_doc_and_field(5, 0, FieldExpirationPredicate::Default, &NOW));
 }
+
+#[test]
+fn bitmask_iter_empty_yields_nothing() {
+    assert_eq!(BitU64Iter::new(0u64).next(), None);
+}
+
+#[test]
+fn bitmask_iter_single_bit() {
+    assert_eq!(BitU64Iter::new(1u64 << 0).collect::<Vec<_>>(), vec![0]);
+    assert_eq!(BitU64Iter::new(1u64 << 17).collect::<Vec<_>>(), vec![17]);
+    assert_eq!(BitU64Iter::new(1u64 << 63).collect::<Vec<_>>(), vec![63]);
+}
+
+#[test]
+fn bitmask_iter_multiple_bits_low_to_high() {
+    let mask: u64 = (1 << 0) | (1 << 5) | (1 << 63);
+    assert_eq!(BitU64Iter::new(mask).collect::<Vec<_>>(), vec![0, 5, 63]);
+}
+
+#[test]
+fn bitmask_iter_max_yields_all_indices() {
+    assert_eq!(
+        BitU64Iter::new(u64::MAX).collect::<Vec<_>>(),
+        (0u32..64).collect::<Vec<_>>()
+    );
+}

--- a/src/redisearch_rs/ttl_table/tests/main.rs
+++ b/src/redisearch_rs/ttl_table/tests/main.rs
@@ -1,0 +1,1140 @@
+use std::num::NonZeroUsize;
+
+use thin_vec::thin_vec;
+use ttl_table::{test_utils::*, *};
+
+#[test]
+fn new_table_doesnt_allocate() {
+    let t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    assert!(t.is_empty());
+    assert_eq!(t.n_allocated_buckets(), 0);
+}
+
+#[test]
+fn add_then_remove_leaves_table_empty() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![FieldExpiration {
+            index: FIELD_INDEX_1,
+            point: FUTURE,
+        }],
+    );
+    assert!(!t.is_empty());
+    t.remove(DOC_ID_1);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn remove_unknown_doc_is_a_noop() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.remove(DOC_ID_1);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn field_expirations_on_empty_table_is_none() {
+    let t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    assert!(t.field_expirations(DOC_ID_1).is_none());
+    // A docId beyond max_size also resolves to None without panic.
+    assert!(t.field_expirations(u64::MAX).is_none());
+}
+
+#[test]
+fn field_expirations_returns_inserted_slice() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    let inserted = thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)];
+    t.add(DOC_ID_1, inserted.clone());
+
+    let got = t.field_expirations(DOC_ID_1).expect("entry must exist");
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].index, FIELD_INDEX_1);
+    assert_eq!(got[0].point.tv_sec, FUTURE.tv_sec);
+    assert_eq!(got[0].point.tv_nsec, FUTURE.tv_nsec);
+    assert_eq!(got[1].index, FIELD_INDEX_2);
+    assert_eq!(got[1].point.tv_sec, PAST.tv_sec);
+    assert_eq!(got[1].point.tv_nsec, PAST.tv_nsec);
+
+    // A docId that was never added returns None even with other entries present.
+    assert!(t.field_expirations(DOC_ID_2).is_none());
+}
+
+#[test]
+fn field_expirations_after_remove_is_none() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert!(t.field_expirations(DOC_ID_1).is_some());
+    t.remove(DOC_ID_1);
+    assert!(t.field_expirations(DOC_ID_1).is_none());
+}
+
+#[test]
+#[should_panic(expected = "at least one field expiration")]
+fn add_with_empty_fields_panics() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(1, empty_fields());
+}
+
+#[test]
+fn field_with_zero_expiration_never_expires() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    // Field never expires
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NEVER)]);
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn field_with_past_expiration_has_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    // Expired field
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn field_with_equal_expiration_has_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NOW)]);
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn nanoseconds_break_seconds_tie() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn field_with_future_expiration_has_not_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)]);
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn verify_field_returns_true_for_unknown_doc() {
+    let t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn verify_field_absent_default_returns_true() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_2,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_2,
+        FieldExpirationPredicate::Missing,
+        &NOW
+    ));
+}
+
+#[test]
+fn verify_mask_returns_true_for_unknown_doc() {
+    let t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[0, 1, 2, 3]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[0, 1, 2, 3]),
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_default_short_circuits_when_more_bits_than_field_expirations() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+    );
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        // The bitmask is longer than the entry, so at least one is not expired (or don't have expiration date)
+        mask_bit(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_default_returns_false_when_all_matched_fields_expired_and_no_extras() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+    );
+    // Mask covers exactly the two expired fields ⇒ no field is valid.
+    let map = identity_ft_id();
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[FIELD_INDEX_1, FIELD_INDEX_2]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_missing_returns_true_when_any_matched_field_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
+    );
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[FIELD_INDEX_1, FIELD_INDEX_2]),
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_missing_returns_false_when_no_matched_field_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+    );
+    let map = identity_ft_id();
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[FIELD_INDEX_1, FIELD_INDEX_2]),
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_default_returns_true_when_at_least_one_matched_field_valid() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)],
+    );
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[FIELD_INDEX_1, FIELD_INDEX_2]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_skips_bits_whose_field_index_is_not_tracked() {
+    const FIELD_ID: usize = 1;
+
+    let mut map: Vec<u16> = (0u16..32).collect();
+    map[FIELD_ID] = FIELD_INDEX_3;
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    // The doc only tracks FIELD_INDEX_1 and FIELD_INDEX_2; bit
+    // UNTRACKED_FIELD_ID translates to FIELD_INDEX_3, which the entry
+    // does not record — so the scan should treat it as "field absent".
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+    );
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[FIELD_ID as u16]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[FIELD_ID as u16]),
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_with_sparse_monotonic_translation_table() {
+    // Bits 0,1,2 translate to fields 1,3,5; field 3 is expired while 1 and
+    // 5 are valid.
+    let map: Vec<u16> = vec![FIELD_INDEX_1, FIELD_INDEX_2, FIELD_INDEX_3, 0, 0];
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![
+            fe(FIELD_INDEX_1, FUTURE),
+            fe(FIELD_INDEX_2, PAST),
+            fe(FIELD_INDEX_3, FUTURE)
+        ],
+    );
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[0, 1, 2]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[0, 1, 2]),
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// verify_doc_and_wide_field_mask (128-bit)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verify_wide_mask_high_bits_use_correct_field_index() {
+    // Single bit at position 100 in a u128 mask. The translation table maps
+    // bit 100 to field index 7. Field 7 is expired ⇒ Default returns false,
+    // Missing returns true.
+    const MAPPING_BIT: usize = 100;
+
+    let mut map: Vec<u16> = vec![0; 128];
+    map[MAPPING_BIT] = FIELD_INDEX_1;
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    let mask: u128 = 1u128 << MAPPING_BIT;
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_returns_true_for_unknown_doc() {
+    let t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_wide_field_mask(
+        1,
+        0b1111u128,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn bucket_array_grows_lazily_from_zero() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    assert_eq!(t.n_allocated_buckets(), 0);
+    t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    // First grow seeds at TTL_BUCKET_INITIAL_CAP = 64.
+    assert_eq!(t.n_allocated_buckets(), 64);
+}
+
+#[test]
+fn bucket_array_grows_to_cover_requested_slot() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    // doc_id 200 is past the initial-cap of 64, so growth must round up to
+    // at least 201. Geometric step from 0 → 64 → 64+1+32 = 97; still not
+    // enough for slot 200, so newcap is bumped to slot+1 = 201.
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert!(t.n_allocated_buckets() >= (DOC_ID_1 as usize + 1));
+}
+
+#[test]
+fn bucket_array_never_exceeds_max_size() {
+    const MAX: usize = 16;
+    let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+    t.add(0, thin_vec![fe(0, FUTURE)]);
+    // Initial cap of 64 gets clamped down to MAX.
+    assert_eq!(t.n_allocated_buckets(), MAX);
+}
+
+#[test]
+fn slot_collisions_are_handled_via_bucket_chains() {
+    const MAX: usize = 8;
+    let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+    // doc_id 1 and doc_id 9 both land in slot 1.
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    t.add(DOC_ID_2, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    assert!(!t.is_empty());
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_2,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+    // Removing one collision-mate doesn't disturb the other.
+    t.remove(DOC_ID_1);
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_2,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW
+    ));
+}
+
+#[test]
+fn no_shrink_on_delete() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(0, FUTURE)]);
+    let cap_after_add = t.n_allocated_buckets();
+    t.remove(DOC_ID_1);
+    assert_eq!(t.n_allocated_buckets(), cap_after_add);
+}
+
+#[test]
+fn verify_wide_mask_with_bits_in_both_halves() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![
+            fe(FIELD_INDEX_1, PAST),
+            fe(FIELD_INDEX_2, PAST),
+            fe(FIELD_INDEX_3, FUTURE),
+            fe(FIELD_INDEX_4, PAST),
+        ],
+    );
+    // NB: 64 and 65 fall in the second half
+    let mut map = vec![0u16; 128];
+    map[0] = FIELD_INDEX_1;
+    map[1] = FIELD_INDEX_2;
+    map[64] = FIELD_INDEX_3;
+    map[65] = FIELD_INDEX_4;
+    let mask = mask_bit_u128(&[0, 1, 64, 65]);
+    // Default: field FIELD_INDEX_3 is FUTURE (valid) ⇒ "one of the fields valid" ⇒ true.
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    // Missing: fields FIELD_INDEX_1, FIELD_INDEX_2, FIELD_INDEX_3 are PAST ⇒ "one of the fields expired" ⇒ true.
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
+    // No fields are queried. Per the predicate definitions
+    // ("one of the fields need to be valid"/"expired"), an empty query
+    // cannot satisfy either ⇒ both predicates return false.
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    let map = identity_ft_id();
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        0u32,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        0u32,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_with_empty_mask_returns_false_for_both_predicates() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    let map = identity_ft_id();
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        0u128,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        0u128,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+#[should_panic(expected = "ft_id_to_field_index must cover the highest set bit of the mask")]
+fn verify_mask_panics_when_translation_table_is_too_short() {
+    let count = 5;
+
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    let map: Vec<u16> = vec![0u16; count];
+    let _ = t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_bit(&[count as u16]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    );
+}
+
+#[test]
+#[should_panic(expected = "ft_id_to_field_index must cover the highest set bit of the mask")]
+fn verify_wide_mask_panics_when_translation_table_is_too_short() {
+    let count = 70;
+
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    let map: Vec<u16> = vec![0u16; count];
+    let _ = t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask_bit_u128(&[count as u16]),
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    );
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "duplicate docId in TTL table")]
+fn add_duplicate_doc_id_panics_in_debug() {
+    // Per docs: in debug builds, `add` panics if `doc_id` is already
+    // present in the table.
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]);
+}
+
+#[test]
+fn add_then_remove_then_add_keeps_count_consistent() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    t.remove(DOC_ID_1);
+    assert!(t.is_empty());
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]);
+    assert!(!t.is_empty());
+
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_2,
+        FieldExpirationPredicate::Default,
+        &NOW,
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_2,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+    ));
+
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW,
+    ));
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+    ));
+
+    t.remove(DOC_ID_1);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn remove_same_doc_twice_is_idempotent() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    t.remove(DOC_ID_1);
+    t.remove(DOC_ID_1);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn verify_field_walks_multi_field_entry() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)],
+    );
+    // Field 1: FUTURE.
+    assert!(t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Missing, &NOW));
+    // Field 3: PAST.
+    assert!(!t.verify_doc_and_field(DOC_ID_1, 3, FieldExpirationPredicate::Default, &NOW));
+    assert!(t.verify_doc_and_field(DOC_ID_1, 3, FieldExpirationPredicate::Missing, &NOW));
+    // Field 5: FUTURE.
+    assert!(t.verify_doc_and_field(DOC_ID_1, 5, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(DOC_ID_1, 5, FieldExpirationPredicate::Missing, &NOW));
+    // Field 2 (gap, untracked).
+    assert!(t.verify_doc_and_field(DOC_ID_1, 2, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(DOC_ID_1, 2, FieldExpirationPredicate::Missing, &NOW));
+    // Field 4 (gap, untracked).
+    assert!(t.verify_doc_and_field(DOC_ID_1, 4, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(DOC_ID_1, 4, FieldExpirationPredicate::Missing, &NOW));
+    // Field 6 (past last entry, untracked).
+    assert!(t.verify_doc_and_field(DOC_ID_1, 6, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(DOC_ID_1, 6, FieldExpirationPredicate::Missing, &NOW));
+}
+
+#[test]
+fn verify_mask_interleaved_skip_and_match_pattern() {
+    // Entry: 5 fields at indices 1, 3, 5, 7, 9.
+    // Identity translation lets us mix tracked and untracked bits.
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![
+            fe(1, PAST),
+            fe(3, FUTURE),
+            fe(5, PAST),
+            fe(7, FUTURE),
+            fe(9, PAST),
+        ],
+    );
+    let map = identity_ft_id();
+
+    // Mask {1, 2, 3, 5, 7}: 5 bits, entry has 5 fields ⇒ no Default
+    // short-circuit. Tracked: 1 PAST, 3 FUTURE, 5 PAST, 7 FUTURE.
+    // Untracked: 2 (between entries 1 and 3) — counts as valid.
+    let mask_mixed = mask_bit(&[1, 2, 3, 5, 7]);
+    // Default: a valid field exists (2 untracked, 3 FUTURE, 7 FUTURE) ⇒ true.
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_mixed,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    // Missing: 1 and 5 are PAST ⇒ true.
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_mixed,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+
+    // Mask {1, 5, 9}: every queried field is tracked AND expired,
+    // and no extras ⇒ no field is valid.
+    let mask_all_expired_tracked = mask_bit(&[1, 5, 9]);
+    // Default: no valid field ⇒ false.
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_all_expired_tracked,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    // Missing: every queried field is expired ⇒ true.
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask_all_expired_tracked,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn field_with_zero_seconds_but_nonzero_nanos_is_not_the_never_sentinel() {
+    // Per docs: NEVER is `(tv_sec, tv_nsec) == (0, 0)`. A point with
+    // tv_sec == 0 but tv_nsec > 0 is a legitimate time (1ns past
+    // epoch), which is in the past relative to NOW ⇒ expired.
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, ts(0, 1))]);
+    assert!(!t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW,
+    ));
+    assert!(t.verify_doc_and_field(
+        DOC_ID_1,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_at_bit_64_uses_correct_field_index() {
+    // Bit 64 sits at the boundary between the two `u64` halves of the
+    // wide mask. Per docs, it must translate via `ft_id_to_field_index`
+    // exactly like any other bit.
+    let mut map = vec![0u16; 128];
+    map[64] = FIELD_INDEX_1;
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    let mask = mask_bit_u128(&[64]);
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_at_bit_127_uses_correct_field_index() {
+    let mut map = vec![0u16; 128];
+    map[127] = FIELD_INDEX_1;
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    let mask = mask_bit_u128(&[127]);
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_default_short_circuits_when_more_bits_than_field_expirations() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+    );
+    let map = identity_ft_id();
+    let mask = mask_bit_u128(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_default_returns_false_when_all_matched_fields_expired_and_no_extras() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+    );
+    let map = identity_ft_id();
+    let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_missing_returns_true_when_any_matched_field_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
+    );
+    let map = identity_ft_id();
+    let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_missing_returns_false_when_no_matched_field_expired() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+    );
+    let map = identity_ft_id();
+    let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_skips_bits_whose_field_index_is_not_tracked() {
+    const FIELD_ID: usize = 1;
+    let mut map: Vec<u16> = (0u16..128).collect();
+    map[FIELD_ID] = FIELD_INDEX_3;
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+    );
+    let mask = mask_bit_u128(&[FIELD_ID as u16]);
+    // Untracked field ⇒ Default true, Missing false.
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    assert!(!t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn bucket_array_grows_geometrically_across_multiple_steps() {
+    // Steps:
+    //   step 1: 0  → 64           (initial cap)
+    //   step 2: 64 → 64+1+32 = 97 (slot 64 forces a grow)
+    //   step 3: 97 → 97+1+48 = 146 (slot 97 forces a grow)
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert_eq!(t.n_allocated_buckets(), 64);
+    t.add(64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert_eq!(t.n_allocated_buckets(), 97);
+    t.add(97, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert_eq!(t.n_allocated_buckets(), 146);
+}
+
+#[test]
+fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
+    // Per docs: newcap is rounded up to cover the requested slot.
+    // First add into slot 500: initial cap of 64 is too small, so the
+    // final cap must be `slot + 1 = 501`.
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(500, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert_eq!(t.n_allocated_buckets(), 501);
+}
+
+#[test]
+fn add_at_max_size_minus_one_works() {
+    const MAX: usize = 16;
+    let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+    t.add((MAX - 1) as u64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert!(!t.is_empty());
+    assert!(t.verify_doc_and_field(
+        (MAX - 1) as u64,
+        FIELD_INDEX_1,
+        FieldExpirationPredicate::Default,
+        &NOW,
+    ));
+}
+
+#[test]
+fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    t.add(2, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    t.add(3, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    t.add(4, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    t.add(5, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    // FUTURE ⇒ Default true; PAST ⇒ Default false.
+    assert!(t.verify_doc_and_field(1, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(2, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
+    assert!(t.verify_doc_and_field(3, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
+    assert!(!t.verify_doc_and_field(4, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
+    assert!(t.verify_doc_and_field(5, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
+    // Mirror for Missing.
+    assert!(!t.verify_doc_and_field(1, FIELD_INDEX_1, FieldExpirationPredicate::Missing, &NOW));
+    assert!(t.verify_doc_and_field(2, FIELD_INDEX_1, FieldExpirationPredicate::Missing, &NOW));
+    assert!(!t.verify_doc_and_field(3, FIELD_INDEX_1, FieldExpirationPredicate::Missing, &NOW));
+    assert!(t.verify_doc_and_field(4, FIELD_INDEX_1, FieldExpirationPredicate::Missing, &NOW));
+    assert!(!t.verify_doc_and_field(5, FIELD_INDEX_1, FieldExpirationPredicate::Missing, &NOW));
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "sorted_by_id is not sorted by index")]
+fn add_unsorted_fields_panics_in_debug() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        // Not sorted
+        thin_vec![fe(FIELD_INDEX_2, FUTURE), fe(FIELD_INDEX_1, FUTURE)],
+    );
+}
+
+#[test]
+fn verify_mask_with_two_bits_translating_to_same_field_index() {
+    let mut map = vec![0u16; 32];
+    map[0] = FIELD_INDEX_1;
+    map[1] = FIELD_INDEX_1;
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(
+        DOC_ID_1,
+        thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+    );
+    let mask = mask_bit(&[0, 1]);
+
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+    // No expired field ⇒ Missing false.
+    assert!(!t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        mask,
+        FieldExpirationPredicate::Missing,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_field_mask(
+        DOC_ID_1,
+        u32::MAX,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]);
+    let map = identity_ft_id();
+    assert!(t.verify_doc_and_wide_field_mask(
+        DOC_ID_1,
+        u128::MAX,
+        FieldExpirationPredicate::Default,
+        &NOW,
+        &map,
+    ));
+}
+
+#[test]
+fn doc_id_zero_is_a_valid_doc_id() {
+    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
+    t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]);
+    assert!(!t.is_empty());
+    assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
+    t.remove(0);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn high_density_chain_alternating_states_with_swap_last_removes() {
+    // Load factor ≈ 4 forces multiple entries per slot. Alternating PAST /
+    // FUTURE proves the chain walk returns the right entry, and removing
+    // every third docId exercises swap-last from arbitrary chain positions
+    // repeatedly — a regression catcher for swap-last bugs that single-3
+    // collider tests can't reach.
+    const MAX: usize = 32;
+    const N: u64 = (MAX as u64) * 4;
+    let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+
+    for d in 1..=N {
+        let point = if d & 1 == 1 { PAST } else { FUTURE };
+        t.add(d, thin_vec![fe(0, point)]);
+    }
+    for d in 1..=N {
+        let valid = t.verify_doc_and_field(d, 0, FieldExpirationPredicate::Default, &NOW);
+        assert_eq!(valid, d & 1 == 0, "docId={d}");
+    }
+
+    for d in (3..=N).step_by(3) {
+        t.remove(d);
+    }
+    for d in 1..=N {
+        let valid = t.verify_doc_and_field(d, 0, FieldExpirationPredicate::Default, &NOW);
+        if d % 3 == 0 {
+            // Removed entries are absent ⇒ Default returns true.
+            assert!(valid, "docId={d}");
+        } else {
+            assert_eq!(valid, d & 1 == 0, "docId={d}");
+        }
+    }
+
+    for d in 1..=N {
+        if d % 3 != 0 {
+            t.remove(d);
+        }
+    }
+    assert!(t.is_empty());
+}
+
+#[test]
+fn production_scale_max_size_keeps_cap_proportional_to_use() {
+    // With a million-bucket modulus, a sparse workload must not balloon
+    // the bucket allocation, and a wrap-around docId must reuse an
+    // already-allocated slot without further growth.
+    const MAX: usize = 1_000_000;
+    let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
+    assert_eq!(t.n_allocated_buckets(), 0);
+
+    let small_ids: [u64; 4] = [1, 5, 42, 100];
+    for d in small_ids {
+        t.add(d, thin_vec![fe(0, PAST)]);
+    }
+    let cap_after_small = t.n_allocated_buckets();
+    assert!(
+        cap_after_small >= 101,
+        "cap must cover slot 100, got {cap_after_small}"
+    );
+    assert!(
+        cap_after_small < MAX / 10,
+        "cap must stay far below max_size, got {cap_after_small}"
+    );
+
+    // Reads for docIds whose slot is still unallocated report "no TTL".
+    assert!(t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
+    t.add(999_999, thin_vec![fe(0, PAST)]);
+    assert!(t.n_allocated_buckets() >= 1_000_000);
+    assert!(!t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
+
+    for d in small_ids {
+        assert!(
+            !t.verify_doc_and_field(d, 0, FieldExpirationPredicate::Default, &NOW),
+            "docId={d}"
+        );
+    }
+
+    // Wrap-around docId routes via modulo into an already-allocated slot,
+    // so cap must NOT change.
+    let cap_before_wrap = t.n_allocated_buckets();
+    t.add(MAX as u64 + 5, thin_vec![fe(0, PAST)]);
+    assert_eq!(t.n_allocated_buckets(), cap_before_wrap);
+    assert!(!t.verify_doc_and_field(MAX as u64 + 5, 0, FieldExpirationPredicate::Default, &NOW,));
+    // The original docId=5 entry must remain distinct from the wrap.
+    assert!(!t.verify_doc_and_field(5, 0, FieldExpirationPredicate::Default, &NOW));
+}

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -589,7 +589,6 @@ def testLastFieldNoExpiration(env):
     # this should lead to the line being hit
     env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT').apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
 
-
 def testDocWithLongExpiration(env):
     # We want to cover this snippet of code:
     # if (ttlEntry->fieldExpirations == NULL || array_len(ttlEntry->fieldExpirations) == 0) {


### PR DESCRIPTION
## Describe the changes in the pull request

Initial porting of TTL Table in Rust.
*Don't*:
- micro benchmarks
- introduce ffi
- replace the C implementation
- remove the C implementation

NB: Sonar fails because it doesn't recognize the Rust workspace, so it expects to have the Cargo.lock committed for each workspace member.

#### Main objects this PR modified
1. TTL Table

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Rust TTL table implementation with `unsafe` insertion preconditions and extensive bitmask/expiration logic; while not wired into production paths yet, it expands the workspace/build surface and could introduce correctness or compilation/test issues.
> 
> **Overview**
> Introduces a new Rust workspace crate, `ttl_table`, implementing a per-(document, field) TTL table with lazy-growing direct-modulo buckets, collision chains, and helpers to verify expirations for single fields and 32-bit/128-bit field masks.
> 
> Adds comprehensive unit/integration tests for bucket growth, collision handling, mask iteration, and predicate semantics, updates the Rust workspace (`Cargo.toml`/`Cargo.lock`) to include the new crate, and makes a tiny formatting-only tweak in `tests/pytests/test_expire.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac790de71b14bb404d725af52ceb88b9929575ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->