### PR TITLE
[MOD-14204] Implement Adhoc-BF Collection Path

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -19,7 +19,7 @@ use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutc
 
 use crate::{
     heap::{ScoredResult, TopKHeap},
-    traits::{CollectionStrategy, ScoreBatch, ScoreSource},
+    traits::{AdhocStrategy, BatchStrategy, ScoreBatch, ScoreSource},
 };
 
 /// Determines which collection algorithm [`TopKIterator`] uses.
@@ -155,22 +155,22 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
 
     /// Set up the unfiltered direct-yield path.
     ///
-    /// Calls [`ScoreSource::next_batch`] exactly once.  Results are streamed
+    /// Calls [`ScoreSource::next_batch_unfiltered`] exactly once. Results are streamed
     /// directly from the batch cursor — no heap is involved.
     ///
     /// # Invariants
     ///
     /// [`TopKMode::Unfiltered`] requires the source to produce at most one
-    /// batch.  In debug builds this method calls [`ScoreSource::next_batch`] a
+    /// batch.  In debug builds this method calls [`ScoreSource::next_batch_unfiltered`] a
     /// second time and panics if another batch is returned, catching
     /// misbehaving implementations early.
     fn prepare_unfiltered_direct(&mut self) -> Result<(), RQEIteratorError> {
-        self.direct_batch = self.source.next_batch()?;
+        self.direct_batch = self.source.next_batch_unfiltered()?;
         if self.direct_batch.is_none() {
             self.at_eof = true;
         }
         debug_assert!(
-            matches!(self.source.next_batch(), Ok(None)),
+            matches!(self.source.next_batch_unfiltered(), Ok(None)),
             "ScoreSource did not return Ok(None) in TopKMode::Unfiltered \
              (extra batch or error); use a batched mode instead"
         );
@@ -190,20 +190,16 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             if let Some(child) = &mut self.child {
                 intersect_batch_with_child(child, &mut batch, &mut self.heap)?;
             }
-
-            match self
-                .source
-                .collection_strategy(self.heap.len(), self.k.get())
-            {
-                CollectionStrategy::Continue => continue,
-                CollectionStrategy::Stop => break,
-                CollectionStrategy::SwitchToAdhoc => {
+            match self.source.batch_strategy(self.heap.len(), self.k.get()) {
+                BatchStrategy::Continue => continue,
+                BatchStrategy::Stop => break,
+                BatchStrategy::SwitchToAdhoc => {
                     self.mode = TopKMode::AdhocBF;
                     // Fall through to adhoc collection; heap is preserved.
                     self.collect_adhoc()?;
                     return Ok(());
                 }
-                CollectionStrategy::SwitchToBatches => {
+                BatchStrategy::SwitchToBatches => {
                     // Clear the heap: the source restarts with new parameters
                     // (e.g. expanded numeric range) and will re-emit previously
                     // collected docs. Keeping stale entries would cause duplicates.
@@ -239,12 +235,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             if let Some(score) = self.source.lookup_score(doc_id) {
                 self.heap.push(doc_id, score);
             }
-
-            if self
-                .source
-                .collection_strategy(self.heap.len(), self.k.get())
-                == CollectionStrategy::Stop
-            {
+            if self.source.adhoc_strategy(self.heap.len(), self.k.get()) == AdhocStrategy::Stop {
                 break;
             }
         }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -43,6 +43,9 @@ pub enum TopKMode {
     /// Fetch score-ordered batches from the source and intersect each one
     /// with the child filter iterator.
     Batches,
+    /// Walk the child iterator and call [`ScoreSource::lookup_score`] for
+    /// each document it yields.
+    AdhocBF,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,8 +63,9 @@ enum Phase {
 
 /// A generic top-k iterator parameterized over a [`ScoreSource`].
 ///
-/// Implements the two execution modes described in the design doc:
-/// [`Unfiltered`](TopKMode::Unfiltered) and [`Batches`](TopKMode::Batches).
+/// Implements the execution mode described in the design doc:
+/// [`Unfiltered`](TopKMode::Unfiltered), [`Batches`](TopKMode::Batches),
+/// and [`AdhocBF`](TopKMode::AdhocBF).
 pub struct TopKIterator<'index, S: ScoreSource> {
     source: S,
     child: Option<Box<dyn RQEIterator<'index> + 'index>>,
@@ -105,6 +109,9 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
+    ///
+    /// Useful for tests and for constructors that want to start in
+    /// [`AdhocBF`](TopKMode::AdhocBF) immediately.
     pub fn new_with_mode(
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
@@ -136,6 +143,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         let result = match self.mode {
             TopKMode::Unfiltered => self.prepare_unfiltered_direct(),
             TopKMode::Batches => self.collect_batches(),
+            TopKMode::AdhocBF => self.collect_adhoc(),
         };
         if result.is_err() {
             // Reset so a retry via read() works: Phase::Collecting has no handler there.
@@ -189,6 +197,55 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             {
                 CollectionStrategy::Continue => continue,
                 CollectionStrategy::Stop => break,
+                CollectionStrategy::SwitchToAdhoc => {
+                    self.mode = TopKMode::AdhocBF;
+                    // Fall through to adhoc collection; heap is preserved.
+                    self.collect_adhoc()?;
+                    return Ok(());
+                }
+                CollectionStrategy::SwitchToBatches => {
+                    // Clear the heap: the source restarts with new parameters
+                    // (e.g. expanded numeric range) and will re-emit previously
+                    // collected docs. Keeping stale entries would cause duplicates.
+                    self.heap = TopKHeap::new(self.k, self.compare);
+                    self.source.rewind();
+                    if let Some(child) = &mut self.child {
+                        child.rewind();
+                    }
+                    continue;
+                }
+            }
+        }
+        self.finalize_collection();
+        Ok(())
+    }
+
+    /// Collect results by walking the child iterator and calling
+    /// [`ScoreSource::lookup_score`] for each document.
+    fn collect_adhoc(&mut self) -> Result<(), RQEIteratorError> {
+        let child = self
+            .child
+            .as_mut()
+            .expect("AdhocBF mode requires a child iterator");
+        child.rewind();
+
+        loop {
+            let Some(result) = child.read()? else {
+                break;
+            };
+            let doc_id = result.doc_id;
+
+            // `self.child` is now free (we only needed `doc_id`).
+            if let Some(score) = self.source.lookup_score(doc_id) {
+                self.heap.push(doc_id, score);
+            }
+
+            if self
+                .source
+                .collection_strategy(self.heap.len(), self.k.get())
+                == CollectionStrategy::Stop
+            {
+                break;
             }
         }
         self.finalize_collection();

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -45,6 +45,8 @@ pub enum TopKMode {
     Batches,
     /// Walk the child iterator and call [`ScoreSource::lookup_score`] for
     /// each document it yields.
+    ///
+    /// `BF` stands for "Brute Force": for the lookup, opposed to score-ordered batches.
     AdhocBF,
 }
 
@@ -92,8 +94,6 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// The execution mode is inferred from `child`:
     /// - `None` → [`TopKMode::Unfiltered`]
     /// - `Some(_)` → [`TopKMode::Batches`]
-    ///
-    /// Use [`new_with_mode`](Self::new_with_mode) to override the initial mode.
     pub fn new(
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
@@ -105,14 +105,26 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         } else {
             TopKMode::Unfiltered
         };
-        Self::new_with_mode(source, child, k, compare, mode)
+        Self::_new_with_mode(source, child, k, compare, mode)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
     ///
     /// Useful for tests and for constructors that want to start in
     /// [`AdhocBF`](TopKMode::AdhocBF) immediately.
+    #[cfg(feature = "test-utils")]
     pub fn new_with_mode(
+        source: S,
+        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        k: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
+        mode: TopKMode,
+    ) -> Self {
+        Self::_new_with_mode(source, child, k, compare, mode)
+    }
+
+    /// Create a new [`TopKIterator`] with an explicit initial mode.
+    fn _new_with_mode(
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
@@ -149,6 +161,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             // Reset so a retry via read() works: Phase::Collecting has no handler there.
             // TODO: MOD-14209: bubble up errors
             self.phase = Phase::NotStarted;
+            self.mode = self.initial_mode;
         }
         result
     }
@@ -231,7 +244,6 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             };
             let doc_id = result.doc_id;
 
-            // `self.child` is now free (we only needed `doc_id`).
             if let Some(score) = self.source.lookup_score(doc_id) {
                 self.heap.push(doc_id, score);
             }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -42,7 +42,16 @@ pub enum TopKMode {
     Unfiltered,
     /// Fetch score-ordered batches from the source and intersect each one
     /// with the child filter iterator.
+    ///
+    /// The source's [`ScoreSource::batch_strategy`] may return
+    /// [`BatchStrategy::SwitchToAdhoc`] mid-run to switch to
+    /// [`AdhocBF`](TopKMode::AdhocBF) when the source considers it more
+    /// efficient.  Use [`ForcedBatches`](TopKMode::ForcedBatches) to suppress
+    /// that switch.
     Batches,
+    /// Like [`Batches`](TopKMode::Batches), but [`BatchStrategy::SwitchToAdhoc`]
+    /// from the source is ignored and treated as [`BatchStrategy::Continue`].
+    ForcedBatches,
     /// Walk the child iterator and call [`ScoreSource::lookup_score`] for
     /// each document it yields.
     ///
@@ -154,7 +163,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         self.phase = Phase::Collecting;
         let result = match self.mode {
             TopKMode::Unfiltered => self.prepare_unfiltered_direct(),
-            TopKMode::Batches => self.collect_batches(),
+            TopKMode::Batches | TopKMode::ForcedBatches => self.collect_batches(),
             TopKMode::AdhocBF => self.collect_adhoc(),
         };
         if result.is_err() {
@@ -207,8 +216,17 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
                 BatchStrategy::Continue => continue,
                 BatchStrategy::Stop => break,
                 BatchStrategy::SwitchToAdhoc => {
+                    if self.mode == TopKMode::ForcedBatches {
+                        // Honour the forced-batches contract: never switch
+                        // mid-run.
+                        continue;
+                    }
                     self.mode = TopKMode::AdhocBF;
-                    // Fall through to adhoc collection; heap is preserved.
+                    // Clear the heap: collect_adhoc rewinds the child and
+                    // rescans every match from scratch, so batch-phase entries
+                    // are redundant. Keeping them would re-admit the same doc id
+                    // (TopKHeap::push only de-dups against the worst element).
+                    self.heap = TopKHeap::new(self.k, self.compare);
                     self.collect_adhoc()?;
                     return Ok(());
                 }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -19,7 +19,7 @@ use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutc
 
 use crate::{
     heap::{ScoredResult, TopKHeap},
-    traits::{AdhocStrategy, BatchStrategy, ScoreBatch, ScoreSource},
+    traits::{BatchStrategy, ScoreBatch, ScoreSource},
 };
 
 /// Determines which collection algorithm [`TopKIterator`] uses.
@@ -177,22 +177,22 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
 
     /// Set up the unfiltered direct-yield path.
     ///
-    /// Calls [`ScoreSource::next_batch_unfiltered`] exactly once. Results are streamed
+    /// Calls [`ScoreSource::all_results_unfiltered_batch`] exactly once. Results are streamed
     /// directly from the batch cursor — no heap is involved.
     ///
     /// # Invariants
     ///
     /// [`TopKMode::Unfiltered`] requires the source to produce at most one
-    /// batch.  In debug builds this method calls [`ScoreSource::next_batch_unfiltered`] a
+    /// batch.  In debug builds this method calls [`ScoreSource::all_results_unfiltered_batch`] a
     /// second time and panics if another batch is returned, catching
     /// misbehaving implementations early.
     fn prepare_unfiltered_direct(&mut self) -> Result<(), RQEIteratorError> {
-        self.direct_batch = self.source.next_batch_unfiltered()?;
+        self.direct_batch = self.source.all_results_unfiltered_batch()?;
         if self.direct_batch.is_none() {
             self.at_eof = true;
         }
         debug_assert!(
-            matches!(self.source.next_batch_unfiltered(), Ok(None)),
+            matches!(self.source.all_results_unfiltered_batch(), Ok(None)),
             "ScoreSource did not return Ok(None) in TopKMode::Unfiltered \
              (extra batch or error); use a batched mode instead"
         );
@@ -264,9 +264,6 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
 
             if let Some(score) = self.source.lookup_score(doc_id) {
                 self.heap.push(doc_id, score);
-            }
-            if self.source.adhoc_strategy(self.heap.len(), self.k.get()) == AdhocStrategy::Stop {
-                break;
             }
         }
         self.finalize_collection();

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -34,4 +34,4 @@ pub mod mock;
 
 pub use heap::{ScoredResult, TopKHeap};
 pub use iterator::{TopKIterator, TopKMode};
-pub use traits::{AdhocStrategy, BatchStrategy, ScoreBatch, ScoreSource};
+pub use traits::{BatchStrategy, ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -17,10 +17,17 @@
 //!
 //! - **Unfiltered** — no child filter; stream results directly from the source's batch.
 //! - **Batches** — intersect score-ordered batches with a child filter (merge-join).
-//!
+//! - **Adhoc-BF** — walk the child filter and call [`ScoreSource::lookup_score`]
+//!   for each document.
 //! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
-//! traits.
+//! traits.  Concrete implementations (`VectorScoreSource`, `NumericScoreSource`) are
+//! introduced in M2 and M3 respectively.
 //!
+//! # Milestones
+//!
+//! - **M1 (this crate)**: shared skeleton — `TopKHeap`, `TopKIterator`, traits, mock sources.
+//! - **M2**: `VectorScoreSource` + planner wiring (`TopKIterator<VectorScoreSource>`).
+//! - **M3**: `NumericScoreSource` + planner wiring (`TopKIterator<NumericScoreSource>`).
 
 pub mod heap;
 pub mod iterator;

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -19,15 +19,6 @@
 //! - **Batches** — intersect score-ordered batches with a child filter (merge-join).
 //! - **Adhoc-BF** — walk the child filter and call [`ScoreSource::lookup_score`]
 //!   for each document.
-//! The score-producing logic is abstracted behind the [`ScoreSource`] / [`ScoreBatch`]
-//! traits.  Concrete implementations (`VectorScoreSource`, `NumericScoreSource`) are
-//! introduced in M2 and M3 respectively.
-//!
-//! # Milestones
-//!
-//! - **M1 (this crate)**: shared skeleton — `TopKHeap`, `TopKIterator`, traits, mock sources.
-//! - **M2**: `VectorScoreSource` + planner wiring (`TopKIterator<VectorScoreSource>`).
-//! - **M3**: `NumericScoreSource` + planner wiring (`TopKIterator<NumericScoreSource>`).
 
 pub mod heap;
 pub mod iterator;

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -43,4 +43,4 @@ pub mod mock;
 
 pub use heap::{ScoredResult, TopKHeap};
 pub use iterator::{TopKIterator, TopKMode};
-pub use traits::{CollectionStrategy, ScoreBatch, ScoreSource};
+pub use traits::{AdhocStrategy, BatchStrategy, ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -18,7 +18,7 @@ use index_result::RSIndexResult;
 use rqe_core::DocId;
 use rqe_iterators::RQEIteratorError;
 
-use crate::traits::{CollectionStrategy, ScoreBatch, ScoreSource};
+use crate::traits::{BatchStrategy, ScoreBatch, ScoreSource};
 
 /// A [`ScoreBatch`] backed by a pre-sorted `Vec<(DocId, f64)>`.
 ///
@@ -62,7 +62,7 @@ impl ScoreBatch for MockScoreBatch {
 ///
 /// ```rust
 /// # use top_k::mock::MockScoreSource;
-/// # use top_k::traits::CollectionStrategy;
+/// # use top_k::traits::BatchStrategy;
 /// let source = MockScoreSource::new(
 ///     // Two batches: each is a Vec<(doc_id, score)>
 ///     vec![
@@ -71,15 +71,15 @@ impl ScoreBatch for MockScoreBatch {
 ///     ],
 ///     // Per-doc scores for adhoc-BF lookup
 ///     vec![(1, 0.5), (3, 0.8), (5, 0.2), (7, 0.9)],
-///     // Strategy: always Continue
-///     |_, _| CollectionStrategy::Continue,
+///     // Batch strategy: always Continue
+///     |_, _| BatchStrategy::Continue,
 /// );
 /// ```
 pub struct MockScoreSource {
     batches: Vec<Vec<(DocId, f64)>>,
     batch_pos: usize,
     scores: HashMap<DocId, f64>,
-    strategy: Box<dyn FnMut(usize, usize) -> CollectionStrategy>,
+    batch_strategy: Box<dyn FnMut(usize, usize) -> BatchStrategy>,
     num_estimated: usize,
 }
 
@@ -88,7 +88,7 @@ impl MockScoreSource {
     ///
     /// - `batches` — sequence of batches; each inner `Vec` is one [`MockScoreBatch`].
     /// - `scores`  — per-document scores returned by [`lookup_score`].
-    /// - `strategy` — function called after each batch / adhoc step.
+    /// - `batch_strategy` — function called after each batch (Batches mode only).
     ///
     /// `num_estimated` defaults to the total number of entries across all batches.
     ///
@@ -96,14 +96,14 @@ impl MockScoreSource {
     pub fn new(
         batches: Vec<Vec<(DocId, f64)>>,
         scores: Vec<(DocId, f64)>,
-        strategy: impl FnMut(usize, usize) -> CollectionStrategy + 'static,
+        batch_strategy: impl FnMut(usize, usize) -> BatchStrategy + 'static,
     ) -> Self {
         let num_estimated = batches.iter().map(Vec::len).sum();
         Self {
             batches,
             batch_pos: 0,
             scores: scores.into_iter().collect(),
-            strategy: Box::new(strategy),
+            batch_strategy: Box::new(batch_strategy),
             num_estimated,
         }
     }
@@ -149,8 +149,8 @@ impl ScoreSource for MockScoreSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
-    fn collection_strategy(&mut self, heap_count: usize, k: usize) -> CollectionStrategy {
-        (self.strategy)(heap_count, k)
+    fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {
+        (self.batch_strategy)(heap_count, k)
     }
 
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -12,6 +12,8 @@
 //!
 //! Gated behind the `test-utils` feature.
 
+use std::collections::HashMap;
+
 use index_result::RSIndexResult;
 use rqe_core::DocId;
 use rqe_iterators::RQEIteratorError;
@@ -67,6 +69,8 @@ impl ScoreBatch for MockScoreBatch {
 ///         vec![(1, 0.5), (3, 0.8)],
 ///         vec![(5, 0.2), (7, 0.9)],
 ///     ],
+///     // Per-doc scores for adhoc-BF lookup
+///     vec![(1, 0.5), (3, 0.8), (5, 0.2), (7, 0.9)],
 ///     // Strategy: always Continue
 ///     |_, _| CollectionStrategy::Continue,
 /// );
@@ -74,6 +78,7 @@ impl ScoreBatch for MockScoreBatch {
 pub struct MockScoreSource {
     batches: Vec<Vec<(DocId, f64)>>,
     batch_pos: usize,
+    scores: HashMap<DocId, f64>,
     strategy: Box<dyn FnMut(usize, usize) -> CollectionStrategy>,
     num_estimated: usize,
 }
@@ -82,17 +87,22 @@ impl MockScoreSource {
     /// Creates a new `MockScoreSource`.
     ///
     /// - `batches` — sequence of batches; each inner `Vec` is one [`MockScoreBatch`].
-    /// - `strategy` — function called after each batch.
+    /// - `scores`  — per-document scores returned by [`lookup_score`].
+    /// - `strategy` — function called after each batch / adhoc step.
     ///
     /// `num_estimated` defaults to the total number of entries across all batches.
+    ///
+    /// [`lookup_score`]: ScoreSource::lookup_score
     pub fn new(
         batches: Vec<Vec<(DocId, f64)>>,
+        scores: Vec<(DocId, f64)>,
         strategy: impl FnMut(usize, usize) -> CollectionStrategy + 'static,
     ) -> Self {
         let num_estimated = batches.iter().map(Vec::len).sum();
         Self {
             batches,
             batch_pos: 0,
+            scores: scores.into_iter().collect(),
             strategy: Box::new(strategy),
             num_estimated,
         }
@@ -118,6 +128,10 @@ impl ScoreSource for MockScoreSource {
             self.batch_pos += 1;
         }
         Ok(batch)
+    }
+
+    fn lookup_score(&mut self, doc_id: DocId) -> Option<f64> {
+        self.scores.get(&doc_id).copied()
     }
 
     fn num_estimated(&self) -> usize {

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -57,28 +57,14 @@ pub enum BatchStrategy {
     Stop,
 }
 
-/// Decision returned by [`ScoreSource::adhoc_strategy`] after each adhoc
-/// lookup, telling [`TopKIterator`] whether to keep walking the child iterator.
-///
-/// [`TopKIterator`]: crate::TopKIterator
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AdhocStrategy {
-    /// Keep walking the child iterator.
-    Continue,
-
-    /// Collection is complete — stop and yield whatever is in the heap.
-    Stop,
-}
-
 /// The score-producing half of a [`TopKIterator`].
 ///
 /// A [`ScoreSource`] knows how to:
 /// 1. Produce score-ordered batches ([`next_batch`]).
-/// 2. Produce all results in a single shot ([`next_batch_unfiltered`]), used in Unfiltered mode.
+/// 2. Produce all results in a single shot ([`all_results_unfiltered_batch`]), used in Unfiltered mode.
 /// 3. Look up the score for an individual document ([`lookup_score`]), used in Adhoc-BF mode.
 /// 4. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
 /// 5. Decide, after each batch, whether to continue or switch strategy ([`batch_strategy`]).
-/// 6. Decide, after each adhoc lookup, whether to keep walking the child ([`adhoc_strategy`]).
 ///
 /// # Result lifetime
 ///
@@ -92,11 +78,10 @@ pub enum AdhocStrategy {
 ///
 /// [`TopKIterator`]: crate::TopKIterator
 /// [`next_batch`]: ScoreSource::next_batch
-/// [`next_batch_unfiltered`]: ScoreSource::next_batch_unfiltered
+/// [`all_results_unfiltered_batch`]: ScoreSource::all_results_unfiltered_batch
 /// [`lookup_score`]: ScoreSource::lookup_score
 /// [`build_result`]: ScoreSource::build_result
 /// [`batch_strategy`]: ScoreSource::batch_strategy
-/// [`adhoc_strategy`]: ScoreSource::adhoc_strategy
 pub trait ScoreSource {
     /// The type of batch cursor this source produces.
     type Batch: ScoreBatch;
@@ -122,7 +107,7 @@ pub trait ScoreSource {
     /// [`next_batch`](Self::next_batch).
     ///
     /// [`TopKIterator`]: crate::TopKIterator
-    fn next_batch_unfiltered(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+    fn all_results_unfiltered_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
         self.next_batch()
     }
 
@@ -165,28 +150,6 @@ pub trait ScoreSource {
     /// - `heap_count` — number of results currently in the heap.
     /// - `k` — the target number of results.
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy;
-
-    /// Called after each adhoc lookup (Adhoc-BF mode only) to decide whether
-    /// collection should continue.
-    ///
-    /// The default implementation always returns [`AdhocStrategy::Continue`]
-    /// because child iterators yield documents in doc-ID order, not score
-    /// order — early termination would produce an incorrect top-k.  Override
-    /// to implement early-stop heuristics when the caller can guarantee
-    /// correctness (e.g., after accumulating enough high-scoring results).
-    ///
-    /// Must **not** be called from Batches mode.
-    ///
-    /// # Arguments
-    /// - `heap_count` — number of results currently in the heap.
-    /// - `k` — the target number of results.
-    fn adhoc_strategy(&mut self, _heap_count: usize, _k: usize) -> AdhocStrategy {
-        // The child yields documents in doc-ID order, not score order, so we
-        // must scan every match to guarantee a correct top-k — stopping when
-        // the heap fills would freeze the answer at the first k child docs.
-        // The bounded `TopKHeap` keeps the result set at k entries regardless.
-        AdhocStrategy::Continue
-    }
 
     /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
     ///

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -35,15 +35,26 @@ pub trait ScoreBatch {
     fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)>;
 }
 
-/// Decision returned by [`ScoreSource::collection_strategy`] after each batch,
-/// telling [`TopKIterator`] how to proceed.
+/// Decision returned by [`ScoreSource::collection_strategy`] after each batch
+/// or adhoc lookup, telling [`TopKIterator`] how to proceed.
 ///
 /// [`TopKIterator`]: crate::TopKIterator
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CollectionStrategy {
-    /// Keep iterating — fetch the next batch.
+    /// Keep iterating — fetch the next batch (Batches mode) or the next child
+    /// document (Adhoc-BF mode).
     Continue,
-
+    /// Switch from Batches mode to Adhoc-BF mode.
+    ///
+    /// The iterator will rewind the child and start calling
+    /// [`ScoreSource::lookup_score`] for each document the child yields.
+    /// Only meaningful when the iterator is currently in Batches mode.
+    SwitchToAdhoc,
+    /// Restart batch collection (e.g. after the source has expanded its range).
+    ///
+    /// The iterator rewinds both the source and the child, then re-enters
+    /// Batches mode from the beginning.
+    SwitchToBatches,
     /// Collection is complete — stop and yield whatever is in the heap.
     Stop,
 }
@@ -52,7 +63,10 @@ pub enum CollectionStrategy {
 ///
 /// A [`ScoreSource`] knows how to:
 /// 1. Produce score-ordered batches ([`next_batch`]).
-/// 2. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
+/// 2. Look up the score for an individual document ([`lookup_score`]), used in Adhoc-BF mode.
+/// 3. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
+/// 4. Decide, after each batch or adhoc step, whether to continue or switch strategy
+///    ([`collection_strategy`]).
 ///
 /// # Result lifetime
 ///
@@ -66,7 +80,9 @@ pub enum CollectionStrategy {
 ///
 /// [`TopKIterator`]: crate::TopKIterator
 /// [`next_batch`]: ScoreSource::next_batch
+/// [`lookup_score`]: ScoreSource::lookup_score
 /// [`build_result`]: ScoreSource::build_result
+/// [`collection_strategy`]: ScoreSource::collection_strategy
 pub trait ScoreSource {
     /// The type of batch cursor this source produces.
     type Batch: ScoreBatch;
@@ -89,6 +105,12 @@ pub trait ScoreSource {
     /// [`TopKMode::Unfiltered`]: crate::TopKMode::Unfiltered
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError>;
 
+    /// Return the score for `doc_id`, or `None` if the document is not in
+    /// the source's index.
+    ///
+    /// Used in Adhoc-BF mode where the child iterator drives traversal.
+    fn lookup_score(&mut self, doc_id: DocId) -> Option<f64>;
+
     /// Return an upper-bound estimate for the number of documents this source
     /// can produce.
     fn num_estimated(&self) -> usize;
@@ -109,7 +131,8 @@ pub trait ScoreSource {
     where
         Self: 'r;
 
-    /// Called after each batch to decide how collection should proceed.
+    /// Called after each batch (Batches mode) or each adhoc lookup (Adhoc-BF mode)
+    /// to decide how collection should proceed.
     ///
     /// # Arguments
     ///

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -35,20 +35,18 @@ pub trait ScoreBatch {
     fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)>;
 }
 
-/// Decision returned by [`ScoreSource::collection_strategy`] after each batch
-/// or adhoc lookup, telling [`TopKIterator`] how to proceed.
+/// Decision returned by [`ScoreSource::batch_strategy`] after each batch,
+/// telling [`TopKIterator`] how to proceed in Batches mode.
 ///
 /// [`TopKIterator`]: crate::TopKIterator
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CollectionStrategy {
-    /// Keep iterating — fetch the next batch (Batches mode) or the next child
-    /// document (Adhoc-BF mode).
+pub enum BatchStrategy {
+    /// Keep fetching batches.
     Continue,
     /// Switch from Batches mode to Adhoc-BF mode.
     ///
     /// The iterator will rewind the child and start calling
     /// [`ScoreSource::lookup_score`] for each document the child yields.
-    /// Only meaningful when the iterator is currently in Batches mode.
     SwitchToAdhoc,
     /// Restart batch collection (e.g. after the source has expanded its range).
     ///
@@ -59,14 +57,28 @@ pub enum CollectionStrategy {
     Stop,
 }
 
+/// Decision returned by [`ScoreSource::adhoc_strategy`] after each adhoc
+/// lookup, telling [`TopKIterator`] whether to keep walking the child iterator.
+///
+/// [`TopKIterator`]: crate::TopKIterator
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdhocStrategy {
+    /// Keep walking the child iterator.
+    Continue,
+
+    /// Collection is complete — stop and yield whatever is in the heap.
+    Stop,
+}
+
 /// The score-producing half of a [`TopKIterator`].
 ///
 /// A [`ScoreSource`] knows how to:
 /// 1. Produce score-ordered batches ([`next_batch`]).
-/// 2. Look up the score for an individual document ([`lookup_score`]), used in Adhoc-BF mode.
-/// 3. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
-/// 4. Decide, after each batch or adhoc step, whether to continue or switch strategy
-///    ([`collection_strategy`]).
+/// 2. Produce all results in a single shot ([`next_batch_unfiltered`]), used in Unfiltered mode.
+/// 3. Look up the score for an individual document ([`lookup_score`]), used in Adhoc-BF mode.
+/// 4. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
+/// 5. Decide, after each batch, whether to continue or switch strategy ([`batch_strategy`]).
+/// 6. Decide, after each adhoc lookup, whether to keep walking the child ([`adhoc_strategy`]).
 ///
 /// # Result lifetime
 ///
@@ -80,30 +92,39 @@ pub enum CollectionStrategy {
 ///
 /// [`TopKIterator`]: crate::TopKIterator
 /// [`next_batch`]: ScoreSource::next_batch
+/// [`next_batch_unfiltered`]: ScoreSource::next_batch_unfiltered
 /// [`lookup_score`]: ScoreSource::lookup_score
 /// [`build_result`]: ScoreSource::build_result
-/// [`collection_strategy`]: ScoreSource::collection_strategy
+/// [`batch_strategy`]: ScoreSource::batch_strategy
+/// [`adhoc_strategy`]: ScoreSource::adhoc_strategy
 pub trait ScoreSource {
     /// The type of batch cursor this source produces.
     type Batch: ScoreBatch;
 
     /// Fetch the next score-ordered batch.
     ///
+    /// Called repeatedly by [`TopKIterator`] in Batches mode.
+    ///
     /// Returns:
     /// - `Ok(Some(batch))` — a new batch is available.
     /// - `Ok(None)` — the source is exhausted; no more batches.
     /// - `Err(RQEIteratorError::TimedOut)` — the query time limit was reached.
     ///
-    /// # Multi-batch support
-    ///
-    /// The API allows an implementation to spread results across multiple
-    /// batches (the caller loops until `Ok(None)`). However, [`TopKMode::Unfiltered`]
-    /// only calls this method once; sources used in that mode **must** return
-    /// all their results in the first batch.  Returning a second batch there
-    /// is a logic error — results would be silently lost.
-    ///
     /// [`TopKMode::Unfiltered`]: crate::TopKMode::Unfiltered
+    /// [`TopKIterator`]: crate::TopKIterator
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError>;
+
+    /// Single-shot query returning all results directly, without a heap.
+    ///
+    /// Called exactly once by [`TopKIterator`] in [`Unfiltered`](crate::TopKMode::Unfiltered)
+    /// mode. Implementations that can answer the full query in one call (e.g.
+    /// `VecSimIndex_TopKQuery`) should override this; the default delegates to
+    /// [`next_batch`](Self::next_batch).
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn next_batch_unfiltered(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        self.next_batch()
+    }
 
     /// Return the score for `doc_id`, or `None` if the document is not in
     /// the source's index.
@@ -131,14 +152,41 @@ pub trait ScoreSource {
     where
         Self: 'r;
 
-    /// Called after each batch (Batches mode) or each adhoc lookup (Adhoc-BF mode)
-    /// to decide how collection should proceed.
+    /// Called after each batch (Batches mode only) to decide how collection
+    /// should proceed.
+    ///
+    /// May update internal estimates as a side effect (e.g., refine child
+    /// selectivity).
+    ///
+    /// Must **not** be called from Adhoc-BF mode.
     ///
     /// # Arguments
     ///
     /// - `heap_count` — number of results currently in the heap.
     /// - `k` — the target number of results.
-    fn collection_strategy(&mut self, heap_count: usize, k: usize) -> CollectionStrategy;
+    fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy;
+
+    /// Called after each adhoc lookup (Adhoc-BF mode only) to decide whether
+    /// collection should continue.
+    ///
+    /// The default implementation always returns [`AdhocStrategy::Continue`]
+    /// because child iterators yield documents in doc-ID order, not score
+    /// order — early termination would produce an incorrect top-k.  Override
+    /// to implement early-stop heuristics when the caller can guarantee
+    /// correctness (e.g., after accumulating enough high-scoring results).
+    ///
+    /// Must **not** be called from Batches mode.
+    ///
+    /// # Arguments
+    /// - `heap_count` — number of results currently in the heap.
+    /// - `k` — the target number of results.
+    fn adhoc_strategy(&mut self, _heap_count: usize, _k: usize) -> AdhocStrategy {
+        // The child yields documents in doc-ID order, not score order, so we
+        // must scan every match to guarantee a correct top-k — stopping when
+        // the heap fills would freeze the answer at the first k child docs.
+        // The bounded `TopKHeap` keeps the result set at k entries regardless.
+        AdhocStrategy::Continue
+    }
 
     /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
     ///

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -443,6 +443,39 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
 }
 
 #[test]
+fn strategy_switch_to_adhoc() {
+    // First call to batch_strategy → SwitchToAdhoc; subsequent → Continue.
+    let mut call_count = 0u32;
+    let strategy = move |_heap: usize, _k: usize| {
+        call_count += 1;
+        if call_count == 1 {
+            BatchStrategy::SwitchToAdhoc
+        } else {
+            BatchStrategy::Continue
+        }
+    };
+    // Doc 2 is found in BOTH phases: the batch (score 3.0) and the adhoc scan
+    // (score 1.0). On SwitchToAdhoc the heap is cleared before the adhoc rescan,
+    // so doc 2 must be admitted exactly once — without the clear it would appear
+    // twice, since TopKHeap::push only de-dups against the worst heap element.
+    // Doc 1 is batch-only (absent from the adhoc scores map) and is dropped.
+    let source = MockScoreSource::new(
+        vec![vec![(1, 5.0), (2, 3.0)]],
+        vec![(2, 1.0), (3, 2.0)],
+        strategy,
+    );
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 2, 3])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    // Adhoc-only scores, doc 2 exactly once: 2(1.0), 3(2.0).
+    assert_eq!(doc_ids, vec![2, 3]);
+}
+
+#[test]
 fn strategy_switch_to_batches_rewinds() {
     // Call 0 → SwitchToBatches (rewinds source+child, restarts loop).
     // Call 1 → Stop (to exit on the second pass).

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -17,8 +17,7 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
 use top_k::{
-    CollectionStrategy, ScoreSource, TopKIterator, TopKMode, mock::MockScoreBatch,
-    mock::MockScoreSource,
+    BatchStrategy, ScoreSource, TopKIterator, TopKMode, mock::MockScoreBatch, mock::MockScoreSource,
 };
 
 // ── Error path stubs ─────────────────────────────────────────────────────────────
@@ -108,8 +107,8 @@ impl ScoreSource for TimingOutSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
-    fn collection_strategy(&mut self, _: usize, _: usize) -> CollectionStrategy {
-        CollectionStrategy::Continue
+    fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
+        BatchStrategy::Continue
     }
 
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
@@ -133,7 +132,7 @@ fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
 #[test]
 fn read_triggers_collection_on_first_call() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
 
@@ -145,7 +144,7 @@ fn read_triggers_collection_on_first_call() {
 #[test]
 fn rewind_resets_to_not_started() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     it.read().unwrap();
@@ -166,9 +165,7 @@ fn rewind_resets_to_not_started() {
 
 #[test]
 fn eof_set_after_results_exhausted() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
-    });
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     it.read().unwrap();
     let eof = it.read().unwrap();
@@ -179,7 +176,7 @@ fn eof_set_after_results_exhausted() {
 #[test]
 fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
 
@@ -197,7 +194,7 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
 #[test]
 fn num_estimated_capped_at_k() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     })
     .with_num_estimated(100);
     let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc);
@@ -212,7 +209,7 @@ fn unfiltered_yields_batch_in_source_order() {
     // Scores are descending (0.9 → 0.5 → 0.1) while doc IDs are ascending.
     // If the iterator re-sorted by score it would yield [3, 2, 1]; source order gives [1, 2, 3].
     let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc);
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -221,7 +218,7 @@ fn unfiltered_yields_batch_in_source_order() {
 
 #[test]
 fn unfiltered_empty_source_is_immediate_eof() {
-    let source = MockScoreSource::new(vec![], vec![], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![], vec![], |_, _| BatchStrategy::Continue);
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -232,9 +229,7 @@ fn unfiltered_empty_source_is_immediate_eof() {
 #[test]
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
-    });
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
@@ -245,9 +240,7 @@ fn revalidate_with_child_delegates_ok() {
     // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
     // for any child iterator that leaves the parent in a valid state.
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
-    });
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
     let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
@@ -257,9 +250,7 @@ fn revalidate_with_child_delegates_ok() {
 #[test]
 fn revalidate_with_child_delegates_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
-    });
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
     let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
@@ -284,7 +275,7 @@ fn batches_overlap_intersection() {
     let source = MockScoreSource::new(
         vec![vec![(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6), (5, 0.5)]],
         vec![],
-        |_, _| CollectionStrategy::Continue,
+        |_, _| BatchStrategy::Continue,
     );
     let mut it = TopKIterator::new(
         source,
@@ -299,7 +290,7 @@ fn batches_overlap_intersection() {
 #[test]
 fn batches_disjoint_yields_nothing() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new(
         source,
@@ -314,7 +305,7 @@ fn batches_disjoint_yields_nothing() {
 #[test]
 fn batches_empty_child_yields_nothing() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new(
         source,
@@ -333,7 +324,7 @@ fn batches_multiple_batches() {
     let source = MockScoreSource::new(
         vec![vec![(1, 3.0), (2, 4.0)], vec![(3, 1.0), (4, 2.0)]],
         vec![],
-        |_, _| CollectionStrategy::Continue,
+        |_, _| BatchStrategy::Continue,
     );
     let mut it = TopKIterator::new(
         source,
@@ -354,7 +345,7 @@ fn strategy_stop_stops_after_first_batch() {
             vec![(4, 0.1)], // NOT fetched
         ],
         vec![],
-        |_, _| CollectionStrategy::Stop,
+        |_, _| BatchStrategy::Stop,
     );
     let mut it = TopKIterator::new(
         source,
@@ -371,7 +362,7 @@ fn strategy_stop_stops_after_first_batch() {
 #[test]
 fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
     use rqe_iterators::RQEIteratorError;
-    use top_k::{CollectionStrategy, ScoreSource, mock::MockScoreBatch};
+    use top_k::{BatchStrategy, ScoreSource, mock::MockScoreBatch};
 
     struct OnceErrorSource {
         batch_call: u32,
@@ -409,7 +400,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         }
 
         fn lookup_score(&mut self, _: DocId) -> Option<f64> {
-            None
+            Some(10f64)
         }
 
         fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
@@ -419,8 +410,8 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             RSIndexResult::build_virt().doc_id(doc_id).build()
         }
 
-        fn collection_strategy(&mut self, _: usize, _: usize) -> CollectionStrategy {
-            CollectionStrategy::Continue
+        fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
+            BatchStrategy::Continue
         }
 
         fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
@@ -493,9 +484,9 @@ fn strategy_switch_to_batches_rewinds() {
         let n = call_count.get();
         call_count.set(n + 1);
         if n == 0 {
-            CollectionStrategy::SwitchToBatches
+            BatchStrategy::SwitchToBatches
         } else {
-            CollectionStrategy::Stop
+            BatchStrategy::Stop
         }
     };
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], strategy);
@@ -515,7 +506,7 @@ fn strategy_switch_to_batches_rewinds() {
 fn adhoc_scores_known_docs_only() {
     // Child: [1,2,3,4,5], source has scores for [2,4] only → yields [2,4].
     let source = MockScoreSource::new(vec![], vec![(2, 1.0), (4, 2.0)], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -533,9 +524,9 @@ fn adhoc_early_stop_when_heap_full() {
     // k=2; strategy signals Stop when heap reaches capacity.
     let source = MockScoreSource::new(vec![], vec![(1, 1.0), (2, 2.0), (3, 0.5)], |heap, k| {
         if heap >= k {
-            CollectionStrategy::Stop
+            BatchStrategy::Stop
         } else {
-            CollectionStrategy::Continue
+            BatchStrategy::Continue
         }
     });
     let mut it = TopKIterator::new_with_mode(
@@ -552,7 +543,7 @@ fn adhoc_early_stop_when_heap_full() {
 #[test]
 fn adhoc_child_eof_returns_what_was_found() {
     let source = MockScoreSource::new(vec![], vec![(1, 0.1), (2, 0.2)], |_, _| {
-        CollectionStrategy::Continue
+        BatchStrategy::Continue
     });
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -567,7 +558,7 @@ fn adhoc_child_eof_returns_what_was_found() {
 
 #[test]
 fn adhoc_empty_child_is_eof() {
-    let source = MockScoreSource::new(vec![], vec![], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![], vec![], |_, _| BatchStrategy::Continue);
     let mut it = TopKIterator::new_with_mode(
         source,
         Some(make_child(vec![])),

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -17,7 +17,8 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
 use top_k::{
-    CollectionStrategy, ScoreSource, TopKIterator, mock::MockScoreBatch, mock::MockScoreSource,
+    CollectionStrategy, ScoreSource, TopKIterator, TopKMode, mock::MockScoreBatch,
+    mock::MockScoreSource,
 };
 
 // ── Error path stubs ─────────────────────────────────────────────────────────────
@@ -90,6 +91,10 @@ impl ScoreSource for TimingOutSource {
         Err(RQEIteratorError::TimedOut)
     }
 
+    fn lookup_score(&mut self, _: ffi::t_docId) -> Option<f64> {
+        None
+    }
+
     fn num_estimated(&self) -> usize {
         0
     }
@@ -127,7 +132,7 @@ fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
 
 #[test]
 fn read_triggers_collection_on_first_call() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         CollectionStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
@@ -139,7 +144,7 @@ fn read_triggers_collection_on_first_call() {
 
 #[test]
 fn rewind_resets_to_not_started() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         CollectionStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
@@ -161,9 +166,10 @@ fn rewind_resets_to_not_started() {
 
 #[test]
 fn eof_set_after_results_exhausted() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
+        CollectionStrategy::Continue
+    });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
-
     it.read().unwrap();
     let eof = it.read().unwrap();
     assert!(eof.is_none());
@@ -172,7 +178,7 @@ fn eof_set_after_results_exhausted() {
 
 #[test]
 fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         CollectionStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
@@ -190,7 +196,7 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
 
 #[test]
 fn num_estimated_capped_at_k() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], vec![], |_, _| {
         CollectionStrategy::Continue
     })
     .with_num_estimated(100);
@@ -205,7 +211,7 @@ fn num_estimated_capped_at_k() {
 fn unfiltered_yields_batch_in_source_order() {
     // Scores are descending (0.9 → 0.5 → 0.1) while doc IDs are ascending.
     // If the iterator re-sorted by score it would yield [3, 2, 1]; source order gives [1, 2, 3].
-    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], vec![], |_, _| {
         CollectionStrategy::Continue
     });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc);
@@ -215,7 +221,7 @@ fn unfiltered_yields_batch_in_source_order() {
 
 #[test]
 fn unfiltered_empty_source_is_immediate_eof() {
-    let source = MockScoreSource::new(vec![], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![], vec![], |_, _| CollectionStrategy::Continue);
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -226,7 +232,9 @@ fn unfiltered_empty_source_is_immediate_eof() {
 #[test]
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
+        CollectionStrategy::Continue
+    });
     let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
@@ -237,7 +245,9 @@ fn revalidate_with_child_delegates_ok() {
     // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
     // for any child iterator that leaves the parent in a valid state.
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
+        CollectionStrategy::Continue
+    });
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
     let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
@@ -247,7 +257,9 @@ fn revalidate_with_child_delegates_ok() {
 #[test]
 fn revalidate_with_child_delegates_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], |_, _| CollectionStrategy::Continue);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| {
+        CollectionStrategy::Continue
+    });
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
     let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
@@ -271,6 +283,7 @@ fn batches_overlap_intersection() {
     // Matches: 1→0.9, 3→0.7, 5→0.5  → best-first ASC: 5, 3, 1
     let source = MockScoreSource::new(
         vec![vec![(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6), (5, 0.5)]],
+        vec![],
         |_, _| CollectionStrategy::Continue,
     );
     let mut it = TopKIterator::new(
@@ -285,7 +298,7 @@ fn batches_overlap_intersection() {
 
 #[test]
 fn batches_disjoint_yields_nothing() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], vec![], |_, _| {
         CollectionStrategy::Continue
     });
     let mut it = TopKIterator::new(
@@ -300,7 +313,7 @@ fn batches_disjoint_yields_nothing() {
 
 #[test]
 fn batches_empty_child_yields_nothing() {
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], |_, _| {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         CollectionStrategy::Continue
     });
     let mut it = TopKIterator::new(
@@ -319,6 +332,7 @@ fn batches_multiple_batches() {
     // Child: [1,3,4]  Matches: 1→3.0, 3→1.0, 4→2.0  best-first → 3,4,1
     let source = MockScoreSource::new(
         vec![vec![(1, 3.0), (2, 4.0)], vec![(3, 1.0), (4, 2.0)]],
+        vec![],
         |_, _| CollectionStrategy::Continue,
     );
     let mut it = TopKIterator::new(
@@ -339,6 +353,7 @@ fn strategy_stop_stops_after_first_batch() {
             vec![(3, 0.5)], // NOT fetched
             vec![(4, 0.1)], // NOT fetched
         ],
+        vec![],
         |_, _| CollectionStrategy::Stop,
     );
     let mut it = TopKIterator::new(
@@ -363,7 +378,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         rewind_count: u32,
     }
 
-    impl<'index> ScoreSource for OnceErrorSource {
+    impl ScoreSource for OnceErrorSource {
         type Batch = MockScoreBatch;
 
         fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
@@ -391,6 +406,10 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         fn rewind(&mut self) {
             self.batch_call = 0;
             self.rewind_count += 1;
+        }
+
+        fn lookup_score(&mut self, _: DocId) -> Option<f64> {
+            None
         }
 
         fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
@@ -430,4 +449,132 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
     // by rewind(), doc 1 and doc 3 are added a second time and appear twice.
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![1, 3]);
+}
+
+#[test]
+fn strategy_switch_to_adhoc() {
+    // First call to collection_strategy → SwitchToAdhoc; subsequent → Continue.
+    let mut call_count = 0u32;
+    let strategy = move |_heap: usize, _k: usize| {
+        call_count += 1;
+        if call_count == 1 {
+            CollectionStrategy::SwitchToAdhoc
+        } else {
+            CollectionStrategy::Continue
+        }
+    };
+    // Doc 2 is found in BOTH phases: the batch (score 3.0) and the adhoc scan
+    // (score 1.0). On SwitchToAdhoc the heap is cleared before the adhoc rescan,
+    // so doc 2 must be admitted exactly once — without the clear it would appear
+    // twice, since TopKHeap::push only de-dups against the worst heap element.
+    // Doc 1 is batch-only (absent from the adhoc scores map) and is dropped.
+    let source = MockScoreSource::new(
+        vec![vec![(1, 5.0), (2, 3.0)]],
+        vec![(2, 1.0), (3, 2.0)],
+        strategy,
+    );
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 2, 3])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    // Adhoc-only scores, doc 2 exactly once: 2(1.0), 3(2.0).
+    assert_eq!(doc_ids, vec![2, 3]);
+}
+
+#[test]
+fn strategy_switch_to_batches_rewinds() {
+    // Call 0 → SwitchToBatches (rewinds source+child, restarts loop).
+    // Call 1 → Stop (to exit on the second pass).
+    let call_count = std::cell::Cell::new(0u32);
+    let strategy = move |_: usize, _: usize| {
+        let n = call_count.get();
+        call_count.set(n + 1);
+        if n == 0 {
+            CollectionStrategy::SwitchToBatches
+        } else {
+            CollectionStrategy::Stop
+        }
+    };
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], strategy);
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![1, 2])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![1, 2]);
+}
+
+// ── Adhoc-BF ──────────────────────────────────────────────────────────────
+
+#[test]
+fn adhoc_scores_known_docs_only() {
+    // Child: [1,2,3,4,5], source has scores for [2,4] only → yields [2,4].
+    let source = MockScoreSource::new(vec![], vec![(2, 1.0), (4, 2.0)], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(make_child(vec![1, 2, 3, 4, 5])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2, 4]);
+}
+
+#[test]
+fn adhoc_early_stop_when_heap_full() {
+    // k=2; strategy signals Stop when heap reaches capacity.
+    let source = MockScoreSource::new(vec![], vec![(1, 1.0), (2, 2.0), (3, 0.5)], |heap, k| {
+        if heap >= k {
+            CollectionStrategy::Stop
+        } else {
+            CollectionStrategy::Continue
+        }
+    });
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(make_child(vec![1, 2, 3])),
+        NonZeroUsize::new(2).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids.len(), 2);
+}
+
+#[test]
+fn adhoc_child_eof_returns_what_was_found() {
+    let source = MockScoreSource::new(vec![], vec![(1, 0.1), (2, 0.2)], |_, _| {
+        CollectionStrategy::Continue
+    });
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(make_child(vec![1, 2])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![1, 2]);
+}
+
+#[test]
+fn adhoc_empty_child_is_eof() {
+    let source = MockScoreSource::new(vec![], vec![], |_, _| CollectionStrategy::Continue);
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(make_child(vec![])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+    assert!(it.read().unwrap().is_none());
+    assert!(it.at_eof());
 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -443,39 +443,6 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
 }
 
 #[test]
-fn strategy_switch_to_adhoc() {
-    // First call to collection_strategy → SwitchToAdhoc; subsequent → Continue.
-    let mut call_count = 0u32;
-    let strategy = move |_heap: usize, _k: usize| {
-        call_count += 1;
-        if call_count == 1 {
-            CollectionStrategy::SwitchToAdhoc
-        } else {
-            CollectionStrategy::Continue
-        }
-    };
-    // Doc 2 is found in BOTH phases: the batch (score 3.0) and the adhoc scan
-    // (score 1.0). On SwitchToAdhoc the heap is cleared before the adhoc rescan,
-    // so doc 2 must be admitted exactly once — without the clear it would appear
-    // twice, since TopKHeap::push only de-dups against the worst heap element.
-    // Doc 1 is batch-only (absent from the adhoc scores map) and is dropped.
-    let source = MockScoreSource::new(
-        vec![vec![(1, 5.0), (2, 3.0)]],
-        vec![(2, 1.0), (3, 2.0)],
-        strategy,
-    );
-    let mut it = TopKIterator::new(
-        source,
-        Some(make_child(vec![1, 2, 3])),
-        NonZeroUsize::new(10).unwrap(),
-        asc,
-    );
-    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
-    // Adhoc-only scores, doc 2 exactly once: 2(1.0), 3(2.0).
-    assert_eq!(doc_ids, vec![2, 3]);
-}
-
-#[test]
 fn strategy_switch_to_batches_rewinds() {
     // Call 0 → SwitchToBatches (rewinds source+child, restarts loop).
     // Call 1 → Stop (to exit on the second pass).

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -125,15 +125,21 @@ fn bench_intersection_overlap(c: &mut Criterion) {
         let child_ids: Vec<u64> = (0..n as u64).step_by(2).map(|i| i * 2).collect();
 
         group.bench_with_input(BenchmarkId::new("batches_50pct_overlap", n), &n, |b, _| {
-            b.iter(|| {
-                let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
-                    BatchStrategy::Continue
-                });
-                let child: Box<dyn RQEIterator> =
-                    Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
-                let mut it = TopKIterator::new(source, Some(child), k, asc);
-                while black_box(it.read()).unwrap().is_some() {}
-            })
+            b.iter_batched(
+                || {
+                    let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
+                        BatchStrategy::Continue
+                    });
+                    let child: Box<dyn RQEIterator> =
+                        Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+                    (source, child)
+                },
+                |(source, child)| {
+                    let mut it = TopKIterator::new(source, Some(child), k, asc);
+                    while black_box(it.read()).unwrap().is_some() {}
+                },
+                BatchSize::SmallInput,
+            )
         });
     }
     group.finish();
@@ -148,39 +154,81 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
         let child_ids: Vec<u64> = (0..n as u64).map(|i| i * 2 + 1).collect();
 
         group.bench_with_input(BenchmarkId::new("batches_0pct_overlap", n), &n, |b, _| {
-            b.iter(|| {
-                let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
-                    BatchStrategy::Continue
-                });
-                let child: Box<dyn RQEIterator> =
-                    Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
-                let mut it = TopKIterator::new(source, Some(child), k, asc);
-                while black_box(it.read()).unwrap().is_some() {}
-            })
+            b.iter_batched(
+                || {
+                    let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
+                        BatchStrategy::Continue
+                    });
+                    let child: Box<dyn RQEIterator> =
+                        Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+                    (source, child)
+                },
+                |(source, child)| {
+                    let mut it = TopKIterator::new(source, Some(child), k, asc);
+                    while black_box(it.read()).unwrap().is_some() {}
+                },
+                BatchSize::SmallInput,
+            )
         });
     }
     group.finish();
 }
 
-fn bench_adhoc_10k_child(c: &mut Criterion) {
-    let n = 10_000usize;
-    let k = NonZeroUsize::new(100).unwrap();
-    // Every 10th document has a score.
-    let scores: Vec<(u64, f64)> = (0..n as u64).step_by(10).map(|i| (i, i as f64)).collect();
-    let child_ids: Vec<u64> = (0..n as u64).collect();
+fn bench_adhoc_vs_batches(c: &mut Criterion) {
+    // Compare Adhoc-BF and Batches on the same inputs as n_child varies.
+    // Source: 100k scored docs. Child: n_child docs spread evenly across the source.
+    // Adhoc-BF is expected to win for small n_child; Batches for large n_child.
+    let mut group = c.benchmark_group("iterator/adhoc_vs_batches");
+    let n_source = 100_000usize;
+    let k = NonZeroUsize::new(10).unwrap();
+    let source_docs: Vec<(u64, f64)> = (0..n_source as u64).map(|i| (i, i as f64)).collect();
 
-    c.bench_function("iterator/adhoc_10k_child", |b| {
-        b.iter(|| {
-            let source =
-                MockScoreSource::new(vec![], scores.clone(), |_, _| BatchStrategy::Continue);
-            let child: Box<dyn RQEIterator> =
-                Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
-            let mut it =
-                TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::AdhocBF);
-            while it.read().unwrap().is_some() {}
-            black_box(it.at_eof())
-        })
-    });
+    for n_child in [100usize, n_source / 2, n_source - 100usize] {
+        let step = n_source / n_child;
+        let child_ids: Vec<u64> = (0..n_source as u64).step_by(step).take(n_child).collect();
+
+        group.bench_with_input(BenchmarkId::new("adhoc", n_child), &n_child, |b, _| {
+            b.iter_batched(
+                || {
+                    let source = MockScoreSource::new(vec![], source_docs.clone(), |_, _| {
+                        BatchStrategy::Continue
+                    });
+                    let child: Box<dyn RQEIterator> =
+                        Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+                    (source, child)
+                },
+                |(source, child)| {
+                    let mut it =
+                        TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::AdhocBF);
+                    while it.read().unwrap().is_some() {}
+                    black_box(it.at_eof())
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_with_input(BenchmarkId::new("batches", n_child), &n_child, |b, _| {
+            b.iter_batched(
+                || {
+                    let source = MockScoreSource::new(vec![source_docs.clone()], vec![], |_, _| {
+                        BatchStrategy::Continue
+                    });
+                    let child: Box<dyn RQEIterator> =
+                        Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+                    (source, child)
+                },
+                |(source, child)| {
+                    let mut it =
+                        TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::Batches);
+                    while it.read().unwrap().is_some() {}
+                    black_box(it.at_eof())
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
 }
 
 criterion_group!(
@@ -189,6 +237,6 @@ criterion_group!(
     bench_heap_pop_all,
     bench_intersection_overlap,
     bench_intersection_disjoint,
-    bench_adhoc_10k_child,
+    bench_adhoc_vs_batches,
 );
 criterion_main!(benches);

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -22,7 +22,7 @@ use std::{cmp::Ordering, num::NonZeroUsize};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{SeedableRng as _, seq::SliceRandom as _};
 use rqe_iterators::RQEIterator;
-use top_k::{CollectionStrategy, TopKHeap, TopKIterator, TopKMode, mock::MockScoreSource};
+use top_k::{BatchStrategy, TopKHeap, TopKIterator, TopKMode, mock::MockScoreSource};
 
 fn asc(a: f64, b: f64) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)
@@ -127,7 +127,7 @@ fn bench_intersection_overlap(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("batches_50pct_overlap", n), &n, |b, _| {
             b.iter(|| {
                 let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
-                    CollectionStrategy::Continue
+                    BatchStrategy::Continue
                 });
                 let child: Box<dyn RQEIterator> =
                     Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
@@ -150,7 +150,7 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("batches_0pct_overlap", n), &n, |b, _| {
             b.iter(|| {
                 let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
-                    CollectionStrategy::Continue
+                    BatchStrategy::Continue
                 });
                 let child: Box<dyn RQEIterator> =
                     Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
@@ -172,7 +172,7 @@ fn bench_adhoc_10k_child(c: &mut Criterion) {
     c.bench_function("iterator/adhoc_10k_child", |b| {
         b.iter(|| {
             let source =
-                MockScoreSource::new(vec![], scores.clone(), |_, _| CollectionStrategy::Continue);
+                MockScoreSource::new(vec![], scores.clone(), |_, _| BatchStrategy::Continue);
             let child: Box<dyn RQEIterator> =
                 Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
             let mut it =

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -22,7 +22,7 @@ use std::{cmp::Ordering, num::NonZeroUsize};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{SeedableRng as _, seq::SliceRandom as _};
 use rqe_iterators::RQEIterator;
-use top_k::{CollectionStrategy, TopKHeap, TopKIterator, mock::MockScoreSource};
+use top_k::{CollectionStrategy, TopKHeap, TopKIterator, TopKMode, mock::MockScoreSource};
 
 fn asc(a: f64, b: f64) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)
@@ -126,8 +126,9 @@ fn bench_intersection_overlap(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("batches_50pct_overlap", n), &n, |b, _| {
             b.iter(|| {
-                let source =
-                    MockScoreSource::new(vec![batch.clone()], |_, _| CollectionStrategy::Continue);
+                let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
+                    CollectionStrategy::Continue
+                });
                 let child: Box<dyn RQEIterator> =
                     Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
                 let mut it = TopKIterator::new(source, Some(child), k, asc);
@@ -148,8 +149,9 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("batches_0pct_overlap", n), &n, |b, _| {
             b.iter(|| {
-                let source =
-                    MockScoreSource::new(vec![batch.clone()], |_, _| CollectionStrategy::Continue);
+                let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
+                    CollectionStrategy::Continue
+                });
                 let child: Box<dyn RQEIterator> =
                     Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
                 let mut it = TopKIterator::new(source, Some(child), k, asc);
@@ -160,11 +162,33 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_adhoc_10k_child(c: &mut Criterion) {
+    let n = 10_000usize;
+    let k = NonZeroUsize::new(100).unwrap();
+    // Every 10th document has a score.
+    let scores: Vec<(u64, f64)> = (0..n as u64).step_by(10).map(|i| (i, i as f64)).collect();
+    let child_ids: Vec<u64> = (0..n as u64).collect();
+
+    c.bench_function("iterator/adhoc_10k_child", |b| {
+        b.iter(|| {
+            let source =
+                MockScoreSource::new(vec![], scores.clone(), |_, _| CollectionStrategy::Continue);
+            let child: Box<dyn RQEIterator> =
+                Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
+            let mut it =
+                TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::AdhocBF);
+            while it.read().unwrap().is_some() {}
+            black_box(it.at_eof())
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_heap_insert,
     bench_heap_pop_all,
     bench_intersection_overlap,
     bench_intersection_disjoint,
+    bench_adhoc_10k_child,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Context

TopKIterator had two collection strategies: Unfiltered (stream results directly from the source) and Batches (intersect score-ordered batches with a child filter). Both work well when the score index is small or when there is good overlap with the filter.

# This PR

This PR adds a third strategy: Adhoc-BF, for when the filter is small relative to the score index. Instead of pulling scored batches, the iterator walks the child filter and scores each matching document individually. The Batches path can switch to Adhoc-BF mid-collection if the source decides the remaining batch scan isn't worth the cost.

The `ScoreSource` trait is also tightened: the single strategy callback is split into two:
- one for Batches mode (batch_strategy)
- one for Adhoc-BF mode (adhoc_strategy).

Each mode now has its own signal set, so future sources only implement what applies to them.

## Benchmarking:

Current benchmark fails to reveal clearly which case is better for which strategy, but it's worth discussing.

Currently we're more benchmarking the data layout of the **mocks** than the TopK **algorithm**...

When we have proper implementations of `ScoreSource` we'll have a better picture.

| filter (against 100 000 docs)  | Adhoc (time)            | batches (time)        |
|----------|------------------------|------------------------|
| 100      | 12.604 – 12.657 µs     | 38.851 – 39.747 µs     |
| 50000    | 302.84 – 311.84 ns     | 207.15 – 209.49 µs     |
| 99900    | 260.80 – 264.74 ns     | 377.87 – 385.93 µs     |

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core top-k collection and ScoreSource trait surface (new required lookup_score); correctness depends on heap clears and rewinds on strategy switches, though impact is limited to the top_k crate until real sources adopt the trait.
> 
> **Overview**
> Adds **Adhoc-BF** top-k collection: walk the child filter and score each doc via **`ScoreSource::lookup_score`**, instead of only merge-joining score-ordered batches.
> 
> **`TopKIterator`** gains **`TopKMode::AdhocBF`** and **`ForcedBatches`** (ignores mid-run switch to adhoc). After each batch, **`batch_strategy`** (renamed from **`collection_strategy`** / **`CollectionStrategy`**) can **`Continue`**, **`Stop`**, **`SwitchToAdhoc`**, or **`SwitchToBatches`**; switches clear the heap, rewind source/child as needed, then run adhoc or restart batches. Collection errors reset **`mode`** to **`initial_mode`**. Unfiltered path uses **`all_results_unfiltered_batch`**; explicit **`new_with_mode`** is **`test-utils`** only.
> 
> **`ScoreSource`** now requires **`lookup_score`**; mocks/tests/benchmarks updated, including adhoc vs batches benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01baac53fb2fe349a8240582144041c2917b655e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->