### PR TITLE
MOD-14368: Bump ramp-packer to 2.5.17 for speedb_git_sha support

### DIFF
--- a/.install/build_package_requirements.txt
+++ b/.install/build_package_requirements.txt
@@ -1,4 +1,4 @@
 addict
 toml
 jinja2
-ramp-packer==2.5.13
+ramp-packer==2.5.17


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `.install/build_package_requirements.txt` pins `ramp-packer==2.5.13`.
2. **Change**: Bump to `ramp-packer==2.5.17`.
3. **Outcome**: 2.5.17 adds native support for the `speedb_git_sha` manifest field, which RediSearch Enterprise needs to record the linked SpeedB commit SHA in the packaged `module.json` (so consumers can identify exactly which SpeedB build was linked in).

This is a one-line dependency bump. RediSearch itself does not consume the new field — it is only injected by RediSearch Enterprise's `sbin/pack.sh` before invoking RAMP.

#### Which additional issues this PR fixes
1. MOD-14368 — Use `rsb` to get speedb in the build process instead of submodule
2. RED-183926 — Include Speedb version in a redisearch zip (absorbed into MOD-14368)

#### Main objects this PR modified
1. `.install/build_package_requirements.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

#### Downstream consumer
Required by [redislabsdev/RediSearchEnterprise#375](https://github.com/redislabsdev/RediSearchEnterprise/pull/375). RSE PR is currently pinned to `RediSearch/RediSearch:rsb-integration` (which is just `master` + this commit) and will be re-pinned to the merge SHA once this lands.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line dependency pin update in build requirements; behavior only changes via the external `ramp-packer` tool version used during packaging.
> 
> **Overview**
> Updates `.install/build_package_requirements.txt` to bump the pinned `ramp-packer` version from `2.5.13` to `2.5.17` to pick up newer packaging behavior (e.g., support for additional manifest fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343bff060180c4ccf264191f251887903ce7d5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->