### PR TITLE
[MOD-15573] Fix RSIndexResult ownership

### DIFF
--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -557,7 +557,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = 2,
+    .arity = -2,
     .since = "8.10.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -557,7 +557,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = -2,
+    .arity = 2,
     .since = "8.10.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -2,10 +2,26 @@
 
 #include "aggregate/aggregate_plan.h"
 #include "query.h"
+#include "query_flags.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Whether a buffering result processor must preserve each result's
+ * `RSIndexResult` past the point where it is buffered across an iterator
+ * advance, by deep-copying it.
+ *
+ * The index result is only read downstream of the buffering point by the
+ * highlighter (`QEXEC_F_SEND_HIGHLIGHT`) and by the `matched_terms()` aggregate
+ * function, which in turn only sees rich results when scores are requested.
+ * When neither is the case, the borrow can simply be dropped instead of copied.
+ */
+static inline bool QEFlags_RequireIndexResultsDownstream(QEFlags flags) {
+  return (flags & QEXEC_F_SEND_HIGHLIGHT) ||
+         (flags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD));
+}
 
 /**
  * Common parameters shared across different pipeline types in RediSearch.

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -411,6 +411,13 @@ void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params, Qu
 
   RLookup_SetCache(first, cache);
 
+  // Buffering RPs only need to preserve each result's RSIndexResult if something
+  // downstream (highlighter or matched_terms()) reads it; otherwise they may drop
+  // the borrow instead of paying for a deep copy. The query and output parts share
+  // this qctx, so setting it here covers the whole pipeline.
+  pipeline->qctx.skipIndexResultDeepCopy =
+      !QEFlags_RequireIndexResultsDownstream(params->common.reqflags);
+
   ResultProcessor *rp = RPQueryIterator_New(params->rootiter, params->querySlots, params->keySpaceVersion, params->common.sctx);
   params->rootiter = NULL; // Ownership of the root iterator is now with the pipeline.
   params->querySlots = NULL; // Ownership of the slot ranges is now with the pipeline.
@@ -539,6 +546,36 @@ error:
   return REDISMODULE_ERR;
 }
 
+// Whether `expr` (or any sub-expression) calls a function that reads the
+// result's RSIndexResult. matched_terms() is currently the only such function;
+// an APPLY/FILTER using it after a buffering step needs the index result kept
+// alive, so the buffering RP must deep-copy rather than drop the borrow.
+static bool exprReadsIndexResult(const RSExpr *expr) {
+  if (!expr) return false;
+  switch (expr->t) {
+    case RSExpr_Function:
+      if (expr->func.name && !strcasecmp(expr->func.name, "matched_terms")) {
+        return true;
+      }
+      if (expr->func.args) {
+        for (size_t i = 0; i < expr->func.args->len; i++) {
+          if (exprReadsIndexResult(expr->func.args->args[i])) return true;
+        }
+      }
+      return false;
+    case RSExpr_Op:
+      return exprReadsIndexResult(expr->op.left) || exprReadsIndexResult(expr->op.right);
+    case RSExpr_Predicate:
+      return exprReadsIndexResult(expr->pred.left) || exprReadsIndexResult(expr->pred.right);
+    case RSExpr_Inverted:
+      return exprReadsIndexResult(expr->inverted.child);
+    case RSExpr_Literal:
+    case RSExpr_Property:
+      return false;
+  }
+  return false;
+}
+
 int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineParams *params, uint32_t *outStateFlags, QueryError *status) {
   AGGPlan *pln = &pipeline->ap;
   ResultProcessor *rp = NULL, *rpUpstream = pipeline->qctx.endProc;
@@ -583,6 +620,12 @@ int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineP
         mstp->parsedExpr = ExprAST_Parse(mstp->expr, status);
         if (!mstp->parsedExpr) {
           goto error;
+        }
+
+        // matched_terms() reads the result's index result; if any APPLY/FILTER
+        // needs it, buffering RPs must deep-copy it rather than drop the borrow.
+        if (exprReadsIndexResult(mstp->parsedExpr)) {
+          pipeline->qctx.skipIndexResultDeepCopy = false;
         }
 
         // Ensure the lookups can actually find what they need

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -322,6 +322,7 @@ typedef struct QueryProcessingCtx {
   bool isProfile;
   RSTimeoutPolicy timeoutPolicy;
   bool canYieldPartialResults;
+  bool skipIndexResultDeepCopy;
 } QueryProcessingCtx;
 """
 

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -330,6 +330,7 @@ includes = ["score_explain.h"]
 after_includes = """
 /* SearchResult flags */
 static const uint8_t Result_ExpiredDoc = 1 << 0;
