### PR TITLE
ci: fix echo labels to match actual step names in task-test.yml

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -512,11 +512,11 @@ jobs:
             steps.coordinator_tests.outcome == 'failure'
           )
         run: |
-          echo "C Unit Tests: ${{ steps.c_unit_tests.outcome }}"
-          echo "Rust Unit Tests: ${{ steps.rust_unit_tests.outcome }}"
-          echo "Rust Unit Tests(Miri): ${{ steps.rust_unit_tests_miri.outcome }}"
-          echo "Standalone: ${{ steps.standalone_tests.outcome }}"
-          echo "Coordinator: ${{ steps.coordinator_tests.outcome }}"
+          echo "C/C++ tests: ${{ steps.c_unit_tests.outcome }}"
+          echo "Rust tests: ${{ steps.rust_unit_tests.outcome }}"
+          echo "Rust tests (MIRI): ${{ steps.rust_unit_tests_miri.outcome }}"
+          echo "Flow tests (standalone): ${{ steps.standalone_tests.outcome }}"
+          echo "Flow tests (coordinator): ${{ steps.coordinator_tests.outcome }}"
           exit 1
       - name: Import Codecov GPG public key
         if: inputs.coverage


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes log `echo` labels in a GitHub Actions workflow and does not affect test execution or conditions.
> 
> **Overview**
> Updates `.github/workflows/task-test.yml` so the final failure-reporting step prints clearer labels that match the current step names (e.g., **C/C++**, **Rust**, and **Flow** tests, including MIRI/standalone/coordinator variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315d800f3f6c2afd77c4c88831df0b045a36c1a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->