### PR TITLE
[MOD-14980] Improve coverage for ttl_table

### DIFF
--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -715,3 +715,66 @@ def test_ttl_table_collision_chain():
     res = env.cmd('FT.SEARCH', 'idx', f'@n:[1 {N}]', 'NOCONTENT', 'LIMIT', '0', str(N))
     returned = sorted(int(d.split(':')[1]) for d in res[1:])
     env.assertEqual(returned, expected)
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_wide_schema_field_expiration(env):
+    # Indexes with >32 text fields are auto-promoted to wide schema encoding.
+    # We use also field index >= 64 to trigger high half loop iteration
+    N_FIELDS = 70
+
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+
+    schema = list(chain.from_iterable((f'f{i}', 'TEXT') for i in range(N_FIELDS)))
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', *schema)
+
+    hello_kv = list(chain.from_iterable((f'f{i}', 'hello') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:plain', *hello_kv)
+    conn.execute_command('HSET', 'doc:short', *hello_kv)
+    conn.execute_command('HPEXPIRE', 'doc:short', '1', 'FIELDS', '1', 'f5')
+
+    kv_scan = list(chain.from_iterable(
+        (f'f{i}', 'needle' if i in (3, 67) else 'filler') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:scan', *kv_scan)
+    conn.execute_command('HPEXPIRE', 'doc:scan', '1', 'FIELDS', '2', 'f3', 'f67')
+
+    conn.execute_command('HSET', 'doc:docexp', *hello_kv)
+    conn.execute_command('EXPIRE', 'doc:docexp', '30000')
+
+    kv_lowexp = list(chain.from_iterable(
+        (f'f{i}', 'tophalf' if i == 67 else 'other') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:lowexp', *kv_lowexp)
+    conn.execute_command('HPEXPIRE', 'doc:lowexp', '1', 'FIELDS', '1', 'f5')
+
+    kv_below = list(chain.from_iterable(
+        (f'f{i}', 'below' if i == 3 else 'other') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:below', *kv_below)
+    conn.execute_command('HPEXPIRE', 'doc:below', '1', 'FIELDS', '1', 'f50')
+
+    kv_live = list(chain.from_iterable(
+        (f'f{i}', 'alive' if i == 3 else 'other') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:live', *kv_live)
+    conn.execute_command('HEXPIRE', 'doc:live', '30000', 'FIELDS', '1', 'f3')
+
+    waitForIndex(env, 'idx')
+
+    time.sleep(0.050)
+
+    # Match because:
+    # - "doc:plain" has no expiration
+    # - "doc:docexp" has a long doc expiration time
+    # - "doc:short" has f5 expired but not the others
+    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT').apply(sort_document_names) \
+        .equal([3, 'doc:docexp', 'doc:plain', 'doc:short'])
+    # Not match because:
+    # - "doc:scan" f3 and f67 were expired
+    env.expect('FT.SEARCH', 'idx', 'needle', 'NOCONTENT').equal([0])
+    # Match because:
+    # - "doc:lowexp" f67 matches so the f5 expiration is not considered
+    env.expect('FT.SEARCH', 'idx', 'tophalf', 'NOCONTENT').equal([1, 'doc:lowexp'])
+    # Match because:
+    # - "doc:below" f3 matches so the f50 expiration is not considered
+    env.expect('FT.SEARCH', 'idx', 'below', 'NOCONTENT').equal([1, 'doc:below'])
+    # Match because:
+    # - "doc:live" f3 matches and it is not expired yet
+    env.expect('FT.SEARCH', 'idx', 'alive', 'NOCONTENT').equal([1, 'doc:live'])


### PR DESCRIPTION
## Describe the changes in the pull request

Add test to cover TimeToLiveTable_VerifyDocAndWideFieldMask function

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new pytest covering wide-schema/hash field expiration behavior without changing production code paths.
> 
> **Overview**
> Adds a new regression test, `test_wide_schema_field_expiration`, to validate TTL-table field-expiration handling when an index is auto-promoted to **wide schema** (>32 text fields, including field IDs in the high half).
> 
> The test creates multiple hash docs with different combinations of `HPEXPIRE`/`HEXPIRE`/key `EXPIRE` and asserts `FT.SEARCH` includes or excludes documents correctly when only some fields are expired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5610c3d3ce76f4b6f2891ec4d15703c2eecd57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->