### PR TITLE
refactor: change RQEIterator::revalidate() to take &mut IndexSpec

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
  "cbindgen",
  "ffi",
  "field",
+ "index_spec",
  "inverted_index",
  "inverted_index_ffi",
  "libc",
@@ -2137,6 +2138,7 @@ dependencies = [
  "ffi",
  "field",
  "idf",
+ "index_spec",
  "inverted_index",
  "libc",
  "numeric_range_tree",
@@ -2190,6 +2192,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "field",
+ "index_spec",
  "inverted_index",
  "inverted_index_ffi",
  "libc",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -23,6 +23,7 @@ bench = false
 ffi.workspace = true
 libc.workspace = true
 field.workspace = true
+index_spec.workspace = true
 inverted_index.workspace = true
 inverted_index_ffi = { path = "../inverted_index_ffi" }
 numeric_range_tree_ffi = { path = "../numeric_range_tree_ffi" }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -10,6 +10,7 @@
 use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use index_spec::IndexSpec;
 use inverted_index::{
     IndexReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
@@ -106,12 +107,11 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-        unsafe { dispatch!(self, revalidate, spec) }
+        dispatch!(self, revalidate, spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -10,7 +10,6 @@
 use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use index_spec::IndexSpec;
 use inverted_index::{
     IndexReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
@@ -109,7 +108,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         dispatch!(self, revalidate, spec)
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -108,7 +108,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut index_spec::IndexSpecReadGuard,
+        spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         dispatch!(self, revalidate, spec)
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -11,7 +11,6 @@ use std::ptr::{self, NonNull};
 
 use ffi::{FieldSpec, RSGlobalConfig};
 use field::FieldFilterContext;
-use index_spec::IndexSpec;
 use inverted_index::NumericFilter;
 use query_node_type::QueryNodeType;
 use rqe_iterator_type::IteratorType;
@@ -89,7 +88,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         self.iterator.revalidate(spec)
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -88,7 +88,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut index_spec::IndexSpecReadGuard,
+        spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         self.iterator.revalidate(spec)
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -11,6 +11,7 @@ use std::ptr::{self, NonNull};
 
 use ffi::{FieldSpec, RSGlobalConfig};
 use field::FieldFilterContext;
+use index_spec::IndexSpec;
 use inverted_index::NumericFilter;
 use query_node_type::QueryNodeType;
 use rqe_iterator_type::IteratorType;
@@ -86,12 +87,11 @@ impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.iterator.revalidate(spec) }
+        self.iterator.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -10,6 +10,7 @@
 use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use index_spec::IndexSpec;
 use inverted_index::{
     IndexReader, RSIndexResult, RSQueryTerm, doc_ids_only::DocIdsOnly,
     raw_doc_ids_only::RawDocIdsOnly, t_docId,
@@ -101,12 +102,11 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-        unsafe { tag_it_dispatch!(self, revalidate, spec) }
+        tag_it_dispatch!(self, revalidate, spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -10,7 +10,6 @@
 use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use index_spec::IndexSpec;
 use inverted_index::{
     IndexReader, RSIndexResult, RSQueryTerm, doc_ids_only::DocIdsOnly,
     raw_doc_ids_only::RawDocIdsOnly, t_docId,
@@ -104,7 +103,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         tag_it_dispatch!(self, revalidate, spec)
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -103,7 +103,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut index_spec::IndexSpecReadGuard,
+        spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         tag_it_dispatch!(self, revalidate, spec)
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -9,6 +9,7 @@
 
 use std::fmt::Debug;
 
+use index_spec::IndexSpec;
 use inverted_index::{
     RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
@@ -97,15 +98,13 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            WildcardIterator::Encoded(w) => unsafe { w.revalidate(spec) },
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            WildcardIterator::Raw(w) => unsafe { w.revalidate(spec) },
+            WildcardIterator::Encoded(w) => w.revalidate(spec),
+            WildcardIterator::Raw(w) => w.revalidate(spec),
         }
     }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -99,7 +99,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut index_spec::IndexSpecReadGuard,
+        spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
             WildcardIterator::Encoded(w) => w.revalidate(spec),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -9,7 +9,6 @@
 
 use std::fmt::Debug;
 
-use index_spec::IndexSpec;
 use inverted_index::{
     RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
@@ -100,7 +99,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for WildcardIterator<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
             WildcardIterator::Encoded(w) => w.revalidate(spec),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -10,7 +10,6 @@
 use std::ptr::NonNull;
 
 use ffi::{QueryIterator, t_docId, timespec};
-use index_spec::IndexSpec;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
     NewWildcardIterator, RQEIterator,
@@ -83,7 +82,7 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
             Self::Not(it) => it.revalidate(spec),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -82,7 +82,7 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut index_spec::IndexSpecReadGuard,
+        spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
             Self::Not(it) => it.revalidate(spec),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -10,6 +10,7 @@
 use std::ptr::NonNull;
 
 use ffi::{QueryIterator, t_docId, timespec};
+use index_spec::IndexSpec;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
     NewWildcardIterator, RQEIterator,
@@ -80,15 +81,13 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         match self {
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            Self::Not(it) => unsafe { it.revalidate(spec) },
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            Self::NotOptimized(it) => unsafe { it.revalidate(spec) },
+            Self::Not(it) => it.revalidate(spec),
+            Self::NotOptimized(it) => it.revalidate(spec),
         }
     }
 

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -65,7 +65,7 @@ impl IndexSpec {
 
     /// Acquire the write lock for this `IndexSpec`. This is required before performing any
     /// modifications to the index spec, such as applying deltas from compaction.
-    pub fn write_lock(&mut self) -> IndexSpecWriteGuard<'_> {
+    pub fn write(&mut self) -> IndexSpecWriteGuard<'_> {
         IndexSpecWriteGuard::new(&mut self.0)
     }
 }

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -50,6 +50,12 @@ impl IndexSpec {
         unsafe { SchemaRule::from_raw(self.0.rule) }
     }
 
+    /// Get a mutable reference to the underlying schema rule.
+    pub const fn rule_mut(&mut self) -> &mut SchemaRule {
+        // Safety: (1.) due to creation with `IndexSpec::from_raw`
+        unsafe { SchemaRule::from_raw_mut(self.0.rule) }
+    }
+
     /// Get the underlying field specs as a slice of `FieldSpec`s.
     pub fn field_specs(&self) -> &[FieldSpec] {
         debug_assert!(!self.0.fields.is_null(), "fields must not be null");
@@ -67,6 +73,116 @@ impl IndexSpec {
     /// modifications to the index spec, such as applying deltas from compaction.
     pub fn lock(&mut self) -> IndexSpecLockGuard<'_> {
         IndexSpecLockGuard::new(&mut self.0)
+    }
+
+    /// Checks if the keys dictionary is available.
+    ///
+    /// The keys dictionary maps TEXT terms to their inverted indexes.
+    /// It may be null in test scenarios where a full spec is not set up.
+    ///
+    /// # Concurrency
+    ///
+    /// Caller must hold at least a read lock on the IndexSpec.
+    pub const fn has_keys_dict(&self) -> bool {
+        !self.0.keysDict.is_null()
+    }
+
+    /// Returns a pointer to the existing documents inverted index.
+    ///
+    /// Used by wildcard queries to match all documents.
+    /// May be null if all documents have been garbage collected.
+    ///
+    /// # Concurrency
+    ///
+    /// Caller must hold at least a read lock on the IndexSpec.
+    pub const fn existing_docs(&self) -> *mut ffi::InvertedIndex {
+        self.0.existingDocs
+    }
+
+    /// Returns the document table.
+    ///
+    /// # Concurrency
+    ///
+    /// Caller must hold at least a read lock on the IndexSpec.
+    pub const fn doc_table(&self) -> ffi::DocTable {
+        self.0.docs
+    }
+
+    /// Returns a const raw pointer to the underlying `ffi::IndexSpec`.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid as long as the wrapper reference is valid.
+    /// Do not dereference the pointer after the wrapper goes out of scope.
+    pub const fn as_raw_ptr(&self) -> *const ffi::IndexSpec {
+        &self.0 as *const ffi::IndexSpec
+    }
+
+    /// Returns a mutable raw pointer to the underlying `ffi::IndexSpec`.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid as long as the wrapper reference is valid.
+    /// Do not dereference the pointer after the wrapper goes out of scope.
+    pub const fn as_mut_raw_ptr(&mut self) -> *mut ffi::IndexSpec {
+        &mut self.0 as *mut ffi::IndexSpec
+    }
+
+    /// Returns a mutable reference to the underlying `ffi::IndexSpec`.
+    ///
+    /// This is useful for test code that needs direct mutable access to fields
+    /// that don't have dedicated accessor methods.
+    pub const fn as_ffi_mut(&mut self) -> &mut ffi::IndexSpec {
+        &mut self.0
+    }
+
+    /// Returns a pointer to the missing field dictionary.
+    ///
+    /// This dictionary maps field names to their missing-value inverted indexes.
+    ///
+    /// # Concurrency
+    ///
+    /// Caller must hold at least a read lock on the IndexSpec.
+    pub const fn missing_field_dict(&self) -> *mut ffi::dict {
+        self.0.missingFieldDict
+    }
+
+    /// Returns a pointer to the fields array.
+    ///
+    /// # Concurrency
+    ///
+    /// Caller must hold at least a read lock on the IndexSpec.
+    pub const fn fields_ptr(&self) -> *mut ffi::FieldSpec {
+        self.0.fields
+    }
+
+    /// Returns the number of strong references to this index spec
+    ///
+    /// # Concurrency
+    ///
+    /// Caller must hold at least a read lock on the IndexSpec.
+    pub const fn own_ref(&self) -> ffi::StrongRef {
+        self.0.own_ref
+    }
+
+    /// Sets the disk index spec pointer.
+    pub const fn set_disk_spec(&mut self, disk_spec: *mut ffi::RedisSearchDiskIndexSpec) {
+        self.0.diskSpec = disk_spec;
+    }
+
+    /// Sets the existing documents inverted index pointer.
+    pub const fn set_existing_docs(&mut self, existing_docs: *mut ffi::InvertedIndex) {
+        self.0.existingDocs = existing_docs;
+    }
+
+    /// Sets whether documents expiration should be monitored.
+    pub const fn set_monitor_document_expiration(&mut self, monitor: bool) {
+        self.0.monitorDocumentExpiration = monitor;
+    }
+
+    /// Sets whether field expiration should be monitored.
+    pub const fn set_monitor_field_expiration(&mut self, monitor: bool) {
+        self.0.monitorFieldExpiration = monitor;
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -75,7 +75,7 @@ impl IndexSpec {
     ///
     /// The returned pointer is valid as long as the wrapper reference is valid.
     /// Do not dereference the pointer after the wrapper goes out of scope.
-    pub const fn as_raw_ptr(&self) -> *const ffi::IndexSpec {
+    pub const fn as_ptr(&self) -> *const ffi::IndexSpec {
         &self.0 as *const ffi::IndexSpec
     }
 
@@ -85,7 +85,7 @@ impl IndexSpec {
     ///
     /// The returned pointer is valid as long as the wrapper reference is valid.
     /// Do not dereference the pointer after the wrapper goes out of scope.
-    pub const fn as_mut_raw_ptr(&mut self) -> *mut ffi::IndexSpec {
+    pub const fn as_mut_ptr(&mut self) -> *mut ffi::IndexSpec {
         &mut self.0 as *mut ffi::IndexSpec
     }
 

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -50,12 +50,6 @@ impl IndexSpec {
         unsafe { SchemaRule::from_raw(self.0.rule) }
     }
 
-    /// Get a mutable reference to the underlying schema rule.
-    pub const fn rule_mut(&mut self) -> &mut SchemaRule {
-        // Safety: (1.) due to creation with `IndexSpec::from_raw`
-        unsafe { SchemaRule::from_raw_mut(self.0.rule) }
-    }
-
     /// Get the underlying field specs as a slice of `FieldSpec`s.
     pub fn field_specs(&self) -> &[FieldSpec] {
         debug_assert!(!self.0.fields.is_null(), "fields must not be null");
@@ -71,41 +65,8 @@ impl IndexSpec {
 
     /// Acquire the write lock for this `IndexSpec`. This is required before performing any
     /// modifications to the index spec, such as applying deltas from compaction.
-    pub fn lock(&mut self) -> IndexSpecLockGuard<'_> {
-        IndexSpecLockGuard::new(&mut self.0)
-    }
-
-    /// Checks if the keys dictionary is available.
-    ///
-    /// The keys dictionary maps TEXT terms to their inverted indexes.
-    /// It may be null in test scenarios where a full spec is not set up.
-    ///
-    /// # Concurrency
-    ///
-    /// Caller must hold at least a read lock on the IndexSpec.
-    pub const fn has_keys_dict(&self) -> bool {
-        !self.0.keysDict.is_null()
-    }
-
-    /// Returns a pointer to the existing documents inverted index.
-    ///
-    /// Used by wildcard queries to match all documents.
-    /// May be null if all documents have been garbage collected.
-    ///
-    /// # Concurrency
-    ///
-    /// Caller must hold at least a read lock on the IndexSpec.
-    pub const fn existing_docs(&self) -> *mut ffi::InvertedIndex {
-        self.0.existingDocs
-    }
-
-    /// Returns the document table.
-    ///
-    /// # Concurrency
-    ///
-    /// Caller must hold at least a read lock on the IndexSpec.
-    pub const fn doc_table(&self) -> ffi::DocTable {
-        self.0.docs
+    pub fn write_lock(&mut self) -> IndexSpecWriteGuard<'_> {
+        IndexSpecWriteGuard::new(&mut self.0)
     }
 
     /// Returns a const raw pointer to the underlying `ffi::IndexSpec`.
@@ -128,61 +89,19 @@ impl IndexSpec {
         &mut self.0 as *mut ffi::IndexSpec
     }
 
+    /// Returns a reference to the underlying `ffi::IndexSpec`.
+    ///
+    /// This is useful for test code that needs direct access to fields that don't have dedicated accessor methods.
+    pub const fn as_ffi(&self) -> &ffi::IndexSpec {
+        &self.0
+    }
+
     /// Returns a mutable reference to the underlying `ffi::IndexSpec`.
     ///
     /// This is useful for test code that needs direct mutable access to fields
     /// that don't have dedicated accessor methods.
     pub const fn as_ffi_mut(&mut self) -> &mut ffi::IndexSpec {
         &mut self.0
-    }
-
-    /// Returns a pointer to the missing field dictionary.
-    ///
-    /// This dictionary maps field names to their missing-value inverted indexes.
-    ///
-    /// # Concurrency
-    ///
-    /// Caller must hold at least a read lock on the IndexSpec.
-    pub const fn missing_field_dict(&self) -> *mut ffi::dict {
-        self.0.missingFieldDict
-    }
-
-    /// Returns a pointer to the fields array.
-    ///
-    /// # Concurrency
-    ///
-    /// Caller must hold at least a read lock on the IndexSpec.
-    pub const fn fields_ptr(&self) -> *mut ffi::FieldSpec {
-        self.0.fields
-    }
-
-    /// Returns the number of strong references to this index spec
-    ///
-    /// # Concurrency
-    ///
-    /// Caller must hold at least a read lock on the IndexSpec.
-    pub const fn own_ref(&self) -> ffi::StrongRef {
-        self.0.own_ref
-    }
-
-    /// Sets the disk index spec pointer.
-    pub const fn set_disk_spec(&mut self, disk_spec: *mut ffi::RedisSearchDiskIndexSpec) {
-        self.0.diskSpec = disk_spec;
-    }
-
-    /// Sets the existing documents inverted index pointer.
-    pub const fn set_existing_docs(&mut self, existing_docs: *mut ffi::InvertedIndex) {
-        self.0.existingDocs = existing_docs;
-    }
-
-    /// Sets whether documents expiration should be monitored.
-    pub const fn set_monitor_document_expiration(&mut self, monitor: bool) {
-        self.0.monitorDocumentExpiration = monitor;
-    }
-
-    /// Sets whether field expiration should be monitored.
-    pub const fn set_monitor_field_expiration(&mut self, monitor: bool) {
-        self.0.monitorFieldExpiration = monitor;
     }
 }
 
@@ -194,11 +113,11 @@ impl IndexSpec {
 ///
 /// # Invariants
 ///
-/// The pointer passed to [`IndexSpecLockGuard::new`] must be a valid `IndexSpec*`
+/// The pointer passed to [`IndexSpecWriteGuard::new`] must be a valid `IndexSpec*`
 /// that remains valid for the lifetime of this guard.
-pub struct IndexSpecLockGuard<'lock>(&'lock mut ffi::IndexSpec);
+pub struct IndexSpecWriteGuard<'lock>(&'lock mut ffi::IndexSpec);
 
-impl<'lock> IndexSpecLockGuard<'lock> {
+impl<'lock> IndexSpecWriteGuard<'lock> {
     /// Creates a new guard, acquiring the write lock.
     ///
     /// Returns `None` if the pointer is null.
@@ -229,11 +148,187 @@ impl<'lock> IndexSpecLockGuard<'lock> {
             ffi::IndexSpec_DecrementNumTerms(self.0, decr);
         }
     }
+
+    /// Creates a guard from an already-locked IndexSpec without acquiring the lock.
+    ///
+    /// Returns `ManuallyDrop<IndexSpecWriteGuard>` to prevent the guard from releasing
+    /// the lock on drop. This is intended for test code where no real lock is acquired
+    /// and the test code maintains responsibility for the spec lifetime.
+    ///
+    /// # Safety
+    ///
+    /// - `index_spec` must be a valid pointer to an IndexSpec
+    /// - In test contexts, no lock is actually held (tests don't use real locks)
+    /// - Test code is responsible for ensuring exclusive access
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // In test code where no real lock is needed:
+    /// let mut guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut *spec_ptr) };
+    /// // guard is ManuallyDrop, won't release lock on drop
+    /// guard.decrement_num_terms(5);
+    /// ```
+    pub const unsafe fn from_locked_mut(
+        index_spec: &'lock mut ffi::IndexSpec,
+    ) -> std::mem::ManuallyDrop<Self> {
+        std::mem::ManuallyDrop::new(Self(index_spec))
+    }
+
+    /// Get a mutable reference to the underlying schema rule.
+    pub const fn rule_mut(&mut self) -> &mut SchemaRule {
+        // SAFETY: We hold the write lock, so we have exclusive access.
+        unsafe { SchemaRule::from_raw_mut(self.0.rule) }
+    }
+
+    /// Sets the disk index spec pointer.
+    pub const fn set_disk_spec(&mut self, disk_spec: *mut ffi::RedisSearchDiskIndexSpec) {
+        self.0.diskSpec = disk_spec;
+    }
+
+    /// Sets the existing documents inverted index pointer.
+    pub const fn set_existing_docs(&mut self, existing_docs: *mut ffi::InvertedIndex) {
+        self.0.existingDocs = existing_docs;
+    }
+
+    /// Sets whether documents expiration should be monitored.
+    pub const fn set_monitor_document_expiration(&mut self, monitor: bool) {
+        self.0.monitorDocumentExpiration = monitor;
+    }
+
+    /// Sets whether field expiration should be monitored.
+    pub const fn set_monitor_field_expiration(&mut self, monitor: bool) {
+        self.0.monitorFieldExpiration = monitor;
+    }
+
+    /// Returns the document table.
+    pub const fn doc_table(&self) -> ffi::DocTable {
+        self.0.docs
+    }
 }
 
-impl Drop for IndexSpecLockGuard<'_> {
+impl Drop for IndexSpecWriteGuard<'_> {
     fn drop(&mut self) {
         // SAFETY: We acquired the lock in new(), so we must release it.
         unsafe { ffi::IndexSpec_ReleaseWriteLock(self.0) };
+    }
+}
+
+/// A guard that holds the IndexSpec read lock and releases it on drop.
+///
+/// This guard implements the RAII pattern for read locks: the lock is acquired
+/// when the guard is created and released when dropped.
+///
+/// # Read vs Write Lock
+///
+/// This is a **read lock** (shared), allowing multiple concurrent readers.
+/// For exclusive write access, use [`IndexSpecWriteGuard`] (write lock).
+///
+/// # Invariants
+///
+/// The pointer passed to `from_locked` must be a valid `IndexSpec*` that remains
+/// valid for the lifetime of this guard.
+pub struct IndexSpecReadGuard<'lock>(&'lock ffi::IndexSpec);
+
+impl<'lock> IndexSpecReadGuard<'lock> {
+    /// Creates a guard from an already-locked IndexSpec without acquiring the lock.
+    ///
+    /// Returns `ManuallyDrop<IndexSpecReadGuard>` to prevent the guard from releasing
+    /// the lock on drop. This is intended for FFI boundaries where C code has already
+    /// acquired the read lock and maintains ownership of the lock lifecycle.
+    ///
+    /// # Safety
+    ///
+    /// - `index_spec` must be a valid pointer to an IndexSpec
+    /// - Caller must have already acquired the read lock
+    /// - C code is responsible for releasing the lock
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // At FFI boundary where C holds the lock:
+    /// let mut guard = unsafe { IndexSpecReadGuard::from_locked(&*spec_ptr) };
+    /// // guard is ManuallyDrop, won't release lock on drop
+    /// iterator.revalidate(&mut *guard)?;
+    /// ```
+    pub const unsafe fn from_locked(index_spec: &'lock ffi::IndexSpec) -> std::mem::ManuallyDrop<Self> {
+        std::mem::ManuallyDrop::new(Self(index_spec))
+    }
+
+    /// Returns whether the keys dictionary is available.
+    ///
+    /// The keys dictionary maps TEXT terms to their inverted indexes.
+    pub const fn has_keys_dict(&self) -> bool {
+        !self.0.keysDict.is_null()
+    }
+
+    /// Returns a pointer to the keys dictionary.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if keys_dict is null. Use `has_keys_dict()` to check first.
+    pub fn keys_dict(&self) -> *mut ffi::dict {
+        debug_assert!(!self.0.keysDict.is_null(), "keys_dict is null");
+        self.0.keysDict
+    }
+
+    /// Returns a pointer to the existing documents inverted index.
+    ///
+    /// May be null if all documents have been garbage collected.
+    pub const fn existing_docs(&self) -> *mut ffi::InvertedIndex {
+        self.0.existingDocs
+    }
+
+    /// Returns a pointer to the missing field dictionary.
+    ///
+    /// This dictionary maps field names to their missing-value inverted indexes.
+    pub const fn missing_field_dict(&self) -> *mut ffi::dict {
+        self.0.missingFieldDict
+    }
+
+    /// Returns a pointer to the fields array.
+    pub const fn fields_ptr(&self) -> *mut ffi::FieldSpec {
+        self.0.fields
+    }
+
+    /// Returns a const raw pointer to the underlying `ffi::IndexSpec`.
+    pub const fn as_ptr(&self) -> *const ffi::IndexSpec {
+        self.0 as *const ffi::IndexSpec
+    }
+
+    /// Returns a mutable raw pointer to the underlying `ffi::IndexSpec`.
+    ///
+    /// # Safety Note
+    ///
+    /// Even though this returns `*mut`, the guard only holds a **read lock** (shared).
+    /// The mutable pointer is needed for FFI calls that take `*mut` but don't actually
+    /// mutate the spec (C convention). Do not perform unsynchronized mutations through
+    /// this pointer.
+    pub const fn as_mut_ptr(&self) -> *mut ffi::IndexSpec {
+        self.0 as *const ffi::IndexSpec as *mut ffi::IndexSpec
+    }
+
+    /// Returns the document table.
+    pub const fn doc_table(&self) -> ffi::DocTable {
+        self.0.docs
+    }
+
+    /// Returns the number of strong references to this index spec.
+    pub const fn own_ref(&self) -> ffi::StrongRef {
+        self.0.own_ref
+    }
+}
+
+impl Drop for IndexSpecReadGuard<'_> {
+    fn drop(&mut self) {
+        // This Drop implementation should never run because:
+        // 1. from_locked() (the only way to create this guard) returns ManuallyDrop
+        // 2. C code is responsible for releasing the read lock via RedisSearchCtx_UnlockSpec
+        //
+        // If this runs, it's a bug - the guard was created incorrectly or manually unwrapped.
+        panic!(
+            "IndexSpecReadGuard::drop() should never run. \
+             This guard must be wrapped in ManuallyDrop at FFI boundaries."
+        );
     }
 }

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -68,41 +68,6 @@ impl IndexSpec {
     pub fn write_lock(&mut self) -> IndexSpecWriteGuard<'_> {
         IndexSpecWriteGuard::new(&mut self.0)
     }
-
-    /// Returns a const raw pointer to the underlying `ffi::IndexSpec`.
-    ///
-    /// # Safety
-    ///
-    /// The returned pointer is valid as long as the wrapper reference is valid.
-    /// Do not dereference the pointer after the wrapper goes out of scope.
-    pub const fn as_ptr(&self) -> *const ffi::IndexSpec {
-        &self.0 as *const ffi::IndexSpec
-    }
-
-    /// Returns a mutable raw pointer to the underlying `ffi::IndexSpec`.
-    ///
-    /// # Safety
-    ///
-    /// The returned pointer is valid as long as the wrapper reference is valid.
-    /// Do not dereference the pointer after the wrapper goes out of scope.
-    pub const fn as_mut_ptr(&mut self) -> *mut ffi::IndexSpec {
-        &mut self.0 as *mut ffi::IndexSpec
-    }
-
-    /// Returns a reference to the underlying `ffi::IndexSpec`.
-    ///
-    /// This is useful for test code that needs direct access to fields that don't have dedicated accessor methods.
-    pub const fn as_ffi(&self) -> &ffi::IndexSpec {
-        &self.0
-    }
-
-    /// Returns a mutable reference to the underlying `ffi::IndexSpec`.
-    ///
-    /// This is useful for test code that needs direct mutable access to fields
-    /// that don't have dedicated accessor methods.
-    pub const fn as_ffi_mut(&mut self) -> &mut ffi::IndexSpec {
-        &mut self.0
-    }
 }
 
 /// A guard that holds the IndexSpec write lock and releases it on drop.
@@ -251,7 +216,9 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     /// // guard is ManuallyDrop, won't release lock on drop
     /// iterator.revalidate(&mut *guard)?;
     /// ```
-    pub const unsafe fn from_locked(index_spec: &'lock ffi::IndexSpec) -> std::mem::ManuallyDrop<Self> {
+    pub const unsafe fn from_locked(
+        index_spec: &'lock ffi::IndexSpec,
+    ) -> std::mem::ManuallyDrop<Self> {
         std::mem::ManuallyDrop::new(Self(index_spec))
     }
 

--- a/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
@@ -106,7 +106,7 @@ impl SchemaRule {
         self.0.type_
     }
 
-    /// Get the underlying `index_all` flag.
+    /// Set the underlying `index_all` flag.
     pub const fn set_index_all(&mut self, value: bool) {
         self.0.index_all = value;
     }

--- a/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
@@ -37,6 +37,22 @@ impl SchemaRule {
         unsafe { ptr.cast::<Self>().as_ref().unwrap() }
     }
 
+    /// Create a mutable `SchemaRule` wrapper from a non-null pointer.
+    ///
+    /// # Safety
+    ///
+    /// 1. `ptr` must be a [valid], non-null pointer to an `IndexSpec` that is properly initialized.
+    ///    This also applies to any of its subfields. Specifically:
+    ///    1. If `lang_field` is non-null, it points to a valid C string.
+    ///    2. If `score_field` is non-null, it points to a valid C string.
+    ///    3. If `payload_field` is non-null, it points to a valid C string.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::SchemaRule) -> &'a mut Self {
+        // Safety: ensured by caller (1.)
+        unsafe { ptr.cast::<Self>().as_mut().unwrap() }
+    }
+
     /// Get the language field [`CStr`], if present.
     pub const fn lang_field(&self) -> Option<&CStr> {
         // Safety: (1.) due to creation with `SchemaRule::from_raw`
@@ -88,6 +104,11 @@ impl SchemaRule {
     /// Get the underlying `type_`.
     pub const fn type_(&self) -> DocumentType {
         self.0.type_
+    }
+
+    /// Get the underlying `index_all` flag.
+    pub const fn set_index_all(&mut self, value: bool) {
+        self.0.index_all = value;
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -18,6 +18,7 @@ ffi.workspace = true
 rqe_iterator_type.workspace = true
 field.workspace = true
 idf.workspace = true
+index_spec.workspace = true
 inverted_index.workspace = true
 libc.workspace = true
 numeric_range_tree.workspace = true

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -18,7 +18,7 @@ use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, interop::RQEIteratorWrapper,
     intersection::Intersection,
 };
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 use std::{
     mem::ManuallyDrop,
@@ -262,7 +262,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
         let callback = unsafe { self.Revalidate.unwrap_unchecked() };
@@ -270,8 +270,8 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         // - We have a unique handle over this iterator.
         // - The C code must guarantee, by constructor, that callbacks
         //   can be called on types that implement its C iterator API.
-        // - spec.as_mut_raw_ptr() is valid for the duration of this call.
-        let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_raw_ptr()) };
+        // - spec.as_mut_ptr() is valid for the duration of this call.
+        let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_ptr()) };
         #[expect(non_upper_case_globals)]
         let status = match status {
             ValidateStatus_VALIDATE_ABORTED => RQEValidateStatus::Aborted,

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -262,7 +262,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
         let callback = unsafe { self.Revalidate.unwrap_unchecked() };

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -18,6 +18,7 @@ use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, interop::RQEIteratorWrapper,
     intersection::Intersection,
 };
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 use std::{
     mem::ManuallyDrop,
@@ -259,9 +260,9 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         unsafe { callback(self.header.as_ptr()) };
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<crate::RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
         let callback = unsafe { self.Revalidate.unwrap_unchecked() };
@@ -269,9 +270,8 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         // - We have a unique handle over this iterator.
         // - The C code must guarantee, by constructor, that callbacks
         //   can be called on types that implement its C iterator API.
-        // - `spec` is a valid `IndexSpec` pointer, guaranteed by the
-        //   `revalidate` trait method contract.
-        let status = unsafe { callback(self.header.as_ptr(), spec.as_ptr()) };
+        // - spec.as_mut_raw_ptr() is valid for the duration of this call.
+        let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_raw_ptr()) };
         #[expect(non_upper_case_globals)]
         let status = match status {
             ValidateStatus_VALIDATE_ABORTED => RQEValidateStatus::Aborted,

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -61,7 +61,7 @@ impl<'index> RQEIterator<'index> for Empty {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpecReadGuard,
+        _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -10,7 +10,7 @@
 //! Supporting types for [`Empty`].
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
@@ -61,7 +61,7 @@ impl<'index> RQEIterator<'index> for Empty {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -10,6 +10,7 @@
 //! Supporting types for [`Empty`].
 
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
@@ -58,9 +59,9 @@ impl<'index> RQEIterator<'index> for Empty {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -10,6 +10,7 @@
 //! Supporting types for [`IdList`].
 
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 use std::cmp::Ordering;
 
@@ -241,9 +242,9 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -244,7 +244,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     #[inline(always)]
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpecReadGuard,
+        _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -10,7 +10,7 @@
 //! Supporting types for [`IdList`].
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 use std::cmp::Ordering;
 
@@ -244,7 +244,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     #[inline(always)]
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -295,9 +295,7 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     // - C has already acquired the read lock (see handleSpecLockAndRevalidate in result_processor.c)
     // - from_locked() returns ManuallyDrop to prevent lock release on drop
     //   (C is responsible for lock lifecycle via RedisSearchCtx_UnlockSpec)
-    let guard = unsafe {
-        index_spec::IndexSpecReadGuard::from_locked(spec_ref)
-    };
+    let guard = unsafe { index_spec::IndexSpecReadGuard::from_locked(spec_ref) };
 
     match wrapper.inner.revalidate(&guard) {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -288,11 +288,18 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
     let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
 
-    // SAFETY: The caller (result processor) guarantees `spec` is valid
-    // and holds the spec read lock for the duration of this call.
-    let spec_wrapper = unsafe { index_spec::IndexSpec::from_raw_mut(spec) };
+    // SAFETY: spec is a valid pointer (guaranteed by C caller)
+    let spec_ref = unsafe { &*spec };
 
-    match wrapper.inner.revalidate(spec_wrapper) {
+    // SAFETY:
+    // - C has already acquired the read lock (see handleSpecLockAndRevalidate in result_processor.c)
+    // - from_locked() returns ManuallyDrop to prevent lock release on drop
+    //   (C is responsible for lock lifecycle via RedisSearchCtx_UnlockSpec)
+    let mut guard = unsafe {
+        index_spec::IndexSpecReadGuard::from_locked(spec_ref)
+    };
+
+    match wrapper.inner.revalidate(&mut guard) {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,
         Ok(RQEValidateStatus::Moved { current }) => {
             if let Some(result) = current {

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -7,8 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ptr::NonNull;
-
 use ffi::{
     IteratorStatus, IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND,
     IteratorStatus_ITERATOR_OK, IteratorStatus_ITERATOR_TIMEOUT, QueryIterator, ValidateStatus,
@@ -286,14 +284,15 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     debug_assert!(!spec.is_null());
+
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
     let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
-    // SAFETY: The caller guarantees `spec` is a valid, non-null pointer to an `IndexSpec`
-    // while the spec read lock is held.
-    let spec = unsafe { NonNull::new_unchecked(spec) };
-    // SAFETY: `spec` points to a valid `IndexSpec` while the spec read lock is held,
-    // satisfying the safety requirements of `RQEIterator::revalidate`.
-    match unsafe { wrapper.inner.revalidate(spec) } {
+
+    // SAFETY: The caller (result processor) guarantees `spec` is valid
+    // and holds the spec read lock for the duration of this call.
+    let spec_wrapper = unsafe { index_spec::IndexSpec::from_raw_mut(spec) };
+
+    match wrapper.inner.revalidate(spec_wrapper) {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,
         Ok(RQEValidateStatus::Moved { current }) => {
             if let Some(result) = current {

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -295,11 +295,11 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     // - C has already acquired the read lock (see handleSpecLockAndRevalidate in result_processor.c)
     // - from_locked() returns ManuallyDrop to prevent lock release on drop
     //   (C is responsible for lock lifecycle via RedisSearchCtx_UnlockSpec)
-    let mut guard = unsafe {
+    let guard = unsafe {
         index_spec::IndexSpecReadGuard::from_locked(spec_ref)
     };
 
-    match wrapper.inner.revalidate(&mut guard) {
+    match wrapper.inner.revalidate(&guard) {
         Ok(RQEValidateStatus::Ok) => ValidateStatus_VALIDATE_OK,
         Ok(RQEValidateStatus::Moved { current }) => {
             if let Some(result) = current {

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -16,6 +16,7 @@
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
@@ -515,17 +516,16 @@ where
         self.is_eof
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let mut any_child_moved = false;
         let mut max_child_doc_id: t_docId = 0;
         let mut moved_to_eof = false;
 
         for child in &mut self.children {
-            // SAFETY: Delegating to child with the same `spec` passed by our caller.
-            match unsafe { child.revalidate(spec) }? {
+            match child.revalidate(spec)? {
                 RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
                 RQEValidateStatus::Moved { current } => {
                     any_child_moved = true;

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -16,7 +16,7 @@
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
@@ -518,7 +518,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let mut any_child_moved = false;
         let mut max_child_doc_id: t_docId = 0;

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -518,7 +518,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let mut any_child_moved = false;
         let mut max_child_doc_id: t_docId = 0;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -7,9 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ptr::NonNull;
-
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::{IndexReader, RSIndexResult};
 
 use crate::{
@@ -288,9 +287,9 @@ where
         self.at_eos
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if !self.reader.needs_revalidation() {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -289,7 +289,7 @@ where
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpecReadGuard,
+        _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if !self.reader.needs_revalidation() {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -8,7 +8,7 @@
 */
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::{IndexReader, RSIndexResult};
 
 use crate::{
@@ -289,7 +289,7 @@ where
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if !self.reader.needs_revalidation() {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -134,7 +134,7 @@ where
     ///    when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    fn should_abort(&self, spec: &mut IndexSpecReadGuard) -> bool {
+    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
         debug_assert!(
             !spec.missing_field_dict().is_null(),
             "spec.missing_field_dict() must be non-null",
@@ -218,7 +218,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Conditions (field_index validity, missingFieldDict, encoding
         // match) are structural invariants guaranteed by the constructor's

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use ffi::{RedisSearchCtx, t_docId, t_fieldIndex};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
 };
@@ -134,7 +134,7 @@ where
     ///    when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    fn should_abort(&self, spec: &mut IndexSpec) -> bool {
+    fn should_abort(&self, spec: &mut IndexSpecReadGuard) -> bool {
         debug_assert!(
             !spec.missing_field_dict().is_null(),
             "spec.missing_field_dict() must be non-null",
@@ -218,7 +218,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Conditions (field_index validity, missingFieldDict, encoding
         // match) are structural invariants guaranteed by the constructor's

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use ffi::{RedisSearchCtx, t_docId, t_fieldIndex};
+use index_spec::IndexSpec;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
 };
@@ -133,19 +134,19 @@ where
     ///    when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    unsafe fn should_abort(&self, spec: &ffi::IndexSpec) -> bool {
+    fn should_abort(&self, spec: &mut IndexSpec) -> bool {
         debug_assert!(
-            !spec.missingFieldDict.is_null(),
-            "spec.missingFieldDict must be non-null",
+            !spec.missing_field_dict().is_null(),
+            "spec.missing_field_dict() must be non-null",
         );
 
-        // SAFETY: 1. guarantees `field_index` is a valid index into `spec.fields`.
-        let field_ptr = unsafe { spec.fields.offset(self.field_index as isize) };
+        // SAFETY: field_index is a valid index into spec.fields (guaranteed by constructor pre-conditions).
+        let field_ptr = unsafe { spec.fields_ptr().offset(self.field_index as isize) };
         // SAFETY: the pointer is valid per the above.
         let field = unsafe { &*field_ptr };
-        // SAFETY: 2. guarantees the dict is non-null and valid.
+        // SAFETY: The dict is non-null and valid (guaranteed by constructor pre-conditions).
         let missing_ii_ptr =
-            unsafe { ffi::RS_dictFetchValue(spec.missingFieldDict, field.fieldName as *mut _) };
+            unsafe { ffi::RS_dictFetchValue(spec.missing_field_dict(), field.fieldName as *mut _) };
 
         if missing_ii_ptr.is_null() {
             // The inverted index was removed from the dict (garbage collected).
@@ -215,23 +216,18 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: The caller guarantees `spec` points to a valid `IndexSpec`
-        // while the spec read lock is held.
-        let spec_ref = unsafe { spec.as_ref() };
-        // SAFETY: `spec_ref` satisfies `should_abort`'s safety requirements.
-        // Conditions 1-3 (field_index validity, missingFieldDict, encoding
+        // Conditions (field_index validity, missingFieldDict, encoding
         // match) are structural invariants guaranteed by the constructor's
         // pre-conditions.
-        if unsafe { self.should_abort(spec_ref) } {
+        if self.should_abort(spec) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.it.revalidate(spec) }
+        self.it.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -184,7 +184,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
@@ -509,7 +509,7 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match self {
             Self::Unfiltered(iter) => iter.revalidate(spec),

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -15,6 +15,7 @@ use crate::{
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 use ffi::{FieldType_INDEXFLD_T_GEO, FieldType_INDEXFLD_T_NUMERIC, IndexFlags, t_docId};
+use index_spec::IndexSpec;
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader, RSIndexResult,
 };
@@ -181,16 +182,15 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.it.revalidate(spec) }
+        self.it.revalidate(spec)
     }
 
     #[inline(always)]
@@ -507,17 +507,14 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match self {
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            Self::Unfiltered(iter) => unsafe { iter.revalidate(spec) },
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            Self::Filtered(iter) => unsafe { iter.revalidate(spec) },
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            Self::Geo(iter) => unsafe { iter.revalidate(spec) },
+            Self::Unfiltered(iter) => iter.revalidate(spec),
+            Self::Filtered(iter) => iter.revalidate(spec),
+            Self::Geo(iter) => iter.revalidate(spec),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -15,7 +15,7 @@ use crate::{
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 use ffi::{FieldType_INDEXFLD_T_GEO, FieldType_INDEXFLD_T_NUMERIC, IndexFlags, t_docId};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader, RSIndexResult,
 };
@@ -184,7 +184,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
@@ -509,7 +509,7 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match self {
             Self::Unfiltered(iter) => iter.revalidate(spec),

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -10,6 +10,7 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, TagIndex, t_docId};
+use index_spec::IndexSpec;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RSIndexResult, RSOffsetSlice,
     opaque::OpaqueEncoding,
@@ -218,16 +219,15 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.it.revalidate(spec) }
+        self.it.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -221,7 +221,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -10,7 +10,7 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, TagIndex, t_docId};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RSIndexResult, RSOffsetSlice,
     opaque::OpaqueEncoding,
@@ -221,7 +221,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort() {
             return Ok(RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -10,7 +10,7 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, t_docId};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::{RSIndexResult, RSOffsetSlice, TermReader};
 use query_term::RSQueryTerm;
 
@@ -100,7 +100,7 @@ where
     ///
     /// The raw pointers inside `spec` (e.g. `keysDict`) must be valid and
     /// dereferenceable for the duration of the call.
-    fn should_abort(&self, spec: &mut IndexSpec) -> bool {
+    fn should_abort(&self, spec: &mut IndexSpecReadGuard) -> bool {
         // Redis_OpenInvertedIndex() relies on keysDict to open the II.
         // It should always be set in production flows but some tests do not set up a full spec.
         if !spec.has_keys_dict() {
@@ -119,12 +119,12 @@ where
             .as_bytes()
             .map_or(std::ptr::null(), |b| b.as_ptr().cast());
 
-        // SAFETY: spec.as_mut_raw_ptr() points to a valid IndexSpec for the duration
+        // SAFETY: spec.as_mut_ptr() points to a valid IndexSpec for the duration
         // of this call, guaranteed by the caller holding the spec read lock.
         // `str_ptr` is a valid byte slice of `term.len()` bytes.
         let idx = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                spec.as_mut_raw_ptr(),
+                spec.as_mut_ptr(),
                 str_ptr,
                 term.len(),
                 false,
@@ -203,7 +203,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort(spec) {
             return Ok(RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -100,7 +100,7 @@ where
     ///
     /// The raw pointers inside `spec` (e.g. `keysDict`) must be valid and
     /// dereferenceable for the duration of the call.
-    fn should_abort(&self, spec: &mut IndexSpecReadGuard) -> bool {
+    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
         // Redis_OpenInvertedIndex() relies on keysDict to open the II.
         // It should always be set in production flows but some tests do not set up a full spec.
         if !spec.has_keys_dict() {
@@ -203,7 +203,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.should_abort(spec) {
             return Ok(RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -10,6 +10,7 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, t_docId};
+use index_spec::IndexSpec;
 use inverted_index::{RSIndexResult, RSOffsetSlice, TermReader};
 use query_term::RSQueryTerm;
 
@@ -99,10 +100,10 @@ where
     ///
     /// The raw pointers inside `spec` (e.g. `keysDict`) must be valid and
     /// dereferenceable for the duration of the call.
-    unsafe fn should_abort(&self, spec: &ffi::IndexSpec) -> bool {
+    fn should_abort(&self, spec: &mut IndexSpec) -> bool {
         // Redis_OpenInvertedIndex() relies on keysDict to open the II.
         // It should always be set in production flows but some tests do not set up a full spec.
-        if spec.keysDict.is_null() {
+        if !spec.has_keys_dict() {
             return false;
         }
 
@@ -118,11 +119,12 @@ where
             .as_bytes()
             .map_or(std::ptr::null(), |b| b.as_ptr().cast());
 
-        // SAFETY: `spec` is a valid `IndexSpec` and
+        // SAFETY: spec.as_mut_raw_ptr() points to a valid IndexSpec for the duration
+        // of this call, guaranteed by the caller holding the spec read lock.
         // `str_ptr` is a valid byte slice of `term.len()` bytes.
         let idx = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                spec as *const ffi::IndexSpec as *mut ffi::IndexSpec,
+                spec.as_mut_raw_ptr(),
                 str_ptr,
                 term.len(),
                 false,
@@ -199,20 +201,15 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: The caller guarantees `spec` points to a valid `IndexSpec`
-        // while the spec read lock is held.
-        let spec_ref = unsafe { spec.as_ref() };
-        // SAFETY: `spec_ref` satisfies `should_abort`'s safety requirements.
-        if unsafe { self.should_abort(spec_ref) } {
+        if self.should_abort(spec) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.it.revalidate(spec) }
+        self.it.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -74,7 +74,7 @@ where
     /// 1. `spec.existingDocs`, when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    fn should_abort(&self, spec: &mut IndexSpecReadGuard) -> bool {
+    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
         let existing_docs = spec
             .existing_docs()
             .cast::<inverted_index::opaque::InvertedIndex>();
@@ -143,7 +143,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // The existingDocs encoding match is a structural invariant: the
         // encoding is determined at index creation and cannot change.

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -8,7 +8,7 @@
 */
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
 };
@@ -74,7 +74,7 @@ where
     /// 1. `spec.existingDocs`, when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    fn should_abort(&self, spec: &mut IndexSpec) -> bool {
+    fn should_abort(&self, spec: &mut IndexSpecReadGuard) -> bool {
         let existing_docs = spec
             .existing_docs()
             .cast::<inverted_index::opaque::InvertedIndex>();
@@ -143,7 +143,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // The existingDocs encoding match is a structural invariant: the
         // encoding is determined at index creation and cannot change.

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -7,9 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ptr::NonNull;
-
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
 };
@@ -75,18 +74,18 @@ where
     /// 1. `spec.existingDocs`, when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    unsafe fn should_abort(&self, spec: &ffi::IndexSpec) -> bool {
+    fn should_abort(&self, spec: &mut IndexSpec) -> bool {
         let existing_docs = spec
-            .existingDocs
+            .existing_docs()
             .cast::<inverted_index::opaque::InvertedIndex>();
         if existing_docs.is_null() {
             // the garbage collector may set existing_docs to NULL after garbage collecting all documents
             return true;
         }
 
-        // SAFETY: 1. guarantees `existingDocs` is valid when non-null, and we just checked it's not null.
+        // SAFETY: spec.existing_docs() returns a valid pointer when non-null, and we just checked it's not null.
         let existing_docs = unsafe { &*existing_docs };
-        // SAFETY: 1. guarantees the encoding variant matches E.
+        // SAFETY: The encoding variant matches E (structural invariant).
         let ii = E::from_opaque(existing_docs);
 
         !self.it.reader.points_to_ii(ii)
@@ -142,22 +141,17 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: The caller guarantees `spec` points to a valid `IndexSpec`
-        // while the spec read lock is held.
-        let spec_ref = unsafe { spec.as_ref() };
-        // SAFETY: `spec_ref` satisfies `should_abort`'s safety requirements.
         // The existingDocs encoding match is a structural invariant: the
         // encoding is determined at index creation and cannot change.
-        if unsafe { self.should_abort(spec_ref) } {
+        if self.should_abort(spec) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.it.revalidate(spec) }
+        self.it.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -10,7 +10,7 @@
 use std::sync::OnceLock;
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use thiserror::Error;
 
 use ::inverted_index::{RSIndexResult, t_fieldMask};
@@ -138,11 +138,13 @@ pub trait RQEIterator<'index> {
     /// The iterator should check if it is still valid by comparing its stored state
     /// against the current index state.
     ///
-    /// The caller (result processor) holds the spec read lock during this call,
-    /// ensuring that `spec` remains valid and unchanged.
+    /// # Locking
+    ///
+    /// The caller must hold the spec read lock, represented by [`IndexSpecReadGuard`].
+    /// The lock ensures the spec remains valid and unchanged during this call.
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
 
     /// Rewind the iterator to the beginning and reset its properties.
@@ -205,7 +207,7 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         (**self).revalidate(spec)
     }
@@ -262,7 +264,7 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         (**self).revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -7,9 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{ptr::NonNull, sync::OnceLock};
+use std::sync::OnceLock;
 
-use ffi::{IndexSpec, t_docId};
+use ffi::t_docId;
+use index_spec::IndexSpec;
 use thiserror::Error;
 
 use ::inverted_index::{RSIndexResult, t_fieldMask};
@@ -134,13 +135,14 @@ pub trait RQEIterator<'index> {
 
     /// Called when the iterator is being revalidated after a concurrent index change.
     ///
-    /// The iterator should check if it is still valid.
+    /// The iterator should check if it is still valid by comparing its stored state
+    /// against the current index state.
     ///
-    /// # Safety
-    /// `spec` must point to a valid [`IndexSpec`] for the duration of the call.
-    unsafe fn revalidate(
+    /// The caller (result processor) holds the spec read lock during this call,
+    /// ensuring that `spec` remains valid and unchanged.
+    fn revalidate(
         &mut self,
-        spec: NonNull<IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
 
     /// Rewind the iterator to the beginning and reset its properties.
@@ -201,12 +203,11 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
         (**self).skip_to(doc_id)
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { (**self).revalidate(spec) }
+        (**self).revalidate(spec)
     }
 
     fn rewind(&mut self) {
@@ -259,12 +260,11 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
         (**self).skip_to(doc_id)
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: NonNull<IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { (**self).revalidate(spec) }
+        (**self).revalidate(spec)
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -144,7 +144,7 @@ pub trait RQEIterator<'index> {
     /// The lock ensures the spec remains valid and unchanged during this call.
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
 
     /// Rewind the iterator to the beginning and reset its properties.
@@ -207,7 +207,7 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         (**self).revalidate(spec)
     }
@@ -264,7 +264,7 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         (**self).revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -10,6 +10,7 @@
 //! Helper wrapping either [`Empty`] or the provided [`RQEIterator`].
 
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 
 use crate::{
@@ -117,15 +118,13 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match &mut self.0 {
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            MaybeEmptyOption::None(empty) => unsafe { empty.revalidate(spec) },
-            // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-            MaybeEmptyOption::Some(it) => unsafe { it.revalidate(spec) },
+            MaybeEmptyOption::None(empty) => empty.revalidate(spec),
+            MaybeEmptyOption::Some(it) => it.revalidate(spec),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -120,7 +120,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match &mut self.0 {
             MaybeEmptyOption::None(empty) => empty.revalidate(spec),

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -10,7 +10,7 @@
 //! Helper wrapping either [`Empty`] or the provided [`RQEIterator`].
 
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 
 use crate::{
@@ -120,7 +120,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         match &mut self.0 {
             MaybeEmptyOption::None(empty) => empty.revalidate(spec),

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -14,7 +14,7 @@ use crate::{
     utils::OwnedSlice,
 };
 use ffi::{RLookupKey, RLookupKeyHandle, t_docId};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 
 /// The different types of metrics.
@@ -188,7 +188,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.base.revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -188,7 +188,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.base.revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -14,6 +14,7 @@ use crate::{
     utils::OwnedSlice,
 };
 use ffi::{RLookupKey, RLookupKeyHandle, t_docId};
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 
 /// The different types of metrics.
@@ -185,12 +186,11 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.base.revalidate(spec) }
+        self.base.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -230,7 +230,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Get child status
         match self.child.revalidate(spec)? {

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -19,6 +19,7 @@ use crate::{
     maybe_empty::MaybeEmpty, utils::TimeoutContext,
 };
 
+use index_spec::IndexSpec;
 /// An iterator that negates the results of its child iterator.
 ///
 /// Yields all document IDs from 1 to `max_doc_id` (inclusive) that are **not**
@@ -227,13 +228,12 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Get child status
-        // SAFETY: Delegating to child with the same `spec` passed by our caller.
-        match unsafe { self.child.revalidate(spec) }? {
+        match self.child.revalidate(spec)? {
             RQEValidateStatus::Aborted => {
                 self.child = MaybeEmpty::new_empty();
                 Ok(RQEValidateStatus::Ok)

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -19,7 +19,7 @@ use crate::{
     maybe_empty::MaybeEmpty, utils::TimeoutContext,
 };
 
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 /// An iterator that negates the results of its child iterator.
 ///
 /// Yields all document IDs from 1 to `max_doc_id` (inclusive) that are **not**
@@ -230,7 +230,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Get child status
         match self.child.revalidate(spec)? {

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -18,6 +18,7 @@ use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     WildcardIterator, maybe_empty::MaybeEmpty, not::NotIterator, utils::TimeoutContext,
 };
+use index_spec::IndexSpec;
 
 /// Check the clock every this many loop iterations to amortize syscall cost.
 const TIMEOUT_CHECK_GRANULARITY: u32 = 5_000;
@@ -266,23 +267,18 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // 1. Revalidate the wildcard iterator first.
-        // SAFETY: Delegating to children with the same `spec` passed by our caller.
-        let wcii_status = unsafe { self.wcii.revalidate(spec) }?;
+        let wcii_status = self.wcii.revalidate(spec)?;
         if matches!(wcii_status, RQEValidateStatus::Aborted) {
             return Ok(RQEValidateStatus::Aborted);
         }
 
         // 2. Revalidate the child iterator.
-        let child_aborted = matches!(
-            // SAFETY: Delegating to child with the same `spec` passed by our caller.
-            unsafe { self.child.revalidate(spec) }?,
-            RQEValidateStatus::Aborted
-        );
+        let child_aborted = matches!(self.child.revalidate(spec)?, RQEValidateStatus::Aborted);
         if child_aborted {
             // When child is aborted, NOT becomes "NOT nothing" = everything
             // from the wildcard iterator.

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -269,7 +269,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // 1. Revalidate the wildcard iterator first.
         let wcii_status = self.wcii.revalidate(spec)?;

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -18,7 +18,7 @@ use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     WildcardIterator, maybe_empty::MaybeEmpty, not::NotIterator, utils::TimeoutContext,
 };
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 
 /// Check the clock every this many loop iterations to amortize syscall cost.
 const TIMEOUT_CHECK_GRANULARITY: u32 = 5_000;
@@ -269,7 +269,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // 1. Revalidate the wildcard iterator first.
         let wcii_status = self.wcii.revalidate(spec)?;

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -228,7 +228,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let Some(ref mut child) = self.child else {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -14,6 +14,7 @@ use inverted_index::RSIndexResult;
 use std::cmp;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use index_spec::IndexSpec;
 
 /// Trait implemented by all optional iterator variants.
 ///
@@ -225,9 +226,9 @@ where
         Ok(Some(SkipToOutcome::Found(&mut self.result)))
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let Some(ref mut child) = self.child else {
             return Ok(RQEValidateStatus::Ok);
@@ -235,8 +236,7 @@ where
         let last_child_doc_id = child.last_doc_id();
 
         // Revalidate the child iterator
-        // SAFETY: Delegating to child with the same `spec` passed by our caller.
-        match unsafe { child.revalidate(spec) }? {
+        match child.revalidate(spec)? {
             // Abort: Handle child validation results (but continue processing)
             status @ (RQEValidateStatus::Aborted | RQEValidateStatus::Moved { .. }) => {
                 if matches!(status, RQEValidateStatus::Aborted) {

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -14,7 +14,7 @@ use inverted_index::RSIndexResult;
 use std::cmp;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 
 /// Trait implemented by all optional iterator variants.
 ///
@@ -228,7 +228,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let Some(ref mut child) = self.child else {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -22,7 +22,7 @@ use crate::{
     optional::OptionalIterator, wildcard::WildcardIterator,
 };
 
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 /// An iterator that emits results for all document IDs present in the index,
 /// driven by a [wildcard iterator](crate::wildcard) over the existing-documents inverted index.
 ///
@@ -246,7 +246,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Simple enum to avoid holding a borrow through the match.
         enum ValidateOutcome {

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -22,6 +22,7 @@ use crate::{
     optional::OptionalIterator, wildcard::WildcardIterator,
 };
 
+use index_spec::IndexSpec;
 /// An iterator that emits results for all document IDs present in the index,
 /// driven by a [wildcard iterator](crate::wildcard) over the existing-documents inverted index.
 ///
@@ -243,9 +244,9 @@ where
         }
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Simple enum to avoid holding a borrow through the match.
         enum ValidateOutcome {
@@ -254,8 +255,7 @@ where
         }
 
         // Step 1: Revalidate wcii. If it aborts or is at EOF, we can return immediately.
-        // SAFETY: Delegating to children with the same `spec` passed by our caller.
-        let wcii_outcome = match unsafe { self.wcii.revalidate(spec) }? {
+        let wcii_outcome = match self.wcii.revalidate(spec)? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { current: Some(_) } => ValidateOutcome::Moved,
             RQEValidateStatus::Moved { current: None } => {
@@ -273,8 +273,7 @@ where
 
         // Step 2: Revalidate child. If it aborts, replace with an empty iterator.
         // Abort is treated as Moved: child's state changed, so we must re-evaluate.
-        // SAFETY: Delegating to child with the same `spec` passed by our caller.
-        let child_outcome = match unsafe { self.child.revalidate(spec) }? {
+        let child_outcome = match self.child.revalidate(spec)? {
             RQEValidateStatus::Ok => ValidateOutcome::Ok,
             RQEValidateStatus::Moved { .. } => ValidateOutcome::Moved,
             RQEValidateStatus::Aborted => {

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -246,7 +246,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Simple enum to avoid holding a borrow through the match.
         enum ValidateOutcome {

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -135,7 +135,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.child.revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use ffi::t_docId;
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 
 /// Profile counters collected during query execution.
@@ -132,12 +133,11 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
         self.child.at_eof()
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to child with the same `spec` passed by our caller.
-        unsafe { self.child.revalidate(spec) }
+        self.child.revalidate(spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use ffi::t_docId;
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::RSIndexResult;
 
 /// Profile counters collected during query execution.
@@ -135,7 +135,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.child.revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -13,6 +13,7 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use index_spec::IndexSpec;
 
 /// A child iterator paired with its original insertion index.
 ///
@@ -505,9 +506,9 @@ where
         self.is_eof
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Already at EOF - nothing to do
         if self.is_eof {
@@ -522,8 +523,7 @@ where
         // We use index-based iteration because we need to remove elements while iterating.
         let mut i = 0;
         while i < self.children.len() {
-            // SAFETY: Delegating to child with the same `spec` passed by our caller.
-            match unsafe { self.children[i].revalidate(spec) }? {
+            match self.children[i].revalidate(spec)? {
                 RQEValidateStatus::Aborted => {
                     // Remove aborted child using swap_remove for O(1) removal.
                     // Order doesn't matter for union iteration.

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -508,7 +508,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Already at EOF - nothing to do
         if self.is_eof {

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -13,7 +13,7 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 
 /// A child iterator paired with its original insertion index.
 ///
@@ -508,7 +508,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Already at EOF - nothing to do
         if self.is_eof {

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -421,7 +421,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.is_eof {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -14,7 +14,7 @@ use inverted_index::RSIndexResult;
 
 use crate::utils::DocIdMinHeap;
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 
 /// Yields documents appearing in ANY child iterator using a binary heap.
 ///
@@ -421,7 +421,7 @@ where
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.is_eof {
             return Ok(RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -14,6 +14,7 @@ use inverted_index::RSIndexResult;
 
 use crate::utils::DocIdMinHeap;
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use index_spec::IndexSpec;
 
 /// Yields documents appearing in ANY child iterator using a binary heap.
 ///
@@ -418,9 +419,9 @@ where
         self.is_eof
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         if self.is_eof {
             return Ok(RQEValidateStatus::Ok);
@@ -432,8 +433,7 @@ where
         // Index-based iteration: swap_remove may reorder elements.
         let mut i = 0;
         while i < self.children.len() {
-            // SAFETY: Delegating to child with the same `spec` passed by our caller.
-            match unsafe { self.children[i].revalidate(spec) }? {
+            match self.children[i].revalidate(spec)? {
                 RQEValidateStatus::Aborted => {
                     self.children.swap_remove(i);
                     any_change = true;

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -31,6 +31,7 @@ use crate::{
     UnionFullHeap, UnionQuickFlat, UnionQuickHeap, UnionTrimmed,
 };
 
+use index_spec::IndexSpec;
 /// Enum holding all possible union iterator variants.
 pub enum UnionVariant<'index, I> {
     FlatFull(UnionFullFlat<'index, I>),
@@ -166,12 +167,11 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-        unsafe { delegate_variant_ref_mut!(self, revalidate, spec) }
+        delegate_variant_ref_mut!(self, revalidate, spec)
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -31,7 +31,7 @@ use crate::{
     UnionFullHeap, UnionQuickFlat, UnionQuickHeap, UnionTrimmed,
 };
 
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 /// Enum holding all possible union iterator variants.
 pub enum UnionVariant<'index, I> {
     FlatFull(UnionFullFlat<'index, I>),
@@ -169,7 +169,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         delegate_variant_ref_mut!(self, revalidate, spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -169,7 +169,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     #[inline(always)]
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         delegate_variant_ref_mut!(self, revalidate, spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -49,6 +49,7 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use index_spec::IndexSpec;
 
 /// Union iterator that drains children sequentially in reverse order.
 ///
@@ -264,9 +265,9 @@ where
     }
 
     #[inline(always)]
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Trimmed unions run in a single, short-lived read path that does not
         // interleave with GC cycles, so revalidation should never be called.

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -49,7 +49,7 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 
 /// Union iterator that drains children sequentially in reverse order.
 ///
@@ -267,7 +267,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Trimmed unions run in a single, short-lived read path that does not
         // interleave with GC cycles, so revalidation should never be called.

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -267,7 +267,7 @@ where
     #[inline(always)]
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpecReadGuard,
+        _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Trimmed unions run in a single, short-lived read path that does not
         // interleave with GC cycles, so revalidation should never be called.

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -12,6 +12,7 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
+use index_spec::IndexSpec;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, RSIndexResult, opaque};
 
@@ -95,9 +96,9 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
         self.result.doc_id >= self.top_id
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -156,12 +157,11 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
         (**self).skip_to(doc_id)
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { (**self).revalidate(spec) }
+        (**self).revalidate(spec)
     }
 
     fn rewind(&mut self) {
@@ -263,12 +263,11 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
         delegate_rqe_iterator!(self, at_eof)
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-        unsafe { delegate_rqe_iterator!(self, revalidate, spec) }
+        delegate_rqe_iterator!(self, revalidate, spec)
     }
 
     #[inline(always)]
@@ -328,12 +327,11 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
         delegate_wildcard_iterator!(self, at_eof)
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to variant with the same `spec` passed by our caller.
-        unsafe { delegate_wildcard_iterator!(self, revalidate, spec) }
+        delegate_wildcard_iterator!(self, revalidate, spec)
     }
 
     #[inline(always)]
@@ -539,12 +537,11 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
         self.0.skip_to(doc_id)
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        spec: std::ptr::NonNull<ffi::IndexSpec>,
+        spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // SAFETY: Delegating to inner iterator with the same `spec` passed by our caller.
-        unsafe { self.0.revalidate(spec) }
+        self.0.revalidate(spec)
     }
 
     fn rewind(&mut self) {

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -12,7 +12,7 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use index_spec::IndexSpec;
+use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, RSIndexResult, opaque};
 
@@ -98,7 +98,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -159,7 +159,7 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         (**self).revalidate(spec)
     }
@@ -265,7 +265,7 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         delegate_rqe_iterator!(self, revalidate, spec)
     }
@@ -329,7 +329,7 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         delegate_wildcard_iterator!(self, revalidate, spec)
     }
@@ -539,7 +539,7 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpec,
+        spec: &mut IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.0.revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -98,7 +98,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpecReadGuard,
+        _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -159,7 +159,7 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         (**self).revalidate(spec)
     }
@@ -265,7 +265,7 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         delegate_rqe_iterator!(self, revalidate, spec)
     }
@@ -329,7 +329,7 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         delegate_wildcard_iterator!(self, revalidate, spec)
     }
@@ -539,7 +539,7 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
 
     fn revalidate(
         &mut self,
-        spec: &mut IndexSpecReadGuard,
+        spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.0.revalidate(spec)
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -67,9 +67,9 @@ fn type_() {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = Empty::default();
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&mut *guard)
+        it.revalidate(&*guard)
             .expect("revalidate failed"),
         RQEValidateStatus::Ok
     );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -69,8 +69,7 @@ fn revalidate() {
     let mut it = Empty::default();
     let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&*guard)
-            .expect("revalidate failed"),
+        it.revalidate(&*guard).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -67,9 +67,9 @@ fn type_() {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = Empty::default();
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(unsafe { mock_ctx.spec_mut() })
+        it.revalidate(&mut *guard)
             .expect("revalidate failed"),
         RQEValidateStatus::Ok
     );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -68,7 +68,7 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = Empty::default();
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -67,9 +67,8 @@ fn type_() {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = Empty::default();
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -67,9 +67,9 @@ fn type_() {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = Empty::default();
-    let guard = mock_ctx.spec_read_guard();
-    assert_eq!(
-        it.revalidate(&*guard).expect("revalidate failed"),
-        RQEValidateStatus::Ok
-    );
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate failed")
+    };
+    assert_eq!(status, RQEValidateStatus::Ok);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -66,11 +66,11 @@ fn type_() {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let mut it = Empty::default();
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(ctx) }.expect("revalidate failed"),
+        it.revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -232,11 +232,11 @@ fn rewind(#[case] case: &[u64]) {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let mut it = IdListSorted::new(vec![1, 2, 3]);
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(ctx) }.expect("revalidate failed"),
+        it.revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -233,9 +233,8 @@ fn rewind(#[case] case: &[u64]) {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = IdListSorted::new(vec![1, 2, 3]);
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -233,9 +233,9 @@ fn rewind(#[case] case: &[u64]) {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = IdListSorted::new(vec![1, 2, 3]);
-    let guard = mock_ctx.spec_read_guard();
-    assert_eq!(
-        it.revalidate(&*guard).expect("revalidate failed"),
-        RQEValidateStatus::Ok
-    );
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate failed")
+    };
+    assert_eq!(status, RQEValidateStatus::Ok);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -235,8 +235,7 @@ fn revalidate() {
     let mut it = IdListSorted::new(vec![1, 2, 3]);
     let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&*guard)
-            .expect("revalidate failed"),
+        it.revalidate(&*guard).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -233,9 +233,9 @@ fn rewind(#[case] case: &[u64]) {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = IdListSorted::new(vec![1, 2, 3]);
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&mut *guard)
+        it.revalidate(&*guard)
             .expect("revalidate failed"),
         RQEValidateStatus::Ok
     );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -234,7 +234,7 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = IdListSorted::new(vec![1, 2, 3]);
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -233,9 +233,9 @@ fn rewind(#[case] case: &[u64]) {
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = IdListSorted::new(vec![1, 2, 3]);
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(unsafe { mock_ctx.spec_mut() })
+        it.revalidate(&mut *guard)
             .expect("revalidate failed"),
         RQEValidateStatus::Ok
     );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -586,7 +586,7 @@ fn revalidate_ok() {
 
     // Revalidate should return Ok
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(matches!(status, RQEValidateStatus::Ok));
@@ -626,7 +626,7 @@ fn revalidate_aborted() {
 
     // Revalidate should return Aborted since one child aborted
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(matches!(status, RQEValidateStatus::Aborted));
@@ -662,7 +662,7 @@ fn revalidate_moved() {
 
     // Revalidate should return Moved
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(
@@ -709,7 +709,7 @@ fn revalidate_mixed_results() {
 
     // Revalidate should return Moved (if any child moved)
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -746,7 +746,7 @@ fn revalidate_after_eof() {
 
     // Revalidate should return OK when already at EOF
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(
@@ -799,7 +799,7 @@ fn revalidate_some_children_moved_to_eof() {
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(
@@ -960,7 +960,7 @@ fn revalidate_before_read() {
 
     // Revalidate before any read
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(
@@ -999,7 +999,7 @@ fn revalidate_move_before_read() {
 
     // Revalidate before any read - children will move
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
 
@@ -1144,7 +1144,7 @@ fn revalidate_moved_skip_to_returns_none() {
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         ii.revalidate(&*guard).expect("revalidate failed")
     };
     assert!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -555,7 +555,6 @@ fn many_children() {
 #[test]
 fn revalidate_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     // Create mock children with const generic arrays
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
@@ -587,7 +586,9 @@ fn revalidate_ok() {
 
     // Revalidate should return Ok
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
     // Should be able to continue reading
@@ -599,7 +600,6 @@ fn revalidate_ok() {
 #[test]
 fn revalidate_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -626,7 +626,9 @@ fn revalidate_aborted() {
 
     // Revalidate should return Aborted since one child aborted
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
 
@@ -634,7 +636,6 @@ fn revalidate_aborted() {
 #[test]
 fn revalidate_moved() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -661,7 +662,9 @@ fn revalidate_moved() {
 
     // Revalidate should return Moved
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
         "Expected Moved with current, got {:?}",
@@ -680,7 +683,6 @@ fn revalidate_moved() {
 #[test]
 fn revalidate_mixed_results() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -707,7 +709,9 @@ fn revalidate_mixed_results() {
 
     // Revalidate should return Moved (if any child moved)
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
 }
@@ -716,7 +720,6 @@ fn revalidate_mixed_results() {
 #[test]
 fn revalidate_after_eof() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     // Pre-set children to return MOVE on revalidate
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
@@ -743,7 +746,9 @@ fn revalidate_after_eof() {
 
     // Revalidate should return OK when already at EOF
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate after EOF should return OK, got {:?}",
@@ -763,7 +768,6 @@ fn revalidate_after_eof() {
 #[test]
 fn revalidate_some_children_moved_to_eof() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     // Child 0 and 2 have normal data, child 1 is small (only 2 elements: [10, 20])
     // When we read doc 10 and then call Move, child 1 moves to 20 and the next Move
     // would go to EOF
@@ -795,7 +799,9 @@ fn revalidate_some_children_moved_to_eof() {
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved to EOF, got {:?}",
@@ -932,7 +938,6 @@ fn overlapping_children_ids() {
 #[test]
 fn revalidate_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -955,7 +960,9 @@ fn revalidate_before_read() {
 
     // Revalidate before any read
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate before read should return Ok"
@@ -970,7 +977,6 @@ fn revalidate_before_read() {
 #[test]
 fn revalidate_move_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
     let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
@@ -993,7 +999,9 @@ fn revalidate_move_before_read() {
 
     // Revalidate before any read - children will move
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
     // the result depends on implementation. The iterator should
@@ -1092,7 +1100,6 @@ fn children_sorted_by_estimated() {
 #[test]
 fn revalidate_moved_skip_to_returns_none() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     // Set up children where:
     // - They share doc 10 (will read this first)
     // - After Move, child0 goes to doc 15, child1 goes to doc 18, child2 goes to doc 22
@@ -1137,7 +1144,9 @@ fn revalidate_moved_skip_to_returns_none() {
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
     // SAFETY: test-only call with valid context
-    let status = unsafe { ii.revalidate(ctx) }.expect("revalidate failed");
+    let status = ii
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved {{ current: None }} when skip_to cannot find consensus, got {:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -585,9 +585,9 @@ fn revalidate_ok() {
     assert_eq!(result.doc_id, 20);
 
     // Revalidate should return Ok
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
@@ -625,9 +625,9 @@ fn revalidate_aborted() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Aborted since one child aborted
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
@@ -661,9 +661,9 @@ fn revalidate_moved() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
@@ -708,9 +708,9 @@ fn revalidate_mixed_results() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved (if any child moved)
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
@@ -745,9 +745,9 @@ fn revalidate_after_eof() {
     assert!(ii.at_eof());
 
     // Revalidate should return OK when already at EOF
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
@@ -798,9 +798,9 @@ fn revalidate_some_children_moved_to_eof() {
 
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
@@ -959,9 +959,9 @@ fn revalidate_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
@@ -998,9 +998,9 @@ fn revalidate_move_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read - children will move
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
@@ -1143,9 +1143,9 @@ fn revalidate_moved_skip_to_returns_none() {
     // skip_to(22) will fail because:
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -586,9 +586,7 @@ fn revalidate_ok() {
 
     // Revalidate should return Ok
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
     // Should be able to continue reading
@@ -626,9 +624,7 @@ fn revalidate_aborted() {
 
     // Revalidate should return Aborted since one child aborted
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
 
@@ -662,9 +658,7 @@ fn revalidate_moved() {
 
     // Revalidate should return Moved
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
         "Expected Moved with current, got {:?}",
@@ -709,9 +703,7 @@ fn revalidate_mixed_results() {
 
     // Revalidate should return Moved (if any child moved)
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
 }
@@ -746,9 +738,7 @@ fn revalidate_after_eof() {
 
     // Revalidate should return OK when already at EOF
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate after EOF should return OK, got {:?}",
@@ -799,9 +789,7 @@ fn revalidate_some_children_moved_to_eof() {
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved to EOF, got {:?}",
@@ -960,9 +948,7 @@ fn revalidate_before_read() {
 
     // Revalidate before any read
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate before read should return Ok"
@@ -999,9 +985,7 @@ fn revalidate_move_before_read() {
 
     // Revalidate before any read - children will move
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
     // the result depends on implementation. The iterator should
@@ -1144,9 +1128,7 @@ fn revalidate_moved_skip_to_returns_none() {
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
     let guard = mock_ctx.spec_read_guard();
-    let status = ii
-        .revalidate(&*guard)
-        .expect("revalidate failed");
+    let status = ii.revalidate(&*guard).expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved {{ current: None }} when skip_to cannot find consensus, got {:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -585,8 +585,10 @@ fn revalidate_ok() {
     assert_eq!(result.doc_id, 20);
 
     // Revalidate should return Ok
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(matches!(status, RQEValidateStatus::Ok));
 
     // Should be able to continue reading
@@ -623,8 +625,10 @@ fn revalidate_aborted() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Aborted since one child aborted
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
 
@@ -657,8 +661,10 @@ fn revalidate_moved() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
         "Expected Moved with current, got {:?}",
@@ -702,8 +708,10 @@ fn revalidate_mixed_results() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved (if any child moved)
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
 }
@@ -737,8 +745,10 @@ fn revalidate_after_eof() {
     assert!(ii.at_eof());
 
     // Revalidate should return OK when already at EOF
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate after EOF should return OK, got {:?}",
@@ -788,8 +798,10 @@ fn revalidate_some_children_moved_to_eof() {
 
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved to EOF, got {:?}",
@@ -947,8 +959,10 @@ fn revalidate_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate before read should return Ok"
@@ -984,8 +998,10 @@ fn revalidate_move_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read - children will move
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
 
     // Since we haven't read anything yet, and children moved,
     // the result depends on implementation. The iterator should
@@ -1127,8 +1143,10 @@ fn revalidate_moved_skip_to_returns_none() {
     // skip_to(22) will fail because:
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
-    let guard = mock_ctx.spec_read_guard();
-    let status = ii.revalidate(&*guard).expect("revalidate failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        ii.revalidate(&*guard).expect("revalidate failed")
+    };
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved {{ current: None }} when skip_to cannot find consensus, got {:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -585,9 +585,9 @@ fn revalidate_ok() {
     assert_eq!(result.doc_id, 20);
 
     // Revalidate should return Ok
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
@@ -625,9 +625,9 @@ fn revalidate_aborted() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Aborted since one child aborted
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
@@ -661,9 +661,9 @@ fn revalidate_moved() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
@@ -708,9 +708,9 @@ fn revalidate_mixed_results() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved (if any child moved)
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
@@ -745,9 +745,9 @@ fn revalidate_after_eof() {
     assert!(ii.at_eof());
 
     // Revalidate should return OK when already at EOF
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
@@ -798,9 +798,9 @@ fn revalidate_some_children_moved_to_eof() {
 
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
@@ -959,9 +959,9 @@ fn revalidate_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
@@ -998,9 +998,9 @@ fn revalidate_move_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read - children will move
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
@@ -1143,9 +1143,9 @@ fn revalidate_moved_skip_to_returns_none() {
     // skip_to(22) will fail because:
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = ii
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -585,10 +585,9 @@ fn revalidate_ok() {
     assert_eq!(result.doc_id, 20);
 
     // Revalidate should return Ok
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Ok));
 
     // Should be able to continue reading
@@ -625,10 +624,9 @@ fn revalidate_aborted() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Aborted since one child aborted
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Aborted));
 }
 
@@ -661,10 +659,9 @@ fn revalidate_moved() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
         "Expected Moved with current, got {:?}",
@@ -708,10 +705,9 @@ fn revalidate_mixed_results() {
     assert_eq!(result.doc_id, 10);
 
     // Revalidate should return Moved (if any child moved)
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(matches!(status, RQEValidateStatus::Moved { .. }));
     assert_eq!(ii.last_doc_id(), 20);
 }
@@ -745,10 +741,9 @@ fn revalidate_after_eof() {
     assert!(ii.at_eof());
 
     // Revalidate should return OK when already at EOF
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate after EOF should return OK, got {:?}",
@@ -798,10 +793,9 @@ fn revalidate_some_children_moved_to_eof() {
 
     // Revalidate should return Moved with current=None (EOF)
     // because child 1 moves to EOF (it only had 1 element which was already read)
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved to EOF, got {:?}",
@@ -959,10 +953,9 @@ fn revalidate_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Ok),
         "Revalidate before read should return Ok"
@@ -998,10 +991,9 @@ fn revalidate_move_before_read() {
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Revalidate before any read - children will move
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
 
     // Since we haven't read anything yet, and children moved,
     // the result depends on implementation. The iterator should
@@ -1143,10 +1135,9 @@ fn revalidate_moved_skip_to_returns_none() {
     // skip_to(22) will fail because:
     // - child0 has no doc >= 22 (only has [10, 15]), goes EOF
     // - Result: Moved { current: None }
-    let status = {
-        let guard = mock_ctx.spec_read();
-        ii.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = ii
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert!(
         matches!(status, RQEValidateStatus::Moved { current: None }),
         "Expected Moved {{ current: None }} when skip_to cannot find consensus, got {:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -151,16 +151,14 @@ mod not_miri {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
         // Verify the iterator works normally and read at least one document
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the missing-field inverted index being garbage collected and
@@ -190,10 +188,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // No restore needed: the new II will be freed by `dictRelease` during
@@ -219,10 +216,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the garbage collector removing the missing-field index
@@ -239,10 +235,9 @@ mod not_miri {
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // No restore needed: the entry was properly freed by `dictDelete`.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -151,16 +151,16 @@ mod not_miri {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
         // Verify the iterator works normally and read at least one document
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -190,9 +190,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -220,9 +220,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -238,9 +238,9 @@ mod not_miri {
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -153,15 +153,13 @@ mod not_miri {
         // Verify the iterator works normally and read at least one document
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -192,8 +190,7 @@ mod not_miri {
         // points to the same index the reader was created from.
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -222,8 +219,7 @@ mod not_miri {
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -240,8 +236,7 @@ mod not_miri {
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -180,7 +180,7 @@ mod not_miri {
         // `is_index` without dereferencing it, so this is safe.
         let guard = test.test.context.spec_read_guard();
         unsafe {
-            let dict = (*guard.as_ptr()).missingFieldDict;
+            let dict = guard.missing_field_dict();
             ffi::RS_dictDelete(dict, field_name as *mut _);
             let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
             assert_eq!(rc, 0, "dictAdd failed");

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -150,18 +150,18 @@ mod not_miri {
     fn missing_revalidate_after_index_disappears() {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.spec;
-
         // Verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -181,7 +181,7 @@ mod not_miri {
         // original II, but `should_abort` only compares pointers via
         // `is_index` without dereferencing it, so this is safe.
         unsafe {
-            let dict = (*test.test.context.spec.as_ptr()).missingFieldDict;
+            let dict = (*test.test.context.spec_ref().as_raw_ptr()).missingFieldDict;
             ffi::RS_dictDelete(dict, field_name as *mut _);
             let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
             assert_eq!(rc, 0, "dictAdd failed");
@@ -191,7 +191,8 @@ mod not_miri {
         // points to the same index the reader was created from.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -218,10 +219,10 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let sctx = test.test.context.spec;
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -230,14 +231,15 @@ mod not_miri {
         // which frees the inverted index.
         let field_name = test.test.context.field_spec().fieldName;
         unsafe {
-            let dict = (*test.test.context.spec.as_ptr()).missingFieldDict;
+            let dict = test.test.context.spec_ref().missing_field_dict();
             ffi::RS_dictDelete(dict, field_name as *mut _);
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -151,17 +151,17 @@ mod not_miri {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
         // Verify the iterator works normally and read at least one document
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the missing-field inverted index being garbage collected and
         // recreated by replacing the dict entry with a new inverted index.
@@ -178,21 +178,23 @@ mod not_miri {
         // Note: the iterator's reader holds a (now-dangling) pointer to the
         // original II, but `should_abort` only compares pointers via
         // `is_index` without dereferencing it, so this is safe.
-        let guard = test.test.context.spec_read_guard();
-        unsafe {
-            let dict = guard.missing_field_dict();
-            ffi::RS_dictDelete(dict, field_name as *mut _);
-            let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
-            assert_eq!(rc, 0, "dictAdd failed");
+        {
+            let guard = test.test.context.spec_read_guard();
+            unsafe {
+                let dict = guard.missing_field_dict();
+                ffi::RS_dictDelete(dict, field_name as *mut _);
+                let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
+                assert_eq!(rc, 0, "dictAdd failed");
+            }
         }
 
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // No restore needed: the new II will be freed by `dictRelease` during
         // `IndexSpec_RemoveFromGlobals` in `TestContext::drop`.
@@ -217,28 +219,31 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the garbage collector removing the missing-field index
         // by deleting the dict entry. `dictDelete` calls the value destructor
         // which frees the inverted index.
         let field_name = test.test.context.field_spec().fieldName;
-        let guard = test.test.context.spec_read_guard();
-        unsafe {
+        {
+            let guard = test.test.context.spec_read_guard();
             let dict = guard.missing_field_dict();
-            ffi::RS_dictDelete(dict, field_name as *mut _);
+
+            unsafe {
+                ffi::RS_dictDelete(dict, field_name as *mut _);
+            }
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // No restore needed: the entry was properly freed by `dictDelete`.
         // `TestContext::drop` calls `dictRelease` which is fine with a

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -152,13 +152,13 @@ mod not_miri {
         let mut it = test.create_iterator();
         // Verify the iterator works normally and read at least one document
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -179,7 +179,7 @@ mod not_miri {
         // original II, but `should_abort` only compares pointers via
         // `is_index` without dereferencing it, so this is safe.
         {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             unsafe {
                 let dict = guard.missing_field_dict();
                 ffi::RS_dictDelete(dict, field_name as *mut _);
@@ -191,7 +191,7 @@ mod not_miri {
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
@@ -220,7 +220,7 @@ mod not_miri {
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -230,7 +230,7 @@ mod not_miri {
         // which frees the inverted index.
         let field_name = test.test.context.field_spec().fieldName;
         {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             let dict = guard.missing_field_dict();
 
             unsafe {
@@ -240,7 +240,7 @@ mod not_miri {
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -176,14 +176,11 @@ mod not_miri {
         // Note: the iterator's reader holds a (now-dangling) pointer to the
         // original II, but `should_abort` only compares pointers via
         // `is_index` without dereferencing it, so this is safe.
-        {
-            let guard = test.test.context.spec_read();
-            unsafe {
-                let dict = guard.missing_field_dict();
-                ffi::RS_dictDelete(dict, field_name as *mut _);
-                let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
-                assert_eq!(rc, 0, "dictAdd failed");
-            }
+        let dict = test.test.context.spec_read().missing_field_dict();
+        unsafe {
+            ffi::RS_dictDelete(dict, field_name as *mut _);
+            let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
+            assert_eq!(rc, 0, "dictAdd failed");
         }
 
         // Revalidate should return Aborted because the missing II no longer
@@ -225,13 +222,9 @@ mod not_miri {
         // by deleting the dict entry. `dictDelete` calls the value destructor
         // which frees the inverted index.
         let field_name = test.test.context.field_spec().fieldName;
-        {
-            let guard = test.test.context.spec_read();
-            let dict = guard.missing_field_dict();
-
-            unsafe {
-                ffi::RS_dictDelete(dict, field_name as *mut _);
-            }
+        let dict = test.test.context.spec_read().missing_field_dict();
+        unsafe {
+            ffi::RS_dictDelete(dict, field_name as *mut _);
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -151,16 +151,16 @@ mod not_miri {
         let test = MissingRevalidateTest::new(10);
         let mut it = test.create_iterator();
         // Verify the iterator works normally and read at least one document
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -180,8 +180,9 @@ mod not_miri {
         // Note: the iterator's reader holds a (now-dangling) pointer to the
         // original II, but `should_abort` only compares pointers via
         // `is_index` without dereferencing it, so this is safe.
+        let guard = test.test.context.spec_read_guard();
         unsafe {
-            let dict = (*test.test.context.spec_ref().as_raw_ptr()).missingFieldDict;
+            let dict = (*guard.as_ptr()).missingFieldDict;
             ffi::RS_dictDelete(dict, field_name as *mut _);
             let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
             assert_eq!(rc, 0, "dictAdd failed");
@@ -189,9 +190,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the missing II no longer
         // points to the same index the reader was created from.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -219,9 +220,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -230,15 +231,16 @@ mod not_miri {
         // by deleting the dict entry. `dictDelete` calls the value destructor
         // which frees the inverted index.
         let field_name = test.test.context.field_spec().fieldName;
+        let guard = test.test.context.spec_read_guard();
         unsafe {
-            let dict = test.test.context.spec_ref().missing_field_dict();
+            let dict = guard.missing_field_dict();
             ffi::RS_dictDelete(dict, field_name as *mut _);
         }
 
         // `should_abort` sees NULL from `dictFetchValue` and returns true.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -407,11 +407,11 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(record.doc_id, 1);
 
     // Revalidate should succeed (not abort) even though there is no range tree.
-    let guard = mock_ctx.spec_read_guard();
-    assert_eq!(
-        it.revalidate(&*guard).expect("revalidate failed"),
-        RQEValidateStatus::Ok
-    );
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate failed")
+    };
+    assert_eq!(status, RQEValidateStatus::Ok);
 }
 
 /// A [`GeoFilter`] with a non-null address so `is_numeric_filter()` returns `false`.
@@ -648,11 +648,11 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        let guard = ctx.spec_read_guard();
-        assert_eq!(
-            iters[0].revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted,
-        );
+        let status = {
+            let guard = ctx.spec_read_guard();
+            iters[0].revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
         // before this point and holds only a `NonNull` (not ownership), so no double-free.
         unsafe { drop(Box::from_raw(tree_ptr)) };
@@ -684,11 +684,11 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        let guard = ctx.spec_read_guard();
-        assert_eq!(
-            iters[0].revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok,
-        );
+        let status = {
+            let guard = ctx.spec_read_guard();
+            iters[0].revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
         // before this point and holds only a `NonNull` (not ownership), so no double-free.
@@ -1002,11 +1002,11 @@ mod not_miri {
 
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // The iterator should still work — doc 1 was removed, so first doc is 3.
         let record = it.read().expect("read failed").expect("expected a result");
@@ -1065,17 +1065,17 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // For numeric iterators, we can simulate index disappearance by
         // manipulating the revision ID. check_abort() compares the stored
@@ -1090,11 +1090,11 @@ mod not_miri {
         }
 
         // Now Revalidate should return Aborted because the revision IDs don't match
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
     }
 
     #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -407,9 +407,9 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(record.doc_id, 1);
 
     // Revalidate should succeed (not abort) even though there is no range tree.
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&mut *guard).expect("revalidate failed"),
+        it.revalidate(&*guard).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }
@@ -648,9 +648,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        let mut guard = ctx.spec_read_guard();
+        let guard = ctx.spec_read_guard();
         assert_eq!(
-            iters[0].revalidate(&mut *guard).expect("revalidate failed"),
+            iters[0].revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted,
         );
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -684,9 +684,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        let mut guard = ctx.spec_read_guard();
+        let guard = ctx.spec_read_guard();
         assert_eq!(
-            iters[0].revalidate(&mut *guard).expect("revalidate failed"),
+            iters[0].revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok,
         );
 
@@ -1002,9 +1002,9 @@ mod not_miri {
 
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard).expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1065,15 +1065,15 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard).expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard).expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1090,9 +1090,9 @@ mod not_miri {
         }
 
         // Now Revalidate should return Aborted because the revision IDs don't match
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard).expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -408,7 +408,7 @@ fn numeric_no_range_tree_revalidate() {
 
     // Revalidate should succeed (not abort) even though there is no range tree.
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -649,7 +649,7 @@ mod from_tree {
         unsafe { (*tree_ptr).increment_revision() };
 
         let status = {
-            let guard = ctx.spec_read_guard();
+            let guard = ctx.spec_read();
             iters[0].revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
@@ -685,7 +685,7 @@ mod from_tree {
         unsafe { (*tree_ptr).increment_revision() };
 
         let status = {
-            let guard = ctx.spec_read_guard();
+            let guard = ctx.spec_read();
             iters[0].revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -1003,7 +1003,7 @@ mod not_miri {
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -1066,13 +1066,13 @@ mod not_miri {
 
         // First, verify the iterator works normally and read at least one document
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -1091,7 +1091,7 @@ mod not_miri {
 
         // Now Revalidate should return Aborted because the revision IDs don't match
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -407,10 +407,9 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(record.doc_id, 1);
 
     // Revalidate should succeed (not abort) even though there is no range tree.
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 
@@ -648,10 +647,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        let status = {
-            let guard = ctx.spec_read();
-            iters[0].revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = iters[0]
+            .revalidate(&*ctx.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
         // before this point and holds only a `NonNull` (not ownership), so no double-free.
@@ -684,10 +682,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        let status = {
-            let guard = ctx.spec_read();
-            iters[0].revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = iters[0]
+            .revalidate(&*ctx.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -1002,10 +999,9 @@ mod not_miri {
 
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // The iterator should still work — doc 1 was removed, so first doc is 3.
@@ -1065,16 +1061,14 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // For numeric iterators, we can simulate index disappearance by
@@ -1090,10 +1084,9 @@ mod not_miri {
         }
 
         // Now Revalidate should return Aborted because the revision IDs don't match
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -407,9 +407,9 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(record.doc_id, 1);
 
     // Revalidate should succeed (not abort) even though there is no range tree.
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        unsafe { it.revalidate(mock_ctx.spec_mut()) }.expect("revalidate failed"),
+        it.revalidate(&mut *guard).expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }
@@ -648,9 +648,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        // SAFETY: test-only call with valid context
+        let mut guard = ctx.spec_read_guard();
         assert_eq!(
-            unsafe { iters[0].revalidate(ctx.spec_mut()) }.expect("revalidate failed"),
+            iters[0].revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted,
         );
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -684,9 +684,9 @@ mod from_tree {
         // write does not violate aliasing rules.
         unsafe { (*tree_ptr).increment_revision() };
 
-        // SAFETY: test-only call with valid context
+        let mut guard = ctx.spec_read_guard();
         assert_eq!(
-            unsafe { iters[0].revalidate(ctx.spec_mut()) }.expect("revalidate failed"),
+            iters[0].revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Ok,
         );
 
@@ -1002,9 +1002,9 @@ mod not_miri {
 
         // Revalidate before any reads. last_doc_id is 0, so even though
         // needs_revalidation is true, we should get Ok.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
+            it.revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1065,15 +1065,15 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
+            it.revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
+            it.revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1090,9 +1090,9 @@ mod not_miri {
         }
 
         // Now Revalidate should return Aborted because the revision IDs don't match
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
+            it.revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -409,7 +409,7 @@ fn numeric_no_range_tree_revalidate() {
     // Revalidate should succeed (not abort) even though there is no range tree.
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(mock_ctx.spec()) }.expect("revalidate failed"),
+        unsafe { it.revalidate(mock_ctx.spec_mut()) }.expect("revalidate failed"),
         RQEValidateStatus::Ok
     );
 }
@@ -650,7 +650,7 @@ mod from_tree {
 
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { iters[0].revalidate(ctx.spec()) }.expect("revalidate failed"),
+            unsafe { iters[0].revalidate(ctx.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted,
         );
         // SAFETY: `tree_ptr` was created by `Box::into_raw` above; `iters` is dropped
@@ -686,7 +686,7 @@ mod from_tree {
 
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { iters[0].revalidate(ctx.spec()) }.expect("revalidate failed"),
+            unsafe { iters[0].revalidate(ctx.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok,
         );
 
@@ -1004,7 +1004,7 @@ mod not_miri {
         // needs_revalidation is true, we should get Ok.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1063,18 +1063,17 @@ mod not_miri {
     fn numeric_revalidate_after_index_disappears() {
         let test = NumericRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.spec;
 
         // First, verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -1093,7 +1092,7 @@ mod not_miri {
         // Now Revalidate should return Aborted because the revision IDs don't match
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -179,16 +179,14 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the tag's inverted index being garbage collected and
@@ -218,10 +216,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
@@ -249,10 +246,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Save the old II pointer so we can free it after the test.
@@ -270,10 +266,9 @@ mod not_miri {
         assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
 
         // `should_abort` sees the tag value is missing and returns true.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -180,13 +180,13 @@ mod not_miri {
 
         // Verify the iterator works normally and read at least one document
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -219,7 +219,7 @@ mod not_miri {
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
@@ -250,7 +250,7 @@ mod not_miri {
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -271,12 +271,10 @@ mod not_miri {
 
         // `should_abort` sees the tag value is missing and returns true.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
-        assert_eq!(status,
-            RQEValidateStatus::Aborted
-        );
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
         // and has not been freed. We are the sole owner after removing it from the TrieMap.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -179,17 +179,17 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the tag's inverted index being garbage collected and
         // recreated by replacing the TrieMap entry with a new inverted index.
@@ -218,11 +218,11 @@ mod not_miri {
 
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
         // and has not been freed. We are the sole owner after removing it from the TrieMap.
@@ -249,11 +249,11 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Save the old II pointer so we can free it after the test.
         let old_ii: *mut inverted_index::opaque::InvertedIndex =
@@ -270,9 +270,11 @@ mod not_miri {
         assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
 
         // `should_abort` sees the tag value is missing and returns true.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status,
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -177,18 +177,19 @@ mod not_miri {
     fn tag_revalidate_after_index_disappears() {
         let test = TagRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.spec;
 
         // Verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -221,7 +222,8 @@ mod not_miri {
         // points to the same index the reader was created from.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -250,10 +252,10 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let sctx = test.test.context.spec;
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -274,7 +276,8 @@ mod not_miri {
         // `should_abort` sees the tag value is missing and returns true.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -179,16 +179,16 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -220,9 +220,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -252,9 +252,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -274,9 +274,9 @@ mod not_miri {
         assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
 
         // `should_abort` sees the tag value is missing and returns true.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -181,15 +181,13 @@ mod not_miri {
         // Verify the iterator works normally and read at least one document
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -222,8 +220,7 @@ mod not_miri {
         // points to the same index the reader was created from.
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -254,8 +251,7 @@ mod not_miri {
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -276,8 +272,7 @@ mod not_miri {
         // `should_abort` sees the tag value is missing and returns true.
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -179,16 +179,16 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -220,9 +220,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because the tag II no longer
         // points to the same index the reader was created from.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -252,9 +252,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -274,9 +274,9 @@ mod not_miri {
         assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
 
         // `should_abort` sees the tag value is missing and returns true.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -356,16 +356,14 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the term's inverted index being garbage collected and
@@ -380,10 +378,9 @@ mod not_miri {
 
         it.swap_index(&mut dummy_ref);
 
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Swap back and free the dummy for proper cleanup.
@@ -426,10 +423,9 @@ mod not_miri {
         // Revalidation calls should_abort which looks up "gc_collected" in
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -357,13 +357,13 @@ mod not_miri {
 
         // First, verify the iterator works normally and read at least one document
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -381,7 +381,7 @@ mod not_miri {
         it.swap_index(&mut dummy_ref);
 
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
@@ -427,7 +427,7 @@ mod not_miri {
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -358,15 +358,13 @@ mod not_miri {
         // First, verify the iterator works normally and read at least one document
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -384,8 +382,7 @@ mod not_miri {
 
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -356,16 +356,16 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -382,9 +382,9 @@ mod not_miri {
 
         it.swap_index(&mut dummy_ref);
 
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -429,9 +429,9 @@ mod not_miri {
         // Revalidation calls should_abort which looks up "gc_collected" in
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
+            it.revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -356,16 +356,16 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -382,9 +382,9 @@ mod not_miri {
 
         it.swap_index(&mut dummy_ref);
 
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -429,9 +429,9 @@ mod not_miri {
         // Revalidation calls should_abort which looks up "gc_collected" in
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard).expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -356,17 +356,17 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // First, verify the iterator works normally and read at least one document
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the term's inverted index being garbage collected and
         // replaced by swapping the reader's stored index pointer to a
@@ -380,11 +380,11 @@ mod not_miri {
 
         it.swap_index(&mut dummy_ref);
 
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Swap back and free the dummy for proper cleanup.
         it.swap_index(&mut dummy_ref);
@@ -426,11 +426,11 @@ mod not_miri {
         // Revalidation calls should_abort which looks up "gc_collected" in
         // keysDict. The term is not there so Redis_OpenInvertedIndex returns
         // null, triggering the abort path.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
     }
 
     #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -354,18 +354,19 @@ mod not_miri {
     fn term_revalidate_after_index_disappears() {
         let test = TermRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.spec;
 
         // First, verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -383,7 +384,8 @@ mod not_miri {
 
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -429,7 +431,7 @@ mod not_miri {
         // null, triggering the abort path.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(test.test.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(test.test.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -497,13 +497,13 @@ impl RevalidateTest {
         I: for<'iterator> RQEIterator<'index>,
     {
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(matches!(it.read(), Ok(Some(_))));
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -518,7 +518,7 @@ impl RevalidateTest {
         while let Some(_record) = it.read().expect("failed to read") {}
         assert!(it.at_eof());
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -576,7 +576,7 @@ impl RevalidateTest {
         I: for<'iterator> RQEIterator<'index>,
     {
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -605,7 +605,7 @@ impl RevalidateTest {
 
         // Nothing changed in the index so revalidate does nothing
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -613,7 +613,7 @@ impl RevalidateTest {
         // Remove an element before the current iteration position.
         self.remove_document(ii, self.doc_ids[0]);
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -623,7 +623,7 @@ impl RevalidateTest {
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
         let status = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -634,7 +634,7 @@ impl RevalidateTest {
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
         let res = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         let current_doc = match res {
@@ -671,7 +671,7 @@ impl RevalidateTest {
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
         let res = {
-            let guard = self.context.spec_read_guard();
+            let guard = self.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -496,15 +496,19 @@ impl RevalidateTest {
     where
         I: for<'iterator> RQEIterator<'index>,
     {
-        // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            {
+                let mut guard = self.context.spec_read_guard();
+                it.revalidate(&mut *guard).expect("revalidate failed")
+            },
             RQEValidateStatus::Ok
         );
         assert!(matches!(it.read(), Ok(Some(_))));
-        // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            {
+                let mut guard = self.context.spec_read_guard();
+                it.revalidate(&mut *guard).expect("revalidate failed")
+            },
             RQEValidateStatus::Ok
         );
     }
@@ -517,9 +521,11 @@ impl RevalidateTest {
         // Read all documents to reach EOF
         while let Some(_record) = it.read().expect("failed to read") {}
         assert!(it.at_eof());
-        // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            {
+                let mut guard = self.context.spec_read_guard();
+                it.revalidate(&mut *guard).expect("revalidate failed")
+            },
             RQEValidateStatus::Ok
         );
     }
@@ -575,9 +581,11 @@ impl RevalidateTest {
     ) where
         I: for<'iterator> RQEIterator<'index>,
     {
-        // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            {
+                let mut guard = self.context.spec_read_guard();
+                it.revalidate(&mut *guard).expect("revalidate failed")
+            },
             RQEValidateStatus::Ok
         );
 
@@ -604,17 +612,21 @@ impl RevalidateTest {
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Nothing changed in the index so revalidate does nothing
-        // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            {
+                let mut guard = self.context.spec_read_guard();
+                it.revalidate(&mut *guard).expect("revalidate failed")
+            },
             RQEValidateStatus::Ok
         );
 
         // Remove an element before the current iteration position.
         self.remove_document(ii, self.doc_ids[0]);
-        // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            {
+                let mut guard = self.context.spec_read_guard();
+                it.revalidate(&mut *guard).expect("revalidate failed")
+            },
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -622,9 +634,9 @@ impl RevalidateTest {
 
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
-        // SAFETY: test-only call with valid context
+        let mut guard = self.context.spec_read_guard();
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
+            it.revalidate(&mut *guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -633,8 +645,8 @@ impl RevalidateTest {
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
-        // SAFETY: test-only call with valid context
-        let res = unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed");
+        let mut guard = self.context.spec_read_guard();
+        let res = it.revalidate(&mut *guard).expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -668,8 +680,8 @@ impl RevalidateTest {
 
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
-        // SAFETY: test-only call with valid context
-        let res = unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed");
+        let mut guard = self.context.spec_read_guard();
+        let res = it.revalidate(&mut *guard).expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -496,21 +496,17 @@ impl RevalidateTest {
     where
         I: for<'iterator> RQEIterator<'index>,
     {
-        assert_eq!(
-            {
-                let guard = self.context.spec_read_guard();
-                it.revalidate(&*guard).expect("revalidate failed")
-            },
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert!(matches!(it.read(), Ok(Some(_))));
-        assert_eq!(
-            {
-                let guard = self.context.spec_read_guard();
-                it.revalidate(&*guard).expect("revalidate failed")
-            },
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
     }
 
     /// test revalidation functionality when iterator is at EOF
@@ -521,13 +517,11 @@ impl RevalidateTest {
         // Read all documents to reach EOF
         while let Some(_record) = it.read().expect("failed to read") {}
         assert!(it.at_eof());
-        assert_eq!(
-            {
-                let guard = self.context.spec_read_guard();
-                it.revalidate(&*guard).expect("revalidate failed")
-            },
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
     }
 
     /// Remove the document with the given id from the inverted index.
@@ -581,13 +575,11 @@ impl RevalidateTest {
     ) where
         I: for<'iterator> RQEIterator<'index>,
     {
-        assert_eq!(
-            {
-                let guard = self.context.spec_read_guard();
-                it.revalidate(&*guard).expect("revalidate failed")
-            },
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // First, read a few documents to establish a position
         let doc = it
@@ -612,41 +604,39 @@ impl RevalidateTest {
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Nothing changed in the index so revalidate does nothing
-        assert_eq!(
-            {
-                let guard = self.context.spec_read_guard();
-                it.revalidate(&*guard).expect("revalidate failed")
-            },
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Remove an element before the current iteration position.
         self.remove_document(ii, self.doc_ids[0]);
-        assert_eq!(
-            {
-                let guard = self.context.spec_read_guard();
-                it.revalidate(&*guard).expect("revalidate failed")
-            },
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
-        let guard = self.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
-        let guard = self.context.spec_read_guard();
-        let res = it.revalidate(&*guard).expect("revalidate failed");
+        let res = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -680,8 +670,10 @@ impl RevalidateTest {
 
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
-        let guard = self.context.spec_read_guard();
-        let res = it.revalidate(&*guard).expect("revalidate failed");
+        let res = {
+            let guard = self.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -498,13 +498,13 @@ impl RevalidateTest {
     {
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(matches!(it.read(), Ok(Some(_))));
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -519,7 +519,7 @@ impl RevalidateTest {
         assert!(it.at_eof());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
     }
@@ -577,7 +577,7 @@ impl RevalidateTest {
     {
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -606,7 +606,7 @@ impl RevalidateTest {
         // Nothing changed in the index so revalidate does nothing
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -614,7 +614,7 @@ impl RevalidateTest {
         self.remove_document(ii, self.doc_ids[0]);
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -624,7 +624,7 @@ impl RevalidateTest {
         self.remove_document(ii, self.doc_ids[4]);
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed"),
+            unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -634,7 +634,7 @@ impl RevalidateTest {
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
         // SAFETY: test-only call with valid context
-        let res = unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed");
+        let res = unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -669,7 +669,7 @@ impl RevalidateTest {
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
         // SAFETY: test-only call with valid context
-        let res = unsafe { it.revalidate(self.context.spec) }.expect("revalidate failed");
+        let res = unsafe { it.revalidate(self.context.spec_mut()) }.expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -498,16 +498,16 @@ impl RevalidateTest {
     {
         assert_eq!(
             {
-                let mut guard = self.context.spec_read_guard();
-                it.revalidate(&mut *guard).expect("revalidate failed")
+                let guard = self.context.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate failed")
             },
             RQEValidateStatus::Ok
         );
         assert!(matches!(it.read(), Ok(Some(_))));
         assert_eq!(
             {
-                let mut guard = self.context.spec_read_guard();
-                it.revalidate(&mut *guard).expect("revalidate failed")
+                let guard = self.context.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate failed")
             },
             RQEValidateStatus::Ok
         );
@@ -523,8 +523,8 @@ impl RevalidateTest {
         assert!(it.at_eof());
         assert_eq!(
             {
-                let mut guard = self.context.spec_read_guard();
-                it.revalidate(&mut *guard).expect("revalidate failed")
+                let guard = self.context.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate failed")
             },
             RQEValidateStatus::Ok
         );
@@ -583,8 +583,8 @@ impl RevalidateTest {
     {
         assert_eq!(
             {
-                let mut guard = self.context.spec_read_guard();
-                it.revalidate(&mut *guard).expect("revalidate failed")
+                let guard = self.context.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate failed")
             },
             RQEValidateStatus::Ok
         );
@@ -614,8 +614,8 @@ impl RevalidateTest {
         // Nothing changed in the index so revalidate does nothing
         assert_eq!(
             {
-                let mut guard = self.context.spec_read_guard();
-                it.revalidate(&mut *guard).expect("revalidate failed")
+                let guard = self.context.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate failed")
             },
             RQEValidateStatus::Ok
         );
@@ -624,8 +624,8 @@ impl RevalidateTest {
         self.remove_document(ii, self.doc_ids[0]);
         assert_eq!(
             {
-                let mut guard = self.context.spec_read_guard();
-                it.revalidate(&mut *guard).expect("revalidate failed")
+                let guard = self.context.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate failed")
             },
             RQEValidateStatus::Ok
         );
@@ -634,9 +634,9 @@ impl RevalidateTest {
 
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
-        let mut guard = self.context.spec_read_guard();
+        let guard = self.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard).expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
@@ -645,8 +645,8 @@ impl RevalidateTest {
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
-        let mut guard = self.context.spec_read_guard();
-        let res = it.revalidate(&mut *guard).expect("revalidate failed");
+        let guard = self.context.spec_read_guard();
+        let res = it.revalidate(&*guard).expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -680,8 +680,8 @@ impl RevalidateTest {
 
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
-        let mut guard = self.context.spec_read_guard();
-        let res = it.revalidate(&mut *guard).expect("revalidate failed");
+        let guard = self.context.spec_read_guard();
+        let res = it.revalidate(&*guard).expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -496,16 +496,14 @@ impl RevalidateTest {
     where
         I: for<'iterator> RQEIterator<'index>,
     {
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(matches!(it.read(), Ok(Some(_))));
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
     }
 
@@ -517,10 +515,9 @@ impl RevalidateTest {
         // Read all documents to reach EOF
         while let Some(_record) = it.read().expect("failed to read") {}
         assert!(it.at_eof());
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
     }
 
@@ -575,10 +572,9 @@ impl RevalidateTest {
     ) where
         I: for<'iterator> RQEIterator<'index>,
     {
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // First, read a few documents to establish a position
@@ -604,28 +600,25 @@ impl RevalidateTest {
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Nothing changed in the index so revalidate does nothing
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Remove an element before the current iteration position.
         self.remove_document(ii, self.doc_ids[0]);
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Remove an element after the current iteration position.
         self.remove_document(ii, self.doc_ids[4]);
-        let status = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
         assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
@@ -633,10 +626,9 @@ impl RevalidateTest {
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
         self.remove_document(ii, self.doc_ids[2]);
-        let res = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let res = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         let current_doc = match res {
             RQEValidateStatus::Moved {
                 current: Some(current),
@@ -670,10 +662,9 @@ impl RevalidateTest {
 
         self.remove_document(ii, last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.
-        let res = {
-            let guard = self.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let res = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -137,15 +137,13 @@ mod not_miri {
         // Verify the iterator works normally and read at least one document
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -165,8 +163,7 @@ mod not_miri {
         // points to the same index the reader was created from.
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
@@ -201,8 +198,7 @@ mod not_miri {
         assert!(it.read().expect("failed to read").is_some());
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -217,8 +213,7 @@ mod not_miri {
 
         let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&*guard)
-                .expect("revalidate failed"),
+            it.revalidate(&*guard).expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -135,16 +135,16 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -163,9 +163,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
@@ -199,9 +199,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -215,9 +215,9 @@ mod not_miri {
             guard.set_existing_docs(std::ptr::null_mut());
         }
 
-        let mut guard = test.test.context.spec_read_guard();
+        let guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(&mut *guard)
+            it.revalidate(&*guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -135,16 +135,16 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
@@ -154,30 +154,29 @@ mod not_miri {
         let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
             inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
-        let old_existing_docs = test.test.context.spec_ref().existing_docs();
-        unsafe {
-            test.test
-                .context
-                .spec_mut()
-                .set_existing_docs(new_ii.cast());
+        let guard = test.test.context.spec_read_guard();
+        let old_existing_docs = guard.existing_docs();
+        {
+            let mut guard = test.test.context.spec_write_guard();
+            guard.set_existing_docs(new_ii.cast());
         }
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
         // Restore original existingDocs and free the temporary index for
         // proper cleanup.
+        {
+            let mut guard = test.test.context.spec_write_guard();
+            guard.set_existing_docs(old_existing_docs);
+        }
         unsafe {
-            test.test
-                .context
-                .spec_mut()
-                .set_existing_docs(old_existing_docs);
             drop(Box::from_raw(new_ii));
         }
     }
@@ -200,36 +199,33 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
         // Simulate the garbage collector setting existingDocs to NULL after
         // collecting all documents.
-        let old_existing_docs = test.test.context.spec_ref().existing_docs();
-        unsafe {
-            test.test
-                .context
-                .spec_mut()
-                .set_existing_docs(std::ptr::null_mut());
+        let guard = test.test.context.spec_read_guard();
+        let old_existing_docs = guard.existing_docs();
+        {
+            let mut guard = test.test.context.spec_write_guard();
+            guard.set_existing_docs(std::ptr::null_mut());
         }
 
-        // SAFETY: test-only call with valid context
+        let mut guard = test.test.context.spec_read_guard();
         assert_eq!(
-            it.revalidate(unsafe { test.test.context.spec_mut() })
+            it.revalidate(&mut *guard)
                 .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
         // Restore for proper cleanup.
-        unsafe {
-            test.test
-                .context
-                .spec_mut()
-                .set_existing_docs(old_existing_docs);
+        {
+            let mut guard = test.test.context.spec_write_guard();
+            guard.set_existing_docs(old_existing_docs);
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -133,18 +133,19 @@ mod not_miri {
     fn wildcard_revalidate_after_index_disappears() {
         let test = WildcardRevalidateTest::new(10);
         let mut it = test.create_iterator();
-        let sctx = test.test.context.spec;
 
         // Verify the iterator works normally and read at least one document
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
         assert!(it.read().expect("failed to read").is_some());
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
@@ -153,26 +154,30 @@ mod not_miri {
         let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
             inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
-        let old_existing_docs;
+        let old_existing_docs = test.test.context.spec_ref().existing_docs();
         unsafe {
-            let spec = test.test.context.spec.as_ptr();
-            old_existing_docs = (*spec).existingDocs;
-            (*spec).existingDocs = new_ii.cast();
+            test.test
+                .context
+                .spec_mut()
+                .set_existing_docs(new_ii.cast());
         }
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
         // Restore original existingDocs and free the temporary index for
         // proper cleanup.
         unsafe {
-            let spec = test.test.context.spec.as_ptr();
-            (*spec).existingDocs = old_existing_docs;
+            test.test
+                .context
+                .spec_mut()
+                .set_existing_docs(old_existing_docs);
             drop(Box::from_raw(new_ii));
         }
     }
@@ -195,32 +200,36 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let sctx = test.test.context.spec;
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Ok
         );
 
         // Simulate the garbage collector setting existingDocs to NULL after
         // collecting all documents.
-        let old_existing_docs;
+        let old_existing_docs = test.test.context.spec_ref().existing_docs();
         unsafe {
-            let spec = test.test.context.spec.as_ptr();
-            old_existing_docs = (*spec).existingDocs;
-            (*spec).existingDocs = std::ptr::null_mut();
+            test.test
+                .context
+                .spec_mut()
+                .set_existing_docs(std::ptr::null_mut());
         }
 
         // SAFETY: test-only call with valid context
         assert_eq!(
-            unsafe { it.revalidate(sctx) }.expect("revalidate failed"),
+            it.revalidate(unsafe { test.test.context.spec_mut() })
+                .expect("revalidate failed"),
             RQEValidateStatus::Aborted
         );
 
         // Restore for proper cleanup.
         unsafe {
-            let spec = test.test.context.spec.as_ptr();
-            (*spec).existingDocs = old_existing_docs;
+            test.test
+                .context
+                .spec_mut()
+                .set_existing_docs(old_existing_docs);
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -136,13 +136,13 @@ mod not_miri {
 
         // Verify the iterator works normally and read at least one document
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -153,18 +153,18 @@ mod not_miri {
             inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
         let old_existing_docs = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             guard.existing_docs()
         };
         {
-            let mut guard = test.test.context.spec_write_guard();
+            let mut guard = test.test.context.spec_write();
             guard.set_existing_docs(new_ii.cast());
         }
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
@@ -172,7 +172,7 @@ mod not_miri {
         // Restore original existingDocs and free the temporary index for
         // proper cleanup.
         {
-            let mut guard = test.test.context.spec_write_guard();
+            let mut guard = test.test.context.spec_write();
             guard.set_existing_docs(old_existing_docs);
         }
         unsafe {
@@ -199,7 +199,7 @@ mod not_miri {
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -207,23 +207,23 @@ mod not_miri {
         // Simulate the garbage collector setting existingDocs to NULL after
         // collecting all documents.
         let old_existing_docs = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             guard.existing_docs()
         };
         {
-            let mut guard = test.test.context.spec_write_guard();
+            let mut guard = test.test.context.spec_write();
             guard.set_existing_docs(std::ptr::null_mut());
         }
 
         let status = {
-            let guard = test.test.context.spec_read_guard();
+            let guard = test.test.context.spec_read();
             it.revalidate(&*guard).expect("revalidate failed")
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restore for proper cleanup.
         {
-            let mut guard = test.test.context.spec_write_guard();
+            let mut guard = test.test.context.spec_write();
             guard.set_existing_docs(old_existing_docs);
         }
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -135,16 +135,14 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate existingDocs being garbage collected and recreated by
@@ -163,10 +161,9 @@ mod not_miri {
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restore original existingDocs and free the temporary index for
@@ -198,10 +195,9 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the garbage collector setting existingDocs to NULL after
@@ -215,10 +211,9 @@ mod not_miri {
             guard.set_existing_docs(std::ptr::null_mut());
         }
 
-        let status = {
-            let guard = test.test.context.spec_read();
-            it.revalidate(&*guard).expect("revalidate failed")
-        };
+        let status = it
+            .revalidate(&*test.test.context.spec_read())
+            .expect("revalidate failed");
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restore for proper cleanup.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -135,25 +135,27 @@ mod not_miri {
         let mut it = test.create_iterator();
 
         // Verify the iterator works normally and read at least one document
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate existingDocs being garbage collected and recreated by
         // pointing spec.existingDocs to a different inverted index.
         let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
             inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
-        let guard = test.test.context.spec_read_guard();
-        let old_existing_docs = guard.existing_docs();
+        let old_existing_docs = {
+            let guard = test.test.context.spec_read_guard();
+            guard.existing_docs()
+        };
         {
             let mut guard = test.test.context.spec_write_guard();
             guard.set_existing_docs(new_ii.cast());
@@ -161,11 +163,11 @@ mod not_miri {
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restore original existingDocs and free the temporary index for
         // proper cleanup.
@@ -196,26 +198,28 @@ mod not_miri {
 
         // Read at least one document so the iterator has a position.
         assert!(it.read().expect("failed to read").is_some());
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Ok
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Ok);
 
         // Simulate the garbage collector setting existingDocs to NULL after
         // collecting all documents.
-        let guard = test.test.context.spec_read_guard();
-        let old_existing_docs = guard.existing_docs();
+        let old_existing_docs = {
+            let guard = test.test.context.spec_read_guard();
+            guard.existing_docs()
+        };
         {
             let mut guard = test.test.context.spec_write_guard();
             guard.set_existing_docs(std::ptr::null_mut());
         }
 
-        let guard = test.test.context.spec_read_guard();
-        assert_eq!(
-            it.revalidate(&*guard).expect("revalidate failed"),
-            RQEValidateStatus::Aborted
-        );
+        let status = {
+            let guard = test.test.context.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate failed")
+        };
+        assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restore for proper cleanup.
         {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -150,14 +150,11 @@ mod not_miri {
         let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
             inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
-        let old_existing_docs = {
-            let guard = test.test.context.spec_read();
-            guard.existing_docs()
-        };
-        {
-            let mut guard = test.test.context.spec_write();
-            guard.set_existing_docs(new_ii.cast());
-        }
+        let old_existing_docs = test.test.context.spec_read().existing_docs();
+        test.test
+            .context
+            .spec_write()
+            .set_existing_docs(new_ii.cast());
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
@@ -168,10 +165,10 @@ mod not_miri {
 
         // Restore original existingDocs and free the temporary index for
         // proper cleanup.
-        {
-            let mut guard = test.test.context.spec_write();
-            guard.set_existing_docs(old_existing_docs);
-        }
+        test.test
+            .context
+            .spec_write()
+            .set_existing_docs(old_existing_docs);
         unsafe {
             drop(Box::from_raw(new_ii));
         }
@@ -202,14 +199,11 @@ mod not_miri {
 
         // Simulate the garbage collector setting existingDocs to NULL after
         // collecting all documents.
-        let old_existing_docs = {
-            let guard = test.test.context.spec_read();
-            guard.existing_docs()
-        };
-        {
-            let mut guard = test.test.context.spec_write();
-            guard.set_existing_docs(std::ptr::null_mut());
-        }
+        let old_existing_docs = test.test.context.spec_read().existing_docs();
+        test.test
+            .context
+            .spec_write()
+            .set_existing_docs(std::ptr::null_mut());
 
         let status = it
             .revalidate(&*test.test.context.spec_read())
@@ -217,10 +211,10 @@ mod not_miri {
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restore for proper cleanup.
-        {
-            let mut guard = test.test.context.spec_write();
-            guard.set_existing_docs(old_existing_docs);
-        }
+        test.test
+            .context
+            .spec_write()
+            .set_existing_docs(old_existing_docs);
     }
 
     /// Test that `reader()` returns a reference to the underlying reader.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -201,10 +201,7 @@ fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::<Infinite>::new_empty();
     let guard = mock_ctx.spec_read_guard();
-    assert_eq!(
-        it.revalidate(&*guard).unwrap(),
-        RQEValidateStatus::Ok
-    );
+    assert_eq!(it.revalidate(&*guard).unwrap(), RQEValidateStatus::Ok);
 }
 
 #[test]
@@ -212,10 +209,7 @@ fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::new(Infinite::default());
     let guard = mock_ctx.spec_read_guard();
-    assert_eq!(
-        it.revalidate(&*guard).unwrap(),
-        RQEValidateStatus::Ok
-    );
+    assert_eq!(it.revalidate(&*guard).unwrap(), RQEValidateStatus::Ok);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -7,7 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use index_spec::IndexSpec;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     maybe_empty::MaybeEmpty,
@@ -54,7 +53,7 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -201,9 +200,9 @@ fn rewind_not_empty() {
 fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::<Infinite>::new_empty();
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap(),
+        it.revalidate(&mut *guard).unwrap(),
         RQEValidateStatus::Ok
     );
 }
@@ -212,9 +211,9 @@ fn revalidate_empty() {
 fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::new(Infinite::default());
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap(),
+        it.revalidate(&mut *guard).unwrap(),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -53,7 +53,7 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut index_spec::IndexSpecReadGuard,
+        _spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -200,9 +200,9 @@ fn rewind_not_empty() {
 fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::<Infinite>::new_empty();
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&mut *guard).unwrap(),
+        it.revalidate(&*guard).unwrap(),
         RQEValidateStatus::Ok
     );
 }
@@ -211,9 +211,9 @@ fn revalidate_empty() {
 fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::new(Infinite::default());
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&mut *guard).unwrap(),
+        it.revalidate(&*guard).unwrap(),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -200,10 +200,7 @@ fn rewind_not_empty() {
 fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::<Infinite>::new_empty();
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).unwrap()
-    };
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 
@@ -211,10 +208,7 @@ fn revalidate_empty() {
 fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::new(Infinite::default());
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).unwrap()
-    };
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use index_spec::IndexSpec;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     maybe_empty::MaybeEmpty,
@@ -51,9 +52,9 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
         false
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         Ok(RQEValidateStatus::Ok)
     }
@@ -199,11 +200,10 @@ fn rewind_not_empty() {
 #[test]
 fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let mut it = MaybeEmpty::<Infinite>::new_empty();
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(ctx) }.unwrap(),
+        it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap(),
         RQEValidateStatus::Ok
     );
 }
@@ -211,11 +211,10 @@ fn revalidate_empty() {
 #[test]
 fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let mut it = MaybeEmpty::new(Infinite::default());
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(ctx) }.unwrap(),
+        it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap(),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -201,7 +201,7 @@ fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::<Infinite>::new_empty();
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).unwrap()
     };
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -212,7 +212,7 @@ fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::new(Infinite::default());
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).unwrap()
     };
     assert_eq!(status, RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -200,16 +200,22 @@ fn rewind_not_empty() {
 fn revalidate_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::<Infinite>::new_empty();
-    let guard = mock_ctx.spec_read_guard();
-    assert_eq!(it.revalidate(&*guard).unwrap(), RQEValidateStatus::Ok);
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).unwrap()
+    };
+    assert_eq!(status, RQEValidateStatus::Ok);
 }
 
 #[test]
 fn revalidate_not_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let mut it = MaybeEmpty::new(Infinite::default());
-    let guard = mock_ctx.spec_read_guard();
-    assert_eq!(it.revalidate(&*guard).unwrap(), RQEValidateStatus::Ok);
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).unwrap()
+    };
+    assert_eq!(status, RQEValidateStatus::Ok);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -285,7 +285,7 @@ fn revalidate() {
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).unwrap()
     };
     assert_eq!(status, RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -284,8 +284,11 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
-    let guard = mock_ctx.spec_read_guard();
-    assert_eq!(it.revalidate(&*guard).unwrap(), RQEValidateStatus::Ok);
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).unwrap()
+    };
+    assert_eq!(status, RQEValidateStatus::Ok);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -284,9 +284,9 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(&mut *guard).unwrap(),
+        it.revalidate(&*guard).unwrap(),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -284,9 +284,9 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     assert_eq!(
-        it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap(),
+        it.revalidate(&mut *guard).unwrap(),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -282,12 +282,11 @@ mod metrics_tests {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
     // SAFETY: test-only call with valid context
     assert_eq!(
-        unsafe { it.revalidate(ctx) }.unwrap(),
+        it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap(),
         RQEValidateStatus::Ok
     );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -285,10 +285,7 @@ fn revalidate() {
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
     let guard = mock_ctx.spec_read_guard();
-    assert_eq!(
-        it.revalidate(&*guard).unwrap(),
-        RQEValidateStatus::Ok
-    );
+    assert_eq!(it.revalidate(&*guard).unwrap(), RQEValidateStatus::Ok);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -284,10 +284,7 @@ fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let metric_data = vec![0.1, 0.2, 0.3];
     let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).unwrap()
-    };
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -310,12 +310,13 @@ fn rewind_resets_state() {
 #[test]
 fn revalidate_child_ok_preserves_exclusions() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // SAFETY: test-only call with valid context
-    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
+    let status = it
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -331,14 +332,15 @@ fn revalidate_child_ok_preserves_exclusions() {
 #[test]
 fn revalidate_child_aborted_replaces_child_with_empty() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // SAFETY: test-only call with valid context
-    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
+    let status = it
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -354,7 +356,6 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
 #[test]
 fn revalidate_child_moved_on_fresh_iterator() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Move);
@@ -362,7 +363,9 @@ fn revalidate_child_moved_on_fresh_iterator() {
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
     // SAFETY: test-only call with valid context
-    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
+    let status = it
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Iterator should still work correctly after revalidate
@@ -379,7 +382,6 @@ fn revalidate_child_moved_on_fresh_iterator() {
 #[test]
 fn revalidate_child_moved_after_read_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child = Mock::new([5, 10]);
     let mut data = child.data();
     let mut it = Not::new(child, 15, 1.0, Duration::ZERO, true);
@@ -395,7 +397,9 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
 
     // This should not panic - child is ahead of NOT's position
     // SAFETY: test-only call with valid context
-    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
+    let status = it
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly
@@ -413,7 +417,6 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
 #[test]
 fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child = Mock::new([8, 15]);
     let mut data = child.data();
     let mut it = Not::new(child, 20, 1.0, Duration::ZERO, true);
@@ -435,7 +438,9 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
 
     // This should not panic - child is ahead of NOT's position
     // SAFETY: test-only call with valid context
-    let status = unsafe { it.revalidate(ctx) }.expect("revalidate() failed");
+    let status = it
+        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -314,9 +314,7 @@ fn revalidate_child_ok_preserves_exclusions() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     let guard = mock_ctx.spec_read_guard();
-    let status = it
-        .revalidate(&*guard)
-        .expect("revalidate() failed");
+    let status = it.revalidate(&*guard).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -338,9 +336,7 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     let guard = mock_ctx.spec_read_guard();
-    let status = it
-        .revalidate(&*guard)
-        .expect("revalidate() failed");
+    let status = it.revalidate(&*guard).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -363,9 +359,7 @@ fn revalidate_child_moved_on_fresh_iterator() {
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
     let guard = mock_ctx.spec_read_guard();
-    let status = it
-        .revalidate(&*guard)
-        .expect("revalidate() failed");
+    let status = it.revalidate(&*guard).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Iterator should still work correctly after revalidate
@@ -397,9 +391,7 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
 
     // This should not panic - child is ahead of NOT's position
     let guard = mock_ctx.spec_read_guard();
-    let status = it
-        .revalidate(&*guard)
-        .expect("revalidate() failed");
+    let status = it.revalidate(&*guard).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly
@@ -438,9 +430,7 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
 
     // This should not panic - child is ahead of NOT's position
     let guard = mock_ctx.spec_read_guard();
-    let status = it
-        .revalidate(&*guard)
-        .expect("revalidate() failed");
+    let status = it.revalidate(&*guard).expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -313,10 +313,9 @@ fn revalidate_child_ok_preserves_exclusions() {
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate() failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -337,10 +336,9 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate() failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -362,10 +360,9 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate() failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Iterator should still work correctly after revalidate
@@ -396,10 +393,9 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate() failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly
@@ -437,10 +433,9 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let status = {
-        let guard = mock_ctx.spec_read();
-        it.revalidate(&*guard).expect("revalidate() failed")
-    };
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -314,7 +314,7 @@ fn revalidate_child_ok_preserves_exclusions() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate() failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -338,7 +338,7 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate() failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -363,7 +363,7 @@ fn revalidate_child_moved_on_fresh_iterator() {
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate() failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -397,7 +397,7 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
 
     // This should not panic - child is ahead of NOT's position
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate() failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);
@@ -438,7 +438,7 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
 
     // This should not panic - child is ahead of NOT's position
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         it.revalidate(&*guard).expect("revalidate() failed")
     };
     assert_eq!(status, RQEValidateStatus::Ok);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -313,9 +313,9 @@ fn revalidate_child_ok_preserves_exclusions() {
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -337,9 +337,9 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -362,9 +362,9 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -396,9 +396,9 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -437,9 +437,9 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let mut guard = mock_ctx.spec_read_guard();
+    let guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(&mut *guard)
+        .revalidate(&*guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -313,9 +313,9 @@ fn revalidate_child_ok_preserves_exclusions() {
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -337,9 +337,9 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -362,9 +362,9 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -396,9 +396,9 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 
@@ -437,9 +437,9 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    // SAFETY: test-only call with valid context
+    let mut guard = mock_ctx.spec_read_guard();
     let status = it
-        .revalidate(unsafe { mock_ctx.spec_mut() })
+        .revalidate(&mut *guard)
         .expect("revalidate() failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -313,8 +313,10 @@ fn revalidate_child_ok_preserves_exclusions() {
     let child = Mock::new([2, 4]);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let guard = mock_ctx.spec_read_guard();
-    let status = it.revalidate(&*guard).expect("revalidate() failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate() failed")
+    };
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -335,8 +337,10 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     data.set_revalidate_result(MockRevalidateResult::Abort);
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
-    let guard = mock_ctx.spec_read_guard();
-    let status = it.revalidate(&*guard).expect("revalidate() failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate() failed")
+    };
     assert_eq!(status, RQEValidateStatus::Ok);
 
     let mut seen = Vec::new();
@@ -358,8 +362,10 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
-    let guard = mock_ctx.spec_read_guard();
-    let status = it.revalidate(&*guard).expect("revalidate() failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate() failed")
+    };
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Iterator should still work correctly after revalidate
@@ -390,8 +396,10 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let guard = mock_ctx.spec_read_guard();
-    let status = it.revalidate(&*guard).expect("revalidate() failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate() failed")
+    };
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly
@@ -429,8 +437,10 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     data.set_revalidate_result(MockRevalidateResult::Move);
 
     // This should not panic - child is ahead of NOT's position
-    let guard = mock_ctx.spec_read_guard();
-    let status = it.revalidate(&*guard).expect("revalidate() failed");
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        it.revalidate(&*guard).expect("revalidate() failed")
+    };
     assert_eq!(status, RQEValidateStatus::Ok);
 
     // Continue reading - should still work correctly

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -600,8 +600,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -618,8 +618,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -635,8 +635,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -665,8 +665,8 @@ mod revalidate {
             guard.set_existing_docs(new_ii.cast());
         }
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restoring the original `existingDocs` pointer and dropping
@@ -696,8 +696,8 @@ mod revalidate {
         // GC doc_id=1 from the wildcard inverted index to trigger Moved.
         gc_document(&context, 1);
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -716,8 +716,8 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -735,8 +735,8 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -758,8 +758,8 @@ mod revalidate {
         // Since child is also at 10, read_inner should advance past it.
         gc_document(&context, 5);
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -789,8 +789,8 @@ mod revalidate {
         // GC the only document so wildcard becomes empty on revalidation.
         gc_document(&context, 1);
 
-        let mut guard = context.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = context.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -601,7 +601,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -619,7 +619,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -636,7 +636,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -656,24 +656,22 @@ mod revalidate {
         let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
             InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
-        let old_existing_docs;
-        // SAFETY: `context.spec` is a valid, test-owned `IndexSpec` pointer.
         // We temporarily swap `existingDocs` to trigger a wildcard abort.
+        let old_existing_docs = context.spec_ref().existing_docs();
+
+        // SAFETY: `context.spec` is a valid, test-owned `IndexSpec` pointer.
         unsafe {
-            let spec = context.spec.as_ptr();
-            old_existing_docs = (*spec).existingDocs;
-            (*spec).existingDocs = new_ii.cast();
+            context.spec_mut().set_existing_docs(new_ii.cast());
         }
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // SAFETY: Restoring the original `existingDocs` pointer and dropping
         // `new_ii` which was created via `Box::into_raw` above.
         unsafe {
-            let spec = context.spec.as_ptr();
-            (*spec).existingDocs = old_existing_docs;
+            context.spec_mut().set_existing_docs(old_existing_docs);
             drop(Box::from_raw(new_ii));
         }
     }
@@ -694,7 +692,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -714,7 +712,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -733,7 +731,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -756,7 +754,7 @@ mod revalidate {
         gc_document(&context, 5);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -787,7 +785,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec) }.unwrap();
+        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -600,8 +600,10 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -618,8 +620,10 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -635,8 +639,10 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -657,16 +663,20 @@ mod revalidate {
             InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
         // We temporarily swap `existingDocs` to trigger a wildcard abort.
-        let guard = context.spec_read_guard();
-        let old_existing_docs = guard.existing_docs();
+        let old_existing_docs = {
+            let guard = context.spec_read_guard();
+            guard.existing_docs()
+        };
 
         {
             let mut guard = context.spec_write_guard();
             guard.set_existing_docs(new_ii.cast());
         }
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restoring the original `existingDocs` pointer and dropping
@@ -696,8 +706,10 @@ mod revalidate {
         // GC doc_id=1 from the wildcard inverted index to trigger Moved.
         gc_document(&context, 1);
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -716,8 +728,10 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -735,8 +749,10 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -758,8 +774,10 @@ mod revalidate {
         // Since child is also at 10, read_inner should advance past it.
         gc_document(&context, 5);
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -789,8 +807,10 @@ mod revalidate {
         // GC the only document so wildcard becomes empty on revalidation.
         gc_document(&context, 1);
 
-        let guard = context.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = context.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -600,10 +600,7 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -620,10 +617,7 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -639,10 +633,7 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -673,10 +664,7 @@ mod revalidate {
             guard.set_existing_docs(new_ii.cast());
         }
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restoring the original `existingDocs` pointer and dropping
@@ -706,10 +694,7 @@ mod revalidate {
         // GC doc_id=1 from the wildcard inverted index to trigger Moved.
         gc_document(&context, 1);
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -728,10 +713,7 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -749,10 +731,7 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -774,10 +753,7 @@ mod revalidate {
         // Since child is also at 10, read_inner should advance past it.
         gc_document(&context, 5);
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -807,10 +783,7 @@ mod revalidate {
         // GC the only document so wildcard becomes empty on revalidation.
         gc_document(&context, 1);
 
-        let status = {
-            let guard = context.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*context.spec_read()).unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -654,25 +654,16 @@ mod revalidate {
             InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
         // We temporarily swap `existingDocs` to trigger a wildcard abort.
-        let old_existing_docs = {
-            let guard = context.spec_read();
-            guard.existing_docs()
-        };
+        let old_existing_docs = context.spec_read().existing_docs();
 
-        {
-            let mut guard = context.spec_write();
-            guard.set_existing_docs(new_ii.cast());
-        }
+        context.spec_write().set_existing_docs(new_ii.cast());
 
         let status = it.revalidate(&*context.spec_read()).unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restoring the original `existingDocs` pointer and dropping
         // `new_ii` which was created via `Box::into_raw` above.
-        {
-            let mut guard = context.spec_write();
-            guard.set_existing_docs(old_existing_docs);
-        }
+        context.spec_write().set_existing_docs(old_existing_docs);
         // SAFETY: Dropping Box from raw pointer.
         unsafe {
             drop(Box::from_raw(new_ii));

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -601,7 +601,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -621,7 +621,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -640,7 +640,7 @@ mod revalidate {
         let original = it.last_doc_id();
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert_eq!(status, RQEValidateStatus::Ok);
@@ -664,17 +664,17 @@ mod revalidate {
         )));
         // We temporarily swap `existingDocs` to trigger a wildcard abort.
         let old_existing_docs = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             guard.existing_docs()
         };
 
         {
-            let mut guard = context.spec_write_guard();
+            let mut guard = context.spec_write();
             guard.set_existing_docs(new_ii.cast());
         }
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert_eq!(status, RQEValidateStatus::Aborted);
@@ -682,7 +682,7 @@ mod revalidate {
         // Restoring the original `existingDocs` pointer and dropping
         // `new_ii` which was created via `Box::into_raw` above.
         {
-            let mut guard = context.spec_write_guard();
+            let mut guard = context.spec_write();
             guard.set_existing_docs(old_existing_docs);
         }
         // SAFETY: Dropping Box from raw pointer.
@@ -707,7 +707,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -729,7 +729,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -750,7 +750,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -775,7 +775,7 @@ mod revalidate {
         gc_document(&context, 5);
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -808,7 +808,7 @@ mod revalidate {
         gc_document(&context, 1);
 
         let status = {
-            let guard = context.spec_read_guard();
+            let guard = context.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -600,8 +600,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -618,8 +618,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(it.last_doc_id(), original);
         it.read().unwrap().unwrap();
@@ -635,8 +635,8 @@ mod revalidate {
         it.read().unwrap().unwrap();
         let original = it.last_doc_id();
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Ok);
         assert_eq!(child_data.revalidate_count(), 1);
         assert_eq!(it.last_doc_id(), original);
@@ -657,21 +657,26 @@ mod revalidate {
             InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
         // We temporarily swap `existingDocs` to trigger a wildcard abort.
-        let old_existing_docs = context.spec_ref().existing_docs();
+        let guard = context.spec_read_guard();
+        let old_existing_docs = guard.existing_docs();
 
-        // SAFETY: `context.spec` is a valid, test-owned `IndexSpec` pointer.
-        unsafe {
-            context.spec_mut().set_existing_docs(new_ii.cast());
+        {
+            let mut guard = context.spec_write_guard();
+            guard.set_existing_docs(new_ii.cast());
         }
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
-        // SAFETY: Restoring the original `existingDocs` pointer and dropping
+        // Restoring the original `existingDocs` pointer and dropping
         // `new_ii` which was created via `Box::into_raw` above.
+        {
+            let mut guard = context.spec_write_guard();
+            guard.set_existing_docs(old_existing_docs);
+        }
+        // SAFETY: Dropping Box from raw pointer.
         unsafe {
-            context.spec_mut().set_existing_docs(old_existing_docs);
             drop(Box::from_raw(new_ii));
         }
     }
@@ -691,8 +696,8 @@ mod revalidate {
         // GC doc_id=1 from the wildcard inverted index to trigger Moved.
         gc_document(&context, 1);
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         // Wildcard moved past 1 → iterator advanced.
         assert!(it.last_doc_id() > original);
@@ -711,8 +716,8 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
     }
@@ -730,8 +735,8 @@ mod revalidate {
 
         gc_document(&context, 1);
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(it.last_doc_id() > original);
         it.read().unwrap().unwrap();
@@ -753,8 +758,8 @@ mod revalidate {
         // Since child is also at 10, read_inner should advance past it.
         gc_document(&context, 5);
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
         assert!(!it.at_eof());
         // Wildcard moved to 10 which matches child → read_inner → 15.
@@ -784,8 +789,8 @@ mod revalidate {
         // GC the only document so wildcard becomes empty on revalidation.
         gc_document(&context, 1);
 
-        // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(context.spec_mut()) }.unwrap();
+        let mut guard = context.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(
             matches!(status, RQEValidateStatus::Moved { current: None }),
             "Expected Moved {{ current: None }}, got {status:?}"

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -158,7 +158,7 @@ fn optimized_path_returns_not_optimized_iterator() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
     {
-        let mut guard = ctx.spec_write_guard();
+        let mut guard = ctx.spec_write();
         guard.rule_mut().set_index_all(true);
     }
 
@@ -196,7 +196,7 @@ fn not_child_access_optimized() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
     {
-        let mut guard = ctx.spec_write_guard();
+        let mut guard = ctx.spec_write();
         guard.rule_mut().set_index_all(true);
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -157,7 +157,7 @@ fn non_optimized_skip_to_works() {
 fn optimized_path_returns_not_optimized_iterator() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
-    unsafe { ctx.set_index_all(true) };
+    unsafe { ctx.spec_mut().rule_mut().set_index_all(true) };
 
     let child = Mock::new([2, 5, 8]);
     let result = call_new_not_iterator(child, 10, &ctx);
@@ -192,7 +192,7 @@ fn not_child_access() {
 fn not_child_access_optimized() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
-    unsafe { ctx.set_index_all(true) };
+    unsafe { ctx.spec_mut().rule_mut().set_index_all(true) };
 
     let child = Mock::new([3, 6]);
     let result = call_new_not_iterator(child, 10, &ctx);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -157,10 +157,7 @@ fn non_optimized_skip_to_works() {
 fn optimized_path_returns_not_optimized_iterator() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
-    {
-        let mut guard = ctx.spec_write();
-        guard.rule_mut().set_index_all(true);
-    }
+    ctx.spec_write().rule_mut().set_index_all(true);
 
     let child = Mock::new([2, 5, 8]);
     let result = call_new_not_iterator(child, 10, &ctx);
@@ -195,10 +192,7 @@ fn not_child_access() {
 fn not_child_access_optimized() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
-    {
-        let mut guard = ctx.spec_write();
-        guard.rule_mut().set_index_all(true);
-    }
+    ctx.spec_write().rule_mut().set_index_all(true);
 
     let child = Mock::new([3, 6]);
     let result = call_new_not_iterator(child, 10, &ctx);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -157,7 +157,10 @@ fn non_optimized_skip_to_works() {
 fn optimized_path_returns_not_optimized_iterator() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
-    unsafe { ctx.spec_mut().rule_mut().set_index_all(true) };
+    {
+        let mut guard = ctx.spec_write_guard();
+        guard.rule_mut().set_index_all(true);
+    }
 
     let child = Mock::new([2, 5, 8]);
     let result = call_new_not_iterator(child, 10, &ctx);
@@ -192,7 +195,10 @@ fn not_child_access() {
 fn not_child_access_optimized() {
     let ctx = MockContext::new(10, 10);
     // SAFETY: No iterators have been created from this context yet.
-    unsafe { ctx.spec_mut().rule_mut().set_index_all(true) };
+    {
+        let mut guard = ctx.spec_write_guard();
+        guard.rule_mut().set_index_all(true);
+    }
 
     let child = Mock::new([3, 6]);
     let result = call_new_not_iterator(child, 10, &ctx);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -685,9 +685,7 @@ mod optional_iterator_revalidate_test {
 
         // Revalidate should return VALIDATE_OK
         let guard = mock_ctx.spec_read_guard();
-        let status = it
-            .revalidate(&*guard)
-            .expect("revalidate without error");
+        let status = it.revalidate(&*guard).expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Verify child was revalidated
@@ -716,9 +714,7 @@ mod optional_iterator_revalidate_test {
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
         let guard = mock_ctx.spec_read_guard();
-        let status = it
-            .revalidate(&*guard)
-            .expect("revalidate without error");
+        let status = it.revalidate(&*guard).expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
         // Should be able to continue reading (now all virtual hits)
@@ -754,9 +750,7 @@ mod optional_iterator_revalidate_test {
 
         // Revalidate should handle child movement
         let guard = mock_ctx.spec_read_guard();
-        let status = it
-            .revalidate(&*guard)
-            .expect("revalidate without error");
+        let status = it.revalidate(&*guard).expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
 
@@ -793,9 +787,7 @@ mod optional_iterator_revalidate_test {
 
         // Since current result is virtual, revalidate should return OK
         let guard = mock_ctx.spec_read_guard();
-        let status = it
-            .revalidate(&*guard)
-            .expect("revalidate without error");
+        let status = it.revalidate(&*guard).expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should be able to continue reading

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -685,7 +685,7 @@ mod optional_iterator_revalidate_test {
 
         // Revalidate should return VALIDATE_OK
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate without error")
         };
         assert!(matches!(status, RQEValidateStatus::Ok));
@@ -716,7 +716,7 @@ mod optional_iterator_revalidate_test {
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate without error")
         };
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
@@ -754,7 +754,7 @@ mod optional_iterator_revalidate_test {
 
         // Revalidate should handle child movement
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate without error")
         };
         // Should be MOVED (as real result was affected)
@@ -793,7 +793,7 @@ mod optional_iterator_revalidate_test {
 
         // Since current result is virtual, revalidate should return OK
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate without error")
         };
         assert!(matches!(status, RQEValidateStatus::Ok));
@@ -829,14 +829,14 @@ mod optional_iterator_revalidate_after_abort {
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).unwrap()
         };
         assert!(matches!(status, RQEValidateStatus::Ok));
@@ -863,7 +863,7 @@ mod optional_iterator_revalidate_after_abort {
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let _ = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).unwrap()
         };
 
@@ -899,7 +899,7 @@ mod optional_iterator_revalidate_after_abort {
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let _ = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).unwrap()
         };
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -8,6 +8,7 @@
 */
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
+use index_spec::IndexSpec;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, optional::Optional,
     wildcard::Wildcard,
@@ -668,7 +669,6 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_ok() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_OK
@@ -686,7 +686,9 @@ mod optional_iterator_revalidate_test {
 
         // Revalidate should return VALIDATE_OK
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
+        let status = it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Verify child was revalidated
@@ -702,7 +704,6 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_aborted() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_ABORTED
@@ -716,7 +717,9 @@ mod optional_iterator_revalidate_test {
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
+        let status = it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
         // Should be able to continue reading (now all virtual hits)
@@ -730,7 +733,6 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_moved() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_MOVED
@@ -753,7 +755,9 @@ mod optional_iterator_revalidate_test {
 
         // Revalidate should handle child movement
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
+        let status = it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
 
@@ -768,7 +772,6 @@ mod optional_iterator_revalidate_test {
     #[test]
     fn test_revalidate_moved_virtual_result() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let (mut it, mut data) = setup_optional_iterator_with_mock_child_and_data();
 
         // Child returns VALIDATE_MOVED
@@ -791,7 +794,9 @@ mod optional_iterator_revalidate_test {
 
         // Since current result is virtual, revalidate should return OK
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.expect("revalidate without error");
+        let status = it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should be able to continue reading
@@ -814,7 +819,6 @@ mod optional_iterator_revalidate_after_abort {
     #[test]
     fn test_revalidate_twice_after_abort() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -826,12 +830,12 @@ mod optional_iterator_revalidate_after_abort {
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.unwrap();
+        let status = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.unwrap();
+        let status = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -845,7 +849,6 @@ mod optional_iterator_revalidate_after_abort {
     #[test]
     fn test_skip_to_after_abort() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -857,7 +860,7 @@ mod optional_iterator_revalidate_after_abort {
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         // SAFETY: test-only call with valid context
-        let _ = unsafe { it.revalidate(ctx) }.unwrap();
+        let _ = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -878,7 +881,6 @@ mod optional_iterator_revalidate_after_abort {
     #[test]
     fn test_rewind_after_abort() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         let child = utils::Mock::new([5, 10, 15]);
         let mut data = child.data();
         let mut it = Optional::new(MAX_DOC_ID, WEIGHT, child);
@@ -892,7 +894,7 @@ mod optional_iterator_revalidate_after_abort {
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         // SAFETY: test-only call with valid context
-        let _ = unsafe { it.revalidate(ctx) }.unwrap();
+        let _ = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
 
         // Rewind with child=None
         it.rewind();
@@ -978,9 +980,9 @@ mod optional_iterator_non_sequential_reads {
             self.read_step >= N
         }
 
-        unsafe fn revalidate(
+        fn revalidate(
             &mut self,
-            _spec: std::ptr::NonNull<ffi::IndexSpec>,
+            _spec: &mut IndexSpec,
         ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
             Ok(RQEValidateStatus::Ok)
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -8,7 +8,6 @@
 */
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use index_spec::IndexSpec;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, optional::Optional,
     wildcard::Wildcard,
@@ -685,9 +684,9 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Revalidate should return VALIDATE_OK
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
@@ -716,9 +715,9 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
@@ -754,9 +753,9 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Revalidate should handle child movement
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -793,9 +792,9 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Since current result is virtual, revalidate should return OK
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
@@ -829,13 +828,13 @@ mod optional_iterator_revalidate_after_abort {
 
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        // SAFETY: test-only call with valid context
-        let status = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
+        let mut guard = mock_ctx.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
-        // SAFETY: test-only call with valid context
-        let status = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
+        let mut guard = mock_ctx.spec_read_guard();
+        let status = it.revalidate(&mut *guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -859,8 +858,8 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        // SAFETY: test-only call with valid context
-        let _ = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
+        let mut guard = mock_ctx.spec_read_guard();
+        let _ = it.revalidate(&mut *guard).unwrap();
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -893,8 +892,8 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        // SAFETY: test-only call with valid context
-        let _ = it.revalidate(unsafe { mock_ctx.spec_mut() }).unwrap();
+        let mut guard = mock_ctx.spec_read_guard();
+        let _ = it.revalidate(&mut *guard).unwrap();
 
         // Rewind with child=None
         it.rewind();
@@ -982,7 +981,7 @@ mod optional_iterator_non_sequential_reads {
 
         fn revalidate(
             &mut self,
-            _spec: &mut IndexSpec,
+            _spec: &mut index_spec::IndexSpecReadGuard,
         ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
             Ok(RQEValidateStatus::Ok)
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -684,9 +684,9 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Revalidate should return VALIDATE_OK
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
@@ -715,9 +715,9 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
@@ -753,9 +753,9 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Revalidate should handle child movement
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
@@ -792,9 +792,9 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Since current result is virtual, revalidate should return OK
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
@@ -828,13 +828,13 @@ mod optional_iterator_revalidate_after_abort {
 
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let mut guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = mock_ctx.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
-        let mut guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&mut *guard).unwrap();
+        let guard = mock_ctx.spec_read_guard();
+        let status = it.revalidate(&*guard).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -858,8 +858,8 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let mut guard = mock_ctx.spec_read_guard();
-        let _ = it.revalidate(&mut *guard).unwrap();
+        let guard = mock_ctx.spec_read_guard();
+        let _ = it.revalidate(&*guard).unwrap();
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -892,8 +892,8 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let mut guard = mock_ctx.spec_read_guard();
-        let _ = it.revalidate(&mut *guard).unwrap();
+        let guard = mock_ctx.spec_read_guard();
+        let _ = it.revalidate(&*guard).unwrap();
 
         // Rewind with child=None
         it.rewind();
@@ -981,7 +981,7 @@ mod optional_iterator_non_sequential_reads {
 
         fn revalidate(
             &mut self,
-            _spec: &mut index_spec::IndexSpecReadGuard,
+            _spec: &index_spec::IndexSpecReadGuard,
         ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
             Ok(RQEValidateStatus::Ok)
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -684,10 +684,9 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Revalidate should return VALIDATE_OK
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate without error")
-        };
+        let status = it
+            .revalidate(&*mock_ctx.spec_read())
+            .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Verify child was revalidated
@@ -715,10 +714,9 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate without error")
-        };
+        let status = it
+            .revalidate(&*mock_ctx.spec_read())
+            .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
         // Should be able to continue reading (now all virtual hits)
@@ -753,10 +751,9 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Revalidate should handle child movement
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate without error")
-        };
+        let status = it
+            .revalidate(&*mock_ctx.spec_read())
+            .expect("revalidate without error");
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
 
@@ -792,10 +789,9 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Since current result is virtual, revalidate should return OK
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate without error")
-        };
+        let status = it
+            .revalidate(&*mock_ctx.spec_read())
+            .expect("revalidate without error");
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should be able to continue reading
@@ -828,17 +824,11 @@ mod optional_iterator_revalidate_after_abort {
 
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -862,10 +852,7 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let _ = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let _ = it.revalidate(&*mock_ctx.spec_read()).unwrap();
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -898,10 +885,7 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let _ = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).unwrap()
-        };
+        let _ = it.revalidate(&*mock_ctx.spec_read()).unwrap();
 
         // Rewind with child=None
         it.rewind();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -684,8 +684,10 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Revalidate should return VALIDATE_OK
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).expect("revalidate without error");
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate without error")
+        };
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Verify child was revalidated
@@ -713,8 +715,10 @@ mod optional_iterator_revalidate_test {
             .expect("read some result, be it virtual or real");
 
         // Optional iterator handles child abort gracefully by replacing with empty iterator
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).expect("revalidate without error");
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate without error")
+        };
         assert!(matches!(status, RQEValidateStatus::Ok)); // Optional iterator continues even when child is aborted
 
         // Should be able to continue reading (now all virtual hits)
@@ -749,8 +753,10 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Revalidate should handle child movement
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).expect("revalidate without error");
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate without error")
+        };
         // Should be MOVED (as real result was affected)
         assert!(matches!(status, RQEValidateStatus::Moved { .. }));
 
@@ -786,8 +792,10 @@ mod optional_iterator_revalidate_test {
         assert_eq!(it.last_doc_id(), DOC_ID);
 
         // Since current result is virtual, revalidate should return OK
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).expect("revalidate without error");
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate without error")
+        };
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should be able to continue reading
@@ -820,13 +828,17 @@ mod optional_iterator_revalidate_after_abort {
 
         // First revalidate with abort: child is dropped
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Second revalidate: child is None, should return Ok immediately
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).unwrap();
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
         assert!(matches!(status, RQEValidateStatus::Ok));
 
         // Should still be able to read (all virtual)
@@ -850,8 +862,10 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let guard = mock_ctx.spec_read_guard();
-        let _ = it.revalidate(&*guard).unwrap();
+        let _ = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
 
         // skip_to with child=None should yield a virtual Found result
         match it.skip_to(8).unwrap().unwrap() {
@@ -884,8 +898,10 @@ mod optional_iterator_revalidate_after_abort {
 
         // Abort the child
         data.set_revalidate_result(utils::MockRevalidateResult::Abort);
-        let guard = mock_ctx.spec_read_guard();
-        let _ = it.revalidate(&*guard).unwrap();
+        let _ = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).unwrap()
+        };
 
         // Rewind with child=None
         it.rewind();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -635,8 +635,10 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
             let _ = it.read().expect("read").expect("result");
 
-            let guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&*guard).expect("revalidate");
+            let status = {
+                let guard = test_ctx.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate")
+            };
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -656,8 +658,10 @@ mod optional_optimized_iterator_revalidate_tests {
             let r = it.read().expect("read").expect("result");
             assert_eq!(r.doc_id, 1);
 
-            let guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&*guard).expect("revalidate");
+            let status = {
+                let guard = test_ctx.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate")
+            };
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -684,8 +688,10 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&*guard).expect("revalidate");
+            let status = {
+                let guard = test_ctx.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate")
+            };
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -704,8 +710,10 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&*guard).expect("revalidate");
+            let status = {
+                let guard = test_ctx.spec_read_guard();
+                it.revalidate(&*guard).expect("revalidate")
+            };
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -727,8 +735,10 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).expect("revalidate");
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
 
@@ -749,8 +759,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        match it.revalidate(&*guard).expect("revalidate") {
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
+        match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, WEIGHT);
@@ -777,8 +790,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        match it.revalidate(&*guard).expect("revalidate") {
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
+        match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual result carries zero weight
@@ -805,8 +821,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        match it.revalidate(&*guard).expect("revalidate") {
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
+        match status {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -837,8 +856,11 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        match it.revalidate(&*guard).expect("revalidate") {
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
+        match status {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -866,8 +888,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        match it.revalidate(&*guard).expect("revalidate") {
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
+        match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual: child is gone
@@ -899,8 +924,10 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        let status = it.revalidate(&*guard).expect("revalidate");
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
         assert_eq!(wcii_data.revalidate_count(), 1);
@@ -927,8 +954,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let guard = mock_ctx.spec_read_guard();
-        match it.revalidate(&*guard).expect("revalidate") {
+        let status = {
+            let guard = mock_ctx.spec_read_guard();
+            it.revalidate(&*guard).expect("revalidate")
+        };
+        match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -636,7 +636,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
 
             let status = {
-                let guard = test_ctx.spec_read_guard();
+                let guard = test_ctx.spec_read();
                 it.revalidate(&*guard).expect("revalidate")
             };
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -659,7 +659,7 @@ mod optional_optimized_iterator_revalidate_tests {
             assert_eq!(r.doc_id, 1);
 
             let status = {
-                let guard = test_ctx.spec_read_guard();
+                let guard = test_ctx.spec_read();
                 it.revalidate(&*guard).expect("revalidate")
             };
             // Child aborted while on a virtual result → Ok (no state change needed)
@@ -689,7 +689,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
             let status = {
-                let guard = test_ctx.spec_read_guard();
+                let guard = test_ctx.spec_read();
                 it.revalidate(&*guard).expect("revalidate")
             };
             // Child moved while on a real result → Moved
@@ -711,7 +711,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
             let status = {
-                let guard = test_ctx.spec_read_guard();
+                let guard = test_ctx.spec_read();
                 it.revalidate(&*guard).expect("revalidate")
             };
             // Child moved while on a virtual result → Ok
@@ -736,7 +736,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         assert!(matches!(status, RQEValidateStatus::Aborted));
@@ -760,7 +760,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         match status {
@@ -791,7 +791,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         match status {
@@ -822,7 +822,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         match status {
@@ -857,7 +857,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         match status {
@@ -889,7 +889,7 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         match status {
@@ -925,7 +925,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         assert!(matches!(status, RQEValidateStatus::Aborted));
@@ -955,7 +955,7 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let status = {
-            let guard = mock_ctx.spec_read_guard();
+            let guard = mock_ctx.spec_read();
             it.revalidate(&*guard).expect("revalidate")
         };
         match status {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -635,10 +635,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
             let _ = it.read().expect("read").expect("result");
 
-            let status = {
-                let guard = test_ctx.spec_read();
-                it.revalidate(&*guard).expect("revalidate")
-            };
+            let status = it.revalidate(&*test_ctx.spec_read()).expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -658,10 +655,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let r = it.read().expect("read").expect("result");
             assert_eq!(r.doc_id, 1);
 
-            let status = {
-                let guard = test_ctx.spec_read();
-                it.revalidate(&*guard).expect("revalidate")
-            };
+            let status = it.revalidate(&*test_ctx.spec_read()).expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -688,10 +682,7 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let status = {
-                let guard = test_ctx.spec_read();
-                it.revalidate(&*guard).expect("revalidate")
-            };
+            let status = it.revalidate(&*test_ctx.spec_read()).expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -710,10 +701,7 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let status = {
-                let guard = test_ctx.spec_read();
-                it.revalidate(&*guard).expect("revalidate")
-            };
+            let status = it.revalidate(&*test_ctx.spec_read()).expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -735,10 +723,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
 
@@ -759,10 +744,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
@@ -790,10 +772,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
@@ -821,10 +800,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         match status {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
@@ -856,10 +832,7 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         match status {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
@@ -888,10 +861,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
@@ -924,10 +894,7 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
         assert_eq!(wcii_data.revalidate_count(), 1);
@@ -954,10 +921,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let status = {
-            let guard = mock_ctx.spec_read();
-            it.revalidate(&*guard).expect("revalidate")
-        };
+        let status = it.revalidate(&*mock_ctx.spec_read()).expect("revalidate");
         match status {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -728,9 +728,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        let status = it
-            .revalidate(&*guard)
-            .expect("revalidate");
+        let status = it.revalidate(&*guard).expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
 
@@ -752,10 +750,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        match it
-            .revalidate(&*guard)
-            .expect("revalidate")
-        {
+        match it.revalidate(&*guard).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, WEIGHT);
@@ -783,10 +778,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        match it
-            .revalidate(&*guard)
-            .expect("revalidate")
-        {
+        match it.revalidate(&*guard).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual result carries zero weight
@@ -814,10 +806,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        match it
-            .revalidate(&*guard)
-            .expect("revalidate")
-        {
+        match it.revalidate(&*guard).expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -849,10 +838,7 @@ mod optional_optimized_iterator_revalidate_tests {
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        match it
-            .revalidate(&*guard)
-            .expect("revalidate")
-        {
+        match it.revalidate(&*guard).expect("revalidate") {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -881,10 +867,7 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        match it
-            .revalidate(&*guard)
-            .expect("revalidate")
-        {
+        match it.revalidate(&*guard).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual: child is gone
@@ -917,9 +900,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        let status = it
-            .revalidate(&*guard)
-            .expect("revalidate");
+        let status = it.revalidate(&*guard).expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
         assert_eq!(wcii_data.revalidate_count(), 1);
@@ -947,10 +928,7 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read_guard();
-        match it
-            .revalidate(&*guard)
-            .expect("revalidate")
-        {
+        match it.revalidate(&*guard).expect("revalidate") {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -636,7 +636,7 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
 
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -657,7 +657,7 @@ mod optional_optimized_iterator_revalidate_tests {
             assert_eq!(r.doc_id, 1);
 
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -685,7 +685,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -705,7 +705,7 @@ mod optional_optimized_iterator_revalidate_tests {
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
             // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec) }.expect("revalidate");
+            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -727,9 +727,10 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.expect("revalidate");
+        let status = it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
 
@@ -750,9 +751,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
+        match it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate")
+        {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, WEIGHT);
@@ -779,9 +782,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
+        match it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate")
+        {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual result carries zero weight
@@ -808,9 +813,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
+        match it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate")
+        {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -841,9 +848,11 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
+        match it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate")
+        {
             RQEValidateStatus::Moved { current: None } => {}
             other => panic!("expected Moved{{None}}, got {other:?}"),
         }
@@ -871,9 +880,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
+        match it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate")
+        {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual: child is gone
@@ -905,9 +916,10 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        let status = unsafe { it.revalidate(ctx) }.expect("revalidate");
+        let status = it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
         assert_eq!(wcii_data.revalidate_count(), 1);
@@ -934,9 +946,11 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let ctx = mock_ctx.spec();
         // SAFETY: test-only call with valid context
-        match unsafe { it.revalidate(ctx) }.expect("revalidate") {
+        match it
+            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .expect("revalidate")
+        {
             RQEValidateStatus::Moved { current: Some(r) } => {
                 assert_eq!(r.doc_id, 20);
                 assert_eq!(r.weight, 0.); // virtual

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -635,8 +635,8 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
             let _ = it.read().expect("read").expect("result");
 
-            // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
+            let mut guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&mut *guard).expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -656,8 +656,8 @@ mod optional_optimized_iterator_revalidate_tests {
             let r = it.read().expect("read").expect("result");
             assert_eq!(r.doc_id, 1);
 
-            // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
+            let mut guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&mut *guard).expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -684,8 +684,8 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
+            let mut guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&mut *guard).expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -704,8 +704,8 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            // SAFETY: test-only call with valid context
-            let status = unsafe { it.revalidate(test_ctx.spec_mut()) }.expect("revalidate");
+            let mut guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&mut *guard).expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -727,9 +727,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
@@ -751,9 +751,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -782,9 +782,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -813,9 +813,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: None } => {}
@@ -848,9 +848,9 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: None } => {}
@@ -880,9 +880,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -916,9 +916,9 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
@@ -946,9 +946,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        // SAFETY: test-only call with valid context
+        let mut guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(unsafe { mock_ctx.spec_mut() })
+            .revalidate(&mut *guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -635,8 +635,8 @@ mod optional_optimized_iterator_revalidate_tests {
             let _ = it.read().expect("read").expect("result");
             let _ = it.read().expect("read").expect("result");
 
-            let mut guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&mut *guard).expect("revalidate");
+            let guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&*guard).expect("revalidate");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
 
@@ -656,8 +656,8 @@ mod optional_optimized_iterator_revalidate_tests {
             let r = it.read().expect("read").expect("result");
             assert_eq!(r.doc_id, 1);
 
-            let mut guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&mut *guard).expect("revalidate");
+            let guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&*guard).expect("revalidate");
             // Child aborted while on a virtual result → Ok (no state change needed)
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(
@@ -684,8 +684,8 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let mut guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&mut *guard).expect("revalidate");
+            let guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&*guard).expect("revalidate");
             // Child moved while on a real result → Moved
             assert!(matches!(status, RQEValidateStatus::Moved { .. }));
             assert_eq!(data.revalidate_count(), 1);
@@ -704,8 +704,8 @@ mod optional_optimized_iterator_revalidate_tests {
             }
 
             data.set_revalidate_result(utils::MockRevalidateResult::Move);
-            let mut guard = test_ctx.spec_read_guard();
-            let status = it.revalidate(&mut *guard).expect("revalidate");
+            let guard = test_ctx.spec_read_guard();
+            let status = it.revalidate(&*guard).expect("revalidate");
             // Child moved while on a virtual result → Ok
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert_eq!(data.revalidate_count(), 1);
@@ -727,9 +727,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
     }
@@ -751,9 +751,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -782,9 +782,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -813,9 +813,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: None } => {}
@@ -848,9 +848,9 @@ mod optional_optimized_iterator_revalidate_tests {
         // wcii is at EOF; Move revalidation returns Moved { current: None }.
         wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: None } => {}
@@ -880,9 +880,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child aborts → replaced by Empty → virtual hit at 20.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {
@@ -916,9 +916,9 @@ mod optional_optimized_iterator_revalidate_tests {
         child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         let status = it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate");
         assert!(matches!(status, RQEValidateStatus::Aborted));
         // wcii was checked; child must NOT have been revalidated (short-circuit).
@@ -946,9 +946,9 @@ mod optional_optimized_iterator_revalidate_tests {
 
         // wcii moves to 20; child moves to 25 — no child hit at 20 → virtual.
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-        let mut guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read_guard();
         match it
-            .revalidate(&mut *guard)
+            .revalidate(&*guard)
             .expect("revalidate")
         {
             RQEValidateStatus::Moved { current: Some(r) } => {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -194,10 +194,7 @@ mod optional_reducer_tests {
         // by the mock; all that matters is that the pointer is non-null.
         let mut disk_spec_storage: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
         // `disk_spec_storage` outlives all iterators created below.
-        {
-            let mut guard = ctx.spec_write();
-            guard.set_disk_spec(&mut disk_spec_storage);
-        }
+        ctx.spec_write().set_disk_spec(&mut disk_spec_storage);
 
         let child = Mock::new(DOCS);
 
@@ -231,10 +228,7 @@ mod optional_reducer_tests {
 
         let ctx = MockContext::new(MAX_DOC_ID, 0);
         // SAFETY: no iterator from `ctx` is alive at this point.
-        {
-            let mut guard = ctx.spec_write();
-            guard.rule_mut().set_index_all(true);
-        }
+        ctx.spec_write().rule_mut().set_index_all(true);
 
         let child = Mock::new(DOCS);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -195,7 +195,7 @@ mod optional_reducer_tests {
         let mut disk_spec_storage: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
         // SAFETY: no iterator from `ctx` is alive at this point, and
         // `disk_spec_storage` outlives all iterators created below.
-        unsafe { ctx.set_disk_spec(&mut disk_spec_storage) };
+        unsafe { ctx.spec_mut().set_disk_spec(&mut disk_spec_storage) };
 
         let child = Mock::new(DOCS);
 
@@ -229,7 +229,7 @@ mod optional_reducer_tests {
 
         let ctx = MockContext::new(MAX_DOC_ID, 0);
         // SAFETY: no iterator from `ctx` is alive at this point.
-        unsafe { ctx.set_index_all(true) };
+        unsafe { ctx.spec_mut().rule_mut().set_index_all(true) };
 
         let child = Mock::new(DOCS);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -193,9 +193,11 @@ mod optional_reducer_tests {
         // Point `spec.diskSpec` at a local storage cell — its value is ignored
         // by the mock; all that matters is that the pointer is non-null.
         let mut disk_spec_storage: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
-        // SAFETY: no iterator from `ctx` is alive at this point, and
         // `disk_spec_storage` outlives all iterators created below.
-        unsafe { ctx.spec_mut().set_disk_spec(&mut disk_spec_storage) };
+        {
+            let mut guard = ctx.spec_write_guard();
+            guard.set_disk_spec(&mut disk_spec_storage);
+        }
 
         let child = Mock::new(DOCS);
 
@@ -229,7 +231,10 @@ mod optional_reducer_tests {
 
         let ctx = MockContext::new(MAX_DOC_ID, 0);
         // SAFETY: no iterator from `ctx` is alive at this point.
-        unsafe { ctx.spec_mut().rule_mut().set_index_all(true) };
+        {
+            let mut guard = ctx.spec_write_guard();
+            guard.rule_mut().set_index_all(true);
+        }
 
         let child = Mock::new(DOCS);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -195,7 +195,7 @@ mod optional_reducer_tests {
         let mut disk_spec_storage: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
         // `disk_spec_storage` outlives all iterators created below.
         {
-            let mut guard = ctx.spec_write_guard();
+            let mut guard = ctx.spec_write();
             guard.set_disk_spec(&mut disk_spec_storage);
         }
 
@@ -232,7 +232,7 @@ mod optional_reducer_tests {
         let ctx = MockContext::new(MAX_DOC_ID, 0);
         // SAFETY: no iterator from `ctx` is alive at this point.
         {
-            let mut guard = ctx.spec_write_guard();
+            let mut guard = ctx.spec_write();
             guard.rule_mut().set_index_all(true);
         }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -161,8 +161,8 @@ fn profile_revalidate() {
     let _ = profile.read(); // doc 2
 
     // Revalidate (Wildcard returns OK)
-    let mut guard = mock_ctx.spec_read_guard();
-    let status = profile.revalidate(&mut *guard);
+    let guard = mock_ctx.spec_read_guard();
+    let status = profile.revalidate(&*guard);
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -154,7 +154,6 @@ fn profile_rewind() {
 #[test]
 fn profile_revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let ctx = mock_ctx.spec();
     let child = Wildcard::new(10, 1.0);
     let mut profile = Profile::new(child);
 
@@ -163,7 +162,7 @@ fn profile_revalidate() {
 
     // Revalidate (Wildcard returns OK)
     // SAFETY: test-only call with valid context
-    let status = unsafe { profile.revalidate(ctx) };
+    let status = profile.revalidate(unsafe { mock_ctx.spec_mut() });
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -161,10 +161,7 @@ fn profile_revalidate() {
     let _ = profile.read(); // doc 2
 
     // Revalidate (Wildcard returns OK)
-    let status = {
-        let guard = mock_ctx.spec_read();
-        profile.revalidate(&*guard)
-    };
+    let status = profile.revalidate(&*mock_ctx.spec_read());
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -161,8 +161,10 @@ fn profile_revalidate() {
     let _ = profile.read(); // doc 2
 
     // Revalidate (Wildcard returns OK)
-    let guard = mock_ctx.spec_read_guard();
-    let status = profile.revalidate(&*guard);
+    let status = {
+        let guard = mock_ctx.spec_read_guard();
+        profile.revalidate(&*guard)
+    };
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -161,8 +161,8 @@ fn profile_revalidate() {
     let _ = profile.read(); // doc 2
 
     // Revalidate (Wildcard returns OK)
-    // SAFETY: test-only call with valid context
-    let status = profile.revalidate(unsafe { mock_ctx.spec_mut() });
+    let mut guard = mock_ctx.spec_read_guard();
+    let status = profile.revalidate(&mut *guard);
     assert!(status.is_ok());
 
     // Verify delegation still works

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -162,7 +162,7 @@ fn profile_revalidate() {
 
     // Revalidate (Wildcard returns OK)
     let status = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         profile.revalidate(&*guard)
     };
     assert!(status.is_ok());

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -528,8 +528,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 15);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -558,8 +558,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -589,8 +589,8 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -621,8 +621,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -651,8 +651,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -689,8 +689,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 20);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -724,8 +724,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -755,8 +755,8 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -810,8 +810,8 @@ macro_rules! union_common_tests {
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = quick_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = quick_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -839,8 +839,8 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                // SAFETY: test-only call with valid context
-                let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+                let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -867,8 +867,8 @@ macro_rules! union_common_tests {
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                // SAFETY: test-only call with valid context
-                let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+                let mut guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -898,8 +898,8 @@ macro_rules! union_common_tests {
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = quick_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = quick_iter.revalidate(&mut *guard).expect("revalidate failed");
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -929,8 +929,8 @@ macro_rules! union_common_tests {
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let _status = union.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let _status = union.revalidate(&mut *guard).expect("revalidate failed");
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -973,8 +973,8 @@ macro_rules! union_common_tests {
 
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union.revalidate(&mut *guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -1019,8 +1019,8 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            // SAFETY: test-only call with valid context
-            let status = union.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
+            let mut guard = mock_ctx.spec_read_guard();
+            let status = union.revalidate(&mut *guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -528,8 +528,10 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 15);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -558,8 +560,10 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -589,8 +593,10 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -621,8 +627,10 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -651,8 +659,10 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -689,8 +699,10 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 20);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -724,8 +736,10 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -755,8 +769,10 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -810,8 +826,10 @@ macro_rules! union_common_tests {
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = quick_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                quick_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -839,8 +857,10 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+                let status = {
+                    let guard = mock_ctx.spec_read_guard();
+                    union_iter.revalidate(&*guard).expect("revalidate failed")
+                };
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -867,8 +887,10 @@ macro_rules! union_common_tests {
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
+                let status = {
+                    let guard = mock_ctx.spec_read_guard();
+                    union_iter.revalidate(&*guard).expect("revalidate failed")
+                };
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -898,8 +920,10 @@ macro_rules! union_common_tests {
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = quick_iter.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                quick_iter.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -929,8 +953,10 @@ macro_rules! union_common_tests {
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let _status = union.revalidate(&*guard).expect("revalidate failed");
+            let _status = {
+                let guard = mock_ctx.spec_read_guard();
+                union.revalidate(&*guard).expect("revalidate failed")
+            };
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -973,8 +999,10 @@ macro_rules! union_common_tests {
 
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -1019,8 +1047,10 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let guard = mock_ctx.spec_read_guard();
-            let status = union.revalidate(&*guard).expect("revalidate failed");
+            let status = {
+                let guard = mock_ctx.spec_read_guard();
+                union.revalidate(&*guard).expect("revalidate failed")
+            };
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -528,8 +528,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 15);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -558,8 +558,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -589,8 +589,8 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -621,8 +621,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -651,8 +651,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -689,8 +689,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 20);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -724,8 +724,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -755,8 +755,8 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -810,8 +810,8 @@ macro_rules! union_common_tests {
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = quick_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = quick_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -839,8 +839,8 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+                let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -867,8 +867,8 @@ macro_rules! union_common_tests {
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let mut guard = mock_ctx.spec_read_guard();
-            let status = union_iter.revalidate(&mut *guard).expect("revalidate failed");
+                let guard = mock_ctx.spec_read_guard();
+            let status = union_iter.revalidate(&*guard).expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -898,8 +898,8 @@ macro_rules! union_common_tests {
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = quick_iter.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = quick_iter.revalidate(&*guard).expect("revalidate failed");
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -929,8 +929,8 @@ macro_rules! union_common_tests {
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let _status = union.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let _status = union.revalidate(&*guard).expect("revalidate failed");
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -973,8 +973,8 @@ macro_rules! union_common_tests {
 
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union.revalidate(&*guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -1019,8 +1019,8 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let mut guard = mock_ctx.spec_read_guard();
-            let status = union.revalidate(&mut *guard).expect("revalidate failed");
+            let guard = mock_ctx.spec_read_guard();
+            let status = union.revalidate(&*guard).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -528,9 +528,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 15);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -559,9 +558,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -591,9 +589,8 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -624,9 +621,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -655,9 +651,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -694,9 +689,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 20);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -730,9 +724,8 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -762,9 +755,8 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -818,9 +810,8 @@ macro_rules! union_common_tests {
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { quick_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = quick_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -848,9 +839,8 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let ctx = mock_ctx.spec();
                 // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+                let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -877,9 +867,8 @@ macro_rules! union_common_tests {
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let ctx = mock_ctx.spec();
                 // SAFETY: test-only call with valid context
-            let status = unsafe { union_iter.revalidate(ctx) }.expect("revalidate failed");
+                let status = union_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -909,9 +898,8 @@ macro_rules! union_common_tests {
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { quick_iter.revalidate(ctx) }.expect("revalidate failed");
+            let status = quick_iter.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -941,9 +929,8 @@ macro_rules! union_common_tests {
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let _status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
+            let _status = union.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -986,9 +973,8 @@ macro_rules! union_common_tests {
 
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
+            let status = union.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -1033,9 +1019,8 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let ctx = mock_ctx.spec();
             // SAFETY: test-only call with valid context
-            let status = unsafe { union.revalidate(ctx) }.expect("revalidate failed");
+            let status = union.revalidate(unsafe { mock_ctx.spec_mut() }).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -529,7 +529,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -561,7 +561,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(
@@ -594,7 +594,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -628,7 +628,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(
@@ -660,7 +660,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(
@@ -700,7 +700,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -737,7 +737,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(
@@ -770,7 +770,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -827,7 +827,7 @@ macro_rules! union_common_tests {
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 quick_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(matches!(status, RQEValidateStatus::Ok));
@@ -858,7 +858,7 @@ macro_rules! union_common_tests {
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
                 let status = {
-                    let guard = mock_ctx.spec_read_guard();
+                    let guard = mock_ctx.spec_read();
                     union_iter.revalidate(&*guard).expect("revalidate failed")
                 };
                 assert!(matches!(
@@ -888,7 +888,7 @@ macro_rules! union_common_tests {
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
                 let status = {
-                    let guard = mock_ctx.spec_read_guard();
+                    let guard = mock_ctx.spec_read();
                     union_iter.revalidate(&*guard).expect("revalidate failed")
                 };
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
@@ -921,7 +921,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 quick_iter.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(matches!(
@@ -954,7 +954,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let _status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union.revalidate(&*guard).expect("revalidate failed")
             };
 
@@ -1000,7 +1000,7 @@ macro_rules! union_common_tests {
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(
@@ -1048,7 +1048,7 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = {
-                let guard = mock_ctx.spec_read_guard();
+                let guard = mock_ctx.spec_read();
                 union.revalidate(&*guard).expect("revalidate failed")
             };
             assert!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -528,10 +528,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 15);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             let result = union_iter.read().expect("read failed").unwrap();
@@ -560,10 +557,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with current, got {:?}",
@@ -593,10 +587,7 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
             assert!(union_iter.at_eof());
         }
@@ -627,10 +618,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when only one child aborts"
@@ -659,10 +647,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Aborted),
                 "Union should abort when all children abort"
@@ -699,10 +684,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 20);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
 
             assert!(!union_iter.at_eof());
@@ -736,10 +718,7 @@ macro_rules! union_common_tests {
             assert_eq!(result.doc_id, 10);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(
                 !matches!(status, RQEValidateStatus::Aborted),
                 "Union should not abort when some children are still Ok"
@@ -769,10 +748,7 @@ macro_rules! union_common_tests {
             assert!(union_iter.at_eof());
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
@@ -826,10 +802,7 @@ macro_rules! union_common_tests {
             assert_eq!(read_docs, vec![10, 20, 30]);
             assert!(quick_iter.at_eof());
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                quick_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = quick_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
 
@@ -857,10 +830,7 @@ macro_rules! union_common_tests {
                 data1.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let status = {
-                    let guard = mock_ctx.spec_read();
-                    union_iter.revalidate(&*guard).expect("revalidate failed")
-                };
+                let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
                 assert!(matches!(
                     status,
                     RQEValidateStatus::Moved { current: Some(_) }
@@ -887,10 +857,7 @@ macro_rules! union_common_tests {
                 data2.set_revalidate_result(MockRevalidateResult::Move);
 
                 let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-                let status = {
-                    let guard = mock_ctx.spec_read();
-                    union_iter.revalidate(&*guard).expect("revalidate failed")
-                };
+                let status = union_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
                 assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
                 assert!(union_iter.at_eof());
             }
@@ -920,10 +887,7 @@ macro_rules! union_common_tests {
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                quick_iter.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = quick_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(matches!(
                 status,
                 RQEValidateStatus::Moved { current: Some(_) }
@@ -953,10 +917,7 @@ macro_rules! union_common_tests {
             data0.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let _status = {
-                let guard = mock_ctx.spec_read();
-                union.revalidate(&*guard).expect("revalidate failed")
-            };
+            let _status = union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
 
             let mut remaining = Vec::new();
             while let Some(result) = union.read().expect("read failed") {
@@ -999,10 +960,7 @@ macro_rules! union_common_tests {
 
             // Revalidate — nothing moved, nothing aborted.
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok when minimum doc_id is unchanged, got {:?}",
@@ -1047,10 +1005,7 @@ macro_rules! union_common_tests {
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = {
-                let guard = mock_ctx.spec_read();
-                union.revalidate(&*guard).expect("revalidate failed")
-            };
+            let status = union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "Expected Moved with a current result, got {status:?}",

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -285,7 +285,7 @@ fn revalidate_panics() {
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let _ = {
-        let guard = mock_ctx.spec_read_guard();
+        let guard = mock_ctx.spec_read();
         union.revalidate(&*guard)
     };
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -284,10 +284,7 @@ fn revalidate_panics() {
     let mut union = UnionTrimmed::new(children, usize::MAX, true);
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let _ = {
-        let guard = mock_ctx.spec_read();
-        union.revalidate(&*guard)
-    };
+    let _ = union.revalidate(&*mock_ctx.spec_read());
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -284,8 +284,10 @@ fn revalidate_panics() {
     let mut union = UnionTrimmed::new(children, usize::MAX, true);
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let guard = mock_ctx.spec_read_guard();
-    let _ = union.revalidate(&*guard);
+    let _ = {
+        let guard = mock_ctx.spec_read_guard();
+        union.revalidate(&*guard)
+    };
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -284,8 +284,8 @@ fn revalidate_panics() {
     let mut union = UnionTrimmed::new(children, usize::MAX, true);
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let mut guard = mock_ctx.spec_read_guard();
-    let _ = union.revalidate(&mut *guard);
+    let guard = mock_ctx.spec_read_guard();
+    let _ = union.revalidate(&*guard);
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -284,8 +284,8 @@ fn revalidate_panics() {
     let mut union = UnionTrimmed::new(children, usize::MAX, true);
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    // SAFETY: test-only call with valid context
-    let _ = unsafe { union.revalidate(mock_ctx.spec_mut()) };
+    let mut guard = mock_ctx.spec_read_guard();
+    let _ = union.revalidate(&mut *guard);
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -285,7 +285,7 @@ fn revalidate_panics() {
 
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     // SAFETY: test-only call with valid context
-    let _ = unsafe { union.revalidate(mock_ctx.spec()) };
+    let _ = unsafe { union.revalidate(mock_ctx.spec_mut()) };
 }
 
 // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -10,7 +10,6 @@
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use index_spec::IndexSpec;
 use inverted_index::{RSIndexResult, RSOffsetSlice};
 use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 
@@ -388,7 +387,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();
@@ -556,7 +555,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -387,7 +387,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut index_spec::IndexSpecReadGuard,
+        _spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();
@@ -555,7 +555,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
 
     fn revalidate(
         &mut self,
-        _spec: &mut index_spec::IndexSpecReadGuard,
+        _spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -10,6 +10,7 @@
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
+use index_spec::IndexSpec;
 use inverted_index::{RSIndexResult, RSOffsetSlice};
 use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 
@@ -385,9 +386,9 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
         }))
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();
@@ -553,9 +554,9 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
         }))
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
         let revalidate_result = {
             let mut data = self.data.0.borrow_mut();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -77,7 +77,7 @@ impl RQEIterator<'static> for FieldMaskMock {
 
     fn revalidate(
         &mut self,
-        _spec: &mut index_spec::IndexSpecReadGuard,
+        _spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'static>, RQEIteratorError> {
         Ok(rqe_iterators::RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -14,6 +14,7 @@ pub(crate) use mock_enterprise_iterators::{MOCK_DISK_WILDCARD_TOP_ID, init_enter
 pub(crate) use mock_iterator::{Mock, MockData, MockIteratorError, MockRevalidateResult, MockVec};
 pub(crate) use wildcard_helper::WildcardHelper;
 
+use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 use rqe_iterators::{IteratorType, RQEIterator, RQEIteratorError, SkipToOutcome};
 
@@ -75,9 +76,9 @@ impl RQEIterator<'static> for FieldMaskMock {
         }
     }
 
-    unsafe fn revalidate(
+    fn revalidate(
         &mut self,
-        _spec: std::ptr::NonNull<ffi::IndexSpec>,
+        _spec: &mut IndexSpec,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'static>, RQEIteratorError> {
         Ok(rqe_iterators::RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -14,7 +14,6 @@ pub(crate) use mock_enterprise_iterators::{MOCK_DISK_WILDCARD_TOP_ID, init_enter
 pub(crate) use mock_iterator::{Mock, MockData, MockIteratorError, MockRevalidateResult, MockVec};
 pub(crate) use wildcard_helper::WildcardHelper;
 
-use index_spec::IndexSpec;
 use inverted_index::RSIndexResult;
 use rqe_iterators::{IteratorType, RQEIterator, RQEIteratorError, SkipToOutcome};
 
@@ -78,7 +77,7 @@ impl RQEIterator<'static> for FieldMaskMock {
 
     fn revalidate(
         &mut self,
-        _spec: &mut IndexSpec,
+        _spec: &mut index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'static>, RQEIteratorError> {
         Ok(rqe_iterators::RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -29,12 +29,8 @@ impl Default for Bencher {
         let context_sparse = TestContext::wildcard((1..Self::MAX_DOC_ID).step_by(100));
         // We set index_all=true so the wildcard iterator returns all doc IDs up to MAX_DOC_ID
         // rather than consulting existingDocs.
-        {
-            let mut guard_all = context_all.spec_write();
-            guard_all.rule_mut().set_index_all(true);
-            let mut guard_sparse = context_sparse.spec_write();
-            guard_sparse.rule_mut().set_index_all(true);
-        }
+        context_all.spec_write().rule_mut().set_index_all(true);
+        context_sparse.spec_write().rule_mut().set_index_all(true);
 
         Self {
             context_all,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -31,8 +31,8 @@ impl Default for Bencher {
         // We set index_all=true so the wildcard iterator returns all doc IDs up to MAX_DOC_ID
         // rather than consulting existingDocs.
         unsafe {
-            context_all.set_index_all(true);
-            context_sparse.set_index_all(true);
+            context_all.spec_mut().rule_mut().set_index_all(true);
+            context_sparse.spec_mut().rule_mut().set_index_all(true);
         }
 
         Self {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -30,9 +30,9 @@ impl Default for Bencher {
         // We set index_all=true so the wildcard iterator returns all doc IDs up to MAX_DOC_ID
         // rather than consulting existingDocs.
         {
-            let mut guard_all = context_all.spec_write_guard();
+            let mut guard_all = context_all.spec_write();
             guard_all.rule_mut().set_index_all(true);
-            let mut guard_sparse = context_sparse.spec_write_guard();
+            let mut guard_sparse = context_sparse.spec_write();
             guard_sparse.rule_mut().set_index_all(true);
         }
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -27,12 +27,13 @@ impl Default for Bencher {
     fn default() -> Self {
         let context_all = TestContext::wildcard(1..Self::MAX_DOC_ID);
         let context_sparse = TestContext::wildcard((1..Self::MAX_DOC_ID).step_by(100));
-        // SAFETY: no iterators have been created from these contexts yet.
         // We set index_all=true so the wildcard iterator returns all doc IDs up to MAX_DOC_ID
         // rather than consulting existingDocs.
-        unsafe {
-            context_all.spec_mut().rule_mut().set_index_all(true);
-            context_sparse.spec_mut().rule_mut().set_index_all(true);
+        {
+            let mut guard_all = context_all.spec_write_guard();
+            guard_all.rule_mut().set_index_all(true);
+            let mut guard_sparse = context_sparse.spec_write_guard();
+            guard_sparse.rule_mut().set_index_all(true);
         }
 
         Self {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
@@ -41,10 +41,11 @@ impl Default for Bencher {
         let context = TestContext::wildcard(1..=Self::MAX_DOC_ID);
         let context_sparse =
             TestContext::wildcard((1..=Self::MAX_DOC_ID).step_by(Self::SPARSE_STEP));
-        // SAFETY: no iterators have been created from these contexts yet.
-        unsafe {
-            context.spec_mut().rule_mut().set_index_all(true);
-            context_sparse.spec_mut().rule_mut().set_index_all(true);
+        {
+            let mut guard = context.spec_write_guard();
+            guard.rule_mut().set_index_all(true);
+            let mut guard_sparse = context_sparse.spec_write_guard();
+            guard_sparse.rule_mut().set_index_all(true);
         }
         Self {
             context,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
@@ -43,8 +43,8 @@ impl Default for Bencher {
             TestContext::wildcard((1..=Self::MAX_DOC_ID).step_by(Self::SPARSE_STEP));
         // SAFETY: no iterators have been created from these contexts yet.
         unsafe {
-            context.set_index_all(true);
-            context_sparse.set_index_all(true);
+            context.spec_mut().rule_mut().set_index_all(true);
+            context_sparse.spec_mut().rule_mut().set_index_all(true);
         }
         Self {
             context,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
@@ -41,12 +41,8 @@ impl Default for Bencher {
         let context = TestContext::wildcard(1..=Self::MAX_DOC_ID);
         let context_sparse =
             TestContext::wildcard((1..=Self::MAX_DOC_ID).step_by(Self::SPARSE_STEP));
-        {
-            let mut guard = context.spec_write();
-            guard.rule_mut().set_index_all(true);
-            let mut guard_sparse = context_sparse.spec_write();
-            guard_sparse.rule_mut().set_index_all(true);
-        }
+        context.spec_write().rule_mut().set_index_all(true);
+        context_sparse.spec_write().rule_mut().set_index_all(true);
         Self {
             context,
             context_sparse,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
@@ -42,9 +42,9 @@ impl Default for Bencher {
         let context_sparse =
             TestContext::wildcard((1..=Self::MAX_DOC_ID).step_by(Self::SPARSE_STEP));
         {
-            let mut guard = context.spec_write_guard();
+            let mut guard = context.spec_write();
             guard.rule_mut().set_index_all(true);
-            let mut guard_sparse = context_sparse.spec_write_guard();
+            let mut guard_sparse = context_sparse.spec_write();
             guard_sparse.rule_mut().set_index_all(true);
         }
         Self {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -170,6 +170,7 @@ impl QueryIterator {
 
     #[inline(always)]
     pub unsafe fn revalidate(&self, spec: *mut ffi::IndexSpec) -> ValidateStatus {
+        // SAFETY: Caller must ensure spec is a valid pointer
         unsafe { (*self.0).Revalidate.unwrap()(self.0, spec) }
     }
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 ffi.workspace = true
 field.workspace = true
+index_spec.workspace = true
 inverted_index = { workspace = true, features = ["test_utils"] }
 inverted_index_ffi = { path = "../c_entrypoint/inverted_index_ffi", features = [
     "test_utils",

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -7,7 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::cell::UnsafeCell;
 use std::ptr::NonNull;
 
 use ffi::{QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId};
@@ -24,7 +23,7 @@ use numeric_range_tree::NumericRangeTree;
 /// with the library's reference creation.
 pub struct MockContext {
     rule: *mut SchemaRule,
-    spec: UnsafeCell<&'static mut index_spec::IndexSpec>,
+    spec: *mut ffi::IndexSpec,
     sctx: *mut RedisSearchCtx,
     qctx: *mut QueryEvalCtx,
     numeric_range_tree: *mut NumericRangeTree,
@@ -43,7 +42,7 @@ impl Drop for MockContext {
                 std::alloc::Layout::new::<SchemaRule>(),
             );
             std::alloc::dealloc(
-                (*self.spec.get()).as_mut_ptr() as *mut u8,
+                self.spec as *mut u8,
                 std::alloc::Layout::new::<ffi::IndexSpec>(),
             );
             std::alloc::dealloc(
@@ -107,14 +106,10 @@ impl MockContext {
             (*qctx_ptr).sctx = sctx_ptr;
             (*qctx_ptr).docTable = std::ptr::addr_of_mut!((*spec_ptr).docs);
 
-            // Convert spec raw pointer to wrapper reference for better type safety
-            let spec: &'static mut index_spec::IndexSpec =
-                index_spec::IndexSpec::from_raw_mut(spec_ptr);
-
-            // Store raw pointers directly (don't convert back to Box)
+            // Store raw pointers directly (don't convert to references)
             Self {
                 rule: rule_ptr,
-                spec: UnsafeCell::new(spec),
+                spec: spec_ptr,
                 sctx: sctx_ptr,
                 qctx: qctx_ptr,
                 numeric_range_tree: numeric_range_tree_ptr,
@@ -144,7 +139,7 @@ impl MockContext {
     pub fn spec_read_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed for safe access.
-        unsafe { index_spec::IndexSpecReadGuard::from_locked((*self.spec.get()).as_ffi()) }
+        unsafe { index_spec::IndexSpecReadGuard::from_locked(&*self.spec) }
     }
 
     /// Creates a write lock guard for testing.
@@ -162,7 +157,7 @@ impl MockContext {
     pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed. Caller guarantees exclusive access.
-        unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut()) }
+        unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut(&mut *self.spec) }
     }
 
     /// Get the query evaluation context from the [`MockContext`].

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -43,7 +43,7 @@ impl Drop for MockContext {
                 std::alloc::Layout::new::<SchemaRule>(),
             );
             std::alloc::dealloc(
-                (*self.spec.get()).as_mut_raw_ptr() as *mut u8,
+                (*self.spec.get()).as_mut_ptr() as *mut u8,
                 std::alloc::Layout::new::<ffi::IndexSpec>(),
             );
             std::alloc::dealloc(
@@ -162,9 +162,7 @@ impl MockContext {
     pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed. Caller guarantees exclusive access.
-        unsafe {
-            index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut())
-        }
+        unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut()) }
     }
 
     /// Get the query evaluation context from the [`MockContext`].

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -132,58 +132,39 @@ impl MockContext {
         NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
     }
 
-    /// Get an immutable reference to the index spec wrapper.
+    /// Creates a read lock guard for testing.
     ///
-    /// This method provides safe read-only access to the [`index_spec::IndexSpec`]
-    /// through the [`UnsafeCell`]. Multiple immutable references can coexist safely.
+    /// Returns `ManuallyDrop<IndexSpecReadGuard>` since tests don't use real locks
+    /// and don't need/want the drop behavior.
     ///
-    /// # Interior Mutability
-    ///
-    /// The spec is stored in an [`UnsafeCell`] to enable interior mutability.
-    /// This allows tests to temporarily mutate the spec (e.g., to simulate
-    /// garbage collection) while iterators are active, which is necessary for
-    /// testing revalidation logic.
-    pub fn spec_ref(&self) -> &index_spec::IndexSpec {
-        // SAFETY: UnsafeCell allows interior mutability. We return an immutable
-        // reference, which is safe as long as no mutable reference is active.
-        unsafe { &**self.spec.get() }
+    /// This is for test-only use. Tests don't use real locks, so this creates
+    /// a guard without actually acquiring a lock. All safety requirements are
+    /// upheld internally - the spec is valid and accessible without a lock in
+    /// test contexts.
+    pub fn spec_read_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
+        // SAFETY: The underlying spec exists and is valid. In test contexts,
+        // no lock is needed for safe access.
+        unsafe { index_spec::IndexSpecReadGuard::from_locked((*self.spec.get()).as_ffi()) }
     }
 
-    /// Get a mutable reference to the index spec wrapper.
+    /// Creates a write lock guard for testing.
     ///
-    /// This method enables mutation of the [`index_spec::IndexSpec`] through the [`UnsafeCell`],
-    /// bypassing Rust's normal borrow checking. This is used in tests to simulate
-    /// concurrent modifications (e.g., garbage collection updating spec fields)
-    /// while iterators are alive.
+    /// Returns `ManuallyDrop<IndexSpecWriteGuard>` since tests don't use real locks
+    /// and don't need/want the drop behavior.
     ///
-    /// # Safety
+    /// This is for test-only use for simulating spec mutations (e.g., garbage
+    /// collection). Tests don't use real locks, so this creates a guard without
+    /// actually acquiring a lock. All safety requirements are upheld internally.
     ///
-    /// Caller must ensure:
-    /// 1. No other references (mutable or immutable) to the spec are active when
-    ///    calling this method
-    /// 2. The returned mutable reference does not alias with any other references
-    /// 3. Mutations do not violate iterator invariants in unexpected ways
-    ///
-    /// Violating these requirements leads to undefined behavior.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // Create iterator (borrows spec immutably through UnsafeCell)
-    /// let mut it = mock_ctx.create_iterator();
-    ///
-    /// // Mutate spec to test revalidation (bypasses borrow checker)
-    /// unsafe {
-    ///     mock_ctx.spec_mut().some_mut_method();
-    /// }
-    ///
-    /// // Iterator can still be used
-    /// it.revalidate(...);
-    /// ```
-    #[expect(clippy::mut_from_ref)]
-    pub unsafe fn spec_mut(&self) -> &mut index_spec::IndexSpec {
-        // SAFETY: Caller guarantees exclusive access.
-        unsafe { &mut **self.spec.get() }
+    /// **Note:** While this provides mutable access to the spec, it's the test's
+    /// responsibility to ensure this is used appropriately (e.g., not while other
+    /// references are actively being used).
+    pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
+        // SAFETY: The underlying spec exists and is valid. In test contexts,
+        // no lock is needed. Caller guarantees exclusive access.
+        unsafe {
+            index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut())
+        }
     }
 
     /// Get the query evaluation context from the [`MockContext`].

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -7,9 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::cell::UnsafeCell;
 use std::ptr::NonNull;
 
-use ffi::{IndexSpec, QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId};
+use ffi::{QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId};
 use numeric_range_tree::NumericRangeTree;
 
 /// Mock search context creating fake objects for testing.
@@ -23,7 +24,7 @@ use numeric_range_tree::NumericRangeTree;
 /// with the library's reference creation.
 pub struct MockContext {
     rule: *mut SchemaRule,
-    spec: *mut IndexSpec,
+    spec: UnsafeCell<&'static mut index_spec::IndexSpec>,
     sctx: *mut RedisSearchCtx,
     qctx: *mut QueryEvalCtx,
     numeric_range_tree: *mut NumericRangeTree,
@@ -41,7 +42,10 @@ impl Drop for MockContext {
                 self.rule as *mut u8,
                 std::alloc::Layout::new::<SchemaRule>(),
             );
-            std::alloc::dealloc(self.spec as *mut u8, std::alloc::Layout::new::<IndexSpec>());
+            std::alloc::dealloc(
+                (*self.spec.get()).as_mut_raw_ptr() as *mut u8,
+                std::alloc::Layout::new::<ffi::IndexSpec>(),
+            );
             std::alloc::dealloc(
                 self.sctx as *mut u8,
                 std::alloc::Layout::new::<RedisSearchCtx>(),
@@ -68,7 +72,7 @@ impl MockContext {
 
         // Create boxes and immediately convert to raw pointers
         let rule_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<SchemaRule>() }));
-        let spec_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<IndexSpec>() }));
+        let spec_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<ffi::IndexSpec>() }));
         let sctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<RedisSearchCtx>() }));
         let qctx_ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<QueryEvalCtx>() }));
         let numeric_range_tree_ptr = Box::into_raw(Box::new(NumericRangeTree::new(false)));
@@ -103,10 +107,14 @@ impl MockContext {
             (*qctx_ptr).sctx = sctx_ptr;
             (*qctx_ptr).docTable = std::ptr::addr_of_mut!((*spec_ptr).docs);
 
+            // Convert spec raw pointer to wrapper reference for better type safety
+            let spec: &'static mut index_spec::IndexSpec =
+                index_spec::IndexSpec::from_raw_mut(spec_ptr);
+
             // Store raw pointers directly (don't convert back to Box)
             Self {
                 rule: rule_ptr,
-                spec: spec_ptr,
+                spec: UnsafeCell::new(spec),
                 sctx: sctx_ptr,
                 qctx: qctx_ptr,
                 numeric_range_tree: numeric_range_tree_ptr,
@@ -124,43 +132,63 @@ impl MockContext {
         NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
     }
 
-    /// Get the index spec pointer from the [`MockContext`].
-    pub const fn spec(&self) -> NonNull<ffi::IndexSpec> {
-        NonNull::new(self.spec).expect("IndexSpec should not be null")
+    /// Get an immutable reference to the index spec wrapper.
+    ///
+    /// This method provides safe read-only access to the [`index_spec::IndexSpec`]
+    /// through the [`UnsafeCell`]. Multiple immutable references can coexist safely.
+    ///
+    /// # Interior Mutability
+    ///
+    /// The spec is stored in an [`UnsafeCell`] to enable interior mutability.
+    /// This allows tests to temporarily mutate the spec (e.g., to simulate
+    /// garbage collection) while iterators are active, which is necessary for
+    /// testing revalidation logic.
+    pub fn spec_ref(&self) -> &index_spec::IndexSpec {
+        // SAFETY: UnsafeCell allows interior mutability. We return an immutable
+        // reference, which is safe as long as no mutable reference is active.
+        unsafe { &**self.spec.get() }
+    }
+
+    /// Get a mutable reference to the index spec wrapper.
+    ///
+    /// This method enables mutation of the [`index_spec::IndexSpec`] through the [`UnsafeCell`],
+    /// bypassing Rust's normal borrow checking. This is used in tests to simulate
+    /// concurrent modifications (e.g., garbage collection updating spec fields)
+    /// while iterators are alive.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure:
+    /// 1. No other references (mutable or immutable) to the spec are active when
+    ///    calling this method
+    /// 2. The returned mutable reference does not alias with any other references
+    /// 3. Mutations do not violate iterator invariants in unexpected ways
+    ///
+    /// Violating these requirements leads to undefined behavior.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Create iterator (borrows spec immutably through UnsafeCell)
+    /// let mut it = mock_ctx.create_iterator();
+    ///
+    /// // Mutate spec to test revalidation (bypasses borrow checker)
+    /// unsafe {
+    ///     mock_ctx.spec_mut().some_mut_method();
+    /// }
+    ///
+    /// // Iterator can still be used
+    /// it.revalidate(...);
+    /// ```
+    #[expect(clippy::mut_from_ref)]
+    pub unsafe fn spec_mut(&self) -> &mut index_spec::IndexSpec {
+        // SAFETY: Caller guarantees exclusive access.
+        unsafe { &mut **self.spec.get() }
     }
 
     /// Get the query evaluation context from the [`MockContext`].
     pub const fn qctx(&self) -> NonNull<ffi::QueryEvalCtx> {
         NonNull::new(self.qctx).expect("QueryEvalCtx should not be null")
-    }
-
-    /// Set [`SchemaRule::index_all`]
-    ///
-    /// # Safety
-    ///
-    /// Must not be called while any iterator created from this context is
-    /// still alive, as it mutates the spec through a raw pointer.
-    pub unsafe fn set_index_all(&self, value: bool) {
-        // SAFETY: Caller guarantees no iterators from this context are alive,
-        // so the write does not race.
-        unsafe { (*self.rule).index_all = value };
-    }
-
-    /// Set [`IndexSpec::diskSpec`] to point to the given disk index spec.
-    ///
-    /// Pass `std::ptr::null_mut()` to clear the field (making the spec appear
-    /// to have no disk index).
-    ///
-    /// # Safety
-    ///
-    /// 1. Must not be called while any iterator created from this context is
-    ///    still alive, as it mutates the spec through a raw pointer.
-    /// 2. `disk_spec`, when non-null, must remain valid for as long as
-    ///    iterators created from this context are alive.
-    pub unsafe fn set_disk_spec(&self, disk_spec: *mut ffi::RedisSearchDiskIndexSpec) {
-        // SAFETY: Caller guarantees no iterators from this context are alive (1),
-        // so the write does not race.
-        unsafe { (*self.spec).diskSpec = disk_spec };
     }
 
     /// Get a zeroed [`TagIndex`](ffi::TagIndex) pointer for basic (non-revalidation) tests.

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -127,7 +127,7 @@ impl MockContext {
         NonNull::new(self.sctx).expect("RedisSearchCtx should not be null")
     }
 
-    /// Creates a read lock guard for testing.
+    /// Returns a read guard for the spec.
     ///
     /// Returns `ManuallyDrop<IndexSpecReadGuard>` since tests don't use real locks
     /// and don't need/want the drop behavior.
@@ -136,13 +136,13 @@ impl MockContext {
     /// a guard without actually acquiring a lock. All safety requirements are
     /// upheld internally - the spec is valid and accessible without a lock in
     /// test contexts.
-    pub fn spec_read_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
+    pub fn spec_read(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed for safe access.
         unsafe { index_spec::IndexSpecReadGuard::from_locked(&*self.spec) }
     }
 
-    /// Creates a write lock guard for testing.
+    /// Returns a write guard for the spec.
     ///
     /// Returns `ManuallyDrop<IndexSpecWriteGuard>` since tests don't use real locks
     /// and don't need/want the drop behavior.
@@ -154,7 +154,7 @@ impl MockContext {
     /// **Note:** While this provides mutable access to the spec, it's the test's
     /// responsibility to ensure this is used appropriately (e.g., not while other
     /// references are actively being used).
-    pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
+    pub fn spec_write(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed. Caller guarantees exclusive access.
         unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut(&mut *self.spec) }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -196,9 +196,7 @@ impl TestContext {
     pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed. Caller guarantees exclusive access.
-        unsafe {
-            index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut())
-        }
+        unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut()) }
     }
 
     /// Create a new [`TestContext`] with a numeric inverted index having the given records.
@@ -223,7 +221,7 @@ impl TestContext {
         let field_name = CString::new("num_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_raw_ptr(),
+                spec.as_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -287,7 +285,7 @@ impl TestContext {
         let field_name = CString::new("text_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_raw_ptr(),
+                spec.as_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -300,7 +298,7 @@ impl TestContext {
         let mut is_new = false;
         let inverted_index = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                spec.as_mut_raw_ptr(),
+                spec.as_mut_ptr(),
                 term.as_ptr(),
                 term.as_bytes().len(),
                 true, // write mode
@@ -398,7 +396,7 @@ impl TestContext {
         let field_name = std::ffi::CString::new("text_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_raw_ptr(),
+                spec.as_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -474,7 +472,7 @@ impl TestContext {
         let field_name = CString::new("tag_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_raw_ptr(),
+                spec.as_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -10,6 +10,7 @@
 //! Test context for creating search contexts with proper FFI setup.
 
 use std::{
+    cell::UnsafeCell,
     ffi::CString,
     ptr::{self, NonNull},
     sync::{
@@ -89,7 +90,7 @@ impl Drop for ModuleCtx {
 pub struct TestContext {
     _ctx: ModuleCtx,
     pub sctx: ptr::NonNull<ffi::RedisSearchCtx>,
-    pub spec: ptr::NonNull<ffi::IndexSpec>,
+    pub spec: UnsafeCell<&'static mut index_spec::IndexSpec>,
 
     inner: TestContextInner,
 }
@@ -123,7 +124,7 @@ fn create_spec_sctx(
     schema: &str,
     index_name: &str,
 ) -> (
-    ptr::NonNull<ffi::IndexSpec>,
+    &'static mut index_spec::IndexSpec,
     ptr::NonNull<ffi::RedisSearchCtx>,
 ) {
     let args = schema
@@ -158,10 +159,72 @@ fn create_spec_sctx(
     let sctx = unsafe { ffi::NewSearchCtxC(ctx.as_ptr(), index_name.as_ptr(), false) };
     let sctx = ptr::NonNull::new(sctx).expect("RedisSearchCtx should not be null");
 
-    (spec, sctx)
+    // Convert spec to wrapper reference for better type safety
+    let spec_ref = unsafe { index_spec::IndexSpec::from_raw_mut(spec.as_ptr()) };
+
+    (spec_ref, sctx)
 }
 
 impl TestContext {
+    /// Get an immutable reference to the index spec wrapper.
+    ///
+    /// This method provides safe read-only access to the [`index_spec::IndexSpec`]
+    /// through the [`UnsafeCell`]. Multiple immutable references can coexist safely.
+    ///
+    /// Most test code should use this method to access the spec when passing it
+    /// to iterator operations like `revalidate()`.
+    ///
+    /// # Interior Mutability
+    ///
+    /// The spec is stored in an [`UnsafeCell`] to enable interior mutability.
+    /// This allows tests to temporarily mutate the spec (e.g., to simulate
+    /// garbage collection) while iterators are active, which is necessary for
+    /// testing revalidation abort conditions.
+    pub fn spec_ref(&self) -> &index_spec::IndexSpec {
+        // SAFETY: UnsafeCell allows interior mutability. We return an immutable
+        // reference, which is safe as long as no mutable reference is active.
+        unsafe { &**self.spec.get() }
+    }
+
+    /// Get a mutable reference to the index spec wrapper.
+    ///
+    /// This method enables mutation of the [`index_spec::IndexSpec`] through the [`UnsafeCell`],
+    /// bypassing Rust's normal borrow checking. This is used in tests to simulate
+    /// concurrent modifications (e.g., garbage collection replacing `existingDocs`)
+    /// while iterators are alive, enabling tests to verify that revalidation
+    /// correctly detects and aborts when the index state changes.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure:
+    /// 1. No other references (mutable or immutable) to the spec are active when
+    ///    calling this method
+    /// 2. The returned mutable reference does not alias with any other references
+    /// 3. Mutations are only used to test revalidation behavior, not to corrupt
+    ///    the spec state in ways that would cause undefined behavior
+    ///
+    /// Violating these requirements leads to undefined behavior.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Create iterator (borrows spec immutably through UnsafeCell)
+    /// let mut it = test.create_iterator();
+    ///
+    /// // Mutate spec to simulate garbage collection
+    /// unsafe {
+    ///     test.context.spec_mut().set_existing_docs(new_ptr);
+    /// }
+    ///
+    /// // Revalidation should detect the change and abort
+    /// assert_eq!(it.revalidate(...), RQEValidateStatus::Aborted);
+    /// ```
+    #[expect(clippy::mut_from_ref)]
+    pub unsafe fn spec_mut(&self) -> &mut index_spec::IndexSpec {
+        // SAFETY: Caller guarantees exclusive access.
+        unsafe { &mut **self.spec.get() }
+    }
+
     /// Create a new [`TestContext`] with a numeric inverted index having the given records.
     ///
     /// # Arguments
@@ -177,14 +240,14 @@ impl TestContext {
         let ctx = ModuleCtx::new();
         // Create IndexSpec for NUMERIC field with unique name to avoid parallel test conflicts
         let index_name = unique_index_name("numeric_idx");
-        let (mut spec, sctx) = create_spec_sctx(&ctx, "SCHEMA num_field NUMERIC", &index_name);
+        let (spec, sctx) = create_spec_sctx(&ctx, "SCHEMA num_field NUMERIC", &index_name);
 
         // We need to properly set up the numeric range tree
         // so that NumericCheckAbort can find it and check revision IDs
         let field_name = CString::new("num_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec.as_raw_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -193,7 +256,7 @@ impl TestContext {
 
         // Create the numeric range tree through the proper API
         let numeric_range_tree = unsafe {
-            rqe_iterators::open_numeric_or_geo_index(spec.as_mut(), fs.as_mut(), true, true)
+            rqe_iterators::open_numeric_or_geo_index(spec.as_ffi_mut(), fs.as_mut(), true, true)
         }
         .expect("NumericRangeTree should not be None");
 
@@ -210,7 +273,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec,
+            spec: UnsafeCell::new(spec),
             inner: TestContextInner::Numeric {
                 field_spec: fs,
                 numeric_range_tree: NonNull::from_mut(numeric_range_tree),
@@ -248,7 +311,7 @@ impl TestContext {
         let field_name = CString::new("text_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec.as_raw_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -261,7 +324,7 @@ impl TestContext {
         let mut is_new = false;
         let inverted_index = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                spec.as_ptr(),
+                spec.as_mut_raw_ptr(),
                 term.as_ptr(),
                 term.as_bytes().len(),
                 true, // write mode
@@ -282,7 +345,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec,
+            spec: UnsafeCell::new(spec),
             inner: TestContextInner::Term {
                 field_spec,
                 inverted_index,
@@ -304,7 +367,7 @@ impl TestContext {
         let ctx = ModuleCtx::new();
         // Create IndexSpec with unique name to avoid parallel test conflicts
         let index_name = unique_index_name("wildcard_idx");
-        let (mut spec, sctx) = create_spec_sctx(&ctx, "SCHEMA text_field TEXT", &index_name);
+        let (spec, sctx) = create_spec_sctx(&ctx, "SCHEMA text_field TEXT", &index_name);
 
         let mut memsize = 0;
         let ii_ptr = inverted_index_ffi::NewInvertedIndex_Ex(
@@ -329,14 +392,12 @@ impl TestContext {
 
         // Set spec.existingDocs so Wildcard::should_abort() can find the index
         // during revalidation (it compares spec.existingDocs with the reader's index).
-        unsafe {
-            spec.as_mut().existingDocs = ii_ptr.cast();
-        }
+        spec.set_existing_docs(ii_ptr.cast());
 
         Self {
             _ctx: ctx,
             sctx,
-            spec,
+            spec: UnsafeCell::new(spec),
             inner: TestContextInner::Wildcard { inverted_index: ii },
         }
     }
@@ -361,7 +422,7 @@ impl TestContext {
         let field_name = std::ffi::CString::new("text_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec.as_raw_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -396,7 +457,7 @@ impl TestContext {
         unsafe {
             let field_name_key = (*field_spec.as_ptr()).fieldName;
             let rc = ffi::RS_dictAdd(
-                (*spec.as_ptr()).missingFieldDict,
+                spec.missing_field_dict(),
                 field_name_key as *mut _,
                 ii_ptr as *mut _,
             );
@@ -406,7 +467,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec,
+            spec: UnsafeCell::new(spec),
             inner: TestContextInner::Missing {
                 field_spec,
                 inverted_index: ii,
@@ -437,7 +498,7 @@ impl TestContext {
         let field_name = CString::new("tag_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec.as_raw_ptr(),
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -484,7 +545,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec,
+            spec: UnsafeCell::new(spec),
             inner: TestContextInner::Tag {
                 field_spec,
                 tag_index,
@@ -709,30 +770,20 @@ impl TestContext {
         tree.node_mut(index).range_mut().unwrap().entries_mut()
     }
 
-    /// Set [`SchemaRule::index_all`](ffi::SchemaRule::index_all).
-    ///
-    /// # Safety
-    ///
-    /// Must not be called while any iterator created from this context is
-    /// still alive, as it mutates the spec's rule through a raw pointer.
-    pub unsafe fn set_index_all(&self, value: bool) {
-        // SAFETY: Caller guarantees no iterators from this context are alive,
-        // so the write does not race. The spec and rule pointers are valid
-        // because they were created during TestContext construction.
-        unsafe {
-            (*(*self.spec.as_ptr()).rule).index_all = value;
-        }
-    }
-
     /// Initialize the TTL table if not already initialized.
     fn verify_ttl_init(&mut self) {
         // SAFETY: self.spec is a valid pointer created via IndexSpec_ParseC.
+        // We own the TestContext and ensure exclusive access.
+        let spec = unsafe { self.spec_mut() };
+
+        spec.set_monitor_document_expiration(true);
+        spec.set_monitor_field_expiration(true);
+
+        let mut doc_table = spec.doc_table();
+
+        // SAFETY: doc_table is a valid pointer to the spec's document table, and maxSize is properly initialized.
         unsafe {
-            let spec = self.spec.as_mut();
-            // Enable expiration monitoring (required for expiration checks to work)
-            spec.monitorDocumentExpiration = true;
-            spec.monitorFieldExpiration = true;
-            ffi::TimeToLiveTable_VerifyInit(&mut spec.docs.ttl, spec.docs.maxSize as usize);
+            ffi::TimeToLiveTable_VerifyInit(&mut doc_table.ttl, doc_table.maxSize as usize);
         }
     }
 
@@ -790,7 +841,7 @@ impl TestContext {
 
         // SAFETY: self.spec is valid, TTL table is initialized, fe is a valid array
         unsafe {
-            ffi::TimeToLiveTable_Add(self.spec.as_ref().docs.ttl, doc_id, fe as _);
+            ffi::TimeToLiveTable_Add(self.spec_ref().doc_table().ttl, doc_id, fe as _);
         }
     }
 
@@ -840,7 +891,7 @@ impl Drop for TestContext {
 
         // Remove spec from globals (this may free associated indices)
         unsafe {
-            ffi::IndexSpec_RemoveFromGlobals(self.spec.as_ref().own_ref, false);
+            ffi::IndexSpec_RemoveFromGlobals(self.spec_ref().own_ref(), false);
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -159,7 +159,7 @@ fn create_spec_sctx(
 }
 
 impl TestContext {
-    /// Creates a read lock guard for testing.
+    /// Returns a read guard for the spec.
     ///
     /// Returns `ManuallyDrop<IndexSpecReadGuard>` since tests don't use real locks
     /// and don't need/want the drop behavior.
@@ -168,13 +168,13 @@ impl TestContext {
     /// a guard without actually acquiring a lock. All safety requirements are
     /// upheld internally - the spec is valid and accessible without a lock in
     /// test contexts.
-    pub fn spec_read_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
+    pub fn spec_read(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed for safe access.
         unsafe { index_spec::IndexSpecReadGuard::from_locked(&*self.spec) }
     }
 
-    /// Creates a write lock guard for testing.
+    /// Returns a write guard for the spec.
     ///
     /// Returns `ManuallyDrop<IndexSpecWriteGuard>` since tests don't use real locks
     /// and don't need/want the drop behavior.
@@ -186,7 +186,7 @@ impl TestContext {
     /// **Note:** While this provides mutable access to the spec, it's the test's
     /// responsibility to ensure this is used appropriately (e.g., not while other
     /// references are actively being used).
-    pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
+    pub fn spec_write(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed. Caller guarantees exclusive access.
         unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut(&mut *self.spec) }
@@ -741,7 +741,7 @@ impl TestContext {
 
     /// Initialize the TTL table if not already initialized.
     fn verify_ttl_init(&mut self) {
-        let mut guard = self.spec_write_guard();
+        let mut guard = self.spec_write();
         guard.set_monitor_document_expiration(true);
         guard.set_monitor_field_expiration(true);
 
@@ -806,7 +806,7 @@ impl TestContext {
         };
 
         // SAFETY: self.spec is valid, TTL table is initialized, fe is a valid array
-        let guard = self.spec_read_guard();
+        let guard = self.spec_read();
         unsafe {
             ffi::TimeToLiveTable_Add(guard.doc_table().ttl, doc_id, fe as _);
         }
@@ -857,7 +857,7 @@ impl Drop for TestContext {
         }
 
         // Remove spec from globals (this may free associated indices)
-        let guard = self.spec_read_guard();
+        let guard = self.spec_read();
         unsafe {
             ffi::IndexSpec_RemoveFromGlobals(guard.own_ref(), false);
         }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -166,63 +166,39 @@ fn create_spec_sctx(
 }
 
 impl TestContext {
-    /// Get an immutable reference to the index spec wrapper.
+    /// Creates a read lock guard for testing.
     ///
-    /// This method provides safe read-only access to the [`index_spec::IndexSpec`]
-    /// through the [`UnsafeCell`]. Multiple immutable references can coexist safely.
+    /// Returns `ManuallyDrop<IndexSpecReadGuard>` since tests don't use real locks
+    /// and don't need/want the drop behavior.
     ///
-    /// Most test code should use this method to access the spec when passing it
-    /// to iterator operations like `revalidate()`.
-    ///
-    /// # Interior Mutability
-    ///
-    /// The spec is stored in an [`UnsafeCell`] to enable interior mutability.
-    /// This allows tests to temporarily mutate the spec (e.g., to simulate
-    /// garbage collection) while iterators are active, which is necessary for
-    /// testing revalidation abort conditions.
-    pub fn spec_ref(&self) -> &index_spec::IndexSpec {
-        // SAFETY: UnsafeCell allows interior mutability. We return an immutable
-        // reference, which is safe as long as no mutable reference is active.
-        unsafe { &**self.spec.get() }
+    /// This is for test-only use. Tests don't use real locks, so this creates
+    /// a guard without actually acquiring a lock. All safety requirements are
+    /// upheld internally - the spec is valid and accessible without a lock in
+    /// test contexts.
+    pub fn spec_read_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
+        // SAFETY: The underlying spec exists and is valid. In test contexts,
+        // no lock is needed for safe access.
+        unsafe { index_spec::IndexSpecReadGuard::from_locked((*self.spec.get()).as_ffi()) }
     }
 
-    /// Get a mutable reference to the index spec wrapper.
+    /// Creates a write lock guard for testing.
     ///
-    /// This method enables mutation of the [`index_spec::IndexSpec`] through the [`UnsafeCell`],
-    /// bypassing Rust's normal borrow checking. This is used in tests to simulate
-    /// concurrent modifications (e.g., garbage collection replacing `existingDocs`)
-    /// while iterators are alive, enabling tests to verify that revalidation
-    /// correctly detects and aborts when the index state changes.
+    /// Returns `ManuallyDrop<IndexSpecWriteGuard>` since tests don't use real locks
+    /// and don't need/want the drop behavior.
     ///
-    /// # Safety
+    /// This is for test-only use for simulating spec mutations (e.g., garbage
+    /// collection). Tests don't use real locks, so this creates a guard without
+    /// actually acquiring a lock. All safety requirements are upheld internally.
     ///
-    /// Caller must ensure:
-    /// 1. No other references (mutable or immutable) to the spec are active when
-    ///    calling this method
-    /// 2. The returned mutable reference does not alias with any other references
-    /// 3. Mutations are only used to test revalidation behavior, not to corrupt
-    ///    the spec state in ways that would cause undefined behavior
-    ///
-    /// Violating these requirements leads to undefined behavior.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // Create iterator (borrows spec immutably through UnsafeCell)
-    /// let mut it = test.create_iterator();
-    ///
-    /// // Mutate spec to simulate garbage collection
-    /// unsafe {
-    ///     test.context.spec_mut().set_existing_docs(new_ptr);
-    /// }
-    ///
-    /// // Revalidation should detect the change and abort
-    /// assert_eq!(it.revalidate(...), RQEValidateStatus::Aborted);
-    /// ```
-    #[expect(clippy::mut_from_ref)]
-    pub unsafe fn spec_mut(&self) -> &mut index_spec::IndexSpec {
-        // SAFETY: Caller guarantees exclusive access.
-        unsafe { &mut **self.spec.get() }
+    /// **Note:** While this provides mutable access to the spec, it's the test's
+    /// responsibility to ensure this is used appropriately (e.g., not while other
+    /// references are actively being used).
+    pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
+        // SAFETY: The underlying spec exists and is valid. In test contexts,
+        // no lock is needed. Caller guarantees exclusive access.
+        unsafe {
+            index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut())
+        }
     }
 
     /// Create a new [`TestContext`] with a numeric inverted index having the given records.
@@ -392,7 +368,7 @@ impl TestContext {
 
         // Set spec.existingDocs so Wildcard::should_abort() can find the index
         // during revalidation (it compares spec.existingDocs with the reader's index).
-        spec.set_existing_docs(ii_ptr.cast());
+        spec.as_ffi_mut().existingDocs = ii_ptr.cast();
 
         Self {
             _ctx: ctx,
@@ -457,7 +433,7 @@ impl TestContext {
         unsafe {
             let field_name_key = (*field_spec.as_ptr()).fieldName;
             let rc = ffi::RS_dictAdd(
-                spec.missing_field_dict(),
+                spec.as_ffi().missingFieldDict,
                 field_name_key as *mut _,
                 ii_ptr as *mut _,
             );
@@ -772,14 +748,11 @@ impl TestContext {
 
     /// Initialize the TTL table if not already initialized.
     fn verify_ttl_init(&mut self) {
-        // SAFETY: self.spec is a valid pointer created via IndexSpec_ParseC.
-        // We own the TestContext and ensure exclusive access.
-        let spec = unsafe { self.spec_mut() };
+        let mut guard = self.spec_write_guard();
+        guard.set_monitor_document_expiration(true);
+        guard.set_monitor_field_expiration(true);
 
-        spec.set_monitor_document_expiration(true);
-        spec.set_monitor_field_expiration(true);
-
-        let mut doc_table = spec.doc_table();
+        let mut doc_table = guard.doc_table();
 
         // SAFETY: doc_table is a valid pointer to the spec's document table, and maxSize is properly initialized.
         unsafe {
@@ -840,8 +813,9 @@ impl TestContext {
         };
 
         // SAFETY: self.spec is valid, TTL table is initialized, fe is a valid array
+        let guard = self.spec_read_guard();
         unsafe {
-            ffi::TimeToLiveTable_Add(self.spec_ref().doc_table().ttl, doc_id, fe as _);
+            ffi::TimeToLiveTable_Add(guard.doc_table().ttl, doc_id, fe as _);
         }
     }
 
@@ -890,8 +864,9 @@ impl Drop for TestContext {
         }
 
         // Remove spec from globals (this may free associated indices)
+        let guard = self.spec_read_guard();
         unsafe {
-            ffi::IndexSpec_RemoveFromGlobals(self.spec_ref().own_ref(), false);
+            ffi::IndexSpec_RemoveFromGlobals(guard.own_ref(), false);
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -122,10 +122,7 @@ fn create_spec_sctx(
     ctx: &ModuleCtx,
     schema: &str,
     index_name: &str,
-) -> (
-    *mut ffi::IndexSpec,
-    ptr::NonNull<ffi::RedisSearchCtx>,
-) {
+) -> (*mut ffi::IndexSpec, ptr::NonNull<ffi::RedisSearchCtx>) {
     let args = schema
         .split(" ")
         .map(|s| CString::new(s).expect("Failed to create CString"))

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -10,7 +10,6 @@
 //! Test context for creating search contexts with proper FFI setup.
 
 use std::{
-    cell::UnsafeCell,
     ffi::CString,
     ptr::{self, NonNull},
     sync::{
@@ -90,7 +89,7 @@ impl Drop for ModuleCtx {
 pub struct TestContext {
     _ctx: ModuleCtx,
     pub sctx: ptr::NonNull<ffi::RedisSearchCtx>,
-    pub spec: UnsafeCell<&'static mut index_spec::IndexSpec>,
+    pub spec: *mut ffi::IndexSpec,
 
     inner: TestContextInner,
 }
@@ -124,7 +123,7 @@ fn create_spec_sctx(
     schema: &str,
     index_name: &str,
 ) -> (
-    &'static mut index_spec::IndexSpec,
+    *mut ffi::IndexSpec,
     ptr::NonNull<ffi::RedisSearchCtx>,
 ) {
     let args = schema
@@ -159,10 +158,7 @@ fn create_spec_sctx(
     let sctx = unsafe { ffi::NewSearchCtxC(ctx.as_ptr(), index_name.as_ptr(), false) };
     let sctx = ptr::NonNull::new(sctx).expect("RedisSearchCtx should not be null");
 
-    // Convert spec to wrapper reference for better type safety
-    let spec_ref = unsafe { index_spec::IndexSpec::from_raw_mut(spec.as_ptr()) };
-
-    (spec_ref, sctx)
+    (spec.as_ptr(), sctx)
 }
 
 impl TestContext {
@@ -178,7 +174,7 @@ impl TestContext {
     pub fn spec_read_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecReadGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed for safe access.
-        unsafe { index_spec::IndexSpecReadGuard::from_locked((*self.spec.get()).as_ffi()) }
+        unsafe { index_spec::IndexSpecReadGuard::from_locked(&*self.spec) }
     }
 
     /// Creates a write lock guard for testing.
@@ -196,7 +192,7 @@ impl TestContext {
     pub fn spec_write_guard(&self) -> std::mem::ManuallyDrop<index_spec::IndexSpecWriteGuard<'_>> {
         // SAFETY: The underlying spec exists and is valid. In test contexts,
         // no lock is needed. Caller guarantees exclusive access.
-        unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut((*self.spec.get()).as_ffi_mut()) }
+        unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut(&mut *self.spec) }
     }
 
     /// Create a new [`TestContext`] with a numeric inverted index having the given records.
@@ -221,7 +217,7 @@ impl TestContext {
         let field_name = CString::new("num_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec,
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -230,7 +226,7 @@ impl TestContext {
 
         // Create the numeric range tree through the proper API
         let numeric_range_tree = unsafe {
-            rqe_iterators::open_numeric_or_geo_index(spec.as_ffi_mut(), fs.as_mut(), true, true)
+            rqe_iterators::open_numeric_or_geo_index(&mut *spec, fs.as_mut(), true, true)
         }
         .expect("NumericRangeTree should not be None");
 
@@ -247,7 +243,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec: UnsafeCell::new(spec),
+            spec,
             inner: TestContextInner::Numeric {
                 field_spec: fs,
                 numeric_range_tree: NonNull::from_mut(numeric_range_tree),
@@ -285,7 +281,7 @@ impl TestContext {
         let field_name = CString::new("text_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec,
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -298,7 +294,7 @@ impl TestContext {
         let mut is_new = false;
         let inverted_index = unsafe {
             ffi::Redis_OpenInvertedIndex(
-                spec.as_mut_ptr(),
+                spec,
                 term.as_ptr(),
                 term.as_bytes().len(),
                 true, // write mode
@@ -319,7 +315,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec: UnsafeCell::new(spec),
+            spec,
             inner: TestContextInner::Term {
                 field_spec,
                 inverted_index,
@@ -366,12 +362,14 @@ impl TestContext {
 
         // Set spec.existingDocs so Wildcard::should_abort() can find the index
         // during revalidation (it compares spec.existingDocs with the reader's index).
-        spec.as_ffi_mut().existingDocs = ii_ptr.cast();
+        unsafe {
+            (&mut *spec).existingDocs = ii_ptr.cast();
+        }
 
         Self {
             _ctx: ctx,
             sctx,
-            spec: UnsafeCell::new(spec),
+            spec,
             inner: TestContextInner::Wildcard { inverted_index: ii },
         }
     }
@@ -396,7 +394,7 @@ impl TestContext {
         let field_name = std::ffi::CString::new("text_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec,
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -431,7 +429,7 @@ impl TestContext {
         unsafe {
             let field_name_key = (*field_spec.as_ptr()).fieldName;
             let rc = ffi::RS_dictAdd(
-                spec.as_ffi().missingFieldDict,
+                (&*spec).missingFieldDict,
                 field_name_key as *mut _,
                 ii_ptr as *mut _,
             );
@@ -441,7 +439,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec: UnsafeCell::new(spec),
+            spec,
             inner: TestContextInner::Missing {
                 field_spec,
                 inverted_index: ii,
@@ -472,7 +470,7 @@ impl TestContext {
         let field_name = CString::new("tag_field").unwrap();
         let fs = unsafe {
             ffi::IndexSpec_GetFieldWithLength(
-                spec.as_ptr(),
+                spec,
                 field_name.as_ptr(),
                 field_name.as_bytes().len(),
             )
@@ -519,7 +517,7 @@ impl TestContext {
         Self {
             _ctx: ctx,
             sctx,
-            spec: UnsafeCell::new(spec),
+            spec,
             inner: TestContextInner::Tag {
                 field_spec,
                 tag_index,


### PR DESCRIPTION
## Describe the changes in the pull request
Makes the revalidate() trait method safe by taking &mut IndexSpec instead of NonNull<ffi::IndexSpec>, reflecting what implementations actually need.

Changes:
- Updated trait signature in rqe_iterators/src/lib.rs to take &mut IndexSpec
- Updated all 24+ iterator implementations to use &mut parameter
- Changed FFI interop layer to use from_raw_mut() instead of from_raw()
- Updated FFI wrapper iterators in c_entrypoint/iterators_ffi/
- Simplified test code to call spec_mut() directly instead of complex pointer conversions (from_raw_mut(ctx.as_ptr() as *mut _))
- Removed unnecessary intermediate variables in test code

Benefits:
- More honest about mutability requirements
- Eliminates unnecessary pointer casts in implementations
- Cleaner, more readable test code
- All 56 unnecessary unsafe blocks automatically removed

All 1733 tests pass.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iterator revalidation across Rust/C FFI boundaries and changes how `IndexSpec` locking/lifetimes are represented, so mistakes could cause subtle correctness issues or UB despite being a refactor.
> 
> **Overview**
> **Makes `RQEIterator::revalidate` safe and lock-aware.** The `revalidate` trait method is changed from `unsafe` raw `IndexSpec` pointer input to `fn revalidate(&IndexSpecReadGuard)`, and all iterator implementations (including `iterators_ffi`) are updated to match.
> 
> **Introduces explicit IndexSpec read/write guard types for FFI and tests.** `index_spec` adds `IndexSpecWriteGuard` (renamed from the old lock guard, plus mutating helpers) and a new `IndexSpecReadGuard` intended for FFI boundaries (constructed as `ManuallyDrop`), and the C interop `revalidate` callback now wraps the incoming `*mut IndexSpec` in this guard.
> 
> **Updates tests/benchers to the new API.** Integration tests and benchmarks stop calling `revalidate` via `unsafe` pointer conversions and instead use `spec_read()`/`spec_write()` helpers and guard methods (e.g., setting `existingDocs`, `diskSpec`, `index_all`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5c44f388177cc10fa23af2e2c6e2ac26c5a0ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->