### PR TITLE
COLLECT LIMIT handling for shard distribution

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -285,9 +285,10 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
       REQFLAGS_AddFlags(papCtx->reqflags, QEXEC_F_NOROWS);
       REQFLAGS_AddFlags(papCtx->reqflags, QEXEC_F_SEND_NOFIELDS);
     } else {
-      size_t max = (*papCtx->reqflags & QEXEC_F_IS_SEARCH) ? *papCtx->maxSearchResults
-                                                            : *papCtx->maxAggregateResults;
-      if (!ValidateLimitBounds(arng->offset, arng->limit, max, status)) {
+      size_t max_count = (*papCtx->reqflags & QEXEC_F_IS_SEARCH) ? *papCtx->maxSearchResults
+                                                                  : *papCtx->maxAggregateResults;
+      if (!ValidateLimitBounds(arng->offset, arng->limit,
+                               *papCtx->maxSearchResults, max_count, status)) {
         return ARG_ERROR;
       }
     }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "aggregate.h"
+#include "util/misc.h"
 #include "reducer.h"
 
 #include <cursor.h>
@@ -283,20 +284,12 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
       // LIMIT 0 0 - only count
       REQFLAGS_AddFlags(papCtx->reqflags, QEXEC_F_NOROWS);
       REQFLAGS_AddFlags(papCtx->reqflags, QEXEC_F_SEND_NOFIELDS);
-      // TODO: unify if when req holds only maxResults according to the query type.
-      //(SEARCH / AGGREGATE)
-    } else if ((arng->limit > *papCtx->maxSearchResults) && (*papCtx->reqflags & (QEXEC_F_IS_SEARCH))) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "LIMIT exceeds maximum of %llu",
-                             *papCtx->maxSearchResults);
-      return ARG_ERROR;
-    } else if ((arng->limit > *papCtx->maxAggregateResults) && !(*papCtx->reqflags & (QEXEC_F_IS_SEARCH))) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "LIMIT exceeds maximum of %llu",
-                             *papCtx->maxAggregateResults);
-      return ARG_ERROR;
-    } else if (arng->offset > *papCtx->maxSearchResults) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "OFFSET exceeds maximum of %llu",
-                             *papCtx->maxSearchResults);
-      return ARG_ERROR;
+    } else {
+      size_t max = (*papCtx->reqflags & QEXEC_F_IS_SEARCH) ? *papCtx->maxSearchResults
+                                                            : *papCtx->maxAggregateResults;
+      if (!ValidateLimitBounds(arng->offset, arng->limit, max, status)) {
+        return ARG_ERROR;
+      }
     }
   } else if (AC_AdvanceIfMatch(ac, "SORTBY")) {
     const char *firstArg;

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -292,7 +292,7 @@ static void handleCollectLimit(ArgParser *parser, const void *value, void *user_
       "LIMIT count must be a positive integer");
     return;
   }
-  if (!ValidateLimitBounds(offset, count, MAX_AGGREGATE_REQUEST_RESULTS, status)) {
+  if (!ValidateLimitBounds(offset, count, MAX_AGGREGATE_REQUEST_RESULTS, MAX_AGGREGATE_REQUEST_RESULTS, status)) {
     return;
   }
 

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -14,7 +14,6 @@
 #include "config.h"
 #include "reducers_rs.h"
 #include <errno.h>
-#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -293,19 +292,7 @@ static void handleCollectLimit(ArgParser *parser, const void *value, void *user_
       "LIMIT count must be a positive integer");
     return;
   }
-  if (offset > MAX_AGGREGATE_REQUEST_RESULTS) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
-      "LIMIT offset exceeds maximum of %llu", MAX_AGGREGATE_REQUEST_RESULTS);
-    return;
-  }
-  if (count > MAX_AGGREGATE_REQUEST_RESULTS) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
-      "LIMIT count exceeds maximum of %llu", MAX_AGGREGATE_REQUEST_RESULTS);
-    return;
-  }
-  if (offset > LLONG_MAX - count) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
-      "Invalid LIMIT offset + count value");
+  if (!ValidateLimitBounds(offset, count, MAX_AGGREGATE_REQUEST_RESULTS, status)) {
     return;
   }
 

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -342,12 +342,10 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   const PLN_Reducer *src = rdctx->srcReducer;
   size_t argc = src->args.argc;
 
-  // Validate and parse the LIMIT clause (if any) from the original args.
-  // distributeCollect runs before RDCRCollect_New, so we also validate here to
-  // surface errors immediately rather than after a shard round-trip.
+  // Pre-parse LIMIT to compute the shard rewrite `LIMIT 0 (offset+count)`;
   bool hasLimit;
   CollectLimit limit;
-  if (!parseCollectLimit(&src->args, RSGlobalConfig.maxAggregateResults,
+  if (!parseCollectLimit(&src->args, MAX_AGGREGATE_REQUEST_RESULTS,
                          &hasLimit, &limit, status)) {
     return REDISMODULE_ERR;
   }

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -339,11 +339,27 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   const PLN_Reducer *src = rdctx->srcReducer;
   size_t argc = src->args.argc;
 
+  // Validate and parse the LIMIT clause (if any) from the original args.
+  // distributeCollect runs before RDCRCollect_New, so we also validate here to
+  // surface errors immediately rather than after a shard round-trip.
+  bool hasLimit;
+  CollectLimit limit;
+  if (!parseCollectLimit(&src->args, RSGlobalConfig.maxAggregateResults,
+                         &hasLimit, &limit, status)) {
+    return REDISMODULE_ERR;
+  }
+
+  // For the shard request, rewrite LIMIT offset count -> LIMIT 0 (offset+count)
+  ShardCollectLimit shardLimit;
+  if (hasLimit) {
+    shardLimit = rewriteCollectLimit(&limit);
+  }
+
   // Build temporary args, then persist their object arrays with copyArgs.
   std::string remoteCountStr = std::to_string(argc);
   std::vector<void *> remoteObjs(collectObjsBufLen(argc, /*has_alias=*/false));
-  ArgsCursor remoteArgs = buildCollectArgs(remoteObjs.data(), remoteCountStr.c_str(),
-                                           &src->args, nullptr);
+  ArgsCursor remoteArgs = buildRemoteCollectArgs(remoteObjs.data(), remoteCountStr.c_str(),
+                                                &src->args, hasLimit ? &shardLimit : nullptr);
   rdctx->copyArgs(&remoteArgs);
 
   const char *alias;
@@ -353,8 +369,8 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
 
   std::string localCountStr = std::to_string(argc);
   std::vector<void *> localObjs(collectObjsBufLen(argc, /*has_alias=*/true));
-  ArgsCursor localArgs = buildCollectArgs(localObjs.data(), localCountStr.c_str(),
-                                          &src->args, src->alias);
+  ArgsCursor localArgs = buildLocalCollectArgs(localObjs.data(), localCountStr.c_str(),
+                                               &src->args, src->alias);
   rdctx->copyArgs(&localArgs);
 
   if (!rdctx->add(rdctx->localGroup, "COLLECT", nullptr, status, &localArgs)) {

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -21,6 +21,9 @@
 #include <sstream>
 #include <algorithm>
 
+constexpr size_t kUint64MaxDecimalLen = 20;  // digits in UINT64_MAX (18446744073709551615)
+constexpr size_t kUint64StrBufSize = kUint64MaxDecimalLen + 1;
+
 static char *getLastAlias(const PLN_GroupStep *gstp) {
   return gstp->reducers[array_len(gstp->reducers) - 1].alias;
 }
@@ -349,17 +352,21 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  // For the shard request, rewrite LIMIT offset count -> LIMIT 0 (offset+count)
-  ShardCollectLimit shardLimit;
+  // For the shard request, rewrite LIMIT offset count -> LIMIT 0 (offset+count).
+  // Allocate from the plan's BlkAlloc so the string outlives distributeCollect.
+  const char *shardCount = nullptr;
   if (hasLimit) {
-    shardLimit = rewriteCollectLimit(&limit);
+    std::string s = std::to_string(limit.offset + limit.count);
+    char *buf = (char *)BlkAlloc_Alloc(rdctx->alloc, s.size() + 1, kUint64StrBufSize);
+    memcpy(buf, s.c_str(), s.size() + 1);
+    shardCount = buf;
   }
 
   // Build temporary args, then persist their object arrays with copyArgs.
   std::string remoteCountStr = std::to_string(argc);
   std::vector<void *> remoteObjs(collectObjsBufLen(argc, /*has_alias=*/false));
   ArgsCursor remoteArgs = buildRemoteCollectArgs(remoteObjs.data(), remoteCountStr.c_str(),
-                                                &src->args, hasLimit ? &shardLimit : nullptr);
+                                                &src->args, shardCount);
   rdctx->copyArgs(&remoteArgs);
 
   const char *alias;

--- a/src/coord/dist_plan_utils.cpp
+++ b/src/coord/dist_plan_utils.cpp
@@ -9,27 +9,112 @@
 
 #include "dist_plan_utils.h"
 #include <string.h>
+#include <string>
 
-ArgsCursor buildCollectArgs(void **objs_buf, const char *count_buf, const ArgsCursor *src_args,
-                            const char *user_alias) {
-  size_t argc = src_args->argc;
+extern "C" {
+#include "rmutil/rm_assert.h"
+#include "util/misc.h"
+}
 
+ArgsCursor buildLocalCollectArgs(void **objs_buf, const char *count_buf,
+                                 const ArgsCursor *src_args, const char *user_alias) {
+
+  // Set args count as the first element
   objs_buf[0] = (void *)count_buf;
-  if (argc) {
-    memcpy(objs_buf + 1, src_args->objs, argc * sizeof(void *));
+  // Copy the remaining args from the source args
+  if (src_args->argc)
+    memcpy(objs_buf + 1, src_args->objs, src_args->argc * sizeof(void *));
+  // Set the AS keyword and user alias
+  objs_buf[src_args->argc + 1] = (void *)"AS";
+  objs_buf[src_args->argc + 2] = (void *)user_alias;
+
+  ArgsCursor out;
+  out.objs = objs_buf;
+  out.type = AC_TYPE_CHAR;
+  out.argc = collectObjsBufLen(src_args->argc, /*has_alias=*/true);
+  out.offset = 0;
+  return out;
+}
+
+bool parseCollectLimit(const ArgsCursor *src_args, uint64_t max_results, bool *out_present,
+                       CollectLimit *out_limit, QueryError *status) {
+  // Scan for the LIMIT keyword — loop does nothing but find the index.
+  size_t limit_idx = src_args->argc;  // sentinel: not found
+  for (size_t i = 0; i < src_args->argc; ++i) {
+    if (strcasecmp((const char *)src_args->objs[i], "LIMIT") == 0) {
+      limit_idx = i;
+      break;
+    }
+  }
+
+  if (limit_idx == src_args->argc) {
+    *out_present = false;
+    return true;
+  }
+
+  // Position a copy of the cursor right after LIMIT and read the next 2 tokens.
+  ArgsCursor ac = *src_args;
+  ac.offset = limit_idx + 1;
+
+  if (AC_NumRemaining(&ac) < 2) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                        "LIMIT requires offset and count arguments");
+    return false;
+  }
+
+  uint64_t offset, count;
+  if (AC_GetU64(&ac, &offset, AC_F_GE0) != AC_OK) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                        "LIMIT offset is not a valid number");
+    return false;
+  }
+  if (AC_GetU64(&ac, &count, AC_F_GE1) != AC_OK) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                        "LIMIT count is not a valid number");
+    return false;
+  }
+
+  if (!ValidateLimitBounds(offset, count, max_results, status)) {
+    return false;
+  }
+
+  *out_present = true;
+  out_limit->offset = offset;
+  out_limit->count = count;
+  return true;
+}
+
+ShardCollectLimit rewriteCollectLimit(const CollectLimit *limit) {
+  return {"0", std::to_string(limit->offset + limit->count)};
+}
+
+ArgsCursor buildRemoteCollectArgs(void **objs_buf, const char *count_buf,
+                                  const ArgsCursor *src_args,
+                                  const ShardCollectLimit *rewrite) {
+  // Set args count as the first element
+  objs_buf[0] = (void *)count_buf;
+  // Copy the remaining args from the source args
+  if (src_args->argc)
+    memcpy(objs_buf + 1, src_args->objs, src_args->argc * sizeof(void *));
+
+  if (rewrite) {
+    // Scan for LIMIT and patch the offset + count slots.
+    bool found = false;
+    for (size_t i = 0; i + 2 <= src_args->argc; ++i) {
+      if (strcasecmp((const char *)src_args->objs[i], "LIMIT") == 0) {
+        objs_buf[1 + i + 1] = (void *)rewrite->offset.c_str();
+        objs_buf[1 + i + 2] = (void *)rewrite->count.c_str();
+        found = true;
+        break;
+      }
+    }
+    RS_ASSERT(found);  // rewrite != NULL implies parseCollectLimit found LIMIT
   }
 
   ArgsCursor out;
-  if (user_alias) {
-    objs_buf[argc + 1] = (void *)"AS";
-    objs_buf[argc + 2] = (void *)user_alias;
-    out.argc = argc + 3;
-  } else {
-    out.argc = argc + 1;
-  }
-
   out.objs = objs_buf;
-  out.offset = 0;
   out.type = AC_TYPE_CHAR;
+  out.argc = collectObjsBufLen(src_args->argc, /*has_alias=*/false);
+  out.offset = 0;
   return out;
 }

--- a/src/coord/dist_plan_utils.cpp
+++ b/src/coord/dist_plan_utils.cpp
@@ -9,7 +9,6 @@
 
 #include "dist_plan_utils.h"
 #include <string.h>
