### PR TITLE
[wontfix] Fix NULL dereference in GROUP BY reducer key loading

### DIFF
--- a/src/aggregate/reducer.c
+++ b/src/aggregate/reducer.c
@@ -64,11 +64,14 @@ int ReducerOpts_GetKey(const ReducerOptions *options, const RLookupKey **out) {
   if (!*out) {
     if (options->loadKeys) {
       *out = RLookup_GetKey_Load(options->srclookup, keyName, keyName, RLOOKUP_F_HIDDEN);
-      *options->loadKeys = array_ensure_append_1(*options->loadKeys, *out);
+      if (*out) {
+        *options->loadKeys = array_ensure_append_1(*options->loadKeys, *out);
+      }
     }
-    // We currently allow implicit loading only for known fields from the schema.
-    // If we can't load keys, or the key we loaded is not in the schema, we fail.
-    if (!options->loadKeys || !(RLookupKey_GetFlags(*out) & RLOOKUP_F_SCHEMASRC)) {
+    if (!*out) {
+      return 1;
+    }
+    if (!(RLookupKey_GetFlags(*out) & RLOOKUP_F_SCHEMASRC)) {
       QueryError_SetWithUserDataFmt(options->status, QUERY_ERROR_CODE_NO_PROP_KEY, "Property not loaded nor in pipeline", ": `%s`", keyName);
       return 0;
     }

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -51,6 +51,9 @@ static inline bool isValueAvailable(const RLookupKey *kk, const RLookupRow *dst,
 
 static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
                         RedisModuleKey **keyobj) {
+  if (!kk) {
+    return REDISMODULE_ERR;
+  }
   if (isValueAvailable(kk, dst, options)) {
     return REDISMODULE_OK;
   }


### PR DESCRIPTION
RLookup_GetKey_Load returns NULL when the key is already loaded or has data available from the sorting vector. The NULL pointer was being appended to the loadKeys array and later dereferenced in getKeyCommonHash, causing a crash during FT.AGGREGATE with GROUP BY.

This fix validates the return of RLookup_GetKey_Load before appending to loadKeys and before checking flags. If the key is already available, the function returns immediately. A defensive NULL check is also added in getKeyCommonHash to prevent crashes if a NULL key pointer is passed.

The crash was reported with Redis 7.2.4 and RediSearch 2.8.4 during FT.AGGREGATE queries with GROUP BY and REDUCE COUNT. The backtrace showed the crash path going through Grouper_rpAccum, rpLoader_loadDocument, loadIndividualKeys, getKeyCommonHash, and RM_HashGet.

Closes #8946
Closes redis/redis#15009