### PR TITLE
[8.6-rse] MOD-14678: Print profile according to iterator type

### DIFF
--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -42,40 +42,50 @@ static void printInvIdxIteratorCounters(RedisModule_Reply *reply, const QueryIte
 }
 
 void printInvIdxIt(RedisModule_Reply *reply, const QueryIterator *root, const ProfileCounters *counters, double cpuTime, PrintProfileConfig *config) {
-  const InvIndIterator *it = (const InvIndIterator *)root;
-  IndexFlags readerFlags = InvIndIterator_GetReaderFlags(it);
-
   RedisModule_Reply_Map(reply);
-  if (readerFlags == Index_DocIdsOnly) {
-    RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
-    if (term != NULL) {
-      printProfileType("TAG");
+
+  switch (root->type) {
+    case INV_IDX_TAG_ITERATOR: {
+      RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
+      if (term != NULL) {
+        printProfileType("TAG");
+        size_t term_len = 0;
+        const char *term_str = QueryTerm_GetStrAndLen(term, &term_len);
+        RedisModule_ReplyKV_StringBuffer(reply, "Term", term_str, term_len);
+      }
+      break;
+    }
+
+    case INV_IDX_NUMERIC_ITERATOR: {
+      const NumericInvIndIterator *numIt = (const NumericInvIndIterator *)root;
+      const NumericFilter *flt = NumericInvIndIterator_GetNumericFilter(numIt);
+      if (!flt || flt->geoFilter == NULL) {
+        printProfileType("NUMERIC");
+        RedisModule_Reply_SimpleString(reply, "Term");
+        RedisModule_Reply_SimpleStringf(reply, "%g - %g", NumericInvIndIterator_GetProfileRangeMin(numIt), NumericInvIndIterator_GetProfileRangeMax(numIt));
+      } else {
+        printProfileType("GEO");
+        RedisModule_Reply_SimpleString(reply, "Term");
+        double se[2];
+        double nw[2];
+        decodeGeo(NumericInvIndIterator_GetProfileRangeMin(numIt), se);
+        decodeGeo(NumericInvIndIterator_GetProfileRangeMax(numIt), nw);
+        RedisModule_Reply_SimpleStringf(reply, "%g,%g - %g,%g", se[0], se[1], nw[0], nw[1]);
+      }
+      break;
+    }
+
+    case INV_IDX_TERM_ITERATOR: {
+      printProfileType("TEXT");
+      RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
       size_t term_len = 0;
       const char *term_str = QueryTerm_GetStrAndLen(term, &term_len);
       RedisModule_ReplyKV_StringBuffer(reply, "Term", term_str, term_len);
+      break;
     }
-  } else if (readerFlags & Index_StoreNumeric) {
-    const NumericInvIndIterator *numIt = (const NumericInvIndIterator *)it;
-    const NumericFilter *flt = NumericInvIndIterator_GetNumericFilter(numIt);
-    if (!flt || flt->geoFilter == NULL) {
-      printProfileType("NUMERIC");
-      RedisModule_Reply_SimpleString(reply, "Term");
-      RedisModule_Reply_SimpleStringf(reply, "%g - %g", NumericInvIndIterator_GetProfileRangeMin(numIt), NumericInvIndIterator_GetProfileRangeMax(numIt));
-    } else {
-      printProfileType("GEO");
-      RedisModule_Reply_SimpleString(reply, "Term");
-      double se[2];
-      double nw[2];
-      decodeGeo(NumericInvIndIterator_GetProfileRangeMin(numIt), se);
-      decodeGeo(NumericInvIndIterator_GetProfileRangeMax(numIt), nw);
-      RedisModule_Reply_SimpleStringf(reply, "%g,%g - %g,%g", se[0], se[1], nw[0], nw[1]);
-    }
-  } else {
-    printProfileType("TEXT");
-    RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
-    size_t term_len = 0;
-    const char *term_str = QueryTerm_GetStrAndLen(term, &term_len);
-    RedisModule_ReplyKV_StringBuffer(reply, "Term", term_str, term_len);
+
+    default:
+      RS_ABORT("unsupported inverted index iterator type");
   }
 
   printInvIdxIteratorCounters(reply, root, counters, cpuTime, config);


### PR DESCRIPTION
# Description
Backport of #9114 to `8.6-rse`.

The cherry-pick had a conflict in `src/profile/profile.c` because `8.6-rse` already includes intermediate refactors that changed the helper signatures (`NumericInvIndIterator_GetNumericFilter`, `NumericInvIndIterator_GetProfileRangeMin/Max` take `NumericInvIndIterator *` rather than `QueryIterator *`). Resolved by keeping the original PR's switch-on-`root->type` structure and adding a `(const NumericInvIndIterator *)root` cast in the `INV_IDX_NUMERIC_ITERATOR` arm. Logic is otherwise identical to the original commit.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only profiling output formatting/branching for inverted-index iterators, with no query execution or data-path modifications; main risk is unexpected `root->type` values triggering the new abort.
> 
> **Overview**
> Updates inverted-index iterator profiling (`printInvIdxIt`) to branch on `root->type` instead of reader flags, ensuring TAG/TEXT/NUMERIC/GEO iterators print the correct profile type and term/range details.
> 
> Adds an explicit default case that aborts on unsupported inverted-index iterator types, and adapts numeric handling to use `NumericInvIndIterator*`-based helper APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921eb29b432e535e1df10aea54a2d1ad04faf64f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->