### PR TITLE
[8.2] CI: backport LLVM tarball toolchain to fix Mariner 2 / Azure Linux 3 snapshots [MOD-13606]

### DIFF
--- a/.install/LLVM_VERSION.sh
+++ b/.install/LLVM_VERSION.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# LLVM version used for building RediSearch
+# This must match the LLVM version used by Rust for LTO to work
+# Check with: rustc --version --verbose | grep "LLVM version"
+LLVM_VERSION=21
+LLVM_FULL_VERSION=21.1.8

--- a/.install/common_base_linux_mariner_2.0.sh
+++ b/.install/common_base_linux_mariner_2.0.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
+# Common Base Linux Mariner is the actual full name of the platform.
+# Don't attempt to change the name of this file.
 MODE=$1 # whether to install using sudo or not
 set -e
 export DEBIAN_FRONTEND=noninteractive
-$MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip rsync \
-                         openssl-devel openssl which clang clang-devel gzip gdb
+$MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip xz rsync \
+                         openssl-devel openssl which gzip gdb curl binutils
+
+# The LLVM tarball binaries need GLIBCXX_3.4.30+ but Mariner 2's system
+# libstdc++ (GCC 11) only provides up to GLIBCXX_3.4.29. Install a newer
+# libstdc++ runtime (.so) from Fedora 36 which provides up to GLIBCXX_3.4.30.
+# Fedora 36 _is_ EOL, but was chosen because its version of glibc (2.35)
+# matches that of Mariner 2.
+ARCH=$(uname -m)
+FEDORA_LIBSTDCXX_URL="https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Everything/${ARCH}/os/Packages/l/libstdc++-12.0.1-0.16.fc36.${ARCH}.rpm"
+curl -fSL -o /tmp/libstdcpp.rpm "$FEDORA_LIBSTDCXX_URL"
+$MODE rpm -Uvh --force --nodeps /tmp/libstdcpp.rpm
+rm -f /tmp/libstdcpp.rpm
+
+# Install LLVM for LTO
+source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -1,23 +1,170 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-# Source the profile update utility
-source "$(dirname "$0")/macos_update_profile.sh"
+export DEBIAN_FRONTEND=noninteractive
+APT_GET_LOCK_TIMEOUT_SECONDS="${APT_GET_LOCK_TIMEOUT_SECONDS:-600}"
+
+# =============================================================================
+# install_llvm.sh — Install LLVM across all CI platforms
+#
+# Usage:
+#   ./install_llvm.sh [MODE]
+#
+# MODE is an optional privilege-escalation prefix (e.g. "sudo").
+# If empty, commands run unprivileged (useful inside containers).
+#
+# Reads LLVM_VERSION.sh for LLVM_VERSION (major, e.g. "21") and
+# LLVM_FULL_VERSION (e.g. "21.1.8").
+#
+# Environment variables:
+#   LLVM_INSTALL_DIR  — Where to unpack tarball installs (default: /usr/local/llvm)
+# =============================================================================
 
 OS_TYPE=$(uname -s)
-VERSION=18
-MODE=$1
+ARCH=$(uname -m)
 
-if [[ $OS_TYPE == Darwin ]]; then
-    brew install llvm@$VERSION
-    BREW_PREFIX=$(brew --prefix)
-    LLVM="$BREW_PREFIX/opt/llvm@$VERSION/bin"
+# Source LLVM_VERSION (major) and LLVM_FULL_VERSION (e.g. 21.1.8)
+source "$(dirname "${BASH_SOURCE[0]}")/LLVM_VERSION.sh"
+LLVM_VER="${LLVM_VERSION}"
+LLVM_FULL_VER="${LLVM_FULL_VERSION}"
 
