### PR TITLE
MOD-14268: Fix coordinator RQ completion timing

### DIFF
--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -303,17 +303,12 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
     ctx->replies[ctx->numReplied++] = r;
   }
 
-  // If we've received the last reply, the fanout/network phase is complete.
-  // Release the RQ slot here before unblocking or handing off to reduction.
+  // If we've received the last reply - unblock the client
   if (ctx->numReplied + ctx->numErrored == ctx->numExpected) {
+    IORuntimeCtx_RequestCompleted(ioRuntime);
     if (!timedOut && ctx->fn) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
-      // `ctx->fn` may hand off to an async reducer that can unblock and free `ctx`
-      // before this libuv callback is scheduled again. Complete the RQ request via
-      // the saved ioRuntime instead of reading more state from `ctx` after the handoff.
-      IORuntimeCtx_RequestCompleted(ioRuntime);
     } else {
-      IORuntimeCtx_RequestCompleted(ioRuntime);
       if (!timedOut) {
         RedisModuleBlockedClient *bc = ctx->bc;
         RS_ASSERT(bc);


### PR DESCRIPTION
## Summary

Original PR: https://github.com/RediSearch/RediSearch/pull/8774

Keep the MRCtx refcount/lifetime mechanism on master, and preserve only the request-queue drain fix: `IORuntimeCtx_RequestCompleted()` is called once from `fanoutCallback` as soon as the final fanout reply/error arrives, before reducer or timeout handling.

The broader refcount revert is unsafe on master: sanitizer exposed a path where blocked-client `free_privdata` can release `MRCtx` while the background reducer still calls back into it. Older branches can drop the refcount because their reducer signals completion before unblocking, but master still has post-unblock `MRCtx` usage, so this variant is intentionally minimal.

## Diff References

- Expected net diff (pure original PR + scoped partial revert): https://github.com/RediSearch/RediSearch/compare/eac69435b56f5f1fa7a32242426db39cb54888e2...mod-14268-expected-net-master

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
