### PR TITLE
[8.6] Gate cargo advisories on new findings

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -26,6 +26,9 @@ jobs:
       packages: write
     uses: ./.github/workflows/task-lint.yml
     secrets: inherit
+    with:
+      compare-advisories-to-base: true
+      advisories-base-ref: ${{ github.event.merge_group.base_sha }}
 
   test-matrix:
     needs: [get-latest-redis-tag, lint]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,6 +16,13 @@ jobs:
       repo: redis/redis
       prefix: '8.6'
 
+  lint:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/task-lint.yml
+    secrets: inherit
+
   test-all-platforms:
     needs: [get-latest-redis-tag]
     permissions:
@@ -36,7 +43,7 @@ jobs:
 
 
   notify-failure:
-    needs: [get-latest-redis-tag, test-all-platforms, micro-benchmarks]
+    needs: [get-latest-redis-tag, lint, test-all-platforms, micro-benchmarks]
     if: failure()
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -28,6 +28,9 @@ jobs:
       packages: write
     uses: ./.github/workflows/task-lint.yml
     secrets: inherit
+    with:
+      compare-advisories-to-base: true
+      advisories-base-ref: ${{ github.event.pull_request.base.sha }}
 
   spellcheck:
     uses: ./.github/workflows/task-spellcheck.yml

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -4,6 +4,15 @@ name: Lint for warnings, missing license headers and check that code is well-for
 
 on:
   workflow_call:
+    inputs:
+      compare-advisories-to-base:
+        description: 'Only fail cargo-deny advisories when findings are new compared to advisories-base-ref.'
+        type: boolean
+        default: false
+      advisories-base-ref:
+        description: 'Git ref or SHA to compare advisory findings against when compare-advisories-to-base is true.'
+        type: string
+        default: ''
 
 jobs:
   build-image:
@@ -18,13 +27,14 @@ jobs:
     needs: build-image
     if: ${{ !cancelled() }}
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
     container: ${{
       needs.build-image.outputs.succeeded == 'true'
         && fromJSON(format('{{"image":"{0}","options":"--user root"}}', needs.build-image.outputs.image))
       || null }}
-    defaults:
-      run:
-        shell: bash -l -eo pipefail {0}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,6 +80,8 @@ jobs:
           workspaces: "src/redisearch_rs -> ../../bin/redisearch_rs"
       - name: Hakari
         run: cargo install cargo-hakari --locked
+      - name: Cargo deny
+        run: cargo install cargo-deny --locked
       - name: Lint
         id: lint
         continue-on-error: true
@@ -89,13 +101,21 @@ jobs:
         id: fmt
         continue-on-error: true
         run: make fmt CHECK=1
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - name: Security advisories
         id: advisories
         continue-on-error: true
-        with:
-          command: check advisories
-          arguments: --all-features
-          manifest-path: src/redisearch_rs/Cargo.toml
+        env:
+          COMPARE_ADVISORIES_TO_BASE: ${{ inputs.compare-advisories-to-base }}
+          ADVISORIES_BASE_REF: ${{ inputs.advisories-base-ref }}
+          MANIFEST_PATH: src/redisearch_rs/Cargo.toml
+        run: |
+          ARGS=()
+          if [[ "$COMPARE_ADVISORIES_TO_BASE" == "true" ]]; then
+            ARGS+=(--compare-to-base --base-ref "$ADVISORIES_BASE_REF")
+          fi
+          python3 scripts/cargo_deny_advisory_gate.py \
+            --manifest-path "$MANIFEST_PATH" \
+            "${ARGS[@]}"
       - uses: EmbarkStudios/cargo-deny-action@v2
         id: dep-licenses
         continue-on-error: true

