### PR TITLE
docs(trie_bencher): drop stale C-comparison instructions

### DIFF
--- a/src/redisearch_rs/trie_bencher/README.md
+++ b/src/redisearch_rs/trie_bencher/README.md
@@ -1,15 +1,11 @@
 # Trie Benchmarks
 
-A set of microbenchmarks for the trie data structure.
-It currently compares:
-- the C implementation from `deps/triemap.c`
-- the Rust implementation from `trie_rs`
+A set of microbenchmarks for the Rust trie map implementation in `trie_rs`.
 
-## Building
-
-In order to benchmark the C implementation, you need to build the `libtrie.a`
-static library first.
-It's enough to run `make build` in the root directory of the repository.
+Originally these benchmarks compared the Rust port against the C implementation
+in `deps/triemap.c`. The C implementation was removed in
+[#6087](https://github.com/RediSearch/RediSearch/pull/6087); the suite is now
+kept as a regression gate for `trie_rs`.
 
 ## Memory Usage
 
@@ -25,13 +21,10 @@ You should see output similar to the following:
 
 ```text
 Statistics:
-- Raw text size: 0.558 MBs
-- Number of words (with duplicates): 103366
-- Number of unique words: 15520
-- Rust -> 1.070 MBs
-          23130 nodes
-- C    -> 0.640 MBs
-          23129 nodes
+- Raw text size: 0.114 MBs
+- Number of unique words: 15524
+- Memory 0.469 MBs
+- 18944 nodes
 ```
 
 ## Performance


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current**: `src/redisearch_rs/trie_bencher/README.md` documents the bencher as comparing the C `deps/triemap.c` implementation against the Rust `trie_rs` port, and instructs the user to build `libtrie.a` first. The example memory-usage block prints both Rust and C lines.
2. **Change**: Drop the C-vs-Rust framing and `libtrie.a` build step (the C implementation was deleted in #6087). Refresh the example output block to match what `cargo run --release` actually prints today (single-implementation stats).
3. **Outcome**: README accurately reflects the current bencher: a Rust-only regression gate for `trie_rs`, runnable standalone without a `make build` prerequisite.

#### Which additional issues this PR fixes
_None._

#### Main objects this PR modified
1. `src/redisearch_rs/trie_bencher/README.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates benchmark README wording and sample output; no code or runtime behavior is modified.
> 
> **Overview**
> Updates `trie_bencher/README.md` to reflect the current **Rust-only** benchmark suite by removing stale references to the deleted C implementation and the `libtrie.a` build prerequisite.
> 
> Refreshes the memory-usage example output to match current `cargo run --release` output (single set of stats), and adds clearer guidance for running benchmark subsets and viewing the Criterion HTML report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb9c091b684b667d0b509619d03758572550f258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->