+static const uint8_t Result_OwnsIndexResult = 1 << 1;
 
 /* Forward decl + reference-counted pointer to a const RSDocumentMetadata.
  * Declared directly here (rather than auto-generated from the document_metadata

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -462,6 +462,9 @@ const PERMITTED_GENERATED_HEADERS: &[&str] = &[
     // `aggregate.h` includes `value_ffi.h`; reachable via
     // `optimizer_reader.h` -> `query_optimizer.h` -> `aggregate.h`.
     "value_ffi.h",
+    // `src/search_result.h` includes this for the `IndexResult_DeepCopy`
+    // declaration used by the inline `SearchResult_TakeOwnedIndexResult`.
+    "types_ffi.h",
     // `src/byte_offsets.h` defines `static inline` functions that call
     // `NewVarintVectorWriter` / `VVW_Free` / `VVW_Write`. The whole file is
     // small (one opaque type + a handful of functions).

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -84,6 +84,18 @@ pub struct QueryProcessingCtx {
     /// RETURN-STRICT timeout path to drain queued shard replies on the main
     /// thread after the background pipeline has aborted.
     pub canYieldPartialResults: bool,
+    /// Whether a buffering result processor may *skip* deep-copying a result's
+    /// `RSIndexResult` and instead drop the borrow when storing it across an
+    /// iterator advance.
+    ///
+    /// Only the highlighter and the `matched_terms()` aggregate function read
+    /// the index result downstream of the buffering point, so this is set iff
+    /// the request needs neither highlighting nor scores.
+    ///
+    /// Polarity is deliberate: the safe (always deep-copy) behavior is the zero
+    /// value, so any qctx that is zero-initialized outside the constructor
+    /// (`{0}`, `calloc`, `memset`) keeps copying. Skipping is opt-in.
+    pub skipIndexResultDeepCopy: bool,
 }
 
 impl QueryProcessingCtx {
@@ -104,6 +116,7 @@ impl QueryProcessingCtx {
             isProfile: false,
             timeoutPolicy: 0,
             canYieldPartialResults: false,
+            skipIndexResultDeepCopy: false,
         };
 
         Box::pin(ctx)

--- a/src/redisearch_rs/headers/result_processor_ffi.h
+++ b/src/redisearch_rs/headers/result_processor_ffi.h
@@ -32,6 +32,7 @@ typedef struct QueryProcessingCtx {
   bool isProfile;
   RSTimeoutPolicy timeoutPolicy;
   bool canYieldPartialResults;
+  bool skipIndexResultDeepCopy;
 } QueryProcessingCtx;
 
 

--- a/src/redisearch_rs/headers/search_result_rs.h
+++ b/src/redisearch_rs/headers/search_result_rs.h
@@ -12,6 +12,7 @@
 #include "rqe_core.h"
 /* SearchResult flags */
 static const uint8_t Result_ExpiredDoc = 1 << 0;