--- a/scripts/cargo_deny_advisory_gate.py
+++ b/scripts/cargo_deny_advisory_gate.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Gate cargo-deny advisories.
+
+By default, this preserves cargo-deny's exit code. With
+--compare-to-base, it compares the current checkout to --base-ref and
+fails only for advisory findings that are new.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def cargo_deny(repo: Path, output: Path, manifest: str) -> int:
+    cmd = [
+        "cargo",
+        "deny",
+        "--format",
+        "json",
+        "--manifest-path",
+        manifest,
+        "--all-features",
+        "check",
+        "--audit-compatible-output",
+        "advisories",
+    ]
+    with output.open("w", encoding="utf-8") as fh:
+        return subprocess.run(cmd, cwd=repo, stdout=fh, stderr=subprocess.STDOUT, text=True).returncode
+
+
+def finding_from_object(value: dict[str, Any]) -> tuple[str, str, str] | None:
+    package = value.get("package") if isinstance(value.get("package"), dict) else None
+    advisory = value.get("advisory") if isinstance(value.get("advisory"), dict) else None
+    if not package or not advisory or not advisory.get("id"):
+        return None
+
+    return (
+        str(advisory["id"]).upper(),
+        str(package.get("name") or ""),
+        str(package.get("version") or ""),
+    )
+
+
+def collect_findings(value: Any, findings: set[tuple[str, str, str]]) -> None:
+    if isinstance(value, list):
+        for item in value:
+            collect_findings(item, findings)
+        return
+
+    if isinstance(value, dict):
+        if finding := finding_from_object(value):
+            findings.add(finding)
+        for item in value.values():
+            collect_findings(item, findings)
+
+
+def parse_findings(path: Path) -> set[tuple[str, str, str]]:
+    findings: set[tuple[str, str, str]] = set()
+
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if line.lstrip().startswith("{"):
+                try:
+                    collect_findings(json.loads(line), findings)
+                except json.JSONDecodeError:
+                    pass
+    return findings
+
+
+def print_findings(title: str, findings: set[tuple[str, str, str]]) -> None:
+    print(title)
+    if not findings:
+        print("  <none>")
+        return
+    for advisory_id, package, version in sorted(findings):
+        crate = package or "<unknown package>"
+        print(f"  - {advisory_id}: {crate}{f' {version}' if version else ''}")
+
+
+def fail_if_unparsed(rc: int, findings: set[tuple[str, str, str]], label: str) -> None:
+    if rc != 0 and not findings:
+        print(f"cargo deny failed for {label}, but no advisory findings could be parsed.")
+        print("Failing conservatively so CI does not hide a tool or configuration error.")
+        sys.exit(rc)
+
+
+def add_base_worktree(base_ref: str, out_dir: Path) -> Path:
+    worktree = Path(tempfile.mkdtemp(prefix="cargo-deny-base-", dir=out_dir))
+    shutil.rmtree(worktree)
+    try:
+        subprocess.run(["git", "fetch", "--no-tags", "--depth=1", "origin", base_ref], check=True)
+        subprocess.run(["git", "worktree", "add", "--detach", str(worktree), "FETCH_HEAD"], check=True)
+    except Exception:
+        shutil.rmtree(worktree, ignore_errors=True)
+        raise
+    return worktree
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compare-to-base", action="store_true")
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--manifest-path", required=True)
+    args = parser.parse_args()
+
+    out_dir = Path(os.getenv("RUNNER_TEMP", tempfile.gettempdir()))
+    head_out = out_dir / "cargo-deny-advisories-head.jsonl"
+
+    head_rc = cargo_deny(Path.cwd(), head_out, args.manifest_path)
+    head_findings = parse_findings(head_out)
+    fail_if_unparsed(head_rc, head_findings, "current checkout")
+
+    if not args.compare_to_base:
+        print_findings("Current advisory findings:", head_findings)
+        return head_rc
+
+    if head_rc == 0:
+        print_findings("Current advisory findings:", head_findings)
+        print("No failing advisory findings in the current checkout.")
+        return 0
+
+    if not args.base_ref:
+        print("--base-ref is required when --compare-to-base is used.")
+        return 2
+
+    worktree = add_base_worktree(args.base_ref, out_dir)
+    try:
+        base_out = out_dir / "cargo-deny-advisories-base.jsonl"
+        base_rc = cargo_deny(worktree, base_out, args.manifest_path)
+        base_findings = parse_findings(base_out)
+        fail_if_unparsed(base_rc, base_findings, "base checkout")
+    finally:
+        subprocess.run(["git", "worktree", "remove", "--force", str(worktree)], check=False)
+        shutil.rmtree(worktree, ignore_errors=True)
+
+    new_findings = head_findings - base_findings
+    print_findings("Base advisory findings:", base_findings)
+    print_findings("Current advisory findings:", head_findings)
+    print_findings("New advisory findings:", new_findings)
+    return 1 if new_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Backport of #9364 to `8.6`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating for Rust security advisories and adds git worktree/fetch logic, which could cause unexpected CI failures or missed advisory blocking if misconfigured. No runtime product code paths are affected.
> 
> **Overview**
> **CI now gates Rust security advisories on regressions.** The `lint` workflow replaces the direct `cargo-deny` advisories action with a script (`scripts/cargo_deny_advisory_gate.py`) that optionally compares advisory findings against a base ref and only fails when *new* advisories are introduced.
> 
> Pull request and merge-queue runs enable this comparison using the PR/merge-group base SHA, while nightly adds `lint` execution and includes it in failure notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c898cc397e65ab6b4b275cccc7b35adfb0917bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->