### PR TITLE
remove unused `normalizeStr`

### DIFF
--- a/src/sortable.c
+++ b/src/sortable.c
@@ -16,36 +16,6 @@
 #include "buffer.h"
 #include "sortable.h"
 
-/* Normalize sorting string for storage. This folds everything to unicode equivalent strings. The
- * allocated return string needs to be freed later */
-char *normalizeStr(const char *str) {
-  size_t buflen = 2 * strlen(str) + 1;
-  char *lower_buffer = rm_calloc(buflen, 1);
-  char *lower = lower_buffer;
-  char *end = lower + buflen;
-
-  const char *p = str;
-  size_t off = 0;
-  while (*p != 0 && lower < end) {
-    uint32_t in = 0;
-    p = nu_utf8_read(p, &in);
-    const char *lo = nu_tofold(in);
-
-    if (lo != 0) {
-      uint32_t u = 0;
-      do {
-        lo = nu_casemap_read(lo, &u);
-        if (u == 0) break;
-        lower = nu_utf8_write(u, lower);
-      } while (u != 0 && lower < end);
-    } else {
-      lower = nu_utf8_write(in, lower);
-    }
-  }
-
-  return lower_buffer;
-}
-
 /* Load a sorting vector from RDB */
 RSSortingVector SortingVector_RdbLoad(RedisModuleIO *rdb) {
 

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -18,10 +18,6 @@ extern "C" {
 /* Load a sorting vector from RDB. Used by legacy RDB load only */
 RSSortingVector SortingVector_RdbLoad(RedisModuleIO *rdb);
 
-/* Normalize sorting string for storage. This folds everything to unicode equivalent strings. The
- * allocated return string needs to be freed later */
-char *normalizeStr(const char *str);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
finally

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that removes an unused string-normalization helper and its header declaration, with no functional path changes.
> 
> **Overview**
> Removes the unused `normalizeStr` Unicode folding/lowercasing helper from `sortable.c` and deletes its declaration from `sortable.h`, leaving only the sorting vector RDB load API exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a481ecdbd386a9fd35900b1e4de7c71d659858f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->