### PR TITLE
MOD-15419: make AArch64 inline LSE atomics opt-out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ function(setup_cc_options)
     #                        silently ignored by GCC).
     # Apple excluded: Apple clang rejects -mno-outline-atomics and Apple
     # Silicon already emits inline LSE.
-    if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$" AND INLINE_LSE_ATOMICS)
         include(CheckCCompilerFlag)
         include(CheckCXXCompilerFlag)
         set(_aarch64_lse_flags "-march=armv8-a+lse -mtune=neoverse-n1 -mno-outline-atomics")
@@ -124,6 +124,9 @@ option(VERBOSE_UTESTS "Enable verbose unit tests" OFF)
 option(ENABLE_ASSERT "Enable assertions" OFF)
 set(MAX_WORKER_THREADS "" CACHE STRING "Override the maximum parallel worker threads allowed in thread-pool")
 option(BUILD_TESTING "Enable testing for cpu-features dep" OFF)
+# Inline LSE atomics on Linux AArch64 (Armv8.1-a+). Disable for pre-Armv8.1-a
+# cores (Cortex-A72, AWS Graviton1, Raspberry Pi 4) to avoid SIGILL on load.
+option(INLINE_LSE_ATOMICS "Inline LSE atomics on Linux AArch64 (Armv8.1-a+)" ON)
 
 
 #----------------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ ifeq ($(LTO),1)
 	BUILD_ARGS += LTO
 endif
 
+ifneq ($(INLINE_LSE_ATOMICS),)
+	BUILD_ARGS += INLINE_LSE_ATOMICS=$(INLINE_LSE_ATOMICS)
+endif
+
 # Package variables (used by pack target)
 MODULE_NAME := search
 PACKAGE_NAME ?=
@@ -154,6 +158,10 @@ Build:
     RUST_DYN_CRT=1     Use dynamic C runtime linking (for Alpine Linux)
     VERBOSE=1          Verbose build output
     LTO=1              Enable Rust/C LTO
+    INLINE_LSE_ATOMICS=0|1
+                       Inline LSE atomics on Linux AArch64 (default: 1).
+                       Set to 0 on pre-Armv8.1-a cores (Cortex-A72,
+                       Graviton1, Raspberry Pi 4) to avoid SIGILL on load.
 
   make clean         Remove build artifacts
     ALL=1              Remove entire artifacts directory

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,9 @@ BUILD_INTEL_SVS_OPT=${BUILD_INTEL_SVS_OPT:-0} # Use SVS pre-compiled library
 # Clang needs to have the same version as the LLVM version used by Rust.
 # Check using `clang --version` and `rustc --version --verbose`.
 LTO=0
+# Inline LSE atomics on Linux AArch64 (Armv8.1-a+). Set to 0 on pre-Armv8.1-a
+# cores (Cortex-A72, AWS Graviton1, Raspberry Pi 4) to avoid SIGILL on load.
+INLINE_LSE_ATOMICS=${INLINE_LSE_ATOMICS:-1}
 
 # Test configuration (0=disabled, 1=enabled)
 BUILD_TESTS=0          # Build test binaries
@@ -151,6 +154,9 @@ parse_arguments() {
         ;;
       LTO?(=1))
         LTO=1
+        ;;
+      INLINE_LSE_ATOMICS=*)
+        INLINE_LSE_ATOMICS="${arg#*=}"
         ;;
       *)
         # Pass all other arguments directly to CMake
