### PR TITLE
profile: add C accessor functions for HybridIterator and OptimizerIterator

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -677,3 +677,35 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   }
   return ri;
 }
+
+// Accessors for profile printing.
+const QueryIterator *HybridIterator_GetChild(const QueryIterator *it) {
+  const HybridIterator *hi = (const HybridIterator *)it;
+  return hi->child;
+}
+
+const char *HybridIterator_GetSearchModeString(const QueryIterator *it) {
+  const HybridIterator *hi = (const HybridIterator *)it;
+  return VecSimSearchMode_ToString(hi->searchMode);
+}
+
+bool HybridIterator_IsBatchMode(const QueryIterator *it) {
+  const HybridIterator *hi = (const HybridIterator *)it;
+  return hi->searchMode == VECSIM_HYBRID_BATCHES ||
+         hi->searchMode == VECSIM_HYBRID_BATCHES_TO_ADHOC_BF;
+}
+
+size_t HybridIterator_GetNumIterations(const QueryIterator *it) {
+  const HybridIterator *hi = (const HybridIterator *)it;
+  return hi->numIterations;
+}
+
+size_t HybridIterator_GetMaxBatchSize(const QueryIterator *it) {
+  const HybridIterator *hi = (const HybridIterator *)it;
+  return hi->maxBatchSize;
+}
+
+size_t HybridIterator_GetMaxBatchIteration(const QueryIterator *it) {
+  const HybridIterator *hi = (const HybridIterator *)it;
+  return hi->maxBatchIteration;
+}

--- a/src/iterators/hybrid_reader.h
+++ b/src/iterators/hybrid_reader.h
@@ -63,6 +63,14 @@ extern "C" {
 
 QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError *status);
 
+// Accessors for profile printing.
+const QueryIterator *HybridIterator_GetChild(const QueryIterator *it);
+const char *HybridIterator_GetSearchModeString(const QueryIterator *it);
+bool HybridIterator_IsBatchMode(const QueryIterator *it);
+size_t HybridIterator_GetNumIterations(const QueryIterator *it);
+size_t HybridIterator_GetMaxBatchSize(const QueryIterator *it);
+size_t HybridIterator_GetMaxBatchIteration(const QueryIterator *it);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -271,3 +271,14 @@ QueryIterator *NewOptimizerIterator(QOptimizer *qOpt, QueryIterator *root, Itera
 
   return &oi->base;
 }
+
+// Accessors for profile printing.
+const QueryIterator *OptimizerIterator_GetChild(const QueryIterator *it) {
+  const OptimizerIterator *oi = (const OptimizerIterator *)it;
+  return oi->child;
+}
+
+const char *OptimizerIterator_GetOptimizationType(const QueryIterator *it) {
+  const OptimizerIterator *oi = (const OptimizerIterator *)it;
+  return QOptimizer_PrintType(oi->optim);
+}

