### PR TITLE
Add `EXCLUDE_WIP_FEATURES` CMake flag to exclude WIP hybrid `LINEAR` mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ option(VERBOSE_UTESTS "Enable verbose unit tests" OFF)
 option(ENABLE_ASSERT "Enable assertions" OFF)
 set(MAX_WORKER_THREADS "" CACHE STRING "Override the maximum parallel worker threads allowed in thread-pool")
 option(BUILD_TESTING "Enable testing for cpu-features dep" OFF)
+option(EXCLUDE_WIP_FEATURES "Exclude work-in-progress features from the build artifact" OFF)
 
 
 #----------------------------------------------------------------------------------------------
@@ -251,6 +252,10 @@ endif()
 
 if(VERBOSE_UTESTS)
     add_compile_definitions(VERBOSE_UTESTS=1)
+endif()
+
+if(EXCLUDE_WIP_FEATURES)
+    add_compile_definitions(RS_EXCLUDE_WIP_FEATURES=1)
 endif()
 
 # Platform-specific settings

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -157,11 +157,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
 
     // Local variable to store the selected method for the lifetime of this function
     const char *methodTarget = NULL;
-#ifdef RS_EXCLUDE_WIP_FEATURES
-    static const char *allowedCombineMethods[] = {"RRF", NULL};
-#else
     static const char *allowedCombineMethods[] = {"RRF", "LINEAR", NULL};
-#endif
     // COMBINE [RRF [K k] [WINDOW window]] | [LINEAR count ALPHA alpha BETA beta] - hybrid fusion method
     ArgParser_AddStringV(parser, "COMBINE", "Fusion method for hybrid search",
                          &methodTarget, 1, -1,

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -157,7 +157,11 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
 
     // Local variable to store the selected method for the lifetime of this function
     const char *methodTarget = NULL;
+#ifdef RS_EXCLUDE_WIP_FEATURES
+    static const char *allowedCombineMethods[] = {"RRF", NULL};
+#else
     static const char *allowedCombineMethods[] = {"RRF", "LINEAR", NULL};
+#endif
     // COMBINE [RRF [K k] [WINDOW window]] | [LINEAR count ALPHA alpha BETA beta] - hybrid fusion method
     ArgParser_AddStringV(parser, "COMBINE", "Fusion method for hybrid search",
                          &methodTarget, 1, -1,


### PR DESCRIPTION
### Motivation
- Provide a compile-time switch to omit work-in-progress features from release artifacts so maintainers can produce cleaner release builds without merging WIP behavior into release branches.

### Description
- Add a new CMake option `EXCLUDE_WIP_FEATURES` (default `OFF`) to the top-level `CMakeLists.txt` to control WIP exclusion at build time.
- When `EXCLUDE_WIP_FEATURES` is enabled the build defines `RS_EXCLUDE_WIP_FEATURES=1` so C code can conditionally compile or gate behavior.
- Gate the `FT.HYBRID` `COMBINE` parser allow-list in `src/hybrid/parse/hybrid_optional_args.c` so that with `RS_EXCLUDE_WIP_FEATURES` defined only the stable `RRF` method is accepted and the WIP `LINEAR` method is excluded.

### Testing
- Ran `cmake -S . -B /tmp/rsbuild-wipflag -DEXCLUDE_WIP_FEATURES=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo`; configuration progressed to option handling and then failed due to external environment issues (missing `deps/hiredis/CMakeLists.txt` and Boost FetchContent failing with HTTP 403 via proxy), so the new option and compile definition were exercised but a full build could not complete in this environment (failure due to dependency/network errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc3f113c688324a7591c2a121eb471)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: compile-time gating of an optional hybrid parsing feature with no runtime behavior change unless the new CMake option is enabled.
> 
> **Overview**
> Adds a new CMake option `EXCLUDE_WIP_FEATURES` that, when enabled, defines `RS_EXCLUDE_WIP_FEATURES=1` for the build.
> 
> With this define set, `FT.HYBRID` optional-args parsing restricts `COMBINE` allowed values to only `RRF`, excluding the work-in-progress `LINEAR` mode from the built artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f38e26094e0610d3ae748c2e7e6c7f34d035dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->