-    # Update profiles with LLVM path
-    [[ -f ~/.bash_profile ]] && update_profile ~/.bash_profile "$LLVM"
-    [[ -f ~/.zshrc ]] && update_profile ~/.zshrc "$LLVM"
+INSTALL_DIR="${LLVM_INSTALL_DIR:-/usr/local/llvm}"
+MODE="${1:-}"
+
+# Download and unpack the official LLVM tarball into $INSTALL_DIR.
+# Works on any glibc-based Linux. Will NOT work on musl/Alpine.
+install_from_tarball() {
+    local tarball_name
+    case "$ARCH" in
+        x86_64)  tarball_name="LLVM-${LLVM_FULL_VER}-Linux-X64.tar.xz" ;;
+        aarch64) tarball_name="LLVM-${LLVM_FULL_VER}-Linux-ARM64.tar.xz" ;;
+        *)       echo "ERROR: unsupported arch ${ARCH}"; return 1 ;;
+    esac
+
+    local url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_FULL_VER}/${tarball_name}"
+
+    echo ">>> Downloading LLVM ${LLVM_FULL_VER} from ${url}"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    curl -fSL --retry 3 -o "${tmpdir}/${tarball_name}" "$url"
+
+    echo ">>> Extracting to ${INSTALL_DIR}..."
+    $MODE mkdir -p "$INSTALL_DIR"
+    $MODE tar -xf "${tmpdir}/${tarball_name}" -C "$INSTALL_DIR" --strip-components=1
+    rm -rf "$tmpdir"
+
+    export_path_gha
+    echo ">>> LLVM ${LLVM_FULL_VER} installed to ${INSTALL_DIR}"
+}
+
+# Wire up $INSTALL_DIR/bin for GitHub Actions and the current shell.
+export_path_gha() {
+    local bindir="${INSTALL_DIR}/bin"
+    if [[ -n "${GITHUB_PATH:-}" ]]; then
+        echo "${bindir}" >> "$GITHUB_PATH"
+    fi
+    if [[ -n "${GITHUB_ENV:-}" ]]; then
+        echo "LIBCLANG_PATH=${INSTALL_DIR}/lib" >> "$GITHUB_ENV"
+    fi
+    export PATH="${bindir}:${PATH}"
+    export LIBCLANG_PATH="${INSTALL_DIR}/lib"
+}
+
+# ---------------------------------------------------------------------------
+# Source the macOS profile updater if present.
+# ---------------------------------------------------------------------------
+if [[ "$OS_TYPE" == "Darwin" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "${SCRIPT_DIR}/macos_update_profile.sh" ]]; then
+        source "${SCRIPT_DIR}/macos_update_profile.sh"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Detect distro and install.
+# ---------------------------------------------------------------------------
+install_llvm() {
+    # ----- macOS (Homebrew) ---------------------------------------------------
+    if [[ "$OS_TYPE" == "Darwin" ]]; then
+        echo ">>> macOS — installing via Homebrew"
+        brew install "llvm@${LLVM_VER}"
+
+        local brew_prefix llvm_bin
+        brew_prefix=$(brew --prefix)
+        llvm_bin="${brew_prefix}/opt/llvm@${LLVM_VER}/bin"
+
+        if type update_profile &>/dev/null; then
+            [[ -f ~/.bash_profile ]] && update_profile ~/.bash_profile "$llvm_bin"
+            [[ -f ~/.zshrc ]]        && update_profile ~/.zshrc "$llvm_bin"
+        fi
+        [[ -n "${GITHUB_PATH:-}" ]] && echo "${llvm_bin}" >> "$GITHUB_PATH"
+        return 0
+    fi
+
+    # ----- Linux: detect distro -----------------------------------------------
+    local distro="" distro_version=""
+    if [[ -f /etc/os-release ]]; then
+        distro=$(. /etc/os-release && echo "${ID:-unknown}")
+        distro_version=$(. /etc/os-release && echo "${VERSION_ID:-}")
+    fi
+    # The GHA Alpine workaround rewrites /etc/os-release ID; detect via apk.
+    if [[ -f /etc/alpine-release ]] && command -v apk &>/dev/null; then
+        distro="alpine"
+        distro_version=$(cat /etc/alpine-release)
+    fi
+
+    echo ">>> Detected distro=${distro} version=${distro_version} arch=${ARCH}"
+
+    case "$distro" in
+
+    # ----- Debian / Ubuntu (apt.llvm.org) ------------------------------------
+    ubuntu|debian)
+        echo ">>> Using apt.llvm.org"
+        $MODE apt-get -o DPkg::Lock::Timeout="$APT_GET_LOCK_TIMEOUT_SECONDS" update -qq
+        $MODE apt-get -o DPkg::Lock::Timeout="$APT_GET_LOCK_TIMEOUT_SECONDS" install -y --no-install-recommends \
+            lsb-release wget software-properties-common gnupg ca-certificates
+        wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+        chmod +x /tmp/llvm.sh
+        $MODE /tmp/llvm.sh "$LLVM_VER"
+        rm -f /tmp/llvm.sh
+        ;;
+
+    # ----- Alpine Linux (apk) ------------------------------------------------
+    alpine)
+        echo ">>> Alpine Linux — trying apk packages"
+        # Alpine 3.23+ has llvm21 in main; 3.22 only has llvm20.
+        # Official tarballs are glibc-based and won't work here.
+        if $MODE apk add --no-cache "llvm${LLVM_VER}" "clang${LLVM_VER}" "lld${LLVM_VER}" 2>/dev/null; then
+            echo ">>> Installed llvm${LLVM_VER} from Alpine repos"
+        elif $MODE apk add --no-cache llvm clang lld; then
+            echo ">>> Installed default llvm/clang (may not be version ${LLVM_VER})"
+        else
+            echo "ERROR: No LLVM package available. Upgrade to Alpine 3.23+ or use edge."
+            return 1
+        fi
+        ;;
+
+    # ----- Everything else: official tarball ----------------------------------
+    # Rocky, CentOS, RHEL, AlmaLinux, Fedora, Amazon Linux, Mariner, Azure Linux
+    *)
+        echo ">>> ${distro} ${distro_version} — installing from official tarball"
+        install_from_tarball
+        ;;
+
+    esac
+}
+
+install_llvm
+
+echo ""
+echo ">>> Verifying..."
+if command -v "clang-${LLVM_VER}" &>/dev/null; then
+    "clang-${LLVM_VER}" --version
+elif command -v clang &>/dev/null; then
+    clang --version
+elif [[ -x "${INSTALL_DIR}/bin/clang" ]]; then
+    "${INSTALL_DIR}/bin/clang" --version
 else