--- a/src/iterators/optimizer_reader.h
+++ b/src/iterators/optimizer_reader.h
@@ -58,6 +58,10 @@ extern "C" {
 
 QueryIterator *NewOptimizerIterator(QOptimizer *q_opt, QueryIterator *root, IteratorsConfig *config);
 
+// Accessors for profile printing.
+const QueryIterator *OptimizerIterator_GetChild(const QueryIterator *it);
+const char *OptimizerIterator_GetOptimizationType(const QueryIterator *it);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -502,7 +502,6 @@ PRINT_PROFILE_METRIC(printMetricSortedByScoreIt, "METRIC SORTED BY SCORE");
 
 void PrintIteratorChildProfile(RedisModule_Reply *reply, const QueryIterator *root, const ProfileCounters *counters, double cpuTime,
                   int depth, int limited, PrintProfileConfig *config, const QueryIterator *child, const char *text) {
-  size_t nlen = 0;
   RedisModule_Reply_Map(reply);
     printProfileType(text);
     if (config->printProfileClock) {
@@ -511,19 +510,22 @@ void PrintIteratorChildProfile(RedisModule_Reply *reply, const QueryIterator *ro
     printProfileCounters(counters);
 
     if (root->type == HYBRID_ITERATOR) {
-      const HybridIterator *hi = (const HybridIterator *)root;
-      printProfileVectorSearchMode(hi->searchMode);
-      if (hi->searchMode == VECSIM_HYBRID_BATCHES ||
-          hi->searchMode == VECSIM_HYBRID_BATCHES_TO_ADHOC_BF) {
-        printProfileNumBatches(hi);
-        printProfileMaxBatchSize(hi);
-        printProfileMaxBatchIteration(hi);
+      const char *mode_str = HybridIterator_GetSearchModeString(root);
+      if (mode_str) {
+        RedisModule_ReplyKV_SimpleString(reply, "Vector search mode", mode_str);
+      }
+      if (HybridIterator_IsBatchMode(root)) {
+        RedisModule_ReplyKV_LongLong(reply, "Batches number", HybridIterator_GetNumIterations(root));
+        RedisModule_ReplyKV_LongLong(reply, "Largest batch size", HybridIterator_GetMaxBatchSize(root));
+        RedisModule_ReplyKV_LongLong(reply, "Largest batch iteration (zero based)", HybridIterator_GetMaxBatchIteration(root));
       }
     }
 
     if (root->type == OPTIMUS_ITERATOR) {
-      const OptimizerIterator *oi = (const OptimizerIterator *)root;
-      printProfileOptimizationType(oi);
+      const char *opt_type = OptimizerIterator_GetOptimizationType(root);
+      if (opt_type) {
+        RedisModule_ReplyKV_SimpleString(reply, "Optimizer mode", opt_type);
+      }
     }
 
     if (child) {
@@ -539,19 +541,21 @@ void PrintIteratorChildProfile(RedisModule_Reply *reply, const QueryIterator *ro
       NULL, (text));                                                                   \
   }
 
-#define PRINT_PROFILE_SINGLE(name, IterType, text)                                     \
-  PRINT_PROFILE_FUNC(name) {                                                           \
-    PrintIteratorChildProfile(reply, (root), counters, cpuTime, depth, limited, config, \
-      ((const IterType *)(root))->child, (text));                                      \
-  }
-
 PRINT_PROFILE_SINGLE_NO_CHILD(printWildcardIt,                  "WILDCARD");
 PRINT_PROFILE_SINGLE_NO_CHILD(printIdListSortedIt,              "ID-LIST-SORTED");
 PRINT_PROFILE_SINGLE_NO_CHILD(printIdListUnsortedIt,            "ID-LIST-UNSORTED");
 PRINT_PROFILE_SINGLE_NO_CHILD(printEmptyIt,                     "EMPTY");
 PRINT_PROFILE_SINGLE_NO_CHILD(printGeoShapeIt,                  "GEO-SHAPE");
-PRINT_PROFILE_SINGLE(printHybridIt, HybridIterator,             "VECTOR");
-PRINT_PROFILE_SINGLE(printOptimusIt, OptimizerIterator,         "OPTIMIZER");
+
+PRINT_PROFILE_FUNC(printHybridIt) {
+  PrintIteratorChildProfile(reply, root, counters, cpuTime, depth, limited, config,
+    HybridIterator_GetChild(root), "VECTOR");
+}
+
+PRINT_PROFILE_FUNC(printOptimusIt) {
+  PrintIteratorChildProfile(reply, root, counters, cpuTime, depth, limited, config,
+    OptimizerIterator_GetChild(root), "OPTIMIZER");
+}
 
 PRINT_PROFILE_FUNC(printNotIt) {
   // Cast is safe: PrintIteratorChildProfile only reads from the child iterator.

--- a/src/profile/profile.h
+++ b/src/profile/profile.h
@@ -32,14 +32,6 @@ typedef struct HybridRequest HybridRequest;
 
 #define printProfileGILTime(vtime) RedisModule_ReplyKV_Double(reply, "GIL-Time", (vtime))
 
-#define printProfileNumBatches(hybrid_reader) \
-  RedisModule_ReplyKV_LongLong(reply, "Batches number", (hybrid_reader)->numIterations)
-#define printProfileMaxBatchSize(hybrid_reader) \
-  RedisModule_ReplyKV_LongLong(reply, "Largest batch size", (hybrid_reader)->maxBatchSize)
-#define printProfileMaxBatchIteration(hybrid_reader) \
-  RedisModule_ReplyKV_LongLong(reply, "Largest batch iteration (zero based)", (hybrid_reader)->maxBatchIteration)
-#define printProfileOptimizationType(oi) \
-  RedisModule_ReplyKV_SimpleString(reply, "Optimizer mode", QOptimizer_PrintType((oi)->optim))
 #define printProfileVectorSearchMode(searchMode) \
   RedisModule_ReplyKV_SimpleString(reply, "Vector search mode", VecSimSearchMode_ToString(searchMode))
 


### PR DESCRIPTION

Add accessor functions for profile printing (child, search mode, batch stats, optimization type) so profile.c no longer needs to cast to concrete iterator types directly.

Use them in profile.c and stop doing direct struct accesses by removing print macros.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to profile printing: replaces direct struct casts/field access with iterator accessor functions while keeping the profile output fields the same.
> 
> **Overview**
> Profile printing no longer casts `QueryIterator` to concrete `HybridIterator`/`OptimizerIterator` types. Instead it adds C accessor functions on those iterators (child, vector search mode, batch stats, optimizer mode) and updates `profile.c` to use them, removing the old profile-printing macros that depended on direct struct field access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c36d56e035901159532ae34c4c77a5db7476c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->