### PR TITLE
MOD-13177 Add support for RERANK attribute in vector queries and update tests

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -2242,7 +2242,8 @@ static int QueryVectorNode_ApplyAttribute(VectorQuery *vq, QueryAttribute *attr,
   } else if (STR_EQCASE(attr->name, attr->namelen, VECSIM_EFRUNTIME) ||
              STR_EQCASE(attr->name, attr->namelen, VECSIM_EPSILON) ||
              STR_EQCASE(attr->name, attr->namelen, VECSIM_HYBRID_POLICY) ||
-             STR_EQCASE(attr->name, attr->namelen, VECSIM_BATCH_SIZE)) {
+             STR_EQCASE(attr->name, attr->namelen, VECSIM_BATCH_SIZE) ||
+             STR_EQCASE(attr->name, attr->namelen, VECSIM_RERANK)) {
     // Move ownership on the value string, so it won't get freed when releasing the QueryAttribute.
     // The name string was not copied by the parser (unlike the value) - so we copy and save it.
     VecSimRawParam param = (VecSimRawParam){ .name = rm_strndup(attr->name, attr->namelen),

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -690,6 +690,14 @@ def test_search_errors():
     env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b EF_FUNTIME 30]', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('SEARCH_OPTION_INVALID Invalid option (Error parsing vector similarity parameters)')
     env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]=>{$EF_RUNTIME: 5; $EF_RUNTIME: 6;}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('SEARCH_PARAM_DUP Parameter was specified twice (Error parsing vector similarity parameters)')
 
+    # RERANK is valid only for disk-based HNSW indexes; on a non-disk HNSW index VecSim
+    # rejects it as an unknown parameter, regardless of whether it was provided via the
+    # inline KNN syntax or via the trailing query-attribute syntax.
+    env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b RERANK TRUE]', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('SEARCH_OPTION_INVALID Invalid option (Error parsing vector similarity parameters)')
+    env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]=>{$RERANK: TRUE;}', 'PARAMS', '2', 'b', 'abcdefgh').error().contains('SEARCH_OPTION_INVALID Invalid option (Error parsing vector similarity parameters)')
+    # RERANK is also unknown on FLAT indexes.
+    env.expect('FT.SEARCH', 'idx', f'*=>[KNN 2 @{v_flat} $b]=>{{$RERANK: TRUE;}}', 'PARAMS', '2', 'b', 'abcdefghabcdefgh').error().contains('SEARCH_OPTION_INVALID Invalid option (Error parsing vector similarity parameters)')
+
     # ef_runtime is invalid for FLAT index.
     env.expect('FT.SEARCH', 'idx', f'*=>[KNN 2 @{v_flat} $b EF_RUNTIME 30]', 'PARAMS', '2', 'b', 'abcdefghabcdefgh').error().contains('SEARCH_OPTION_INVALID Invalid option (Error parsing vector similarity parameters)')
 


### PR DESCRIPTION

## Describe the changes in the pull request

a RERANK as a query param for vector queries

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to vector-query attribute parsing plus new negative tests; behavior is gated by VecSim validation and should only affect queries that specify `RERANK`.
> 
> **Overview**
> Adds support for passing `RERANK` via the trailing query-attribute syntax (`=>{$RERANK: ...;}`) by treating it like other VecSim raw params and forwarding it to VecSim for validation.
> 
> Extends `test_search_errors` to assert consistent error handling when `RERANK` is supplied on unsupported index types (non-disk HNSW and FLAT), both inline and via query attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb64c850d4bbc5a4a3fba7c69e731b6e0b3dc845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->