### PR TITLE
CI: rebalance 8.6-rse PR and merge queue validation

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos-15,macos-26,alpine:3.22,intel'  # on feature branches this should be 'all'
+      platform: all
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -37,8 +37,10 @@ jobs:
     uses: ./.github/workflows/generate-basic-matrix.yml
     with:
       include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
-      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
-      include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
+      # Keep version-branch PRs lightweight: run expensive coverage/sanitizer jobs only
+      # when explicitly requested on ready-for-review PRs. Drafts should stay cheap.
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
+      include-sanitize: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
       separate-coordinator-job: true
 
   test-matrix:


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 8.6-rse PRs automatically run coverage and sanitizer for regular non-draft code/test changes, while merge queue uses a narrower platform set.
2. Change: Make coverage and sanitizer label-forced in non-draft PRs, and expand merge queue validation to the full platform matrix.
3. Outcome: PRs provide lighter author feedback, while the merge queue acts as the release-gate validation for the branch.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. GitHub Actions workflows for 8.6-rse PR and merge queue validation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating and platform coverage for PR vs merge-queue runs; misconfiguration could skip intended validations or increase queue runtime.
> 
> **Overview**
> Rebalances CI between pull requests and the merge queue by **making coverage and sanitizer jobs opt-in on non-draft PRs via `enforce:coverage` / `enforce:sanitize` labels**, instead of running automatically on code/test changes.
> 
> Expands merge-queue validation to run the full `platform: all` matrix (rather than a narrower set), keeping the merge queue as the heavier release-gate signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99b0100c9217ad5d15f7e7ffdf13844b753f6e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->