+static const uint8_t Result_OwnsIndexResult = 1 << 1;
 
 /* Forward decl + reference-counted pointer to a const RSDocumentMetadata.
  * Declared directly here (rather than auto-generated from the document_metadata

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -19,7 +19,12 @@ use document_metadata::{DocumentMetadata, OwnedDocumentMetadata};
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum SearchResultFlag {
-    ExpiredDoc = 1,
+    ExpiredDoc = 1 << 0,
+    /// `_index_result` owns its `RSIndexResult` allocation (created via
+    /// `IndexResult_DeepCopy` or equivalent). When set, `clear()` reconstitutes
+    /// the `Box` and drops it. When unset, `_index_result` is a borrow into an
+    /// iterator-owned slot and must not be freed here.
+    OwnsIndexResult = 1 << 1,
 }
 
 pub type SearchResultFlags = enumflags2::BitFlags<SearchResultFlag>;
@@ -98,6 +103,15 @@ impl<'index> SearchResult<'index> {
             }
         }
 
+        // If we own the index_result, reclaim and drop the Box.
+        if self._flags.contains(SearchResultFlag::OwnsIndexResult)
+            && let Some(ir) = self._index_result.take()
+        {
+            // SAFETY: `OwnsIndexResult` is set iff `_index_result` was populated from a `Box<RSIndexResult>`.
+            // Reconstituting and dropping the box reverses that allocation.
+            // The reference is unaliased because the SearchResult is the unique holder while the flag is set.
+            drop(unsafe { Box::from_raw(std::ptr::from_ref(ir).cast_mut()) });
+        }
         self._index_result = None;
 
         self._flags = SearchResultFlags::empty();

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -208,6 +208,25 @@ static void setSearchResult(ResultProcessor *base, SearchResult *res, RSIndexRes
 }
 
 /**
+ * Prepare a result's borrowed RSIndexResult before a buffering RP stores the
+ * result across an iterator advance.
+ *
+ * The borrow points into the source iterator's `it->current` slot, which the
+ * next Read() overwrites. Unless the pipeline has opted into skipping the copy
+ * (`qctx.skipIndexResultDeepCopy`, set only when nothing downstream — highlighter
+ * or matched_terms() — reads the index result), promote the borrow to an owned
+ * deep copy. Otherwise drop the borrow so the buffered result never retains a
+ * dangling pointer, without paying for the copy.
+ */
+static inline void SearchResult_BufferIndexResult(ResultProcessor *rp, SearchResult *res) {
+  if (rp->parent->skipIndexResultDeepCopy) {
+    SearchResult_SetBorrowedIndexResult(res, NULL);
+  } else {
+    SearchResult_DeepCopyAndOwnIndexResult(res);
+  }
+}
+
+/**
  * Handle initial spec lock and iterator revalidation.
  * Returns true if we should goto validate_current (VALIDATE_MOVED case).
  *
@@ -692,10 +711,10 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
 
     // The pooled result currently borrows `it->current` from the source
     // iterator; the next Read() overwrites that slot, so the borrow would
-    // dangle once the SearchResult lives in the heap across reads. Promote
-    // the borrow to an owned deep copy; the SearchResult will free it on
-    // Clear/Destroy via the Result_OwnsIndexResult flag.
-    SearchResult_DeepCopyAndOwnIndexResult(self->pooledResult);
+    // dangle once the SearchResult lives in the heap across reads. Preserve it
+    // as an owned deep copy when something downstream needs it, otherwise drop
+    // the borrow.
+    SearchResult_BufferIndexResult(rp, self->pooledResult);
     mmh_insert(self->pq, self->pooledResult);
     if (SearchResult_GetScore(self->pooledResult) < rp->parent->minScore) {
       rp->parent->minScore = SearchResult_GetScore(self->pooledResult);
@@ -714,10 +733,9 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
 
     // if needed - pop it and insert a new result
     if (self->cmp(self->pooledResult, minh, self->cmpCtx) > 0) {
-      // Promote the borrowed RSIndexResult to an owned deep copy before the
-      // SearchResult enters the heap; see the matching insert path above for
-      // the lifetime rationale.
-      SearchResult_DeepCopyAndOwnIndexResult(self->pooledResult);
+      // Preserve or drop the borrowed RSIndexResult before the SearchResult
+      // enters the heap; see the matching insert path above for the rationale.
+      SearchResult_BufferIndexResult(rp, self->pooledResult);
       self->pooledResult = mmh_exchange_min(self->pq, self->pooledResult);
     }
     // clear the result in preparation for the next iteration
@@ -1165,8 +1183,9 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
     // Decrease the result limit after getting a result from the upstream
     rp->parent->resultLimit--;
     // Buffered SearchResults outlive the source iterator's `it->current` slot;
-    // promote any borrowed RSIndexResult to an owned copy before storing.
-    SearchResult_DeepCopyAndOwnIndexResult(&resToBuffer);
+    // preserve any borrowed RSIndexResult as an owned copy when something
+    // downstream needs it, otherwise drop the borrow before storing.
+    SearchResult_BufferIndexResult(rp, &resToBuffer);
     // Buffer the result.
     currBlock = InsertResult(self, &resToBuffer, currBlock);
 
@@ -1587,8 +1606,8 @@ static int RPMaxScoreNormalizerNext_innerLoop(ResultProcessor *rp, SearchResult 
 
   self->maxValue = MAX(self->maxValue, SearchResult_GetScore(self->pooledResult));
   // The pooled result outlives the upstream iterator's `it->current` slot;
-  // promote the borrow to an owned deep copy before storing in the pool.
-  SearchResult_DeepCopyAndOwnIndexResult(self->pooledResult);
+  // preserve or drop the borrowed RSIndexResult before storing in the pool.
+  SearchResult_BufferIndexResult(rp, self->pooledResult);
   array_ensure_append_1(self->pool, self->pooledResult);
 
   // we need to allocate a new result for the next iteration
@@ -1827,8 +1846,8 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
   *r = SearchResult_New();
   while ((rc = self->base.upstream->Next(self->base.upstream, r)) == RS_RESULT_OK) {
     // Buffered SearchResults outlive the source iterator's `it->current`
-    // slot; promote any borrowed RSIndexResult to an owned copy.
-    SearchResult_DeepCopyAndOwnIndexResult(r);
+    // slot; preserve or drop the borrowed RSIndexResult before buffering.
+    SearchResult_BufferIndexResult(&self->base, r);
     array_append(self->results, r);
     r = rm_calloc(1, sizeof(*r));
     *r = SearchResult_New();
@@ -2300,8 +2319,8 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
 
    SearchResult_SetScore(r, score);
    // The merger holds `r` in its dictionary across further upstream Reads;
-   // promote any borrowed RSIndexResult to an owned copy so it survives.
-   SearchResult_DeepCopyAndOwnIndexResult(r);
+   // preserve or drop the borrowed RSIndexResult so it does not dangle.
+   SearchResult_BufferIndexResult(&self->base, r);
    HybridSearchResult_StoreResult(hybridResult, r, upstreamIndex);
    return true;
  }
@@ -2844,8 +2863,8 @@ static void RPDepleter_Deplete(RPDepleter *self) {
   // Deplete all results from upstream
   while ((rc = self->base.upstream->Next(self->base.upstream, r)) == RS_RESULT_OK) {
     // Buffered SearchResults outlive the source iterator's `it->current`
-    // slot; promote any borrowed RSIndexResult to an owned copy.
-    SearchResult_DeepCopyAndOwnIndexResult(r);
+    // slot; preserve or drop the borrowed RSIndexResult before buffering.
+    SearchResult_BufferIndexResult(&self->base, r);
     array_append(self->results, r);
     r = rm_calloc(1, sizeof(*r));
     *r = SearchResult_New();

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -201,7 +201,7 @@ static void setSearchResult(ResultProcessor *base, SearchResult *res, RSIndexRes
   RS_LOG_ASSERT(SearchResult_GetDocumentMetadata(res) == NULL, "SearchResult already has associated document metadata");
   base->parent->totalResults++;
   SearchResult_SetDocId(res, dmd->id);
-  SearchResult_SetIndexResult(res, indexResult);
+  SearchResult_SetBorrowedIndexResult(res, indexResult);
   SearchResult_SetScore(res, 0);
   SearchResult_SetDocumentMetadata(res, dmd);
   RLookupRow_SetSortingVector(SearchResult_GetRowDataMut(res), &dmd->sortVector);
@@ -690,8 +690,12 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   // If the queue is not full - we just push the result into it
   if (self->pq->count < self->pq->size) {
 
-    // copy the index result to make it thread safe - but only if it is pushed to the heap
-    SearchResult_SetIndexResult(self->pooledResult, NULL);
+    // The pooled result currently borrows `it->current` from the source
+    // iterator; the next Read() overwrites that slot, so the borrow would
+    // dangle once the SearchResult lives in the heap across reads. Promote
+    // the borrow to an owned deep copy; the SearchResult will free it on
+    // Clear/Destroy via the Result_OwnsIndexResult flag.
+    SearchResult_DeepCopyAndOwnIndexResult(self->pooledResult);
     mmh_insert(self->pq, self->pooledResult);
     if (SearchResult_GetScore(self->pooledResult) < rp->parent->minScore) {
       rp->parent->minScore = SearchResult_GetScore(self->pooledResult);
@@ -710,7 +714,10 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
 
     // if needed - pop it and insert a new result
     if (self->cmp(self->pooledResult, minh, self->cmpCtx) > 0) {
-      SearchResult_SetIndexResult(self->pooledResult, NULL);
+      // Promote the borrowed RSIndexResult to an owned deep copy before the
+      // SearchResult enters the heap; see the matching insert path above for
+      // the lifetime rationale.
+      SearchResult_DeepCopyAndOwnIndexResult(self->pooledResult);
       self->pooledResult = mmh_exchange_min(self->pq, self->pooledResult);
     }
     // clear the result in preparation for the next iteration
@@ -1028,10 +1035,13 @@ typedef struct RPSafeLoader {
 
 /************************* Safe Loader private functions *************************/
 