-    $MODE apt install -y lsb-release wget software-properties-common gnupg
-    wget https://apt.llvm.org/llvm.sh
-    chmod +x llvm.sh
-    $MODE ./llvm.sh $VERSION
+    echo "WARNING: clang not found on PATH. You may need to add ${INSTALL_DIR}/bin to PATH."
 fi

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -3,9 +3,10 @@ MODE=$1 # whether to install using sudo or not
 set -e
 export DEBIAN_FRONTEND=noninteractive
 
-$MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip \
-                         rsync openssl-devel \
-                         which clang libxcrypt-devel clang-devel gdb
+$MODE tdnf install -yq build-essential ca-certificates gdb git libxcrypt-devel openssl-devel rsync tar unzip wget which xz
+
+# Install LLVM for LTO
+source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ RUN bash retry.sh bash -l -eo pipefail install_script.sh
 WORKDIR /project
 RUN bash .install/retry.sh bash -l -eo pipefail .install/test_deps/install_rust_deps.sh
 # Expose newly-installed Rust and Python tools via PATH
-ENV PATH="/root/.cargo/bin:/root/.local/bin:${PATH}"
+ENV PATH="/usr/local/llvm/bin:/root/.cargo/bin:/root/.local/bin:${PATH}"
 
 WORKDIR /project


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: 8.2 builds Redis from `redis/redis@unstable` (hard-coded in `flow-build-artifacts.yml`). After [redis/redis#15096](https://github.com/redis/redis/pull/15096) (merged 2026-05-09), the bundled jemalloc is now built with `-flto=auto` and exports new `je_*_with_usize` symbols. The Mariner 2 and Azure Linux 3 jobs in `deploy-snapshots` fail because their stock `binutils` (`nm`/`ar`/`ranlib`) cannot read LTO bitcode without GCC's `liblto_plugin.so`, so jemalloc's symbol-extraction step (`nm -a … | gawk -f private_symbols.awk`) silently produces an empty `.sym` file and the final `redis-server` link fails with `undefined reference to je_malloc_with_usize` (and the other three `_with_usize` variants). All other 18 platforms pass. See [run 25624654869](https://github.com/RediSearch/RediSearch/actions/runs/25624654869).
2. Change: Backport three commits from `master` that already solved this on the toolchain side:
   - #8722 — rewrite `install_llvm.sh` to download the official LLVM 21.1.8 tarball into `/usr/local/llvm` for non-Debian distros (replaces the apt-only 8.2 version);
   - #8828 — wire `install_llvm.sh` into `microsoft_azure_linux_3.0.sh` and add `xz` for tarball extraction;
   - #8830 — wire `install_llvm.sh` into `common_base_linux_mariner_2.0.sh`, add `xz`/`curl`/`binutils`, and install Fedora 36's `libstdc++` rpm to satisfy the LLVM tarball's `GLIBCXX_3.4.30+` requirement (Mariner 2's GCC 11 only ships up to 3.4.29).

   Two hunks from the master commits were dropped to keep the backport minimal:
   - the `enable_lto: '1'` additions in `task-get-config.yml` from #8828 and #8830 — that key has no consumer on 8.2, so it would be dead code;
   - the `source install_llvm.sh` line added to `ubuntu_24.04.sh` by #8722 — Ubuntu builds are not affected by the upstream Redis LTO change, so we leave them on the existing apt toolchain.
3. Outcome: The Mariner 2 and Azure Linux 3 jobs use LLVM 21 `clang`/`lld`, which understand LTO bitcode natively. Jemalloc symbol extraction succeeds, the `je_*_with_usize` symbols are exported, and the `redis-server` link resolves. `deploy-snapshots` for `mariner:2 (x86_64)`, `azurelinux:3 (x86_64)`, and `azurelinux:3 (aarch64)` go green again. The fix is scoped to 8.2 by being a branch-only change; no other version branches are touched.

#### Which additional issues this PR fixes
1. MOD-13606

#### Main objects this PR modified
1. `.install/install_llvm.sh` (rewritten — tarball-based, multi-distro)
2. `.install/LLVM_VERSION.sh` (new — pins LLVM 21.1.8)
3. `.install/microsoft_azure_linux_3.0.sh` (sources `install_llvm.sh`, adds `xz`, drops `clang`/`clang-devel` now provided by the LLVM tarball)
4. `.install/common_base_linux_mariner_2.0.sh` (sources `install_llvm.sh`, adds `xz`/`curl`/`binutils`, installs Fedora 36 `libstdc++` for `GLIBCXX_3.4.30+`)
5. `Dockerfile` (prepends `/usr/local/llvm/bin` to `PATH`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author