### PR TITLE
MOD-6607: fix flaky test numbers

### DIFF
--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -136,6 +136,10 @@ def testRangeParentsConfig(env):
 def testEmptyNumericLeakIncrease(env):
     # test numeric field which updates with increasing value
 
+    # Make sure GC is not triggered sporadically (only manually)
+    env.expect(config_cmd(), 'SET', 'FORK_GC_RUN_INTERVAL', 3600).equal('OK')
+    env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
+
     conn = getConnectionByEnv(env)
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a single pytest and only adjust test setup to avoid nondeterministic background GC affecting assertions.
> 
> **Overview**
> Stabilizes `testEmptyNumericLeakIncrease` by explicitly configuring fork GC to not run automatically (long `FORK_GC_RUN_INTERVAL` and `FORK_GC_CLEAN_THRESHOLD=0`), ensuring the test’s GC-related assertions only observe manually-invoked collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ffc13e41f2c6faa65404cc300f3c2582368c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->