### PR TITLE
[8.0] MOD-15487: Stop Updating numRecords For Vector Fields

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -629,7 +629,6 @@ FIELD_BULK_INDEXER(vectorIndexer) {
     VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
     curr_vec += fdata->vecLen;
   }
-  sp->stats.numRecords += fdata->numVec;
   return 0;
 }
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1824,7 +1824,7 @@ def test_index_multi_value_json():
             waitForIndex(env, 'idx')
             info = index_info(env, 'idx')
             env.assertEqual(info['num_docs'], n)
-            env.assertEqual(info['num_records'], n * per_doc * len(info['attributes']))
+            env.assertEqual(info['num_records'], 0)
             env.assertEqual(info['hash_indexing_failures'], 0)
 
             cmd_knn[2] = f'*=>[KNN {k} @hnsw $b AS {score_field_name}]'
@@ -1878,7 +1878,7 @@ def test_bad_index_multi_value_json():
     # we should NOT fail if some of the vectors are NULLs
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), None, (np.ones(dim) * 2).tolist()]})
     env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], failures)
-    env.assertEqual(index_info(env, 'idx')['num_records'], 2)
+    env.assertEqual(index_info(env, 'idx')['num_records'], 0)
 
     # ...or if the path returns NULL
     conn.json().set(46, '.', {'vecs': None})


### PR DESCRIPTION
# Description
Backport of #9500 to `8.0`.

Num records in the vector field context has no real meaning
It also never got decremented so it skewed the stats of num records.
Will stop updating it entirely.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes index statistics reporting (`num_records`) for vector fields and adjusts tests accordingly, without affecting indexing/query behavior.
> 
> **Overview**
> Stops incrementing `IndexSpec->stats.numRecords` when adding vectors in `vectorIndexer` (including multi-value vector JSON paths), since the counter is not meaningful for vector fields and was never decremented.
> 
> Updates vecsim pytests to expect `num_records` to remain `0` after vector indexing and reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6401ac16e9a8b8e11e92e0434db339ed037db4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->