-#include <string>
 
 extern "C" {
 #include "rmutil/rm_assert.h"
@@ -84,31 +83,23 @@ bool parseCollectLimit(const ArgsCursor *src_args, uint64_t max_results, bool *o
   return true;
 }
 
-ShardCollectLimit rewriteCollectLimit(const CollectLimit *limit) {
-  return {"0", std::to_string(limit->offset + limit->count)};
-}
-
 ArgsCursor buildRemoteCollectArgs(void **objs_buf, const char *count_buf,
-                                  const ArgsCursor *src_args,
-                                  const ShardCollectLimit *rewrite) {
-  // Set args count as the first element
+                                  const ArgsCursor *src_args, const char *shard_count) {
   objs_buf[0] = (void *)count_buf;
-  // Copy the remaining args from the source args
   if (src_args->argc)
     memcpy(objs_buf + 1, src_args->objs, src_args->argc * sizeof(void *));
 
-  if (rewrite) {
-    // Scan for LIMIT and patch the offset + count slots.
+  if (shard_count) {
     bool found = false;
     for (size_t i = 0; i + 2 <= src_args->argc; ++i) {
       if (strcasecmp((const char *)src_args->objs[i], "LIMIT") == 0) {
-        objs_buf[1 + i + 1] = (void *)rewrite->offset.c_str();
-        objs_buf[1 + i + 2] = (void *)rewrite->count.c_str();
+        objs_buf[1 + i + 1] = (void *)"0";
+        objs_buf[1 + i + 2] = (void *)shard_count;
         found = true;
         break;
       }
     }
-    RS_ASSERT(found);  // rewrite != NULL implies parseCollectLimit found LIMIT
+    RS_ASSERT(found);  // shard_count != NULL implies parseCollectLimit found LIMIT
   }
 
   ArgsCursor out;

--- a/src/coord/dist_plan_utils.cpp
+++ b/src/coord/dist_plan_utils.cpp
@@ -73,7 +73,7 @@ bool parseCollectLimit(const ArgsCursor *src_args, uint64_t max_results, bool *o
     return false;
   }
 
-  if (!ValidateLimitBounds(offset, count, max_results, status)) {
+  if (!ValidateLimitBounds(offset, count, max_results, max_results, status)) {
     return false;
   }
 

--- a/src/coord/dist_plan_utils.h
+++ b/src/coord/dist_plan_utils.h
@@ -10,8 +10,10 @@
 #pragma once
 
 #include "rmutil/args.h"
+#include "query_error.h"
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define COLLECT_ARGS_COUNT_BUF_LEN 24  // Enough digits for a 64-bit decimal count plus NUL.
 
@@ -21,7 +23,7 @@ extern "C" {
 
 /**
  * Returns the number of object slots the caller must reserve in `objs_buf`
- * passed to `buildCollectArgs`.
+ * passed to `buildLocalCollectArgs` or `buildRemoteCollectArgs`.
  *
  * Layout reminder:
  *   - 1 slot for `nargs`
@@ -33,31 +35,95 @@ static inline size_t collectObjsBufLen(size_t argc, bool has_alias) {
 }
 
 /**
- * Build COLLECT args for distributed planning.
+ * Parsed and validated LIMIT clause from a COLLECT reducer's argument list.
+ */
+typedef struct CollectLimit {
+  uint64_t offset;
+  uint64_t count;
+} CollectLimit;
+
+/**
+ * Scan `src_args` for a `LIMIT offset count` triplet, parse and validate it.
  *
- * Remote layout: [nargs, original_args...].
- * Local layout:  [nargs, original_args..., AS, user_alias].
+ * On no LIMIT keyword: returns true and sets *out_present = false.
+ * On valid LIMIT:      returns true, sets *out_present = true and *out_limit.
+ * On invalid LIMIT (missing tail tokens, non-numeric offset/count, exceeds
+ *                   max_results, or offset+count overflow): returns false and
+ *                   sets *status.
  *
- * Distributed COLLECT splits the innermost GROUPBY reducer pair. The remote
- * COLLECT consumes ordinary item rows on each shard and emits one payload per
- * shard group. The local COLLECT consumes coordinator merge rows, where each
- * row is already a shard group and the collected items are stored under
- * PLN_Reducer.inputAlias. Outer coordinator GROUPBY reducers continue to
- * consume ordinary item rows.
+ * @param src_args    The reducer's parsed args (without the leading nargs).
+ * @param max_results Maximum permitted value for offset and count individually,
+ *                    and their sum must fit in a signed 64-bit integer.
+ * @param out_present Set to true iff a LIMIT triplet was found and valid.
+ * @param out_limit   Populated with the parsed values when *out_present is true.
+ * @param status      Receives a human-readable error on failure.
+ */
+bool parseCollectLimit(const ArgsCursor *src_args, uint64_t max_results, bool *out_present,
+                       CollectLimit *out_limit, QueryError *status);
+
+#ifdef __cplusplus
+}
+
+#include <string>
+
+/**
+ * Pre-computed shard-side LIMIT tokens, ready to slot into an objs_buf.
+ *
+ * The shard request rewrites `LIMIT offset count` to `LIMIT 0 (offset+count)`
+ * so the shard streams enough rows for the coordinator to apply the original
+ * window. Both members are decimal strings built by rewriteCollectLimit().
+ */
+struct ShardCollectLimit {
+  std::string offset;  // always "0"
+  std::string count;   // decimal of original_offset + original_count
+};
+
+/**
+ * Build a ShardCollectLimit from a validated CollectLimit.
+ * The result is safe to pass to buildRemoteCollectArgs().
+ */
+ShardCollectLimit rewriteCollectLimit(const CollectLimit *limit);
+
+/**
+ * Build COLLECT args for the coordinator-side (local) reducer.
+ *
+ * Layout: [nargs, original_args..., AS, user_alias].
  *
  * The local input source is not encoded in args; it is carried as planner
  * metadata and later resolved into ReducerOptions::input_key.
  *
- * @param objs_buf     Caller-provided buffer; size = collectObjsBufLen(src_args->argc, user_alias != NULL)
- * @param count_buf    Caller-formatted decimal string of `src_args->argc`. Lifetime
- *                     must outlive the returned ArgsCursor (typically a stack buffer
- *                     at the call site, sized to COLLECT_ARGS_COUNT_BUF_LEN).
- * @param src_args     The original reducer's parsed args (without the leading nargs)
- * @param user_alias   User-visible alias to preserve via AS, or NULL for remote args
+ * @param objs_buf    Caller-provided buffer;
+ *                    size = collectObjsBufLen(src_args->argc, true)
+ * @param count_buf   Caller-formatted decimal string of src_args->argc.
+ * @param src_args    The original reducer's parsed args (without leading nargs).
+ * @param user_alias  User-visible alias to preserve via AS.
  */
-ArgsCursor buildCollectArgs(void **objs_buf, const char *count_buf, const ArgsCursor *src_args,
-                            const char *user_alias);
+ArgsCursor buildLocalCollectArgs(void **objs_buf, const char *count_buf,
+                                 const ArgsCursor *src_args, const char *user_alias);
 
-#ifdef __cplusplus
-}
+/**
+ * Build COLLECT args for the shard-side (remote) reducer, optionally rewriting
+ * a pre-parsed LIMIT triplet to `LIMIT 0 (offset + count)`.
+ *
+ * Layout: [nargs, original_args...].
+ *
+ * If `rewrite` is non-NULL, scans `src_args` for the LIMIT keyword (case-
+ * insensitive) and patches the corresponding slots in `objs_buf` with
+ * `rewrite->offset.c_str()` and `rewrite->count.c_str()`. `rewrite` must
+ * outlive the returned ArgsCursor (i.e. until copyArgs() is called to
+ * deep-copy the strings into the plan's BlkAlloc).
+ *
+ * Precondition: if `rewrite` is non-NULL, `src_args` must contain a LIMIT
+ * keyword (guaranteed when the caller used parseCollectLimit() to detect it).
+ *
+ * @param objs_buf   Caller-provided buffer;
+ *                   size = collectObjsBufLen(src_args->argc, false)
+ * @param count_buf  Caller-formatted decimal string of src_args->argc.
+ * @param src_args   The original reducer's parsed args (without leading nargs).
+ * @param rewrite    Pre-computed shard-side LIMIT tokens, or NULL for no rewrite.
+ */
+ArgsCursor buildRemoteCollectArgs(void **objs_buf, const char *count_buf,
+                                  const ArgsCursor *src_args,
+                                  const ShardCollectLimit *rewrite);
+
 #endif

--- a/src/coord/dist_plan_utils.h
+++ b/src/coord/dist_plan_utils.h
@@ -64,26 +64,6 @@ bool parseCollectLimit(const ArgsCursor *src_args, uint64_t max_results, bool *o
 #ifdef __cplusplus
 }
 
-#include <string>
-
-/**
- * Pre-computed shard-side LIMIT tokens, ready to slot into an objs_buf.
- *
- * The shard request rewrites `LIMIT offset count` to `LIMIT 0 (offset+count)`
- * so the shard streams enough rows for the coordinator to apply the original
- * window. Both members are decimal strings built by rewriteCollectLimit().
- */
-struct ShardCollectLimit {
-  std::string offset;  // always "0"
-  std::string count;   // decimal of original_offset + original_count
-};
-
-/**
- * Build a ShardCollectLimit from a validated CollectLimit.
- * The result is safe to pass to buildRemoteCollectArgs().
- */
-ShardCollectLimit rewriteCollectLimit(const CollectLimit *limit);
-
 /**
  * Build COLLECT args for the coordinator-side (local) reducer.
  *
@@ -103,27 +83,26 @@ ArgsCursor buildLocalCollectArgs(void **objs_buf, const char *count_buf,
 
 /**
  * Build COLLECT args for the shard-side (remote) reducer, optionally rewriting
- * a pre-parsed LIMIT triplet to `LIMIT 0 (offset + count)`.
+ * a pre-parsed LIMIT triplet to `LIMIT 0 shard_count`.
  *
  * Layout: [nargs, original_args...].
  *
- * If `rewrite` is non-NULL, scans `src_args` for the LIMIT keyword (case-
- * insensitive) and patches the corresponding slots in `objs_buf` with
- * `rewrite->offset.c_str()` and `rewrite->count.c_str()`. `rewrite` must
- * outlive the returned ArgsCursor (i.e. until copyArgs() is called to
- * deep-copy the strings into the plan's BlkAlloc).
+ * If `shard_count` is non-NULL, scans `src_args` for the LIMIT keyword (case-
+ * insensitive) and patches the corresponding slots in `objs_buf` with the
+ * literal `"0"` and `shard_count`. The string pointed to by `shard_count` must
+ * outlive the plan (i.e. be allocated from the plan's BlkAlloc).
  *
- * Precondition: if `rewrite` is non-NULL, `src_args` must contain a LIMIT
+ * Precondition: if `shard_count` is non-NULL, `src_args` must contain a LIMIT
  * keyword (guaranteed when the caller used parseCollectLimit() to detect it).
  *
- * @param objs_buf   Caller-provided buffer;
- *                   size = collectObjsBufLen(src_args->argc, false)
- * @param count_buf  Caller-formatted decimal string of src_args->argc.
- * @param src_args   The original reducer's parsed args (without leading nargs).
- * @param rewrite    Pre-computed shard-side LIMIT tokens, or NULL for no rewrite.
+ * @param objs_buf    Caller-provided buffer;
+ *                    size = collectObjsBufLen(src_args->argc, false)
+ * @param count_buf   Caller-formatted decimal string of src_args->argc.
+ * @param src_args    The original reducer's parsed args (without leading nargs).
+ * @param shard_count Decimal string of (offset + count) to use as the shard-side
+ *                    LIMIT count, or NULL for no rewrite.
  */
 ArgsCursor buildRemoteCollectArgs(void **objs_buf, const char *count_buf,
-                                  const ArgsCursor *src_args,
-                                  const ShardCollectLimit *rewrite);
+                                  const ArgsCursor *src_args, const char *shard_count);
 
 #endif

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -72,7 +72,8 @@ void handleLimit(ArgParser *parser, const void *value, void *user_data) {
         // LIMIT 0 0 - only count
         REQFLAGS_AddFlags(ctx->reqFlags, QEXEC_F_NOROWS);
         REQFLAGS_AddFlags(ctx->reqFlags, QEXEC_F_SEND_NOFIELDS);
-    } else if (!ValidateLimitBounds(offset, num, *ctx->maxResults, *ctx->maxResults, status)) {
+    } else if (!ValidateLimitBounds(offset, num, MAX_AGGREGATE_REQUEST_RESULTS,
+                                    *ctx->maxResults, status)) {
         return;
     }
 

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -72,7 +72,7 @@ void handleLimit(ArgParser *parser, const void *value, void *user_data) {
         // LIMIT 0 0 - only count
         REQFLAGS_AddFlags(ctx->reqFlags, QEXEC_F_NOROWS);
         REQFLAGS_AddFlags(ctx->reqFlags, QEXEC_F_SEND_NOFIELDS);
-    } else if (!ValidateLimitBounds(offset, num, *ctx->maxResults, status)) {
+    } else if (!ValidateLimitBounds(offset, num, *ctx->maxResults, *ctx->maxResults, status)) {
         return;
     }
 

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -72,14 +72,7 @@ void handleLimit(ArgParser *parser, const void *value, void *user_data) {
         // LIMIT 0 0 - only count
         REQFLAGS_AddFlags(ctx->reqFlags, QEXEC_F_NOROWS);
         REQFLAGS_AddFlags(ctx->reqFlags, QEXEC_F_SEND_NOFIELDS);
-        // TODO: unify if when req holds only maxResults according to the query type.
-        //(SEARCH / AGGREGATE)
-    } else if (num > *ctx->maxResults) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "LIMIT exceeds maximum of %llu",
-                             *ctx->maxResults);
-        return;
-    } else if (offset > LLONG_MAX - num) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "LIMIT offset + count overflow");
+    } else if (!ValidateLimitBounds(offset, num, *ctx->maxResults, status)) {
         return;
     }
 

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -9,7 +9,10 @@
 #include "misc.h"
 #include <stdlib.h>
 #include <ctype.h>
