### PR TITLE
CI: rebalance 8.6 PR and merge queue validation

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos-15,macos-26,alpine:3.22,intel'  # on feature branches this should be 'all'
+      platform: all
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -37,8 +37,10 @@ jobs:
     uses: ./.github/workflows/generate-basic-matrix.yml
     with:
       include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
-      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
-      include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
+      # Keep version-branch PRs lightweight: run expensive coverage/sanitizer jobs only
+      # when explicitly requested on ready-for-review PRs. Drafts should stay cheap.
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
+      include-sanitize: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
       separate-coordinator-job: true
 
   test-matrix:


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 8.6 PRs automatically run coverage and sanitizer for regular non-draft code/test changes, while merge queue uses a narrower platform set.
2. Change: Make coverage and sanitizer label-forced in non-draft PRs, and expand merge queue validation to the full platform matrix.
3. Outcome: PRs provide lighter author feedback, while the merge queue acts as the release-gate validation for the branch.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. GitHub Actions workflows for 8.6 PR and merge queue validation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI gating conditions and platform coverage, which can alter what gets validated pre-merge and impact build times and merge reliability.
> 
> **Overview**
> Rebalances CI for the `8.6` branch by **expanding merge-queue validation** to run the full `platform: all` test matrix in `event-merge-to-queue.yml`.
> 
> Makes PR validation **lighter by default** in `event-pull_request.yml` by only enabling coverage and sanitizer jobs on non-draft PRs when explicitly requested via `enforce:coverage` / `enforce:sanitize` labels (still respecting `ENABLE_CODE_COVERAGE`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936f5a643f6acd1cf41c26b0bb3d9226ebe333be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->