### PR TITLE
wildcard: box NonOptimized as NewWildcardIterator enum

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -11,7 +11,7 @@ use std::ptr::NonNull;
 
 use ffi::{QueryIterator, t_docId};
 use rqe_iterator_type::IteratorType;
-use rqe_iterators::{Wildcard, interop::RQEIteratorWrapper};
+use rqe_iterators::{NewWildcardIterator, Wildcard, interop::RQEIteratorWrapper};
 
 /// Creates a new non-optimized wildcard iterator over the `[0, max_id]` document id range.
 #[unsafe(no_mangle)]
@@ -19,7 +19,8 @@ pub extern "C" fn NewWildcardIterator_NonOptimized(
     max_id: t_docId,
     weight: f64,
 ) -> *mut QueryIterator {
-    RQEIteratorWrapper::boxed_new(Wildcard::new(max_id, weight))
+    let it = NewWildcardIterator::NotOptimized(Wildcard::new(max_id, weight));
+    RQEIteratorWrapper::boxed_new(it)
 }
 
 /// Returns `true` if `it` is a wildcard iterator (either optimized or non-optimized).


### PR DESCRIPTION
  `NewWildcardIterator_NonOptimized` previously boxed a bare `Wildcard` as                                                     
  `RQEIteratorWrapper<Wildcard>`, while `NewWildcardIterator` boxed the                                                        
  `NewWildcardIterator` enum as `RQEIteratorWrapper<NewWildcardIterator>`.                                                     
  Both produce iterators with `IteratorType::Wildcard`, but the heap
  layouts differ. The profile printing dispatch matches on `IteratorType`                                                      
  and casts the raw pointer to a concrete `RQEIteratorWrapper<T>`; with
  two different `T` behind the same discriminant, any single cast is                                                           
  unsound for one of them.                              
                                                                                                                               
  Wrap in `NewWildcardIterator::NotOptimized` before boxing so both
  factories produce the same heap type and the dispatch can always cast                                                        
  to `RQEIteratorWrapper<NewWildcardIterator>`.         
                                         
  `NewWildcardIterator_NonOptimized` is only used in a hybrid reader test                                                      
  so that should not affect performances.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FFI iterator construction and heap layout for wildcard iterators; while intended to fix an unsound cast, any mismatch in expected wrapper type could surface as runtime crashes if other code assumes the old layout.
> 
> **Overview**
> Fixes wildcard iterator FFI construction so *all* wildcard factories heap-allocate the same concrete wrapper type.
> 
> `NewWildcardIterator_NonOptimized` now wraps `Wildcard::new(...)` in `NewWildcardIterator::NotOptimized` before boxing, aligning its heap layout with `NewWildcardIterator`/optimized variants and avoiding type-unsafe downcasts that dispatch solely on `IteratorType::Wildcard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff833247ff63fde969fd3b4dec2e2b90eba68a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->