### PR TITLE
Use S3 Bucket For sccache

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -36,11 +36,18 @@ runs:
     - name: Configure sccache environment
       # Use --noprofile --norc to avoid Alpine's /etc/profile resetting PATH,
       # which would hide the sccache binary installed by the previous step.
+      # Input values are passed via env (not interpolated into the script)
+      # to satisfy scanners that flag ${{ inputs.* }} inside `run:` blocks
+      # as script-injection sinks.
       shell: bash --noprofile --norc -eo pipefail {0}
+      env:
+        INPUT_S3_BUCKET: ${{ inputs.s3-bucket }}
+        INPUT_S3_REGION: ${{ inputs.s3-region }}
+        INPUT_S3_KEY_PREFIX: ${{ inputs.s3-key-prefix }}
       run: |
-        echo "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> "$GITHUB_ENV"
-        echo "SCCACHE_REGION=${{ inputs.s3-region }}" >> "$GITHUB_ENV"
-        echo "SCCACHE_S3_KEY_PREFIX=${{ inputs.s3-key-prefix }}" >> "$GITHUB_ENV"
+        echo "SCCACHE_BUCKET=$INPUT_S3_BUCKET" >> "$GITHUB_ENV"
+        echo "SCCACHE_REGION=$INPUT_S3_REGION" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_KEY_PREFIX=$INPUT_S3_KEY_PREFIX" >> "$GITHUB_ENV"
         echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
         # Disable idle timeout so the sccache server stays alive for the
         # entire job, otherwise stats are lost if it shuts down between steps.

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,22 +1,47 @@
 name: Setup sccache
-description: Setup sccache with GitHub Actions cache backend
+description: |
+  Assume the sccache AWS role via OIDC, install the sccache binary, and export
+  sccache S3 env vars. Calling job MUST grant `id-token: write`.
+
+inputs:
+  aws-role:
+    description: 'AWS IAM role ARN for sccache S3 access (pass vars.SCCACHE_AWS_ROLE_TO_ASSUME)'
+    required: true
+  s3-bucket:
+    description: 'S3 bucket name for sccache (pass vars.SCCACHE_S3_BUCKET)'
+    required: true
+  s3-region:
+    description: 'AWS region of the sccache S3 bucket (pass vars.SCCACHE_S3_REGION)'
+    required: true
+  s3-key-prefix:
+    description: 'S3 key prefix for sccache objects (pass vars.SCCACHE_S3_KEY_PREFIX)'
+    required: true
 
 runs:
   using: composite
   steps:
-    - name: Setup sccache
+    - name: Configure AWS Credentials for sccache
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws-role }}
+        aws-region: ${{ inputs.s3-region }}
+
+    - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.10
       with:
         # Disable the post-run stats annotation as it runs outside the
         # container and reports nothing. We show stats ourselves.
         disable_annotations: true
+
     - name: Configure sccache environment
       # Use --noprofile --norc to avoid Alpine's /etc/profile resetting PATH,
       # which would hide the sccache binary installed by the previous step.
       shell: bash --noprofile --norc -eo pipefail {0}
       run: |
-        SCCACHE=$(command -v sccache)
-        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> "$GITHUB_ENV"
+        echo "SCCACHE_REGION=${{ inputs.s3-region }}" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_KEY_PREFIX=${{ inputs.s3-key-prefix }}" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
         # Disable idle timeout so the sccache server stays alive for the
         # entire job, otherwise stats are lost if it shuts down between steps.
         echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -42,12 +42,18 @@ jobs:
   # Build RediSearch ONCE per-arch. Every benchmark job below downloads the
   # resulting redisearch.so as an artifact instead of rebuilding it.
   build-redisearch:
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/flow-build-benchmark-binary.yml
     with:
       arch: x86_64
       artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   build-redisearch-aarch64:
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/flow-build-benchmark-binary.yml
     with:
       arch: aarch64

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -20,6 +20,9 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.number }}-benchmark
       cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
 
@@ -36,6 +39,9 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.number }}-msmarco-benchmark
       cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
     with:
@@ -60,6 +66,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.number }}-rust-micro-benchmark
       cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-rust-micro-benchmarks.yml)
+      actions: read   # dawidd6/action-download-artifact reads cross-workflow artifacts (used inside flow-rust-micro-benchmarks.yml)
     uses: ./.github/workflows/flow-rust-micro-benchmarks.yml
     secrets: inherit
 
@@ -82,5 +92,8 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.number }}-micro-benchmark
       cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-micro-benchmarks-runner.yml)
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     secrets: inherit

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -34,6 +34,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-lint.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-lint.yml)
     uses: ./.github/workflows/task-lint.yml
     secrets: inherit
     with:
@@ -48,6 +50,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-test.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-test.yml)
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -35,6 +35,9 @@ jobs:
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 
   micro-benchmarks:
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-micro-benchmarks-runner.yml)
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     secrets: inherit
 

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-lint.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-lint.yml)
     uses: ./.github/workflows/task-lint.yml
     secrets: inherit
 
@@ -21,6 +23,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-test.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-test.yml)
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-periodic-msmarco-e2e-benchmarks.yml
+++ b/.github/workflows/event-periodic-msmarco-e2e-benchmarks.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   run-benchmarks:
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -28,6 +28,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-lint.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-lint.yml)
     uses: ./.github/workflows/task-lint.yml
     secrets: inherit
     with:
