### PR TITLE
[MOD-14865] ffi: add headers required for QAST porting

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -70,6 +70,8 @@ fn main() {
         src.join("geo_index.h"),
         src.join("rs_geo.h"),
         deps.join("geohash").join("geohash.h"),
+        src.join("geometry").join("geometry_api.h"),
+        src.join("geometry_index.h"),
         src.join("index_result").join("index_result.h"),
         src.join("json.h"),
         src.join("obfuscation").join("hidden.h"),
@@ -91,12 +93,16 @@ fn main() {
         src.join("stopwords.h"),
         src.join("numeric_filter.h"),
         src.join("tag_index.h"),
+        src.join("suffix.h"),
+        src.join("trie").join("rune_util.h"),
         src.join("trie").join("trie.h"),
         src.join("trie").join("trie_type.h"),
         src.join("ttl_table").join("ttl_table.h"),
         src.join("util").join("arr").join("arr.h"),
         src.join("util").join("dict").join("dict.h"),
         src.join("util").join("references.h"),
+        src.join("util").join("strconv.h"),
+        src.join("wildcard").join("wildcard.h"),
     ];
 
     let mut bindings = bindgen::Builder::default();


### PR DESCRIPTION
Add missing C headers to ffi/build.rs containing API which will be needed to port QAST_Iterate.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the bindgen header allowlist, which can change generated Rust FFI bindings and potentially introduce new/altered symbols at compile time. Limited to build-time binding generation with no runtime logic changes.
> 
> **Overview**
> Extends `src/redisearch_rs/ffi/build.rs` to include additional C headers (e.g., geometry, suffix/trie rune utilities, `util/strconv.h`, and wildcard APIs) in the bindgen inputs/allowlist, ensuring the build script tracks them for `rerun-if-changed` and generates Rust bindings for these APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da610ae3674868cff9f04f05dae7f66582a259fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->