### PR TITLE
[MOD-15118] Use clear error message on DEBUG_PARAMS_COUNT == 0

### DIFF
--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "aggregate_debug.h"
+#include "debug_commands.h"
 #include "module.h"
 #include "result_processor.h"
 
@@ -20,7 +21,7 @@
 
 AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status) {
 
-  AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, status);
+  AREQ_Debug_params debug_params = parseAggregateDebugParamsCount(argv, argc, status);
   if (debug_params.debug_params_count == 0) {
     return NULL;
   }
@@ -233,21 +234,12 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
   return REDISMODULE_OK;
 }
 
-AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
+AREQ_Debug_params parseAggregateDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
   AREQ_Debug_params debug_params = {0};
-  // Verify DEBUG_PARAMS_COUNT exists in its expected position
-  size_t n;
-  const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
-  if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
-    return debug_params;
-  }
 
-  unsigned long long debug_params_count;
-  // The count of debug params is the last argument in argv
-  if (RedisModule_StringToULongLong(argv[argc - 1], &debug_params_count) != REDISMODULE_OK) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid DEBUG_PARAMS_COUNT count");
-    return debug_params;
+  unsigned long long debug_params_count = 0;
+  if (parseDebugParamsCount(argv, argc, status, &debug_params_count) != 0) {
+      return debug_params;
   }
 
   debug_params.debug_params_count = debug_params_count;

--- a/src/aggregate/aggregate_debug.h
+++ b/src/aggregate/aggregate_debug.h
@@ -267,7 +267,7 @@ typedef struct {
 // Will hold AREQ by value, so we can use AREQ_Debug->r in all functions
 // expecting AREQ, including AREQ_Free
 AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status);
-AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
+AREQ_Debug_params parseAggregateDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
 int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status);
 
 // Debug command to wrap single shard FT.AGGREGATE

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2237,6 +2237,38 @@ DEBUG_COMMAND(getIsRPPaused) {
   return RedisModule_ReplyWithLongLong(ctx, QueryDebugCtx_IsPaused());
 }
 
+
+int parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status, unsigned long long *debug_params_count) {
+    // Verify DEBUG_PARAMS_COUNT exists in its expected position (second to last argument)
+    if (argc < 2) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing");
+      return 1;
+    }
+
+    size_t n;
+    const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
+    if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
+      return 1;
+    }
+
+    // The count of debug params is the last argument in argv
+    unsigned long long count = 0;
+    if (RedisModule_StringToULongLong(argv[argc - 1], &count) != REDISMODULE_OK || count == 0) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid DEBUG_PARAMS_COUNT count");
+      return 1;
+    }
+
+    if (count > (unsigned long long)(argc - 2)) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                          "DEBUG_PARAMS_COUNT exceeds the number of available arguments");
+      return 1;
+    }
+
+    *debug_params_count = count;
+    return 0;
+}
+
 #ifdef ENABLE_ASSERT
 /**
  * FT.DEBUG QUERY_CONTROLLER SET_PAUSE_BEFORE_REDUCE <N>

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -59,6 +59,7 @@ void QueryDebugCtx_SetPause(bool pause);
 ResultProcessor* QueryDebugCtx_GetDebugRP(void);
 void QueryDebugCtx_SetDebugRP(ResultProcessor* debugRP);
 bool QueryDebugCtx_HasDebugRP(void);
+int parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status, unsigned long long *debug_params_count);
 
 #ifdef ENABLE_ASSERT
 // Named sentinel values for the pauseBeforeN field of CoordReduceDebugCtx

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -8,6 +8,7 @@
  */
 
 #include "hybrid_debug.h"
+#include "debug_commands.h"
 #include "config.h"
 #include "hybrid_exec.h"
 #include "hybrid_request.h"
@@ -26,30 +27,9 @@ typedef struct {
 HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
   HybridDebugParams debug_params = {0};
 
-  // Verify DEBUG_PARAMS_COUNT exists in its expected position (second to last argument)
-  if (argc < 2) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing");
-    return debug_params;
-  }
-
-  size_t n;
-  const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
-  if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
-    return debug_params;
-  }
-
-  unsigned long long debug_params_count;
-  // The count of debug params is the last argument in argv
-  if (RedisModule_StringToULongLong(argv[argc - 1], &debug_params_count) != REDISMODULE_OK) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid DEBUG_PARAMS_COUNT count");
-    return debug_params;
-  }
-
-  if (debug_params_count > (unsigned long long)(argc - 2)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
-                        "DEBUG_PARAMS_COUNT exceeds the number of available arguments");
-    return debug_params;
+  unsigned long long debug_params_count = 0;
+  if (parseDebugParamsCount(argv, argc, status, &debug_params_count) != 0) {
+      return debug_params;
   }
 
   debug_params.debug_params_count = debug_params_count;

