### PR TITLE
[MOD-15378] fix: A few TrieMap_* FFI functions don't need &mut access to the undelying data structure

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
@@ -26,7 +26,7 @@ use thin_vec::SmallThinVec;
 /// [`NewTrieMap`]: crate::NewTrieMap
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_FindPrefixes(
-    t: *mut TrieMap,
+    t: *const TrieMap,
     str: *const c_char,
     len: tm_len_t,
 ) -> TrieMapResultBuf {
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn TrieMap_FindPrefixes(
     // state the caller is to ensure that the pointer `t` is
     // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
     // If that invariant is upheld, then the following line is sound.
-    let TrieMap(trie) = unsafe { &mut *t };
+    let TrieMap(trie) = unsafe { &*t };
 
     let prefix: &[u8] = if len > 0 {
         debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn TrieMap_Add(
 ///   and the pointer must not be dereferenced.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Find(
-    t: *mut TrieMap,
+    t: *const TrieMap,
     str: *const c_char,
     len: tm_len_t,
 ) -> *mut c_void {
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn TrieMap_Find(
     // state the caller is to ensure that the pointer `t` is
     // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
     // If that invariant is upheld, then the following line is sound.
-    let TrieMap(trie) = unsafe { &mut *t };
+    let TrieMap(trie) = unsafe { &*t };
 
     let key: &[u8] = if len > 0 {
         debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
@@ -324,14 +324,14 @@ pub unsafe extern "C" fn TrieMap_MemUsage(t: *mut TrieMap) -> usize {
 ///
 /// The following invariants must be upheld when calling this function:
 /// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
-pub unsafe extern "C" fn TrieMap_NUniqueKeys(t: *mut TrieMap) -> usize {
+pub unsafe extern "C" fn TrieMap_NUniqueKeys(t: *const TrieMap) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
 
     // SAFETY: The safety requirements of this function
     // state the caller is to ensure that the pointer `t` is
     // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
     // If that invariant is upheld, then the following line is sound.
-    let TrieMap(trie) = unsafe { &mut *t };
+    let TrieMap(trie) = unsafe { &*t };
     trie.n_unique_keys()
 }
 
@@ -344,13 +344,13 @@ pub unsafe extern "C" fn TrieMap_NUniqueKeys(t: *mut TrieMap) -> usize {
 ///
 /// The following invariants must be upheld when calling this function:
 /// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
-pub unsafe extern "C" fn TrieMap_NNodes(t: *mut TrieMap) -> usize {
+pub unsafe extern "C" fn TrieMap_NNodes(t: *const TrieMap) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
 
     // SAFETY: The safety requirements of this function
     // state the caller is to ensure that the pointer `t` is
     // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
     // If that invariant is upheld, then the following line is sound.
-    let TrieMap(trie) = unsafe { &mut *t };
+    let TrieMap(trie) = unsafe { &*t };
     trie.n_nodes()
 }

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
@@ -41,7 +41,7 @@ pub type TrieMapRangeCallback =
 /// [`NewTrieMap`]: crate::NewTrieMap
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_IterateRange(
-    trie: *mut TrieMap,
+    trie: *const TrieMap,
     min: *const c_char, // May be NULL iff minlen == 0
     minlen: c_int,      // if 0, execute special case
     includeMin: bool,
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn TrieMap_IterateRange(
     };
 
     // SAFETY: caller is to ensure that `trie` is valid and not null
-    let TrieMap(trie) = unsafe { &mut *trie };
+    let TrieMap(trie) = unsafe { &*trie };
 
     let filter = RangeFilter {
         min: min.map(|m| RangeBoundary {

--- a/src/redisearch_rs/headers/triemap.h
+++ b/src/redisearch_rs/headers/triemap.h
@@ -133,7 +133,7 @@ int TrieMap_Add(TrieMap *t,
  * - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
  *   and the pointer must not be dereferenced.
  */
-void *TrieMap_Find(TrieMap *t, const char *str, tm_len_t len);
+void *TrieMap_Find(const TrieMap *t, const char *str, tm_len_t len);
 
 /**
  * Mark a node as deleted. It also optimizes the trie by merging nodes if
@@ -179,7 +179,7 @@ uintptr_t TrieMap_MemUsage(TrieMap *t);
  * The following invariants must be upheld when calling this function:
  * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  */
-uintptr_t TrieMap_NUniqueKeys(TrieMap *t);
+uintptr_t TrieMap_NUniqueKeys(const TrieMap *t);
 
 /**
  * The number of nodes stored in the provided triemap.
@@ -191,7 +191,7 @@ uintptr_t TrieMap_NUniqueKeys(TrieMap *t);
  * The following invariants must be upheld when calling this function:
  * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  */
-uintptr_t TrieMap_NNodes(TrieMap *t);
+uintptr_t TrieMap_NNodes(const TrieMap *t);
 
 /**
  * Find nodes that have a given prefix. Results are placed in an array.
@@ -207,7 +207,7 @@ uintptr_t TrieMap_NNodes(TrieMap *t);
  *
  * [`NewTrieMap`]: crate::NewTrieMap
  */
-TrieMapResultBuf TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len);
+TrieMapResultBuf TrieMap_FindPrefixes(const TrieMap *t, const char *str, tm_len_t len);
 
 /**
  * Free the [`TrieMapResultBuf`] and its contents.
@@ -350,7 +350,7 @@ int TrieMapIterator_Next(struct TrieMapIterator *it,
  *
  * [`NewTrieMap`]: crate::NewTrieMap
  */
-void TrieMap_IterateRange(TrieMap *trie,
+void TrieMap_IterateRange(const TrieMap *trie,
                           const char *min,
                           int minlen,
                           bool includeMin,


### PR DESCRIPTION
## Describe the changes in the pull request

Ensure we take the right level of mutability at the FFI boundary for the corresponding `TrieMap_*` operation.
Unlikely to have caused any real runtime issue.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only tighten mutability at the Rust/C FFI boundary for read-only TrieMap operations, with no behavioral logic changes beyond removing unnecessary `&mut` access.
> 
> **Overview**
> Updates several `TrieMap_*` FFI functions that only read from the trie to accept `*const TrieMap`/`const TrieMap *` instead of mutable pointers, and switches internal dereferences from `&mut *t` to `&*t`.
> 
> This affects `TrieMap_Find`, `TrieMap_FindPrefixes`, `TrieMap_NUniqueKeys`, `TrieMap_NNodes`, and `TrieMap_IterateRange`, and regenerates the corresponding `triemap.h` prototypes to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77157d11271aa931e11fe05ab77fdb34ab1a3664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->