### PR TITLE
[MOD-15393] Trie - Encapsulate Trie internals behind wrapper APIs

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -375,7 +375,7 @@ DEBUG_COMMAND(DumpTerms) {
   int dist = 0;
   size_t termLen;
 
-  RedisModule_ReplyWithArray(ctx, sctx->spec->terms->size);
+  RedisModule_ReplyWithArray(ctx, Trie_Size(sctx->spec->terms));
 
   TrieIterator *it = Trie_Iterate(sctx->spec->terms, "", 0, 0, 1);
   while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, &dist)) {

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -712,7 +712,7 @@ DEBUG_COMMAND(DumpSuffix) {
     long resultSize = 0;
 
     // iterate trie and reply with terms
-    TrieIterator *it = TrieNode_Iterate(suffix->root, NULL, NULL, NULL);
+    TrieIterator *it = Trie_IterateAll(suffix);
     rune *rstr;
     t_len len;
     float score;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -54,7 +54,7 @@ int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
   }
 
   // Delete the dictionary if it's empty
-  if (t->size == 0) {
+  if (Trie_Size(t) == 0) {
     dictDelete(spellCheckDicts, dictName);
     TrieType_Free(t);
   }
@@ -75,7 +75,7 @@ void Dictionary_Dump(RedisModuleCtx *ctx, const char *dictName) {
   int dist = 0;
   size_t termLen;
 
-  RedisModule_ReplyWithSet(ctx, t->size);
+  RedisModule_ReplyWithSet(ctx, Trie_Size(t));
 
   TrieIterator *it = Trie_Iterate(t, "", 0, 0, 1);
   while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, &dist)) {
@@ -158,7 +158,7 @@ static void Propagate_Dict(RedisModuleCtx* ctx, const char* dictName, Trie* trie
   float score = 0;
   int dist = 0;
 
-  RedisModuleString **terms = rm_malloc(trie->size * sizeof(RedisModuleString*));
+  RedisModuleString **terms = rm_malloc(Trie_Size(trie) * sizeof(RedisModuleString*));
   size_t termsCount = 0;
 
   TrieIterator *it = Trie_Iterate(trie, "", 0, 0, 1);
@@ -169,8 +169,8 @@ static void Propagate_Dict(RedisModuleCtx* ctx, const char* dictName, Trie* trie
   }
   TrieIterator_Free(it);
 
-  RS_ASSERT(termsCount == trie->size);
-  RS_LOG_ASSERT(trie->size != 0, "Empty dictionary should not exist in the dictionary list");
+  RS_ASSERT(termsCount == Trie_Size(trie));
+  RS_LOG_ASSERT(Trie_Size(trie) != 0, "Empty dictionary should not exist in the dictionary list");
   int rc = RedisModule_ClusterPropagateForSlotMigration(ctx, RS_DICT_ADD, "cv", dictName, terms, termsCount);
   if (rc != REDISMODULE_OK) {
     RedisModule_Log(ctx, "warning", "Failed to propagate dictionary '%s' during slot migration. errno: %d", RSGlobalConfig.hideUserDataFromLog ? "****" : dictName, errno);
@@ -206,7 +206,7 @@ static int SpellCheckDictAuxLoad(RedisModuleIO *rdb, int encver, int when) {
       RedisModule_Free(key);
       goto cleanup;
     }
-    if (val->size) {
+    if (Trie_Size(val)) {
       dictAdd(spellCheckDicts, key, val);
     } else {
       TrieType_Free(val);

--- a/src/query.c
+++ b/src/query.c
@@ -720,7 +720,7 @@ static QueryIterator *Query_EvalPrefixNode(QueryEvalCtx *q, QueryNode *qn) {
     if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
        (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
       SuffixCtx sufCtx = {
-        .root = spec->suffix,
+        .trie = spec->suffix,
         .rune = str,
         .runelen = nstr,
         .type = qn->pfx.prefix ? SUFFIX_TYPE_CONTAINS : SUFFIX_TYPE_SUFFIX,
@@ -777,7 +777,7 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
     if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
        (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
       SuffixCtx sufCtx = {
-        .root = spec->suffix,
+        .trie = spec->suffix,
         .rune = str,
         .runelen = nstr,
         .cstr = token->str,

--- a/src/query.c
+++ b/src/query.c
@@ -720,7 +720,7 @@ static QueryIterator *Query_EvalPrefixNode(QueryEvalCtx *q, QueryNode *qn) {
     if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
        (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
       SuffixCtx sufCtx = {
-        .root = spec->suffix->root,
+        .root = spec->suffix,
         .rune = str,
         .runelen = nstr,
         .type = qn->pfx.prefix ? SUFFIX_TYPE_CONTAINS : SUFFIX_TYPE_SUFFIX,
@@ -777,7 +777,7 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
     if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
        (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
       SuffixCtx sufCtx = {
-        .root = spec->suffix->root,
+        .root = spec->suffix,
         .rune = str,
         .runelen = nstr,
         .cstr = token->str,

--- a/src/query.c
+++ b/src/query.c
@@ -733,9 +733,9 @@ static QueryIterator *Query_EvalPrefixNode(QueryEvalCtx *q, QueryNode *qn) {
       QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC, "Contains query on fields without WITHSUFFIXTRIE support");
     }
   } else {
-    TrieNode_IterateContains(t->root, str, nstr, qn->pfx.prefix, qn->pfx.suffix,
-                           runeIterCb, &ctx, &q->sctx->time.timeout,
-                           q->sctx->time.skipTimeoutChecks);
+    Trie_IterateContains(t, str, nstr, qn->pfx.prefix, qn->pfx.suffix,
+                         runeIterCb, &ctx, &q->sctx->time.timeout,
+                         q->sctx->time.skipTimeoutChecks);
   }
 
   rm_free(str);

--- a/src/query.c
+++ b/src/query.c
@@ -910,8 +910,8 @@ static QueryIterator *Query_EvalLexRangeNode(QueryEvalCtx *q, QueryNode *lx) {
     end = strToLowerRunes(lx->lxrng.end, strlen(lx->lxrng.end), &nend);
   }
 
-  TrieNode_IterateRange(t->root, begin, begin ? nbegin : -1, lx->lxrng.includeBegin, end,
-                        end ? nend : -1, lx->lxrng.includeEnd, runeIterCb, &ctx);
+  Trie_IterateRange(t, begin, begin ? nbegin : -1, lx->lxrng.includeBegin, end,
+                    end ? nend : -1, lx->lxrng.includeEnd, runeIterCb, &ctx);
   rm_free(begin);
   rm_free(end);
 

--- a/src/query.c
+++ b/src/query.c
@@ -566,7 +566,7 @@ QueryIterator *Query_EvalTokenNode(QueryEvalCtx *q, QueryNode *qn) {
     size_t rlen = 0;
     runeBuf buf;
     rune *runes = runeBufFill(qn->tn.str, qn->tn.len, &buf, &rlen);
-    TrieNode *trienode = TrieNode_Get(q->sctx->spec->terms->root, runes, rlen, true, NULL);
+    TrieNode *trienode = Trie_GetNode(q->sctx->spec->terms, runes, rlen, true, NULL);
     runeBufFree(&buf);
     size_t numDocsInTerm = trienode ? trienode->numDocs : 0;
     double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
@@ -648,7 +648,7 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
     size_t rlen = 0;
     runeBuf buf;
     rune *runes = runeBufFill("", 1, &buf, &rlen);
-    TrieNode *emptyNode = TrieNode_Get(terms->root, runes, rlen, true, NULL);
+    TrieNode *emptyNode = Trie_GetNode(terms, runes, rlen, true, NULL);
     runeBufFree(&buf);
     size_t numDocsInEmpty = emptyNode ? emptyNode->numDocs : 0;
     addTerm("", 0, numDocsInEmpty, q, opts, &its, &itsSz, &itsCap);
@@ -869,7 +869,7 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
     size_t rlen = 0;
     runeBuf buf;
     rune *runes = runeBufFill(tok.str, tok.len, &buf, &rlen);
-    TrieNode *trienode = TrieNode_Get(q->sctx->spec->terms->root, runes, rlen, true, NULL);
+    TrieNode *trienode = Trie_GetNode(q->sctx->spec->terms, runes, rlen, true, NULL);
     runeBufFree(&buf);
     size_t numDocsInTerm = trienode ? trienode->numDocs : 0;
     double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);

--- a/src/query.c
+++ b/src/query.c
@@ -798,8 +798,8 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
   }
 
   if (!spec->suffix || fallbackBruteForce) {
-    TrieNode_IterateWildcard(t->root, str, nstr, runeIterCb, &ctx, &q->sctx->time.timeout,
-                             q->sctx->time.skipTimeoutChecks);
+    Trie_IterateWildcard(t, str, nstr, runeIterCb, &ctx, &q->sctx->time.timeout,
+                         q->sctx->time.skipTimeoutChecks);
   }
 
   rm_free(str);

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -160,7 +160,7 @@ static void SpellCheck_FindSuggestions(SpellCheckCtx *scCtx, Trie *t, const char
 
 RS_Suggestion **spellCheck_GetSuggestions(RS_Suggestions *s) {
   TrieIterator *iter = Trie_Iterate(s->suggestionsTrie, "", 0, 0, 1);
-  RS_Suggestion **ret = array_new(RS_Suggestion *, s->suggestionsTrie->size);
+  RS_Suggestion **ret = array_new(RS_Suggestion *, Trie_Size(s->suggestionsTrie));
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -168,14 +168,14 @@ static int recursiveAdd(TrieNode *node, SuffixCtx *sufCtx) {
 void Suffix_IterateContains(SuffixCtx *sufCtx) {
   if (sufCtx->type == SUFFIX_TYPE_CONTAINS) {
     // get string from node and children
-    TrieNode *node = Trie_GetNode(sufCtx->root, sufCtx->rune, sufCtx->runelen, false, NULL);
+    TrieNode *node = Trie_GetNode(sufCtx->trie, sufCtx->rune, sufCtx->runelen, false, NULL);
     if (!node) {
       return;
     }
     recursiveAdd(node, sufCtx);
   } else if (sufCtx->type == SUFFIX_TYPE_SUFFIX) {
     // exact match. Get strings from a single node
-    TrieNode *node = Trie_GetNode(sufCtx->root, sufCtx->rune, sufCtx->runelen, true, NULL);
+    TrieNode *node = Trie_GetNode(sufCtx->trie, sufCtx->rune, sufCtx->runelen, true, NULL);
     suffixData *data = Suffix_GetData(node);
     if (data) {
       processSuffixData(data, sufCtx);
@@ -339,7 +339,7 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
   }
   token[toklen] = (rune)'\0';
 
-  Trie_IterateWildcard(sufCtx->root, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,
+  Trie_IterateWildcard(sufCtx->trie, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,
                        sufCtx->skipTimeoutChecks);
   return 1;
 }

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -61,7 +61,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   if (!data) {
     suffixData newdata = createSuffixNode(copyStr, 1);
     RSPayload payload = { .data = (char*)&newdata, .len = sizeof(newdata) };
-    Trie_InsertRune(trie, runes, rlen, 1, ADD_REPLACE, &payload, 0);
+    Trie_InsertRuneNoSize(trie, runes, rlen, 1, ADD_REPLACE, &payload, 0);
   } else {
     RS_LOG_ASSERT(!data->term, "can't reach here");
     data->term = copyStr;

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -168,14 +168,14 @@ static int recursiveAdd(TrieNode *node, SuffixCtx *sufCtx) {
 void Suffix_IterateContains(SuffixCtx *sufCtx) {
   if (sufCtx->type == SUFFIX_TYPE_CONTAINS) {
     // get string from node and children
-    TrieNode *node = TrieNode_Get(sufCtx->root, sufCtx->rune, sufCtx->runelen, 0, NULL);
+    TrieNode *node = Trie_GetNode(sufCtx->root, sufCtx->rune, sufCtx->runelen, false, NULL);
     if (!node) {
       return;
     }
     recursiveAdd(node, sufCtx);
   } else if (sufCtx->type == SUFFIX_TYPE_SUFFIX) {
     // exact match. Get strings from a single node
-    TrieNode *node = TrieNode_Get(sufCtx->root, sufCtx->rune, sufCtx->runelen, 1, NULL);
+    TrieNode *node = Trie_GetNode(sufCtx->root, sufCtx->rune, sufCtx->runelen, true, NULL);
     suffixData *data = Suffix_GetData(node);
     if (data) {
       processSuffixData(data, sufCtx);
@@ -339,8 +339,8 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
   }
   token[toklen] = (rune)'\0';
 
-  TrieNode_IterateWildcard(sufCtx->root, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,
-                           sufCtx->skipTimeoutChecks);
+  Trie_IterateWildcard(sufCtx->root, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,
+                       sufCtx->skipTimeoutChecks);
   return 1;
 }
 

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -61,7 +61,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   if (!data) {
     suffixData newdata = createSuffixNode(copyStr, 1);
     RSPayload payload = { .data = (char*)&newdata, .len = sizeof(newdata) };
-    TrieNode_Add(&trie->root, runes, rlen, &payload, 1, ADD_REPLACE, trie->freecb, 0);
+    Trie_InsertRune(trie, runes, rlen, 1, ADD_REPLACE, &payload, 0);
   } else {
     RS_LOG_ASSERT(!data->term, "can't reach here");
     data->term = copyStr;

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -44,7 +44,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   runeBuf buf;
   rune *runes = runeBufFill(str, len, &buf, &rlen);
 
-  TrieNode *trienode = TrieNode_Get(trie->root, runes, rlen, 1, NULL);
+  TrieNode *trienode = Trie_GetNode(trie, runes, rlen, true, NULL);
   suffixData *data = NULL;
   if (trienode) {
     // suffixData *node = TrieNode_GetValue(trie->root, runes, rlen, 1);
@@ -71,7 +71,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   // Save string copy to all suffixes of it
   // If it exists, move to the next field
   for (int j = 1; j < len - MIN_SUFFIX + 1; ++j) {
-    TrieNode *trienode = TrieNode_Get(trie->root, runes + j, rlen - j, 1, NULL);
+    TrieNode *trienode = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
 
     data = Suffix_GetData(trienode);
     if (!trienode || !trienode->payload) {
@@ -107,7 +107,7 @@ void deleteSuffixTrie(Trie *trie, const char *str, uint32_t len) {
 
   // iterate all matching terms and remove word
   for (int j = 0; j < len - MIN_SUFFIX + 1; ++j) {
-    TrieNode *node = TrieNode_Get(trie->root, runes + j, rlen - j, 1, NULL);
+    TrieNode *node = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
     suffixData *data = Suffix_GetData(node);
     // suffix trie is shared between all text fields in index, even if they don't use it.
     // if the trie is owned by other fields and not any one containing this suffix,

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -28,7 +28,7 @@ typedef enum {
 /*****************        Trie          ********************/
 /***********************************************************/
 typedef struct SuffixCtx {
-    Trie *root;
+    Trie *trie;
     rune *rune;
     size_t runelen;
     const char *cstr;

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -28,7 +28,7 @@ typedef enum {
 /*****************        Trie          ********************/
 /***********************************************************/
 typedef struct SuffixCtx {
-    TrieNode *root;
+    Trie *root;
     rune *rune;
     size_t runelen;
     const char *cstr;

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -100,7 +100,7 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   /* Insert the new element. */
   Trie_Insert(tree, val, score, incr, &payload, 0);
 
-  RedisModule_ReplyWithLongLong(ctx, tree->size);
+  RedisModule_ReplyWithLongLong(ctx, Trie_Size(tree));
   RedisModule_ReplicateVerbatim(ctx);
 
 end:
@@ -137,7 +137,7 @@ int RSSuggestLenCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   tree = RedisModule_ModuleTypeGetValue(key);
-  RedisModule_ReplyWithLongLong(ctx, tree ? tree->size : 0);
+  RedisModule_ReplyWithLongLong(ctx, Trie_Size(tree));
 
 end:
   if (key) {
@@ -186,7 +186,7 @@ int RSSuggestDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   str = RedisModule_StringPtrLen(argv[2], &len);
   RedisModule_ReplyWithLongLong(ctx, Trie_Delete(tree, str, len));
 
-  if (tree->size == 0) {
+  if (Trie_Size(tree) == 0) {
     RedisModule_DeleteKey(key);
   }
 

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -137,7 +137,7 @@ int RSSuggestLenCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   tree = RedisModule_ModuleTypeGetValue(key);
-  RedisModule_ReplyWithLongLong(ctx, Trie_Size(tree));
+  RedisModule_ReplyWithLongLong(ctx, tree ? tree->size : 0);
 
 end:
   if (key) {

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -101,6 +101,12 @@ TrieNode *Trie_GetNode(Trie *t, const rune *str, t_len len, bool exact, int *off
   return TrieNode_Get(t->root, str, len, exact, offsetOut);
 }
 
+void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
+                       const rune *max, int maxlen, bool includeMax,
+                       TrieRangeCallback callback, void *ctx) {
+  TrieNode_IterateRange(t->root, min, minlen, includeMin, max, maxlen, includeMax, callback, ctx);
+}
+
 // Forward declaration for the internal rune-based function
 static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, size_t len, size_t delta);
 

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -97,6 +97,10 @@ int Trie_DeleteRunes(Trie *t, const rune *runes, size_t len) {
   return rc;
 }
 
+TrieNode *Trie_GetNode(Trie *t, const rune *str, t_len len, bool exact, int *offsetOut) {
+  return TrieNode_Get(t->root, str, len, exact, offsetOut);
+}
+
 // Forward declaration for the internal rune-based function
 static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, size_t len, size_t delta);
 

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -114,6 +114,12 @@ void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool 
                            skipTimeoutChecks);
 }
 
+void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
+                          TrieRangeCallback callback, void *ctx, struct timespec *timeout,
+                          bool skipTimeoutChecks) {
+  TrieNode_IterateWildcard(t->root, str, nstr, callback, ctx, timeout, skipTimeoutChecks);
+}
+
 // Forward declaration for the internal rune-based function
 static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, size_t len, size_t delta);
 

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -65,6 +65,16 @@ int Trie_InsertRune(Trie *t, const rune *runes, size_t len, double score, int in
   return rc;
 }
 
+int Trie_InsertRuneNoSize(Trie *t, const rune *runes, size_t len, double score, int incr,
+                          RSPayload *payload, size_t numDocs) {
+  int rc = 0;
+  if (runes && len && len < TRIE_INITIAL_STRING_LEN) {
+    rc = TrieNode_Add(&t->root, runes, len, payload, (float)score, incr ? ADD_INCR : ADD_REPLACE,
+                      t->freecb, numDocs);
+  }
+  return rc;
+}
+
 void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact) {
   if (len > TRIE_INITIAL_STRING_LEN * sizeof(rune)) {
     return 0;

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -67,12 +67,9 @@ int Trie_InsertRune(Trie *t, const rune *runes, size_t len, double score, int in
 
 int Trie_InsertRuneNoSize(Trie *t, const rune *runes, size_t len, double score, int incr,
                           RSPayload *payload, size_t numDocs) {
-  int rc = 0;
-  if (runes && len && len < TRIE_INITIAL_STRING_LEN) {
-    rc = TrieNode_Add(&t->root, runes, len, payload, (float)score, incr ? ADD_INCR : ADD_REPLACE,
+  if (!runes || !len) return 0;
+  return TrieNode_Add(&t->root, runes, len, payload, (float)score, incr ? ADD_INCR : ADD_REPLACE,
                       t->freecb, numDocs);
-  }
-  return rc;
 }
 
 void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact) {

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -199,6 +199,10 @@ static int cmpEntries(const void *p1, const void *p2, const void *udata) {
   return 0;
 }
 
+TrieIterator *Trie_IterateAll(Trie *t) {
+  return TrieNode_Iterate(t->root, NULL, NULL, NULL);
+}
+
 TrieIterator *Trie_Iterate(Trie *t, const char *prefix, size_t len, int maxDist, int prefixMode) {
   size_t rlen;
   rune *runes = strToLowerRunes(prefix, len, &rlen);

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -107,6 +107,13 @@ void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
   TrieNode_IterateRange(t->root, min, minlen, includeMin, max, maxlen, includeMax, callback, ctx);
 }
 
+void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
+                          TrieRangeCallback callback, void *ctx, struct timespec *timeout,
+                          bool skipTimeoutChecks) {
+  TrieNode_IterateContains(t->root, str, nstr, prefix, suffix, callback, ctx, timeout,
+                           skipTimeoutChecks);
+}
+
 // Forward declaration for the internal rune-based function
 static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, size_t len, size_t delta);
 

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -67,7 +67,6 @@ int Trie_InsertRune(Trie *t, const rune *runes, size_t len, double score, int in
 
 int Trie_InsertRuneNoSize(Trie *t, const rune *runes, size_t len, double score, int incr,
                           RSPayload *payload, size_t numDocs) {
-  if (!runes || !len) return 0;
   return TrieNode_Add(&t->root, runes, len, payload, (float)score, incr ? ADD_INCR : ADD_REPLACE,
                       t->freecb, numDocs);
 }

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -62,6 +62,10 @@ void *Trie_GetValueRune(Trie *t, const rune *runes, size_t len, bool exact);
 int Trie_Delete(Trie *t, const char *s, size_t len);
 int Trie_DeleteRunes(Trie *t, const rune *runes, size_t len);
 
+/* Look up a node by rune key. Wraps TrieNode_Get on the trie's root so callers do not
+ * need to reach into Trie internals. See TrieNode_Get for parameter semantics. */
+TrieNode *Trie_GetNode(Trie *t, const rune *str, t_len len, bool exact, int *offsetOut);
+
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
   TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -55,11 +55,13 @@ int Trie_InsertRune(Trie *t, const rune *s, size_t len, double score, int incr,
                     RSPayload *payload, size_t numDocs);
 
 /* Insert a rune-keyed entry without updating the trie's size counter. Behaves
- * exactly like Trie_InsertRune except t->size is left untouched.
+ * exactly like calling TrieNode_Add(&t->root, ...) directly: no length guard,
+ * no size bookkeeping.
  *
  * Intended only for the suffix-trie full-word insert in addSuffixTrie(), which
- * historically called TrieNode_Add directly and therefore never incremented
- * size. Suffix tries never read ->size, so the omission is harmless there.
+ * historically called TrieNode_Add directly to bypass both the size update
+ * (suffix tries never read ->size) and Trie_InsertRune's length guard (the
+ * suffix trie's full-word entries are not subject to that guard).
  *
  * Do not use for new call sites - prefer Trie_InsertRune so size stays in sync
  * with TrieNode_Add's return value. */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -11,6 +11,7 @@
 
 #include "redismodule.h"
 
+#include "rmutil/rm_assert.h"
 #include "trie.h"
 #include "levenshtein.h"
 
@@ -98,7 +99,10 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
                           bool skipTimeoutChecks);
 
 /* Number of terminal entries in the trie. Wraps the internal size counter. */
-static inline size_t Trie_Size(const Trie *t) { return t->size; }
+static inline size_t Trie_Size(const Trie *t) {
+  RS_ASSERT(t);
+  return t->size;
+}
 
 /* Iterate every node in the trie with no filter or distance constraint. Wraps
  * TrieNode_Iterate on the trie's root with no filter. Used by debug paths that

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -88,6 +88,11 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
 /* Number of terminal entries in the trie. Wraps the internal size counter. */
 static inline size_t Trie_Size(const Trie *t) { return t ? t->size : 0; }
 
+/* Iterate every node in the trie with no filter or distance constraint. Wraps
+ * TrieNode_Iterate(t->root, NULL, NULL, NULL). Used by debug paths that want raw
+ * traversal; production code should prefer Trie_Iterate with a prefix/maxDist. */
+TrieIterator *Trie_IterateAll(Trie *t);
+
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
   TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -98,7 +98,7 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
                           bool skipTimeoutChecks);
 
 /* Number of terminal entries in the trie. Wraps the internal size counter. */
-static inline size_t Trie_Size(const Trie *t) { return t ? t->size : 0; }
+static inline size_t Trie_Size(const Trie *t) { return t->size; }
 
 /* Iterate every node in the trie with no filter or distance constraint. Wraps
  * TrieNode_Iterate on the trie's root with no filter. Used by debug paths that

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -79,6 +79,12 @@ void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool 
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                           bool skipTimeoutChecks);
 
+/* Iterate all nodes matching a wildcard pattern. Wraps TrieNode_IterateWildcard on the
+ * trie's root. See TrieNode_IterateWildcard for parameter semantics. */
+void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
+                          TrieRangeCallback callback, void *ctx, struct timespec *timeout,
+                          bool skipTimeoutChecks);
+
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
   TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -66,6 +66,12 @@ int Trie_DeleteRunes(Trie *t, const rune *runes, size_t len);
  * need to reach into Trie internals. See TrieNode_Get for parameter semantics. */
 TrieNode *Trie_GetNode(Trie *t, const rune *str, t_len len, bool exact, int *offsetOut);
 
+/* Iterate all nodes within a lexicographic range. Wraps TrieNode_IterateRange on the
+ * trie's root. See TrieNode_IterateRange for parameter semantics. */
+void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
+                       const rune *max, int maxlen, bool includeMax,
+                       TrieRangeCallback callback, void *ctx);
+
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
   TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -89,8 +89,9 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
 static inline size_t Trie_Size(const Trie *t) { return t ? t->size : 0; }
 
 /* Iterate every node in the trie with no filter or distance constraint. Wraps
- * TrieNode_Iterate(t->root, NULL, NULL, NULL). Used by debug paths that want raw
- * traversal; production code should prefer Trie_Iterate with a prefix/maxDist. */
+ * TrieNode_Iterate on the trie's root with no filter. Used by debug paths that
+ * want raw traversal; production code should prefer Trie_Iterate with a
+ * prefix/maxDist. */
 TrieIterator *Trie_IterateAll(Trie *t);
 
 /* Result codes for Trie_DecrementNumDocs */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -53,6 +53,18 @@ int Trie_InsertStringBuffer(Trie *t, const char *s, size_t len, double score, in
 int Trie_InsertRune(Trie *t, const rune *s, size_t len, double score, int incr,
                     RSPayload *payload, size_t numDocs);
 
+/* Insert a rune-keyed entry without updating the trie's size counter. Behaves
+ * exactly like Trie_InsertRune except t->size is left untouched.
+ *
+ * Intended only for the suffix-trie full-word insert in addSuffixTrie(), which
+ * historically called TrieNode_Add directly and therefore never incremented
+ * size. Suffix tries never read ->size, so the omission is harmless there.
+ *
+ * Do not use for new call sites - prefer Trie_InsertRune so size stays in sync
+ * with TrieNode_Add's return value. */
+int Trie_InsertRuneNoSize(Trie *t, const rune *s, size_t len, double score, int incr,
+                          RSPayload *payload, size_t numDocs);
+
 /* Get the payload from the node. if `exact` is 0, the payload is return even if local offset!=len
    Use for debug only! */
 void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact);

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -72,6 +72,13 @@ void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
                        const rune *max, int maxlen, bool includeMax,
                        TrieRangeCallback callback, void *ctx);
 
+/* Iterate all nodes that contain (or begin/end with) the given pattern. Wraps
+ * TrieNode_IterateContains on the trie's root. See TrieNode_IterateContains for
+ * parameter semantics. */
+void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
+                          TrieRangeCallback callback, void *ctx, struct timespec *timeout,
+                          bool skipTimeoutChecks);
+
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
   TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -85,6 +85,9 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                           bool skipTimeoutChecks);
 
+/* Number of terminal entries in the trie. Wraps the internal size counter. */
+static inline size_t Trie_Size(const Trie *t) { return t ? t->size : 0; }
+
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
   TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -313,7 +313,7 @@ bool trieContains(Trie *t, const char *s) {
   if (!runes) {
     return false;
   }
-  TrieNode *node = TrieNode_Get(t->root, runes, len, 0, NULL);
+  TrieNode *node = Trie_GetNode(t, runes, len, 0, NULL);
   runeBufFree(&buf);
   return node != NULL;
 }
@@ -820,7 +820,7 @@ static size_t trieGetNumDocs(Trie *t, const char *s) {
   runeBuf buf;
   size_t runeLen = strlen(s);
   rune *runes = runeBufFill(s, runeLen, &buf, &runeLen);
-  TrieNode *node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  TrieNode *node = Trie_GetNode(t, runes, runeLen, true, NULL);
   runeBufFree(&buf);
   if (node == NULL) {
     return 0;

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -66,7 +66,7 @@ static ElemSet trieIterRange(Trie *t, const char *begin, size_t nbegin, const ch
   }
 
   ElemSet foundElements;
-  TrieNode_IterateRange(t->root, r1Ptr, nr1, true, r2Ptr, nr2, false,
+  Trie_IterateRange(t, r1Ptr, nr1, true, r2Ptr, nr2, false,
                         rangeFunc, &foundElements);
   return foundElements;
 }

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -895,7 +895,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithNumDocs) {
   EXPECT_EQ(300, trieGetNumDocs(loadedTrie, "ABC"));
 
   // Verify numDocs via iterator as well
-  TrieIterator *it = TrieNode_Iterate(loadedTrie->root, NULL, NULL, NULL);
+  TrieIterator *it = Trie_IterateAll(loadedTrie);
   rune *rstr;
   t_len len;
   float score;

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -93,7 +93,7 @@ TEST_F(TrieTest, testBasicRange) {
 
   // What does a NULL range return? the entire trie
   ret = trieIterRange(t, NULL, NULL);
-  ASSERT_EQ(t->size, ret.size());
+  ASSERT_EQ(Trie_Size(t), ret.size());
 
   // Min and max the same- should return only one value
   ret = trieIterRange(t, "1", "1");
@@ -131,7 +131,7 @@ TEST_F(TrieTest, testBasicRangeWithScore) {
 
   // What does a NULL range return? the entire trie
   ret = trieIterRange(t, NULL, NULL);
-  ASSERT_EQ(t->size, ret.size());
+  ASSERT_EQ(Trie_Size(t), ret.size());
 
   // Min and max the same- should return only one value
   ret = trieIterRange(t, "1", "1");
@@ -366,7 +366,7 @@ TEST_F(TrieTest, testbenchmark) {
 
 // Helper function to compare two tries for equality
 static bool compareTrieContents(Trie *original, Trie *loaded) {
-  if (original->size != loaded->size) {
+  if (Trie_Size(original) != Trie_Size(loaded)) {
     return false;
   }
 
@@ -453,7 +453,7 @@ TEST_F(TrieTest, testBasicRdbSaveLoad) {
   trieInsertByScore(originalTrie, "books", 8.0);       // Extension of "book"
   trieInsertByScore(originalTrie, "booking", 2.0);     // Extension of "book"
 
-  ASSERT_EQ(8, originalTrie->size);
+  ASSERT_EQ(8, Trie_Size(originalTrie));
 
   // Create RDB IO context
   RedisModuleIO *io = RMCK_CreateRdbIO();
@@ -478,7 +478,7 @@ TEST_F(TrieTest, testBasicRdbSaveLoad) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Compare the original and loaded tries
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
   // Verify all entries are present in the loaded trie
   EXPECT_TRUE(trieContains(loadedTrie, "app"));
@@ -511,7 +511,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithPayloads) {
   bool r2 = Trie_InsertStringBuffer(originalTrie, "running", 7, 3.0, 0, &p2, 0);    // Extension with payload
   bool r3 = Trie_InsertStringBuffer(originalTrie, "runner", 6, 4.0, 0, &p3, 0);     // Extension with payload
 
-  EXPECT_EQ(3, originalTrie->size);
+  EXPECT_EQ(3, Trie_Size(originalTrie));
 
   // Create RDB IO context
   RedisModuleIO *io = RMCK_CreateRdbIO();
@@ -536,7 +536,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithPayloads) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Compare the original and loaded tries
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
   // Verify all entries are present in the loaded trie
   EXPECT_TRUE(trieContains(loadedTrie, "run"));
@@ -577,7 +577,7 @@ TEST_F(TrieTest, testRdbSaveLoadPayloadsNotSerialized) {
   Trie_InsertStringBuffer(originalTrie, "care", 4, 6.0, 0, &p2, 0);       // Extension with payload
   Trie_InsertStringBuffer(originalTrie, "careful", 7, 4.0, 0, &p3, 0);    // Extension with payload
 
-  EXPECT_EQ(3, originalTrie->size);
+  EXPECT_EQ(3, Trie_Size(originalTrie));
 
   // Create RDB IO context
   RedisModuleIO *io = RMCK_CreateRdbIO();
@@ -602,7 +602,7 @@ TEST_F(TrieTest, testRdbSaveLoadPayloadsNotSerialized) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Compare the original and loaded tries - sizes should match
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
   // Verify all entries are present in the loaded trie
   EXPECT_TRUE(trieContains(loadedTrie, "car"));
@@ -638,7 +638,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithoutPayloads) {
   Trie_InsertStringBuffer(originalTrie, "help", 4, 7.0, 0, NULL, 0);      // Related word without payload
   Trie_InsertStringBuffer(originalTrie, "helper", 6, 5.0, 0, &p2, 0);    // Extension with payload
 
-  EXPECT_EQ(4, originalTrie->size);
+  EXPECT_EQ(4, Trie_Size(originalTrie));
 
   // Create RDB IO context
   RedisModuleIO *io = RMCK_CreateRdbIO();
@@ -663,7 +663,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithoutPayloads) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Compare sizes - entries should be preserved
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
   // Verify all entries are present in the loaded trie
   EXPECT_TRUE(trieContains(loadedTrie, "hello"));
@@ -690,7 +690,7 @@ TEST_F(TrieTest, testRdbSaveLoadEmptyTrie) {
     TrieType_Free(trie);
   });
 
-  ASSERT_EQ(0, originalTrie->size);
+  ASSERT_EQ(0, Trie_Size(originalTrie));
 
   // Create RDB IO context
   RedisModuleIO *io = RMCK_CreateRdbIO();
@@ -715,8 +715,8 @@ TEST_F(TrieTest, testRdbSaveLoadEmptyTrie) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Compare the original and loaded tries
-  EXPECT_EQ(0, loadedTrie->size);
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(0, Trie_Size(loadedTrie));
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 }
 
 TEST_F(TrieTest, testRdbSaveLoadLexSortedTrie) {
@@ -743,7 +743,7 @@ TEST_F(TrieTest, testRdbSaveLoadLexSortedTrie) {
   trieInsertByScore(originalTrie, "careful", 13.0);    // Extension of "care"
   trieInsertByScore(originalTrie, "carefully", 14.0);  // Extension of "careful"
 
-  ASSERT_EQ(14, originalTrie->size);
+  ASSERT_EQ(14, Trie_Size(originalTrie));
 
   // Verify all entries exist in the original trie
   EXPECT_TRUE(trieContains(originalTrie, "test"));
@@ -784,7 +784,7 @@ TEST_F(TrieTest, testRdbSaveLoadLexSortedTrie) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Compare the original and loaded tries
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
   // Note: The loaded trie will have Trie_Sort_Score (default from TrieType_GenericLoad)
   // but all the entries should still be present, even though the sorting mode changed
@@ -843,7 +843,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithNumDocs) {
   trieInsertWithNumDocs(originalTrie, "AB", 5.0, 200);      // numDocs = 200
   trieInsertWithNumDocs(originalTrie, "ABC", 6.0, 300);     // numDocs = 300
 
-  ASSERT_EQ(6, originalTrie->size);
+  ASSERT_EQ(6, Trie_Size(originalTrie));
 
   // Verify original numDocs values
   EXPECT_EQ(10, trieGetNumDocs(originalTrie, "help"));
@@ -876,7 +876,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithNumDocs) {
   EXPECT_EQ(0, RMCK_IsIOError(io));
 
   // Verify the loaded trie has the same size
-  EXPECT_EQ(originalTrie->size, loadedTrie->size);
+  EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
   // Verify all entries are present
   EXPECT_TRUE(trieContains(loadedTrie, "help"));

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -350,40 +350,40 @@ int testNumDocs() {
   // Insert "help"
   int rc = Trie_InsertStringBuffer(t, "help", 4, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(1, rc);
-  node = TrieNode_Get(t->root, helpRunes, helpLen, true, NULL);
+  node = Trie_GetNode(t, helpRunes, helpLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
   // Insert "helping" - "help" is a prefix of "helping"
   rc = Trie_InsertStringBuffer(t, "helping", 7, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(1, rc);
-  node = TrieNode_Get(t->root, helpingRunes, helpingLen, true, NULL);
+  node = Trie_GetNode(t, helpingRunes, helpingLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
   // Insert "helper" - shares "help" prefix
   rc = Trie_InsertStringBuffer(t, "helper", 6, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(1, rc);
-  node = TrieNode_Get(t->root, helperRunes, helperLen, true, NULL);
+  node = Trie_GetNode(t, helperRunes, helperLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
   // Insert chain: A -> AB -> ABC (each is prefix of the next)
   rc = Trie_InsertStringBuffer(t, "A", 1, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(1, rc);
-  node = TrieNode_Get(t->root, aRunes, aLen, true, NULL);
+  node = Trie_GetNode(t, aRunes, aLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
   rc = Trie_InsertStringBuffer(t, "AB", 2, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(1, rc);
-  node = TrieNode_Get(t->root, abRunes, abLen, true, NULL);
+  node = Trie_GetNode(t, abRunes, abLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
   rc = Trie_InsertStringBuffer(t, "ABC", 3, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(1, rc);
-  node = TrieNode_Get(t->root, abcRunes, abcLen, true, NULL);
+  node = Trie_GetNode(t, abcRunes, abcLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
@@ -392,39 +392,39 @@ int testNumDocs() {
   ASSERT_EQUAL(0, rc);
   rc = Trie_InsertStringBuffer(t, "help", 4, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(0, rc);
-  node = TrieNode_Get(t->root, helpRunes, helpLen, true, NULL);
+  node = Trie_GetNode(t, helpRunes, helpLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(3, node->numDocs);
 
   // Increment numDocs for "AB" (middle of chain)
   rc = Trie_InsertStringBuffer(t, "AB", 2, 1.0, 0, NULL, 1);
   ASSERT_EQUAL(0, rc);
-  node = TrieNode_Get(t->root, abRunes, abLen, true, NULL);
+  node = Trie_GetNode(t, abRunes, abLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(2, node->numDocs);
 
   // Final verification: check all values
-  node = TrieNode_Get(t->root, helpRunes, helpLen, true, NULL);
+  node = Trie_GetNode(t, helpRunes, helpLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(3, node->numDocs);
 
-  node = TrieNode_Get(t->root, helpingRunes, helpingLen, true, NULL);
+  node = Trie_GetNode(t, helpingRunes, helpingLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
-  node = TrieNode_Get(t->root, helperRunes, helperLen, true, NULL);
+  node = Trie_GetNode(t, helperRunes, helperLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
-  node = TrieNode_Get(t->root, aRunes, aLen, true, NULL);
+  node = Trie_GetNode(t, aRunes, aLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
-  node = TrieNode_Get(t->root, abRunes, abLen, true, NULL);
+  node = Trie_GetNode(t, abRunes, abLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(2, node->numDocs);
 
-  node = TrieNode_Get(t->root, abcRunes, abcLen, true, NULL);
+  node = Trie_GetNode(t, abcRunes, abcLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1, node->numDocs);
 
@@ -487,33 +487,33 @@ int testDecrementNumDocs() {
   // Test 2: Insert term and decrement partially
   int insertRc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 0, NULL, 10);
   ASSERT_EQUAL(1, insertRc);
-  node = TrieNode_Get(t->root, helloRunes, helloLen, true, NULL);
+  node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(10, node->numDocs);
 
   rc = Trie_DecrementNumDocs(t, "hello", 5, 3);
   ASSERT_EQUAL(TRIE_DECR_UPDATED, rc);
-  node = TrieNode_Get(t->root, helloRunes, helloLen, true, NULL);
+  node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(7, node->numDocs);
 
   // Test 3: Decrement to exactly zero (should delete)
   rc = Trie_DecrementNumDocs(t, "hello", 5, 7);
   ASSERT_EQUAL(TRIE_DECR_DELETED, rc);
-  node = TrieNode_Get(t->root, helloRunes, helloLen, true, NULL);
+  node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node == NULL);  // Node should be deleted
   ASSERT_EQUAL(0, t->size);  // Trie size should be 0
 
   // Test 4: Decrement with delta > numDocs (should clamp and delete)
   insertRc = Trie_InsertStringBuffer(t, "world", 5, 1.0, 0, NULL, 5);
   ASSERT_EQUAL(1, insertRc);
-  node = TrieNode_Get(t->root, worldRunes, worldLen, true, NULL);
+  node = Trie_GetNode(t, worldRunes, worldLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(5, node->numDocs);
 
   rc = Trie_DecrementNumDocs(t, "world", 5, 100);  // delta > numDocs
   ASSERT_EQUAL(TRIE_DECR_DELETED, rc);
-  node = TrieNode_Get(t->root, worldRunes, worldLen, true, NULL);
+  node = Trie_GetNode(t, worldRunes, worldLen, true, NULL);
   ASSERT(node == NULL);  // Node should be deleted
 
   // Test 5: Unicode string - "café" (UTF-8: 0x63 0x61 0x66 0xC3 0xA9)
@@ -523,13 +523,13 @@ int testDecrementNumDocs() {
 
   insertRc = Trie_InsertStringBuffer(t, cafe, cafeUtf8Len, 1.0, 0, NULL, 8);
   ASSERT_EQUAL(1, insertRc);
-  node = TrieNode_Get(t->root, cafeRunes, cafeLen, true, NULL);
+  node = Trie_GetNode(t, cafeRunes, cafeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(8, node->numDocs);
 
   rc = Trie_DecrementNumDocs(t, cafe, cafeUtf8Len, 3);
   ASSERT_EQUAL(TRIE_DECR_UPDATED, rc);
-  node = TrieNode_Get(t->root, cafeRunes, cafeLen, true, NULL);
+  node = Trie_GetNode(t, cafeRunes, cafeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(5, node->numDocs);
 
@@ -550,15 +550,15 @@ int testDecrementNumDocs() {
   rc = Trie_DecrementNumDocs(t, "help", 4, 5);
   ASSERT_EQUAL(TRIE_DECR_UPDATED, rc);
 
-  node = TrieNode_Get(t->root, helpRunes, helpLen, true, NULL);
+  node = Trie_GetNode(t, helpRunes, helpLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(5, node->numDocs);
 
-  node = TrieNode_Get(t->root, helperRunes, helperLen, true, NULL);
+  node = Trie_GetNode(t, helperRunes, helperLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(5, node->numDocs);  // Unchanged
 
-  node = TrieNode_Get(t->root, helpingRunes, helpingLen, true, NULL);
+  node = Trie_GetNode(t, helpingRunes, helpingLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(3, node->numDocs);  // Unchanged
 
@@ -667,13 +667,13 @@ int testDecrementNumDocsComplex() {
   rune *runes;
 
   runes = strToRunes("redis", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(500, node->numDocs);
   free(runes);
 
   runes = strToRunes("banana", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(80, node->numDocs);
   free(runes);
@@ -720,7 +720,7 @@ int testDecrementNumDocsComplex() {
     ASSERT_EQUAL(decrements[i].expectedResult, rc);
 
     runes = strToRunes(decrements[i].term, &runeLen);
-    node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+    node = Trie_GetNode(t, runes, runeLen, true, NULL);
 
     if (decrements[i].expectedNumDocsAfter == 0) {
       ASSERT(node == NULL);  // Node should be deleted
@@ -733,75 +733,75 @@ int testDecrementNumDocsComplex() {
 
   // Verify that "bandana" was deleted but "band" and "banana" still exist
   runes = strToRunes("bandana", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);
   free(runes);
 
   runes = strToRunes("band", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(25, node->numDocs);  // Unchanged
   free(runes);
 
   runes = strToRunes("banana", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(77, node->numDocs);  // Was decremented
   free(runes);
 
   // Verify Unicode terms: caféine and 東京 were deleted, café still exists
   runes = strToRunes(cafeine, &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);  // caféine was deleted
   free(runes);
 
   runes = strToRunes(tokyo, &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);  // 東京 was deleted
   free(runes);
 
   runes = strToRunes(cafe, &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(100, node->numDocs);  // café: was decremented from 120 to 100
   free(runes);
 
   // Verify 日本語 is unchanged (shares prefix with 日本 which was decremented)
   runes = strToRunes(nihongo, &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(150, node->numDocs);  // 日本語 unchanged
   free(runes);
 
   // Verify 日本 was decremented
   runes = strToRunes(nihon, &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(150, node->numDocs);  // 日本: 200 -> 150
   free(runes);
 
   // Verify Zürich is unchanged (different prefix from München which was decremented)
   runes = strToRunes(zurich, &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(70, node->numDocs);  // Zürich unchanged
   free(runes);
 
   // Verify terms that were not touched remain unchanged
   runes = strToRunes("cat", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(200, node->numDocs);
   free(runes);
 
   runes = strToRunes("redisearch", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(300, node->numDocs);
   free(runes);
 
   runes = strToRunes("red", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1000, node->numDocs);
   free(runes);
@@ -828,17 +828,17 @@ int testDecrementNumDocsComplex() {
 
   // Verify all "app*" terms are gone
   runes = strToRunes("apple", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);
   free(runes);
 
   runes = strToRunes("application", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);
   free(runes);
 
   runes = strToRunes("apply", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);
   free(runes);
 
@@ -859,7 +859,7 @@ int testDecrementNumDocsComplex() {
   // ========================================
   // Decrement "redis" by more than it has
   runes = strToRunes("redis", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   size_t currentRedisCount = node->numDocs;  // Should be 490
   ASSERT_EQUAL(490, currentRedisCount);
@@ -870,19 +870,19 @@ int testDecrementNumDocsComplex() {
   ASSERT_EQUAL(TRIE_DECR_DELETED, rc);  // Should clamp to 0 and delete
 
   runes = strToRunes("redis", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);  // Should be deleted
   free(runes);
 
   // But "redisearch" and "red" should still exist
   runes = strToRunes("redisearch", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(300, node->numDocs);
   free(runes);
 
   runes = strToRunes("red", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(1000, node->numDocs);
   free(runes);
@@ -911,7 +911,7 @@ int testDecrementNumDocsNonTerminal() {
 
   // Verify "helloworld" exists and is terminal
   runes = strToRunes("helloworld", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT(__trieNode_isTerminal(node));
   ASSERT_EQUAL(100, node->numDocs);
@@ -924,7 +924,7 @@ int testDecrementNumDocsNonTerminal() {
 
   // Verify "helloworld" is still intact
   runes = strToRunes("helloworld", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(100, node->numDocs);
   free(runes);
@@ -942,7 +942,7 @@ int testDecrementNumDocsNonTerminal() {
 
   // Verify "hello" is now terminal
   runes = strToRunes("hello", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT(__trieNode_isTerminal(node));
   ASSERT_EQUAL(50, node->numDocs);
@@ -953,14 +953,14 @@ int testDecrementNumDocsNonTerminal() {
   ASSERT_EQUAL(TRIE_DECR_UPDATED, rc);
 
   runes = strToRunes("hello", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(40, node->numDocs);
   free(runes);
 
   // "helloworld" should still be intact
   runes = strToRunes("helloworld", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(100, node->numDocs);
   free(runes);
@@ -975,7 +975,7 @@ int testDecrementNumDocsNonTerminal() {
 
   // "hello" should no longer be found (deleted)
   runes = strToRunes("hello", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node == NULL);
   free(runes);
 
@@ -985,7 +985,7 @@ int testDecrementNumDocsNonTerminal() {
 
   // "helloworld" should still be intact
   runes = strToRunes("helloworld", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(100, node->numDocs);
   free(runes);
@@ -1015,7 +1015,7 @@ int testDecrementNumDocsNonTerminal() {
   ASSERT_EQUAL(TRIE_DECR_UPDATED, rc);
 
   runes = strToRunes("abcdefgh", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(150, node->numDocs);
   free(runes);
@@ -1040,14 +1040,14 @@ int testDecrementNumDocsNonTerminal() {
   ASSERT_EQUAL(TRIE_DECR_UPDATED, rc);
 
   runes = strToRunes("redis", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(400, node->numDocs);
   free(runes);
 
   // "redisearch" should be unaffected
   runes = strToRunes("redisearch", &runeLen);
-  node = TrieNode_Get(t->root, runes, runeLen, true, NULL);
+  node = Trie_GetNode(t, runes, runeLen, true, NULL);
   ASSERT(node != NULL);
   ASSERT_EQUAL(300, node->numDocs);
   free(runes);

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -429,7 +429,7 @@ int testNumDocs() {
   ASSERT_EQUAL(1, node->numDocs);
 
   // Verify numDocs via iterator
-  TrieIterator *it = TrieNode_Iterate(t->root, NULL, NULL, NULL);
+  TrieIterator *it = Trie_IterateAll(t);
   rune *s;
   t_len iterLen;
   float score;

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -502,7 +502,7 @@ int testDecrementNumDocs() {
   ASSERT_EQUAL(TRIE_DECR_DELETED, rc);
   node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node == NULL);  // Node should be deleted
-  ASSERT_EQUAL(0, t->size);  // Trie size should be 0
+  ASSERT_EQUAL(0, Trie_Size(t));  // Trie size should be 0
 
   // Test 4: Decrement with delta > numDocs (should clamp and delete)
   insertRc = Trie_InsertStringBuffer(t, "world", 5, 1.0, 0, NULL, 5);
@@ -660,7 +660,7 @@ int testDecrementNumDocsComplex() {
                                      1.0, 0, NULL, initialTerms[i].numDocs);
     ASSERT_EQUAL(1, rc);
   }
-  ASSERT_EQUAL(numTerms, t->size);
+  ASSERT_EQUAL(numTerms, Trie_Size(t));
 
   // Verify initial state
   size_t runeLen;
@@ -807,7 +807,7 @@ int testDecrementNumDocsComplex() {
   free(runes);
 
   // Trie size should be numTerms - 3 (bandana, caféine, 東京 were deleted)
-  ASSERT_EQUAL(numTerms - 3, t->size);
+  ASSERT_EQUAL(numTerms - 3, Trie_Size(t));
 
   // ========================================
   // Simulate another GC pass: more aggressive cleanup
@@ -843,7 +843,7 @@ int testDecrementNumDocsComplex() {
   free(runes);
 
   // Trie size should now be numTerms - 6 (3 from first pass + 3 app* terms)
-  ASSERT_EQUAL(numTerms - 6, t->size);
+  ASSERT_EQUAL(numTerms - 6, Trie_Size(t));
 
   // ========================================
   // Test decrementing a non-existent term (already deleted)
@@ -907,7 +907,7 @@ int testDecrementNumDocsNonTerminal() {
   // ========================================
   int insertRc = Trie_InsertStringBuffer(t, "helloworld", 10, 1.0, 0, NULL, 100);
   ASSERT_EQUAL(1, insertRc);
-  ASSERT_EQUAL(1, t->size);
+  ASSERT_EQUAL(1, Trie_Size(t));
 
   // Verify "helloworld" exists and is terminal
   runes = strToRunes("helloworld", &runeLen);
@@ -930,7 +930,7 @@ int testDecrementNumDocsNonTerminal() {
   free(runes);
 
   // Trie size should still be 1
-  ASSERT_EQUAL(1, t->size);
+  ASSERT_EQUAL(1, Trie_Size(t));
 
   // ========================================
   // Test 2: Now insert "hello" as a terminal node
@@ -938,7 +938,7 @@ int testDecrementNumDocsNonTerminal() {
   // ========================================
   insertRc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 0, NULL, 50);
   ASSERT_EQUAL(1, insertRc);
-  ASSERT_EQUAL(2, t->size);
+  ASSERT_EQUAL(2, Trie_Size(t));
 
   // Verify "hello" is now terminal
   runes = strToRunes("hello", &runeLen);
@@ -971,7 +971,7 @@ int testDecrementNumDocsNonTerminal() {
   // ========================================
   rc = Trie_DecrementNumDocs(t, "hello", 5, 40);
   ASSERT_EQUAL(TRIE_DECR_DELETED, rc);
-  ASSERT_EQUAL(1, t->size);
+  ASSERT_EQUAL(1, Trie_Size(t));
 
   // "hello" should no longer be found (deleted)
   runes = strToRunes("hello", &runeLen);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Callers across `dictionary.c`, `suffix.c`, `suggest.c`, `spell_check.c`, `query.c`, `debug_commands.c`, and the C/C++ trie tests reach directly into `Trie` internals — `t->root` for iteration/lookup and `t->size` for entry counts. `SuffixCtx` carried only a raw `TrieNode *root`, so suffix paths had no access to the surrounding `Trie`.
2. **Change**: Introduce wrapper APIs in `src/trie/trie_type.h` that forward to the existing `TrieNode_*` operations on `t->root`:
   - `Trie_GetNode`
   - `Trie_IterateRange`
   - `Trie_IterateContains`
   - `Trie_IterateWildcard`
   - `Trie_IterateAll`
   - `Trie_Size` (`static inline`)

   Migrate every caller off `t->root` / `t->size`. Convert `SuffixCtx.root` (`TrieNode *`) → `SuffixCtx.trie` (`Trie *`) and update suffix-add to use the existing `Trie_InsertRune`.
3. **Outcome**: `Trie` is opaque from the perspective of callers outside `src/trie/`. No behavior change — wrappers are thin forwarders. Sets up the C trie for the Rust port by removing direct field access on the C struct.

#### Which additional issues this PR fixes
N/A — preparatory refactor for the C trie Rust port.

#### Main objects this PR modified
1. `src/trie/trie_type.{h,c}` — new wrapper APIs
2. `src/suffix.{h,c}` — `SuffixCtx.root` → `SuffixCtx.trie`
3. `src/dictionary.c`, `src/suggest.c`, `src/spell_check.c`, `src/query.c`, `src/debug_commands.c` — migrate to wrappers
4. `tests/cpptests/test_cpp_trie.cpp`, `tests/ctests/test_trie.c` — migrate to wrappers

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor across query/suffix/dictionary/suggest paths to stop direct `Trie` struct access; while wrappers are thin, mistakes could impact term lookup/iteration and affect query results or debug output.
> 
> **Overview**
> Refactors trie usage to **hide `Trie` internals** from callers by adding wrapper APIs in `trie_type` (e.g. `Trie_Size`, `Trie_GetNode`, `Trie_Iterate*`, `Trie_IterateAll`) and migrating production code and tests off direct `t->root` / `t->size` access.
> 
> Updates suffix-trie plumbing by changing `SuffixCtx` to carry a `Trie*` (instead of `TrieNode* root`) and adjusts suffix insertion/iteration call sites accordingly, including adding `Trie_InsertRuneNoSize` for the one historical case that bypasses size bookkeeping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c03733c4fe1b7dd65f7399e1585dc91adcb3189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->