@@ -63,6 +65,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-test.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-test.yml)
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -15,6 +15,9 @@ jobs:
   benchmark:
     needs: check-what-changed
     if: ${{ needs.check-what-changed.outputs.BENCHMARK_CHANGED == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
     with:
@@ -23,5 +26,8 @@ jobs:
   micro-benchmarks:
     needs: check-what-changed
     if: ${{ needs.check-what-changed.outputs.BENCHMARK_CHANGED == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-micro-benchmarks-runner.yml)
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     secrets: inherit

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   run-benchmarks:
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
     with:

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -23,6 +23,9 @@ jobs:
     # so we run the build natively on the matching-arch runner instead of
     # cross-compiling.
     runs-on: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    permissions:
+      contents: read  # actions/checkout
+      id-token: write # OIDC role assumption for sccache S3
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -45,6 +48,11 @@ jobs:
         run: ./install_boost.sh
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          s3-region: ${{ vars.SCCACHE_S3_REGION }}
+          s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Build RediSearch
         run: make build LTO=1
       - name: Show sccache stats

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -53,6 +53,9 @@ jobs:
     name: Run micro-benchmarks on runner
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.runner_label }}
+    permissions:
+      contents: read  # actions/checkout
+      id-token: write # OIDC role assumption for sccache S3
     steps:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get -y --no-install-recommends install git
@@ -73,6 +76,11 @@ jobs:
           python-version: 3.11
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          s3-region: ${{ vars.SCCACHE_S3_REGION }}
+          s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Install benchmark dependencies
         run: |
           export HOME=/home/ubuntu

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -65,6 +65,9 @@ jobs:
   run_micro_benchmarks:
     name: Run ${{ matrix.architecture }} micro-benchmarks
     needs: prepare_runner_configurations
+    permissions:
+      contents: read
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-micro-benchmarks-runner.yml)
     uses: ./.github/workflows/flow-micro-benchmarks-runner.yml
     secrets: inherit
     strategy:

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   benchmarks:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions:
+      contents: read  # actions/checkout
+      id-token: write # OIDC role assumption for sccache S3
+      actions: read   # dawidd6/action-download-artifact (cross-workflow)
     env:
       RUST_BACKTRACE: full
     steps:
@@ -18,6 +22,11 @@ jobs:
         run: ./install_script.sh sudo
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          s3-region: ${{ vars.SCCACHE_S3_REGION }}
+          s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Build RediSearch
         run: make build LTO=1
       - name: Download Latest Baseline Artifact from master

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -122,6 +122,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside task-test.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-test.yml)
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -134,6 +134,11 @@ jobs:
           ref: ${{ env.REF }}
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          s3-region: ${{ vars.SCCACHE_S3_REGION }}
+          s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Setup
         if: needs.build-image.outputs.succeeded != 'true'
         uses: ./.github/actions/retry-command

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -27,6 +27,11 @@ jobs:
     needs: build-image
     if: ${{ !cancelled() }}
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions:
+      contents: read  # actions/checkout
+      id-token: write # OIDC role assumption for sccache S3
+      packages: read  # pull container image from GHCR
+      actions: write  # Swatinem/rust-cache read/write of GH cache
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -66,6 +71,11 @@ jobs:
           fi
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          s3-region: ${{ vars.SCCACHE_S3_REGION }}
+          s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Setup
         if: needs.build-image.outputs.succeeded != 'true'
         working-directory: .install

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -152,6 +152,12 @@ jobs:
         )
       || null }}
 
+    permissions:
+      contents: read  # actions/checkout
+      id-token: write # OIDC role assumption for sccache S3
+      packages: read  # pull container image from GHCR
+      actions: write  # Swatinem/rust-cache read/write of GH cache
+
     env:
       # LTO is disabled on coverage and sanitizer tasks
       LTO: ${{ needs.get-config.outputs.enable_lto == '1' && inputs.san == '' && !inputs.coverage && 1 || 0 }}
@@ -262,6 +268,11 @@ jobs:
           echo "========================"
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
+        with:
+          aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
+          s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
+          s3-region: ${{ vars.SCCACHE_S3_REGION }}
+          s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Setup
         if: needs.build-image.outputs.succeeded != 'true'
         uses: ./.github/actions/retry-command


### PR DESCRIPTION
Migrate sccache from the GitHub Actions cache backend to S3.

GitHub Actions cache has a hard 10 GB-per-repo quota and an LRU-style eviction policy. sccache entries accumulate quickly across PRs and platforms, so the cache churns: useful entries get evicted, hit rate drops, and CI builds end up doing more work than necessary. 

Moving sccache to a dedicated S3 bucket removes the quota pressure entirely:

predictable retention via an S3 lifecycle policy (objects expire after N days)
no contention with other GHA caches in the repo

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI caching/auth setup by introducing OIDC role assumption and new required `permissions`/vars; misconfiguration could break builds or reduce cache effectiveness.
> 
> **Overview**
> Updates the `setup-sccache` composite action to **assume an AWS role via OIDC** and configure sccache to use an **S3 backend** (`SCCACHE_BUCKET/REGION/S3_KEY_PREFIX`) instead of the GitHub Actions cache.
> 
> Propagates this change across CI by adding required job `permissions` (notably `id-token: write`, plus `actions` where needed) and wiring S3/role inputs (`vars.SCCACHE_*`) into all workflows that call `setup-sccache` (tests, lint, artifacts, benchmarks, and micro-benchmark flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c078633c141c0b215959a37b9ea59ed21a1b8010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->