+#include <limits.h>
 #include <string.h>
+
+#include "rmutil/rm_assert.h"
 
 void GenericAofRewrite_DisabledHandler(RedisModuleIO *aof, RedisModuleString *key, void *value) {
   RedisModule_Log(RedisModule_GetContextFromIO(aof), "error",
@@ -34,4 +37,23 @@ const char *ExtractKeyName(const char *s, size_t *len, QueryError *status, bool 
   } else {
     return s;
   }
+}
+
+bool ValidateLimitBounds(uint64_t offset, uint64_t count,
+                         uint64_t max_results, QueryError *status) {
+  // Precondition: see header. Guarantees `(uint64_t)LLONG_MAX - count`
+  // does not underflow in the overflow check below.
+  RS_ASSERT(max_results <= (uint64_t)LLONG_MAX);
+
+  if (offset > max_results || count > max_results) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
+        "LIMIT exceeds maximum of %llu", (unsigned long long)max_results);
+    return false;
+  }
+  if (offset > (uint64_t)LLONG_MAX - count) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+        "LIMIT offset + count overflow");
+    return false;
+  }
+  return true;
 }

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -40,21 +40,24 @@ const char *ExtractKeyName(const char *s, size_t *len, QueryError *status, bool 
 }
 
 bool ValidateLimitBounds(uint64_t offset, uint64_t count,
-                         uint64_t max_results, QueryError *status) {
-  // Precondition: see header. Guarantees `(uint64_t)LLONG_MAX - count`
-  // does not underflow in the overflow check below.
-  RS_ASSERT(max_results <= (uint64_t)LLONG_MAX);
+                         uint64_t max_offset, uint64_t max_count,
+                         QueryError *status) {
+  // Preconditions: see header. `max_count <= LLONG_MAX` guarantees that
+  // `(uint64_t)LLONG_MAX - count` does not underflow in the overflow check.
+  RS_ASSERT(max_offset <= (uint64_t)LLONG_MAX);
+  RS_ASSERT(max_count  <= (uint64_t)LLONG_MAX);
 
-  if (offset > max_results) {
+  if (offset > max_offset) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
-        "OFFSET exceeds maximum of %llu", (unsigned long long)max_results);
+        "OFFSET exceeds maximum of %llu", (unsigned long long)max_offset);
     return false;
   }
-  if (count > max_results) {
+  if (count > max_count) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
-        "LIMIT exceeds maximum of %llu", (unsigned long long)max_results);
+        "LIMIT exceeds maximum of %llu", (unsigned long long)max_count);
     return false;
   }