--- a/src/module.c
+++ b/src/module.c
@@ -4493,7 +4493,7 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // and must be excluded from the search query parsing to avoid false keyword matches.
   int parse_argc = argc;
   if (isDebug) {
-    AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
+    AREQ_Debug_params debug_params = parseAggregateDebugParamsCount(argv, argc, &status);
     if (QueryError_HasError(&status)) {
       QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
       return QueryError_ReplyAndClear(ctx, &status);
@@ -4935,7 +4935,7 @@ static int DEBUG_FlatSearchCommandHandler(struct MRCtx *mrctx, RedisModuleBlocke
   req->coordQueueTime = handlerCtx->coordQueueTime;
 
   // Parse debug params to extract the debug argument count
-  AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
+  AREQ_Debug_params debug_params = parseAggregateDebugParamsCount(argv, argc, &status);
 
   if (QueryError_HasError(&status)) {
     RS_ASSERT(debug_params.debug_params_count == 0);

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -123,8 +123,7 @@ def test_hybrid_debug_no_component_timeout_sa():
 def test_hybrid_debug_no_component_timeout_cluster():
     """Test error when no component timeout parameter is specified (cluster).
 
-    DEBUG_PARAMS_COUNT of 0 is now rejected by the shared parseDebugParamsCount
-    validator before reaching the hybrid-specific parseHybridDebugParams.
+    DEBUG_PARAMS_COUNT of 0 is now rejected.
     """
     env = Env(enableDebugCommand=True)
     setup_basic_index(env)

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -116,20 +116,21 @@ def test_hybrid_debug_no_component_timeout_sa():
     """
     env = Env(enableDebugCommand=True)
     setup_basic_index(env)
-    env.expect(*_base_hybrid_debug_cmd(), 'DEBUG_PARAMS_COUNT', '0').error()
+    env.expect(*_base_hybrid_debug_cmd(), 'DEBUG_PARAMS_COUNT', '0').error().contains('Invalid DEBUG_PARAMS_COUNT count')
+
 
 @skip(cluster=False)
 def test_hybrid_debug_no_component_timeout_cluster():
     """Test error when no component timeout parameter is specified (cluster).
 
-    In cluster mode, RSShardedHybridCommand_Debug calls parseHybridDebugParams
-    which validates that at least one component timeout is present.
+    DEBUG_PARAMS_COUNT of 0 is now rejected by the shared parseDebugParamsCount
+    validator before reaching the hybrid-specific parseHybridDebugParams.
     """
     env = Env(enableDebugCommand=True)
     setup_basic_index(env)
     env.expect(*_base_hybrid_debug_cmd(),
                'DEBUG_PARAMS_COUNT', '0') \
-        .error().contains('At least one component timeout parameter')
+        .error().contains('Invalid DEBUG_PARAMS_COUNT count')
 
 def test_hybrid_debug_invalid_timeout_values():
     """Test error when timeout count values are invalid."""

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -52,3 +52,25 @@ def TestLimitWithCursor():
         total_res += len(res["results"])
     # before the bug fix we got total_res = limit - cursor_reads
     env.assertEqual(total_res, num_docs, message="unexpected results count")
+
+
+def test_search_debug_zero_params_count():
+    """Test that DEBUG_PARAMS_COUNT 0 returns an error for FT.SEARCH.
+    Include a dummy debug param so we pass the arity check (argc >= 7).
+    """
+    env = Env(enableDebugCommand=True)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    env.expect(debug_cmd(), 'FT.SEARCH', 'idx', '*',
+               'TIMEOUT_AFTER_N', '100',
+               'DEBUG_PARAMS_COUNT', '0').error().contains('Invalid DEBUG_PARAMS_COUNT count')
+
+
+def test_aggregate_debug_zero_params_count():
+    """Test that DEBUG_PARAMS_COUNT 0 returns an error for FT.AGGREGATE.
+    Include a dummy debug param so we pass the arity check (argc >= 7).
+    """
+    env = Env(enableDebugCommand=True)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    env.expect(debug_cmd(), 'FT.AGGREGATE', 'idx', '*',
+               'TIMEOUT_AFTER_N', '100',
+               'DEBUG_PARAMS_COUNT', '0').error().contains('Invalid DEBUG_PARAMS_COUNT count')


### PR DESCRIPTION
Before this change, the error message used to be `Success (no error)`. This change also pulls out the logic for parsing `DEBUG_PARAMS_COUNT` in a separate function.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to debug-command argument parsing and associated tests, with minimal impact on normal query execution paths.
> 
> **Overview**
> Debug command parsing now **fails fast with a clear error** when `DEBUG_PARAMS_COUNT` is `0` (or otherwise invalid), instead of silently treating it as “no debug params” and producing confusing status.
> 
> The `DEBUG_PARAMS_COUNT` validation logic was **factored into a shared helper** `parseDebugParamsCount` (in `debug_commands`), and both aggregate (`parseAggregateDebugParamsCount`) and hybrid debug parsing were updated to use it; distributed search/aggregate debug paths in `module.c` were updated to call the renamed aggregate helper. Tests were updated and expanded to assert the new error behavior for `FT.SEARCH`, `FT.AGGREGATE`, and hybrid debug commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a567cf5059d60e9024cb5e39f32ce9aa1a216b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->