### PR TITLE
MOD-15254 Enable vector range queries for disk indexes

### DIFF
--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -32,7 +32,6 @@
 #include <assert.h>
 
 #include "../parse.h"
-#include "../../search_disk.h"
 
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
@@ -2483,9 +2482,6 @@ static YYACTIONTYPE yy_reduce(
   yylhsminor.yy3 = NULL;
   if (ctx->sctx->spec && !FIELD_IS(yymsp[-4].minor.yy150.fs, INDEXFLD_T_VECTOR)) {
     REPORT_WRONG_FIELD_TYPE(yymsp[-4].minor.yy150, SPEC_VECTOR_STR);
-    QueryNode_Free(yymsp[-1].minor.yy3);
-  } else if (SearchDisk_IsEnabledForValidation()) {
-    reportSyntaxError(ctx->status, &yymsp[-4].minor.yy150.tok, "Syntax error: vector range queries are currently not supported in Redis Flex");
     QueryNode_Free(yymsp[-1].minor.yy3);
   } else if (yymsp[-1].minor.yy3) {
     yymsp[-1].minor.yy3->vn.vq->field = yymsp[-4].minor.yy150.fs;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -75,7 +75,6 @@
 #include <assert.h>
 
 #include "../parse.h"
-#include "../../search_disk.h"
 
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
@@ -1130,9 +1129,6 @@ expr(A) ::= modifier(B) COLON LSQB vector_range_command(C) RSQB. {
   A = NULL;
   if (ctx->sctx->spec && !FIELD_IS(B.fs, INDEXFLD_T_VECTOR)) {
     REPORT_WRONG_FIELD_TYPE(B, SPEC_VECTOR_STR);
-    QueryNode_Free(C);
-  } else if (SearchDisk_IsEnabledForValidation()) {
-    reportSyntaxError(ctx->status, &B.tok, "Syntax error: vector range queries are currently not supported in Redis Flex");
     QueryNode_Free(C);
   } else if (C) {
     C->vn.vq->field = B.fs;

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -136,14 +136,11 @@ TEST_F(QueryTest, testDiskVectorQueryRestrictions) {
       "@title:hello=>[KNN 2 @vec_field $BLOB]=>{$HYBRID_POLICY:BATCHES;}";
 
   {
-    // Disk-backed specs reject VECTOR_RANGE during parsing.
+    // Disk-backed specs accept VECTOR_RANGE during parsing.
     QASTCXX ast;
     ast.setContext(&ctx);
-    ASSERT_FALSE(ast.parse(range_query, version));
-    ASSERT_NE(ast.getError(), nullptr);
-    ASSERT_NE(strstr(ast.getError(), "vector range queries are currently not supported in Redis Flex"),
-              nullptr)
-        << ast.getError();
+    ASSERT_TRUE(ast.parse(range_query, version))
+        << (ast.getError() ? ast.getError() : "");
   }
 
   SearchOptionsCXX opts;

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -461,10 +461,6 @@ def test_disk_vector_query_validation(env: Env):
 
     query_blob = create_np_array_typed([1.0, 1.0], 'FLOAT32').tobytes()
 
-    env.expect('FT.SEARCH', 'idx', '@v:[VECTOR_RANGE 10 $b]', 'NOCONTENT',
-                'PARAMS', '2', 'b', query_blob).error().contains(
-                    'vector range queries are currently not supported in Redis Flex')
-
     env.expect('FT.SEARCH', 'idx', '@t:hello=>[KNN 2 @v $b]', 'NOCONTENT',
                 'PARAMS', '2', 'b', query_blob).error().contains(
                     'Redis Flex pre-filtered vector queries currently require explicit HYBRID_POLICY')
@@ -480,6 +476,31 @@ def test_disk_vector_query_validation(env: Env):
         res = env.cmd('FT.SEARCH', 'idx', query, 'NOCONTENT', 'PARAMS', '2', 'b', query_blob)
         env.assertEqual(res[0], 2, message=f'Expected 2 results for query "{query}"')
         env.assertEqual(set(res[1:]), {'doc:1', 'doc:2'}, message=f'Expected results doc:1 and doc:2 for query "{query}"')
+
+    # Vector range queries are supported on Flex disk indexes. With L2 (squared)
+    # distance and a query vector of [1.0, 1.0]: doc:1 -> 0, doc:2 -> 2,
+    # doc:3 -> 4802. Radius 10 returns doc:1 and doc:2; radius 0 returns doc:1
+    # only; a very large radius returns all docs.
+    range_cases = [
+        ('@v:[VECTOR_RANGE 10 $b]', {'doc:1', 'doc:2'}),
+        ('@v:[VECTOR_RANGE 0 $b]', {'doc:1'}),
+        ('@v:[VECTOR_RANGE 100000 $b]', {'doc:1', 'doc:2', 'doc:3'}),
+        # Hybrid range with text prefilter exercises the BY_ID intersection path.
+        ('@t:hello @v:[VECTOR_RANGE 10 $b]', {'doc:1', 'doc:2'}),
+        ('@t:goodbye @v:[VECTOR_RANGE 100000 $b]', {'doc:3'}),
+    ]
+
+    for query, expected in range_cases:
+        res = env.cmd('FT.SEARCH', 'idx', query, 'NOCONTENT',
+                      'PARAMS', '2', 'b', query_blob)
+        env.assertEqual(res[0], len(expected),
+                        message=f'Expected {len(expected)} results for query "{query}"')
+        env.assertEqual(set(res[1:]), expected,
+                        message=f'Unexpected results for query "{query}"')
+
+    # Negative radius is still rejected by the vector index validation path.
+    env.expect('FT.SEARCH', 'idx', '@v:[VECTOR_RANGE -1 $b]', 'NOCONTENT',
+               'PARAMS', '2', 'b', query_blob).error()
 
 
 @skip(cluster=True)


### PR DESCRIPTION

## Describe the changes in the pull request

enable range queries for disk index

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `VECTOR_RANGE` queries for disk-backed/Flex indexes by removing a parser-level rejection, which changes supported query surface and could affect runtime validation/iterator behavior for vector search on disk.
> 
> **Overview**
> Allows `VECTOR_RANGE` vector range queries to be parsed for disk-backed (Flex) specifications by removing the `SearchDisk_IsEnabledForValidation()`-gated syntax error from the v2 query grammar (`parser.y`) and its generated output (`parser.c`).
> 
> Updates C++ and Python Flex validation tests to expect `VECTOR_RANGE` parsing and execution to succeed (including result-set assertions for different radii and hybrid text+range cases), while still rejecting invalid radii via the existing vector index validation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c766a66851535ab9583ddcaa45b5e3d997921a6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->