### PR TITLE
MOD-14913: Use GetNumRecords Disk API

### DIFF
--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -260,7 +260,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   REPLY_KVINT("num_terms", sp->stats.scoring.numTerms);
 
   const bool isDisk = sp->diskSpec != NULL;
-  size_t num_records = isDisk ? 0 : sp->stats.numRecords;
+  size_t num_records = isDisk ? SearchDisk_GetNumRecords(sp->diskSpec) : sp->stats.numRecords;
   // Vector indexes (e.g. HNSW) remain in memory even when the rest of the
   // index is stored on disk, so their memory must always be reported.
   size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
@@ -293,8 +293,6 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   REPLY_KVNUM("geoshapes_sz_mb", geoshapes_size / (float)0x100000);
   REPLY_KVNUM("records_per_doc_avg",
               (float)num_records / (float)sp->stats.scoring.numDocuments);
-  // Disk metrics expose inverted size but not posting record count yet; keep NaN
-  // when denominator is unavailable to avoid returning +/-inf.
   double bytes_per_record_avg = num_records ?
     (float)inverted_size / (float)num_records : NAN;
   REPLY_KVNUM("bytes_per_record_avg",

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -303,8 +303,9 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   double offsets_per_term_avg = (isDisk || !num_records) ? NAN :
     (float)offset_vec_records / (float)num_records;
   REPLY_KVNUM("offsets_per_term_avg", offsets_per_term_avg);
-  REPLY_KVNUM("offset_bits_per_record_avg",
-              (float)CHAR_BIT * (float)offset_vecs_size / (float)offset_vec_records);
+  double offset_bits_per_record_avg = (isDisk || !offset_vec_records) ? NAN :
+    (float)CHAR_BIT * (float)offset_vecs_size / (float)offset_vec_records;
+  REPLY_KVNUM("offset_bits_per_record_avg", offset_bits_per_record_avg);
   // TODO: remove this once "hash_indexing_failures" is deprecated
   // Legacy for not breaking changes
   REPLY_KVINT("hash_indexing_failures", sp->stats.indexError.error_count);

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include <math.h>
+#include <limits.h>
 
 #include "spec.h"
 #include "inverted_index.h"
@@ -303,7 +304,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
     (float)offset_vec_records / (float)num_records;
   REPLY_KVNUM("offsets_per_term_avg", offsets_per_term_avg);
   REPLY_KVNUM("offset_bits_per_record_avg",
-              8.0F * (float)offset_vecs_size / (float)offset_vec_records);
+              (float)CHAR_BIT * (float)offset_vecs_size / (float)offset_vec_records);
   // TODO: remove this once "hash_indexing_failures" is deprecated
   // Legacy for not breaking changes
   REPLY_KVINT("hash_indexing_failures", sp->stats.indexError.error_count);

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -297,8 +297,11 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
     (float)inverted_size / (float)num_records : NAN;
   REPLY_KVNUM("bytes_per_record_avg",
               bytes_per_record_avg);
