### PR TITLE
[2.8] Use ubuntu-slim In Some Workflows

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -206,7 +206,7 @@ jobs:
       - benchmark-search-oss-standalone-profiler
       - benchmark-vecsim-oss-standalone-profiler
     if: ${{ failure() && inputs.notify_failure }}
-    runs-on: ${{ vars.RUNS_ON }}
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -81,7 +81,7 @@ jobs:
       - test-macos
       - coverage
       - sanitize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -61,7 +61,7 @@ jobs:
       - basic-test
       - coverage
       - sanitize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -99,7 +99,7 @@ jobs:
 
   update-version:
     # Generate a PR to bump the version for the next patch (if releasing from a version branch)
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ubuntu-slim
     needs: validate-tag
     if: needs.validate-tag.outputs.should_bump == 'true'
     env:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -45,7 +45,7 @@ jobs:
 
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [get-latest-redis-tag]
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |


### PR DESCRIPTION
# Description
Backport of #9482 to `2.8`.

Reduce workflow costs by switching light tasks that don't require a
multi-core machine to use the `ubuntu-slim` runner.

## Conflict resolution

The auto-backport failed because the cherry-pick of b4a357681a
produced merge conflicts in every touched workflow file: the `runs-on:`
lines on `master` had drifted from this branch (different default runner
value, restructured jobs, new files). The resolution applied here keeps
this branch's existing structure and only changes the relevant `runs-on:`
values to `ubuntu-slim`, matching the intent of #9482.

### Files updated (8)

| File | Job | Previous `runs-on` |
|------|-----|--------------------|
| `.github/workflows/benchmark-runner.yml` | `notify-failure` | `${{ vars.RUNS_ON }}` |
| `.github/workflows/event-deploy-snapshots.yml` | `notify-failure` | `ubuntu-latest` |
| `.github/workflows/event-release.yml` | `update-version` | `${{ vars.RUNS_ON \|\| 'ubuntu-latest' }}` |
| `.github/workflows/flow-build-artifacts.yml` | `setup` | `ubuntu-latest` |
| `.github/workflows/task-backport_pr.yml` | `backport` | `ubuntu-latest` |
| `.github/workflows/task-get-latest-tag.yml` | `get-tag` | `ubuntu-latest` |
| `.github/workflows/task-release-drafter.yml` | `update_release_draft` | `ubuntu-latest` |
| `.github/workflows/task-website-deploy.yml` | `trigger` | `ubuntu-latest` |

### Files from #9482 that don't exist on `2.8` (12)

These workflows were added after `2.8` diverged, so the change has
nothing to apply to here:

- `.github/workflows/event-merge-queue-resubmit.yml`
- `.github/workflows/flow-micro-benchmarks.yml`
- `.github/workflows/generate-basic-matrix.yml`
- `.github/workflows/generate-matrix.yml`
- `.github/workflows/link-check.yml`
- `.github/workflows/task-assign-for-issue.yml`
- `.github/workflows/task-check-changes.yml`
- `.github/workflows/task-get-config.yml`
- `.github/workflows/task-release-notes-check.yml`
- `.github/workflows/task-spellcheck.yml`
- `.github/workflows/task-stale.yml`
- `.github/workflows/task-take-shift.yml`

### Jobs from #9482 that don't exist on `2.8` (8)

These jobs were added or restructured on `master` after `2.8` diverged,
so the change has nothing to apply to here:

- `.github/workflows/benchmark-runner.yml` :: `notify-msmarco-failure`
- `.github/workflows/event-merge-to-queue.yml` :: `get-latest-redis-tag`
- `.github/workflows/event-merge-to-queue.yml` :: `notify-failure`
- `.github/workflows/event-nightly.yml` :: `notify-failure`
- `.github/workflows/event-pull_request.yml` :: `notify-failure`
- `.github/workflows/event-weekly.yml` :: `link-check`
- `.github/workflows/task-test.yml` :: `start-runner`
- `.github/workflows/task-test.yml` :: `stop-runner`

### Jobs that delegate to a reusable workflow (1)

On `2.8` these jobs `uses:` a reusable workflow rather than running
inline, so they have no `runs-on:` of their own — the runner change is picked
up from the reusable workflow already updated in this PR:

- `.github/workflows/event-pull_request.yml` :: `get-latest-redis-tag`

## Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk runner-only change, but could break if any of these jobs implicitly rely on tools/packages present on `ubuntu-24.04`/custom runners but not on `ubuntu-slim`.
> 
> **Overview**
> Updates multiple GitHub Actions workflows to run *lightweight* jobs on `ubuntu-slim` instead of `ubuntu-24.04` or `${{ vars.RUNS_ON }}`.
> 
> This affects jobs like failure notifications, PR validation gate jobs, version bump PR creation, artifact workflow setup, backport automation, latest-tag lookup, release drafter, and website deploy trigger—aimed at reducing CI runner cost without changing job logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64eeaa429687ac15c43ac179e2c5ab95e7667c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->