### PR TITLE
[MOD-14203] Implement Filtered Batch Intersection Engine

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -346,8 +346,7 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
 /// Intersect one score-ordered batch with a child filter iterator,
 /// pushing matches into `heap`.
 ///
-/// Uses a merge-join (alternating `skip_to` calls) to find matching doc IDs
-/// in O((n + m) log k) time where n = batch size, m = child size, k = heap capacity.
+/// Uses a merge-join (alternating `skip_to` calls) to find matching doc IDs.
 ///
 /// The child is **rewound** at the start of each call.
 fn intersect_batch_with_child<'index>(

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -189,17 +189,6 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             {
                 CollectionStrategy::Continue => continue,
                 CollectionStrategy::Stop => break,
-                CollectionStrategy::SwitchToBatches => {
-                    // Clear the heap: the source restarts with new parameters
-                    // (e.g. expanded numeric range) and will re-emit previously
-                    // collected docs. Keeping stale entries would cause duplicates.
-                    self.heap = TopKHeap::new(self.k, self.compare);
-                    self.source.rewind();
-                    if let Some(child) = &mut self.child {
-                        child.rewind();
-                    }
-                    continue;
-                }
             }
         }
         self.finalize_collection();

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -9,7 +9,7 @@
 
 //! [`TopKIterator`] — the generic top-k state machine.
 
-use std::num::NonZeroUsize;
+use std::{cmp::Ordering, num::NonZeroUsize};
 
 use ffi::t_docId;
 use index_result::RSIndexResult;
@@ -17,7 +17,10 @@ use index_spec::IndexSpecReadGuard;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
-use crate::traits::{ScoreBatch, ScoreSource};
+use crate::{
+    heap::{ScoredResult, TopKHeap},
+    traits::{CollectionStrategy, ScoreBatch, ScoreSource},
+};
 
 /// Determines which collection algorithm [`TopKIterator`] uses.
 ///
@@ -37,6 +40,9 @@ pub enum TopKMode {
     /// Any additional batches are not consumed and their results are silently
     /// lost.  In debug builds, [`TopKIterator`] asserts this invariant.
     Unfiltered,
+    /// Fetch score-ordered batches from the source and intersect each one
+    /// with the child filter iterator.
+    Batches,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,10 +53,6 @@ enum Phase {
     /// Actively collecting results (transient; only visible inside collection methods).
     Collecting,
     /// Collection is done; yielding results from `results` in order.
-    #[expect(
-        dead_code,
-        reason = "TopKMode::Unfiltered is without child so no yielding necessary"
-    )]
     Yielding,
     /// Unfiltered path: yielding directly from `direct_batch` without a heap.
     YieldingDirect,
