### PR TITLE
ttl_table: suppress deprecated libc::time_t warning on musl

### DIFF
--- a/src/redisearch_rs/ttl_table/src/test_utils.rs
+++ b/src/redisearch_rs/ttl_table/src/test_utils.rs
@@ -16,8 +16,12 @@ use thin_vec::ThinVec;
 use crate::FieldExpiration;
 
 pub const fn ts(sec: i64, nsec: i64) -> timespec {
+    // `libc::time_t` is deprecated on musl (musl 1.2 changed it to 64-bit,
+    // and the libc crate will follow suit — see libc#1848).
+    #[cfg_attr(target_env = "musl", expect(deprecated))]
+    let tv_sec = sec as libc::time_t;
     timespec {
-        tv_sec: sec as libc::time_t,
+        tv_sec,
         tv_nsec: nsec as libc::c_long,
     }
 }


### PR DESCRIPTION

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only helper change that just silences a musl-specific deprecation warning without altering runtime logic.
> 
> **Overview**
> Updates `ttl_table` test helper `ts()` to silence the `libc::time_t` deprecation warning on musl by assigning `tv_sec` via a `#[cfg_attr(target_env = "musl", expect(deprecated))]` cast and reusing the local in the returned `timespec`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471a5427ae3c57ba4a2b869d0a290d04efdc877a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->