### PR TITLE
[8.2] Use ubuntu-slim In Some Workflows

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -214,7 +214,7 @@ jobs:
       - benchmark-search-oss-standalone-profiler
       - benchmark-vecsim-oss-standalone-profiler
     if: ${{ failure() && inputs.notify_failure }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -24,7 +24,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -52,7 +52,7 @@ jobs:
       - get-latest-redis-tag
       - lint
       - test-matrix
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -37,7 +37,7 @@ jobs:
   notify-failure:
     needs: [lint, test-all-platforms, micro-benchmarks]
     if: failure()
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -73,7 +73,7 @@ jobs:
       - spellcheck
       - lint
       - test-matrix
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -95,7 +95,7 @@ jobs:
 
   update-version:
     # Generate a PR to bump the version for the next patch (if releasing from a version branch)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     needs: validate-tag
     if: needs.validate-tag.outputs.should_bump == 'true'
     env:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
       redis-ref: ${{ steps.get-redis.outputs.tag }}

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   prepare_runner_configurations:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/generate-basic-matrix.yml
+++ b/.github/workflows/generate-basic-matrix.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Assign:
     if: ${{ !contains(github.event.issue.labels.*.name, 'feature') }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   change-checks:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs: # Make sure to return "true" if any workflow was changed, to make sure the workflow works
       CODE_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
       BENCHMARK_CHANGED: ${{ steps.check-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   get-config:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       env: ${{ steps.get-config.outputs.env }}
       container: ${{ steps.get-config.outputs.container }}

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-release-notes-check.yml
+++ b/.github/workflows/task-release-notes-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-release-notes:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - name: Check release notes checkbox
         env:

--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -4,7 +4,7 @@ on: [workflow_call]
 
 jobs:
   spellcheck:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   take:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     env:
       GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
       ASSIGNEE: ${{ inputs.assignee || github.actor }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -87,7 +87,7 @@ jobs:
     needs: get-config
     name: Start self-hosted EC2 runner
     if: ${{ needs.get-config.outputs.ec2_image_id }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     env:
       TAGS: | # Make sure there is no trailing comma!
         [
@@ -507,7 +507,7 @@ jobs:
     name: Stop self-hosted EC2 runner
     needs: [start-runner, common-flow]
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |


### PR DESCRIPTION
# Description
Backport of #9482 to `8.2`.

Reduce workflow costs by switching light tasks that don't require a
multi-core machine to use the `ubuntu-slim` runner.

## Conflict resolution

The auto-backport failed because the cherry-pick of b4a357681a
produced merge conflicts in every touched workflow file: the `runs-on:`
lines on `master` had drifted from this branch (different default runner
value, restructured jobs, new files). The resolution applied here keeps
this branch's existing structure and only changes the relevant `runs-on:`
values to `ubuntu-slim`, matching the intent of #9482.

### Files updated (21)

| File | Job | Previous `runs-on` |
|------|-----|--------------------|
| `.github/workflows/benchmark-runner.yml` | `notify-failure` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/event-deploy-snapshots.yml` | `notify-failure` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/event-nightly.yml` | `notify-failure` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/event-release.yml` | `update-version` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/flow-build-artifacts.yml` | `setup` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/flow-micro-benchmarks.yml` | `prepare_runner_configurations` | `ubuntu-24.04` |
| `.github/workflows/generate-basic-matrix.yml` | `generate` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/generate-matrix.yml` | `generate` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-assign-for-issue.yml` | `Assign` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-backport_pr.yml` | `backport` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-check-changes.yml` | `change-checks` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-get-config.yml` | `get-config` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-get-latest-tag.yml` | `get-tag` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-release-drafter.yml` | `update_release_draft` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-release-notes-check.yml` | `check-release-notes` | `ubuntu-24.04` |
| `.github/workflows/task-spellcheck.yml` | `spellcheck` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-stale.yml` | `stale` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-take-shift.yml` | `take` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-test.yml` | `start-runner` | `ubuntu-24.04` |
| `.github/workflows/task-test.yml` | `stop-runner` | `ubuntu-24.04` |
| `.github/workflows/task-website-deploy.yml` | `trigger` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |

### Files from #9482 that don't exist on `8.2` (2)

These workflows were added after `8.2` diverged, so the change has
nothing to apply to here:

- `.github/workflows/event-merge-queue-resubmit.yml`
- `.github/workflows/link-check.yml`

### Jobs from #9482 that don't exist on `8.2` (4)

These jobs were added or restructured on `master` after `8.2` diverged,
so the change has nothing to apply to here:

- `.github/workflows/benchmark-runner.yml` :: `notify-msmarco-failure`
- `.github/workflows/event-merge-to-queue.yml` :: `notify-failure`
- `.github/workflows/event-pull_request.yml` :: `notify-failure`
- `.github/workflows/event-weekly.yml` :: `link-check`

### Jobs that delegate to a reusable workflow (2)

On `8.2` these jobs `uses:` a reusable workflow rather than running
inline, so they have no `runs-on:` of their own — the runner change is picked
up from the reusable workflow already updated in this PR:

- `.github/workflows/event-merge-to-queue.yml` :: `get-latest-redis-tag`
- `.github/workflows/event-pull_request.yml` :: `get-latest-redis-tag`

## Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `runs-on` runner selection in GitHub Actions workflows, with no impact on product code. Main risk is CI behavior differences/availability of the `ubuntu-slim` runner causing workflow failures or slower execution for affected jobs.
> 
> **Overview**
> Switches a set of *lightweight GitHub Actions jobs* (e.g., matrix generation, PR validation gates, notifications, issue/PR automation, and EC2 runner start/stop helpers) from `${{ vars.RUNS_ON || 'ubuntu-24.04' }}`/`ubuntu-24.04` to `ubuntu-slim` to reduce CI cost.
> 
> No workflow logic changes beyond runner selection; core build/test jobs and other heavier tasks remain on their existing runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04eba798729acc7d2f6d1064e56fbea2eee8d567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->