### PR TITLE
[2.8] MOD-15487: Stop Updating numRecords For Vector Fields

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -696,7 +696,6 @@ FIELD_BULK_INDEXER(vectorIndexer) {
     VecSimIndex_AddVector(vecsim, curr_vec, aCtx->doc->docId);
     curr_vec += fdata->vecLen;
   }
-  sp->stats.numRecords += fdata->numVec;
   return 0;
 }
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1815,7 +1815,7 @@ def test_index_multi_value_json():
             waitForIndex(env, 'idx')
             info = index_info(env, 'idx')
             env.assertEqual(info['num_docs'], info_type(n))
-            env.assertEqual(info['num_records'], info_type(n * per_doc * len(info['attributes'])))
+            env.assertEqual(info['num_records'], info_type(0))
             env.assertEqual(info['hash_indexing_failures'], info_type(0))
 
             cmd_knn[2] = f'*=>[KNN {k} @hnsw $b AS {score_field_name}]'
@@ -1870,7 +1870,7 @@ def test_bad_index_multi_value_json():
     # we should NOT fail if some of the vectors are NULLs
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), None, (np.ones(dim) * 2).tolist()]})
     env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
-    env.assertEqual(index_info(env, 'idx')['num_records'], info_type(2))
+    env.assertEqual(index_info(env, 'idx')['num_records'], info_type(0))
 
     # ...or if the path returns NULL
     conn.json().set(46, '.', {'vecs': None})


### PR DESCRIPTION
# Description
Backport of #9500 to `2.8`.

Num records in the vector field context has no real meaning
It also never got decremented so it skewed the stats of num records.
Will stop updating it entirely.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to index statistics reporting for vector fields and corresponding test expectations, with no impact on vector search/indexing behavior.
> 
> **Overview**
> Stops incrementing `IndexSpec.stats.numRecords` when indexing vector fields in `vectorIndexer`, since the metric was misleading for vectors and never decremented.
> 
> Updates vecsim Python tests to expect `FT.INFO num_records` to remain `0` even when indexing multi-value vectors and when vectors include NULLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b24a00b408e360b2eb6d8dfe44029096779b59f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->