### PR TITLE
fix: UB in ArgvList when accessing empty vector

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -308,7 +308,8 @@ end_group() {
 prepare_coverage_capture() {
   start_group "Code Coverage Preparation"
   lcov --zerocounters      --directory $BINROOT --base-directory $ROOT
-  lcov --capture --initial --directory $BINROOT --base-directory $ROOT -o $BINROOT/base.info
+  lcov --capture --initial --directory $BINROOT --base-directory $ROOT -o $BINROOT/base.info \
+    --exclude '*/_deps/*'
   end_group
 }
 
@@ -322,7 +323,8 @@ capture_coverage() {
   start_group "Code Coverage Capture ($NAME)"
 
   # Capture coverage collected while running tests previously
-  lcov --capture --directory $BINROOT --base-directory $ROOT -o $BINROOT/test.info
+  lcov --capture --directory $BINROOT --base-directory $ROOT -o $BINROOT/test.info \
+    --exclude '*/_deps/*'
 
   # Accumulate results with the baseline captured before the test
   lcov --add-tracefile $BINROOT/base.info --add-tracefile $BINROOT/test.info -o $BINROOT/full.info

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -1693,7 +1693,7 @@ void RMCK_Bootstrap(RMCKModuleLoadFunction fn, const char **s, size_t n) {
   // Create the context:
   RedisModuleCtx ctxTmp;
   RMCK::ArgvList args(&ctxTmp, s, n);
-  fn(&ctxTmp, &args[0], args.size());
+  fn(&ctxTmp, args.data(), args.size());
 }
 
 void RMCK_Shutdown(void) {

--- a/tests/cpptests/redismock/util.h
+++ b/tests/cpptests/redismock/util.h
@@ -102,8 +102,12 @@ class ArgvList {
     clear();
   }
 
+  RedisModuleString **data() {
+    return m_list.data();
+  }
+
   operator RedisModuleString **() {
-    return &m_list[0];
+    return data();
   }
 
   size_t size() const {


### PR DESCRIPTION
Use data() instead of &operator[](0) to get a pointer to the underlying RedisModuleString* array. The latter is undefined behavior when the vector is empty (e.g. RMCK_Bootstrap called with n=0), and aborts under GCC 15 debug builds which enable bounds checking.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-only `redismock` argument handling and coverage report filtering, with no impact on production module logic.
> 
> **Overview**
> Fixes a potential undefined-behavior crash in `tests/cpptests/redismock` by switching `ArgvList` pointer access from `&vec[0]` to `vec.data()` (and updating `RMCK_Bootstrap` to use it), which is safe when the argv vector is empty.
> 
> Updates coverage collection in `build.sh` to exclude `*/_deps/*` from both baseline and test `lcov` captures, reducing noise from third-party build artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac6ac1a16570c78ee13aa91c377b514a74a5977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->