### PR TITLE
[MOD-15393] Trie - Make struct opaque

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -236,7 +236,7 @@ static void SpellCheckDictAuxSave(RedisModuleIO *rdb, int when) {
   while ((entry = dictNext(iter))) {
     const char *key = dictGetKey(entry);
     Trie *val = dictGetVal(entry);
-    RS_LOG_ASSERT(val->size != 0, "Empty dictionary should not exist in the dictionary list");
+    RS_LOG_ASSERT(Trie_Size(val) != 0, "Empty dictionary should not exist in the dictionary list");
     RedisModule_SaveStringBuffer(rdb, key, strlen(key) + 1 /* we save the /0*/);
     TrieType_GenericSave(rdb, val, false, false);
   }

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -143,7 +143,7 @@ int RSSuggestLenCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   tree = RedisModule_ModuleTypeGetValue(key);
-  RedisModule_ReplyWithLongLong(ctx, tree ? tree->size : 0);
+  RedisModule_ReplyWithLongLong(ctx, tree ? Trie_Size(tree) : 0);
 
 end:
   if (key) {

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -23,6 +23,18 @@
 #include <string.h>
 #include <limits.h>
 
+struct Trie {
+  TrieNode *root;
+  size_t size;
+  TrieFreeCallback freecb;
+  TrieSortMode sortMode;
+};
+
+size_t Trie_Size(const Trie *t) {
+  RS_ASSERT(t);
+  return t->size;
+}
+
 Trie *NewTrie(TrieFreeCallback freecb, TrieSortMode sortMode) {
   Trie *tree = rm_malloc(sizeof(Trie));
   rune *rs = strToRunes("", 0);

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -25,12 +25,7 @@ extern RedisModuleType *TrieType;
 #define TRIE_ENCVER_NUMDOCS 2
 #define TRIE_ENCVER_PAYLOADS 1
 
-typedef struct {
-  TrieNode *root;
-  size_t size;
-  TrieFreeCallback freecb;
-  TrieSortMode sortMode;
-} Trie;
+typedef struct Trie Trie;
 
 typedef struct {
   char *str;
@@ -96,10 +91,7 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
                           bool skipTimeoutChecks);
 
 /* Number of terminal entries in the trie. Wraps the internal size counter. */
-static inline size_t Trie_Size(const Trie *t) {
-  RS_ASSERT(t);
-  return t->size;
-}
+size_t Trie_Size(const Trie *t);
 
 /* Iterate every node in the trie with no filter or distance constraint. Wraps
  * TrieNode_Iterate on the trie's root with no filter. Used by debug paths that

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -574,7 +574,7 @@ TEST_F(RdbMockTest, testTrieRdbLoadMoreThan65535Elements) {
         Trie_InsertStringBuffer(originalTrie, buf, strlen(buf), 1.0, 0, NULL, 0);
     }
 
-    ASSERT_EQ(NUM_ELEMENTS, originalTrie->size);
+    ASSERT_EQ(NUM_ELEMENTS, Trie_Size(originalTrie));
 
     // Create RDB IO context
     RedisModuleIO *io = RMCK_CreateRdbIO();
@@ -599,7 +599,7 @@ TEST_F(RdbMockTest, testTrieRdbLoadMoreThan65535Elements) {
     EXPECT_EQ(0, RMCK_IsIOError(io));
 
     // Verify the loaded trie has the correct size
-    EXPECT_EQ(NUM_ELEMENTS, loadedTrie->size);
+    EXPECT_EQ(NUM_ELEMENTS, Trie_Size(loadedTrie));
 }
 
 TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
@@ -627,7 +627,7 @@ TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
         io->read_pos = 0;
         Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
         ASSERT_TRUE(trie != nullptr) << "Failed to load trie with normal payload";
-        EXPECT_EQ(1, trie->size);
+        EXPECT_EQ(1, Trie_Size(trie));
         TrieType_Free(trie);
     }
 
@@ -647,7 +647,7 @@ TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
         io->read_pos = 0;
         Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
         ASSERT_TRUE(trie != nullptr) << "Failed to load trie with 1MB payload";
-        EXPECT_EQ(1, trie->size);
+        EXPECT_EQ(1, Trie_Size(trie));
         TrieType_Free(trie);
     }
 
@@ -713,7 +713,7 @@ TEST_F(RdbMockTest, testTriePayloadOverflowDirectInsert) {
 
         int rc = Trie_InsertStringBuffer(trie, key, strlen(key), 1.0, 0, &payload, 0);
         EXPECT_EQ(TRIE_OK_NEW, rc) << "Normal payload insertion should succeed";
-        EXPECT_EQ(1, trie->size);
+        EXPECT_EQ(1, Trie_Size(trie));
     }
 
     // Test 2: Payload with length that would overflow uint32_t should fail
@@ -731,7 +731,7 @@ TEST_F(RdbMockTest, testTriePayloadOverflowDirectInsert) {
 
         int rc = Trie_InsertStringBuffer(trie, key, strlen(key), 1.0, 0, &payload, 0);
         EXPECT_EQ(TRIE_ERR_PAYLOAD_OVERFLOW, rc) << "Payload overflow should be detected";
-        EXPECT_EQ(1, trie->size) << "Trie size should not change on failed insert";
+        EXPECT_EQ(1, Trie_Size(trie)) << "Trie size should not change on failed insert";
     }
 
     // Test 3: Payload with SIZE_MAX length should also fail (extreme case)
@@ -745,7 +745,7 @@ TEST_F(RdbMockTest, testTriePayloadOverflowDirectInsert) {
 
         int rc = Trie_InsertStringBuffer(trie, key, strlen(key), 1.0, 0, &payload, 0);
         EXPECT_EQ(TRIE_ERR_PAYLOAD_OVERFLOW, rc) << "SIZE_MAX payload should trigger overflow";
-        EXPECT_EQ(1, trie->size) << "Trie size should not change on failed insert";
+        EXPECT_EQ(1, Trie_Size(trie)) << "Trie size should not change on failed insert";
     }
 
 }

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -38,7 +38,7 @@ static void *triePayload(Trie *t, const char *s, size_t len, bool exact) {
   }
   runeBuf buf;
   rune *runes = runeBufFill(s, len, &buf, &len);
-  TrieNode *node = TrieNode_Get(t->root, runes, len, exact, NULL);
+  TrieNode *node = Trie_GetNode(t, runes, len, exact, NULL);
   runeBufFree(&buf);
   return (node && node->payload) ? node->payload->data : nullptr;
 }


### PR DESCRIPTION
## Describe the changes in the pull request

This is the **final step** in encapsulating the C trie. PR #9430 migrated all callers off direct field access; this PR enforces that boundary at the type level by making `struct Trie` opaque.

1. **Current**: `struct Trie` is fully defined in `src/trie/trie_type.h`, exposing `root`, `size`, `freecb`, and `sortMode` to every translation unit that includes it. The previous PR (#9430) migrated all callers off direct field access, but the struct stayed transparent.
2. **Change**: Move `struct Trie`'s definition out of the public header into `src/trie/trie_type.c` and forward-declare it as `typedef struct Trie Trie;` in the header. Convert `Trie_Size` from `static inline` (which required visibility into `t->size`) to an out-of-line function defined in the `.c` file. Sweep up two leftover field accesses that the previous PR missed (only surfaced now that opacity is enforced).
3. **Outcome**: `Trie` is now opaque to all callers outside `src/trie/`. Direct field access fails to compile, making the encapsulation enforced rather than conventional. With this in place, the C trie is ready to be ported to Rust — the C struct's layout is no longer part of the ABI seen by callers.

#### Which additional issues this PR fixes
N/A — preparatory refactor for the C trie Rust port.

#### Main objects this PR modified
1. `src/trie/trie_type.h` — replace `struct Trie { ... }` with forward declaration; change `Trie_Size` to a regular prototype
2. `src/trie/trie_type.c` — define `struct Trie` and out-of-line `Trie_Size`
3. `src/suggest.c` — `FT.SUGLEN` switched from `tree->size` to `Trie_Size(tree)`
4. `tests/cpptests/test_cpp_trie.cpp` — switched from `t->root` to `Trie_GetNode(t, ...)`
5. `src/dictionary.c` — `SpellCheckDictAuxSave` switched from `t->size` to `Trie_Size(t)`
6. `tests/cpptests/test_cpp_rdb.cpp` — adapted seven `trie->size` reads to `Trie_Size(trie)` (file added by #9448 on master after this PR was opened)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that tightens encapsulation by removing external field access to `Trie`; main risk is compile/link issues or missed direct accesses in downstream/less-covered code paths.
> 
> **Overview**
> **Enforces trie encapsulation** by making `struct Trie` opaque: the full struct definition is moved out of `trie_type.h` into `trie_type.c` and the header now forward-declares `Trie`.
> 
> Updates remaining call sites to stop accessing internal fields directly (e.g., `tree->size`, `t->root`) and instead use public APIs like `Trie_Size()` and `Trie_GetNode()`, including in `FT.SUGLEN`, dictionary RDB aux-save assertions, and C++ tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45a1996521b68a99080b152b519bebdeeb1a04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
