### PR TITLE
MOD-13118: Add RDB load validations and limits

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1336,7 +1336,9 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
 
   // check possible optimization after creation of QueryIterator tree
   if (IsOptimized(req)) {
-    QOptimizer_Iterators(req, req->optimizer);
+    if (QOptimizer_Iterators(req, req->optimizer, status) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
+    }
   }
 
   if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {

--- a/src/config.h
+++ b/src/config.h
@@ -372,6 +372,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_MAX_TRIM_DELAY 5000  // 5 seconds in milliseconds
 #define DEFAULT_TRIMMING_STATE_CHECK_DELAY 100 // 0.1 seconds in milliseconds (We check the trimming state every 0.1 seconds, between MIN_TRIM_DELAY and MAX_TRIM_DELAY)
 #define DEFAULT_DISK_BUFFER_PERCENTAGE 20  // 20% of available memory for disk write buffer
+#define DEFAULT_MAX_INDEXES 200000
 
 // default configuration
 #define RS_DEFAULT_CONFIG {                                                    \

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2970,7 +2970,7 @@ DEBUG_COMMAND(SetMaxIndexes) {
   size_t numIndexes = Indexes_Count();
   if (newMaxIndexes < numIndexes) {
     return RedisModule_ReplyWithErrorFormat(ctx,
-        "Invalid value. Must be at least current number of indexes: %d.", numIndexes);
+        "Invalid value. Must be at least current number of indexes: %zu.", numIndexes);
   }
 
   maxIndexes_g = (uint32_t)newMaxIndexes;

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2942,6 +2942,41 @@ DEBUG_COMMAND(RegisterTestScorers) {
   }
 }
 
+// Global variable defined in spec.c - maximum number of indexes allowed
+extern uint32_t maxIndexes_g;
+
+/**
+ * FT.DEBUG SET_MAX_INDEXES <value>
+ * Set the maximum number of indexes allowed (for testing only).
+ * Value must be between max(1, current number of indexes) and
+ * DEFAULT_MAX_INDEXES (200000).
+ */
+DEBUG_COMMAND(SetMaxIndexes) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  long long newMaxIndexes;
+  if (RedisModule_StringToLongLong(argv[2], &newMaxIndexes) != REDISMODULE_OK ||
+      newMaxIndexes < 1 || newMaxIndexes > DEFAULT_MAX_INDEXES) {
+    return RedisModule_ReplyWithErrorFormat(ctx,
+        "Invalid value. Must be between 1 and %d.", DEFAULT_MAX_INDEXES);
+  }
+
+  // Get current number of indexes
+  size_t numIndexes = Indexes_Count();
+  if (newMaxIndexes < numIndexes) {
+    return RedisModule_ReplyWithErrorFormat(ctx,
+        "Invalid value. Must be at least current number of indexes: %d.", numIndexes);
+  }
+
+  maxIndexes_g = (uint32_t)newMaxIndexes;
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
 DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all the inverted index entries.
                                {"DUMP_NUMIDX", DumpNumericIndex}, // Print all the headers (optional) + entries of the numeric tree.
                                {"DUMP_NUMIDXTREE", DumpNumericIndexTree}, // Print tree general info, all leaves + nodes + stats
@@ -2987,7 +3022,8 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"GET_MAX_DOC_ID", GetMaxDocId},
                                {"DUMP_DELETED_IDS", DumpDeletedIds},
                                {"DISK_IO_CONTROL", DiskIOControl},
-                               {"REGISTER_TEST_SCORERS", RegisterTestScorers}, // Register test scorers
+                               {"REGISTER_TEST_SCORERS", RegisterTestScorers},
+                               {"SET_MAX_INDEXES", SetMaxIndexes},
                                /**
                                 * The following commands are for debugging distributed search/aggregation.
                                 */

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -17,6 +17,7 @@
 #include "commands.h"
 #include "config.h"
 #include "module.h"
+#include "util/likely.h"
 
 dict *spellCheckDicts = NULL;
 
@@ -35,7 +36,11 @@ int Dictionary_Add(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
   RS_LOG_ASSERT_ALWAYS(t != NULL, "Failed to open dictionary in write mode");
 
   for (int i = 0; i < len; ++i) {
-    valuesAdded += Trie_Insert(t, values[i], 1, 1, NULL, 0);
+    // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur
+    int rc = Trie_Insert(t, values[i], 1, 1, NULL, 0);
+    if (likely(rc == TRIE_OK_NEW)) {
+      valuesAdded++;
+    }
   }
 
   return valuesAdded;

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -440,7 +440,7 @@ int DocTable_Replace(DocTable *t, const char *from_str, size_t from_len, const c
   return REDISMODULE_OK;
 }
 
-void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
+int DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
   long long deletedElements = 0;
   t->size = RedisModule_LoadUnsigned(rdb);
   t->maxDocId = RedisModule_LoadUnsigned(rdb);
@@ -462,6 +462,13 @@ void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
     t->memsize -= t->cap * sizeof(DMDChain);
     t->cap = t->maxSize;
     rm_free(t->buckets);
+    t->buckets = NULL;
+    size_t alloc_size;
+    if (__builtin_mul_overflow(t->cap, sizeof(DMDChain), &alloc_size)) {
+      RedisModule_LogIOError(rdb, "warning", "DocTable_LegacyRdbLoad: allocation overflow");
+      t->cap = 0;
+      return REDISMODULE_ERR;
+    }
     t->buckets = rm_calloc(t->cap, sizeof(*t->buckets));
     t->memsize += t->cap * sizeof(DMDChain);
   }
@@ -534,6 +541,7 @@ void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
     }
   }
   t->size -= deletedElements;
+  return REDISMODULE_OK;
 }
 
 t_docId DocTable_GetMaxDocId(const DocTable *t) {

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -223,7 +223,10 @@ static inline void DMD_Return(const RSDocumentMetadata *cdmd) {
   }
 }
 
