### PR TITLE
rqe_iterators_bencher: make revalidate as unsafe

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -169,7 +169,7 @@ impl QueryIterator {
     }
 
     #[inline(always)]
-    pub fn revalidate(&self, spec: *mut ffi::IndexSpec) -> ValidateStatus {
+    pub unsafe fn revalidate(&self, spec: *mut ffi::IndexSpec) -> ValidateStatus {
         unsafe { (*self.0).Revalidate.unwrap()(self.0, spec) }
     }
 


### PR DESCRIPTION
Fix clippy warning.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small API signature change that only affects callers by requiring an `unsafe` context; no behavioral logic changes.
> 
> **Overview**
> Marks `QueryIterator::revalidate` as `unsafe` in `rqe_iterators_bencher` to reflect its raw-pointer FFI contract and silence clippy warnings, requiring callers to wrap invocations in an `unsafe` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2316127bc4852657ea97db86b0afaffce6c2823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->