### PR TITLE
MOD-15395: Fix flaky test_return_strict_timeout_channel_drain_aggregate via deterministic channel-drain wait

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -26,7 +26,6 @@
 #include "info/info_redis/threads/current_thread.h"
 #include "rpnet.h"
 #include "coord/dist_utils.h"
-#include "debug_commands.h"
 #include "info/global_stats.h"
 #include "search_disk.h"
 #include "debug_commands.h"

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -26,6 +26,7 @@
 #include "info/info_redis/threads/current_thread.h"
 #include "rpnet.h"
 #include "coord/dist_utils.h"
+#include "debug_commands.h"
 #include "info/global_stats.h"
 #include "search_disk.h"
 #include "debug_commands.h"
@@ -100,6 +101,10 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // this reader if it blocks in MRIterator_NextWithTimeout after AREQ timed out.
   // Paired with RequestSyncCtx_UnregisterAbortWakeChannel in rpnetFree.
   RequestSyncCtx_RegisterAbortWakeChannel(&nc->areq->syncCtx, MRIterator_GetChannel(it));
+#ifdef ENABLE_ASSERT
+  // Expose the iterator to FT.DEBUG BG_PENDING_REPLIES; cleared in rpnetFree.
+  DebugBgIterator_Set(it);
+#endif
   nc->base.Next = rpnetNext;
   return rpnetNext(rp, r);
 }

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -467,6 +467,9 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     if (nc->areq) {
       RequestSyncCtx_RegisterAbortWakeChannel(&nc->areq->syncCtx, MRIterator_GetChannel(nc->it));
     }
+#ifdef ENABLE_ASSERT
+    DebugBgIterator_Set(nc->it);
+#endif
     nc->base.Next = rpnetNext;
 
     return rpnetNext(rp, r);
@@ -488,6 +491,10 @@ void rpnetFree(ResultProcessor *rp) {
     if (nc->areq) {
       RequestSyncCtx_UnregisterAbortWakeChannel(&nc->areq->syncCtx);
     }
+#ifdef ENABLE_ASSERT
+    // Drop the FT.DEBUG BG_PENDING_REPLIES handle before releasing the iterator.
+    DebugBgIterator_Clear(nc->it);
+#endif
     RS_DEBUG_LOG("rpnetFree: calling MRIterator_Release");
     MRIterator_Release(nc->it);
   }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -38,6 +38,7 @@
 #include "ext/debug_scorers.h"
 #include "query_error.h"
 #include "doc_id_meta.h"
+#include "coord/rmr/rmr.h"
 
 DebugCTX globalDebugCtx = {0};
 
