### PR TITLE
[Skill] Document PR history rewrite policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Invoke [/jj-fix-conflicts](.skills/jj-fix-conflicts/SKILL.md) to resolve conflic
 - Once a branch has an open pull request, do not amend, rebase, squash, or force-push it unless the user explicitly asks for history rewriting.
 - Address review feedback with normal follow-up commits and regular pushes.
 - Before opening a pull request, history cleanup is acceptable when it is useful and does not discard user work.
+- When opening a pull request, use `.github/PULL_REQUEST_TEMPLATE.md` for the description and keep all template sections.
+- Write PR titles as concise user-facing summaries; if release notes are required, describe the user impact in the title as requested by the template.
 
 ## License Header (Required)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ Invoke [/write-rust-tests](.skills/write-rust-tests/SKILL.md) to add tests to Ru
 Invoke [/verify](.skills/verify/SKILL.md) to verify the correctness of your work before wrapping up.
 Invoke [/jj-fix-conflicts](.skills/jj-fix-conflicts/SKILL.md) to resolve conflicts in a jj changes.
 
+## Pull Request Workflow
+
+- Once a branch has an open pull request, do not amend, rebase, squash, or force-push it unless the user explicitly asks for history rewriting.
+- Address review feedback with normal follow-up commits and regular pushes.
+- Before opening a pull request, history cleanup is acceptable when it is useful and does not discard user work.
+
 ## License Header (Required)
 ```
 /*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,9 @@ Invoke [/jj-fix-conflicts](.skills/jj-fix-conflicts/SKILL.md) to resolve conflic
 - Address review feedback with normal follow-up commits and regular pushes.
 - Before opening a pull request, history cleanup is acceptable when it is useful and does not discard user work.
 - When opening a pull request, use `.github/PULL_REQUEST_TEMPLATE.md` for the description and keep all template sections.
-- Write PR titles as concise user-facing summaries; if release notes are required, describe the user impact in the title as requested by the template.
+- For normal PRs to `master` or another primary target branch, use the title format `[MOD-xyz] concise user-facing summary` when a Jira ticket exists. If no ticket is known, ask the user whether one should be opened before choosing the title.
+- For backport PRs, use the title format `[x.y] original title`, where `x.y` is the target branch. In the PR description, link back to the original PR.
+- If release notes are required, make sure the title describes the user impact as requested by the PR template.
 
 ## License Header (Required)
 ```


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The repo-level agent instructions do not explicitly say how to handle history rewriting once a pull request is open.
2. Change: Add a pull request workflow section to `AGENTS.md` that forbids amend/rebase/squash/force-push after a PR is open unless the user explicitly asks for history rewriting.
3. Outcome: Future review fixes should be added as normal follow-up commits and pushed normally, reducing review disruption.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `AGENTS.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it adds PR workflow guidance and does not affect runtime behavior.
> 
> **Overview**
> Adds a new **Pull Request Workflow** section to `AGENTS.md` that documents expectations for PR hygiene.
> 
> It explicitly discourages amending/rebasing/squashing/force-pushing once a PR is open (unless requested), and sets conventions for follow-up commits, using the PR template, and PR/backport title formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603cea636eb761fa7ff991aefbfeca4bba99b1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->