### PR TITLE
CI: rebalance 2.6 PR and merge queue validation

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -80,7 +80,6 @@ jobs:
     secrets: inherit
     with:
       redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
-      test-config: QUICK=1
       architecture: aarch64
 
   # test-macos:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -33,11 +33,7 @@ jobs:
 
   coverage:
     needs: [get-latest-redis-7-2-tag]
-    if: >
-      (
-        vars.ENABLE_CODE_COVERAGE != 'false' &&
-        (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'enforce:coverage'))
-      )
+    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
     uses: ./.github/workflows/task-test.yml
     with:
       coverage: true
@@ -48,10 +44,7 @@ jobs:
 
   sanitize:
     needs: [get-latest-redis-7-2-tag]
-    if: >
-      (
-        (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize'))
-      )
+    if: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
     secrets: inherit
     uses: ./.github/workflows/task-test.yml
     with:


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 2.6 PRs automatically run coverage and sanitizer for regular non-draft changes, and the aarch64 merge queue job still uses `QUICK=1`.
2. Change: Make coverage and sanitizer label-forced in non-draft PRs, and remove `QUICK=1` from the aarch64 merge queue job.
3. Outcome: PRs provide lighter author feedback, while the 2.6 merge queue keeps its multi-Redis release-gate role with fuller platform validation where feasible.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. GitHub Actions workflows for 2.6 PR and merge queue validation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
