### PR TITLE
fix(rlookup): preserve path on tombstoned keys

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -348,14 +348,7 @@ impl<'a> RLookupKey<'a> {
         // step stores a key pointer, then an APPLY with the same name overrides/tombstones it).
         // Those callers still need a valid path string to continue working (e.g. to load the
         // field value from the document before the APPLY overwrites it).
-        //
-        // The backing memory for `header.path` transfers to the new key's `_name` or `_path`
-        // via `override_current`, and both the tombstone and the new key share the same
-        // `RLookup` lifetime, so the pointer remains valid.
-        //
-        // This mirrors the original C behaviour: `overrideKey` never cleared `_path`.
-
-        let path = mem::take(me._path.deref_mut());
+        let path = me._path.clone();
 
         // this will exclude it from iteration
         me.header.flags |= RLookupKeyFlag::Hidden;


### PR DESCRIPTION
## Describe the changes in the pull request

The loader RP holds pointers to the path fields of keys _even_ after we override them. We cannot therefore remove the path from tombstone keys, we must keep them around. The comment in `RLookupKey::make_tombstone` correctly calls this out, but the actual code disagreed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FFI-facing key lifetime semantics by keeping `header.path` memory alive across tombstoning; mistakes here could surface as C-side use-after-free or unexpected allocations, though the change is small and localized.
> 
> **Overview**
> Fixes tombstoning of `RLookupKey` so the tombstoned key retains its `_path` instead of moving it out with `mem::take`.
> 
> `make_tombstone` now returns a cloned `Option<Cow<CStr>>` for the replacement key while keeping the original path backing memory intact, matching the documented requirement that C callers may still read `header.path` after a key is overridden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3254f7b2ec045aecea3de59b317b9446ce0c27f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->