@@ -119,6 +120,23 @@ bool StoreResultsDebugCtx_IsPaused(void) {
 
 void StoreResultsDebugCtx_SetPause(bool pause) {
   atomic_store(&globalStoreResultsDebugCtx.pause, pause);
+}
+
+// Tracks the currently active coordinator MRIterator. Set by RPNet after the
+// iterator is created, cleared before it is released. A simple pointer is
+// sufficient since tests only run one blocked aggregate at a time.
+static _Atomic(struct MRIterator *) globalDebugBgIterator = NULL;
+
+void DebugBgIterator_Set(struct MRIterator *it) {
+  atomic_store_explicit(&globalDebugBgIterator, it, memory_order_release);
+}
+
+void DebugBgIterator_Clear(struct MRIterator *it) {
+  // CAS so a stale clear (if iterators ever overlapped) cannot wipe the
+  // pointer set by a newer iterator.
+  struct MRIterator *expected = it;
+  atomic_compare_exchange_strong_explicit(&globalDebugBgIterator, &expected, NULL,
+                                          memory_order_release, memory_order_relaxed);
 }
 
 // ============================================================================
@@ -2573,6 +2591,22 @@ DEBUG_COMMAND(syncPoint) {
 }
 
 /**
+ * FT.DEBUG BG_PENDING_REPLIES
+ * Returns the `pending` shard counter of the currently active coordinator
+ * MRIterator (the number of shards that have not yet delivered their final
+ * reply / EOF). Returns -1 when no iterator is active. Tests use this to
+ * deterministically wait until every shard reply has been admitted into the
+ * coordinator's channel before firing CLIENT UNBLOCK TIMEOUT.
+ */
+DEBUG_COMMAND(bgPendingReplies) {
+  if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  if (argc != 2) return RedisModule_WrongArity(ctx);
+  struct MRIterator *it = atomic_load_explicit(&globalDebugBgIterator, memory_order_acquire);
+  long long pending = it ? (long long)MRIterator_GetPending(it) : -1;
+  return RedisModule_ReplyWithLongLong(ctx, pending);
+}
+
+/**
  * FT.DEBUG QUERY_CONTROLLER SET_CURSOR_READ_SIZE <N>
  * Override RSGlobalConfig.cursorReadSize at runtime. Returns the previous
  * value so the caller can restore it. N must be >= 1.
@@ -2931,6 +2965,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
 // Add new assert-only commands to this array instead of hard-coding #ifdef blocks
 static DebugCommandType assertOnlyCommands[] = {
     {"SYNC_POINT", syncPoint},
+    {"BG_PENDING_REPLIES", bgPendingReplies},
     {NULL, NULL}};
 #endif
 

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -154,6 +154,14 @@ void HybridStoreCursorsDebugCtx_SetPauseAfterEnabled(bool enabled);
 bool HybridStoreCursorsDebugCtx_IsPaused(void);
 void HybridStoreCursorsDebugCtx_SetPause(bool pause);
 
+// Tracks the currently active coordinator MRIterator so tests can poll the
+// `pending` shard counter via FT.DEBUG BG_PENDING_REPLIES. Set after the
+// iterator is created in the RPNet start path; cleared before it is released
+// in rpnetFree. Only one query is expected to be active at a time in tests.
+struct MRIterator;
+void DebugBgIterator_Set(struct MRIterator *it);
+void DebugBgIterator_Clear(struct MRIterator *it);
+
 #endif  // ENABLE_ASSERT
 
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -2050,24 +2050,20 @@ class TestCoordinatorTimeout:
     def test_return_strict_timeout_channel_drain_aggregate(self):
         """RETURN_STRICT timeout while shard replies are queued in the channel.
 
-        Parks BG at RpnetReplyAdmitted after the first reply is admitted, lets
-        every shard finish so the remaining replies pile up in the channel,
-        then fires the blocked-client timeout. BG breaks out of the
-        interruptible wait via the timedOut flag and drains the queued items
-        (PopWithTimeout returns queued items regardless of the abort flag),
-        then completes the pipeline naturally because MRIterator_GetPending
-        is already 0. The full row count must be present in the reply.
+        Parks BG at RpnetReplyAdmitted after the first reply is admitted, waits
+        until every shard reply has been admitted into the coordinator's
+        channel (FT.DEBUG BG_PENDING_REPLIES == 0), then fires the blocked-client
+        timeout. BG breaks out of the interruptible wait via the timedOut flag
+        and drains the queued items (PopWithTimeout returns queued items
+        regardless of the abort flag), then completes the pipeline naturally
+        because MRIterator_GetPending is already 0. The full row count must be
+        present in the reply.
         """
         env = self.env
         skipIfNoEnableAssert(env)
 
         prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
         env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict')
-
-        shard_conns = [env.getConnection(shardId)
-                       for shardId in range(1, env.shardsCount + 1)]
-        base_jobs_done = [getWorkersThpoolStatsFromShard(c)['totalJobsDone']
-                          for c in shard_conns]
 
         sync_point = 'RpnetReplyAdmitted'
         env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
@@ -2089,17 +2085,15 @@ class TestCoordinatorTimeout:
             f'Timeout waiting for BG to park at {sync_point}'
         )
 
-        # Wait for every shard to complete its _FT.AGGREGATE job so the
-        # remaining replies are pushed into the channel by the IO threads.
+        # Wait until every shard's reply has been admitted into the coordinator
+        # channel. `BG_PENDING_REPLIES` returns the iterator's `pending` counter
+        # (number of shards that have not yet sent EOF). The IO callback
+        # decrements `pending` only after it has called MRChannel_Push on the
+        # reply, so reaching 0 guarantees all replies are physically queued.
         wait_for_condition(
-            lambda: (
-                all(getWorkersThpoolStatsFromShard(c)['totalJobsDone'] >= base + 1
-                    for c, base in zip(shard_conns, base_jobs_done)),
-                {'totalJobsDone': [getWorkersThpoolStatsFromShard(c)['totalJobsDone']
-                                   for c in shard_conns],
-                 'base': base_jobs_done}
-            ),
-            'Timeout waiting for all shards to complete their aggregate jobs'
+            lambda: (env.cmd(debug_cmd(), 'BG_PENDING_REPLIES') == 0,
+                     {'pending': env.cmd(debug_cmd(), 'BG_PENDING_REPLIES')}),
+            'Timeout waiting for all shard replies to be admitted into the coordinator channel'
         )
 
         # Fire the blocked-client timeout while BG is still parked at the sync

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -84,15 +84,16 @@ class TestDebugCommands(object):
         ]
         coord_help_list = ['SHARD_CONNECTION_STATES', 'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY']
         help_list.extend(coord_help_list)
-        # SYNC_POINT is only available in ENABLE_ASSERT builds
+        # SYNC_POINT and BG_PENDING_REPLIES are only available in ENABLE_ASSERT builds
         if isEnableAssertEnabled(self.env):
             help_list.append('SYNC_POINT')
+            help_list.append('BG_PENDING_REPLIES')
 
         self.env.expect(debug_cmd(), 'help').equal(help_list)
 
         arity_2_cmds = ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_LOCAL_CURSORS', 'SHARD_CONNECTION_STATES',
                         'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY', 'INFO', 'INDEXES', 'GET_HIDE_USER_DATA_FROM_LOGS',
-                        'REGISTER_TEST_SCORERS']
+                        'REGISTER_TEST_SCORERS', 'BG_PENDING_REPLIES']
         for cmd in [c for c in help_list if c not in arity_2_cmds]:
             self.env.expect(debug_cmd(), cmd).error().contains(err_msg)
 


### PR DESCRIPTION
## Summary

Fixes the flake in `test_return_strict_timeout_channel_drain_aggregate`
(`tests/pytests/test_blocked_client_timeout.py::TestCoordinatorTimeout`)
tracked by [MOD-15395](https://redislabs.atlassian.net/browse/MOD-15395).

## Root Cause

The pre-existing wait condition gated only on shard-local pipeline
completion:

```python
all(getWorkersThpoolStatsFromShard(c)['totalJobsDone'] >= base + 1
    for c, base in zip(shard_conns, base_jobs_done))
```

`totalJobsDone` is bumped when the shard worker finishes the local
pipeline. It does **not** prove that:

1. the shard's IO thread has serialized + sent the reply over TCP,
2. the coordinator's IO thread has read it, or
3. `MRIteratorCallback` has called `MRChannel_Push` and decremented
   the iterator's `pending` counter.

If `CLIENT UNBLOCK ... TIMEOUT` fired during that window, the coordinator
treated the still-in-flight shards as aborted under `RETURN_STRICT` and
returned a partial row count (e.g. 71/100 instead of the expected 100).
This produced sporadic CI failures with no signal change in the product
behavior under test.

## Fix — Deterministic Channel-Drain Wait

Introduce an assert-only debug subcommand
**`FT.DEBUG BG_PENDING_REPLIES`** that returns the `pending` shard
counter of the currently active coordinator `MRIterator`.

The IO callback decrements `pending` only **after** calling
`MRChannel_Push`, so observing `pending == 0` is a strict guarantee that
every shard reply is physically queued in the coordinator's channel.
The test now polls this command before triggering the blocked-client
timeout, eliminating the race deterministically.

## Implementation

All new symbols are guarded by `#ifdef ENABLE_ASSERT` and have zero
overhead in release builds.

- **`src/debug_commands.{c,h}`** — global
  `_Atomic(MRIterator *) globalDebugBgIterator` plus
  `DebugBgIterator_Set` / `DebugBgIterator_Clear` helpers
  (CAS on clear so a stale clear cannot wipe a newer iterator). New
  `DEBUG_COMMAND(bgPendingReplies)` registered in `assertOnlyCommands`,
  returning the iterator's pending count via `MRIterator_GetPending`,
  or `-1` when no iterator is active.
- **`src/coord/rpnet.c`** — publish the iterator pointer right after
  `MR_IterateWithPrivateData`; clear it in `rpnetFree` immediately
  before `MRIterator_Release`.
- **`src/coord/dist_aggregate.c`** — same set/clear around the
  aggregate iterator (matching `getResultsReducer`/`rpnetFree`).
- **`tests/pytests/test_blocked_client_timeout.py`** — replace the
  `totalJobsDone` shard poll with a `BG_PENDING_REPLIES == 0` poll on
  the coordinator, and update the test docstring to describe the new
  synchronization.

## Verification

- `test_return_strict_timeout_channel_drain_aggregate`:
  **10/10 PASS** in 10 consecutive runs.
- Full `TestCoordinatorTimeout` class:
  **44/44 PASS** (`make pytest TEST=test_blocked_client_timeout.py:TestCoordinatorTimeout QUICK=1 SA=0 DEBUG=1`).

## Scope / Risk

- Production code paths unchanged (all additions are
  `#ifdef ENABLE_ASSERT`).
- The new debug command follows the existing `assertOnlyCommands`
  pattern and is gated by `debugCommandsEnabled`.
- No public API change; the global iterator pointer is internal to the
  debug surface.

## Related

- Jira: [MOD-15395](https://redislabs.atlassian.net/browse/MOD-15395)
- The harvest-on-timeout behavior under `RETURN_STRICT` exercised by
  this test was implemented under
  [MOD-13617](https://redislabs.atlassian.net/browse/MOD-13617).


[MOD-15395]: https://redislabs.atlassian.net/browse/MOD-15395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-15395]: https://redislabs.atlassian.net/browse/MOD-15395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are gated behind `ENABLE_ASSERT` and primarily affect debug/test builds, with minimal impact limited to publishing/clearing an `MRIterator*` around iterator lifecycle.
> 
> **Overview**
> Adds an `ENABLE_ASSERT`-only debug subcommand `FT.DEBUG BG_PENDING_REPLIES` that exposes the active coordinator `MRIterator`'s shard `pending` counter via a global atomic pointer set/cleared by RPNet.
> 
> Hooks iterator publication into the coordinator aggregate/cursor-mapping start paths and clears it in `rpnetFree` before releasing the iterator, then updates the flaky `test_return_strict_timeout_channel_drain_aggregate` to wait on `BG_PENDING_REPLIES == 0` instead of shard worker stats; debug help/arity expectations are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b021f86cea1e224e284b7a4572dbeb3faec706ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->