+  // count <= max_count <= LLONG_MAX, so the subtraction below cannot underflow.
   if (offset > (uint64_t)LLONG_MAX - count) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
         "LIMIT offset + count overflow");

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -45,7 +45,12 @@ bool ValidateLimitBounds(uint64_t offset, uint64_t count,
   // does not underflow in the overflow check below.
   RS_ASSERT(max_results <= (uint64_t)LLONG_MAX);
 
-  if (offset > max_results || count > max_results) {
+  if (offset > max_results) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
+        "OFFSET exceeds maximum of %llu", (unsigned long long)max_results);
+    return false;
+  }
+  if (count > max_results) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
         "LIMIT exceeds maximum of %llu", (unsigned long long)max_results);
     return false;

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -34,24 +34,26 @@ int GetRedisErrorCodeLength(const char* error);
 const char *ExtractKeyName(const char *s, size_t *len, QueryError *status, bool strictPrefix, const char *context);
 
 /**
- * Validate `(offset, count)` against `max_results` and check that
+ * Validate `(offset, count)` against independent caps and check that
  * `offset + count` does not overflow.
  *
- * Precondition: `max_results <= LLONG_MAX`. The overflow check below relies
- * on this so that `(uint64_t)LLONG_MAX - count` does not underflow when
- * `count > LLONG_MAX`. All current callers cap `max_results` at
+ * Precondition: both `max_offset` and `max_count` must be <= LLONG_MAX.
+ * The overflow check relies on `max_count <= LLONG_MAX` so that
+ * `(uint64_t)LLONG_MAX - count` does not underflow after the count guard
+ * passes. All current callers cap their maxima at
  * `MAX_AGGREGATE_REQUEST_RESULTS` (= 1ULL << 31), well within the bound.
- * Violation is asserted in debug builds.
+ * Violations are asserted in debug builds.
  *
  * On failure sets `*status` and returns false:
- *   - offset > max -> "OFFSET exceeds maximum of <max>"
+ *   - offset > max_offset -> "OFFSET exceeds maximum of <max_offset>"
  *     with QUERY_ERROR_CODE_LIMIT
- *   - count > max  -> "LIMIT exceeds maximum of <max>"
+ *   - count > max_count   -> "LIMIT exceeds maximum of <max_count>"
  *     with QUERY_ERROR_CODE_LIMIT
- *   - offset + count > LLONG_MAX  -> "LIMIT offset + count overflow"
+ *   - offset + count > LLONG_MAX -> "LIMIT offset + count overflow"
  *     with QUERY_ERROR_CODE_PARSE_ARGS
  */
 bool ValidateLimitBounds(uint64_t offset, uint64_t count,
-                         uint64_t max_results, QueryError *status);
+                         uint64_t max_offset, uint64_t max_count,
+                         QueryError *status);
 
 #endif

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -44,7 +44,9 @@ const char *ExtractKeyName(const char *s, size_t *len, QueryError *status, bool 
  * Violation is asserted in debug builds.
  *
  * On failure sets `*status` and returns false:
- *   - offset > max OR count > max -> "LIMIT exceeds maximum of <max>"
+ *   - offset > max -> "OFFSET exceeds maximum of <max>"
+ *     with QUERY_ERROR_CODE_LIMIT
+ *   - count > max  -> "LIMIT exceeds maximum of <max>"
  *     with QUERY_ERROR_CODE_LIMIT
  *   - offset + count > LLONG_MAX  -> "LIMIT offset + count overflow"
  *     with QUERY_ERROR_CODE_PARSE_ARGS

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -9,6 +9,9 @@
 #ifndef RS_MISC_H
 #define RS_MISC_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "redismodule.h"
 #include "query_error.h"
 
@@ -29,5 +32,24 @@ int GetRedisErrorCodeLength(const char* error);
  * @return The key name, or NULL if an error occurred
  */
 const char *ExtractKeyName(const char *s, size_t *len, QueryError *status, bool strictPrefix, const char *context);
+
+/**
+ * Validate `(offset, count)` against `max_results` and check that
+ * `offset + count` does not overflow.
+ *
+ * Precondition: `max_results <= LLONG_MAX`. The overflow check below relies
+ * on this so that `(uint64_t)LLONG_MAX - count` does not underflow when
+ * `count > LLONG_MAX`. All current callers cap `max_results` at
+ * `MAX_AGGREGATE_REQUEST_RESULTS` (= 1ULL << 31), well within the bound.
+ * Violation is asserted in debug builds.
+ *
+ * On failure sets `*status` and returns false:
+ *   - offset > max OR count > max -> "LIMIT exceeds maximum of <max>"
+ *     with QUERY_ERROR_CODE_LIMIT
+ *   - offset + count > LLONG_MAX  -> "LIMIT offset + count overflow"
+ *     with QUERY_ERROR_CODE_PARSE_ARGS
+ */
+bool ValidateLimitBounds(uint64_t offset, uint64_t count,
+                         uint64_t max_results, QueryError *status);
 
 #endif

--- a/tests/cpptests/coord_tests/test_cpp_dist_plan_utils.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_dist_plan_utils.cpp
@@ -10,9 +10,9 @@
 #include "gtest/gtest.h"
 #include "dist_plan_utils.h"
 
-#include <array>
 #include <initializer_list>
 #include <string>
+#include <vector>
 
 static ArgsCursor makeArgs(const char **argv, size_t argc) {
   ArgsCursor ac;
@@ -23,140 +23,98 @@ static ArgsCursor makeArgs(const char **argv, size_t argc) {
   return ac;
 }
 
-static void assertArgs(const ArgsCursor& out, std::initializer_list<const char*> expected) {
+static void assertArgs(const ArgsCursor &out, std::initializer_list<const char *> expected) {
   ASSERT_EQ(out.argc, expected.size());
-
   size_t i = 0;
-  for (const char* arg : expected) {
-    ASSERT_STREQ((const char*)out.objs[i], arg) << "objs[" << i << "]";
+  for (const char *arg : expected) {
+    ASSERT_STREQ((const char *)out.objs[i], arg) << "objs[" << i << "]";
     i++;
   }
 }
 
-// --- buildRemoteCollectArgs (no rewrite) ---
+static ArgsCursor callRemote(std::vector<void *> &objs, std::string &countStr,
+                              const ArgsCursor &src, const ShardCollectLimit *rewrite) {
+  countStr = std::to_string(src.argc);
+  objs.assign(collectObjsBufLen(src.argc, /*has_alias=*/false), nullptr);
+  return buildRemoteCollectArgs(objs.data(), countStr.c_str(), &src, rewrite);
+}
 
-TEST(DistPlanUtils, RemoteCollectArgs_FieldsOnly) {
+static ArgsCursor callLocal(std::vector<void *> &objs, std::string &countStr,
+                             const ArgsCursor &src, const char *alias) {
+  countStr = std::to_string(src.argc);
+  objs.assign(collectObjsBufLen(src.argc, /*has_alias=*/true), nullptr);
+  return buildLocalCollectArgs(objs.data(), countStr.c_str(), &src, alias);
+}
+
+// --- Full distribution cycle ---
+
+TEST(DistPlanUtils, Collect_DistributeWithLimit) {
+  // Full cycle: parse → rewrite → build shard args.
+  // offset=5, count=10 → shard gets LIMIT 0 15.
+  const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "5", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 10);
+
+  bool hasLimit;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+  ASSERT_TRUE(parseCollectLimit(&srcArgs, 1000, &hasLimit, &limit, &status));
+  ASSERT_TRUE(hasLimit);
+
+  ShardCollectLimit shardLimit = rewriteCollectLimit(&limit);
+  std::vector<void *> objs;
+  std::string countStr;
+  ArgsCursor out = callRemote(objs, countStr, srcArgs, &shardLimit);
+
+  assertArgs(out,
+             {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "15"});
+}
+
+TEST(DistPlanUtils, Collect_DistributeNoLimit) {
+  // No LIMIT in src args → parseCollectLimit returns false, shard args pass through unchanged.
   const char *src[] = {"FIELDS", "2", "@a", "@b"};
   ArgsCursor srcArgs = makeArgs(src, 4);
 
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 5> objs;  // collectObjsBufLen(4, /*has_alias=*/false)
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
+  bool hasLimit;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+  ASSERT_TRUE(parseCollectLimit(&srcArgs, 1000, &hasLimit, &limit, &status));
+  ASSERT_FALSE(hasLimit);
 
-  ASSERT_EQ(out.offset, 0u);
-  ASSERT_EQ(out.type, AC_TYPE_CHAR);
+  std::vector<void *> objs;
+  std::string countStr;
+  ArgsCursor out = callRemote(objs, countStr, srcArgs, nullptr);
+
   assertArgs(out, {"4", "FIELDS", "2", "@a", "@b"});
-}
-
-TEST(DistPlanUtils, RemoteCollectArgs_FieldsSortbyLimit) {
-  const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 10);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 11> objs;  // collectObjsBufLen(10, /*has_alias=*/false)
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
-
-  assertArgs(out, {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0",
-                   "10"});
-  for (size_t i = 0; i < 10; i++) {
-    ASSERT_EQ(out.objs[i + 1], srcArgs.objs[i])
-        << "objs[" << i + 1 << "] should point to src_args element " << i;
+  // Forwarded args point directly into srcArgs (no copy).
+  for (size_t i = 0; i < 4; i++) {
+    ASSERT_EQ(out.objs[i + 1], srcArgs.objs[i]);
   }
-}
-
-TEST(DistPlanUtils, RemoteCollectArgs_EmptyArgs) {
-  ArgsCursor srcArgs = makeArgs(nullptr, 0);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 1> objs;  // collectObjsBufLen(0, /*has_alias=*/false)
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
-
-  assertArgs(out, {"0"});
 }
 
 // --- buildLocalCollectArgs ---
 
-TEST(DistPlanUtils, LocalCollectArgs_FieldsOnly) {
+TEST(DistPlanUtils, LocalCollectArgs_Basic) {
   const char *src[] = {"FIELDS", "2", "@a", "@b"};
   ArgsCursor srcArgs = makeArgs(src, 4);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 7> objs;  // collectObjsBufLen(4, /*has_alias=*/true)
-  ArgsCursor out = buildLocalCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "my_collect");
+  std::vector<void *> objs;
+  std::string countStr;
+  ArgsCursor out = callLocal(objs, countStr, srcArgs, "my_collect");
 
   ASSERT_EQ(out.offset, 0u);
   ASSERT_EQ(out.type, AC_TYPE_CHAR);
   assertArgs(out, {"4", "FIELDS", "2", "@a", "@b", "AS", "my_collect"});
 }
 
-TEST(DistPlanUtils, LocalCollectArgs_FieldsSortbyLimit) {
-  const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 10);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 13> objs;  // collectObjsBufLen(10, /*has_alias=*/true)
-  ArgsCursor out = buildLocalCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "user_alias");
-
-  assertArgs(out, {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0",
-                   "10", "AS", "user_alias"});
-
-  // Original args forwarded in order
-  for (size_t i = 0; i < 10; i++) {
-    ASSERT_EQ(out.objs[i + 1], srcArgs.objs[i])
-        << "objs[" << i + 1 << "] should point to src_args element " << i;
-  }
-}
-
-TEST(DistPlanUtils, LocalCollectArgs_EmptyOriginalArgs) {
+TEST(DistPlanUtils, LocalCollectArgs_EmptyArgs) {
   ArgsCursor srcArgs = makeArgs(nullptr, 0);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 3> objs;  // collectObjsBufLen(0, /*has_alias=*/true)
-  ArgsCursor out = buildLocalCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "ua");
+  std::vector<void *> objs;
+  std::string countStr;
+  ArgsCursor out = callLocal(objs, countStr, srcArgs, "ua");
 
   assertArgs(out, {"0", "AS", "ua"});
 }
 
-// --- parseCollectLimit ---
-
-TEST(DistPlanUtils, ParseCollectLimit_NoLimitKeyword) {
-  const char *src[] = {"FIELDS", "1", "@x"};
-  ArgsCursor srcArgs = makeArgs(src, 3);
-  bool present = true;
-  CollectLimit limit{};
-  QueryError status = QueryError_Default();
-
-  ASSERT_TRUE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
-  ASSERT_FALSE(present);
-  ASSERT_FALSE(QueryError_HasError(&status));
-}
-
-TEST(DistPlanUtils, ParseCollectLimit_Valid) {
-  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 6);
-  bool present = false;
-  CollectLimit limit{};
-  QueryError status = QueryError_Default();
-
-  ASSERT_TRUE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
-  ASSERT_TRUE(present);
-  ASSERT_EQ(limit.offset, 5u);
-  ASSERT_EQ(limit.count, 10u);
-  ASSERT_FALSE(QueryError_HasError(&status));
-}
-
-TEST(DistPlanUtils, ParseCollectLimit_ValidOffsetZero) {
-  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 6);
-  bool present = false;
-  CollectLimit limit{};
-  QueryError status = QueryError_Default();
-
-  ASSERT_TRUE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
-  ASSERT_TRUE(present);
-  ASSERT_EQ(limit.offset, 0u);
-  ASSERT_EQ(limit.count, 10u);
-}
+// --- parseCollectLimit error paths ---
 
 TEST(DistPlanUtils, ParseCollectLimit_ExceedsMax) {
   const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "200"};