@@ -580,6 +586,13 @@ prepare_cmake_arguments() {
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DSVS_SHARED_LIB=OFF"
   fi
 
+  # Forward INLINE_LSE_ATOMICS to CMake (controls the C/C++ side).
+  if [[ "$INLINE_LSE_ATOMICS" == "1" ]]; then
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DINLINE_LSE_ATOMICS=ON"
+  else
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DINLINE_LSE_ATOMICS=OFF"
+  fi
+
   # Handle RUST_DYN_CRT flag for Alpine Linux compatibility
   if [[ "$RUST_DYN_CRT" == "1" ]]; then
     # Add the dynamic C runtime flag to RUSTFLAGS
@@ -589,8 +602,9 @@ prepare_cmake_arguments() {
   # implies +lse so rustc emits LDADDH/LDADD instead of an ldxrh/stxrh LL/SC loop.
   # macOS is excluded to match the CMake NOT APPLE gate: Apple Silicon's default
   # target-cpu (apple-m1) is already ≥Armv8.5-a with inline LSE, so overriding it
-  # with neoverse-n1 would only downgrade scheduling.
-  if [[ "$ARCH" == "aarch64" && "$OS_NAME" != "macos" ]]; then
+  # with neoverse-n1 would only downgrade scheduling. Gated by INLINE_LSE_ATOMICS
+  # so users on pre-Armv8.1-a cores (Cortex-A72, Graviton1, RPi4) can opt out.
+  if [[ "$ARCH" == "aarch64" && "$OS_NAME" != "macos" && "$INLINE_LSE_ATOMICS" == "1" ]]; then
     RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C target-cpu=neoverse-n1"
   fi
   # Set up RUSTFLAGS for warnings


### PR DESCRIPTION
## Describe the changes in the pull request

**Current:** PR #9262 (MOD-14916) unconditionally added `-march=armv8-a+lse -mtune=neoverse-n1 -mno-outline-atomics` (C/C++) and `-C target-cpu=neoverse-n1` (Rust) on every Linux+AArch64 build. The resulting `.so` requires Armv8.1-a+ (LSE) and `SIGILL`s at module load on pre-v8.1-a cores: Cortex-A72, AWS Graviton1, Raspberry Pi 4. Reported on RPi4 in redis/redis#15175.

**Change:** Pure build-system change, no source changes.
- **`CMakeLists.txt`:** New `option(INLINE_LSE_ATOMICS "Inline LSE atomics on Linux AArch64 (Armv8.1-a+)" ON)`. The existing AArch64 LSE stanza in `setup_cc_options()` now also gates on this option.
- **`build.sh`:** New `INLINE_LSE_ATOMICS=${INLINE_LSE_ATOMICS:-1}` default; new `parse_arguments` case; `prepare_cmake_arguments` forwards `-DINLINE_LSE_ATOMICS=ON/OFF` to CMake; the Rust `-C target-cpu=neoverse-n1` line is gated on the same flag (matching the CMake side, including the `NOT APPLE` exclusion).
- **`Makefile`:** Plumbs `make INLINE_LSE_ATOMICS=…` into `BUILD_ARGS`; help text updated.

**Outcome:** Default behavior is unchanged — all Linux AArch64 builds still emit inline LSE on Neoverse-N1/V1/V2 (Graviton2/3/4). To produce a backward-compatible binary on pre-Armv8.1-a cores:

```sh
make INLINE_LSE_ATOMICS=0 build
# or
./build.sh INLINE_LSE_ATOMICS=0
```

The Redis-side change that exposes and documents this flag in `modules/redisearch/Makefile` and `README.md` will be opened against `redis/redis` once a RediSearch tag containing this flag is bumped in `MODULE_VERSION`.

### Validation

Built `redisearch.so` twice inside `arm64v8/ubuntu:24.04` (native on Apple Silicon, no QEMU), once per flag value, and inspected the resulting binaries with `nm` / `objdump`:

| metric | `INLINE_LSE_ATOMICS=1` (default) | `INLINE_LSE_ATOMICS=0` |
|---|---:|---:|
| inline LSE instructions (`ldadd*`/`cas*`/`swp*`/`stadd*`/`ldset*`) | **1,375** | **21** |
| `__aarch64_*` outline-atomic helper symbols | 16 | **37** |
| `bl <__aarch64_*>` outline-atomic call sites | 277 | **2,693** |
| `.so` size | 19,309,400 B | 19,181,544 B |

With the flag off, inline LSE drops by ~65× (the 21 residual sites come from third-party static libs with hand-written LSE asm, e.g. SVS, and aren't governed by our compile flags), and atomics are routed through `libgcc`'s outline dispatcher (`__aarch64_have_lse_atomics`) — the path that runs safely on Cortex-A72 / Graviton1 / RPi4.

#### Which additional issues this PR fixes
1. MOD-15419
2. redis/redis#15175
3. Follow-up to #9262

#### Main objects this PR modified
1. `CMakeLists.txt` — new `INLINE_LSE_ATOMICS` option; `setup_cc_options()` AArch64 LSE stanza gated on it
2. `build.sh` — `INLINE_LSE_ATOMICS` default + parsing; `prepare_cmake_arguments()` forwards to CMake and gates Rust `RUSTFLAGS`
3. `Makefile` — `BUILD_ARGS` plumbing + help text

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Release note: Inline LSE atomics on Linux AArch64 are now opt-out via the `INLINE_LSE_ATOMICS` build flag (default `1`). Set to `0` when building on pre-Armv8.1-a cores (Cortex-A72, AWS Graviton1, Raspberry Pi 4) to avoid `SIGILL` on module load.
