### PR TITLE
[MOD-15384] add test showing issue with assertion

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1897,3 +1897,60 @@ def test_mod_14112(env: Env):
   )
   # Verify that `FT.SEARCH` queries return an error (not crash)
   env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')
+
+@skip(cluster=True)
+def test_filter_cursor_no_assert(env):
+    """
+    Regression for the assertion failure at
+    src/aggregate/expr/expression.c:509 ('rp->parent->totalResults > 0').
+
+    Pipeline shape that triggers the bug:
+        ... -> SORTBY (caches results in a heap) -> FILTER -> LIMIT pager
+    served via FT.AGGREGATE WITHCURSOR.
+
+    On the first cursor read the sorter accumulates all upstream results,
+    which increments qctx->totalResults via RPQueryIterator. After the
+    first batch is sent, finishSendChunk resets qctx->totalResults to 0.
+    On subsequent cursor reads the sorter yields cached rows from its
+    heap without re-incrementing the counter; if the FILTER then rejects
+    one of those cached rows it tries to decrement totalResults from 0
+    and the assertion fires (introduced in PR #6880 / MOD-11416).
+    """
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'n', 'NUMERIC', 'SORTABLE').ok()
+
+    # Six docs with deterministic numeric values.
+    for i in range(1, 7):
+        conn.execute_command('HSET', f'doc{i}', 'n', str(i))
+
+    # SORTBY ASC orders cached results as 1,2,3,4,5,6.
+    # FILTER keeps n<4, so only 1,2,3 pass; 4,5,6 are rejected.
+    # WITHCURSOR COUNT 2 forces multiple cursor reads:
+    #   batch 1 -> rows for n=1, n=2 (no rejections yet)
+    #   batch 2 -> row for n=3, then n=4 is rejected -> decrement on 0.
+    res, cursor = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'LOAD', '1', '@n',
+        'SORTBY', '2', '@n', 'ASC',
+        'FILTER', '@n<4',
+        'WITHCURSOR', 'COUNT', '2')
+    env.assertNotEqual(cursor, 0)
+    # First batch: n=1 and n=2.
+    env.assertEqual(res[1:], [['n', '1'], ['n', '2']])
+
+    # Drain the cursor. Without the fix the second read crashes the
+    # server with the totalResults assertion. Bound the loop so a buggy
+    # build that returns spurious data cannot make the test hang.
+    rows = list(res[1:])
+    for _ in range(10):
+        if cursor == 0:
+            break
+        res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        rows.extend(res[1:])
+    env.assertEqual(cursor, 0,
+                    message='cursor was not drained within the bounded reads')
+
+    # Exactly the rows that pass the filter, in sort order.
+    env.assertEqual(rows, [['n', '1'], ['n', '2'], ['n', '3']])


### PR DESCRIPTION
## Issue this PR adds a regression test for

This PR adds a **failing regression test** for an assertion crash in `rpevalNext_filter` that is reproducible on the current `master`.

### 1. Current

`FT.AGGREGATE ... SORTBY ... FILTER ... WITHCURSOR` crashes the server on the second `FT.CURSOR READ` with:

```
# Assertion failed: rp->parent->totalResults > 0
# ==> src/aggregate/expr/expression.c:509 'rp->parent->totalResults > 0' is not true
   ...
   9: rpevalNext_filter
        at src/aggregate/expr/expression.c:509
  10: rppagerNext_Limit
  11: sendChunk_Resp2
  12: sendChunk
  13: runCursor
  14: cursorRead
  15: RSCursorReadCommand
```

### 2. Root cause

`qctx->totalResults` is meant to be balanced:
- **Incremented** in `RPQueryIterator` (`src/result_processor.c:174`) for each row it yields.
- **Decremented** in `rpevalNext_filter` (`src/aggregate/expr/expression.c:509-510`) for each row dropped by the `FILTER` step.

For cursored aggregates with a caching upstream (`SORTBY` / `GROUPBY`) and a downstream `FILTER`, the invariant breaks:

1. `RPSorter` accumulates everything into a heap on the first cursor batch (`rpsortNext_Accum`); all `totalResults++` happen during that batch.
2. `finishSendChunk` (`src/aggregate/aggregate_exec.c:389`) resets `qctx->totalResults = 0` between cursor batches.
3. On subsequent batches, the sorter yields cached rows via `rpsortNext_Yield` without re-entering `RPQueryIterator`, so the counter is **not** re-incremented.
4. If `FILTER` rejects one of those cached rows, it tries to decrement `totalResults` while it is `0` → the assertion fires (without it the `uint32_t` would silently underflow).

### 3. Relation to previous PR

The decrement and the assertion that crashes here were both introduced in:
- PR #6880 / MOD-11416 — *Fix `total_result` Accuracy When Using FILTER*
- Commit `021d5d9417a605c2f24d35ecb0966a5b5d7a4c9e`

```diff
+    // Reduce the total number of results
+    RS_ASSERT(rp->parent->totalResults > 0);
+    rp->parent->totalResults--;
     SearchResult_Clear(r);
```

That PR correctly addressed the single-pipeline-run / hybrid case but did not consider the cursored aggregate case where the counter is reset between batches while a caching upstream keeps producing rows the `FILTER` may still reject.

### 4. What this PR adds

A single, deterministic regression test in `tests/pytests/test_issues.py`:

- 6 documents with `n=1..6`.
- `FT.AGGREGATE ... SORTBY @n ASC FILTER @n<4 WITHCURSOR COUNT 2`.
- Batch 1 yields `n=1, n=2` (no rejections, `totalResults` is then reset to 0).
- Batch 2 yields `n=3`, then encounters `n=4` (rejected) → `totalResults--` from `0` → assertion fires.
- The test is bounded (max 10 reads) so a buggy build cannot hang it.
- `@skip(cluster=True)` keeps the per-shard caching shape deterministic.

### 5. Outcome

- **Today**: the test fails — the server crashes with the assertion above, reproducing a real crash seen under stress (`FT.AGGREGATE`+`CURSOR` workload).
- **After the fix** (separate PR): the test should pass without changes, asserting the cursor returns exactly `[['n','1'], ['n','2'], ['n','3']]` across batches.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
