### PR TITLE
CI: rebalance 2.8 PR and merge queue validation

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -39,7 +39,6 @@ jobs:
     secrets: inherit
     with:
       redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
-      test-config: QUICK=1
       architecture: aarch64
 
   # Should only run on with latest Redis tag
@@ -49,7 +48,6 @@ jobs:
     secrets: inherit
     with:
       redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
-      test-config: QUICK=1
       rejson-branch: '2.6'
 
   coverage:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -28,11 +28,7 @@ jobs:
 
   coverage:
     needs: [get-latest-redis-tag]
-    if: >
-      (
-        vars.ENABLE_CODE_COVERAGE != 'false' &&
-        (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'enforce:coverage'))
-      )
+    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
     uses: ./.github/workflows/task-test.yml
     with:
       coverage: true
@@ -43,10 +39,7 @@ jobs:
 
   sanitize:
     needs: [get-latest-redis-tag]
-    if: >
-      (
-        (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize'))
-      )
+    if: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
     secrets: inherit
     uses: ./.github/workflows/task-test.yml
     with:


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 2.8 PRs automatically run coverage and sanitizer for regular non-draft changes, and some merge queue platform jobs still use `QUICK=1`.
2. Change: Make coverage and sanitizer label-forced in non-draft PRs, and remove `QUICK=1` from aarch64 and macOS merge queue jobs.
3. Outcome: PRs provide lighter author feedback, while merge queue platform jobs run fuller release-gate validation using the existing older workflow structure.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. GitHub Actions workflows for 2.8 PR and merge queue validation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