-static void SetResult(SearchResult *buffered_result,  SearchResult *result_output) {
-  // Free the RLookup row before overriding it.
-  RLookupRow_Reset(SearchResult_GetRowDataMut(result_output));
-  *result_output = *buffered_result;
+static void SetResult(SearchResult *buffered_result, SearchResult *result_output) {
+  // Move ownership from the buffer slot into result_output, dropping result_output's
+  // old resources (RLookupRow, owned _index_result) in the process.
+  SearchResult_Override(result_output, buffered_result);
+  // Reinitialize the now-consumed buffer slot so rpSafeLoaderFree (or any future
+  // traversal) never sees a dangling owned _index_result pointer there.
+  *buffered_result = SearchResult_New();
 }
 
 static SearchResult *GetResultsBlock(RPSafeLoader *self, size_t idx) {
@@ -1154,6 +1164,9 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   while (rp->parent->resultLimit && ((result_status = rp->upstream->Next(rp->upstream, &resToBuffer)) == RS_RESULT_OK)) {
     // Decrease the result limit after getting a result from the upstream
     rp->parent->resultLimit--;
+    // Buffered SearchResults outlive the source iterator's `it->current` slot;
+    // promote any borrowed RSIndexResult to an owned copy before storing.
+    SearchResult_DeepCopyAndOwnIndexResult(&resToBuffer);
     // Buffer the result.
     currBlock = InsertResult(self, &resToBuffer, currBlock);
 
@@ -1573,8 +1586,9 @@ static int RPMaxScoreNormalizerNext_innerLoop(ResultProcessor *rp, SearchResult 
   }
 
   self->maxValue = MAX(self->maxValue, SearchResult_GetScore(self->pooledResult));
-  // copy the index result to make it thread safe - but only if it is pushed to the heap
-  SearchResult_SetIndexResult(self->pooledResult, NULL);
+  // The pooled result outlives the upstream iterator's `it->current` slot;
+  // promote the borrow to an owned deep copy before storing in the pool.
+  SearchResult_DeepCopyAndOwnIndexResult(self->pooledResult);
   array_ensure_append_1(self->pool, self->pooledResult);
 
   // we need to allocate a new result for the next iteration
@@ -1812,6 +1826,9 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
   SearchResult *r = rm_calloc(1, sizeof(*r));
   *r = SearchResult_New();
   while ((rc = self->base.upstream->Next(self->base.upstream, r)) == RS_RESULT_OK) {
+    // Buffered SearchResults outlive the source iterator's `it->current`
+    // slot; promote any borrowed RSIndexResult to an owned copy.
+    SearchResult_DeepCopyAndOwnIndexResult(r);
     array_append(self->results, r);
     r = rm_calloc(1, sizeof(*r));
     *r = SearchResult_New();
@@ -2282,6 +2299,9 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   }
 
    SearchResult_SetScore(r, score);
+   // The merger holds `r` in its dictionary across further upstream Reads;
+   // promote any borrowed RSIndexResult to an owned copy so it survives.
+   SearchResult_DeepCopyAndOwnIndexResult(r);
    HybridSearchResult_StoreResult(hybridResult, r, upstreamIndex);
    return true;
  }
@@ -2823,6 +2843,9 @@ static void RPDepleter_Deplete(RPDepleter *self) {
 
   // Deplete all results from upstream
   while ((rc = self->base.upstream->Next(self->base.upstream, r)) == RS_RESULT_OK) {
+    // Buffered SearchResults outlive the source iterator's `it->current`
+    // slot; promote any borrowed RSIndexResult to an owned copy.
+    SearchResult_DeepCopyAndOwnIndexResult(r);
     array_append(self->results, r);
     r = rm_calloc(1, sizeof(*r));
     *r = SearchResult_New();

--- a/src/search_result.h
+++ b/src/search_result.h
@@ -14,6 +14,7 @@
 #include "rlookup.h"
 #include "index_result.h"
 #include "search_result_rs.h"
+#include "types_ffi.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -168,18 +169,81 @@ static inline bool SearchResult_HasIndexResult(const SearchResult *res) {
 }
 
 /**
- * Sets the [`RSIndexResult`] associated with `res`.
+ * Sets the [`RSIndexResult`] associated with `res` as a *borrow*.
+ *
+ * `res` does not take ownership of `index_result`; the caller must keep it
+ * alive for as long as `res` references it. After this call,
+ * `Result_OwnsIndexResult` is cleared.
+ *
+ * Passing `NULL` clears the field (and frees any prior owned copy).
  *
  * # Safety
  *
  * 1. `res` must be a [valid], non-null pointer to a [`SearchResult`].
- * 2. `index_result` must be a [valid] pointer to a [`ffi::RSIndexResult`].
- * 3. `index_result` must be [valid] for the entire lifetime of `res`.
+ * 2. If non-NULL, `index_result` must be a [valid] pointer to an
+ *    [`ffi::RSIndexResult`] that outlives every dereference of `res`'s
+ *    `_index_result` field.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-static inline void SearchResult_SetIndexResult(SearchResult *res, const RSIndexResult *index_result) {
+static inline void SearchResult_SetBorrowedIndexResult(SearchResult *res, const RSIndexResult *index_result) {
+  if ((res->_flags & Result_OwnsIndexResult) && res->_index_result != index_result) {
+    IndexResult_Free((RSIndexResult *)res->_index_result);
+  }
   res->_index_result = index_result;
+  res->_flags &= ~Result_OwnsIndexResult;
+}
+
+/**
+ * Sets the [`RSIndexResult`] associated with `res` as an *owned* allocation.
+ *
+ * `res` takes ownership of `index_result` and `Result_OwnsIndexResult` is
+ * set, so `SearchResult_Clear` / `SearchResult_Destroy` will release it via
+ * `IndexResult_Free`. The caller must not free `index_result` itself.
+ *
+ * If `res` previously owned its `_index_result`, the prior owned copy is
+ * freed before the new pointer is installed.
+ *
+ * # Safety
+ *
+ * 1. `res` must be a [valid], non-null pointer to a [`SearchResult`].
+ * 2. `index_result` must be a non-NULL pointer to an [`ffi::RSIndexResult`]
+ *    allocated by one of the constructors documented on
+ *    [`IndexResult_Free`] (e.g. `IndexResult_DeepCopy`).
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+static inline void SearchResult_SetOwnedIndexResult(SearchResult *res, RSIndexResult *index_result) {
+  if ((res->_flags & Result_OwnsIndexResult) && res->_index_result != index_result) {
+    IndexResult_Free((RSIndexResult *)res->_index_result);
+  }
+  res->_index_result = index_result;
+  res->_flags |= Result_OwnsIndexResult;
+}
+
+/**
+ * Promote the borrowed `_index_result` of `res` to an owned deep copy.
+ *
+ * Idempotent: if `res` has no `_index_result`, or it already owns one
+ * (`Result_OwnsIndexResult` is set), this is a no-op. Otherwise the existing
+ * borrow is replaced with `IndexResult_DeepCopy(borrow)` and the
+ * `Result_OwnsIndexResult` flag is set so that `SearchResult_Clear` /
+ * `SearchResult_Destroy` will free the copy.
+ *
+ * Call this in any pipeline stage that buffers a `SearchResult` across an
+ * iterator advance — the borrow into `it->current` will dangle once the
+ * iterator is read again.
+ *
+ * # Safety
+ *
+ * 1. `res` must be a valid, non-null pointer to a `SearchResult`.
+ * 2. If `_index_result` is non-NULL it must currently be a valid pointer
+ *    (either a live borrow or an already-owned copy).
+ */
+static inline void SearchResult_DeepCopyAndOwnIndexResult(SearchResult *res) {
+  if (!res->_index_result) return;
+  if (res->_flags & Result_OwnsIndexResult) return;
+  SearchResult_SetOwnedIndexResult(res, IndexResult_DeepCopy(res->_index_result));
 }
 
 /**
@@ -246,7 +310,13 @@ static inline void SearchResult_SetFlags(SearchResult *res, uint8_t flags) {
 }
 
 /**
- * Merge the flags (union) `other` into `res`
+ * Merge the flags (union) of `other` into `res`.
+ *
+ * Only document-semantic flags are propagated. Ownership/lifecycle flags
+ * (e.g. `Result_OwnsIndexResult`) describe a property of *this* `SearchResult`'s
+ * own allocations and must never be inherited from another result — doing so
+ * would cause `SearchResult_Clear` / `SearchResult_Destroy` to free memory
+ * that `res` does not actually own.
  *
  * # Safety
  *
@@ -257,7 +327,9 @@ static inline void SearchResult_SetFlags(SearchResult *res, uint8_t flags) {
  */
 static inline void SearchResult_MergeFlags(SearchResult *res, const SearchResult *other)  {
   RS_ASSERT(res && other);
-  res->_flags |= other->_flags;
+  // Flags that describe per-result memory ownership — must NOT be merged.
+  const uint8_t ownership_flags = Result_OwnsIndexResult;
+  res->_flags |= (other->_flags & ~ownership_flags);
 }
 
 #ifdef __cplusplus

--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -1292,6 +1292,11 @@ TEST_F(HybridMergerTest, testHybridMergerErrorPrecedence) {
   HybridLookupContext *lookupCtx = CreateDummyLookupContext(3);
   ResultProcessor *hybridMerger = CreateLinearHybridMerger(upstreams, 3, weights, lookupCtx);
 
+  // Attach the merger to a query processing context: like every buffering RP it
+  // reads its qctx (here, the index-result copy decision) during Next().
+  QueryProcessingCtx qitr = {0};
+  QITR_PushRP(&qitr, hybridMerger);
+
   // Process and verify that the most severe error (RS_RESULT_ERROR) is returned
   SearchResult r = SearchResult_New();
   int result;
@@ -1448,6 +1453,11 @@ TEST_F(HybridMergerTest, testUpstreamReturnCodes) {
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
   ResultProcessor *hybridMerger = RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, 3, NULL, NULL, returnCodes, lookupCtx);
+
+  // Attach the merger to a query processing context: like every buffering RP it
+  // reads its qctx (here, the index-result copy decision) during Next().
+  QueryProcessingCtx qitr = {0};
+  QITR_PushRP(&qitr, hybridMerger);
 
   // Process results - this should capture the return codes
   SearchResult r = SearchResult_New();

--- a/tests/cpptests/test_cpp_resultprocessor.cpp
+++ b/tests/cpptests/test_cpp_resultprocessor.cpp
@@ -116,3 +116,27 @@ TEST_F(ResultProcessorTest, testmergeFlags_ExpiredDoc) {
   SearchResult_MergeFlags(&a, &b);
   EXPECT_TRUE(SearchResult_GetFlags(&a) & Result_ExpiredDoc);
 }
+
+/*
+ * Test that SearchResult_MergeFlags does NOT propagate the ownership flag
+ * `Result_OwnsIndexResult` from `other` into `res`. This flag is a per-result
+ * memory-management property (it tracks whether *this* result's `_index_result`
+ * was deep-copied and therefore must be freed by `SearchResult_Clear`).
+ * Inheriting it from a sibling would cause `clear()` to free a borrowed
+ * (or NULL) pointer.
+ */
+TEST_F(ResultProcessorTest, testmergeFlags_OwnsIndexResultNotPropagated) {
+  SearchResult a = SearchResult_New();
+  SearchResult b = SearchResult_New();
+  // `b` "owns" its index result; `a` does not.
+  SearchResult_SetFlags(&b, Result_OwnsIndexResult | Result_ExpiredDoc);
+
+  SearchResult_MergeFlags(&a, &b);
+
+  // Document-semantic flag should propagate.
+  EXPECT_TRUE(SearchResult_GetFlags(&a) & Result_ExpiredDoc);
+  // Ownership flag must NOT propagate — `a` did not perform a deep copy.
+  EXPECT_FALSE(SearchResult_GetFlags(&a) & Result_OwnsIndexResult);
+  // `b`'s flags must be left untouched by the merge.
+  EXPECT_TRUE(SearchResult_GetFlags(&b) & Result_OwnsIndexResult);
+}

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3246,6 +3246,19 @@ def testMatchedTerms(env):
     env.expect('ft.aggregate', 'idx', 'foo', 'LOAD', '1', '@test', 'APPLY', 'matched_terms(-100)', 'as', 'a').equal([1, ['test', 'foo', 'a', ['foo']]])
     env.expect('ft.aggregate', 'idx', 'foo', 'LOAD', '1', '@test', 'APPLY', 'matched_terms("test")', 'as', 'a').equal([1, ['test', 'foo', 'a', ['foo']]])
 
+def testMatchedTermsAfterSort(env):
+    # matched_terms() reads the index result. When it runs after a buffering step
+    # (SORTBY/GROUPBY) the buffering RP must keep the index result alive, even
+    # without scores or highlighting. Regression guard for the deep-copy gating.
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT', 'n', 'NUMERIC').equal('OK')
+    env.assertOk(env.getClusterConnectionIfNeeded().execute_command('ft.add', 'idx', 'd1', '1.0', 'FIELDS', 'test', 'foo', 'n', '1'))
+    env.assertOk(env.getClusterConnectionIfNeeded().execute_command('ft.add', 'idx', 'd2', '1.0', 'FIELDS', 'test', 'foo', 'n', '2'))
+    # matched_terms() AFTER SORTBY
+    res = env.cmd('ft.aggregate', 'idx', 'foo', 'LOAD', '2', '@test', '@n', 'SORTBY', '2', '@n', 'ASC',
+                  'APPLY', 'matched_terms()', 'as', 'a')
+    for row in res[1:]:
+        env.assertEqual(row[-1], ['foo'])
+
 def testStrFormatError(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT').equal('OK')
     env.assertOk(env.getClusterConnectionIfNeeded().execute_command('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', 'foo'))

--- a/tests/pytests/test_highlight.py
+++ b/tests/pytests/test_highlight.py
@@ -182,3 +182,141 @@ def test_highlight_empty_string_not_index_empty():
     })
 
     env.expect('FT.SEARCH', 't_idx', '@t:("")', 'HIGHLIGHT', 'FIELDS', '1', 't').error().contains("Use `INDEXEMPTY` in field creation in order to index and query for empty strings")
+
+
+# Contract test: the highlight processor needs the RSIndexResult that carries
+# term records and offsets. Buffering pipeline stages (RPSorter, RPDepleter,
+# RPSafeDepleter) hold SearchResults across iterator advances, so they must
+# take ownership of the RSIndexResult — a borrow into the iterator's
+# `it->current` slot would dangle once the iterator is read again.
+#
+# These tests pin highlighted/summarized output to ground truth and run the
+# same logical query through several pipeline shapes (default score sort,
+# explicit numeric SORTBY, KNN-rooted query). All shapes go through a sorter
+# stage; if any of them drops or truncates the RSIndexResult, the highlighted
+# fragment will differ from ground truth — catching regressions that the
+# pre-existing crash-only repros (e.g. test_mod_8695) miss when a stage
+# silently NULLs the field instead of crashing.
+
+def _docs(res):
+    """Return {doc_id: {field: value}} from an FT.SEARCH reply (RESP2)."""
+    out = {}
+    for i in range(1, len(res), 2):
+        fields = res[i + 1]
+        out[res[i]] = dict(zip(fields[0::2], fields[1::2]))
+    return out
+
+
+def test_highlight_contract_across_sorter_modes(env):
+    """Highlighted fragments must match across pipelines that route through
+    different RPSorter modes. Verifies the deep-copied RSIndexResult preserves
+    term records and offsets — not just doc-id and score."""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
+               'body', 'TEXT',
+               'rank', 'NUMERIC', 'SORTABLE').ok()
+
+    conn.hset('doc:1', mapping={'body': 'the quick brown fox jumps over the lazy dog', 'rank': 3})
+    conn.hset('doc:2', mapping={'body': 'a brown dog ran past the brown fence',        'rank': 1})
+    conn.hset('doc:3', mapping={'body': 'no match here',                                'rank': 2})
+
+    waitForIndex(env, 'idx')
+
+    expected = {
+        'doc:1': 'the quick <b>brown</b> fox jumps over the lazy <b>dog</b>',
+        'doc:2': 'a <b>brown</b> <b>dog</b> ran past the <b>brown</b> fence',
+    }
+
+    # Default: score sort → RPSorter_NewByScore.
+    res_score = env.cmd('FT.SEARCH', 'idx', 'brown|dog', 'HIGHLIGHT', 'FIELDS', '1', 'body')
+    env.assertEqual(res_score[0], 2)
+    docs_score = _docs(res_score)
+    for doc_id, want in expected.items():
+        env.assertEqual(docs_score[doc_id]['body'], want)
+
+    # Explicit SORTBY on a numeric field → RPSorter_NewByFields. Different
+    # sorter mode, same buffering invariant; highlighted output must match.
+    res_sortby = env.cmd('FT.SEARCH', 'idx', 'brown|dog', 'SORTBY', 'rank', 'ASC',
+                         'HIGHLIGHT', 'FIELDS', '1', 'body')
+    env.assertEqual(res_sortby[0], 2)
+    docs_sortby = _docs(res_sortby)
+    for doc_id, want in expected.items():
+        env.assertEqual(docs_sortby[doc_id]['body'], want)
+
+
+def test_highlight_contract_multi_field(env):
+    """Highlighting touches every TEXT field in the matched document. Verifies
+    the deep-copied IR carries per-field term records, not just one."""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
+               'title', 'TEXT',
+               'body', 'TEXT').ok()
+
+    conn.hset('doc:1', mapping={
+        'title': 'a brown report on dogs',
+        'body':  'the brown dog walked',
+    })
+    waitForIndex(env, 'idx')
+
+    res = env.cmd('FT.SEARCH', 'idx', 'brown dog',
+                  'HIGHLIGHT', 'FIELDS', '2', 'title', 'body')
+    env.assertEqual(res[0], 1)
+    docs = _docs(res)
+    env.assertEqual(docs['doc:1']['title'], 'a <b>brown</b> report on <b>dogs</b>')
+    env.assertEqual(docs['doc:1']['body'],  'the <b>brown</b> <b>dog</b> walked')
+
+
+def test_summarize_contract_after_sorter(env):
+    """Fragment-mode highlighting after the sorter. SUMMARIZE selects the
+    fragment window from the deep-copied RSIndexResult's byte offsets;
+    HIGHLIGHT wraps the matched term within that window using the same
+    offsets. Both stages read from the RSIndexResult that RPSorter buffers
+    across iterator advances — if the deep copy drops or truncates term
+    offsets, either the window will not contain the term or the term will
+    not be wrapped. SUMMARIZE alone does not apply tags (that is HIGHLIGHT's
+    job), so we pass both clauses to exercise the full offset-consuming path
+    end-to-end."""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'body', 'TEXT').ok()
+
+    body = ('lorem ipsum dolor sit amet ' * 4 +
+            'and then a brown fox appeared ' +
+            'lorem ipsum dolor sit amet ' * 4)
+    conn.hset('doc:1', mapping={'body': body})
+    waitForIndex(env, 'idx')
+
+    res = env.cmd('FT.SEARCH', 'idx', 'brown',
+                  'SUMMARIZE', 'FIELDS', '1', 'body', 'FRAGS', '1', 'LEN', '5',
+                  'HIGHLIGHT', 'FIELDS', '1', 'body')
+    env.assertEqual(res[0], 1)
+    fragment = _docs(res)['doc:1']['body']
+    # The exact window boundaries depend on the tokenizer; we only assert
+    # that the matched term is wrapped, not the full fragment shape.
+    env.assertContains('<b>brown</b>', fragment)
+
+
+def test_highlight_contract_knn_matches_plain(env):
+    """Mirror of test_mod_8695, broadened to multi-term queries. The KNN
+    pipeline routes through HybridIterator + RPSorter; the plain pipeline
+    routes through an inverted-index root + RPSorter. Both must produce
+    identical highlighted output for the same matched documents."""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TEXT',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
+    conn.execute_command('HSET', 'doc1', 't', 'quick brown fox',  'v', '????????')
+    conn.execute_command('HSET', 'doc2', 't', 'lazy brown dog',   'v', '????????')
+    conn.execute_command('HSET', 'doc3', 't', 'a swift red fox',  'v', '????????')
+    waitForIndex(env, 'idx')
+
+    # Multi-term query — exercises offset preservation for two distinct terms.
+    # DIALECT 2 is required for the KNN attribute syntax.
+    plain = env.cmd('FT.SEARCH', 'idx', 'brown fox',
+                    'HIGHLIGHT', 'FIELDS', 1, 't', 'RETURN', 1, 't',
+                    'DIALECT', 2)
+    knn = env.cmd('FT.SEARCH', 'idx', '(brown fox)=>[KNN 10 @v $BLOB]',
+                  'PARAMS', 2, 'BLOB', '????????',
+                  'HIGHLIGHT', 'FIELDS', 1, 't', 'RETURN', 1, 't',
+                  'DIALECT', 2)
+    env.assertEqual(_docs(plain), _docs(knn))


