### PR TITLE
[8.2] CI: Pin Redis to latest 8.2 tag instead of unstable [MOD-14918]

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -40,23 +40,24 @@ on:
         default: all
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.2'
+
   setup:
+    needs: [get-latest-redis-tag]
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-24.04' }}
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       version-suffix: ${{ steps.set-version.outputs.VERSION_SUFFIX }}
     steps:
       - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=unstable" >> $GITHUB_OUTPUT
       - name: Generate Version Suffix
         id: set-version
         run: |


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `flow-build-artifacts.yml` on 8.2 hard-codes `redis-ref: unstable`. The recent Redis change [redis/redis#15096](https://github.com/redis/redis/pull/15096) (merged 2026-05-09) enabled `-flto=auto` for the bundled jemalloc and added new `je_*_with_usize` symbols. The default `nm` shipped on `mariner:2` and `azurelinux:3` cannot read LTO bitcode without GCC's `liblto_plugin.so`, so jemalloc's symbol-extraction step silently produces an empty `.sym` file and the final `redis-server` link fails with `undefined reference to je_malloc_with_usize`. Snapshot deploys for `mariner:2 (x86_64)`, `azurelinux:3 (x86_64)`, and `azurelinux:3 (aarch64)` are red.
2. Change: Mirror the workaround already in place on 8.6 (PR #9116). Add a `get-latest-redis-tag` job that calls `task-get-latest-tag.yml` with `repo: redis/redis` and `prefix: '8.2'`, wire `setup` to depend on it, and source `redis-ref` from the new job's output. The inline `get-redis` step is dropped. RediSearch 8.2 is now validated against the matching Redis 8.2 release line (currently `8.2.6`, published 2026-05-05) — the same line it ships into.
3. Outcome: Snapshot deploys go green again on Mariner 2 / Azure Linux 3. CI no longer tracks `redis/redis@unstable`, so it is insulated from future breaking changes there.

#### Which additional issues this PR fixes
1. MOD-14918

#### Main objects this PR modified
1. `.github/workflows/flow-build-artifacts.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.