### PR TITLE
[MOD-6430][MOD-6416] make sure CURSORS clean after MAXIDLE.

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -257,7 +257,7 @@ static void Cursors_RequestRescheduleSweep(CursorList *cl) {
     return;
   }
   // The `cl` pointer outlives any pending one-shot: both `g_CursorsList` and
-  // `g_CursorsListCoord` are global statics with process lifetime, and
+  // `g_CursorsListCoord` are global variables with process lifetime, and
   // `CursorList_Empty` only clears their contents (it never destroys the
   // struct, its mutex, its lookup, or its idle array). If this ever changes
   // (e.g. heap-allocated per-index lists), this call site needs a refcount

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -178,10 +178,16 @@ int Cursors_CollectIdle(CursorList *cl) {
   return rc;
 }
 
-// Walks the idle list to find the earliest `nextTimeoutNs` over all idle
-// cursors. Returns 0 when the idle list is empty. Assumed to be called under
-// the cursor list lock.
-static uint64_t Cursors_FindNextTimeoutNsLocked(const CursorList *cl) {
+// Returns the earliest `nextTimeoutNs` over all idle cursors, or 0 when the
+// idle list is empty. Uses `cl->nextIdleTimeoutNs` as a cache: if non-zero it
+// is already the minimum (maintained by `Cursor_Pause` and invalidated by
+// `Cursor_RemoveFromIdle` when the minimum-holding cursor is removed), so the
+// scan is skipped. Otherwise the idle list is walked and the result is cached
+// before returning. Assumed to be called under the cursor list lock.
+static uint64_t Cursors_FindNextTimeoutNsLocked(CursorList *cl) {
+  if (cl->nextIdleTimeoutNs != 0) {
+    return cl->nextIdleTimeoutNs;
+  }
   uint64_t min_ns = 0;
   size_t n = ARRAY_GETSIZE_AS(&cl->idle, Cursor *);
   for (size_t i = 0; i < n; ++i) {
@@ -190,6 +196,7 @@ static uint64_t Cursors_FindNextTimeoutNsLocked(const CursorList *cl) {
       min_ns = cur->nextTimeoutNs;
     }
   }
+  cl->nextIdleTimeoutNs = min_ns;
   return min_ns;
 }
 
@@ -226,7 +233,6 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
   if (next_ns == 0) {
     return;
   }
-  cl->nextIdleTimeoutNs = next_ns;
 
   uint64_t now_ns = curTimeNs();
   mstime_t period_ms = 0;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -389,12 +389,16 @@ int Cursor_Pause(Cursor *cur) {
 
     // Set the next timeout to be the current time + timeout interval
     cur->nextTimeoutNs = curTimeNs() + ((uint64_t)cur->timeoutIntervalMs * 1000000);
-    if (cur->nextTimeoutNs < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
+    // Maintain the `nextIdleTimeoutNs` cache invariant: when non-zero it must
+    // equal the actual minimum deadline among the idle cursors. Only narrow it when
+    // it is already valid; if it has been invalidated (set to 0 by
+    // `Cursor_RemoveFromIdle` because the previous minimum-holding cursor was
+    // removed), leave it 0 so that `Cursors_FindNextTimeoutNsLocked` will
+    // rescan and recompute the true minimum.
+    if (cl->nextIdleTimeoutNs != 0 && cur->nextTimeoutNs < cl->nextIdleTimeoutNs) {
       cl->nextIdleTimeoutNs = cur->nextTimeoutNs;
-      // `Cursor_Pause` may run on a worker thread (see `cursorRead_ctx`), where
-      // the module timer API is unsafe to call directly. Defer the timer
-      // (re)arm to the main thread via a thread-safe one-shot. Skip when the
-      // already-armed timer fires no later than this cursor's deadline.
+      Cursors_RequestRescheduleSweep(cl);
+    } else if (cl->nextIdleTimeoutNs == 0) {
       Cursors_RequestRescheduleSweep(cl);
     }
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -16,6 +16,10 @@
 
 #define Cursor_IsIdle(cur) ((cur)->pos != -1)
 
+// Sentinel `RedisModuleTimerID` value meaning "no idle-sweep timer is armed".
+// Redis assigns timer IDs from a non-zero seed, so `0` is safe to reserve.
+#define IDLE_SWEEP_TIMER_NONE ((RedisModuleTimerID)0)
+
 static void Cursors_RescheduleSweepLocked(CursorList *cl);
 static void Cursors_RequestRescheduleSweep(CursorList *cl);
 
@@ -196,7 +200,7 @@ static void cursorIdleSweepTimerCb(RedisModuleCtx *ctx, void *data) {
   CursorList *cl = data;
   CursorList_Lock(cl);
   // The timer ID is consumed when the callback fires.
-  cl->idleSweepTimerSet = false;
+  cl->idleSweepTimerId = IDLE_SWEEP_TIMER_NONE;
   Cursors_GCInternal(cl, 1);
   Cursors_RescheduleSweepLocked(cl);
   CursorList_Unlock(cl);
@@ -213,9 +217,9 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
     return;
   }
 
-  if (cl->idleSweepTimerSet) {
+  if (cl->idleSweepTimerId != IDLE_SWEEP_TIMER_NONE) {
     RedisModule_StopTimer(RSDummyContext, cl->idleSweepTimerId, NULL);
-    cl->idleSweepTimerSet = false;
+    cl->idleSweepTimerId = IDLE_SWEEP_TIMER_NONE;
   }
 
   uint64_t next_ns = Cursors_FindNextTimeoutNsLocked(cl);
@@ -234,7 +238,6 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
 
   cl->idleSweepTimerId = RedisModule_CreateTimer(RSDummyContext, period_ms,
                                                  cursorIdleSweepTimerCb, cl);
-  cl->idleSweepTimerSet = true;
 }
 
 // Event-loop one-shot callback that re-arms the idle-sweep timer on the main
@@ -382,15 +385,16 @@ int Cursor_Pause(Cursor *cur) {
     cur->nextTimeoutNs = curTimeNs() + ((uint64_t)cur->timeoutIntervalMs * 1000000);
     if (cur->nextTimeoutNs < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
       cl->nextIdleTimeoutNs = cur->nextTimeoutNs;
+      // `Cursor_Pause` may run on a worker thread (see `cursorRead_ctx`), where
+      // the module timer API is unsafe to call directly. Defer the timer
+      // (re)arm to the main thread via a thread-safe one-shot. Skip when the
+      // already-armed timer fires no later than this cursor's deadline.
+      Cursors_RequestRescheduleSweep(cl);
     }
 
     /* Add to idle list */
     cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **);
     *(Cursor **)(ARRAY_ADD_AS(&cl->idle, Cursor *)) = cur;
-    // `Cursor_Pause` may run on a worker thread (see `cursorRead_ctx`), where
-    // the module timer API is unsafe to call directly. Defer the timer
-    // (re)arm to the main thread via a thread-safe one-shot.
-    Cursors_RequestRescheduleSweep(cl);
   }
 
   CursorList_Unlock(cl);
@@ -524,9 +528,9 @@ void Cursors_RenderStatsForInfo(CursorList *cl, CursorList *cl_coord, const Inde
 
 void CursorList_Empty(CursorList *cl) {
   CursorList_Lock(cl);
-  if (cl->idleSweepTimerSet) {
+  if (cl->idleSweepTimerId != IDLE_SWEEP_TIMER_NONE) {
     RedisModule_StopTimer(RSDummyContext, cl->idleSweepTimerId, NULL);
-    cl->idleSweepTimerSet = false;
+    cl->idleSweepTimerId = IDLE_SWEEP_TIMER_NONE;
   }
   for (khiter_t ii = 0; ii != kh_end(cl->lookup); ++ii) {
     if (!kh_exist(cl->lookup, ii)) {

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -256,6 +256,12 @@ static void Cursors_RequestRescheduleSweep(CursorList *cl) {
   if (RS_IsMock) {
     return;
   }
+  // The `cl` pointer outlives any pending one-shot: both `g_CursorsList` and
+  // `g_CursorsListCoord` are global statics with process lifetime, and
+  // `CursorList_Empty` only clears their contents (it never destroys the
+  // struct, its mutex, its lookup, or its idle array). If this ever changes
+  // (e.g. heap-allocated per-index lists), this call site needs a refcount
+  // or in-flight counter to keep `cl` alive until the one-shot drains.
   RedisModule_EventLoopAddOneShot(cursorRescheduleSweepOneShotCb, cl);
 }
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -17,6 +17,7 @@
 #define Cursor_IsIdle(cur) ((cur)->pos != -1)
 
 static void Cursors_RescheduleSweepLocked(CursorList *cl);
+static void Cursors_RequestRescheduleSweep(CursorList *cl);
 
 // coord cursors will have odd ids and regular cursors will have even ids
 CursorList g_CursorsList;
@@ -164,6 +165,7 @@ static int Cursors_GCInternal(CursorList *cl, int force) {
   return ctx.numCollected;
 }
 
+// Runs on the main Redis thread with the GIL held.
 int Cursors_CollectIdle(CursorList *cl) {
   CursorList_Lock(cl);
   int rc = Cursors_GCInternal(cl, 1);
@@ -203,7 +205,9 @@ static void cursorIdleSweepTimerCb(RedisModuleCtx *ctx, void *data) {
 // Re-arms the per-list idle-sweep timer to fire at the earliest idle cursor
 // deadline. Cancels any previously armed timer first. Skipped when the module
 // timer API is unavailable (e.g. unit tests). Refreshes `nextIdleTimeoutNs`
-// from the live idle list. Assumed to be called under the cursor list lock.
+// from the live idle list. Must be called from the main Redis thread (with
+// the GIL held) and under the cursor list lock, since it manipulates a module
+// timer.
 static void Cursors_RescheduleSweepLocked(CursorList *cl) {
   if (RS_IsMock) {
     return;
@@ -231,6 +235,28 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
   cl->idleSweepTimerId = RedisModule_CreateTimer(RSDummyContext, period_ms,
                                                  cursorIdleSweepTimerCb, cl);
   cl->idleSweepTimerSet = true;
+}
+
+// Event-loop one-shot callback that re-arms the idle-sweep timer on the main
+// thread. Used from contexts that may run on worker threads, where calling
+// the module timer API directly is unsafe.
+static void cursorRescheduleSweepOneShotCb(void *data) {
+  CursorList *cl = data;
+  CursorList_Lock(cl);
+  Cursors_RescheduleSweepLocked(cl);
+  CursorList_Unlock(cl);
+}
+
+// Posts a one-shot job onto the Redis event loop to re-arm the idle-sweep
+// timer on the main thread. Safe to call from any thread; the actual timer
+// manipulation happens later under the GIL. Used from `Cursor_Pause`, which
+// may run on background worker threads (e.g. when FT.CURSOR READ is dispatched
+// to a worker via `cursorRead_ctx`).
+static void Cursors_RequestRescheduleSweep(CursorList *cl) {
+  if (RS_IsMock) {
+    return;
+  }
+  RedisModule_EventLoopAddOneShot(cursorRescheduleSweepOneShotCb, cl);
 }
 
 CursorsInfoStats Cursors_GetInfoStats(void) {
@@ -355,10 +381,10 @@ int Cursor_Pause(Cursor *cur) {
     /* Add to idle list */
     cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **);
     *(Cursor **)(ARRAY_ADD_AS(&cl->idle, Cursor *)) = cur;
-
-    // Arm/refresh the idle-sweep timer so that this cursor is reaped at its
-    // MAXIDLE deadline even if no further client traffic arrives.
-    Cursors_RescheduleSweepLocked(cl);
+    // `Cursor_Pause` may run on a worker thread (see `cursorRead_ctx`), where
+    // the module timer API is unsafe to call directly. Defer the timer
+    // (re)arm to the main thread via a thread-safe one-shot.
+    Cursors_RequestRescheduleSweep(cl);
   }
 
   CursorList_Unlock(cl);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -215,16 +215,17 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
   }
 
   uint64_t next_ns = Cursors_FindNextTimeoutNsLocked(cl);
-  cl->nextIdleTimeoutNs = next_ns;
   if (next_ns == 0) {
     return;
   }
+  cl->nextIdleTimeoutNs = next_ns;
 
   uint64_t now_ns = curTimeNs();
   mstime_t period_ms = 0;
   if (next_ns > now_ns) {
     // Round up so we never fire before the deadline.
-    period_ms = (mstime_t)((next_ns - now_ns + 999999) / 1000000);
+    const uint64_t NS_PER_MS = 1000000;
+    period_ms = (mstime_t)((next_ns - now_ns + NS_PER_MS - 1) / NS_PER_MS);
   }
 
   cl->idleSweepTimerId = RedisModule_CreateTimer(RSDummyContext, period_ms,

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "cursor.h"
+#include "module.h"
 #include "resp3.h"
 #include <time.h>
 #include <assert.h>
@@ -14,6 +15,8 @@
 #include <err.h>
 
 #define Cursor_IsIdle(cur) ((cur)->pos != -1)
+
+static void Cursors_RescheduleSweepLocked(CursorList *cl);
 
 // coord cursors will have odd ids and regular cursors will have even ids
 CursorList g_CursorsList;
@@ -164,8 +167,69 @@ static int Cursors_GCInternal(CursorList *cl, int force) {
 int Cursors_CollectIdle(CursorList *cl) {
   CursorList_Lock(cl);
   int rc = Cursors_GCInternal(cl, 1);
+  Cursors_RescheduleSweepLocked(cl);
   CursorList_Unlock(cl);
   return rc;
+}
+
+// Walks the idle list to find the earliest `nextTimeoutNs` over all idle
+// cursors. Returns 0 when the idle list is empty. Assumed to be called under
+// the cursor list lock.
+static uint64_t Cursors_FindNextTimeoutNsLocked(const CursorList *cl) {
+  uint64_t min_ns = 0;
+  size_t n = ARRAY_GETSIZE_AS(&cl->idle, Cursor *);
+  for (size_t i = 0; i < n; ++i) {
+    const Cursor *cur = *ARRAY_GETITEM_AS(&cl->idle, i, Cursor **);
+    if (min_ns == 0 || cur->nextTimeoutNs < min_ns) {
+      min_ns = cur->nextTimeoutNs;
+    }
+  }
+  return min_ns;
+}
+
+// Module timer callback: reaps expired idle cursors at MAXIDLE deadlines and
+// re-arms the timer for the next earliest deadline. Runs on the main Redis
+// thread with the GIL held.
+static void cursorIdleSweepTimerCb(RedisModuleCtx *ctx, void *data) {
+  CursorList *cl = data;
+  CursorList_Lock(cl);
+  // The timer ID is consumed when the callback fires.
+  cl->idleSweepTimerSet = false;
+  Cursors_GCInternal(cl, 1);
+  Cursors_RescheduleSweepLocked(cl);
+  CursorList_Unlock(cl);
+}
+
+// Re-arms the per-list idle-sweep timer to fire at the earliest idle cursor
+// deadline. Cancels any previously armed timer first. Skipped when the module
+// timer API is unavailable (e.g. unit tests). Refreshes `nextIdleTimeoutNs`
+// from the live idle list. Assumed to be called under the cursor list lock.
+static void Cursors_RescheduleSweepLocked(CursorList *cl) {
+  if (RS_IsMock) {
+    return;
+  }
+
+  if (cl->idleSweepTimerSet) {
+    RedisModule_StopTimer(RSDummyContext, cl->idleSweepTimerId, NULL);
+    cl->idleSweepTimerSet = false;
+  }
+
+  uint64_t next_ns = Cursors_FindNextTimeoutNsLocked(cl);
+  cl->nextIdleTimeoutNs = next_ns;
+  if (next_ns == 0) {
+    return;
+  }
+
+  uint64_t now_ns = curTimeNs();
+  mstime_t period_ms = 0;
+  if (next_ns > now_ns) {
+    // Round up so we never fire before the deadline.
+    period_ms = (mstime_t)((next_ns - now_ns + 999999) / 1000000);
+  }
+
+  cl->idleSweepTimerId = RedisModule_CreateTimer(RSDummyContext, period_ms,
+                                                 cursorIdleSweepTimerCb, cl);
+  cl->idleSweepTimerSet = true;
 }
 
 CursorsInfoStats Cursors_GetInfoStats(void) {
@@ -290,6 +354,10 @@ int Cursor_Pause(Cursor *cur) {
     /* Add to idle list */
     cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **);
     *(Cursor **)(ARRAY_ADD_AS(&cl->idle, Cursor *)) = cur;
+
+    // Arm/refresh the idle-sweep timer so that this cursor is reaped at its
+    // MAXIDLE deadline even if no further client traffic arrives.
+    Cursors_RescheduleSweepLocked(cl);
   }
 
   CursorList_Unlock(cl);
@@ -423,6 +491,10 @@ void Cursors_RenderStatsForInfo(CursorList *cl, CursorList *cl_coord, const Inde
 
 void CursorList_Empty(CursorList *cl) {
   CursorList_Lock(cl);
+  if (cl->idleSweepTimerSet) {
+    RedisModule_StopTimer(RSDummyContext, cl->idleSweepTimerId, NULL);
+    cl->idleSweepTimerSet = false;
+  }
   for (khiter_t ii = 0; ii != kh_end(cl->lookup); ++ii) {
     if (!kh_exist(cl->lookup, ii)) {
       continue;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -11,6 +11,7 @@
 
 #include <unistd.h>
 #include <pthread.h>
+#include "redismodule.h"
 #include "util/khash.h"
 #include "util/array.h"
 #include "search_ctx.h"
@@ -102,6 +103,16 @@ typedef struct CursorList {
    * This is used as a hint to avoid excessive sweeps.
    */
   uint64_t nextIdleTimeoutNs;
+
+  /**
+   * Module timer that fires at `nextIdleTimeoutNs` to reap expired idle
+   * cursors without requiring further client traffic. Valid iff
+   * `idleSweepTimerSet` is true.
+   */
+  RedisModuleTimerID idleSweepTimerId;
+
+  /** Whether `idleSweepTimerId` currently refers to an armed timer. */
+  bool idleSweepTimerSet;
 
   /** Is it an internal coordinator cursor or a user cursor */
   bool is_coord;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -106,13 +106,10 @@ typedef struct CursorList {
 
   /**
    * Module timer that fires at `nextIdleTimeoutNs` to reap expired idle
-   * cursors without requiring further client traffic. Valid iff
-   * `idleSweepTimerSet` is true.
+   * cursors without requiring further client traffic. Equal to
+   * `IDLE_SWEEP_TIMER_NONE` when no timer is currently armed.
    */
   RedisModuleTimerID idleSweepTimerId;
-
-  /** Whether `idleSweepTimerId` currently refers to an armed timer. */
-  bool idleSweepTimerSet;
 
   /** Is it an internal coordinator cursor or a user cursor */
   bool is_coord;

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -162,6 +162,49 @@ def testMaxIdleAutoReap(env):
             sleep(0.05)
 
 @skip(cluster=True)
+def testMaxIdleAutoReapAfterCacheInvalidation(env):
+    # Regression test: when the previous minimum-holding idle cursor is
+    # removed (e.g. via FT.CURSOR DEL), the per-list `nextIdleTimeoutNs`
+    # cache is reset. A subsequent FT.AGGREGATE WITHCURSOR with a later
+    # MAXIDLE must not stomp the cache with that later deadline while
+    # another idle cursor (with an earlier deadline) is still present,
+    # otherwise the idle-sweep timer would be armed past the true
+    # minimum and the still-idle cursor would be reaped well after its
+    # MAXIDLE.
+    loadDocs(env, idx='idx1')
+
+    # Three cursors with strictly increasing MAXIDLE values. After
+    # deleting A (the original minimum), B becomes the true minimum,
+    # and C is paused last with a much larger MAXIDLE.
+    q_a = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1',
+           'WITHCURSOR', 'COUNT', 1, 'MAXIDLE', 500]
+    q_b = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1',
+           'WITHCURSOR', 'COUNT', 1, 'MAXIDLE', 1500]
+    q_c = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1',
+           'WITHCURSOR', 'COUNT', 1, 'MAXIDLE', 8000]
+
+    _, cid_a = env.cmd(*q_a)
+    env.cmd(*q_b)
+    env.assertEqual(2, getCursorStats(env, 'idx1')['index_total'])
+
+    # Remove A, the minimum-holding cursor; this resets the cache to 0.
+    env.cmd('FT.CURSOR', 'DEL', 'idx1', cid_a)
+    env.assertEqual(1, getCursorStats(env, 'idx1')['index_total'])
+
+    # Pause C with a deadline far after B's. The cache must be
+    # recomputed against the live idle list (yielding B's deadline);
+    # it must not be set to C's deadline.
+    env.cmd(*q_c)
+    env.assertEqual(2, getCursorStats(env, 'idx1')['index_total'])
+
+    # Within ~B's MAXIDLE, B must be reaped while C remains idle.
+    # If the cache is stale at C's deadline, B's reap is delayed
+    # until C's MAXIDLE (~8s) and the TimeLimit fires.
+    with TimeLimit(4, "B was not reaped at its MAXIDLE (stale cache)"):
+        while getCursorStats(env, 'idx1')['index_total'] != 1:
+            sleep(0.05)
+
+@skip(cluster=True)
 def testDropIndexFreesIdleCursors(env):
     # Regression test for MOD-6416: idle cursors created by FT.AGGREGATE
     # WITHCURSOR keep the dropped IndexSpec (and their AREQ) alive until

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -151,6 +151,26 @@ def testTimeout(env):
             break
     env.assertEqual(0, rv)
 
+@skip(cluster=True)
+def testMaxIdleAutoReap(env):
+    # Regression test for MOD-6430: idle cursors must be reaped at MAXIDLE
+    # without requiring further client traffic (no explicit FT.CURSOR GC).
+    loadDocs(env, idx='idx1')
+    q1 = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1', 'WITHCURSOR', 'COUNT', 10, 'MAXIDLE', 50]
+    env.cmd(*q1)
+    env.assertEqual(1, getCursorStats(env, 'idx1')['index_total'])
+
+    # Wait comfortably longer than MAXIDLE; the module timer should have
+    # reaped the cursor by now without us issuing any other command.
+    exptime = time() + 2.5
+    rv = 1
+    while time() < exptime:
+        sleep(0.05)
+        rv = getCursorStats(env, 'idx1')['index_total']
+        if not rv:
+            break
+    env.assertEqual(0, rv)
+
 def testLeaked(env):
     # Ensure that sanitizer doesn't report memory leak for idle cursors.
     n_docs = env.shardsCount * 1100

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -171,6 +171,40 @@ def testMaxIdleAutoReap(env):
             break
     env.assertEqual(0, rv)
 
+@skip(cluster=True)
+def testDropIndexFreesIdleCursors(env):
+    # Regression test for MOD-6416: idle cursors created by FT.AGGREGATE
+    # WITHCURSOR keep the dropped IndexSpec (and their AREQ) alive until
+    # they are reaped. Without automatic reaping at MAXIDLE, the memory
+    # held by idle cursors persists past FT.DROPINDEX with no further
+    # client traffic. With the timer-based sweep, the cursors expire on
+    # their own and the global cursor count drops to zero.
+    loadDocs(env, idx='idx1')
+    # Second index used only to read FT.INFO after idx1 is dropped, since
+    # the global cursor stats are exposed per-index.
+    loadDocs(env, count=1, idx='idx2')
+
+    n_cursors = 5
+    for _ in range(n_cursors):
+        # Don't read from the cursor: it goes idle immediately.
+        env.cmd('FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1',
+                'WITHCURSOR', 'COUNT', 1, 'MAXIDLE', 50)
+
+    env.assertEqual(n_cursors, getCursorStats(env, 'idx2')['global_total'])
+
+    env.cmd('FT.DROPINDEX', 'idx1')
+
+    # Wait comfortably longer than MAXIDLE; the module timer must reap
+    # the orphaned idle cursors without any further cursor traffic.
+    exptime = time() + 2.5
+    rv = n_cursors
+    while time() < exptime:
+        sleep(0.05)
+        rv = getCursorStats(env, 'idx2')['global_total']
+        if not rv:
+            break
+    env.assertEqual(0, rv)
+
 def testLeaked(env):
     # Ensure that sanitizer doesn't report memory leak for idle cursors.
     n_docs = env.shardsCount * 1100

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -1,6 +1,6 @@
 from common import *
 
-from time import sleep, time
+from time import sleep
 from redis import ResponseError
 
 from cmath import inf
@@ -141,15 +141,10 @@ def testTimeout(env):
     # Maximum idle of 1ms
     q1 = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1', 'WITHCURSOR', 'COUNT', 10, 'MAXIDLE', 1]
     env.cmd(*q1)
-    exptime = time() + 2.5
-    rv = 1
-    while time() < exptime:
-        sleep(0.01)
-        env.cmd('FT.CURSOR', 'GC', 'idx1', '0')
-        rv = getCursorStats(env, 'idx1')['index_total']
-        if not rv:
-            break
-    env.assertEqual(0, rv)
+    with TimeLimit(2.5, "idle cursor was not reaped after MAXIDLE"):
+        while getCursorStats(env, 'idx1')['index_total']:
+            sleep(0.01)
+            env.cmd('FT.CURSOR', 'GC', 'idx1', '0')
 
 @skip(cluster=True)
 def testMaxIdleAutoReap(env):
@@ -162,14 +157,9 @@ def testMaxIdleAutoReap(env):
 
     # Wait comfortably longer than MAXIDLE; the module timer should have
     # reaped the cursor by now without us issuing any other command.
-    exptime = time() + 2.5
-    rv = 1
-    while time() < exptime:
-        sleep(0.05)
-        rv = getCursorStats(env, 'idx1')['index_total']
-        if not rv:
-            break
-    env.assertEqual(0, rv)
+    with TimeLimit(2.5, "idle cursor was not reaped at MAXIDLE"):
+        while getCursorStats(env, 'idx1')['index_total']:
+            sleep(0.05)
 
 @skip(cluster=True)
 def testDropIndexFreesIdleCursors(env):
@@ -196,14 +186,9 @@ def testDropIndexFreesIdleCursors(env):
 
     # Wait comfortably longer than MAXIDLE; the module timer must reap
     # the orphaned idle cursors without any further cursor traffic.
-    exptime = time() + 2.5
-    rv = n_cursors
-    while time() < exptime:
-        sleep(0.05)
-        rv = getCursorStats(env, 'idx2')['global_total']
-        if not rv:
-            break
-    env.assertEqual(0, rv)
+    with TimeLimit(2.5, "orphaned idle cursors were not reaped"):
+        while getCursorStats(env, 'idx2')['global_total']:
+            sleep(0.05)
 
 def testLeaked(env):
     # Ensure that sanitizer doesn't report memory leak for idle cursors.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: When a cursor created by `FT.AGGREGATE ... WITHCURSOR MAXIDLE N` goes idle, it sits in the per-list idle array waiting to be reaped. The reaper (`Cursors_GCInternal`) only runs as a side-effect of further cursor activity:
   - every `RSCURSORS_SWEEP_INTERVAL` (500) cursor operations, or
   - when a client explicitly issues `FT.CURSOR GC`, or
   - inline from `Cursor_Pause` / `Cursors_TakeForExecution` / `Cursor_Free` / `Cursors_Purge`.

   If the client creates a cursor and then stops talking to the shard, nothing fires the sweep. The cursor lives well past its `MAXIDLE`, `FT.CURSOR READ` keeps finding it, and the memory it holds (its `AREQ`, the strong ref to the `IndexSpec`, etc.) is never released. After `FT.DROPINDEX` / `FLUSHDB` the same idle cursors keep the spec alive too.

2. **Change**: Each `CursorList` (user list and coordinator-internal list) now owns a single Redis Module timer that fires at the **earliest** `nextTimeoutNs` across its idle cursors. When it fires, it runs the existing `Cursors_GCInternal(force=1)` (which iterates the whole idle list and reaps every expired cursor in one pass) and then re-arms itself for the next-earliest deadline. The timer is:
   - armed/refreshed on every `Cursor_Pause` (so a newly paused cursor with a smaller deadline pulls the wake-up earlier),
   - re-armed at the end of each timer fire and after `Cursors_CollectIdle`,
   - cancelled in `CursorList_Empty` and skipped entirely under `RS_IsMock` (cpptests).

   Per-list (vs per-cursor) keeps the design O(1) timer regardless of cursor count; the existing `nextIdleTimeoutNs` hint is reused. The timer callback runs on the main Redis thread with the GIL held, the same conditions under which `FT.CURSOR GC` already drives the sweep, so freeing AREQs from there is safe.

3. **Outcome**: Idle cursors are reaped within ~`MAXIDLE` ms regardless of further client traffic. `FT.CURSOR READ` no longer succeeds against an expired cursor, used memory drops back, and AREQ + spec references held by the cursor are released, which also unblocks `FT.DROPINDEX` / `FLUSHDB` from leaving cursor memory behind.

#### Which additional issues this PR fixes
1. MOD-6430 — `CURSOR MAXIDLE time isn't enforced`
2. MOD-6416 — `FT.DROPINDEX or FLUSHDB didn't clear all memory used by CURSOR` (idle cursors now expire on their own, releasing the spec ref they hold)

#### Main objects this PR modified
1. `src/cursor.h` — added `idleSweepTimerId` / `idleSweepTimerSet` to `CursorList`.
2. `src/cursor.c` — new helpers `Cursors_FindNextTimeoutNsLocked`, `cursorIdleSweepTimerCb`, `Cursors_RescheduleSweepLocked`; wired into `Cursor_Pause`, `Cursors_CollectIdle`, `CursorList_Empty`.
3. `tests/pytests/test_cursors.py` — new `testMaxIdleAutoReap` regression test that asserts an idle cursor is reaped after `MAXIDLE` without any explicit `FT.CURSOR GC`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: cursors created with `MAXIDLE` are now reliably reaped at the configured deadline even when the client does not issue further cursor commands, preventing memory accumulation and stale `FT.CURSOR READ` results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces Redis module timers and cross-thread rescheduling to reap idle cursors without client traffic, which touches concurrency/timer lifecycle and could affect cursor GC timing and resource cleanup.
> 
> **Overview**
> Idle cursors created with `WITHCURSOR MAXIDLE` are now reaped automatically at their deadlines, without requiring additional cursor commands or explicit `FT.CURSOR GC`.
> 
> Each `CursorList` now maintains a single Redis Module timer (`idleSweepTimerId`) that is (re)armed for the earliest idle cursor timeout, runs a forced `Cursors_GCInternal()` sweep when it fires, and is canceled when the list is emptied. Timer manipulation is routed onto the main event loop when triggered from potentially worker-thread contexts (e.g. `Cursor_Pause`), and the `nextIdleTimeoutNs` cache logic is tightened to avoid stale minima after cache invalidation.
> 
> Pytests are updated and expanded with regressions that assert MAXIDLE auto-reaping (including after cache invalidation) and that dropping an index does not leave orphaned idle cursors alive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd61e883d0ddab1ecb55f65dbf09e576e0c6c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->