### PR DESCRIPTION
# Take ownership of `RSIndexResult` in buffering result-processor stages

See https://github.com/RediSearch/RediSearch/pull/9479/files#r3208792072 for a very short TL;DR in context.

<details><summary>Other TL;DR as a diagram.</summary>
<p>

```mermaid
flowchart TD
    subgraph ITERATOR["Query Iterator"]
        SLOT["it→current\n(single shared slot,\noverwritten on every Next())"]
    end

    subgraph BORROW["SearchResult (from Next())"]
        RES["_index_result ──── borrow ──→ it→current\nResult_OwnsIndexResult = ✗"]
    end

    subgraph BUFFERS["Buffering stages (RPSorter · RPSafeLoader · RPDepleter · RPSafeDepleter · RPHybridMerger · RPMaxScoreNormalizer)"]
        NULL_HACK["❌ Old: SetIndexResult(NULL)\n→ pointer discarded before buffering"]
        DANGLING["⚠️  Others: pointer kept\n→ dangled silently\n(nothing downstream read it… yet)"]
        OWN["✅ Now: SearchResult_BufferIndexResult()\ngate skipIndexResultDeepCopy:\n• affected RP downstream → DeepCopyAndOwn (heap copy, owns ✓)\n• else → drop borrow (safe, no copy)"]
    end

    subgraph CONSUMERS["Affected result processors (read _index_result: highlighter, matched_terms())"]
        FALLBACK["❌ Old: _index_result == NULL\n→ recover via root iterator\n   (highlighter: Rewind + SkipTo/re-read)\n→ O(K²) for KNN+HIGHLIGHT\n→ implicit contract on root iterator\n   (no SkipTo? broken.)"]
        DIRECT["✅ Now: _index_result present (gate kept the copy)\n→ read offsets directly\n→ O(1) per document\n→ fallback path skipped"]
    end

    subgraph RUST["Rust TopK migration"]
        FAKE["❌ Old: TopK must fake SkipTo\n(yields by score, not doc-id —\n The function pointer to SkipTo is NULL for hybrid iterators)"]
        HONEST["✅ New: TopK keeps honest unimplemented!()\n→ hidden contract gone\n→ migration unblocked"]
    end

    SLOT -. "borrow" .-> RES
    SLOT -. "overwritten on next Next()" .-> SLOT

    RES --> NULL_HACK
    RES --> DANGLING
    RES -->|"this PR"| OWN

    NULL_HACK --> FALLBACK
    DANGLING -.->|"accidental safety"| FALLBACK
    OWN --> DIRECT

    FALLBACK --> FAKE
    DIRECT --> HONEST

    style ITERATOR  fill:#1a1a2e,stroke:#4a90d9,color:#ddd
    style BORROW    fill:#16213e,stroke:#e94560,color:#ddd
    style BUFFERS   fill:#1a1a2e,stroke:#888,color:#ddd
    style CONSUMERS fill:#16213e,stroke:#f5a623,color:#ddd
    style RUST      fill:#1a1a2e,stroke:#9b59b6,color:#ddd
    style NULL_HACK fill:#3d0000,stroke:#e94560,color:#ff9090
    style DANGLING  fill:#3d1500,stroke:#e9a000,color:#ffcc80
    style OWN       fill:#003d1a,stroke:#27ae60,color:#90ffb0
    style FALLBACK  fill:#3d0000,stroke:#e94560,color:#ff9090
    style DIRECT    fill:#003d1a,stroke:#27ae60,color:#90ffb0
    style FAKE      fill:#3d0000,stroke:#e94560,color:#ff9090
    style HONEST    fill:#003d1a,stroke:#27ae60,color:#90ffb0
```


