### PR TITLE
fix(rlookup): default rule field key path to name when not in schema

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -441,7 +441,7 @@ fn create_key_from_data<'a>(
 ) -> RLookupKey<'a> {
     const NO_MATCH: i32 = -1;
     if NO_MATCH == index {
-        RLookupKey::new(filter_field, RLookupKeyFlags::empty())
+        RLookupKey::new_with_path(filter_field, filter_field, RLookupKeyFlags::empty())
     } else {
         let index = usize::try_from(index).expect("index must be positive and fit into usize");
         let field_spec = &field_specs[index];
@@ -1290,7 +1290,7 @@ mod tests {
         assert_eq!(actual.len(), 3);
 
         assert_eq!(actual[0].name(), c"ff0");
-        assert_eq!(actual[0].path(), &None);
+        assert_eq!(actual[0].path(), &Some(c"ff0".into()));
 
         assert_eq!(actual[1].name(), c"fn0");
         assert_eq!(actual[1].path(), &Some(c"fp0".into()));


### PR DESCRIPTION
## Describe the changes in the pull request

This restores previous C behavior that the tests relied on

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavior change in `rlookup` key creation plus a test expectation update; impact is limited to rule filter fields that are not matched to schema fields.
> 
> **Overview**
> Restores legacy behavior when building rule filter-field keys that are *not* found in the schema: the created `RLookupKey` now explicitly sets its `path` to the field name (via `new_with_path`) instead of leaving `path` unset.
> 
> Updates the `create_keys_from_spec` unit test to expect `path == Some(name)` for the unmatched filter field case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49374da6541dcbbd1ffdedea6c9377a0d2c013ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->