### PR TITLE
MOD-14810: Test FT.HYBRID and COLLECT integration

### DIFF
--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -143,6 +143,50 @@ def test_hybrid_groupby_large():
     expected_categories = Counter(doc['category'] for doc in test_docs.values() if l2_from_bytes(doc['embedding'], query_vector)**2 <= radius)
     env.assertEqual(Counter(results), expected_categories)
 
+def test_hybrid_groupby_collect_yielded_scores():
+    """Two COLLECT reducers in one GROUPBY, each projecting a YIELD_SCORE_AS alias from a different subquery"""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    test_docs = setup_hybrid_groupby_index(env)
+
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+    radius = 2**2  # vector subset = docs at L2 distance <= 2 (6 of 9 docs)
+
+    response = env.cmd('FT.HYBRID', 'idx',
+                            'SEARCH', 'red', 'YIELD_SCORE_AS', 'search_score',
+                            'VSIM', '@embedding', '$BLOB', 'RANGE', '2', 'RADIUS', str(radius),
+                                'YIELD_SCORE_AS', 'vector_score',
+                       'LOAD', '1', '@__key',
+                       'GROUPBY', '1', '@category',
+                            'REDUCE', 'COLLECT', '4', 'FIELDS', '2', '@__key', '@vector_score', 'AS', 'vector_results',
+                            'REDUCE', 'COLLECT', '4', 'FIELDS', '2', '@__key', '@search_score', 'AS', 'search_results',
+                       'PARAMS', '2', 'BLOB', query_vector)
+
+    in_vector = {k for k, d in test_docs.items() if l2_from_bytes(d['embedding'], query_vector)**2 <= radius}
+    expected = {cat: {k for k, d in test_docs.items() if d['category'] == cat}
+                for cat in {d['category'] for d in test_docs.values()}}
+
+    groups = {row['category']: row for row in response['results']}
+    env.assertEqual(set(groups), set(expected))
+
+    for category, keys in expected.items():
+        search = groups[category]['search_results']
+        env.assertEqual({e['__key'] for e in search}, keys)
+        for e in search:
+            env.assertEqual(set(e), {'__key', 'search_score'})
+            env.assertGreater(float(e['search_score']), 0.0)
+
+        vector = groups[category]['vector_results']
+        env.assertEqual({e['__key'] for e in vector}, keys)
+        for e in vector:
+            if e['__key'] in in_vector:
+                env.assertEqual(set(e), {'__key', 'vector_score'})
+                expected_score = 1.0 / (1.0 + l2_from_bytes(test_docs[e['__key']]['embedding'], query_vector)**2)
+                env.assertAlmostEqual(float(e['vector_score']), expected_score, delta=1e-6)
+            else:
+                env.assertEqual(set(e), {'__key'})
+
+
 def test_hybrid_groupby_with_filter():
     """Test hybrid search with groupby + filter to verify result count consistency"""
     env = Env()


### PR DESCRIPTION

Add `test_hybrid_groupby_collect_yielded_scores` in `tests/pytests/test_hybrid_groupby.py`, which runs an `FT.HYBRID` with two `COLLECT` reducers in one `GROUPBY` - each projecting `@__key` plus a different subquery's `YIELD_SCORE_AS` alias. Verifies hybrid RLookup integration and results with the `COLLECT` reducer.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because the PR only adds a new pytest that exercises `FT.HYBRID` behavior; no production logic is modified.
> 
> **Overview**
> Adds a new regression test, `test_hybrid_groupby_collect_yielded_scores`, that runs `FT.HYBRID` with a single `GROUPBY` containing **two `COLLECT` reducers**, each collecting `@__key` plus a different `YIELD_SCORE_AS` alias (search vs vector). The test validates per-group collected rows, presence/absence of projected score fields based on subquery participation, and checks vector scores against the expected L2-based formula.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6040b7cd7d6d5d2e5fca4b2897d50507439b0a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->