### PR TITLE
MOD-15487: Stop Updating numRecords For Vector Fields

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -648,7 +648,6 @@ FIELD_BULK_INDEXER(vectorIndexer) {
     VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
     curr_vec += fdata->vecLen;
   }
-  sp->stats.numRecords += fdata->numVec;
   return 0;
 }
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1956,7 +1956,7 @@ def test_index_multi_value_json():
             waitForIndex(env, 'idx')
             info = index_info(env, 'idx')
             env.assertEqual(info['num_docs'], n, message=f'data_t: {data_t}')
-            env.assertEqual(info['num_records'], n * per_doc * len(info['attributes']), message=f'data_t: {data_t}')
+            env.assertEqual(info['num_records'], 0, message=f'data_t: {data_t}')
             env.assertEqual(info['hash_indexing_failures'], 0, message=f'data_t: {data_t}')
 
             cmd_knn[2] = f'*=>[KNN {k} @hnsw $b AS {score_field_name}]'
@@ -2026,7 +2026,7 @@ def test_bad_index_multi_value_json():
     # we should NOT fail if some of the vectors are NULLs
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), None, (np.ones(dim) * 2).tolist()]})
     env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], failures)
-    env.assertEqual(index_info(env, 'idx')['num_records'], 4)
+    env.assertEqual(index_info(env, 'idx')['num_records'], 0)
 
     # ...or if the path returns NULL
     conn.json().set(46, '.', {'vecs': None})


### PR DESCRIPTION
Num records in the vector field context has no real meaning
It also never got decremented so it skewed the stats of num records.
Will stop updating it entirely.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the externally visible `FT.INFO num_records` metric by no longer counting vectors as records, which may impact monitoring/expectations but not search correctness.
> 
> **Overview**
> Stops updating `IndexSpec.stats.numRecords` when indexing vector fields (i.e., `vectorIndexer` no longer increments `numRecords` per stored vector).
> 
> Updates vecsim pytest expectations to reflect that `FT.INFO num_records` remains `0` in vector-only indexing scenarios, including multi-value JSON vector paths and NULL-skipping cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03321620229800459a39ac82871b7a6ebf413b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->