### PR TITLE
[2.6] CI: pin ubuntu-latest to ubuntu-24.04 [MOD-15421]

### DIFF
--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -127,7 +127,7 @@ jobs:
       # - test-macos
       - coverage
       - sanitize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !cancelled() }}
     env:
       RESULTS: ${{ toJson(needs.*.result) }} # For debugging purposes

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -40,4 +40,4 @@ jobs:
       get-redis: unstable
       test-config: QUICK=1
       san: address
-      env: ubuntu-latest
+      env: ubuntu-24.04

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -67,7 +67,7 @@ jobs:
       - basic-test
       - coverage
       - sanitize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   validate-tag:
     # Verify that the tag matches the version in src/version.h
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       cur_version: ${{ steps.verify.outputs.cur_version }}
       next_version: ${{ steps.verify.outputs.next_version }}
@@ -99,7 +99,7 @@ jobs:
 
   update-version:
     # Generate a PR to bump the version for the next patch (if releasing from a version branch)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     needs: validate-tag
     if: needs.validate-tag.outputs.should_bump == 'true'
     env:
@@ -165,7 +165,7 @@ jobs:
 
   set-artifacts:
     needs: [validate-tag, generate-matrix]
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
 
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [get-latest-redis-tag]
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
@@ -85,7 +85,7 @@ jobs:
       architecture: ${{ inputs.architecture }}
 
   decide-macos:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ contains(fromJson('["macos", "all"]'), inputs.platform) }}
     outputs:
       platforms: ${{ steps.decide.outputs.platforms }}

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -31,7 +31,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -66,7 +66,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - run # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
     inputs:
       env:
-        default: ubuntu-latest
+        default: ubuntu-24.04
         type: string
       container:
         type: string

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   get-required-envs:
     name: for ${{ inputs.platform }} platform on ${{ inputs.architecture }} architecture
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       platforms_arm: ${{ steps.get_platforms.outputs.arm_platforms }}
       platforms_x86: ${{ steps.get_platforms.outputs.x86_platforms }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       env:
-        default: ubuntu-latest
+        default: ubuntu-24.04
         type: string
       container:
         type: string

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: GitHub Actions is migrating the `ubuntu-latest` runner image alias from `ubuntu-24.04` to `ubuntu-26.04`. Workflows on this branch reference `ubuntu-latest` directly, via `${{ vars.RUNS_ON || 'ubuntu-latest' }}` fallbacks, and as `env:`/`default:` inputs to `task-test.yml` / `task-build-artifacts.yml`. Once the alias flips, jobs will start running on Ubuntu 26.04, which 2.6 does not support.
2. Change: Pin all `ubuntu-latest` references in `.github/workflows/` to `ubuntu-24.04`, including the `default:` values for the `env` workflow_call inputs and the `${{ vars.RUNS_ON || 'ubuntu-latest' }}` fallbacks. The commented-out line in `event-push-to-integ.yml` is left alone.
3. Outcome: 2.6 CI keeps running on `ubuntu-24.04` regardless of when GHA flips the `ubuntu-latest` alias to `ubuntu-26.04`.

#### Which additional issues this PR fixes
1. MOD-15421

#### Main objects this PR modified
1. `.github/workflows/*.yml` — 14 files, 18 replacements of `ubuntu-latest` → `ubuntu-24.04`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change affecting CI runner images; main risk is CI failures if any job implicitly depended on the previous `ubuntu-latest` environment.
> 
> **Overview**
> Pins GitHub Actions workflows to run on `ubuntu-24.04` instead of `ubuntu-latest`, including direct `runs-on` usages, `${{ vars.RUNS_ON || ... }}` fallbacks, and `workflow_call` input defaults.
> 
> This keeps snapshot deploys, PR/merge queue validation, nightly runs, releases, backports, release drafting, and website deploy jobs from unintentionally moving to a newer Ubuntu image when GitHub updates the `ubuntu-latest` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b75d7a7af37fdd7658bad762470550fb9fbb27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->