### PR TITLE
protect clang compile option

### DIFF
--- a/tests/cpptests/micro-benchmarks/CMakeLists.txt
+++ b/tests/cpptests/micro-benchmarks/CMakeLists.txt
@@ -26,9 +26,12 @@ include_directories("${googlebench_SOURCE_DIR}/include")
 # being standardized in C2y (the C standard after C23). googlebench uses -pedantic-errors
 # and -Werror, turning this into a fatal error. __COUNTER__ has been a de facto compiler
 # extension so is fine to use it, but we need to suppress the warning now that clang 22+
-# is more strict.
-target_compile_options(benchmark PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>)
-target_compile_options(benchmark_main PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>)
+# is more strict. Earlier clang versions don't know -Wno-c2y-extensions, so we also pass
+# -Wno-unknown-warning-option to keep the unknown-flag diagnostic from being fatal there.
+target_compile_options(benchmark PRIVATE
+  $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-warning-option -Wno-c2y-extensions>)
+target_compile_options(benchmark_main PRIVATE
+  $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-warning-option -Wno-c2y-extensions>)
 
 file(GLOB BENCHMARK_ITER_SOURCES "benchmark_*_iterator.cpp")
 foreach(benchmark_file ${BENCHMARK_ITER_SOURCES})


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `tests/cpptests/micro-benchmarks/CMakeLists.txt` passes `-Wno-c2y-extensions` to googlebench targets to silence the new clang 22+ warning about `__COUNTER__`. Earlier clang versions don't recognize this flag and, combined with googlebench's `-Werror -pedantic-errors`, fail the build with `error: unknown warning option '-Wno-c2y-extensions' [-Werror,-Wunknown-warning-option]`.
2. **Change**: Also pass `-Wno-unknown-warning-option` ahead of `-Wno-c2y-extensions` so older clang versions silently ignore the unrecognized flag instead of erroring out.
3. **Outcome**: The googlebench targets build cleanly across the clang versions we support: clang 22+ keeps the `-Wc2y-extensions` warning suppressed, while older clang versions no longer fail on the unknown flag.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `tests/cpptests/micro-benchmarks/CMakeLists.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes