### PR TITLE
ci: fix echo labels to match actual step names in task-lint.yml

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -150,11 +150,11 @@ jobs:
           steps.dep-licenses.outcome == 'failure' ||
           steps.workspace_hack.outcome == 'failure'
         run: |
-          echo "Linting: ${{ steps.lint.outcome }}"
-          echo "License header: ${{ steps.license-header.outcome }}"
+          echo "Lint: ${{ steps.lint.outcome }}"
           echo "Generated files: ${{ steps.git-diff.outcome }}"
-          echo "Formatting: ${{ steps.fmt.outcome }}"
+          echo "License header: ${{ steps.license-header.outcome }}"
+          echo "Format check: ${{ steps.fmt.outcome }}"
           echo "Security advisories: ${{ steps.advisories.outcome }}"
           echo "Dependency licenses: ${{ steps.dep-licenses.outcome }}"
-          echo "Workspace hack: ${{ steps.workspace_hack.outcome }}"
+          echo "Workspace hack check: ${{ steps.workspace_hack.outcome }}"
           exit 1

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -514,9 +514,9 @@ jobs:
         run: |
           echo "C/C++ tests: ${{ steps.c_unit_tests.outcome }}"
           echo "Rust tests: ${{ steps.rust_unit_tests.outcome }}"
-          echo "Rust tests (MIRI): ${{ steps.rust_unit_tests_miri.outcome }}"
           echo "Flow tests (standalone): ${{ steps.standalone_tests.outcome }}"
           echo "Flow tests (coordinator): ${{ steps.coordinator_tests.outcome }}"
+          echo "Rust tests (MIRI): ${{ steps.rust_unit_tests_miri.outcome }}"
           exit 1
       - name: Import Codecov GPG public key
         if: inputs.coverage


### PR DESCRIPTION
Also use the same order as the steps.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts log/echo output ordering and wording in GitHub Actions workflows without changing any execution logic or conditions.
> 
> **Overview**
> Tightens the failure-summary output in CI workflows so the final `exit 1` step prints **labels that match the actual step names** (e.g., `Lint`, `Format check`, `Workspace hack check`) and keeps them in a consistent order.
> 
> Also reorders the `Rust tests (MIRI)` line in `task-test.yml`’s failure-report block to match the step listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bba460415135f473bc4e6932d44337ce923e5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->