@@ -58,17 +60,23 @@ enum Phase {
 
 /// A generic top-k iterator parameterized over a [`ScoreSource`].
 ///
-/// Implements [`Unfiltered`](TopKMode::Unfiltered).
+/// Implements the two execution modes described in the design doc:
+/// [`Unfiltered`](TopKMode::Unfiltered) and [`Batches`](TopKMode::Batches).
 pub struct TopKIterator<'index, S: ScoreSource> {
     source: S,
     child: Option<Box<dyn RQEIterator<'index> + 'index>>,
     mode: TopKMode,
     /// Preserved so [`rewind`](Self::rewind) can restore the original mode.
     initial_mode: TopKMode,
+    heap: TopKHeap,
     /// Holds the in-progress batch for the Unfiltered path.
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
+    compare: fn(f64, f64) -> Ordering,
     phase: Phase,
+    /// Heap contents drained into score order for yielding.
+    results: Vec<ScoredResult>,
+    yield_pos: usize,
     current: Option<RSIndexResult<'index>>,
     last_doc_id: t_docId,
     at_eof: bool,
@@ -77,16 +85,23 @@ pub struct TopKIterator<'index, S: ScoreSource> {
 impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// Create a new [`TopKIterator`].
     ///
-    /// The execution mode is always Unfiltered.
+    /// The execution mode is inferred from `child`:
+    /// - `None` → [`TopKMode::Unfiltered`]
+    /// - `Some(_)` → [`TopKMode::Batches`]
     ///
-    /// For now, only [`TopKMode::Unfiltered`] exists.
+    /// Use [`new_with_mode`](Self::new_with_mode) to override the initial mode.
     pub fn new(
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
     ) -> Self {
-        let mode = TopKMode::Unfiltered;
-        Self::new_with_mode(source, child, k, mode)
+        let mode = if child.is_some() {
+            TopKMode::Batches
+        } else {
+            TopKMode::Unfiltered
+        };
+        Self::new_with_mode(source, child, k, compare, mode)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
@@ -94,16 +109,21 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
         mode: TopKMode,
     ) -> Self {
         Self {
+            heap: TopKHeap::new(k, compare),
             source,
             child,
             mode,
             initial_mode: mode,
             direct_batch: None,
             k,
+            compare,
             phase: Phase::NotStarted,
+            results: Vec::new(),
+            yield_pos: 0,
             current: None,
             last_doc_id: 0,
             at_eof: false,
@@ -115,6 +135,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         self.phase = Phase::Collecting;
         let result = match self.mode {
             TopKMode::Unfiltered => self.prepare_unfiltered_direct(),
+            TopKMode::Batches => self.collect_batches(),
         };
         if result.is_err() {
             // Reset so a retry via read() works: Phase::Collecting has no handler there.
@@ -149,6 +170,52 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         Ok(())
     }
 
+    /// Collect results by intersecting score-ordered batches with the child filter.
+    fn collect_batches(&mut self) -> Result<(), RQEIteratorError> {
+        loop {
+            let Some(mut batch) = self.source.next_batch()? else {
+                break;
+            };
+
+            // Borrow-checker split: we can't hold `&mut self.child` and call
+            // `self.heap.push` at the same time.  Pass fields explicitly.
+            if let Some(child) = &mut self.child {
+                intersect_batch_with_child(child, &mut batch, &mut self.heap)?;
+            }
+
+            match self
+                .source
+                .collection_strategy(self.heap.len(), self.k.get())
+            {
+                CollectionStrategy::Continue => continue,
+                CollectionStrategy::Stop => break,
+                CollectionStrategy::SwitchToBatches => {
+                    // Clear the heap: the source restarts with new parameters
+                    // (e.g. expanded numeric range) and will re-emit previously
+                    // collected docs. Keeping stale entries would cause duplicates.
+                    self.heap = TopKHeap::new(self.k, self.compare);
+                    self.source.rewind();
+                    if let Some(child) = &mut self.child {
+                        child.rewind();
+                    }
+                    continue;
+                }
+            }
+        }
+        self.finalize_collection();
+        Ok(())
+    }
+
+    /// Drain the heap into `self.results` in best-first order and transition to
+    /// the [`Yielding`](Phase::Yielding) phase.
+    fn finalize_collection(&mut self) {
+        // Replace heap with a fresh one; drain_sorted consumes the old one.
+        let old_heap = std::mem::replace(&mut self.heap, TopKHeap::new(self.k, self.compare));
+        self.results = old_heap.drain_sorted();
+        self.yield_pos = 0;
+        self.phase = Phase::Yielding;
+    }
+
     /// Yield the next result from the unfiltered direct batch.
     fn advance_unfiltered_direct(
         &mut self,
@@ -168,6 +235,22 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
                 Ok(None)
             }
         }
+    }
+
+    /// Yield the next result from the pre-sorted `results` vec.
+    fn advance_from_results(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if self.yield_pos >= self.results.len() {
+            self.at_eof = true;
+            return Ok(None);
+        }
+        let ScoredResult { doc_id, score } = self.results[self.yield_pos];
+        self.yield_pos += 1;
+        let result = self.source.build_result(doc_id, score);
+        self.current = Some(result);
+        self.last_doc_id = doc_id;
+        Ok(self.current.as_mut())
     }
 }
 
@@ -189,9 +272,7 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
 
         match self.phase {
             Phase::YieldingDirect => self.advance_unfiltered_direct(),
-            Phase::Yielding => {
-                unreachable!("`Phase::Yielding` is dead code (planned for batches - MOD-14203).")
-            }
+            Phase::Yielding => self.advance_from_results(),
             Phase::NotStarted | Phase::Collecting => {
                 unreachable!("collect() must set phase to YieldingDirect or Yielding")
             }
@@ -226,7 +307,10 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
             child.rewind();
         }
         self.mode = self.initial_mode;
+        self.heap = TopKHeap::new(self.k, self.compare);
         self.direct_batch = None;
+        self.results.clear();
+        self.yield_pos = 0;
         self.current = None;
         self.last_doc_id = 0;
         self.at_eof = false;
@@ -257,4 +341,68 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
     fn intersection_sort_weight(&self, _: bool) -> f64 {
         1.0
     }