</p>
</details> 

## What

`SearchResult::_index_result` is a non-owning pointer into the source query iterator's `it->current` slot. Several pipeline stages buffer `SearchResult`s across iterator advancement (`RPSorter`, `RPDepleter`, `RPSafeDepleter`, `RPHybridMerger` — each of them holds a pointer that will dangle as soon as the iterator is read again.

This PR makes those buffering stages take ownership of the `RSIndexResult` they hold, via a `Result_OwnsIndexResult` flag on `SearchResult` that is freed on clear/destroy.

This ownership copying is only enabled for those 6 result processors:

| Result processor | Sites | Buffers because… | Triggered by |
| --- | --- | --- | --- |
| `RPSorter` | 2 (heap insert + heap exchange) | keeps a top-N heap across all reads | `SORTBY`, or default sort-by-score |
| `RPSafeLoader` | 1 | accumulates a block to load fields off-GIL | `LOAD`/`RETURN` fields in a **threaded** query |
| `RPMaxScoreNormalizer` | 1 | accumulates all results to find the max score | the `BM25STD.NORM` scorer |
| `RPSafeDepleter` | 1 | drains a subquery on its own thread into an array | **background** hybrid depletion |
| `RPDepleter` | 1 | drains the whole upstream into an array | cursor/threaded reads with no `SORTBY`/`GROUPBY` |
| `RPHybridMerger` | 1 | holds results in a dict to merge across upstreams | `FT.HYBRID` |

