### PR TITLE
[2.10] Use ubuntu-slim In Some Workflows

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -207,7 +207,7 @@ jobs:
       - benchmark-search-oss-standalone-profiler
       - benchmark-vecsim-oss-standalone-profiler
     if: ${{ failure() && inputs.notify_failure }}
-    runs-on: ${{ vars.RUNS_ON }}
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -38,7 +38,7 @@ jobs:
     needs:
       - get-latest-redis-tag
       - test-matrix
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -48,7 +48,7 @@ jobs:
     needs:
       - get-latest-redis-tag
       - test-matrix
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -99,7 +99,7 @@ jobs:
 
   update-version:
     # Generate a PR to bump the version for the next patch (if releasing from a version branch)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     needs: validate-tag
     if: needs.validate-tag.outputs.should_bump == 'true'
     env:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -45,7 +45,7 @@ jobs:
 
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     needs: [get-latest-redis-tag]
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}

--- a/.github/workflows/generate-basic-matrix.yml
+++ b/.github/workflows/generate-basic-matrix.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Assign:
     if: ${{ !contains(github.event.issue.labels.*.name, 'feature') }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   get-config:
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
+    runs-on: ubuntu-slim
     outputs:
       env: ${{ steps.get-config.outputs.env }}
       container: ${{ steps.get-config.outputs.container }}

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-release-notes-check.yml
+++ b/.github/workflows/task-release-notes-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-release-notes:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - name: Check release notes checkbox
         env:

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   take:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     env:
       GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
       ASSIGNEE: ${{ inputs.assignee || github.actor }}

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |


### PR DESCRIPTION
# Description
Backport of #9482 to `2.10`.

Reduce workflow costs by switching light tasks that don't require a
multi-core machine to use the `ubuntu-slim` runner.

## Conflict resolution

The auto-backport failed because the cherry-pick of b4a357681a
produced merge conflicts in every touched workflow file: the `runs-on:`
lines on `master` had drifted from this branch (different default runner
value, restructured jobs, new files). The resolution applied here keeps
this branch's existing structure and only changes the relevant `runs-on:`
values to `ubuntu-slim`, matching the intent of #9482.

### Files updated (15)

| File | Job | Previous `runs-on` |
|------|-----|--------------------|
| `.github/workflows/benchmark-runner.yml` | `notify-failure` | `${{ vars.RUNS_ON }}` |
| `.github/workflows/event-deploy-snapshots.yml` | `notify-failure` | `ubuntu-24.04` |
| `.github/workflows/event-release.yml` | `update-version` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/flow-build-artifacts.yml` | `setup` | `ubuntu-24.04` |
| `.github/workflows/generate-basic-matrix.yml` | `generate` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/generate-matrix.yml` | `generate` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-assign-for-issue.yml` | `Assign` | `ubuntu-24.04` |
| `.github/workflows/task-backport_pr.yml` | `backport` | `ubuntu-24.04` |
| `.github/workflows/task-get-config.yml` | `get-config` | `${{ vars.RUNS_ON \|\| 'ubuntu-24.04' }}` |
| `.github/workflows/task-get-latest-tag.yml` | `get-tag` | `ubuntu-24.04` |
| `.github/workflows/task-release-drafter.yml` | `update_release_draft` | `ubuntu-24.04` |
| `.github/workflows/task-release-notes-check.yml` | `check-release-notes` | `ubuntu-24.04` |
| `.github/workflows/task-stale.yml` | `stale` | `ubuntu-24.04` |
| `.github/workflows/task-take-shift.yml` | `take` | `ubuntu-24.04` |
| `.github/workflows/task-website-deploy.yml` | `trigger` | `ubuntu-24.04` |

### Files from #9482 that don't exist on `2.10` (5)

These workflows were added after `2.10` diverged, so the change has
nothing to apply to here:

- `.github/workflows/event-merge-queue-resubmit.yml`
- `.github/workflows/flow-micro-benchmarks.yml`
- `.github/workflows/link-check.yml`
- `.github/workflows/task-check-changes.yml`
- `.github/workflows/task-spellcheck.yml`

### Jobs from #9482 that don't exist on `2.10` (7)

These jobs were added or restructured on `master` after `2.10` diverged,
so the change has nothing to apply to here:

- `.github/workflows/benchmark-runner.yml` :: `notify-msmarco-failure`
- `.github/workflows/event-merge-to-queue.yml` :: `notify-failure`
- `.github/workflows/event-nightly.yml` :: `notify-failure`
- `.github/workflows/event-pull_request.yml` :: `notify-failure`
- `.github/workflows/event-weekly.yml` :: `link-check`
- `.github/workflows/task-test.yml` :: `start-runner`
- `.github/workflows/task-test.yml` :: `stop-runner`

### Jobs that delegate to a reusable workflow (2)

On `2.10` these jobs `uses:` a reusable workflow rather than running
inline, so they have no `runs-on:` of their own — the runner change is picked
up from the reusable workflow already updated in this PR:

- `.github/workflows/event-merge-to-queue.yml` :: `get-latest-redis-tag`
- `.github/workflows/event-pull_request.yml` :: `get-latest-redis-tag`

## Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions `runs-on` values for several lightweight CI jobs; behavior should be unchanged aside from runner environment differences.
> 
> **Overview**
> Switches multiple GitHub Actions workflows on the `2.10` branch to run lightweight jobs (matrix generation, validation, notifications, backport automation, and website deploy trigger) on the cheaper `ubuntu-slim` runner instead of `ubuntu-24.04` or `${{ vars.RUNS_ON }}`.
> 
> User impact: **reduced CI cost** (and potentially faster scheduling) with no intended change to build/test logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de6621b86ff13b6ddc39d4077ae3ffda26797377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->