### PR TITLE
[CI] Tune CI change filtering

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -25,7 +25,12 @@ jobs:
     # with:
     #   repo: redis/redis
 
+  check-what-changed:
+    uses: ./.github/workflows/task-check-changes.yml
+
   lint:
+    needs: check-what-changed
+    if: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -36,7 +41,10 @@ jobs:
       advisories-base-ref: ${{ github.event.merge_group.base_sha }}
 
   test-matrix:
-    needs: [get-latest-redis-tag, lint]
+    # Wait for lint so we do not spend MQ test capacity when CI is already going to fail.
+    # Use explicit status checks so test-only changes still run even when lint is skipped.
+    needs: [get-latest-redis-tag, check-what-changed, lint]
+    if: ${{ !cancelled() && !failure() && (needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true') }}
     permissions:
       contents: read
       packages: write
@@ -54,6 +62,7 @@ jobs:
   pr-validation:
     needs:
       - get-latest-redis-tag
+      - check-what-changed
       - lint
       - test-matrix
     runs-on: ubuntu-slim

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -40,17 +40,38 @@ jobs:
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
-                **
-                .*
-                .*/**
+                src/**
+                deps/**
+                build/**
+                cmake/**
+                srcutil/**
+                sbin/**
+                scripts/**
+                pack/**
+                .install/**
+                .clang-format
+                .codespell/**
+                .devcontainer/**
+                .dockerignore
+                .gitignore
+                .gitmodules
+                .python-version
+                .rust-nightly
+                CMakeLists.txt
+                Makefile
+                Dockerfile
+                build.sh
+                commands.json
+                module.conf
+                pyproject.toml
+                rust-toolchain.toml
+                uv.lock
           files_ignore: |
-                .github/**
                 .skills/**
                 docs/**
                 tests/**
                 **/*.md
                 **/*.markdown
-                **/*.txt
                 **/README
                 **/LICENSE
                 **/NOTICE
@@ -91,7 +112,6 @@ jobs:
           files_ignore: |
               **/*.md
               **/*.markdown
-              **/*.txt
               **/README
               **/LICENSE
               **/NOTICE

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs: # Make sure to return "true" if any workflow was changed, to make sure the workflow works
       CODE_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
-      BENCHMARK_CHANGED: ${{ steps.check-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
+      BENCHMARK_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
       RUST_CODE_CHANGED: ${{ steps.check-micro-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
       TESTS_CHANGED: ${{ steps.check-tests.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
     steps:
@@ -35,27 +35,44 @@ jobs:
           files: |
                 .github/workflows/**
                 .github/actions/**
-      - name: Check if code were changed
+      - name: Check if code was changed
         id: check-code
         uses: tj-actions/changed-files@v47.0.6
-        with: # Only run on changes to these paths (code, deps)
+        with:
           files: |
-                src/**
-                deps/**
-                **/CMakeLists.txt
-                **/Makefile
+                **
+                .*
+                .*/**
+          files_ignore: |
+                .github/**
+                .skills/**
+                docs/**
+                tests/**
+                **/*.md
+                **/*.markdown
+                **/*.txt
+                **/README
+                **/LICENSE
+                **/NOTICE
+                **/CHANGELOG
+                **/*.adoc
+                **/*.rst
+                **/*.svg
+                **/*.png
+                **/*.jpg
+                **/*.jpeg
+                **/*.gif
+                **/*.webp
+                **/*.ico
+                **/*.pdf
           fetch_additional_submodule_history: true
-      - name: Check if benchmarks or code were changed
+      - name: Check if benchmark files were changed
         id: check-benchmarks
         uses: tj-actions/changed-files@v47.0.6
-        with: # Only run on changes to these paths (code, deps, and benchmarks related changes)
+        with:
           files: |
-                src/**
-                deps/**
                 tests/benchmarks/**
                 .github/workflows/benchmark-*.yml
-                **/CMakeLists.txt
-                **/Makefile
           fetch_additional_submodule_history: true
       - name: Check if tests were changed
         id: check-tests
@@ -71,3 +88,21 @@ jobs:
         with: # Only run on changes to these paths (redisearch_rs)
           files: |
               src/redisearch_rs/**
+          files_ignore: |
+              **/*.md
+              **/*.markdown
+              **/*.txt
+              **/README
+              **/LICENSE
+              **/NOTICE
+              **/CHANGELOG
+              **/*.adoc
+              **/*.rst
+              **/*.svg
+              **/*.png
+              **/*.jpg
+              **/*.jpeg
+              **/*.gif
+              **/*.webp
+              **/*.ico
+              **/*.pdf

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -18,9 +18,9 @@ jobs:
   change-checks:
     runs-on: ubuntu-slim
     outputs: # Make sure to return "true" if any workflow was changed, to make sure the workflow works
-      CODE_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
-      BENCHMARK_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
-      RUST_CODE_CHANGED: ${{ steps.check-micro-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
+      CODE_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-cmake.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
+      BENCHMARK_CHANGED: ${{ steps.check-code.outputs.any_modified == 'true' || steps.check-cmake.outputs.any_modified == 'true' || steps.check-benchmarks.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
+      RUST_CODE_CHANGED: ${{ steps.check-micro-benchmarks.outputs.any_modified == 'true' || steps.check-rust-cmake.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
       TESTS_CHANGED: ${{ steps.check-tests.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
     steps:
       - name: Checkout
@@ -40,6 +40,8 @@ jobs:
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
+                *
+                .*
                 src/**
                 deps/**
                 build/**
@@ -49,29 +51,16 @@ jobs:
                 scripts/**
                 pack/**
                 .install/**
-                .clang-format
                 .codespell/**
                 .devcontainer/**
-                .dockerignore
-                .gitignore
-                .gitmodules
-                .python-version
-                .rust-nightly
-                CMakeLists.txt
-                Makefile
-                Dockerfile
-                build.sh
-                commands.json
-                module.conf
-                pyproject.toml
-                rust-toolchain.toml
-                uv.lock
           files_ignore: |
+                .github/**
                 .skills/**
                 docs/**
                 tests/**
                 **/*.md
                 **/*.markdown
+                **/*.txt
                 **/README
                 **/LICENSE
                 **/NOTICE
@@ -87,6 +76,12 @@ jobs:
                 **/*.ico
                 **/*.pdf
           fetch_additional_submodule_history: true
+      - name: Check if CMake files were changed
+        id: check-cmake
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+                **/CMakeLists.txt
       - name: Check if benchmark files were changed
         id: check-benchmarks
         uses: tj-actions/changed-files@v47.0.6
@@ -126,3 +121,9 @@ jobs:
               **/*.webp
               **/*.ico
               **/*.pdf
+      - name: Check if Rust CMake files were changed
+        id: check-rust-cmake
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+              src/redisearch_rs/CMakeLists.txt


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: PR and merge queue CI filtering is based on a narrow set of code paths. This skips docs-only changes in many cases, but it can still run CI for Markdown files under code/test directories and can miss build-adjacent files such as root configs, build scripts, `cmake/**`, and `srcutil/**`.
2. Change: Tune the reusable change-check workflow so `CODE_CHANGED` is broad by default while ignoring docs, Markdown/prose files, skills, tests, workflow metadata, and static assets. Keep tests and workflow changes as explicit triggers, and reuse the same change-check outputs in the merge queue workflow.
3. Outcome: Docs-only and other non-code-only PRs avoid expensive lint/build/test jobs in both PR and merge queue flows, while code, tests, CI, and build-affecting changes still trigger the relevant CI.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `.github/workflows/task-check-changes.yml`
2. `.github/workflows/event-merge-to-queue.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Validation:

- Parsed the touched workflows with Python YAML loading.
- Ran `git diff --check`.
- `actionlint` was not installed locally, so it was not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating logic for lint/tests based on path filters, so misclassification could incorrectly skip required checks or run extra CI in merge queue.
> 
> **Overview**
> Updates merge-queue workflow `event-merge-to-queue.yml` to reuse `task-check-changes.yml` outputs, running `lint` only when `CODE_CHANGED` and running the test matrix when either `CODE_CHANGED` or `TESTS_CHANGED` (while still waiting for lint to finish).
> 
> Expands and refines `task-check-changes.yml` path filters: broadens what counts as `CODE_CHANGED` (including root/build tooling paths) while explicitly ignoring docs/prose/static assets, and adds dedicated checks for `**/CMakeLists.txt` and Rust CMake changes to improve build-impact detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db699b7ac2104688beb442f5f96ce0a8994e1d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->