### PR TITLE
skills: write-flow-tests: clarify waitForIndex usage based on data insertion timing

### DIFF
--- a/.skills/write-flow-tests/SKILL.md
+++ b/.skills/write-flow-tests/SKILL.md
@@ -45,8 +45,9 @@ Tests use the `RLTest` framework. The typical pattern is:
 
 ## Waiting for index
 
-- Only call `waitForIndex(env, 'idx')` when there is data that has been indexed and needs to be queryable.
-- Do not call `waitForIndex` right after `FT.CREATE` with no data — there is nothing to wait for.
+- **Data inserted before `FT.CREATE`**: Background indexing is activated. Call `waitForIndex(env, 'idx')` after `FT.CREATE` to wait for the backfill to complete before querying.
+- **Data inserted after `FT.CREATE`**: Each `HSET`/`JSON.SET` is immediately acknowledged by the index — no `waitForIndex` needed.
+- Do not call `waitForIndex` right after `FT.CREATE` with no pre-existing data — there is nothing to wait for.
 
 ## Assertions
 


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies when `waitForIndex` is required based on whether data existed before `FT.CREATE`, reducing chances of flaky or unnecessary waits in tests.
> 
> **Overview**
> Clarifies the flow-test guidelines for `waitForIndex` by distinguishing **pre-existing data before `FT.CREATE`** (requires waiting for background backfill) versus **data written after `FT.CREATE`** (no wait needed), and reiterates that calling `waitForIndex` immediately after `FT.CREATE` with no data is unnecessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec677486071c1c48064d2464aa3c6bbc4b94a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->