### PR TITLE
[8.4] CI: bump remaining actions/checkout@v4 -> @v6 (MOD-15112 followup)

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -206,7 +206,7 @@ jobs:
       # Get Redis
       - name: Get Redis (node20)
         if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: redis/redis
           ref: ${{ inputs.redis-ref }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -349,7 +349,7 @@ jobs:
           echo "ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-$CLANG_VERSION/bin/llvm-symbolizer" >> $GITHUB_ENV
       - name: Get Redis (node20)
         if: ${{ steps.node20.outputs.supported == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: redis/redis
           ref: ${{ inputs.redis-ref }}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Two `actions/checkout@v4` references on the `8.4` branch were missed by the MOD-15112 cherry-pick (`a9fc15bd`):
   - `.github/workflows/task-test.yml:352` — `Get Redis (node20)`
   - `.github/workflows/task-build-artifacts.yml:209` — `Get Redis (node20)`
   
   Their misleading `(node20)` step names probably caused them to be skipped during the bulk bump. They run on every platform where `steps.node20.outputs.supported == 'true'` (i.e. everything except `amazonlinux:2`).
2. **Change**: Bump both to `actions/checkout@v6`. No other changes — the `node20`-detection split is left in place because `8.4` still ships `amazonlinux:2`, which has glibc too old for Node 24 (and increasingly Node 20).
3. **Outcome**: Completes the Node 20 deprecation cleanup on `8.4` ahead of GitHub's 2026-06-02 forced-Node-24 cutover. Removes the `Node.js 20 actions are deprecated` warning currently emitted by every snapshot deploy run.

Verified after this PR: `grep -rn 'actions/checkout@v4' .github/` returns no matches on `8.4`.

#### Which additional issues this PR fixes
1. MOD-15112 (cherry-pick gap)

#### Main objects this PR modified
1. `.github/workflows/task-test.yml`
2. `.github/workflows/task-build-artifacts.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions workflow dependencies (`actions/checkout@v4` to `@v6`) for Redis source checkout, with no product/runtime code changes.
> 
> **Overview**
> Updates CI workflows to use `actions/checkout@v6` for the `Get Redis (node20)` steps in both `task-test.yml` and `task-build-artifacts.yml`, eliminating remaining `@v4` usage and associated Node 20 deprecation warnings during CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a679fa2144b9bbbd429cec7f5042c024b0af9fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->