## Why

### The codebase has been silently working around this

`RPSorter` defensively NULLs `_index_result` before pushing into its heap. The leading comment claims "thread safety," but the real reason is lifetime: a NULL pointer is fine, a dangling pointer is not. The other three buffering stages don't NULL the field; they get away with it only because nothing currently downstream of them dereferences it.

<details><summary>Performance implications, while true, not the main point of this PR.</summary>
<p>

### The highlight processor has paid the cost

Highlighting needs the `RSIndexResult` (term offsets, frequency, field mask) to compute fragments. When it doesn't find one on the `SearchResult`, it falls back to walking the **root iterator** with `Rewind` + `SkipTo` (or a `Read`-loop when `SkipTo` is unavailable) to re-derive the result. That fallback embeds two unstated invariants on the root iterator:

1. it provides a working `SkipTo(docId)`, **or**
2. it tolerates being re-read from scratch and produces the same `docId`
   again.

Both are accidental properties of today's root iterators, not part of any contract. There is no test, no comment, and no type-level guarantee that a new root iterator must satisfy either.

### Cost: O(K²) per HIGHLIGHT-over-KNN query, today

For a query returning K documents, the recovery path runs K full root restarts. For KNN with `K = 10` over a `HybridIterator` (which sets SkipTo = NULL` and falls back to the Read-loop), this is the dominant cost of HIGHLIGHT. With this PR, the highlighter reads the field directly off the `SearchResult` and the recovery path becomes dead code.


</p>
</details> 

### Soundness

By encoding ownership as a flag bit, "this SearchResult survives across an iterator advance" is now an enforceable property: the buffering stages opt in, `clear()` / `Destroy` automatically free the deep copy, and downstream consumers can dereference `_index_result` without reasoning about the upstream pipeline shape. The hidden coupling between "who is at the root of the query tree" and "is the highlighter correct/cheap" goes away.

### Why now: it unblocks the Rust TopK migration

The Rust port of `TopK` has no honest `SkipTo` semantics — it yields by score, not by doc-id, so "advance to docId" has no meaning. With the recovery path still load-bearing, the migration is forced to either grow a fake `SkipTo` on `TopK` or paper over the gap at the FFI boundary. Landing this fix on master first lets `TopK` keep an honest `unimplemented!()` `skip_to` and removes the migration's pressure to preserve a contract that shouldn't have existed in the first place.

## Tests

- `tests/pytests/test_issues.py::test_mod_8695` — HIGHLIGHT over KNN.
- `tests/pytests/test_hybrid.py::testHybridSearch::test_knn_default_output`
  — exercises the hybrid-merger buffer path.

## Noteworthy

### Benchmarks

Highlight is not benchmarked as far as I know, so we should consider to add benchmarks to it?

We still benchmark RPDepleter, RPSorter and RPHybridMerger indirectly though.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes memory ownership across the core search result pipeline and every stage that buffers results; incorrect ownership would cause use-after-free or leaks, but behavior is covered by new highlight contract tests and a merge-flags unit test.
> 
> **Overview**
> **`SearchResult::_index_result`** is no longer treated as always living in the iterator’s `it->current` slot. A new **`Result_OwnsIndexResult`** flag records when the result holds a heap **`IndexResult_DeepCopy`**, with Rust **`clear()`** and C **`SearchResult_Clear`/`Destroy`** freeing it. Inline helpers split **borrowed** vs **owned** sets, and **`SearchResult_DeepCopyAndOwnIndexResult`** promotes a borrow before buffering.
> 
> Buffering stages (**`RPSorter`**, safe loader, depleters, hybrid merger, max-score normalizer) call that promotion instead of clearing **`_index_result`** (the old “thread safety” NULL). Immediate pipeline steps use **`SearchResult_SetBorrowedIndexResult`**. **`SearchResult_MergeFlags`** no longer copies the ownership bit. Safe-loader handoff uses **`SearchResult_Override`** and re-inits consumed buffer slots.
> 
> Regression tests assert **HIGHLIGHT**/**SUMMARIZE** output (including KNN vs plain) after sorter buffering, so term offsets stay on the result. **`FT.ALIASLIST`** command arity is adjusted to **-2** (minor metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ab15051d02828d18facbe8a2eb97f840ce3229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->