### PR TITLE
[8.6-rse] CI: pin ubuntu-latest to ubuntu-24.04 [MOD-15421]

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -291,7 +291,7 @@ jobs:
       - benchmark-vecsim-oss-standalone-profiler
       - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
     if: ${{ always() && contains(needs.*.result, 'failure') && inputs.notify_failure }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1
@@ -307,7 +307,7 @@ jobs:
     needs:
       - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
     if: ${{ always() && needs.benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8.result == 'failure' && inputs.notify_failure }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Notify MSMARCO Benchmark Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   generate-and-send-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -24,7 +24,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   detect-resubmit:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Check for resubmission without new commits
         id: check

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -48,7 +48,7 @@ jobs:
       - get-latest-redis-tag
       - lint
       - test-matrix
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -38,7 +38,7 @@ jobs:
   notify-failure:
     needs: [get-latest-redis-tag, test-all-platforms, micro-benchmarks]
     if: failure()
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -79,7 +79,7 @@ jobs:
       - spellcheck
       - lint
       - test-matrix
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   validate-tag:
     # Verify that the tag matches the version in src/version.h
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       cur_version: ${{ steps.verify.outputs.cur_version }}
       next_version: ${{ steps.verify.outputs.next_version }}
@@ -95,7 +95,7 @@ jobs:
 
   update-version:
     # Generate a PR to bump the version for the next patch (if releasing from a version branch)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     needs: validate-tag
     if: needs.validate-tag.outputs.should_bump == 'true'
     env:
@@ -160,7 +160,7 @@ jobs:
 
   set-artifacts:
     needs: [validate-tag, generate-matrix]
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -15,7 +15,7 @@ jobs:
       notify_failure: true
 
   link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -57,7 +57,7 @@ jobs:
   setup:
     needs: [get-latest-redis-tag]
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       runner_label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2_instance_id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -162,7 +162,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - micro-benchmark # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   prepare_runner_configurations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -78,7 +78,7 @@ jobs:
   compare_micro_benchmarks:
     needs: run_micro_benchmarks
     if: github.event.number
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PERFORMANCE_GH_TOKEN: ${{ secrets.PERFORMANCE_GH_TOKEN }}
       PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     env:
       RUST_BACKTRACE: full
     steps:

--- a/.github/workflows/generate-basic-matrix.yml
+++ b/.github/workflows/generate-basic-matrix.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     # Run if files changed OR if 'check-links' label is added
     if: >

--- a/.github/workflows/pr_label_size.yml
+++ b/.github/workflows/pr_label_size.yml
@@ -8,7 +8,7 @@ jobs:
         pull-requests: write
         contents: read
         issues: write
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04
       name: Label the PR size
       steps:
         - uses: codelytv/pr-size-labeler@v1

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -31,7 +31,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -66,7 +66,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - run # required to wait when the main job is done
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Assign:
     if: ${{ !contains(github.event.issue.labels.*.name, 'feature') }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/task-build-cached-container.yml
     with:
       container: ${{ needs.get-config.outputs.container }}
-      runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+      runner-env: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04' }}
       checkout-ref: ${{ inputs.sha || inputs.ref || github.sha }}
 
   build:
@@ -59,7 +59,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.get-config.result == 'success'
-    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for OIDC role assumption during upload
       contents: read  # Required for actions/checkout

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   change-checks:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs: # Make sure to return "true" if any workflow was changed, to make sure the workflow works
       CODE_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
       BENCHMARK_CHANGED: ${{ steps.check-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -129,12 +129,12 @@ jobs:
               },
               "ubuntu:default": {
                   "x86_64": {
-                      'container': 'ubuntu:latest',
+                      'container': 'ubuntu:noble',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest x86_64'
                   },
                   "aarch64": {
-                      'container': 'ubuntu:latest',
+                      'container': 'ubuntu:noble',
                       'setup_script': 'apt update && apt install -y git',
                       'name': 'Ubuntu Latest ARM64'
                   }

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -48,7 +48,7 @@ on:
 
 jobs:
   get-config:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       env: ${{ steps.get-config.outputs.env }}
       container: ${{ steps.get-config.outputs.container }}
@@ -78,7 +78,7 @@ jobs:
 
           # Default environment per architecture
           # Use GitHub variables if available, otherwise use fallback values
-          runs_on = "${{ vars.RUNS_ON || 'ubuntu-latest' }}"
+          runs_on = "${{ vars.RUNS_ON || 'ubuntu-24.04' }}"
           runs_on_arm = "${{ vars.RUNS_ON_ARM || 'ubuntu24-arm64-2-8' }}"
 
           default_env = {

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -11,13 +11,13 @@ jobs:
     uses: ./.github/workflows/task-build-cached-container.yml
     with:
       container: ubuntu:noble
-      runner-env: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+      runner-env: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
 
   lint:
     name: Linting
     needs: build-image
     if: ${{ !cancelled() }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     container: ${{
       needs.build-image.outputs.succeeded == 'true'
         && fromJSON(format('{{"image":"{0}","options":"--user root"}}', needs.build-image.outputs.image))

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-release-notes-check.yml
+++ b/.github/workflows/task-release-notes-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-release-notes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check release notes checkbox
         env:

--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -4,7 +4,7 @@ on: [workflow_call]
 
 jobs:
   spellcheck:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   take:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     env:
       GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
       ASSIGNEE: ${{ inputs.assignee || github.actor }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -90,7 +90,7 @@ jobs:
     needs: get-config
     name: Start self-hosted EC2 runner
     if: ${{ needs.get-config.outputs.ec2_image_id }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       TAGS: | # Make sure there is no trailing comma!
         [
@@ -142,7 +142,7 @@ jobs:
       needs.get-config.result == 'success' &&
       (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
       (inputs.standalone || inputs.coordinator || inputs.unit-tests)
-    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-24.04' }}
     container: ${{
       needs.get-config.outputs.container
         && fromJSON(
@@ -614,7 +614,7 @@ jobs:
     name: Stop self-hosted EC2 runner
     needs: [start-runner, common-flow]
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Workflows fall back to `ubuntu-latest`, which currently resolves to `ubuntu-24.04` but is scheduled to migrate to `ubuntu-26.04` once GitHub publishes the runner image.
2. Change: Pin every `ubuntu-latest` reference (including the `'ubuntu-latest'` fallback inside `${{ vars.RUNS_ON || ... }}` expressions) to `ubuntu-24.04` across `.github/workflows/`. The `vars.RUNS_ON` repository variable still takes precedence when set.
3. Outcome: 8.6-rse CI keeps running on `ubuntu-24.04` regardless of when GHA flips the `ubuntu-latest` alias to `ubuntu-26.04`. We do not need to ship artifacts for Ubuntu 26.04 on 8.6-rse, so this PR is scoped to runner pinning only.

#### Which additional issues this PR fixes
1. MOD-15421

#### Main objects this PR modified
1. `.github/workflows/*.yml` (32 files, 43 replacements)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many CI workflows and changes the runner image selection, which can surface OS/tooling differences and cause CI failures. No production code changes, but CI reliability and artifact reproducibility could be impacted.
> 
> **Overview**
> Pins GitHub Actions Linux runner selection across workflows from `ubuntu-latest` to **`ubuntu-24.04`**, including fallbacks inside `${{ vars.RUNS_ON || ... }}` expressions, to prevent an automatic future shift to newer Ubuntu images.
> 
> Also updates the default Ubuntu container mapping in `task-get-config.yml` from `ubuntu:latest` to **`ubuntu:noble`** so container-based jobs remain aligned with the pinned runner baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4844ce0f6a1660c281a1b186e2a50d1d1b34c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->