+}
+
+/// Intersect one score-ordered batch with a child filter iterator,
+/// pushing matches into `heap`.
+///
+/// Uses a merge-join (alternating `skip_to` calls) to find matching doc IDs
+/// in O((n + m) log k) time where n = batch size, m = child size, k = heap capacity.
+///
+/// The child is **rewound** at the start of each call.
+fn intersect_batch_with_child<'index>(
+    child: &mut Box<dyn RQEIterator<'index> + 'index>,
+    batch: &mut impl ScoreBatch,
+    heap: &mut TopKHeap,
+) -> Result<(), RQEIteratorError> {
+    child.rewind();
+
+    // Prime both cursors.
+    let Some((mut batch_doc, mut batch_score)) = batch.next() else {
+        return Ok(());
+    };
+    let Some(first) = child.read()? else {
+        return Ok(());
+    };
+    let mut child_doc = first.doc_id;
+
+    loop {
+        match batch_doc.cmp(&child_doc) {
+            Ordering::Equal => {
+                heap.push(batch_doc, batch_score);
+                // Advance both cursors.
+                match batch.next() {
+                    Some((d, s)) => {
+                        batch_doc = d;
+                        batch_score = s;
+                    }
+                    None => break,
+                }
+                match child.read()? {
+                    Some(r) => child_doc = r.doc_id,
+                    None => break,
+                }
+            }
+            Ordering::Less => {
+                // batch is behind child — skip batch forward to child_doc.
+                match batch.skip_to(child_doc) {
+                    Some((d, s)) => {
+                        batch_doc = d;
+                        batch_score = s;
+                    }
+                    None => break,
+                }
+            }
+            Ordering::Greater => {
+                // child is behind batch — skip child forward to batch_doc.
+                match child.skip_to(batch_doc)? {
+                    Some(SkipToOutcome::Found(r) | SkipToOutcome::NotFound(r)) => {
+                        child_doc = r.doc_id;
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -13,11 +13,10 @@
 //! # Architecture
 //!
 //! The core abstraction is [`TopKIterator<S>`], a state machine that drives
-//! top-k collection in three modes:
+//! top-k collection in the following modes:
 //!
 //! - **Unfiltered** — no child filter; stream results directly from the source's batch.
 //! - **Batches** — intersect score-ordered batches with a child filter (merge-join).
-//!   for each document.
 //!
 //! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
 //! traits.

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -16,9 +16,12 @@
 //! top-k collection in three modes:
 //!
 //! - **Unfiltered** — no child filter; stream results directly from the source's batch.
+//! - **Batches** — intersect score-ordered batches with a child filter (merge-join).
+//!   for each document.
 //!
 //! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
 //! traits.
+//!
 
 pub mod heap;
 pub mod iterator;
@@ -34,4 +37,4 @@ pub mod mock;
 
 pub use heap::{ScoredResult, TopKHeap};
 pub use iterator::{TopKIterator, TopKMode};
-pub use traits::{ScoreBatch, ScoreSource};
+pub use traits::{CollectionStrategy, ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -16,7 +16,7 @@ use ffi::t_docId;
 use index_result::RSIndexResult;
 use rqe_iterators::RQEIteratorError;
 
-use crate::traits::{ScoreBatch, ScoreSource};
+use crate::traits::{CollectionStrategy, ScoreBatch, ScoreSource};
 
 /// A [`ScoreBatch`] backed by a pre-sorted `Vec<(t_docId, f64)>`.
 ///
@@ -47,6 +47,13 @@ impl ScoreBatch for MockScoreBatch {
         }
         item
     }
+
+    fn skip_to(&mut self, target: t_docId) -> Option<(t_docId, f64)> {
+        while self.pos < self.items.len() && self.items[self.pos].0 < target {
+            self.pos += 1;
+        }
+        self.next()
+    }
 }
 
 /// A [`ScoreSource`] backed by fixed data for use in tests and benchmarks.
@@ -55,17 +62,21 @@ impl ScoreBatch for MockScoreBatch {
 ///
 /// ```rust
 /// # use top_k::mock::MockScoreSource;
+/// # use top_k::traits::CollectionStrategy;
 /// let source = MockScoreSource::new(
 ///     // Two batches: each is a Vec<(doc_id, score)>
 ///     vec![
 ///         vec![(1, 0.5), (3, 0.8)],
 ///         vec![(5, 0.2), (7, 0.9)],
 ///     ],
+///     // Strategy: always Continue
+///     |_, _| CollectionStrategy::Continue,
 /// );
 /// ```
 pub struct MockScoreSource {
     batches: Vec<Vec<(t_docId, f64)>>,
     batch_pos: usize,
+    strategy: Box<dyn FnMut(usize, usize) -> CollectionStrategy>,
     num_estimated: usize,
 }
 
@@ -76,11 +87,15 @@ impl MockScoreSource {
     /// - `strategy` — function called after each batch.
     ///
     /// `num_estimated` defaults to the total number of entries across all batches.
-    pub fn new(batches: Vec<Vec<(t_docId, f64)>>) -> Self {
+    pub fn new(
+        batches: Vec<Vec<(t_docId, f64)>>,
+        strategy: impl FnMut(usize, usize) -> CollectionStrategy + 'static,
+    ) -> Self {
         let num_estimated = batches.iter().map(Vec::len).sum();
         Self {
             batches,
             batch_pos: 0,
+            strategy: Box::new(strategy),
             num_estimated,
         }
     }
@@ -120,6 +135,10 @@ impl ScoreSource for MockScoreSource {
         Self: 'r,
     {
         RSIndexResult::build_virt().doc_id(doc_id).build()
+    }
+
+    fn collection_strategy(&mut self, heap_count: usize, k: usize) -> CollectionStrategy {
+        (self.strategy)(heap_count, k)
     }
 
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -49,9 +49,7 @@ impl ScoreBatch for MockScoreBatch {
     }
 
     fn skip_to(&mut self, target: t_docId) -> Option<(t_docId, f64)> {
-        while self.pos < self.items.len() && self.items[self.pos].0 < target {
-            self.pos += 1;
-        }
+        self.pos += self.items[self.pos..].partition_point(|(id, _)| *id < target);
         self.next()
     }
 }

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -44,12 +44,6 @@ pub enum CollectionStrategy {
     /// Keep iterating — fetch the next batch.
     Continue,
 
-    /// Restart batch collection (e.g. after the source has expanded its range).
-    ///
-    /// The iterator rewinds both the source and the child, then re-enters
-    /// Batches mode from the beginning.
-    SwitchToBatches,
-
     /// Collection is complete — stop and yield whatever is in the heap.
     Stop,
 }

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -18,8 +18,9 @@ use rqe_iterators::RQEIteratorError;
 
 /// A cursor over a single score-ordered batch of `(doc_id, score)` pairs.
 ///
-/// Produced by [`ScoreSource::next_batch`] and streamed by [`TopKIterator`].
-/// Doc IDs within a batch must be **strictly increasing**.
+/// Batches are produced by [`ScoreSource::next_batch`] and consumed by the
+/// [`TopKIterator`]'s intersection engine.  Doc IDs within a batch must be
+/// **strictly increasing**.
 ///
 /// [`TopKIterator`]: crate::TopKIterator
 pub trait ScoreBatch {
@@ -27,6 +28,32 @@ pub trait ScoreBatch {
     ///
     /// Returns `None` when the batch is exhausted.
     fn next(&mut self) -> Option<(t_docId, f64)>;
+
+    /// Skip forward to the first pair whose `doc_id >= target`.
+    ///
+    /// Returns `None` if no such pair exists in this batch.
+    fn skip_to(&mut self, target: t_docId) -> Option<(t_docId, f64)>;
+}
+
+// ── CollectionStrategy ────────────────────────────────────────────────────────
+
+/// Decision returned by [`ScoreSource::collection_strategy`] after each batch,
+/// telling [`TopKIterator`] how to proceed.
+///
+/// [`TopKIterator`]: crate::TopKIterator
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollectionStrategy {
+    /// Keep iterating — fetch the next batch.
+    Continue,
+
+    /// Restart batch collection (e.g. after the source has expanded its range).
+    ///
+    /// The iterator rewinds both the source and the child, then re-enters
+    /// Batches mode from the beginning.
+    SwitchToBatches,
+
+    /// Collection is complete — stop and yield whatever is in the heap.
+    Stop,
 }
 
 /// The score-producing half of a [`TopKIterator`].
@@ -89,6 +116,12 @@ pub trait ScoreSource {
     fn build_result<'r>(&self, doc_id: t_docId, score: f64) -> RSIndexResult<'r>
     where
         Self: 'r;
+
+    /// Called after each batch to decide how collection should proceed.
+    ///
+    /// - `heap_count` — number of results currently in the heap.
+    /// - `k` — the target number of results.
+    fn collection_strategy(&mut self, heap_count: usize, k: usize) -> CollectionStrategy;
 
     /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
     ///

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -35,8 +35,6 @@ pub trait ScoreBatch {
     fn skip_to(&mut self, target: t_docId) -> Option<(t_docId, f64)>;
 }
 
-// ── CollectionStrategy ────────────────────────────────────────────────────────
-
 /// Decision returned by [`ScoreSource::collection_strategy`] after each batch,
 /// telling [`TopKIterator`] how to proceed.
 ///
@@ -118,6 +116,8 @@ pub trait ScoreSource {
         Self: 'r;
 
     /// Called after each batch to decide how collection should proceed.
+    ///
+    /// # Arguments
     ///
     /// - `heap_count` — number of results currently in the heap.
     /// - `k` — the target number of results.

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -9,12 +9,12 @@
 
 //! Integration tests for [`TopKIterator`].
 
-use std::num::NonZeroUsize;
+use std::{cmp::Ordering, num::NonZeroUsize};
 
-use index_result::RSIndexResult;
-use index_spec::IndexSpecReadGuard;
-use rqe_iterators::{RQEIterator, RQEIteratorError};
-use top_k::{ScoreSource, TopKIterator, mock::MockScoreBatch, mock::MockScoreSource};
+use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
+use top_k::{
+    mock::MockScoreBatch, mock::MockScoreSource, CollectionStrategy, ScoreSource, TopKIterator,
+};
 
 // ── Error path stubs ─────────────────────────────────────────────────────────────
 
@@ -99,17 +99,35 @@ impl ScoreSource for TimingOutSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
+    fn collection_strategy(&mut self, _: usize, _: usize) -> CollectionStrategy {
+        CollectionStrategy::Continue
+    }
+
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
         rqe_iterator_type::IteratorType::Mock
     }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Ascending comparator: lower score is better (e.g. vector distance).
+fn asc(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+fn make_child<'a>(ids: Vec<ffi::t_docId>) -> Box<dyn RQEIterator<'a> + 'a> {
+    Box::new(IdList::<true>::new(ids))
 }
 
 // ── State machine ─────────────────────────────────────────────────────────────
 
 #[test]
 fn read_triggers_collection_on_first_call() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+
     assert!(!it.at_eof());
     let result = it.read().unwrap().expect("should have a result");
     assert_eq!(result.doc_id, 1);
@@ -117,8 +135,10 @@ fn read_triggers_collection_on_first_call() {
 
 #[test]
 fn rewind_resets_to_not_started() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     it.read().unwrap();
     it.read().unwrap();
     let eof = it.read().unwrap();
@@ -137,8 +157,9 @@ fn rewind_resets_to_not_started() {
 
 #[test]
 fn eof_set_after_results_exhausted() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+
     it.read().unwrap();
     let eof = it.read().unwrap();
     assert!(eof.is_none());
@@ -147,8 +168,10 @@ fn eof_set_after_results_exhausted() {
 
 #[test]
 fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
 
     assert_eq!(it.last_doc_id(), 0);
 
@@ -163,9 +186,12 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
 
 #[test]
 fn num_estimated_capped_at_k() {
-    let source =
-        MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]]).with_num_estimated(100);
-    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap());
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], |_, _| {
+        CollectionStrategy::Continue
+    })
+    .with_num_estimated(100);
+    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc);
+
     assert_eq!(it.num_estimated(), 3);
 }
 
@@ -173,16 +199,20 @@ fn num_estimated_capped_at_k() {
 
 #[test]
 fn unfiltered_yields_batch_in_source_order() {
-    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap());
+    // Scores are descending (0.9 → 0.5 → 0.1) while doc IDs are ascending.
+    // If the iterator re-sorted by score it would yield [3, 2, 1]; source order gives [1, 2, 3].
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc);
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(ids, vec![1, 2, 3]);
 }
 
 #[test]
 fn unfiltered_empty_source_is_immediate_eof() {
-    let source = MockScoreSource::new(vec![]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    let source = MockScoreSource::new(vec![], |_, _| CollectionStrategy::Continue);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
 }
@@ -192,8 +222,8 @@ fn unfiltered_empty_source_is_immediate_eof() {
 #[test]
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap());
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
@@ -203,9 +233,9 @@ fn revalidate_with_child_delegates_ok() {
     // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
     // for any child iterator that leaves the parent in a valid state.
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
-    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap());
+    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
@@ -213,18 +243,215 @@ fn revalidate_with_child_delegates_ok() {
 #[test]
 fn revalidate_with_child_delegates_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]]);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
-    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap());
+    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
 }
 
 #[test]
 fn unfiltered_timeout_propagated() {
-    let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap());
+    let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap(), asc);
     assert!(matches!(
         it.read().unwrap_err(),
         rqe_iterators::RQEIteratorError::TimedOut
     ));
+}
+
+// ── Batches intersection ──────────────────────────────────────────────────
+
+#[test]
+fn batches_overlap_intersection() {
+    // Child: [1,3,5], Batch: [(1,0.9),(2,0.8),(3,0.7),(4,0.6),(5,0.5)]
+    // Matches: 1→0.9, 3→0.7, 5→0.5  → best-first ASC: 5, 3, 1
+    let source = MockScoreSource::new(
+        vec![vec![(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6), (5, 0.5)]],
+        |_, _| CollectionStrategy::Continue,
+    );
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 3, 5])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![5, 3, 1]);
+}
+
+#[test]
+fn batches_disjoint_yields_nothing() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![10, 20])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    assert!(it.read().unwrap().is_none());
+    assert!(it.at_eof());
+}
+
+#[test]
+fn batches_empty_child_yields_nothing() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    assert!(it.read().unwrap().is_none());
+    assert!(it.at_eof());
+}
+
+#[test]
+fn batches_multiple_batches() {
+    // Batch 1: [(1,3.0),(2,4.0)], Batch 2: [(3,1.0),(4,2.0)]
+    // Child: [1,3,4]  Matches: 1→3.0, 3→1.0, 4→2.0  best-first → 3,4,1
+    let source = MockScoreSource::new(
+        vec![vec![(1, 3.0), (2, 4.0)], vec![(3, 1.0), (4, 2.0)]],
+        |_, _| CollectionStrategy::Continue,
+    );
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 3, 4])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![3, 4, 1]);
+}
+
+#[test]
+fn strategy_stop_stops_after_first_batch() {
+    let source = MockScoreSource::new(
+        vec![
+            vec![(1, 1.0), (2, 2.0)],
+            vec![(3, 0.5)], // NOT fetched
+            vec![(4, 0.1)], // NOT fetched
+        ],
+        |_, _| CollectionStrategy::Stop,
+    );
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 2, 3, 4])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids.len(), 2);
+}
+
+/// When collection fails mid-batch, the heap holds partial results.
+/// A subsequent rewind() followed by read() must not produce duplicate doc IDs.
+#[test]
+fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
+    use rqe_iterators::RQEIteratorError;
+    use top_k::{mock::MockScoreBatch, CollectionStrategy, ScoreSource};
+
+    struct OnceErrorSource {
+        batch_call: u32,
+        rewind_count: u32,
+    }
+
+    impl<'index> ScoreSource<'index> for OnceErrorSource {
+        type Batch = MockScoreBatch;
+
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            let n = self.batch_call;
+            self.batch_call += 1;
+            if self.rewind_count == 0 {
+                // Session 1: return one batch then error, leaving the heap dirty.
+                match n {
+                    0 => Ok(Some(MockScoreBatch::new(vec![(1, 1.0), (3, 3.0)]))),
+                    _ => Err(RQEIteratorError::TimedOut),
+                }
+            } else {
+                // Session 2 (after rewind): return the same batch then stop cleanly.
+                match n {
+                    0 => Ok(Some(MockScoreBatch::new(vec![(1, 1.0), (3, 3.0)]))),
+                    _ => Ok(None),
+                }
+            }
+        }
+
+        fn num_estimated(&self) -> usize {
+            10
+        }
+
+        fn rewind(&mut self) {
+            self.batch_call = 0;
+            self.rewind_count += 1;
+        }
+
+        fn build_result(
+            &self,
+            doc_id: ffi::t_docId,
+            _: f64,
+        ) -> inverted_index::RSIndexResult<'index> {
+            inverted_index::RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .build()
+        }
+
+        fn collection_strategy(&mut self, _: usize, _: usize) -> CollectionStrategy {
+            CollectionStrategy::Continue
+        }
+
+        fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
+            rqe_iterator_type::IteratorType::Mock
+        }
+    }
+
+    let source = OnceErrorSource {
+        batch_call: 0,
+        rewind_count: 0,
+    };
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 3])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+
+    // Session 1: the source returns one batch (doc 1, doc 3 land in the heap)
+    // then errors before finalize_collection() can drain it.
+    assert!(matches!(it.read().unwrap_err(), RQEIteratorError::TimedOut));
+
+    it.rewind();
+
+    // Session 2: the source replays the same batch.  If the heap was not cleared
+    // by rewind(), doc 1 and doc 3 are added a second time and appear twice.
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![1, 3]);
+}
+
+#[test]
+fn strategy_switch_to_batches_rewinds() {
+    // Call 0 → SwitchToBatches (rewinds source+child, restarts loop).
+    // Call 1 → Stop (to exit on the second pass).
+    let call_count = std::cell::Cell::new(0u32);
+    let strategy = move |_: usize, _: usize| {
+        let n = call_count.get();
+        call_count.set(n + 1);
+        if n == 0 {
+            CollectionStrategy::SwitchToBatches
+        } else {
+            CollectionStrategy::Stop
+        }
+    };
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], strategy);
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 2])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![1, 2]);
 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -11,6 +11,8 @@
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
 use top_k::{
     CollectionStrategy, ScoreSource, TopKIterator, mock::MockScoreBatch, mock::MockScoreSource,
@@ -359,7 +361,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         rewind_count: u32,
     }
 
