### PR TITLE
[8.0] CI: pin ubuntu-latest to ubuntu-24.04 [MOD-15421]

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -58,7 +58,7 @@ jobs:
       rejson-branch: '8.0'
       test-config: '' # run all tests
       san: address
-      env: ubuntu-latest
+      env: ubuntu-24.04
 
   pr-validation:
     needs:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -41,7 +41,7 @@ jobs:
       get-redis: unstable
       test-config: QUICK=1
       san: address
-      env: ubuntu-latest
+      env: ubuntu-24.04
 
   notify-failure:
     needs: [test-linux, test-macos, coverage, sanitize]


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The sanitize jobs in `event-merge-to-queue.yml` and `event-nightly.yml` pass `env: ubuntu-latest` into `task-test.yml`, which uses it as `runs-on`. `ubuntu-latest` currently resolves to `ubuntu-24.04` but is scheduled to migrate to `ubuntu-26.04` once GitHub publishes the runner image.
2. Change: Pin those two `env: ubuntu-latest` references to `ubuntu-24.04`. All other workflow runners on this branch use `${{ vars.RUNS_ON }}` directly (no `ubuntu-latest` fallback), so they are unaffected.
3. Outcome: 8.0 CI keeps running on `ubuntu-24.04` regardless of when GHA flips the `ubuntu-latest` alias to `ubuntu-26.04`. We do not need to ship artifacts for Ubuntu 26.04 on 8.0, so this PR is scoped to runner pinning only.

#### Which additional issues this PR fixes
1. MOD-15421

#### Main objects this PR modified
1. `.github/workflows/event-merge-to-queue.yml`
2. `.github/workflows/event-nightly.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that pins the `sanitize` job environment to a specific GitHub runner image to avoid future `ubuntu-latest` alias shifts.
> 
> **Overview**
> Pins the `sanitize` job in the merge-queue (`event-merge-to-queue.yml`) and nightly (`event-nightly.yml`) workflows to run on `ubuntu-24.04` instead of `ubuntu-latest`, ensuring CI stays on 24.04 even if GitHub updates the `ubuntu-latest` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521a6fa81044d47ef3e45e015cc029b0226f6207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->