@@ -166,7 +124,6 @@ TEST(DistPlanUtils, ParseCollectLimit_ExceedsMax) {
   QueryError status = QueryError_Default();
 
   ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
-  ASSERT_TRUE(QueryError_HasError(&status));
   ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_LIMIT);
   ASSERT_NE(strstr(QueryError_GetUserError(&status), "LIMIT exceeds maximum of 100"), nullptr);
   QueryError_ClearError(&status);
@@ -180,13 +137,11 @@ TEST(DistPlanUtils, ParseCollectLimit_MalformedNumber) {
   QueryError status = QueryError_Default();
 
   ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
-  ASSERT_TRUE(QueryError_HasError(&status));
   ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS);
   QueryError_ClearError(&status);
 }
 
 TEST(DistPlanUtils, ParseCollectLimit_CountZeroRejected) {
-  // AC_F_GE1 on count means 0 is invalid.
   const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "0"};
   ArgsCursor srcArgs = makeArgs(src, 6);
   bool present = false;
@@ -199,7 +154,6 @@ TEST(DistPlanUtils, ParseCollectLimit_CountZeroRejected) {
 }
 
 TEST(DistPlanUtils, ParseCollectLimit_Truncated) {
-  // Only one token after LIMIT — AC_GetSlice returns AC_ERR_NOARG.
   const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5"};
   ArgsCursor srcArgs = makeArgs(src, 5);
   bool present = false;
@@ -207,79 +161,6 @@ TEST(DistPlanUtils, ParseCollectLimit_Truncated) {
   QueryError status = QueryError_Default();
 
   ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
-  ASSERT_TRUE(QueryError_HasError(&status));
   ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS);
   QueryError_ClearError(&status);
 }
-
-// --- buildRemoteCollectArgs ---
-
-TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimitAtStart) {
-  // LIMIT is the very first token — scan must start at i=0 to find it.
-  const char *src[] = {"LIMIT", "5", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 3);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 4> objs;  // collectObjsBufLen(3, /*has_alias=*/false)
-  ShardCollectLimit rewrite{"0", "15"};
-
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
-  assertArgs(out, {"3", "LIMIT", "0", "15"});
-}
-
-TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimit) {
-  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 6);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 7> objs;  // collectObjsBufLen(6, /*has_alias=*/false)
-  ShardCollectLimit rewrite{"0", "15"};
-
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
-  assertArgs(out, {"6", "FIELDS", "1", "@x", "LIMIT", "0", "15"});
-}
-
-TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimitOffsetZero) {
-  // offset=0 + count=10 -> "0" + "10" (no-op rewrite, but path still exercised)
-  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 6);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 7> objs;
-  ShardCollectLimit rewrite{"0", "10"};
-
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
-  assertArgs(out, {"6", "FIELDS", "1", "@x", "LIMIT", "0", "10"});
-}
-
-TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimitWithSortby) {
-  // LIMIT appears after SORTBY; the scan must still find and patch it.
-  const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "5", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 10);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 11> objs;  // collectObjsBufLen(10, /*has_alias=*/false)
-  ShardCollectLimit rewrite{"0", "15"};
-
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
-  assertArgs(out, {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "15"});
-}
-
-TEST(DistPlanUtils, BuildRemoteCollectArgs_NullRewriteNoChange) {
-  // nullptr rewrite -> tokens forwarded verbatim, original LIMIT values preserved.
-  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5", "10"};
-  ArgsCursor srcArgs = makeArgs(src, 6);
-
-  std::string countStr = std::to_string(srcArgs.argc);
-  std::array<void *, 7> objs;
-
-  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
-  // Tokens are forwarded verbatim; original LIMIT values preserved.
-  assertArgs(out, {"6", "FIELDS", "1", "@x", "LIMIT", "5", "10"});
-  // Pointers alias src_args.
-  for (size_t i = 0; i < 6; i++) {
-    ASSERT_EQ(out.objs[i + 1], srcArgs.objs[i])
-        << "objs[" << i + 1 << "] should alias src_args.objs[" << i << "]";
-  }
-}
-

