### PR TITLE
MOD-14708: Add macOS 14 Intel CI target

### DIFF
--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -78,6 +78,7 @@ jobs:
               ('azurelinux:3', 'aarch64'),
               ('alpine:3.23', 'x86_64'),
               ('alpine:3.23', 'aarch64'),
+              ('macos-14', 'x86_64'),
               ('macos-14', 'aarch64'),
               ('macos-15', 'x86_64'),
               ('macos-15', 'aarch64'),

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -98,6 +98,11 @@ jobs:
           # Platform configurations
           platform_configs = {
               "macos-14": {
+                  "x86_64": {
+                      'env': 'macos-14-large',
+                      'name': 'macOS 14 x86_64',
+                      'enable_lto': '0' # Currently not possible on macOS.
+                  },
                   "aarch64": {
                       'env': 'macos-14',
                       # Apple's ld (through Xcode 16.2) has an ARM64 linker bug that misaligns


### PR DESCRIPTION
## Describe the changes in the pull request
Add macOS 14 Intel (x86_64) without LTO

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow matrix/configuration and don’t affect production code, but may increase CI runtime/cost or expose platform-specific build failures.
> 
> **Overview**
> Adds **macOS 14 x86_64** as a first-class CI platform by including it in the generated test matrix.
> 
> Extends `task-get-config.yml` with a `macos-14` Intel runner configuration (`env: macos-14-large`) and explicitly keeps `enable_lto` disabled for this target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c155bf7024c02317129a1bbfa06999730183434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->