### PR TITLE
CI: rebalance 2.10 PR and merge queue validation

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -30,7 +30,7 @@ jobs:
       platform: all
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      job-test-config: '{"test": "QUICK=1", "coverage": "", "sanitize": ""}'
+      job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,fail-fast,sanitize' }}
       rejson-branch: '2.8'
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -21,8 +21,8 @@ jobs:
     uses: ./.github/workflows/generate-basic-matrix.yml
     with:
       include-basic-test: true
-      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft) || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
-      include-sanitize: ${{ (!github.event.pull_request.draft) || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
+      include-sanitize: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
 
   test-matrix:
     needs: [get-latest-redis-tag, generate-basic-matrix]


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 2.10 PRs automatically run coverage and sanitizer for regular non-draft changes, and merge queue still runs normal tests with `QUICK=1`.
2. Change: Make coverage and sanitizer label-forced in non-draft PRs, and remove `QUICK=1` from merge queue tests.
3. Outcome: PRs provide lighter author feedback, while merge queue runs the full release-gate test suite.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. GitHub Actions workflows for 2.10 PR and merge queue validation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