--- a/tests/cpptests/coord_tests/test_cpp_dist_plan_utils.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_dist_plan_utils.cpp
@@ -33,10 +33,10 @@ static void assertArgs(const ArgsCursor &out, std::initializer_list<const char *
 }
 
 static ArgsCursor callRemote(std::vector<void *> &objs, std::string &countStr,
-                              const ArgsCursor &src, const ShardCollectLimit *rewrite) {
+                              const ArgsCursor &src, const char *shard_count) {
   countStr = std::to_string(src.argc);
   objs.assign(collectObjsBufLen(src.argc, /*has_alias=*/false), nullptr);
-  return buildRemoteCollectArgs(objs.data(), countStr.c_str(), &src, rewrite);
+  return buildRemoteCollectArgs(objs.data(), countStr.c_str(), &src, shard_count);
 }
 
 static ArgsCursor callLocal(std::vector<void *> &objs, std::string &countStr,
@@ -60,10 +60,10 @@ TEST(DistPlanUtils, Collect_DistributeWithLimit) {
   ASSERT_TRUE(parseCollectLimit(&srcArgs, 1000, &hasLimit, &limit, &status));
   ASSERT_TRUE(hasLimit);
 
-  ShardCollectLimit shardLimit = rewriteCollectLimit(&limit);
+  std::string shardCountStr = std::to_string(limit.offset + limit.count);
   std::vector<void *> objs;
   std::string countStr;
-  ArgsCursor out = callRemote(objs, countStr, srcArgs, &shardLimit);
+  ArgsCursor out = callRemote(objs, countStr, srcArgs, shardCountStr.c_str());
 
   assertArgs(out,
              {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "15"});

--- a/tests/cpptests/coord_tests/test_cpp_dist_plan_utils.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_dist_plan_utils.cpp
@@ -33,28 +33,28 @@ static void assertArgs(const ArgsCursor& out, std::initializer_list<const char*>
   }
 }
 
-// --- buildCollectArgs remote ---
+// --- buildRemoteCollectArgs (no rewrite) ---
 
-TEST(DistPlanUtils, ShardCollectArgs_FieldsOnly) {
+TEST(DistPlanUtils, RemoteCollectArgs_FieldsOnly) {
   const char *src[] = {"FIELDS", "2", "@a", "@b"};
   ArgsCursor srcArgs = makeArgs(src, 4);
 
   std::string countStr = std::to_string(srcArgs.argc);
   std::array<void *, 5> objs;  // collectObjsBufLen(4, /*has_alias=*/false)
-  ArgsCursor out = buildCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
 
   ASSERT_EQ(out.offset, 0u);
   ASSERT_EQ(out.type, AC_TYPE_CHAR);
   assertArgs(out, {"4", "FIELDS", "2", "@a", "@b"});
 }
 
-TEST(DistPlanUtils, ShardCollectArgs_FieldsSortbyLimit) {
+TEST(DistPlanUtils, RemoteCollectArgs_FieldsSortbyLimit) {
   const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "10"};
   ArgsCursor srcArgs = makeArgs(src, 10);
 
   std::string countStr = std::to_string(srcArgs.argc);
   std::array<void *, 11> objs;  // collectObjsBufLen(10, /*has_alias=*/false)
-  ArgsCursor out = buildCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
 
   assertArgs(out, {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0",
                    "10"});
@@ -64,38 +64,38 @@ TEST(DistPlanUtils, ShardCollectArgs_FieldsSortbyLimit) {
   }
 }
 
-TEST(DistPlanUtils, ShardCollectArgs_EmptyArgs) {
+TEST(DistPlanUtils, RemoteCollectArgs_EmptyArgs) {
   ArgsCursor srcArgs = makeArgs(nullptr, 0);
 
   std::string countStr = std::to_string(srcArgs.argc);
   std::array<void *, 1> objs;  // collectObjsBufLen(0, /*has_alias=*/false)
-  ArgsCursor out = buildCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
 
   assertArgs(out, {"0"});
 }
 
-// --- buildCollectArgs local ---
+// --- buildLocalCollectArgs ---
 
-TEST(DistPlanUtils, CoordCollectArgs_FieldsOnly) {
+TEST(DistPlanUtils, LocalCollectArgs_FieldsOnly) {
   const char *src[] = {"FIELDS", "2", "@a", "@b"};
   ArgsCursor srcArgs = makeArgs(src, 4);
 
   std::string countStr = std::to_string(srcArgs.argc);
   std::array<void *, 7> objs;  // collectObjsBufLen(4, /*has_alias=*/true)
-  ArgsCursor out = buildCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "my_collect");
+  ArgsCursor out = buildLocalCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "my_collect");
 
   ASSERT_EQ(out.offset, 0u);
   ASSERT_EQ(out.type, AC_TYPE_CHAR);
   assertArgs(out, {"4", "FIELDS", "2", "@a", "@b", "AS", "my_collect"});
 }
 
-TEST(DistPlanUtils, CoordCollectArgs_FieldsSortbyLimit) {
+TEST(DistPlanUtils, LocalCollectArgs_FieldsSortbyLimit) {
   const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "10"};
   ArgsCursor srcArgs = makeArgs(src, 10);
 
   std::string countStr = std::to_string(srcArgs.argc);
   std::array<void *, 13> objs;  // collectObjsBufLen(10, /*has_alias=*/true)
-  ArgsCursor out = buildCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "user_alias");
+  ArgsCursor out = buildLocalCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "user_alias");
 
   assertArgs(out, {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0",
                    "10", "AS", "user_alias"});
@@ -107,12 +107,179 @@ TEST(DistPlanUtils, CoordCollectArgs_FieldsSortbyLimit) {
   }
 }
 
-TEST(DistPlanUtils, CoordCollectArgs_EmptyOriginalArgs) {
+TEST(DistPlanUtils, LocalCollectArgs_EmptyOriginalArgs) {
   ArgsCursor srcArgs = makeArgs(nullptr, 0);
 
   std::string countStr = std::to_string(srcArgs.argc);
   std::array<void *, 3> objs;  // collectObjsBufLen(0, /*has_alias=*/true)
-  ArgsCursor out = buildCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "ua");
+  ArgsCursor out = buildLocalCollectArgs(objs.data(), countStr.c_str(), &srcArgs, "ua");
 
   assertArgs(out, {"0", "AS", "ua"});
 }