-    impl<'index> ScoreSource<'index> for OnceErrorSource {
+    impl<'index> ScoreSource for OnceErrorSource {
         type Batch = MockScoreBatch;
 
         fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
@@ -389,14 +391,11 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             self.rewind_count += 1;
         }
 
-        fn build_result(
-            &self,
-            doc_id: ffi::t_docId,
-            _: f64,
-        ) -> inverted_index::RSIndexResult<'index> {
-            inverted_index::RSIndexResult::build_virt()
-                .doc_id(doc_id)
-                .build()
+        fn build_result<'r>(&self, doc_id: ffi::t_docId, _: f64) -> RSIndexResult<'r>
+        where
+            Self: 'r,
+        {
+            RSIndexResult::build_virt().doc_id(doc_id).build()
         }
 
         fn collection_strategy(&mut self, _: usize, _: usize) -> CollectionStrategy {
@@ -429,29 +428,4 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
     // by rewind(), doc 1 and doc 3 are added a second time and appear twice.
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![1, 3]);
-}
-
-#[test]
-fn strategy_switch_to_batches_rewinds() {
-    // Call 0 → SwitchToBatches (rewinds source+child, restarts loop).
-    // Call 1 → Stop (to exit on the second pass).
-    let call_count = std::cell::Cell::new(0u32);
-    let strategy = move |_: usize, _: usize| {
-        let n = call_count.get();
-        call_count.set(n + 1);
-        if n == 0 {
-            CollectionStrategy::SwitchToBatches
-        } else {
-            CollectionStrategy::Stop
-        }
-    };
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], strategy);
-    let mut it = TopKIterator::new(
-        source,
-        Some(make_child(vec![1, 2])),
-        NonZeroUsize::new(10).unwrap(),
-        asc,
-    );
-    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
-    assert_eq!(doc_ids, vec![1, 2]);
 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -13,7 +13,7 @@ use std::{cmp::Ordering, num::NonZeroUsize};
 
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
 use top_k::{
-    mock::MockScoreBatch, mock::MockScoreSource, CollectionStrategy, ScoreSource, TopKIterator,
+    CollectionStrategy, ScoreSource, TopKIterator, mock::MockScoreBatch, mock::MockScoreSource,
 };
 
 // ── Error path stubs ─────────────────────────────────────────────────────────────