-void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver);
+/* Load the doc table from RDB. This is used for legacy RDB load only.
+ * Returns REDISMODULE_OK on success, REDISMODULE_ERR on allocation failure.
+ */
+int DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver);
 
 t_docId DocTable_GetMaxDocId(const DocTable *t);
 

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -223,12 +223,32 @@ IteratorStatus OPT_Read(QueryIterator *self) {
 }
 
 QueryIterator *NewOptimizerIterator(QOptimizer *qOpt, QueryIterator *root, IteratorsConfig *config) {
+  // Check for overflow in result array allocation: (limit + 1) * sizeof(RSIndexResult)
+  size_t resArr_alloc_size;
+  if (__builtin_add_overflow(qOpt->limit, 1, &resArr_alloc_size)) {
+    return NULL;
+  }
+  if (__builtin_mul_overflow(resArr_alloc_size, sizeof(RSIndexResult), &resArr_alloc_size)) {
+    return NULL;
+  }
+
+  // Check for overflow in heap allocation: (limit * sizeof(void*)) + sizeof(heap_t)
+  // Note: We only check the multiplication overflow.
+  // The test for overflow due to the addition of sizeof(heap_t) is not needed
+  // because sizeof(RSIndexResult) > sizeof(void*), so any limit that would
+  // cause the heap addition to overflow would have already triggered the resArr
+  // multiplication overflow check above.
+  size_t heap_array_size;
+  if (__builtin_mul_overflow((size_t)qOpt->limit, sizeof(void *), &heap_array_size)) {
+    return NULL;
+  }
+
   OptimizerIterator *oi = rm_calloc(1, sizeof(*oi));
   oi->child = root;
   oi->optim = qOpt;
 
   oi->cmp = qOpt->asc ? cmpAsc : cmpDesc;
-  oi->resArr = rm_malloc((qOpt->limit + 1) * sizeof(RSIndexResult));
+  oi->resArr = rm_malloc(resArr_alloc_size);
   oi->pooledResult = oi->resArr;
   oi->heap = rm_malloc(heap_sizeof(qOpt->limit));
   heap_init(oi->heap, oi->cmp, NULL, qOpt->limit);

--- a/src/json.c
+++ b/src/json.c
@@ -564,7 +564,12 @@ switch (params->algo) {
   if (!multi)
     goto fail;
 
-  if (!(df->blobArr = rm_malloc(fs->vectorOpts.expBlobSize * len))) {
+  size_t alloc_size;
+  if (__builtin_mul_overflow(fs->vectorOpts.expBlobSize, len, &alloc_size)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Failed to allocate memory for multi-vector field");
+    goto fail;
+  }
+  if (!(df->blobArr = rm_malloc(alloc_size))) {
     goto fail;
   }
   df->blobSize = fs->vectorOpts.expBlobSize;
@@ -669,7 +674,12 @@ void JSONIterable_Clean(JSONIterable *iterable) {
 }
 
 int JSON_StoreTextInDocField(size_t len, JSONIterable *iterable, struct DocumentField *df, QueryError *status) {
-  df->multiVal = rm_calloc(len , sizeof(*df->multiVal));
+  size_t alloc_size;
+  if (__builtin_mul_overflow(len, sizeof(*df->multiVal), &alloc_size)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Failed to allocate memory for text field");
+    return REDISMODULE_ERR;
+  }
+  df->multiVal = rm_calloc(1, alloc_size);
   int i = 0, nulls = 0;
   size_t strlen;
   RedisJSON json;

--- a/src/json.h
+++ b/src/json.h
@@ -54,6 +54,12 @@ int JSON_LoadDocumentField(JSONResultsIterator jsonIter, size_t len, FieldSpec *
                            struct DocumentField *df, RedisModuleCtx *ctx, bool rejectMultiValue,
                            QueryError *status);
 
+/* Stores text values from a JSON iterable into a document field */
+int JSON_StoreTextInDocField(size_t len, JSONIterable *iterable, struct DocumentField *df, QueryError *status);
+
+/* Stores multi-vector values from a JSON iterable into a document field */
+int JSON_StoreMultiVectorInDocField(FieldSpec *fs, JSONIterable *itr, size_t len, struct DocumentField *df, QueryError *status);
+
 /* Checks if JSONType fits the FieldType */
 int FieldSpec_CheckJsonType(FieldType fieldType, JSONType type, QueryError *status);
 

--- a/src/module.c
+++ b/src/module.c
@@ -829,7 +829,16 @@ int SynUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   IndexSpec_InitializeSynonym(sp);
 
-  SynonymMap_UpdateRedisStr(sp->smap, argv + offset, argc - offset, id);
+  SynonymMapResult ret = SynonymMap_UpdateRedisStr(sp->smap, argv + offset, argc - offset, id);
+  if (ret == SYNONYM_MAP_ERR_MAX_TERMS) {
+    RedisSearchCtx_UnlockSpec(&sctx);
+    CurrentThread_ClearIndexSpec();
+    return RedisModule_ReplyWithError(ctx, "Maximum synonym terms limit reached");
+  } else if (ret == SYNONYM_MAP_ERR_MAX_GROUP_IDS) {
+    RedisSearchCtx_UnlockSpec(&sctx);
+    CurrentThread_ClearIndexSpec();
+    return RedisModule_ReplyWithError(ctx, "Maximum group IDs per term limit reached");
+  }
 
   if (initialScan) {
     IndexSpec_ScanAndReindex(ctx, ref);

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -226,7 +226,7 @@ static void updateRootIter(AREQ *req, QueryIterator *root, QueryIterator *new) {
   }
 }
 
-void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
+int QOptimizer_Iterators(AREQ *req, QOptimizer *opt, QueryError *status) {
   IndexSpec *spec = AREQ_SearchCtx(req)->spec;
   QueryIterator *root = req->rootiter;
 
@@ -238,12 +238,17 @@ void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
     case Q_OPT_NO_SORTER:
     case Q_OPT_NONE:
     case Q_OPT_FILTER:
-      return;
+      return REDISMODULE_OK;
 
     // limit range to number of required LIMIT
     case Q_OPT_PARTIAL_RANGE: {
       if (root->type == WILDCARD_ITERATOR) {
         req->rootiter = NewOptimizerIterator(opt, root, &req->ast.config);
+        if (!req->rootiter) {
+          req->rootiter = root;
+          QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT, "OFFSET/LIMIT too large for optimizer allocation");
+          return REDISMODULE_ERR;
+        }
       } else if (req->ast.root->type == QN_NUMERIC) {
         // trim the union numeric iterator to have the minimal number of ranges
         if (root->type == UNION_ITERATOR) {
@@ -251,8 +256,13 @@ void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
         }
       } else {
         req->rootiter = NewOptimizerIterator(opt, root, &req->ast.config);
+        if (!req->rootiter) {
+          req->rootiter = root;
+          QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT, "OFFSET/LIMIT too large for optimizer allocation");
+          return REDISMODULE_ERR;
+        }
       }
-      return;
+      return REDISMODULE_OK;
     }
     case Q_OPT_UNDECIDED: {
       if (!opt->field) {
@@ -263,13 +273,19 @@ void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
         QueryIterator *numericIter = NewNumericFilterIterator(AREQ_SearchCtx(req), opt->sortbyNode->nn.nf, INDEXFLD_T_NUMERIC,
                                                               &req->ast.config, &filterCtx);
         updateRootIter(req, root, numericIter);
-        return;
+        return REDISMODULE_OK;
       }
       opt->type = Q_OPT_HYBRID;
       // replace root with OptimizerIterator
       req->rootiter = NewOptimizerIterator(opt, root, &req->ast.config);
+      if (!req->rootiter) {
+        req->rootiter = root;
+        QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT, "OFFSET/LIMIT too large for optimizer allocation");
+        return REDISMODULE_ERR;
+      }
     }
   }
+  return REDISMODULE_OK;
 }
 
 void QOptimizer_UpdateTotalResults(AREQ *req) {

--- a/src/query_optimizer.h
+++ b/src/query_optimizer.h
@@ -79,6 +79,10 @@ typedef struct QOptimizer {
     RedisSearchCtx *sctx;
 } QOptimizer;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* create a new QOptimizer struct */
 QOptimizer *QOptimizer_New();
 
@@ -94,8 +98,10 @@ void QOptimizer_Parse(AREQ *req);
  **/
 void QOptimizer_QueryNodes(QueryNode *root, QOptimizer *opt);
 
-/* iterate over index iterator, check estimations and performs further optimizations */
-void QOptimizer_Iterators(AREQ *req, QOptimizer *opt);
+/* iterate over index iterator, check estimations and performs further
+ * optimizations.
+ * Returns REDISMODULE_OK on success, REDISMODULE_ERR on failure (allocation overflow). */
+int QOptimizer_Iterators(AREQ *req, QOptimizer *opt, QueryError *status);
 
 /* estimate the number of documents that should be checked before reaching the
  * `limit` requirement of the the query. */
@@ -106,3 +112,7 @@ void QOptimizer_UpdateTotalResults(AREQ *req);
 
 /* print type of optimizer */
 const char *QOptimizer_PrintType(QOptimizer *opt);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -54,11 +54,7 @@ impl IndexSpec {
     pub fn field_specs(&self) -> &[FieldSpec] {
         debug_assert!(!self.0.fields.is_null(), "fields must not be null");
         let data = self.0.fields.cast::<FieldSpec>();
-        let len = self
-            .0
-            .numFields
-            .try_into()
-            .expect("numFields must fit into usize");
+        let len = self.0.numFields.into();
         // Safety: (1.) due to creation with `IndexSpec::from_raw`
         unsafe { slice::from_raw_parts(data, len) }
     }

--- a/src/rules.c
+++ b/src/rules.c
@@ -14,6 +14,9 @@
 #include "json.h"
 #include "rdb.h"
 #include "fast_float/fast_float_strtod.h"
+#include "util/likely.h"
+#include "spec.h"
+#include "rmutil/rm_assert.h"
 
 TrieMap *SchemaPrefixes_g = NULL;
 
@@ -408,6 +411,7 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver, QueryError
 #define RULEARGS_INITIAL_NUM_PREFIXES_ON_STACK 32
   char *prefixes[RULEARGS_INITIAL_NUM_PREFIXES_ON_STACK];
   uint64_t exist = 0;
+  uint64_t nprefixes_u64 = 0;
   double score_default = 0.0;
   RSLanguage lang_default = DEFAULT_LANGUAGE;
   bool index_all = false;
@@ -417,7 +421,19 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver, QueryError
   int ret = REDISMODULE_OK;
   args.type = LoadStringBuffer_IOError(rdb, &len, goto cleanup);
 
-  args.nprefixes = LoadUnsigned_IOError(rdb, goto cleanup);
+  nprefixes_u64 = LoadUnsigned_IOError(rdb, goto cleanup);
+
+  RS_ASSERT(MAX_SCHEMA_PREFIXES <= UINT32_MAX);
+  if (unlikely(nprefixes_u64 > MAX_SCHEMA_PREFIXES)) {
+    QueryError_SetWithoutUserDataFmt(
+        status, QUERY_ERROR_CODE_LIMIT,
+        "RDB Load: Number of prefixes (%llu) exceeds maximum allowed (%d)",
+        (unsigned long long)nprefixes_u64, MAX_SCHEMA_PREFIXES);
+    ret = REDISMODULE_ERR;
+    goto cleanup;
+  }
+
+  args.nprefixes = (unsigned int)nprefixes_u64;
   if (args.nprefixes <= RULEARGS_INITIAL_NUM_PREFIXES_ON_STACK) {
     args.prefixes = (const char **)prefixes;
     memset(args.prefixes, 0, args.nprefixes * sizeof(*args.prefixes));

--- a/src/spec.c
+++ b/src/spec.c
@@ -15,6 +15,7 @@
 
 #include "triemap.h"
 #include "util/logging.h"
+#include "util/likely.h"
 #include "util/misc.h"
 #include "rmutil/vector.h"
 #include "rmutil/util.h"
@@ -63,6 +64,11 @@ RedisModuleType *IndexSpecType;
 dict *specDict_g = NULL;
 dict *specIdDict_g = NULL;
 IndexesScanner *global_spec_scanner = NULL;
+
+// Maximum number of indexes that can be created.
+// Can be modified via FT.DEBUG for testing.
+uint32_t maxIndexes_g = DEFAULT_MAX_INDEXES;
+
 size_t pending_global_indexing_ops = 0;
 dict *legacySpecDict;
 dict *legacySpecRules;
@@ -555,6 +561,12 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
   setMemoryInfo(ctx);
   if (checkIfSpecExists(rawSpecName)) {
     QueryError_SetCode(status, QUERY_ERROR_CODE_INDEX_EXISTS);
+    return NULL;
+  }
+  if (dictSize(specDict_g) >= maxIndexes_g) {
+    QueryError_SetWithoutUserDataFmt(
+      status, QUERY_ERROR_CODE_LIMIT,
+      "Maximum number of indexes (%u) reached", maxIndexes_g);
     return NULL;
   }
   size_t nameLen;
@@ -1846,6 +1858,13 @@ static StrongRef IndexSpec_ParseFromArgCursor(RedisModuleCtx *ctx, const HiddenS
   spec->timeout = timeout * 1000;  // convert to ms
 
   if (rule_prefixes.argc > 0) {
+    if (rule_prefixes.argc > MAX_SCHEMA_PREFIXES) {
+      QueryError_SetWithoutUserDataFmt(
+          status, QUERY_ERROR_CODE_LIMIT,
+          "Number of prefixes (%zu) exceeds maximum allowed (%d)",
+          rule_prefixes.argc, MAX_SCHEMA_PREFIXES);
+      goto failure;
+    }
     spec->rule = SchemaRule_CreateWithPrefixesAC(&rule_args, &rule_prefixes, spec_ref, status);
   } else {
     rule_args.nprefixes = 1;
@@ -1940,8 +1959,9 @@ size_t IndexSpec_GetIndexErrorCount(const IndexSpec *sp) {
 
 // Assuming the spec is properly locked for writing before calling this function.
 void IndexSpec_AddTerm(IndexSpec *sp, const char *term, size_t len) {
+  // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur
   int isNew = Trie_InsertStringBuffer(sp->terms, (char *)term, len, 1, 1, NULL, 1);
-  if (isNew) {
+  if (isNew == TRIE_OK_NEW) {
     sp->stats.scoring.numTerms++;
     sp->stats.termsSize += len;
   }
@@ -2354,7 +2374,7 @@ static void initializeFieldSpec(FieldSpec *fs, t_fieldIndex index) {
 // Helper function for initializing an index spec
 // Solves issues where a field is initialized in index creation but not when loading from RDB
 static void initializeIndexSpec(IndexSpec *sp, const HiddenString *name, IndexFlags flags,
-                                int16_t numFields) {
+                                uint16_t numFields) {
   sp->flags = flags;
   sp->numFields = numFields;
   sp->fields = rm_calloc(numFields, sizeof(FieldSpec));
@@ -3373,6 +3393,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
   StrongRef spec_ref = {0};
   IndexFlags flags = 0;
   int16_t numFields = 0;
+  uint64_t numFields_u64 = 0;
   size_t narr = 0;
   char *rawName = NULL;
   size_t len = 0;
@@ -3395,9 +3416,16 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
     flags |= Index_StoreFreqs;
   }
   IndexSpec_NormalizeStorageFlagsOnLoad(&flags);
-  numFields = LoadUnsigned_IOError(rdb, goto cleanup);
+  numFields_u64 = LoadUnsigned_IOError(rdb, goto cleanup);
 
-  initializeIndexSpec(sp, specName, flags, numFields);
+  if (unlikely(numFields_u64 > SPEC_MAX_FIELDS)) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
+                           "RDB Load: Schema is limited to %d fields",
+                           SPEC_MAX_FIELDS);
+    goto cleanup;
+  }
+
+  initializeIndexSpec(sp, specName, flags, numFields_u64);
 
   sp->isDuplicate = dictFetchValue(specDict_g, sp->specName) != NULL;
 
@@ -3593,7 +3621,17 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
   IndexSpec_NormalizeStorageFlagsOnLoad(&sp->flags);
 
-  sp->numFields = RedisModule_LoadUnsigned(rdb);
+  uint64_t numFields_u64 = RedisModule_LoadUnsigned(rdb);
+
+  if (unlikely(numFields_u64 > SPEC_MAX_FIELDS)) {
+    RedisModule_LogIOError(
+        rdb, "warning", "RDB Load: Schema is limited to %d fields",
+        SPEC_MAX_FIELDS);
+    StrongRef_Release(spec_ref);
+    return NULL;
+  }
+
+  sp->numFields = (uint16_t)numFields_u64;
   sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));
   int maxSortIdx = -1;
   for (int i = 0; i < sp->numFields; i++) {
@@ -3609,16 +3647,27 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
 
   IndexStats_RdbLoad(rdb, &sp->stats, encver);
 
-  DocTable_LegacyRdbLoad(&sp->docs, rdb, encver);
+  if (DocTable_LegacyRdbLoad(&sp->docs, rdb, encver) != REDISMODULE_OK) {
+    StrongRef_Release(spec_ref);
+    return NULL;
+  }
   /* For version 3 or up - load the generic trie */
   if (encver >= 3) {
     sp->terms = TrieType_GenericLoad(rdb, false, false);
+    if (sp->terms == NULL) {
+      StrongRef_Release(spec_ref);
+      return NULL;
+    }
   } else {
     sp->terms = NewTrie(NULL, Trie_Sort_Lex);
   }
 
   if (sp->flags & Index_HasCustomStopwords) {
     sp->stopwords = StopWordList_RdbLoad(rdb, encver);
+    if (sp->stopwords == NULL) {
+      StrongRef_Release(spec_ref);
+      return NULL;
+    }
   } else {
     sp->stopwords = DefaultStopWordList();
   }
@@ -3626,6 +3675,10 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   sp->smap = NULL;
   if (sp->flags & Index_HasSmap) {
     sp->smap = SynonymMap_RdbLoad(rdb, encver);
+    if (sp->smap == NULL) {
+      StrongRef_Release(spec_ref);
+      return NULL;
+    }
   }
   if (encver < INDEX_MIN_EXPIRE_VERSION) {
     sp->timeout = -1;
@@ -3693,6 +3746,14 @@ int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when) {
   }
 
   nIndexes = LoadUnsigned_IOError(rdb, goto cleanup);
+
+  if (unlikely(nIndexes > maxIndexes_g)) {
+    RedisModule_LogIOError(
+        rdb, "warning",
+        "RDB Load: Number of indexes (%zu) exceeds maximum allowed (%u)",
+        nIndexes, maxIndexes_g);
+    return REDISMODULE_ERR;
+  }
   if (!SearchDisk_CheckLimitNumberOfIndexes(nIndexes)) {
     RedisModule_LogIOError(rdb, "warning", "Too many indexes for flex. Having %zu indexes, but flex only supports %d.", nIndexes, FLEX_MAX_INDEX_COUNT);
     return REDISMODULE_ERR;

--- a/src/spec.h
+++ b/src/spec.h
@@ -117,6 +117,9 @@ struct IndexesScanner;
 
 #define SPEC_MAX_FIELDS 1024
 #define SPEC_MAX_FIELD_ID (sizeof(t_fieldMask) * 8)
+#define MAX_SCHEMA_PREFIXES 1000000
+#define MAX_SYNONYM_TERMS 1000000     // reasonable limit for synonym map terms
+#define MAX_SYNONYM_GROUP_IDS 4096    // reasonable limit for group IDs per term
 
 // The threshold after which we move to a special encoding for wide fields
 #define SPEC_WIDEFIELD_THRESHOLD 32
@@ -303,8 +306,8 @@ typedef struct IndexSpec {
   char *obfuscatedName;           // Index hashed name
   uint64_t specId;                // Unique monotonically increasing ID for this spec incarnation
   FieldSpec *fields;              // Fields in the index schema
-  int16_t numFields;              // Number of fields
-  int16_t numSortableFields;      // Number of sortable fields
+  uint16_t numFields;             // Number of fields
+  uint16_t numSortableFields;     // Number of sortable fields
 
   IndexFlags flags;               // Flags
   IndexStats stats;               // Statistics of memory used and quantities

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -59,6 +59,7 @@ void RS_SuggestionsAdd(RS_Suggestions *s, char *term, size_t len, double score, 
 
   if (!incr) {
     if (!isExists) {
+      // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur.
       Trie_InsertStringBuffer(s->suggestionsTrie, term, len, score, incr, NULL, 0);
     }
     return;
@@ -72,6 +73,7 @@ void RS_SuggestionsAdd(RS_Suggestions *s, char *term, size_t len, double score, 
     incr = 0;
   }
 
+  // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur.
   Trie_InsertStringBuffer(s->suggestionsTrie, term, len, score, incr, NULL, 0);
 }
 

--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -11,11 +11,10 @@
 #include "triemap.h"
 #include "rmalloc.h"
 #include "util/strconv.h"
+#include "util/likely.h"
 #include "rmutil/rm_assert.h"
 #include <ctype.h>
 #include "rdb.h"
-
-#define MAX_STOPWORDLIST_SIZE 1024
 
 typedef struct StopWordList {
   TrieMap *m;
@@ -174,6 +173,15 @@ void StopWordList_FreeGlobals(void) {
 StopWordList *StopWordList_RdbLoad(RedisModuleIO *rdb, int encver) {
   StopWordList *sl = NULL;
   uint64_t elements = LoadUnsigned_IOError(rdb, goto cleanup);
+
+  if (unlikely(elements > MAX_STOPWORDLIST_SIZE)) {
+    RedisModule_LogIOError(
+        rdb, "warning",
+        "RDB Load: Stopword list size (%llu) exceeds maximum allowed (%d)",
+        (unsigned long long)elements, MAX_STOPWORDLIST_SIZE);
+    goto cleanup;
+  }
+
   sl = rm_malloc(sizeof(*sl));
   sl->m = NewTrieMap();
   sl->refcount = 1;

--- a/src/stopwords.h
+++ b/src/stopwords.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#define MAX_STOPWORDLIST_SIZE 1024
+
 static const char *DEFAULT_STOPWORDS[] = {
     "a",    "is",    "the",   "an",   "and",  "are", "as",  "at",   "be",   "but",  "by",   "for",
     "if",   "in",    "into",  "it",   "no",   "not", "of",  "on",   "or",   "such", "that", "their",

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -59,7 +59,18 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   if (!data) {
     suffixData newdata = createSuffixNode(copyStr, 1);
     RSPayload payload = { .data = (char*)&newdata, .len = sizeof(newdata) };
-    Trie_InsertRuneNoSize(trie, runes, rlen, 1, ADD_REPLACE, &payload, 0);
+    int rc = Trie_InsertRuneNoSize(trie, runes, rlen, 1, ADD_REPLACE, &payload, 0);
+    RS_LOG_ASSERT(rc != TRIE_ERR_PAYLOAD_OVERFLOW,
+                  "Trie_InsertRuneNoSize failed due to payload overflow");
+    if (rc == TRIE_ERR_PAYLOAD_OVERFLOW) {
+      RedisModule_Log(
+          RSDummyContext, "warning",
+          "Suffix trie: Trie_InsertRuneNoSize() failed due to payload overflow, suffix trie entry was not added");
+      array_free(newdata.array);
+      rm_free(copyStr);
+      runeBufFree(&buf);
+      return;
+    }
   } else {
     RS_LOG_ASSERT(!data->term, "can't reach here");
     data->term = copyStr;
@@ -75,7 +86,18 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
     if (!trienode || !trienode->payload) {
       suffixData newdata = createSuffixNode(copyStr, 0);
       RSPayload payload = { .data = (char*)&newdata, .len = sizeof(newdata) };
-      Trie_InsertRune(trie, runes + j, rlen - j, 1, ADD_REPLACE, &payload, 0);
+      int rc = Trie_InsertRune(trie, runes + j, rlen - j, 1, ADD_REPLACE, &payload, 0);
+      RS_LOG_ASSERT(rc != TRIE_ERR_PAYLOAD_OVERFLOW,
+                  "TrieNode_Add failed due to payload overflow");
+      if (rc == TRIE_ERR_PAYLOAD_OVERFLOW) {
+        RedisModule_Log(
+            RSDummyContext, "warning",
+            "Suffix trie: Trie_InsertRune() failed due to payload overflow, suffix trie entry was not added");
+        array_free(newdata.array);
+        runeBufFree(&buf);
+        return;
+      }
+
     } else {
       data->array = array_ensure_append_1(data->array, copyStr);
     }

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -48,6 +48,10 @@ typedef struct suffixData {
 } suffixData;
 
 
+/* Add string to suffix trie. If string already exists, do nothing.
+ * In case of allocation overflow in TrieNode_Add, log error and return without
+ * adding the string.
+ */
 void addSuffixTrie(Trie *trie, const char *str, uint32_t len);
 void deleteSuffixTrie(Trie *trie, const char *str, uint32_t len);
 

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -12,6 +12,7 @@
 #include "rmutil/args.h"
 #include "trie/trie_type.h"
 #include "query_error.h"
+#include "util/likely.h"
 
 extern bool isCrdt;
 
@@ -75,6 +76,7 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   RedisModuleString *val = NULL;
   double score = 0.0;
   Trie *tree = NULL;
+  int rc = 0;
 
   RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ | REDISMODULE_WRITE);
   int type = RedisModule_KeyType(key);
@@ -98,7 +100,11 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   /* Insert the new element. */
-  Trie_Insert(tree, val, score, incr, &payload, 0);
+  rc = Trie_Insert(tree, val, score, incr, &payload, 0);
+  if (unlikely(rc == TRIE_ERR_PAYLOAD_OVERFLOW)) {
+    RedisModule_ReplyWithError(ctx, "Payload too large");
+    goto end;
+  }
 
   RedisModule_ReplyWithLongLong(ctx, Trie_Size(tree));
   RedisModule_ReplicateVerbatim(ctx);

--- a/src/synonym_map.c
+++ b/src/synonym_map.c
@@ -12,6 +12,7 @@
 #include "util/fnv.h"
 #include "rmutil/rm_assert.h"
 #include "rdb.h"
+#include "util/likely.h"
 
 #define INITIAL_CAPACITY 2
 #define SYNONYM_PREFIX "~%s"
@@ -41,18 +42,24 @@ static bool TermData_IdExists(TermData* t_data, const char* id) {
   return false;
 }
 
-static void TermData_AddId(TermData* t_data, const char* id) {
+static SynonymMapResult TermData_AddId(TermData* t_data, const char* id) {
   if (!TermData_IdExists(t_data, id)) {
+    if (unlikely(array_len(t_data->groupIds) >= MAX_SYNONYM_GROUP_IDS)) {
+      return SYNONYM_MAP_ERR_MAX_GROUP_IDS;
+    }
     char* newId;
     rm_asprintf(&newId, SYNONYM_PREFIX, id);
     array_append(t_data->groupIds, newId);
   }
+  return SYNONYM_MAP_OK;
 }
 
 static TermData* TermData_Copy(TermData* t_data) {
   TermData* copy = TermData_New(rm_strdup(t_data->term));
   for (int i = 0; i < array_len(t_data->groupIds); ++i) {
-    TermData_AddId(copy, t_data->groupIds[i] + 1 /*we do not need the ~*/);
+    SynonymMapResult ret = TermData_AddId(copy, t_data->groupIds[i] + 1 /*we do not need the ~*/);
+    // If source is valid, copy should never fail (same number of group IDs)
+    RS_LOG_ASSERT(ret == SYNONYM_MAP_OK, "TermData_Copy: unexpected failure in TermData_AddId");
   }
   return copy;
 }
@@ -68,7 +75,7 @@ static void TermData_RdbSave(RedisModuleIO* rdb, TermData* t_data) {
 }
 
 // todo: fix
-static TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver) {
+TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver) {
   TermData *t_data = NULL;
   char* term = NULL;
   uint64_t ids_len = 0;
@@ -77,6 +84,15 @@ static TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver) {
   t_data = TermData_New(rm_strdup(term));
   RedisModule_Free(term);
   ids_len = LoadUnsigned_IOError(rdb, goto cleanup);
+
+  if (unlikely(ids_len > MAX_SYNONYM_GROUP_IDS)) {
+    RedisModule_LogIOError(
+        rdb, "warning",
+        "RDB Load: Synonym group IDs (%llu) exceeds maximum allowed (%d)",
+        ids_len, MAX_SYNONYM_GROUP_IDS);
+    goto cleanup;
+  }
+
   for (int i = 0; i < ids_len; ++i) {
     char* groupId = NULL;
     if (encver <= INDEX_MIN_WITH_SYNONYMS_INT_GROUP_ID) {
@@ -85,7 +101,9 @@ static TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver) {
     } else {
       groupId = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
     }
-    TermData_AddId(t_data, groupId);
+    SynonymMapResult ret = TermData_AddId(t_data, groupId);
+    // Should not fail since we already checked ids_len <= MAX_SYNONYM_GROUP_IDS
+    RS_LOG_ASSERT(ret == SYNONYM_MAP_OK, "TermData_RdbLoad: unexpected failure in TermData_AddId");
     rm_free(groupId);
   }
   return t_data;
@@ -135,21 +153,29 @@ static const char** SynonymMap_RedisStringArrToArr(RedisModuleString** synonyms,
   return arr;
 }
 
-void SynonymMap_UpdateRedisStr(SynonymMap* smap, RedisModuleString** synonyms, size_t size,
+SynonymMapResult SynonymMap_UpdateRedisStr(SynonymMap* smap, RedisModuleString** synonyms, size_t size,
                                const char* groupId) {
   const char** arr = SynonymMap_RedisStringArrToArr(synonyms, size);
-  SynonymMap_Update(smap, arr, size, groupId);
+  SynonymMapResult ret = SynonymMap_Update(smap, arr, size, groupId);
   rm_free(arr);
+  return ret;
 }
 
-void SynonymMap_Add(SynonymMap* smap, const char* groupId, const char** synonyms, size_t size) {
-  SynonymMap_Update(smap, synonyms, size, groupId);
+SynonymMapResult SynonymMap_Add(SynonymMap* smap, const char* groupId, const char** synonyms, size_t size) {
+  return SynonymMap_Update(smap, synonyms, size, groupId);
 }
 
-void SynonymMap_Update(SynonymMap* smap, const char** synonyms, size_t size, const char* groupId) {
+SynonymMapResult SynonymMap_Update(SynonymMap* smap, const char** synonyms, size_t size, const char* groupId) {
   RS_LOG_ASSERT(!smap->is_read_only, "SynonymMap should not be read only");
-  int ret;
+
+  SynonymMapResult ret = SYNONYM_MAP_OK;
   for (size_t i = 0; i < size; i++) {
+    // Check if we've reached the maximum number of terms
+    if (unlikely(dictSize(smap->h_table) >= MAX_SYNONYM_TERMS)) {
+      ret = SYNONYM_MAP_ERR_MAX_TERMS;
+      break;
+    }
+
     char *lowerSynonym = rm_strdup(synonyms[i]);
     size_t len = strlen(lowerSynonym);
     char *dst = unicode_tolower(lowerSynonym, &len);
@@ -169,12 +195,16 @@ void SynonymMap_Update(SynonymMap* smap, const char** synonyms, size_t size, con
       termData = TermData_New(lowerSynonym); //strtolower
       dictAdd(smap->h_table, lowerSynonym, termData);
     }
-    TermData_AddId(termData, groupId);
+    ret = TermData_AddId(termData, groupId);
+    if (ret != SYNONYM_MAP_OK) {
+      break;
+    }
   }
   if (smap->read_only_copy) {
     SynonymMap_Free(smap->read_only_copy);
     smap->read_only_copy = NULL;
   }
+  return ret;
 }
 
 TermData* SynonymMap_GetIdsBySynonym(SynonymMap* smap, const char* synonym, size_t len) {
@@ -251,6 +281,15 @@ void* SynonymMap_RdbLoad(RedisModuleIO* rdb, int encver) {
     unused = LoadUnsigned_IOError(rdb, goto cleanup);
   }
   smap_kh_size = LoadUnsigned_IOError(rdb, goto cleanup);
+
+  if (unlikely(smap_kh_size > MAX_SYNONYM_TERMS)) {
+    RedisModule_LogIOError(
+        rdb, "warning",
+        "RDB Load: Synonym map size (%llu) exceeds maximum allowed (%d)",
+        (unsigned long long)smap_kh_size, MAX_SYNONYM_TERMS);
+    goto cleanup;
+  }
+
   for (int i = 0; i < smap_kh_size; ++i) {
     if (encver <= INDEX_MIN_WITH_SYNONYMS_INT_GROUP_ID) {
       uint64_t unudes = LoadUnsigned_IOError(rdb, goto cleanup);

--- a/src/synonym_map.h
+++ b/src/synonym_map.h
@@ -16,7 +16,17 @@
 #include "util/strconv.h"
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SYNONYM_PREFIX_CHAR '~'
+
+typedef enum {
+  SYNONYM_MAP_OK,
+  SYNONYM_MAP_ERR_MAX_TERMS,
+  SYNONYM_MAP_ERR_MAX_GROUP_IDS,
+} SynonymMapResult;
 
 /**
  * Holding a term data
@@ -56,16 +66,22 @@ void SynonymMap_Free(SynonymMap* smap);
  * synonyms - RedisModuleString array contains the terms to add to the synonym map
  * size - RedisModuleString array size
  * id - the synonym group id to update
+ * Returns SYNONYM_MAP_OK on success,
+ * SYNONYM_MAP_ERR_MAX_TERMS if the maximum number of terms is reached,
+ * SYNONYM_MAP_ERR_MAX_GROUP_IDS if the maximum number of group ids is reached
  */
-void SynonymMap_UpdateRedisStr(SynonymMap* smap, RedisModuleString** synonyms, size_t size, const char* groupId);
+SynonymMapResult SynonymMap_UpdateRedisStr(SynonymMap* smap, RedisModuleString** synonyms, size_t size, const char* groupId);
 
 /**
  * Add new synonym group
  * smap - the synonym map
  * synonyms - char* array contains the terms to add to the synonym map
  * size - char* array size
+ * Returns SYNONYM_MAP_OK on success,
+ * SYNONYM_MAP_ERR_MAX_TERMS if the maximum number of terms is reached,
+ * SYNONYM_MAP_ERR_MAX_GROUP_IDS if the maximum number of group ids is reached
  */
-void SynonymMap_Add(SynonymMap* smap, const char* groupId, const char** synonyms, size_t size);
+SynonymMapResult SynonymMap_Add(SynonymMap* smap, const char* groupId, const char** synonyms, size_t size);
 
 /**
  * Updating an already existing synonym group
@@ -73,8 +89,11 @@ void SynonymMap_Add(SynonymMap* smap, const char* groupId, const char** synonyms
  * synonyms - char* array contains the terms to add to the synonym map
  * size - char* array size
  * id - the synonym group id to update
+ * Returns SYNONYM_MAP_OK on success,
+ * SYNONYM_MAP_ERR_MAX_GROUP_IDS if the maximum number of group ids is reached
+ * SYNONYM_MAP_ERR_MAX_TERMS if the maximum number of terms is reached
  */
-void SynonymMap_Update(SynonymMap* smap, const char** synonyms, size_t size, const char* groupId);
+SynonymMapResult SynonymMap_Update(SynonymMap* smap, const char** synonyms, size_t size, const char* groupId);
 
 /**
  * Return all the ids of a given term
@@ -116,5 +135,15 @@ void SynonymMap_RdbSave(RedisModuleIO* rdb, void* value);
  * Loading smap from an rdb
  */
 void* SynonymMap_RdbLoad(RedisModuleIO* rdb, int encver);
+
+/**
+ * Loading a single term's data from an rdb.
+ * Returns NULL on error (including when group IDs exceed MAX_SYNONYM_GROUP_IDS).
+ */
+TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SRC_SYNONYM_MAP_H_ */

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -75,13 +75,33 @@ do {                                                      \
 
 /* The byte size of a node, based on its internal string length and number of
  * children */
-static size_t __trieNode_Sizeof(t_len numChildren, t_len slen) {
-  return sizeof(TrieNode) + numChildren * (sizeof(rune) + sizeof(TrieNode *)) + sizeof(rune) * (slen + 1);
+size_t __trieNode_Sizeof(t_len numChildren, t_len slen) {
+  // Calculate:
+  // sizeof(TrieNode) + numChildren * (sizeof(rune) + sizeof(TrieNode *))
+  // + sizeof(rune) * (slen + 1)
+  //
+  // Overflow analysis:
+  // t_len is uint16_t (max 65535), and rune is uint16_t (2 bytes) by default.
+  // Maximum possible size on 64-bit: ~21 + 65535 * (2 + 8) + 65536 * 2 ≈ 786 KB
+  // Maximum possible size on 32-bit: ~17 + 65535 * (2 + 4) + 65536 * 2 ≈ 524 KB
+  // Both are far below SIZE_MAX, so overflow is not possible with current type
+  // constraints.
+  return sizeof(TrieNode) + numChildren * (sizeof(rune) + sizeof(TrieNode *)) +
+         sizeof(rune) * (slen + 1);
+}
+
+// Check if payload length + 1 (for null terminator) overflows uint32_t
+// Returns true if overflow would occur, false otherwise
+static bool __payloadOverflow(size_t plen) {
+  uint32_t alloc_size;
+  if (__builtin_add_overflow(sizeof(TriePayload) + 1, plen, &alloc_size)) {
+    return true;  // Overflow in total allocation size
+  }
+  return false;
 }
 
 // Allocate a new trie payload struct
 static inline TriePayload *triePayload_New(const char *payload, uint32_t plen) {
-
   TriePayload *p = rm_malloc(sizeof(TriePayload) + sizeof(char) * (plen + 1));
   p->len = plen;
   memcpy(p->data, payload, sizeof(char) * plen);
@@ -108,7 +128,7 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
   n->numDocs = numDocs;
   memcpy(n->str, str + offset, sizeof(rune) * (len - offset));
   if (payload != NULL && plen > 0) {
-    n->payload = triePayload_New(payload, plen);
+    n->payload = triePayload_New(payload, (uint32_t)plen);
   }
   return n;
 }
@@ -208,12 +228,11 @@ static TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback f
   return merged;
 }
 
-int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, float score,
-                 TrieAddOp op, TrieFreeCallback freecb, size_t numDocs) {
+static int __trieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, float score,
+                   TrieAddOp op, TrieFreeCallback freecb, size_t numDocs) {
   if (score == 0 || len == 0) {
-    return 0;
+    return TRIE_OK_UPDATED;
   }
-
   TrieNode *n = *np;
 
   int offset = 0;
@@ -243,7 +262,7 @@ int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, 
         n->payload = NULL;
       }
       if (payload != NULL && payload->data != NULL && payload->len > 0) {
-        n->payload = triePayload_New(payload->data, payload->len);
+        n->payload = triePayload_New(payload->data, (uint32_t)payload->len);
       }
 
       __trieNode_children(n)[0] = newChild;
@@ -254,7 +273,7 @@ int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, 
       updateScore(n, score);
     }
     *np = n;
-    return 1;
+    return TRIE_OK_NEW;
   }
 
   updateScore(n, score);
@@ -280,14 +299,14 @@ int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, 
         triePayload_Free(n->payload, freecb);
         n->payload = NULL;
       }
-      n->payload = triePayload_New(payload->data, payload->len);
+      n->payload = triePayload_New(payload->data, (uint32_t)payload->len);
     }
     // set the node as terminal
     n->flags |= TRIENODE_TERMINAL;
     // if it was deleted, make sure it's not now
     n->flags &= ~TRIENODE_DELETED;
     *np = n;
-    return (term && !deleted) ? 0 : 1;
+    return (term && !deleted) ? TRIE_OK_UPDATED : TRIE_OK_NEW;
   }
 
   // proceed to the next child or add a new child for the current rune
@@ -297,7 +316,9 @@ int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, 
     const rune *childKey = __trieNode_childKey(n, idx);
     TrieNode *child = __trieNode_children(n)[idx];
     if (str[offset] == *childKey) {
-      int rc = TrieNode_Add(&child, str + offset, len - offset, payload, score, op, freecb,
+      // Payload is validated at the entry point (TrieNode_Add), so
+      // TRIE_ERR_PAYLOAD_OVERFLOW cannot occur here.
+      int rc = __trieNode_Add(&child, str + offset, len - offset, payload, score, op, freecb,
                             numDocs);
       *__trieNode_childKey(n, idx) = str[offset];
       __trieNode_children(n)[idx] = child;
@@ -325,7 +346,22 @@ int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, 
     idx = scoreIdx;
   }
   *np = __trie_AddChildIdx(n, str, offset, len, payload, score, idx, numDocs);
-  return 1;
+  return TRIE_OK_NEW;
+}
+
+int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, float score,
+                 TrieAddOp op, TrieFreeCallback freecb, size_t numDocs) {
+  if (score == 0 || len == 0) {
+    return TRIE_OK_UPDATED;
+  }
+
+  if (payload != NULL && payload->data != NULL) {
+    if (__payloadOverflow(payload->len)) {
+      return TRIE_ERR_PAYLOAD_OVERFLOW;
+    }
+  }
+
+  return __trieNode_Add(np, str, len, payload, score, op, freecb, numDocs);
 }
 
 TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int *offsetOut) {

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -26,6 +26,11 @@ typedef uint16_t t_len;
 #define TRIENODE_TERMINAL 0x1
 #define TRIENODE_DELETED 0x2
 
+/* TrieNode_Add return codes */
+#define TRIE_OK_NEW                1   /* Successfully added a new entry */
+#define TRIE_OK_UPDATED            0   /* Entry already existed, score/payload updated */
+#define TRIE_ERR_PAYLOAD_OVERFLOW -1   /* Payload too large or allocation overflow */
+
 typedef enum {
   Trie_Sort_Lex = 0,
   Trie_Sort_Score = 1,
@@ -96,11 +101,18 @@ typedef enum {
   ADD_REPLACE,
   ADD_INCR,
 } TrieAddOp;
-/* Add a new string to a trie. Returns 1 if the string did not exist there, or 0
- * if we just replaced
- * the score. We pass a pointer to the node because it may actually change when
- * splitting.
- * numDocs: the value to add to the existing numDocs */
+/* Add a new string to a trie. We pass a pointer to the node because it may
+ * actually change when splitting.
+ * numDocs: the value to add to the existing numDocs
+ *
+ * Returns:
+ *   TRIE_OK_NEW (1)                - String was added (new entry)
+ *   TRIE_OK_UPDATED (0)            - String already existed, score/payload updated
+ *   TRIE_ERR_PAYLOAD_OVERFLOW (-1) - Payload too large or allocation overflow
+ *
+ * Note: The return value is used by Trie_InsertRune to update the Trie size
+ * member (incremented only when TRIE_OK_NEW is returned).
+ */
 int TrieNode_Add(TrieNode **n, const rune *str, t_len len, RSPayload *payload,
                  float score, TrieAddOp op, TrieFreeCallback freecb,
                  size_t numDocs);

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -60,7 +60,9 @@ int Trie_InsertRune(Trie *t, const rune *runes, size_t len, double score, int in
   if (runes && len && len < TRIE_INITIAL_STRING_LEN) {
     rc = TrieNode_Add(&t->root, runes, len, payload, (float)score, incr ? ADD_INCR : ADD_REPLACE,
                       t->freecb, numDocs);
-    t->size += rc;
+    if (rc == TRIE_OK_NEW) {
+      t->size += rc;
+    }
   }
   return rc;
 }
@@ -381,6 +383,7 @@ void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDo
   Trie *tree = NULL;
   char *str = NULL;
   uint64_t elements = LoadUnsigned_IOError(rdb, goto cleanup);
+
   tree = NewTrie(NULL, Trie_Sort_Score);
 
   while (elements--) {
@@ -397,9 +400,19 @@ void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDo
     if (loadNumDocs) {
       numDocs = LoadUnsigned_IOError(rdb, goto cleanup);
     }
-    Trie_InsertStringBuffer(tree, str, len - 1, score, 0, payload.len ? &payload : NULL, numDocs);
+    int rc = Trie_InsertStringBuffer(tree, str, len - 1, score, 0, payload.len ? &payload : NULL, numDocs);
     RedisModule_Free(str);
-    if (payload.data != NULL) RedisModule_Free(payload.data);
+    str = NULL;
+    if (payload.data != NULL) {
+      RedisModule_Free(payload.data);
+      payload.data = NULL;
+    }
+    if (rc == TRIE_ERR_PAYLOAD_OVERFLOW) {
+      RedisModule_LogIOError(
+          rdb, "warning",
+          "RDB Load: Failed to insert trie entry (payload overflow)");
+      goto cleanup;
+    }
   }
   return tree;
 

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -755,6 +755,20 @@ int RMCK_IsIOError(RedisModuleIO *io) {
   return result;
 }
 
+void RMCK_LogIOError(RedisModuleIO *io, const char *levelstr, const char *fmt, ...) {
+  (void)io;
+  int ilevel = loglevelFromString(levelstr);
+  if (ilevel < RMCK_LogLevel) {
+    return;
+  }
+  va_list ap;
+  va_start(ap, fmt);
+  fprintf(stderr, "[%s] ", levelstr);
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
+  va_end(ap);
+}
+
 void *RMCK_LoadDataTypeFromStringEncver(const RedisModuleString *str,
                                         const RedisModuleType *mt,
                                         int encver) {
@@ -1658,6 +1672,7 @@ static void registerApis() {
   REGISTER_API(LoadString);
   REGISTER_API(LoadStringBuffer);
   REGISTER_API(IsIOError);
+  REGISTER_API(LogIOError);
   REGISTER_API(GetContextFromIO);
   // Serialization
   REGISTER_API(LoadDataTypeFromStringEncver);

--- a/tests/cpptests/redismock/redismock.h
+++ b/tests/cpptests/redismock/redismock.h
@@ -70,6 +70,7 @@ void RMCK_SaveStringBuffer(RedisModuleIO *io, const char *str, size_t len);
 RedisModuleString *RMCK_LoadString(RedisModuleIO *io);
 char *RMCK_LoadStringBuffer(RedisModuleIO *io, size_t *lenptr);
 int RMCK_IsIOError(RedisModuleIO *io);
+void RMCK_LogIOError(RedisModuleIO *io, const char *levelstr, const char *fmt, ...);
 RedisModuleCtx *RMCK_GetContextFromIO(RedisModuleIO *io);
 int RMCK_StringToULongLong(const RedisModuleString *str, unsigned long long *ull);
 

--- a/tests/cpptests/test_cpp_iterator_optimizer.cpp
+++ b/tests/cpptests/test_cpp_iterator_optimizer.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "rmutil/alloc.h"
+#include "gtest/gtest.h"
+#include "src/iterators/optimizer_reader.h"
+#include "src/query_optimizer.h"
+#include "iterators_rs.h"
+
+class OptimizerIteratorTest : public ::testing::Test {
+protected:
+  IteratorsConfig config;
+
+  void SetUp() override {
+    // Initialize with default config
+    memset(&config, 0, sizeof(config));
+  }
+};
+
+// Test 1: Addition overflow (limit + 1 overflows)
+TEST_F(OptimizerIteratorTest, AdditionOverflowReturnsNull) {
+  // When limit = SIZE_MAX, then limit + 1 overflows
+  QOptimizer *opt = QOptimizer_New();
+  ASSERT_NE(opt, nullptr);
+
+  opt->limit = SIZE_MAX;  // limit + 1 will overflow
+  opt->asc = true;
+
+  QueryIterator *child = NewWildcardIterator_NonOptimized(10, 1.0);
+  ASSERT_NE(child, nullptr);
+
+  QueryIterator *optIter = NewOptimizerIterator(opt, child, &config);
+
+  // Should return NULL due to addition overflow check
+  EXPECT_EQ(optIter, nullptr);
+
+  child->Free(child);
+  QOptimizer_Free(opt);
+}
+
+// Test 2: Multiplication overflow ((limit + 1) * sizeof(RSIndexResult) overflows)
+TEST_F(OptimizerIteratorTest, MultiplicationOverflowReturnsNull) {
+  // Use a limit where limit + 1 is valid, but multiplication overflows
+  // SIZE_MAX / sizeof(RSIndexResult) is the boundary
+  QOptimizer *opt = QOptimizer_New();
+  ASSERT_NE(opt, nullptr);
+
+  // This limit won't overflow on +1, but will overflow on multiplication
+  opt->limit = SIZE_MAX / sizeof(RSIndexResult);
+  opt->asc = true;
+
+  QueryIterator *child = NewWildcardIterator_NonOptimized(10, 1.0);
+  ASSERT_NE(child, nullptr);
+
+  QueryIterator *optIter = NewOptimizerIterator(opt, child, &config);
+
+  // Should return NULL due to multiplication overflow check
+  EXPECT_EQ(optIter, nullptr);
+
+  child->Free(child);
+  QOptimizer_Free(opt);
+}

--- a/tests/cpptests/test_cpp_json.cpp
+++ b/tests/cpptests/test_cpp_json.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "gtest/gtest.h"
+#include "json.h"
+#include "document.h"
+#include "field_spec.h"
+#include "VecSim/vec_sim.h"
+#include <climits>
+#include <cstring>
+
+class JSONTest : public ::testing::Test {};
+
+TEST_F(JSONTest, testStoreTextOverflow) {
+  // Test that JSON_StoreTextInDocField returns an error when `len` would cause
+  // an overflow in the allocation size calculation (len * sizeof(char*)).
+  DocumentField df = {0};
+  QueryError status = QueryError_Default();
+
+  // Use a length that would cause overflow when multiplied by sizeof(char*)
+  // SIZE_MAX / sizeof(char*) + 1 will overflow when multiplied by sizeof(char*)
+  size_t overflow_len = (SIZE_MAX / sizeof(char*)) + 1;
+
+  int rv = JSON_StoreTextInDocField(overflow_len, nullptr, &df, &status);
+  ASSERT_EQ(REDISMODULE_ERR, rv);
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_GENERIC);
+  const char *err_msg = QueryError_GetUserError(&status);
+  ASSERT_STREQ(err_msg, "SEARCH_GENERIC Failed to allocate memory for text field");
+
+  QueryError_ClearError(&status);
+}
+
+TEST_F(JSONTest, testStoreMultiVectorOverflow) {
+  // Test that JSON_StoreMultiVectorInDocField returns an error when len would
+  // cause an overflow in the allocation size calculation (expBlobSize * len).
+  DocumentField df = {0};
+  QueryError status = QueryError_Default();
+
+  // Set up a minimal FieldSpec with vector options for BF algorithm with
+  // multi=true
+  FieldSpec fs;
+  memset(&fs, 0, sizeof(fs));
+  fs.types = INDEXFLD_T_VECTOR;
+
+  // Configure BF params with multi=true
+  fs.vectorOpts.vecSimParams.algo = VecSimAlgo_BF;
+  fs.vectorOpts.vecSimParams.algoParams.bfParams.type = VecSimType_FLOAT32;
+  fs.vectorOpts.vecSimParams.algoParams.bfParams.dim = 4;
+  fs.vectorOpts.vecSimParams.algoParams.bfParams.multi = true;
+
+  // Set expBlobSize to a value that will overflow when multiplied by a large len
+  // expBlobSize = dim * sizeof(float) = 4 * 4 = 16 bytes
+  fs.vectorOpts.expBlobSize = 16;
+
+  // Use a length that would cause overflow when multiplied by expBlobSize (16)
+  // SIZE_MAX / 16 + 1 will overflow when multiplied by 16
+  size_t overflow_len = (SIZE_MAX / fs.vectorOpts.expBlobSize) + 1;
+
+  int rv = JSON_StoreMultiVectorInDocField(&fs, nullptr, overflow_len, &df, &status);
+  ASSERT_EQ(REDISMODULE_ERR, rv);
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_GENERIC);
+  const char *err_msg = QueryError_GetUserError(&status);
+  ASSERT_STREQ(err_msg, "SEARCH_GENERIC Failed to allocate memory for multi-vector field");
+
+  QueryError_ClearError(&status);
+}
+

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -8,18 +8,26 @@
  */
 
 #include "gtest/gtest.h"
+#include "gtest/internal/gtest-port.h"  // For CaptureStderr/GetCapturedStderr
 #include "common.h"
 #include "redismock/redismock.h"
+#include "synonym_map.h"
+#include "trie/trie_type.h"
+#include <cstdint>  // For SIZE_MAX, UINT32_MAX
 
 extern "C" {
 #include "spec.h"
 #include "query_error.h"
+#include "rules.h"
+#include "stopwords.h"
+#include "doc_table.h"
 
 // Forward declarations for RDB functions
 extern void Indexes_RdbSave(RedisModuleIO *rdb, int when);
 extern int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when);
 extern void Spec_AddToDict(RefManager *rm);  // Helper to add spec to global dict
 }
+
 
 class RdbMockTest : public ::testing::Test {
 protected:
@@ -352,4 +360,561 @@ TEST_F(RdbMockTest, testDuplicateIndexRdbLoad) {
 
     // Clean up
     IndexSpec_RemoveFromGlobals(loaded_spec_ref, false);
+}
+
+TEST_F(RdbMockTest, testSynonymMapRdbSerialization) {
+    // Create a SynonymMap and add some terms
+    SynonymMap *smap = SynonymMap_New(false);
+    ASSERT_TRUE(smap != nullptr);
+    std::unique_ptr<SynonymMap, std::function<void(SynonymMap *)>> smapPtr(smap, [](SynonymMap *s) {
+        SynonymMap_Free(s);
+    });
+
+    // Add terms to synonym groups
+    const char *group1_terms[] = {"hello", "hi", "greetings"};
+    const char *group2_terms[] = {"bye", "goodbye", "farewell"};
+    // hello and bye belong to multiple groups
+    const char *group3_terms[] = {"hello", "bye"};
+
+    ASSERT_EQ(SYNONYM_MAP_OK, SynonymMap_Add(smap, "greet", group1_terms, 3));
+    ASSERT_EQ(SYNONYM_MAP_OK, SynonymMap_Add(smap, "part", group2_terms, 3));
+    ASSERT_EQ(SYNONYM_MAP_OK, SynonymMap_Add(smap, "common", group3_terms, 2));
+
+    // Verify the synonym map has the expected terms
+    TermData *td = SynonymMap_GetIdsBySynonym_cstr(smap, "hello");
+    ASSERT_TRUE(td != nullptr);
+    // hello belongs to "greet" and "common"
+    EXPECT_EQ(2, array_len(td->groupIds));
+
+    // Create RDB IO context
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Save synonym map to RDB
+    SynonymMap_RdbSave(io, smap);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Reset read position to load it back
+    io->read_pos = 0;
+
+    // Load synonym map from RDB
+    SynonymMap *loadedSmap = (SynonymMap *)SynonymMap_RdbLoad(io, INDEX_CURRENT_VERSION);
+    ASSERT_TRUE(loadedSmap != nullptr);
+    std::unique_ptr<SynonymMap, std::function<void(SynonymMap *)>> loadedSmapPtr(loadedSmap, [](SynonymMap *s) {
+        SynonymMap_Free(s);
+    });
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Verify loaded synonym map has the same terms
+    td = SynonymMap_GetIdsBySynonym_cstr(loadedSmap, "hello");
+    ASSERT_TRUE(td != nullptr);
+    EXPECT_EQ(2, array_len(td->groupIds));
+
+    td = SynonymMap_GetIdsBySynonym_cstr(loadedSmap, "hi");
+    ASSERT_TRUE(td != nullptr);
+    EXPECT_EQ(1, array_len(td->groupIds));
+
+    td = SynonymMap_GetIdsBySynonym_cstr(loadedSmap, "bye");
+    ASSERT_TRUE(td != nullptr);
+    EXPECT_EQ(2, array_len(td->groupIds));
+
+    td = SynonymMap_GetIdsBySynonym_cstr(loadedSmap, "farewell");
+    ASSERT_TRUE(td != nullptr);
+    EXPECT_EQ(1, array_len(td->groupIds));
+}
+
+TEST_F(RdbMockTest, testSynonymMapRdbLoadExceedsTermsLimit) {
+    // Test that loading a synonym map with more terms than MAX_SYNONYM_TERMS fails
+    // The check is in SynonymMap_RdbLoad at the dict_size level
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Write dict_size that exceeds MAX_SYNONYM_TERMS
+    uint64_t dict_size = MAX_SYNONYM_TERMS + 1;
+    RMCK_SaveUnsigned(io, dict_size);
+
+    // Write some dummy data to prove failure is from limit check, not EOF
+    const char *term = "test_term";
+    RMCK_SaveStringBuffer(io, term, strlen(term) + 1);
+
+    // Reset read position
+    io->read_pos = 0;
+
+    // Capture stderr to verify the error message
+    testing::internal::CaptureStderr();
+
+    // Try to load - should fail due to exceeding MAX_SYNONYM_TERMS
+    SynonymMap *loadedSmap = (SynonymMap *)SynonymMap_RdbLoad(io, INDEX_CURRENT_VERSION);
+    EXPECT_TRUE(loadedSmap == nullptr) << "Expected RDB load to fail when terms exceed limit";
+
+    // Verify the error message was logged to stderr
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    std::string expected = "RDB Load: Synonym map size (" +
+        std::to_string(dict_size) +
+        ") exceeds maximum allowed (" +
+        std::to_string(MAX_SYNONYM_TERMS) + ")";
+    EXPECT_TRUE(stderr_output.find(expected) != std::string::npos)
+        << "Expected: " << expected << ", got: " << stderr_output;
+}
+
+TEST_F(RdbMockTest, testTermDataRdbLoadExceedsGroupIdsLimit) {
+    // Test that loading term data with more group IDs than MAX_SYNONYM_GROUP_IDS fails
+    // The check is in TermData_RdbLoad at the group IDs level
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Write term string
+    const char *term = "test_term";
+    RMCK_SaveStringBuffer(io, term, strlen(term) + 1);
+
+    // Write number of group IDs - exceeds the limit
+    uint64_t num_group_ids = MAX_SYNONYM_GROUP_IDS + 1;
+    RMCK_SaveUnsigned(io, num_group_ids);
+
+    // Write some dummy data to prove failure is from limit check, not EOF
+    const char *dummy = "dummy_group";
+    RMCK_SaveStringBuffer(io, dummy, strlen(dummy) + 1);
+
+    // Reset read position
+    io->read_pos = 0;
+
+    // Capture stderr to verify the error message
+    testing::internal::CaptureStderr();
+
+    // Try to load - should fail due to exceeding MAX_SYNONYM_GROUP_IDS
+    TermData *td = TermData_RdbLoad(io, INDEX_CURRENT_VERSION);
+    EXPECT_TRUE(td == nullptr) << "Expected RDB load to fail when synonym groups exceed limit";
+
+    // Verify the error message was logged to stderr
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    std::string expected = "RDB Load: Synonym group IDs (" +
+        std::to_string(num_group_ids) +
+        ") exceeds maximum allowed (" +
+        std::to_string(MAX_SYNONYM_GROUP_IDS) + ")";
+    EXPECT_TRUE(stderr_output.find(expected) != std::string::npos)
+        << "Expected: " << expected << ", got: " << stderr_output;
+}
+
+TEST_F(RdbMockTest, testSynonymMapRdbLoadValidGroupIds) {
+    // Test that loading a synonym map with valid group IDs succeeds
+    // We manually craft an RDB payload with a valid number of group IDs
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Write RDB data: dict_size, then for each term: term_string, num_group_ids, group_id_strings...
+    uint64_t dict_size = 1;  // One term
+    RMCK_SaveUnsigned(io, dict_size);
+
+    // Write term data
+    const char *term = "test_term";
+    RMCK_SaveStringBuffer(io, term, strlen(term) + 1);  // +1 for null terminator
+
+    // Write number of group IDs
+    uint64_t num_group_ids = 2;
+    RMCK_SaveUnsigned(io, num_group_ids);
+
+    // Write the actual group ID strings (without the ~ prefix, as that's added during load)
+    const char *group1 = "group1";
+    const char *group2 = "group2";
+    RMCK_SaveStringBuffer(io, group1, strlen(group1) + 1);
+    RMCK_SaveStringBuffer(io, group2, strlen(group2) + 1);
+
+    // Reset read position
+    io->read_pos = 0;
+
+    // Load should succeed
+    SynonymMap *loadedSmap = (SynonymMap *)SynonymMap_RdbLoad(io, INDEX_CURRENT_VERSION);
+    ASSERT_TRUE(loadedSmap != nullptr) << "Expected RDB load to succeed with valid group IDs";
+    std::unique_ptr<SynonymMap, std::function<void(SynonymMap *)>> loadedSmapPtr(loadedSmap, [](SynonymMap *s) {
+        SynonymMap_Free(s);
+    });
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Verify the loaded data
+    TermData *td = SynonymMap_GetIdsBySynonym_cstr(loadedSmap, "test_term");
+    ASSERT_TRUE(td != nullptr);
+    EXPECT_EQ(2, array_len(td->groupIds));
+}
+
+TEST_F(RdbMockTest, testTrieRdbLoadMoreThan65535Elements) {
+    // Test that a trie with more than 65535 (UINT16_MAX) elements can be
+    // saved and loaded correctly from RDB.
+
+    const size_t NUM_ELEMENTS = 65536 + 100;  // Just over UINT16_MAX
+    const char *MIDDLE = "_dictionary_entry_with_a_long_string_to_stress_test_the_trie_node_allocation_";
+
+    // Create a trie and populate it with many elements
+    Trie *originalTrie = NewTrie(NULL, Trie_Sort_Lex);
+    ASSERT_TRUE(originalTrie != nullptr);
+    std::unique_ptr<Trie, std::function<void(Trie *)>> originalTriePtr(originalTrie, [](Trie *t) {
+        TrieType_Free(t);
+    });
+
+    // Insert NUM_ELEMENTS entries using longer strings with number as prefix
+    // AND suffix. This creates more unique trie paths instead of one prefix
+    // node with many children
+    for (size_t i = 0; i < NUM_ELEMENTS; i++) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "%zu%s%zu", i, MIDDLE, i);
+        Trie_InsertStringBuffer(originalTrie, buf, strlen(buf), 1.0, 0, NULL, 0);
+    }
+
+    ASSERT_EQ(NUM_ELEMENTS, originalTrie->size);
+
+    // Create RDB IO context
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Save the trie to RDB (without payloads, like dictionary)
+    TrieType_GenericSave(io, originalTrie, 0, false);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Reset read position to load it back
+    io->read_pos = 0;
+
+    // Load the trie from RDB
+    Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, 0, false);
+    ASSERT_TRUE(loadedTrie != nullptr) << "Failed to load trie with more than 65535 elements";
+    std::unique_ptr<Trie, std::function<void(Trie *)>> loadedTriePtr(loadedTrie, [](Trie *t) {
+        TrieType_Free(t);
+    });
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Verify the loaded trie has the correct size
+    EXPECT_EQ(NUM_ELEMENTS, loadedTrie->size);
+}
+
+TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
+    // Test that triePayload_New correctly handles large payloads without
+    // overflow
+
+    // Create RDB IO context
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Test 1: Normal payload - should succeed
+    {
+        const char *normal_payload = "This is a normal payload";
+        size_t normal_len = strlen(normal_payload);
+
+        // Save a trie entry with normal payload
+        RMCK_SaveUnsigned(io, 1);  // 1 element
+        RMCK_SaveStringBuffer(io, "test", 5);  // key with null terminator
+        RMCK_SaveDouble(io, 1.0);  // score
+        RMCK_SaveStringBuffer(io, normal_payload, normal_len + 1);  // payload with null terminator
+
+        io->read_pos = 0;
+        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
+        ASSERT_TRUE(trie != nullptr) << "Failed to load trie with normal payload";
+        EXPECT_EQ(1, trie->size);
+        TrieType_Free(trie);
+    }
+
+    // Test 2: Large but valid payload (1MB) - should succeed
+    RMCK_ResetRdbIO(io);
+    {
+        const size_t large_size = 1024 * 1024;  // 1MB
+        std::vector<char> large_payload(large_size, 'A');
+        large_payload[large_size - 1] = '\0';
+
+        // Save a trie entry with large payload
+        RMCK_SaveUnsigned(io, 1);  // 1 element
+        RMCK_SaveStringBuffer(io, "large", 6);  // key with null terminator
+        RMCK_SaveDouble(io, 1.0);  // score
+        RMCK_SaveStringBuffer(io, large_payload.data(), large_size);  // payload with null terminator
+
+        io->read_pos = 0;
+        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
+        ASSERT_TRUE(trie != nullptr) << "Failed to load trie with 1MB payload";
+        EXPECT_EQ(1, trie->size);
+        TrieType_Free(trie);
+    }
+
+    // Test 3: Maximum valid uint32_t payload length - should handle gracefully
+    // Note: We can't actually allocate UINT32_MAX bytes in a test, but we can
+    // verify the RDB load handles the size correctly
+    RMCK_ResetRdbIO(io);
+    {
+        // Create a malicious RDB with a payload length that would cause overflow
+        // if not properly checked: UINT32_MAX
+        RMCK_SaveUnsigned(io, 1);  // 1 element
+        RMCK_SaveStringBuffer(io, "overflow", 9);  // key with null terminator
+        RMCK_SaveDouble(io, 1.0);  // score
+
+        // Save a payload length of UINT32_MAX (this would overflow when adding 1)
+        RMCK_SaveUnsigned(io, UINT32_MAX);
+
+        io->read_pos = 0;
+        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
+
+        // The load should fail gracefully (return NULL) rather than crash
+        // due to integer overflow in the allocation
+        EXPECT_TRUE(trie == nullptr) << "Expected RDB load to fail with UINT32_MAX payload length";
+    }
+}
+
+TEST_F(RdbMockTest, testTriePayloadOverflowDirectInsert) {
+    // Test that Trie_InsertRune correctly detects payload overflow
+    // when payload length would cause uint32_t overflow in allocation.
+    //
+    // LIMITATION: This overflow check is impractical to trigger via FT.SUGADD
+    // command:
+    // - Redis defaults to 512MB max string size (proto-max-bulk-len), though
+    //   it is configurable
+    // - The overflow requires payload size > ~4GB (UINT32_MAX - sizeof(TriePayload) - 1)
+    // - Even if proto-max-bulk-len is increased, allocating ~4GB for a single
+    //   suggestion payload would likely fail due to memory constraints before
+    //   reaching the overflow check
+    //
+    // The overflow check exists to protect against:
+    // 1. Malicious/corrupted RDB files with crafted payload lengths
+    // 2. Internal API misuse where payload.len could be set to an invalid value
+    //
+    // This test exercises the overflow check directly via
+    // Trie_InsertStringBuffer with artificially large payload.len values
+    // (without actually allocating memory).
+
+    // Create a trie
+    Trie *trie = NewTrie(NULL, Trie_Sort_Score);
+    ASSERT_TRUE(trie != nullptr);
+    std::unique_ptr<Trie, std::function<void(Trie *)>> triePtr(trie, [](Trie *t) {
+        TrieType_Free(t);
+    });
+
+    // Test 1: Normal payload insertion should succeed
+    {
+        const char *key = "normal_key";
+        const char *payload_data = "normal_payload";
+        RSPayload payload = {
+            .data = const_cast<char*>(payload_data),
+            .len = strlen(payload_data)
+        };
+
+        int rc = Trie_InsertStringBuffer(trie, key, strlen(key), 1.0, 0, &payload, 0);
+        EXPECT_EQ(TRIE_OK_NEW, rc) << "Normal payload insertion should succeed";
+        EXPECT_EQ(1, trie->size);
+    }
+
+    // Test 2: Payload with length that would overflow uint32_t should fail
+    // The overflow check is: sizeof(TriePayload) + 1 + plen > UINT32_MAX
+    // sizeof(TriePayload) is 4 (for the uint32_t len field)
+    // So overflow occurs when plen > UINT32_MAX - 5
+    {
+        const char *key = "overflow_key";
+        char dummy_data = 'X';  // Non-NULL pointer to trigger the overflow check
+        RSPayload payload = {
+            .data = &dummy_data,
+            // This will overflow: 4 + 1 + (UINT32_MAX - 4) > UINT32_MAX
+            .len = static_cast<size_t>(UINT32_MAX) - 4
+        };
+
+        int rc = Trie_InsertStringBuffer(trie, key, strlen(key), 1.0, 0, &payload, 0);
+        EXPECT_EQ(TRIE_ERR_PAYLOAD_OVERFLOW, rc) << "Payload overflow should be detected";
+        EXPECT_EQ(1, trie->size) << "Trie size should not change on failed insert";
+    }
+
+    // Test 3: Payload with SIZE_MAX length should also fail (extreme case)
+    {
+        const char *key = "extreme_key";
+        char dummy_data = 'Y';
+        RSPayload payload = {
+            .data = &dummy_data,
+            .len = SIZE_MAX
+        };
+
+        int rc = Trie_InsertStringBuffer(trie, key, strlen(key), 1.0, 0, &payload, 0);
+        EXPECT_EQ(TRIE_ERR_PAYLOAD_OVERFLOW, rc) << "SIZE_MAX payload should trigger overflow";
+        EXPECT_EQ(1, trie->size) << "Trie size should not change on failed insert";
+    }
+
+}
+
+TEST_F(RdbMockTest, testSchemaPrefixesRdbLoadExceedsLimit) {
+    // Test that loading schema rules with more prefixes than
+    // MAX_SCHEMA_PREFIXES fails.
+    // This exercises the RDB load path in SchemaRule_RdbLoad (src/rules.c).
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Craft RDB data with prefixes exceeding MAX_SCHEMA_PREFIXES (1024)
+    // RDB format for SchemaRule:
+    //   1. type string (e.g., "HASH")
+    //   2. number of prefixes (uint64)
+    //   3. prefix strings...
+
+    // Write type string
+    const char *type = "HASH";
+    RMCK_SaveStringBuffer(io, type, strlen(type) + 1);
+
+    // Write number of prefixes exceeding the limit
+    uint64_t nprefixes = MAX_SCHEMA_PREFIXES + 1;
+    RMCK_SaveUnsigned(io, nprefixes);
+
+    // Write some dummy prefix data to prove failure is from limit check, not EOF
+    const char *prefix = "prefix:";
+    RMCK_SaveStringBuffer(io, prefix, strlen(prefix) + 1);
+
+    // Reset read position
+    io->read_pos = 0;
+
+    // Create QueryError to capture the error message
+    QueryError status = QueryError_Default();
+
+    // Try to load - should fail due to exceeding MAX_SCHEMA_PREFIXES
+    // We pass an invalid StrongRef since we expect failure before it's used
+    StrongRef dummy_ref = INVALID_STRONG_REF;
+    int rc = SchemaRule_RdbLoad(dummy_ref, io, INDEX_CURRENT_VERSION, &status);
+
+    EXPECT_EQ(REDISMODULE_ERR, rc) << "Expected RDB load to fail when prefixes exceed limit";
+    EXPECT_TRUE(QueryError_HasError(&status)) << "Expected QueryError to be set";
+
+    // Verify the error message mentions the limit
+    const char *err_msg = QueryError_GetUserError(&status);
+    EXPECT_TRUE(err_msg != nullptr);
+    if (err_msg) {
+        std::string expected = "RDB Load: Number of prefixes (" +
+            std::to_string(MAX_SCHEMA_PREFIXES + 1) +
+            ") exceeds maximum allowed (" +
+            std::to_string(MAX_SCHEMA_PREFIXES) + ")";
+        EXPECT_TRUE(strstr(err_msg, expected.c_str()) != nullptr)
+            << "Expected: " << expected << ", got: " << err_msg;
+    }
+
+    QueryError_ClearError(&status);
+}
+
+TEST_F(RdbMockTest, testStopWordListRdbLoadExceedsLimit) {
+    // Test that loading a stopword list with more elements than
+    // MAX_STOPWORDLIST_SIZE fails.
+    // This exercises the RDB load path in StopWordList_RdbLoad (src/stopwords.c).
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Craft RDB data with elements exceeding MAX_STOPWORDLIST_SIZE
+    // RDB format for StopWordList:
+    //   1. number of elements (uint64)
+    //   2. element strings...
+
+    // Write number of elements exceeding the limit
+    uint64_t num_elements = MAX_STOPWORDLIST_SIZE + 1;
+    RMCK_SaveUnsigned(io, num_elements);
+
+    // Write some dummy stopword data to prove failure is from limit check, not EOF
+    const char *stopword = "the";
+    RMCK_SaveStringBuffer(io, stopword, strlen(stopword));
+
+    // Reset read position
+    io->read_pos = 0;
+
+    // Capture stderr to verify the error message
+    testing::internal::CaptureStderr();
+
+    // Try to load - should fail due to exceeding MAX_STOPWORDLIST_SIZE
+    StopWordList *loadedList = StopWordList_RdbLoad(io, INDEX_CURRENT_VERSION);
+    EXPECT_TRUE(loadedList == nullptr) << "Expected RDB load to fail when stopwords exceed limit";
+
+    // Verify the error message was logged to stderr
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    std::string expected = "RDB Load: Stopword list size (" +
+        std::to_string(num_elements) +
+        ") exceeds maximum allowed (" +
+        std::to_string(MAX_STOPWORDLIST_SIZE) + ")";
+    EXPECT_TRUE(stderr_output.find(expected) != std::string::npos)
+        << "Expected: " << expected << ", got: " << stderr_output;
+}
+
+
+TEST_F(RdbMockTest, testDocTableLegacyRdbLoadOverflow) {
+    // Test that DocTable_LegacyRdbLoad correctly handles allocation overflow
+    // when maxDocId > maxSize and the allocation would overflow.
+    //
+    // The overflow check is: t->cap * sizeof(DMDChain) > SIZE_MAX
+    // We craft RDB data with a maxSize that would cause this overflow.
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+    ASSERT_TRUE(io != nullptr);
+
+    // Create a DocTable with initial small capacity
+    // Use NewDocTable directly to avoid RSGlobalConfig dependency
+    DocTable t = NewDocTable(16, 1000000);
+    std::unique_ptr<DocTable, std::function<void(DocTable *)>> tablePtr(&t, [](DocTable *t) {
+        DocTable_Free(t);
+    });
+
+    // Craft RDB data that will trigger the overflow check:
+    // - size: 2 (at least 1 document to load)
+    // - maxDocId: SIZE_MAX (very large, will be > maxSize)
+    // - maxSize: (SIZE_MAX / sizeof(DMDChain)) + 1 (will cause overflow in allocation)
+    //
+    // RDB format for legacy DocTable (encver >= INDEX_MIN_COMPACTED_DOCTABLE_VERSION):
+    //   1. size (uint64)
+    //   2. maxDocId (uint64)
+    //   3. maxSize (uint64)
+    //   4. document entries...
+
+    uint64_t size = 2;
+    uint64_t maxDocId = SIZE_MAX;
+    // Calculate a maxSize that will cause overflow: cap * sizeof(DMDChain) > SIZE_MAX
+    // sizeof(DMDChain) is typically 8 bytes (pointer to DLLIST2)
+    uint64_t maxSize = (SIZE_MAX / sizeof(DMDChain)) + 1;
+
+    RMCK_SaveUnsigned(io, size);
+    RMCK_SaveUnsigned(io, maxDocId);
+    RMCK_SaveUnsigned(io, maxSize);
+
+    // Write some dummy document data (won't be reached due to early return)
+    const char *docKey = "doc:1";
+    RMCK_SaveStringBuffer(io, docKey, strlen(docKey));
+
+    // Reset read position
+    io->read_pos = 0;
+
+    // Capture stderr to verify the error message
+    testing::internal::CaptureStderr();
+
+    // Try to load - should fail due to allocation overflow
+    int rc = DocTable_LegacyRdbLoad(&t, io, INDEX_MIN_COMPACTED_DOCTABLE_VERSION);
+    EXPECT_EQ(REDISMODULE_ERR, rc) << "Expected DocTable_LegacyRdbLoad to fail on allocation overflow";
+
+    // Verify the error message was logged
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(stderr_output.find("DocTable_LegacyRdbLoad: allocation overflow") != std::string::npos)
+        << "Expected overflow error message, got: " << stderr_output;
+
+    // Verify the DocTable is in a safe state after failure
+    // buckets should be NULL and cap should be 0
+    EXPECT_TRUE(t.buckets == nullptr) << "buckets should be NULL after overflow error";
+    EXPECT_EQ(0, t.cap) << "cap should be 0 after overflow error";
 }

--- a/tests/ctests/test_synonym_map.c
+++ b/tests/ctests/test_synonym_map.c
@@ -14,8 +14,8 @@ int testSynonymMapAddGetId() {
   SynonymMap* smap = SynonymMap_New(false);
   const char* values1[] = {"val1", "val2", "val3", "val4"};
   const char* values2[] = {"val5", "val6", "val7", "val8"};
-  SynonymMap_Add(smap, "g1", values1, 4);
-  SynonymMap_Add(smap, "g2", values2, 4);
+  ASSERT(SynonymMap_Add(smap, "g1", values1, 4) == SYNONYM_MAP_OK);
+  ASSERT(SynonymMap_Add(smap, "g2", values2, 4) == SYNONYM_MAP_OK);
   TermData* ret_id;
 
   ASSERT(ret_id = SynonymMap_GetIdsBySynonym_cstr(smap, "val1"));
@@ -43,7 +43,7 @@ int testSynonymUpdate() {
   SynonymMap* smap = SynonymMap_New(false);
   const char* values[] = {"val1", "val2", "val3", "val4"};
   const char* update_values[] = {"val5", "val6", "val7", "val8"};
-  SynonymMap_Add(smap, "g1", values, 4);
+  ASSERT(SynonymMap_Add(smap, "g1", values, 4) == SYNONYM_MAP_OK);
   TermData* ret_id;
 
   ASSERT(ret_id = SynonymMap_GetIdsBySynonym_cstr(smap, "val1"));
@@ -55,7 +55,7 @@ int testSynonymUpdate() {
   ASSERT(ret_id = SynonymMap_GetIdsBySynonym_cstr(smap, "val4"));
   ASSERT_STRING_EQ(ret_id->groupIds[0], "~g1");
 
-  SynonymMap_Update(smap, update_values, 4, "g1");
+  ASSERT(SynonymMap_Update(smap, update_values, 4, "g1") == SYNONYM_MAP_OK);
 
   ASSERT(ret_id = SynonymMap_GetIdsBySynonym_cstr(smap, "val5"));
   ASSERT_STRING_EQ(ret_id->groupIds[0], "~g1");
@@ -76,16 +76,16 @@ int testSynonymGetReadOnlyCopy() {
   const char* values2[] = {"val5", "val6", "val7", "val8"};
   const char* values3[] = {"val9", "val10", "val11", "val12"};
   const char* values4[] = {"val13", "val14", "val15", "val16"};
-  SynonymMap_Add(smap, "g1", values1, 4);
-  SynonymMap_Add(smap, "g2", values2, 4);
-  SynonymMap_Add(smap, "g3", values3, 4);
+  ASSERT(SynonymMap_Add(smap, "g1", values1, 4) == SYNONYM_MAP_OK);
+  ASSERT(SynonymMap_Add(smap, "g2", values2, 4) == SYNONYM_MAP_OK);
+  ASSERT(SynonymMap_Add(smap, "g3", values3, 4) == SYNONYM_MAP_OK);
 
   SynonymMap* read_only_copy1 = SynonymMap_GetReadOnlyCopy(smap);
   SynonymMap* read_only_copy2 = SynonymMap_GetReadOnlyCopy(smap);
 
   ASSERT(read_only_copy1 == read_only_copy2);
 
-  SynonymMap_Add(smap, "g4", values4, 4);
+  ASSERT(SynonymMap_Add(smap, "g4", values4, 4) == SYNONYM_MAP_OK);
 
   SynonymMap* read_only_copy3 = SynonymMap_GetReadOnlyCopy(smap);
 

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -17,11 +17,15 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #include <assert.h>
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/param.h>
 #include <time.h>
+
+// Forward declaration of internal helper from trie.c, exposed here for testing only.
+size_t __trieNode_Sizeof(t_len numChildren, t_len slen);
 
 int count = 0;
 
@@ -1061,6 +1065,34 @@ int testDecrementNumDocsNonTerminal() {
   return 0;
 }
 
+int testTrieNodeSizeof() {
+  // Test __trieNode_Sizeof size calculation
+  //
+  // Note: Overflow is not possible with t_len (uint16_t) inputs since
+  // max possible size is: 65535 * 12 + 65536 * 4 ≈ 1MB, far below SIZE_MAX.
+
+  // Maximum uint16_t values should work (no overflow possible)
+  size_t result = __trieNode_Sizeof(UINT16_MAX, UINT16_MAX);
+  ASSERT(result > 0);
+
+  // Verify the size calculation matches expected formula
+  size_t expected = sizeof(TrieNode) +
+                    (size_t)UINT16_MAX * (sizeof(rune) + sizeof(TrieNode *)) +
+                    ((size_t)UINT16_MAX + 1) * sizeof(rune);
+  ASSERT_EQUAL(result, expected);
+
+  // Normal values
+  result = __trieNode_Sizeof(10, 100);
+  ASSERT(result > 0);
+
+  // Edge case: zero children and zero length
+  result = __trieNode_Sizeof(0, 0);
+  // Should be sizeof(TrieNode) + sizeof(rune) for the null terminator
+  ASSERT_EQUAL(result, sizeof(TrieNode) + sizeof(rune));
+
+  return 0;
+}
+
 TEST_MAIN({
   RMUTil_InitAlloc();
   TESTFUNC(testRuneUtil);
@@ -1072,4 +1104,5 @@ TEST_MAIN({
   TESTFUNC(testDecrementNumDocs);
   TESTFUNC(testDecrementNumDocsComplex);
   TESTFUNC(testDecrementNumDocsNonTerminal);
+  TESTFUNC(testTrieNodeSizeof);
 });

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -73,6 +73,7 @@ class TestDebugCommands(object):
             'DUMP_DELETED_IDS',
             'DISK_IO_CONTROL',
             'REGISTER_TEST_SCORERS',
+            'SET_MAX_INDEXES',
             'FT.AGGREGATE',
             '_FT.AGGREGATE',
             'FT.SEARCH',

--- a/tests/pytests/test_limits.py
+++ b/tests/pytests/test_limits.py
@@ -1,0 +1,175 @@
+from common import *
+
+
+def testDebugSetMaxIndexes(env):
+    """Test that FT.DEBUG SET_MAX_INDEXES works"""
+    DEFAULT_MAX_INDEXES = 200_000
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', DEFAULT_MAX_INDEXES).ok()
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', 0).error()\
+        .contains(f'Invalid value. Must be between 1 and {DEFAULT_MAX_INDEXES}')
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', DEFAULT_MAX_INDEXES + 1).error()\
+        .contains(f'Invalid value. Must be between 1 and {DEFAULT_MAX_INDEXES}')
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', 1000).ok()
+
+    num_indexes = 10
+    for i in range(num_indexes):
+        env.expect('FT.CREATE', f'idx{i}', 'ON', 'HASH',
+                   'SCHEMA', 'name', 'TEXT').ok()
+
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', num_indexes).ok()
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', num_indexes - 1).error()\
+        .contains(f'Invalid value. Must be at least current number of indexes: {num_indexes}')
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', DEFAULT_MAX_INDEXES).ok()
+
+
+def testMaxIndexesLimit(env):
+    """Test that creating more indexes than MAX_INDEXES fails"""
+    MAX_INDEXES = 5
+
+    # Set a small MAX_INDEXES limit for testing using the debug command
+    env.expect(debug_cmd(), 'SET_MAX_INDEXES', MAX_INDEXES).ok()
+
+    # Create indexes up to the limit (should succeed)
+    for i in range(MAX_INDEXES):
+        env.expect('FT.CREATE', f'idx{i}', 'ON', 'HASH',
+                   'SCHEMA', 'name', 'TEXT').ok()
+
+    # Read number of indexes from INFO SEARCH
+    info_search = env.cmd('INFO', 'SEARCH')
+    env.assertEqual(info_search['search_number_of_indexes'], MAX_INDEXES)
+
+    # Creating one more index should fail
+    err_message = f'Maximum number of indexes ({MAX_INDEXES}) reached'
+    env.expect('FT.CREATE', 'idx_overflow', 'ON', 'HASH',
+               'PREFIX', '1', 'overflow:',
+               'SCHEMA', 'name', 'TEXT').error().contains(err_message)
+
+    # Drop one index and verify we can create a new one
+    env.expect('FT.DROPINDEX', 'idx0').ok()
+    info_search = env.cmd('INFO', 'SEARCH')
+    env.assertEqual(info_search['search_number_of_indexes'], MAX_INDEXES - 1)
+
+    env.expect('FT.CREATE', 'idx_new', 'ON', 'HASH',
+               'PREFIX', '1', 'new:',
+               'SCHEMA', 'name', 'TEXT').ok()
+    info_search = env.cmd('INFO', 'SEARCH')
+    env.assertEqual(info_search['search_number_of_indexes'], MAX_INDEXES)
+
+    # Verify we're back at the limit
+    env.expect('FT.CREATE', 'idx_overflow2', 'ON', 'HASH',
+               'PREFIX', '1', 'overflow2:',
+               'SCHEMA', 'name', 'TEXT').error().contains(err_message)
+    info_search = env.cmd('INFO', 'SEARCH')
+    env.assertEqual(info_search['search_number_of_indexes'], MAX_INDEXES)
+
+def testMaxSchemaPrefixesLimit(env):
+    """Test that creating an index with more than MAX_SCHEMA_PREFIXES (1024)
+    prefixes fails"""
+    MAX_SCHEMA_PREFIXES = 1_000_000
+
+    # Generate prefixes exceeding the limit
+    prefixes = [f'prefix{i}:' for i in range(MAX_SCHEMA_PREFIXES + 1)]
+
+    # Build the FT.CREATE command with too many prefixes
+    cmd = ['FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', str(len(prefixes))]
+    cmd += prefixes + ['SCHEMA', 'name', 'text']
+
+    # Expect an error due to exceeding the prefix limit
+    err_message = f'Number of prefixes ({MAX_SCHEMA_PREFIXES + 1}) exceeds maximum allowed ({MAX_SCHEMA_PREFIXES})'
+    env.expect(*cmd).error().contains(err_message)
+
+    # Verify that creating an index with exactly MAX_SCHEMA_PREFIXES works
+    prefixes_at_limit = prefixes[:-1]
+    cmd_at_limit = ['FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX']
+    cmd_at_limit += [str(len(prefixes_at_limit))] + prefixes_at_limit
+    cmd_at_limit += ['SCHEMA', 'name', 'text']
+    env.expect(*cmd_at_limit).ok()
+
+
+def testMaxSynonymGroupIdsLimit(env):
+    """Test that adding a term to more than MAX_SYNONYM_GROUP_IDS (4096)
+    synonym groups fails"""
+    MAX_SYNONYM_GROUP_IDS = 4096
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'text').ok()
+
+    # Add the same term to MAX_SYNONYM_GROUP_IDS groups (should succeed)
+    # Each FT.SYNUPDATE adds a term to a group, and a term can belong to
+    # multiple groups
+    term = 'commonterm'
+    for i in range(MAX_SYNONYM_GROUP_IDS):
+        env.expect('FT.SYNUPDATE', 'idx', f'group{i}', term).ok()
+
+    # Adding the term to one more group should fail
+    env.expect('FT.SYNUPDATE', 'idx', f'group{MAX_SYNONYM_GROUP_IDS}', term) \
+        .error().contains('Maximum group IDs per term limit reached')
+
+
+def testMaxSynonymTermsLimit(env):
+    """Test that adding more than MAX_SYNONYM_TERMS (1,000,000) unique terms
+    to a synonym map fails (regardless of how many groups they belong to)"""
+    MAX_SYNONYM_TERMS = 1_000_000
+    BATCH_SIZE = 1000  # Add 1000 terms per FT.SYNUPDATE call for efficiency
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'text').ok()
+
+    # Add terms in batches until we reach the limit
+    num_batches = MAX_SYNONYM_TERMS // BATCH_SIZE
+    for batch in range(num_batches):
+        terms = [f'term{batch * BATCH_SIZE + i}' for i in range(BATCH_SIZE)]
+        env.expect('FT.SYNUPDATE', 'idx', f'group{batch}', *terms).ok()
+
+    # Adding one more term should fail
+    env.expect('FT.SYNUPDATE', 'idx', 'overflow_group', 'overflow_term') \
+        .error().contains('Maximum synonym terms limit reached')
+
+
+def testMaxFieldsLimit(env):
+    """Test that creating an index with more than SPEC_MAX_FIELDS (1024) fields
+    fails"""
+    SPEC_MAX_FIELDS = 1024
+
+    # Verify that creating an index with exactly SPEC_MAX_FIELDS works
+    fields = []
+    for i in range(SPEC_MAX_FIELDS):
+        fields.extend([f'field{i}', 'TAG'])
+    cmd_at_limit = ['FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA'] + fields
+    env.expect(*cmd_at_limit).ok()
+
+    # Build the FT.CREATE command with too many fields
+    cmd_overflow = ['FT.CREATE', 'idx2', 'ON', 'HASH', 'SCHEMA'] + fields
+    cmd_overflow.extend(['overflow_field', 'TAG'])
+
+    # Expect an error due to exceeding the field limit
+    err_message = f'Schema is limited to {SPEC_MAX_FIELDS} fields'
+    env.expect(*cmd_overflow).error().contains(err_message)
+
+
+def testMaxStopwordsLimit(env):
+    """Test that creating an index with more than MAX_STOPWORDLIST_SIZE (1024)
+    stopwords silently truncates to the limit.
+
+    Note: Unlike other limits, exceeding MAX_STOPWORDLIST_SIZE does NOT return
+    an error - it silently truncates the list. This test verifies the current
+    behavior."""
+    MAX_STOPWORDLIST_SIZE = 1024
+
+    # Generate stopwords exceeding the limit
+    stopwords = [f'w{i}' for i in range(MAX_STOPWORDLIST_SIZE + 100)]
+
+    # Build the FT.CREATE command with too many stopwords
+    cmd = ['FT.CREATE', 'idx', 'ON', 'HASH',  'STOPWORDS', str(len(stopwords))]
+    cmd += stopwords + ['SCHEMA', 'name', 'TEXT']
+
+    # Currently this succeeds (silently truncates) rather than returning an error
+    env.expect(*cmd).ok()
+
+    # Verify the index was created
+    env.expect('FT._LIST').contains('idx')
+
+    # Verify the stopwords list is truncated to the limit
+    idx_info = env.cmd('FT.INFO', 'idx')
+    idx_stopwords = idx_info[idx_info.index('stopwords_list') + 1]
+    env.assertEqual(len(idx_stopwords), MAX_STOPWORDLIST_SIZE)


### PR DESCRIPTION
## Description
Sync master with PR #9439

Add validation of limits during RDB load and data creation.

Existing limits that are now verified during RDB load:
- `SPEC_MAX_FIELDS` 1,024

New limits:
- `MAX_SCHEMA_PREFIXES` 1,000,000
- `MAX_SYNONYM_TERMS` 1,000,000
- `MAX_SYNONYM_GROUP_IDS` 4,096
- `MAX_INDEXES` 200,000 (default value, modifiable up to 200,000 for testing using `FT.DEBUG`)

## Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

**User Impact:** Adds validations during RDB load to prevent potential memory corruption from malformed RDB files. Enforces limits on schema prefixes, synonym terms, synonym group IDs, and total index count.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB deserialization and query optimizer/trie allocation paths; mistakes could reject valid data or change runtime behavior, though changes are largely defensive bounds/overflow checks with added tests.
> 
> **Overview**
> Adds *defensive limits and overflow validation* across index creation and RDB load paths to prevent oversized/malformed inputs from causing allocation issues.
> 
> Enforces new caps for **number of indexes**, **schema prefixes**, **synonym terms**, **synonym group IDs per term**, and stopword list size; failures now surface as errors (or IO warnings) during `FT.CREATE`/`FT.SYNUPDATE` and during RDB load. A debug-only `FT.DEBUG SET_MAX_INDEXES` is added to adjust the index-count limit for testing.
> 
> Hardens several allocation sites (optimizer iterator, JSON multi-value/text storage, legacy doc table load, trie payload handling) with explicit overflow checks and propagates errors via `QueryError` where applicable, with extensive new C++/C/pytest coverage for these edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4940e1759874846a4569163cadeb3f5bb67a61d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->