+
+// --- parseCollectLimit ---
+
+TEST(DistPlanUtils, ParseCollectLimit_NoLimitKeyword) {
+  const char *src[] = {"FIELDS", "1", "@x"};
+  ArgsCursor srcArgs = makeArgs(src, 3);
+  bool present = true;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_TRUE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_FALSE(present);
+  ASSERT_FALSE(QueryError_HasError(&status));
+}
+
+TEST(DistPlanUtils, ParseCollectLimit_Valid) {
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+  bool present = false;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_TRUE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_TRUE(present);
+  ASSERT_EQ(limit.offset, 5u);
+  ASSERT_EQ(limit.count, 10u);
+  ASSERT_FALSE(QueryError_HasError(&status));
+}
+
+TEST(DistPlanUtils, ParseCollectLimit_ValidOffsetZero) {
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+  bool present = false;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_TRUE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_TRUE(present);
+  ASSERT_EQ(limit.offset, 0u);
+  ASSERT_EQ(limit.count, 10u);
+}
+
+TEST(DistPlanUtils, ParseCollectLimit_ExceedsMax) {
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "200"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+  bool present = false;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_TRUE(QueryError_HasError(&status));
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_LIMIT);
+  ASSERT_NE(strstr(QueryError_GetUserError(&status), "LIMIT exceeds maximum of 100"), nullptr);
+  QueryError_ClearError(&status);
+}
+
+TEST(DistPlanUtils, ParseCollectLimit_MalformedNumber) {
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "abc", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+  bool present = false;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_TRUE(QueryError_HasError(&status));
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS);
+  QueryError_ClearError(&status);
+}
+
+TEST(DistPlanUtils, ParseCollectLimit_CountZeroRejected) {
+  // AC_F_GE1 on count means 0 is invalid.
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "0"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+  bool present = false;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_TRUE(QueryError_HasError(&status));
+  QueryError_ClearError(&status);
+}
+
+TEST(DistPlanUtils, ParseCollectLimit_Truncated) {
+  // Only one token after LIMIT — AC_GetSlice returns AC_ERR_NOARG.
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5"};
+  ArgsCursor srcArgs = makeArgs(src, 5);
+  bool present = false;
+  CollectLimit limit{};
+  QueryError status = QueryError_Default();
+
+  ASSERT_FALSE(parseCollectLimit(&srcArgs, 100, &present, &limit, &status));
+  ASSERT_TRUE(QueryError_HasError(&status));
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS);
+  QueryError_ClearError(&status);
+}
+
+// --- buildRemoteCollectArgs ---
+
+TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimitAtStart) {
+  // LIMIT is the very first token — scan must start at i=0 to find it.
+  const char *src[] = {"LIMIT", "5", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 3);
+
+  std::string countStr = std::to_string(srcArgs.argc);
+  std::array<void *, 4> objs;  // collectObjsBufLen(3, /*has_alias=*/false)
+  ShardCollectLimit rewrite{"0", "15"};
+
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
+  assertArgs(out, {"3", "LIMIT", "0", "15"});
+}
+
+TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimit) {
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+
+  std::string countStr = std::to_string(srcArgs.argc);
+  std::array<void *, 7> objs;  // collectObjsBufLen(6, /*has_alias=*/false)
+  ShardCollectLimit rewrite{"0", "15"};
+
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
+  assertArgs(out, {"6", "FIELDS", "1", "@x", "LIMIT", "0", "15"});
+}
+
+TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimitOffsetZero) {
+  // offset=0 + count=10 -> "0" + "10" (no-op rewrite, but path still exercised)
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "0", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+
+  std::string countStr = std::to_string(srcArgs.argc);
+  std::array<void *, 7> objs;
+  ShardCollectLimit rewrite{"0", "10"};
+
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
+  assertArgs(out, {"6", "FIELDS", "1", "@x", "LIMIT", "0", "10"});
+}
+
+TEST(DistPlanUtils, BuildRemoteCollectArgs_RewritesLimitWithSortby) {
+  // LIMIT appears after SORTBY; the scan must still find and patch it.
+  const char *src[] = {"FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "5", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 10);
+
+  std::string countStr = std::to_string(srcArgs.argc);
+  std::array<void *, 11> objs;  // collectObjsBufLen(10, /*has_alias=*/false)
+  ShardCollectLimit rewrite{"0", "15"};
+
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, &rewrite);
+  assertArgs(out, {"10", "FIELDS", "1", "@x", "SORTBY", "2", "@x", "ASC", "LIMIT", "0", "15"});
+}
+
+TEST(DistPlanUtils, BuildRemoteCollectArgs_NullRewriteNoChange) {
+  // nullptr rewrite -> tokens forwarded verbatim, original LIMIT values preserved.
+  const char *src[] = {"FIELDS", "1", "@x", "LIMIT", "5", "10"};
+  ArgsCursor srcArgs = makeArgs(src, 6);
+
+  std::string countStr = std::to_string(srcArgs.argc);
+  std::array<void *, 7> objs;
+
+  ArgsCursor out = buildRemoteCollectArgs(objs.data(), countStr.c_str(), &srcArgs, nullptr);
+  // Tokens are forwarded verbatim; original LIMIT values preserved.
+  assertArgs(out, {"6", "FIELDS", "1", "@x", "LIMIT", "5", "10"});
+  // Pointers alias src_args.
+  for (size_t i = 0; i < 6; i++) {
+    ASSERT_EQ(out.objs[i + 1], srcArgs.objs[i])
+        << "objs[" << i + 1 << "] should alias src_args.objs[" << i << "]";
+  }
+}
+

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -583,12 +583,12 @@ TEST_F(CollectParserTest, LimitCountExceedsAggregateMax) {
   std::string count =
       std::to_string(static_cast<unsigned long long>(MAX_AGGREGATE_REQUEST_RESULTS) + 1ULL);
   expectError({"FIELDS", "1", "@x", "LIMIT", "0", count.c_str()},
-      "LIMIT count exceeds maximum of");
+      "LIMIT exceeds maximum of");
 }
 
 TEST_F(CollectParserTest, LimitOffsetExceedsAggregateMax) {
   registerKeys({"x"});
   expectError({"FIELDS", "1", "@x", "LIMIT", "9999999999", "10"},
-      "LIMIT offset exceeds maximum of");
+      "LIMIT exceeds maximum of");
 }
 

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -589,6 +589,6 @@ TEST_F(CollectParserTest, LimitCountExceedsAggregateMax) {
 TEST_F(CollectParserTest, LimitOffsetExceedsAggregateMax) {
   registerKeys({"x"});
   expectError({"FIELDS", "1", "@x", "LIMIT", "9999999999", "10"},
-      "LIMIT exceeds maximum of");
+      "OFFSET exceeds maximum of");
 }
 


### PR DESCRIPTION
`COLLECT`'s `LIMIT OFFSET COUNT` clause was parsed but never applied in the distributed path, and shards received the original `OFFSET COUNT` unchanged - meaning they wouldn't stream enough rows for the coordinator to apply the correct window.

Changes:

- Add `ValidateLimitBounds` utility (`src/util/misc.c/.h`) for consistent `LIMIT` validation across the codebase
- Add `parseCollectLimit` to validate at distribute-time and detect the `LIMIT` clause; the rewrite `(OFFSET, COUNT) → (0, OFFSET+COUNT)` is computed inline in `distributeCollect` and persisted in the plan's `BlkAlloc` to avoid a use-after-free
- Replace `buildCollectArgs` with `buildLocalCollectArgs` / `buildRemoteCollectArgs` - self-contained, clearly-named functions

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed query planning and LIMIT validation, which can change result windows and error behavior for `FT.AGGREGATE`/hybrid queries. Risk is moderate due to potential off-by-one/overflow or compatibility changes in LIMIT error messages.
> 
> **Overview**
> Fixes a distributed-planning bug where `COLLECT ... LIMIT offset count` was forwarded to shards unchanged, causing shards to return too few rows for the coordinator to apply the requested window.
> 
> This introduces a shared `ValidateLimitBounds()` helper and switches multiple LIMIT parsers to use it, then updates `distributeCollect()` to pre-parse COLLECT’s LIMIT and rewrite shard args to `LIMIT 0 (offset+count)` using plan-owned storage. The coordinator/shard arg construction is also split into clearer `buildLocalCollectArgs()` and `buildRemoteCollectArgs()`, with new unit tests covering the rewrite and validation/error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062c6407eaf66a26ab829ee0e7d08e72f524e290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->