@@ -352,7 +352,7 @@ fn strategy_stop_stops_after_first_batch() {
 #[test]
 fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
     use rqe_iterators::RQEIteratorError;
-    use top_k::{mock::MockScoreBatch, CollectionStrategy, ScoreSource};
+    use top_k::{CollectionStrategy, ScoreSource, mock::MockScoreBatch};
 
     struct OnceErrorSource {
         batch_call: u32,

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -21,7 +21,8 @@ use std::{cmp::Ordering, num::NonZeroUsize};
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{SeedableRng as _, seq::SliceRandom as _};
-use top_k::TopKHeap;
+use rqe_iterators::RQEIterator;
+use top_k::{CollectionStrategy, TopKHeap, TopKIterator, mock::MockScoreSource};
 
 fn asc(a: f64, b: f64) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)
@@ -113,5 +114,57 @@ fn bench_heap_pop_all(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_heap_insert, bench_heap_pop_all);
+// ── Iterator benchmarks (mock sources) ───────────────────────────────────────
+
+fn bench_intersection_overlap(c: &mut Criterion) {
+    let mut group = c.benchmark_group("iterator");
+    let k = NonZeroUsize::new(100).unwrap();
+    // 50% overlap: batch docs are even numbers, child docs are every other even.
+    for n in [1_000usize, 10_000] {
+        let batch: Vec<(u64, f64)> = (0..n as u64).map(|i| (i * 2, i as f64)).collect();
+        let child_ids: Vec<u64> = (0..n as u64).step_by(2).map(|i| i * 2).collect();
+
+        group.bench_with_input(BenchmarkId::new("batches_50pct_overlap", n), &n, |b, _| {
+            b.iter(|| {
+                let source =
+                    MockScoreSource::new(vec![batch.clone()], |_, _| CollectionStrategy::Continue);
+                let child: Box<dyn RQEIterator> =
+                    Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+                let mut it = TopKIterator::new(source, Some(child), k, asc);
+                while black_box(it.read()).unwrap().is_some() {}
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_intersection_disjoint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("iterator");
+    let k = NonZeroUsize::new(100).unwrap();
+    // 0% overlap: batch has even IDs, child has odd IDs.
+    for n in [1_000usize, 10_000] {
+        let batch: Vec<(u64, f64)> = (0..n as u64).map(|i| (i * 2, i as f64)).collect();
+        let child_ids: Vec<u64> = (0..n as u64).map(|i| i * 2 + 1).collect();
+
+        group.bench_with_input(BenchmarkId::new("batches_0pct_overlap", n), &n, |b, _| {
+            b.iter(|| {
+                let source =
+                    MockScoreSource::new(vec![batch.clone()], |_, _| CollectionStrategy::Continue);
+                let child: Box<dyn RQEIterator> =
+                    Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+                let mut it = TopKIterator::new(source, Some(child), k, asc);
+                while black_box(it.read()).unwrap().is_some() {}
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_heap_insert,
+    bench_heap_pop_all,
+    bench_intersection_overlap,
+    bench_intersection_disjoint,
+);
 criterion_main!(benches);


### PR DESCRIPTION
- Based on https://github.com/RediSearch/RediSearch/pull/9276

### Score-ordered batches

To understand this PR, understanding `score-ordered batches` is important:

Batches are emitted in sequence, containing top candidates, then the next top candidates, etc. 

BUT ! We sort elements within a batch according to their `doc_id`, to be able to merge them in "parallel" (advancing 2 cursors) with the child filter through `skip_to`.

### Context

RediSearch has two query patterns that need to return the _k best_ results from a large candidate set:

- **Hybrid vector search** — a vector index produces score-ordered batches of candidates; a filter expression restricts which documents are valid.
- **Numeric SORTBY optimizer** — the numeric range tree produces score-ordered batches sorted by field value; a query filter restricts results.

Both share the same structure: a score-producing source emits batches, a child filter prunes them, and the engine keeps only the top-k survivors. This PR implements that shared engine.

### What this PR does

Adds a second execution mode — **`Batches`** — to the `TopKIterator`. When a child filter is provided, the iterator:

1. Pulls the next score-ordered batch from the source.
2. Intersects it with the child filter using a merge-join, pushing matches into the top-k heap.
3. Asks the source how to proceed, via a new `CollectionStrategy` protocol (`Continue`, `Stop`, or `SwitchToBatches`).
4. Repeats until the source signals done, or instructs a full restart (e.g. the source expands its numeric range or its ANN (Approximate Nearest Neighbor) search radius and wants to re-collect from the beginning).

At the end of collection, the heap is drained into a sorted result list, and `read()` yields from that list in best-first order.

### Design decisions

This respects `docs/design/TOP_K_DESIGN.md`, key concepts are:

**`CollectionStrategy` as a source-side protocol.** Rather than hard-coding stopping logic in the iterator, each `ScoreSource` decides — after every batch — whether to keep going, stop, or restart. This keeps the generic engine unaware of domain specifics.

**Merge-join intersection.** For each batch, the intersection uses alternating `skip_to` calls on both cursors, O((n + m) log k). This is efficient when batches are small relative to the full filter universe — the typical case for both ANN retrieval and selective numeric ranges.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core query iterator behavior for filtered top-k (hybrid/numeric paths); correctness depends on merge-join and heap ordering, though coverage is strong in new integration tests.
> 
> **Overview**
> Adds **`TopKMode::Batches`** to `TopKIterator`: when a child filter is present, the iterator pulls score batches from a `ScoreSource`, **merge-joins** each batch with the child via `skip_to` on both sides, and keeps survivors in a **top-k heap** keyed by a new **`compare`** argument. After collection, the heap is drained and `read()` yields in **best-first** order (unfiltered mode still streams a single batch without the heap).
> 
> Extends **`ScoreBatch`** with `skip_to` and **`ScoreSource`** with **`CollectionStrategy`** (`Continue` / `Stop`) so sources decide whether to fetch more batches after each intersection. Constructors and mocks now take `compare` and a strategy callback; **`rewind`** resets heap and yielded results (including after mid-collection errors).
> 
> Integration tests cover overlap/disjoint filters, multi-batch collection, early stop, and stale-heap behavior; benchmarks add filtered intersection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed6143cb5f652f0bf5b523758c7f6afffdd50e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->