-  REPLY_KVNUM("offsets_per_term_avg",
-              (float)offset_vec_records / (float)num_records);
+  // Disk indexes don't track offset record counts; report NaN rather than 0
+  // (which would falsely imply the metric is meaningful).
+  double offsets_per_term_avg = (isDisk || !num_records) ? NAN :
+    (float)offset_vec_records / (float)num_records;
+  REPLY_KVNUM("offsets_per_term_avg", offsets_per_term_avg);
   REPLY_KVNUM("offset_bits_per_record_avg",
               8.0F * (float)offset_vecs_size / (float)offset_vec_records);
   // TODO: remove this once "hash_indexing_failures" is deprecated

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -408,8 +408,8 @@ uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
 }
 
 uint64_t SearchDisk_GetNumRecords(RedisSearchDiskIndexSpec* index) {
-  RS_ASSERT(disk && disk_db && index);
-  return disk->metrics.getNumRecords(disk_db, index);
+  RS_ASSERT(disk && index);
+  return disk->metrics.getNumRecords(index);
 }
 
 void SearchDisk_OutputInfoMetrics(RedisModuleInfoCtx* ctx) {

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -553,11 +553,10 @@ typedef struct MetricsDiskAPI {
    *
    * Returns the disk-side num_records counter used by FT.INFO.
    *
-   * @param disk Pointer to the disk context
    * @param index Pointer to the index spec
    * @return Number of records in the index
    */
-  uint64_t (*getNumRecords)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
+  uint64_t (*getNumRecords)(RedisSearchDiskIndexSpec *index);
 
   /**
    * @brief Output aggregated disk metrics to Redis INFO

--- a/src/spec.c
+++ b/src/spec.c
@@ -3139,20 +3139,27 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
   // More properties
   RedisModule_InfoAddFieldLongLong(ctx, "number_of_docs", sp->stats.scoring.numDocuments);
 
+  const bool isDisk = sp->diskSpec != NULL;
+  size_t num_records = isDisk ? SearchDisk_GetNumRecords(sp->diskSpec) : sp->stats.numRecords;
+  size_t inverted_size = isDisk ? SearchDisk_GetInvertedIndexTotalMemory(sp->diskSpec) :
+    sp->stats.invertedSize;
+  size_t doc_table_size = isDisk ? SearchDisk_GetDocTableTotalMemory(sp->diskSpec) :
+    sp->docs.memsize;
+
   RedisModule_InfoBeginDictField(ctx, "index_properties");
   RedisModule_InfoAddFieldULongLong(ctx, "max_doc_id", sp->docs.maxDocId);
   RedisModule_InfoAddFieldLongLong(ctx, "num_terms", sp->stats.scoring.numTerms);
-  RedisModule_InfoAddFieldLongLong(ctx, "num_records", sp->stats.numRecords);
+  RedisModule_InfoAddFieldLongLong(ctx, "num_records", num_records);
   RedisModule_InfoEndDictField(ctx);
 
   RedisModule_InfoBeginDictField(ctx, "index_properties_in_mb");
-  RedisModule_InfoAddFieldDouble(ctx, "inverted_size", sp->stats.invertedSize / (float)0x100000);
+  RedisModule_InfoAddFieldDouble(ctx, "inverted_size", inverted_size / (float)0x100000);
   if (!skip_unsafe_ops) {
     // Skip when unsafe - calls dictFetchValue which can trigger dict rehashing with rm_free
     RedisModule_InfoAddFieldDouble(ctx, "vector_index_size", IndexSpec_VectorIndexesSize(sp) / (float)0x100000);
   }
   RedisModule_InfoAddFieldDouble(ctx, "offset_vectors_size", sp->stats.offsetVecsSize / (float)0x100000);
-  RedisModule_InfoAddFieldDouble(ctx, "doc_table_size", sp->docs.memsize / (float)0x100000);
+  RedisModule_InfoAddFieldDouble(ctx, "doc_table_size", doc_table_size / (float)0x100000);
   RedisModule_InfoAddFieldDouble(ctx, "sortable_values_size", sp->docs.sortablesSize / (float)0x100000);
   RedisModule_InfoAddFieldDouble(ctx, "key_table_size", TrieMap_MemUsage(sp->docs.dim.tm) / (float)0x100000);
   if (!skip_unsafe_ops) {
@@ -3167,9 +3174,11 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
   RedisModule_InfoAddFieldULongLong(ctx, "total_inverted_index_blocks", TotalIIBlocks());
 
   RedisModule_InfoBeginDictField(ctx, "index_properties_averages");
-  RedisModule_InfoAddFieldDouble(ctx, "records_per_doc_avg",(float)sp->stats.numRecords / (float)sp->stats.scoring.numDocuments);
-  RedisModule_InfoAddFieldDouble(ctx, "bytes_per_record_avg",(float)sp->stats.invertedSize / (float)sp->stats.numRecords);
-  RedisModule_InfoAddFieldDouble(ctx, "offsets_per_term_avg",(float)sp->stats.offsetVecRecords / (float)sp->stats.numRecords);
+  RedisModule_InfoAddFieldDouble(ctx, "records_per_doc_avg",(float)num_records / (float)sp->stats.scoring.numDocuments);
+  double bytes_per_record_avg = num_records ?
+    (float)inverted_size / (float)num_records : NAN;
+  RedisModule_InfoAddFieldDouble(ctx, "bytes_per_record_avg", bytes_per_record_avg);
+  RedisModule_InfoAddFieldDouble(ctx, "offsets_per_term_avg",(float)sp->stats.offsetVecRecords / (float)num_records);
   RedisModule_InfoAddFieldDouble(ctx, "offset_bits_per_record_avg",8.0F * (float)sp->stats.offsetVecsSize / (float)sp->stats.offsetVecRecords);
   RedisModule_InfoEndDictField(ctx);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -11,6 +11,7 @@
 
 #include <math.h>
 #include <ctype.h>
+#include <limits.h>
 
 #include "triemap.h"
 #include "util/logging.h"
@@ -3185,7 +3186,7 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
   double offsets_per_term_avg = (isDisk || !num_records) ? NAN :
     (float)offset_vec_records / (float)num_records;
   double offset_bits_per_record_avg = (isDisk || !offset_vec_records) ? NAN :
-    8.0F * (float)offset_vecs_size / (float)offset_vec_records;
+    (float)CHAR_BIT * (float)offset_vecs_size / (float)offset_vec_records;
   RedisModule_InfoAddFieldDouble(ctx, "offsets_per_term_avg", offsets_per_term_avg);
   RedisModule_InfoAddFieldDouble(ctx, "offset_bits_per_record_avg", offset_bits_per_record_avg);
   RedisModule_InfoEndDictField(ctx);

--- a/src/spec.c
+++ b/src/spec.c
@@ -3178,8 +3178,16 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
   double bytes_per_record_avg = num_records ?
     (float)inverted_size / (float)num_records : NAN;
   RedisModule_InfoAddFieldDouble(ctx, "bytes_per_record_avg", bytes_per_record_avg);
-  RedisModule_InfoAddFieldDouble(ctx, "offsets_per_term_avg",(float)sp->stats.offsetVecRecords / (float)num_records);
-  RedisModule_InfoAddFieldDouble(ctx, "offset_bits_per_record_avg",8.0F * (float)sp->stats.offsetVecsSize / (float)sp->stats.offsetVecRecords);
+  // Disk indexes don't track offset record counts/sizes; report NaN so the
+  // metrics aren't misread as meaningful zeros.
+  size_t offset_vec_records = isDisk ? 0 : sp->stats.offsetVecRecords;
+  size_t offset_vecs_size = isDisk ? 0 : sp->stats.offsetVecsSize;
+  double offsets_per_term_avg = (isDisk || !num_records) ? NAN :
+    (float)offset_vec_records / (float)num_records;
+  double offset_bits_per_record_avg = (isDisk || !offset_vec_records) ? NAN :
+    8.0F * (float)offset_vecs_size / (float)offset_vec_records;
+  RedisModule_InfoAddFieldDouble(ctx, "offsets_per_term_avg", offsets_per_term_avg);
+  RedisModule_InfoAddFieldDouble(ctx, "offset_bits_per_record_avg", offset_bits_per_record_avg);
   RedisModule_InfoEndDictField(ctx);
 
   RedisModule_InfoBeginDictField(ctx, "index_failures");


### PR DESCRIPTION
Use the GetNumRecords disk API to obtain num_records metric.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FT.INFO/INFO index metrics calculations for disk-backed indexes and alters the disk metrics API signature, which could affect enterprise/disk backend integrations and reported stats.
> 
> **Overview**
> Improves `FT.INFO` and Redis `INFO` index stats for disk-backed indexes by sourcing `num_records` (and related sizes) from the disk metrics API instead of defaulting to `0`, making record/memory averages reflect actual disk data.
> 
> Updates average metrics to avoid invalid divisions: disk indexes now report `NaN` for offset-related averages that aren’t tracked, and bit/byte calculations use `CHAR_BIT` (via `<limits.h>`). Also changes the disk API callback signature for `getNumRecords` and updates the wrapper to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0e25f618ec95c725b95bafa53db5d5fa6b5031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->