### PR TITLE
[codex] Detect unchanged merge queue resubmissions

### DIFF
--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -31,6 +31,7 @@ jobs:
           import re
           import subprocess
           import sys
+          import urllib.parse
           import uuid
 
           QUERY = """
@@ -118,12 +119,13 @@ jobs:
               return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
 
 
-          def query_previous_merge_group_run(repo, pr_number, removed_at):
+          def query_previous_merge_group_run(repo, queue_branch, removed_at):
+              encoded_branch = urllib.parse.quote(queue_branch, safe="")
               result = subprocess.run(
                   [
                       "gh",
                       "api",
-                      f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
+                      f"/repos/{repo}/actions/runs?event=merge_group&branch={encoded_branch}&per_page=20",
                   ],
                   check=True,
                   capture_output=True,
@@ -131,14 +133,9 @@ jobs:
               )
 
               current_run_id = int(os.environ["CURRENT_RUN_ID"])
-              pr_ref_pattern = re.compile(rf"(^|/)pr-{pr_number}-")
               candidates = []
               for run in json.loads(result.stdout)["workflow_runs"]:
                   if run["id"] == current_run_id:
-                      continue
-
-                  head_branch = run.get("head_branch") or ""
-                  if not pr_ref_pattern.search(head_branch):
                       continue
 
                   if run.get("created_at", "") > removed_at:
@@ -168,6 +165,7 @@ jobs:
           repo = os.environ["REPO"]
           owner, repo_name = repo.split("/", maxsplit=1)
           head_ref = os.environ["HEAD_REF"]
+          queue_branch = head_ref.removeprefix("refs/heads/")
           match = re.search(r"(^|/)pr-(\d+)-", head_ref)
           if not match:
               finish_without_alert(f"Could not extract PR number from merge queue ref: {head_ref}")
@@ -206,7 +204,7 @@ jobs:
           enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
           enqueuer_login = enqueuer.get("login") or ""
           detector_workflow_url = f"{os.environ['SERVER_URL']}/{repo}/actions/runs/{os.environ['CURRENT_RUN_ID']}"
-          previous_run = query_previous_merge_group_run(repo, pr_number, latest_removal["createdAt"])
+          previous_run = query_previous_merge_group_run(repo, queue_branch, latest_removal["createdAt"])
           previous_run_url = (previous_run or {}).get("html_url") or detector_workflow_url
 
           try:
@@ -247,7 +245,6 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           errors: true
-          payload-delimiter: "_"
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}
           webhook-type: webhook-trigger
           payload: |

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -215,15 +215,8 @@ jobs:
           except (json.JSONDecodeError, AttributeError):
               slack_mapping = {}
 
-          def normalize_slack_id(value):
-              value = str(value or "").strip()
-              if value.startswith("<@") and value.endswith(">"):
-                  value = value[2:-1]
-              return value.removeprefix("@")
-
-
           def slack_id_for(login):
-              return normalize_slack_id(slack_mapping.get(login.lower())) if login else ""
+              return slack_mapping.get(login.lower(), "") if login else ""
 
 
           author_login = (pull_request.get("author") or {}).get("login") or ""

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -20,6 +20,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          GH_HANDLE_TO_SLACK_JSON: ${{ secrets.GH_HANDLE_TO_SLACK_JSON }}
         shell: python
         run: |
           import json
@@ -158,6 +159,21 @@ jobs:
           reason = latest_removal.get("reason") or "No reason provided"
           actor = latest_removal.get("actor") or {}
           enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
+          enqueuer_login = enqueuer.get("login") or ""
+
+          try:
+              raw_mapping = json.loads(os.environ.get("GH_HANDLE_TO_SLACK_JSON") or "{}")
+              slack_mapping = {str(k).lower(): str(v) for k, v in raw_mapping.items()}
+          except (json.JSONDecodeError, AttributeError):
+              slack_mapping = {}
+
+          slack_id = slack_mapping.get(enqueuer_login.lower())
+          if slack_id:
+              enqueued_by_mention = f"<@{slack_id}>"
+          elif enqueuer_login:
+              enqueued_by_mention = f"@{enqueuer_login}"
+          else:
+              enqueued_by_mention = ""
 
           print("PR was resubmitted after removal without new commits")
           print(f"Removal reason: {reason}")
@@ -170,7 +186,8 @@ jobs:
           append_output("pr_author", (pull_request.get("author") or {}).get("login"))
           append_output("reason", reason)
           append_output("removed_by", actor.get("login"))
-          append_output("enqueued_by", enqueuer.get("login"))
+          append_output("enqueued_by", enqueuer_login)
+          append_output("enqueued_by_mention", enqueued_by_mention)
           append_output("removed_at", latest_removal["createdAt"])
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
@@ -193,6 +210,7 @@ jobs:
               "Resubmitted At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
               "Removed By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued By": ${{ toJson(steps.check.outputs.enqueued_by) }},
+              "Enqueued By Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
               "Head Commit": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head Committed At": ${{ toJson(steps.check.outputs.head_committed_at) }},
               "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -20,74 +20,59 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        shell: python
         run: |
-          if [[ "$HEAD_REF" =~ (^|/)pr-([0-9]+)- ]]; then
-            PR_NUM="${BASH_REMATCH[2]}"
-          else
-            echo "Could not extract PR number from merge queue ref: $HEAD_REF"
-            echo "resubmit=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          import uuid
 
-          OWNER="${REPO%/*}"
-          REPO_NAME="${REPO#*/}"
-          RESPONSE_FILE="$RUNNER_TEMP/pr-merge-queue-events.json"
-
-          echo "Checking whether PR #$PR_NUM was resubmitted without new commits"
-
-          gh api graphql \
-            -f owner="$OWNER" \
-            -f repo="$REPO_NAME" \
-            -F number="$PR_NUM" \
-            -f query='
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    title
-                    url
-                    headRefOid
-                    author {
-                      login
+          QUERY = """
+          query($owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $number) {
+                title
+                url
+                headRefOid
+                author {
+                  login
+                }
+                timelineItems(
+                  last: 50
+                  itemTypes: [
+                    ADDED_TO_MERGE_QUEUE_EVENT
+                    REMOVED_FROM_MERGE_QUEUE_EVENT
+                  ]
+                ) {
+                  nodes {
+                    __typename
+                    ... on AddedToMergeQueueEvent {
+                      createdAt
+                      enqueuer {
+                        login
+                      }
                     }
-                    timelineItems(
-                      last: 50
-                      itemTypes: [
-                        ADDED_TO_MERGE_QUEUE_EVENT
-                        REMOVED_FROM_MERGE_QUEUE_EVENT
-                      ]
-                    ) {
-                      nodes {
-                        __typename
-                        ... on AddedToMergeQueueEvent {
-                          createdAt
-                          enqueuer {
-                            login
-                          }
-                        }
-                        ... on RemovedFromMergeQueueEvent {
-                          createdAt
-                          reason
-                          actor {
-                            login
-                          }
-                          enqueuer {
-                            login
-                          }
-                          beforeCommit {
-                            oid
-                          }
-                        }
+                    ... on RemovedFromMergeQueueEvent {
+                      createdAt
+                      reason
+                      actor {
+                        login
+                      }
+                      enqueuer {
+                        login
+                      }
+                      beforeCommit {
+                        oid
                       }
                     }
                   }
                 }
-              }' > "$RESPONSE_FILE"
-
-          python3 - "$RESPONSE_FILE" <<'PY'
-          import json
-          import os
-          import sys
-          import uuid
+              }
+            }
+          }
+          """
 
 
           def append_output(name, value):
@@ -96,47 +81,73 @@ jobs:
                   output.write(f"{name}<<{delimiter}\n{value or ''}\n{delimiter}\n")
 
 
+          def finish_without_alert(message):
+              print(message)
+              append_output("resubmit", "false")
+              sys.exit(0)
+
+
+          def query_pull_request(owner, repo, number):
+              result = subprocess.run(
+                  [
+                      "gh",
+                      "api",
+                      "graphql",
+                      "-f",
+                      f"owner={owner}",
+                      "-f",
+                      f"repo={repo}",
+                      "-F",
+                      f"number={number}",
+                      "-f",
+                      f"query={QUERY}",
+                  ],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+              return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
+
+
           def latest(events, event_type):
               matching = [event for event in events if event["__typename"] == event_type]
               return max(matching, key=lambda event: event["createdAt"], default=None)
 
 
-          with open(sys.argv[1], encoding="utf-8") as response_file:
-              response = json.load(response_file)
+          repo = os.environ["REPO"]
+          owner, repo_name = repo.split("/", maxsplit=1)
+          head_ref = os.environ["HEAD_REF"]
+          match = re.search(r"(^|/)pr-(\d+)-", head_ref)
+          if not match:
+              finish_without_alert(f"Could not extract PR number from merge queue ref: {head_ref}")
 
-          pull_request = response["data"]["repository"]["pullRequest"]
+          pr_number = int(match.group(2))
+          print(f"Checking whether PR #{pr_number} was resubmitted without new commits")
+
+          pull_request = query_pull_request(owner, repo_name, pr_number)
           events = pull_request["timelineItems"]["nodes"]
           latest_add = latest(events, "AddedToMergeQueueEvent")
           latest_removal = latest(events, "RemovedFromMergeQueueEvent")
 
           if not latest_add:
-              print("No merge queue add event found for this submission")
-              append_output("resubmit", "false")
-              sys.exit(0)
+              finish_without_alert("No merge queue add event found for this submission")
 
           if not latest_removal:
-              print("No previous merge queue removal event found")
-              append_output("resubmit", "false")
-              sys.exit(0)
+              finish_without_alert("No previous merge queue removal event found")
 
           if latest_removal["createdAt"] > latest_add["createdAt"]:
-              print("The latest merge queue event is a removal, not this submission")
-              append_output("resubmit", "false")
-              sys.exit(0)
+              finish_without_alert("The latest merge queue event is a removal, not this submission")
 
           current_head = pull_request["headRefOid"]
           removed_head = (latest_removal.get("beforeCommit") or {}).get("oid")
           if not removed_head:
-              print("The latest removal event does not include the PR head commit")
-              append_output("resubmit", "false")
-              sys.exit(0)
+              finish_without_alert("The latest removal event does not include the PR head commit")
 
           if current_head != removed_head:
               print("The PR head changed since the last merge queue removal")
               print(f"Current head: {current_head}")
               print(f"Removed head: {removed_head}")
-              append_output("resubmit", "false")
-              sys.exit(0)
+              finish_without_alert("No unchanged resubmission detected")
 
           reason = latest_removal.get("reason") or "No reason provided"
           actor = latest_removal.get("actor") or {}
@@ -156,7 +167,6 @@ jobs:
           append_output("removed_at", latest_removal["createdAt"])
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
-          PY
 
       - name: Notify Slack about unchanged merge queue resubmission
         if: steps.check.outputs.resubmit == 'true'

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -226,18 +226,7 @@ jobs:
               return normalize_slack_id(slack_mapping.get(login.lower())) if login else ""
 
 
-          def slack_mention_for(login):
-              slack_id = slack_id_for(login)
-              if slack_id:
-                  return f"<@{slack_id}>"
-              if login:
-                  return f"@{login}"
-              return ""
-
-
           author_login = (pull_request.get("author") or {}).get("login") or ""
-          author_slack_id = slack_id_for(author_login)
-          enqueued_by_slack_id = slack_id_for(enqueuer_login)
 
           print("PR was resubmitted after removal without new commits")
           print(f"Removal reason: {reason}")
@@ -248,13 +237,11 @@ jobs:
           append_output("pr_title", pull_request["title"])
           append_output("pr_url", pull_request["url"])
           append_output("pr_author", author_login)
-          append_output("author_slack_id", author_slack_id)
-          append_output("author_mention", slack_mention_for(author_login))
+          append_output("author_mention", slack_id_for(author_login))
           append_output("reason", reason)
           append_output("removed_by", actor.get("login"))
           append_output("enqueued_by", enqueuer_login)
-          append_output("enqueued_by_slack_id", enqueued_by_slack_id)
-          append_output("enqueued_by_mention", slack_mention_for(enqueuer_login))
+          append_output("enqueued_by_mention", slack_id_for(enqueuer_login))
           append_output("removed_at", latest_removal["createdAt"])
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
@@ -276,14 +263,12 @@ jobs:
               "PR": ${{ toJson(steps.check.outputs.pr_url) }},
               "Title": ${{ toJson(steps.check.outputs.pr_title) }},
               "Author": ${{ toJson(steps.check.outputs.pr_author) }},
-              "Author_Slack_ID": ${{ toJson(steps.check.outputs.author_slack_id) }},
               "Author_Mention": ${{ toJson(steps.check.outputs.author_mention) }},
               "Reason": ${{ toJson(steps.check.outputs.reason) }},
               "Removed_At": ${{ toJson(steps.check.outputs.removed_at) }},
               "Resubmitted_At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
               "Removed_By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued_By": ${{ toJson(steps.check.outputs.enqueued_by) }},
-              "Enqueued_By_Slack_ID": ${{ toJson(steps.check.outputs.enqueued_by_slack_id) }},
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
               "Head_Commit": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -1,66 +1,41 @@
-name: Detect Merge Queue Removal
+name: Detect Merge Queue Resubmission Without New Commits
 
 on:
-  workflow_run:
-    workflows: ["Merge a pull request"]
-    types: [completed]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
-  actions: read
   contents: read
   issues: read
   pull-requests: read
 
 jobs:
-  detect-removal:
-    name: Detect pull request removal from merge queue
+  detect-resubmit:
+    name: Detect resubmission after merge queue removal
     runs-on: ubuntu-slim
-    if: >
-      github.event.workflow_run.event == 'merge_group' &&
-      github.event.workflow_run.conclusion != 'success'
     steps:
-      - name: Check whether GitHub removed the pull request from the queue
+      - name: Check whether this is an unchanged resubmission
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
-          VALIDATION_RUN_CREATED_AT: ${{ github.event.workflow_run.created_at }}
-          VALIDATION_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          VALIDATION_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           if [[ "$HEAD_REF" =~ (^|/)pr-([0-9]+)- ]]; then
             PR_NUM="${BASH_REMATCH[2]}"
           else
             echo "Could not extract PR number from merge queue ref: $HEAD_REF"
-            echo "removed=false" >> "$GITHUB_OUTPUT"
+            echo "resubmit=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           OWNER="${REPO%/*}"
           REPO_NAME="${REPO#*/}"
+          RESPONSE_FILE="$RUNNER_TEMP/pr-merge-queue-events.json"
 
-          echo "Checking PR #$PR_NUM for a merge queue removal event"
-          echo "Validation run conclusion: $VALIDATION_RUN_CONCLUSION"
-          echo "Validation run URL: $VALIDATION_RUN_URL"
+          echo "Checking whether PR #$PR_NUM was resubmitted without new commits"
 
-          append_output() {
-            local name="$1"
-            local value="$2"
-            local delimiter="EOF_${name}_${RANDOM}_${RANDOM}"
-
-            {
-              echo "$name<<$delimiter"
-              echo "$value"
-              echo "$delimiter"
-            } >> "$GITHUB_OUTPUT"
-          }
-
-          # GitHub records the removal after it consumes the required-check result.
-          # Give the PR timeline a short window to catch up before querying it.
-          sleep 60
-
-          RESPONSE=$(gh api graphql \
+          gh api graphql \
             -f owner="$OWNER" \
             -f repo="$REPO_NAME" \
             -F number="$PR_NUM" \
@@ -70,12 +45,12 @@ jobs:
                   pullRequest(number: $number) {
                     title
                     url
-                    isInMergeQueue
+                    headRefOid
                     author {
                       login
                     }
                     timelineItems(
-                      last: 20
+                      last: 50
                       itemTypes: [
                         ADDED_TO_MERGE_QUEUE_EVENT
                         REMOVED_FROM_MERGE_QUEUE_EVENT
@@ -106,61 +81,85 @@ jobs:
                     }
                   }
                 }
-              }')
+              }' > "$RESPONSE_FILE"
 
-          PR_DATA=$(echo "$RESPONSE" | jq -c '.data.repository.pullRequest')
-          LATEST_ADD_AT=$(echo "$PR_DATA" | jq -r '
-            [.timelineItems.nodes[] | select(.__typename == "AddedToMergeQueueEvent")]
-            | max_by(.createdAt).createdAt // empty')
-          LATEST_REMOVAL=$(echo "$PR_DATA" | jq -c '
-            [.timelineItems.nodes[] | select(.__typename == "RemovedFromMergeQueueEvent")]
-            | max_by(.createdAt) // empty')
+          python3 - "$RESPONSE_FILE" <<'PY'
+          import json
+          import os
+          import sys
+          import uuid
 
-          if [[ -z "$LATEST_REMOVAL" ]]; then
-            echo "No merge queue removal event found for PR #$PR_NUM"
-            echo "removed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
-          REMOVED_AT=$(echo "$LATEST_REMOVAL" | jq -r '.createdAt')
-          if [[ -n "$LATEST_ADD_AT" && "$REMOVED_AT" < "$LATEST_ADD_AT" ]]; then
-            echo "Latest merge queue event is an add, not a removal"
-            echo "removed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          def append_output(name, value):
+              delimiter = f"EOF_{name}_{uuid.uuid4().hex}"
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+                  output.write(f"{name}<<{delimiter}\n{value or ''}\n{delimiter}\n")
 
-          if [[ "$REMOVED_AT" < "$VALIDATION_RUN_CREATED_AT" ]]; then
-            echo "Latest removal predates this validation run"
-            echo "removed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
-          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
-          PR_URL=$(echo "$PR_DATA" | jq -r '.url')
-          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // empty')
-          REASON=$(echo "$LATEST_REMOVAL" | jq -r '.reason // "No reason provided"')
-          ACTOR=$(echo "$LATEST_REMOVAL" | jq -r '.actor.login // empty')
-          ENQUEUER=$(echo "$LATEST_REMOVAL" | jq -r '.enqueuer.login // empty')
-          BEFORE_COMMIT=$(echo "$LATEST_REMOVAL" | jq -r '.beforeCommit.oid // empty')
+          def latest(events, event_type):
+              matching = [event for event in events if event["__typename"] == event_type]
+              return max(matching, key=lambda event: event["createdAt"], default=None)
 
-          echo "GitHub removed PR #$PR_NUM from the merge queue"
-          echo "Removal reason: $REASON"
-          echo "Removal time: $REMOVED_AT"
-          echo "removed=true" >> "$GITHUB_OUTPUT"
-          append_output "pr_number" "$PR_NUM"
-          append_output "pr_title" "$PR_TITLE"
-          append_output "pr_url" "$PR_URL"
-          append_output "pr_author" "$PR_AUTHOR"
-          append_output "reason" "$REASON"
-          append_output "actor" "$ACTOR"
-          append_output "enqueuer" "$ENQUEUER"
-          append_output "removed_at" "$REMOVED_AT"
-          append_output "before_commit" "$BEFORE_COMMIT"
-          append_output "validation_run_url" "$VALIDATION_RUN_URL"
-          append_output "validation_run_conclusion" "$VALIDATION_RUN_CONCLUSION"
 
-      - name: Notify Slack about merge queue removal
-        if: steps.check.outputs.removed == 'true'
+          with open(sys.argv[1], encoding="utf-8") as response_file:
+              response = json.load(response_file)
+
+          pull_request = response["data"]["repository"]["pullRequest"]
+          events = pull_request["timelineItems"]["nodes"]
+          latest_add = latest(events, "AddedToMergeQueueEvent")
+          latest_removal = latest(events, "RemovedFromMergeQueueEvent")
+
+          if not latest_add:
+              print("No merge queue add event found for this submission")
+              append_output("resubmit", "false")
+              sys.exit(0)
+
+          if not latest_removal:
+              print("No previous merge queue removal event found")
+              append_output("resubmit", "false")
+              sys.exit(0)
+
+          if latest_removal["createdAt"] > latest_add["createdAt"]:
+              print("The latest merge queue event is a removal, not this submission")
+              append_output("resubmit", "false")
+              sys.exit(0)
+
+          current_head = pull_request["headRefOid"]
+          removed_head = (latest_removal.get("beforeCommit") or {}).get("oid")
+          if not removed_head:
+              print("The latest removal event does not include the PR head commit")
+              append_output("resubmit", "false")
+              sys.exit(0)
+
+          if current_head != removed_head:
+              print("The PR head changed since the last merge queue removal")
+              print(f"Current head: {current_head}")
+              print(f"Removed head: {removed_head}")
+              append_output("resubmit", "false")
+              sys.exit(0)
+
+          reason = latest_removal.get("reason") or "No reason provided"
+          actor = latest_removal.get("actor") or {}
+          enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
+
+          print("PR was resubmitted after removal without new commits")
+          print(f"Removal reason: {reason}")
+          print(f"Head commit: {current_head}")
+
+          append_output("resubmit", "true")
+          append_output("pr_title", pull_request["title"])
+          append_output("pr_url", pull_request["url"])
+          append_output("pr_author", (pull_request.get("author") or {}).get("login"))
+          append_output("reason", reason)
+          append_output("removed_by", actor.get("login"))
+          append_output("enqueued_by", enqueuer.get("login"))
+          append_output("removed_at", latest_removal["createdAt"])
+          append_output("resubmitted_at", latest_add["createdAt"])
+          append_output("head_commit", current_head)
+          PY
+
+      - name: Notify Slack about unchanged merge queue resubmission
+        if: steps.check.outputs.resubmit == 'true'
         uses: slackapi/slack-github-action@v1
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}
@@ -173,8 +172,9 @@ jobs:
               "Author": ${{ toJson(steps.check.outputs.pr_author) }},
               "Reason": ${{ toJson(steps.check.outputs.reason) }},
               "Removed At": ${{ toJson(steps.check.outputs.removed_at) }},
-              "Removed By": ${{ toJson(steps.check.outputs.actor) }},
-              "Enqueued By": ${{ toJson(steps.check.outputs.enqueuer) }},
-              "Validation Conclusion": ${{ toJson(steps.check.outputs.validation_run_conclusion) }},
-              "Validation Workflow": ${{ toJson(steps.check.outputs.validation_run_url) }}
+              "Resubmitted At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
+              "Removed By": ${{ toJson(steps.check.outputs.removed_by) }},
+              "Enqueued By": ${{ toJson(steps.check.outputs.enqueued_by) }},
+              "Head Commit": ${{ toJson(steps.check.outputs.head_commit) }},
+              "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -101,7 +101,7 @@ jobs:
               return (
                   datetime.fromisoformat(value.replace("Z", "+00:00"))
                   .astimezone(timezone.utc)
-                  .strftime("%Y %m %d %H:%M:%S UTC")
+                  .strftime("%Y-%m-%d %H:%M:%S UTC")
               )
 
 

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -5,6 +5,7 @@ on:
     types: [checks_requested]
 
 permissions:
+  actions: read
   contents: read
   issues: read
   pull-requests: read
@@ -21,6 +22,8 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.event.merge_group.head_ref }}
           GH_HANDLE_TO_SLACK_JSON: ${{ secrets.GH_HANDLE_TO_SLACK_JSON }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
         shell: python
         run: |
           import json
@@ -115,6 +118,48 @@ jobs:
               return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
 
 
+          def query_previous_merge_group_run(repo, pr_number, removed_at):
+              result = subprocess.run(
+                  [
+                      "gh",
+                      "api",
+                      f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
+                  ],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+
+              current_run_id = int(os.environ["CURRENT_RUN_ID"])
+              pr_ref_pattern = re.compile(rf"(^|/)pr-{pr_number}-")
+              candidates = []
+              for run in json.loads(result.stdout)["workflow_runs"]:
+                  if run["id"] == current_run_id:
+                      continue
+
+                  head_branch = run.get("head_branch") or ""
+                  if not pr_ref_pattern.search(head_branch):
+                      continue
+
+                  if run.get("created_at", "") > removed_at:
+                      continue
+
+                  if run.get("name") == "Detect Merge Queue Resubmission Without New Commits":
+                      continue
+
+                  candidates.append(run)
+
+              failed_candidates = [
+                  run
+                  for run in candidates
+                  if run.get("conclusion") in {"failure", "cancelled", "timed_out", "action_required"}
+              ]
+              if failed_candidates:
+                  return max(failed_candidates, key=lambda run: run["created_at"])
+
+              return max(candidates, key=lambda run: run["created_at"], default=None)
+
+
           def latest(events, event_type):
               matching = [event for event in events if event["__typename"] == event_type]
               return max(matching, key=lambda event: event["createdAt"], default=None)
@@ -160,6 +205,9 @@ jobs:
           actor = latest_removal.get("actor") or {}
           enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
           enqueuer_login = enqueuer.get("login") or ""
+          detector_workflow_url = f"{os.environ['SERVER_URL']}/{repo}/actions/runs/{os.environ['CURRENT_RUN_ID']}"
+          previous_run = query_previous_merge_group_run(repo, pr_number, latest_removal["createdAt"])
+          previous_run_url = (previous_run or {}).get("html_url") or detector_workflow_url
 
           try:
               raw_mapping = json.loads(os.environ.get("GH_HANDLE_TO_SLACK_JSON") or "{}")
@@ -192,11 +240,15 @@ jobs:
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
           append_output("head_committed_at", head_commit["committedDate"])
+          append_output("previous_merge_queue_run", previous_run_url)
+          append_output("detector_workflow", detector_workflow_url)
 
       - name: Notify Slack about unchanged merge queue resubmission
         if: steps.check.outputs.resubmit == 'true'
         uses: slackapi/slack-github-action@v3
         with:
+          errors: true
+          payload-delimiter: "_"
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}
           webhook-type: webhook-trigger
           payload: |
@@ -213,5 +265,7 @@ jobs:
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
               "Head_Commit": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},
-              "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "Workflow": ${{ toJson(steps.check.outputs.previous_merge_queue_run) }},
+              "Previous_Merge_Queue_Run": ${{ toJson(steps.check.outputs.previous_merge_queue_run) }},
+              "Detector_Workflow": ${{ toJson(steps.check.outputs.detector_workflow) }}
             }

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -32,6 +32,7 @@ jobs:
           import subprocess
           import sys
           import uuid
+          from datetime import datetime, timezone
 
           QUERY = """
           query($owner: String!, $repo: String!, $number: Int!) {
@@ -96,6 +97,14 @@ jobs:
               sys.exit(0)
 
 
+          def format_timestamp(value):
+              return (
+                  datetime.fromisoformat(value.replace("Z", "+00:00"))
+                  .astimezone(timezone.utc)
+                  .strftime("%Y %m %d %H:%M:%S UTC")
+              )
+
+
           def query_pull_request(owner, repo, number):
               result = subprocess.run(
                   [
@@ -142,23 +151,21 @@ jobs:
 
                   candidates.append(run)
 
+              candidates.sort(key=lambda run: run["created_at"], reverse=True)
+
+              current_queue_run_index = next(
+                  (
+                      index
+                      for index, run in enumerate(candidates)
+                      if run.get("head_branch") == queue_branch
+                  ),
+                  None,
+              )
+              if current_queue_run_index is not None and current_queue_run_index + 1 < len(candidates):
+                  return candidates[current_queue_run_index + 1]
+
               previous_queue_runs = [run for run in candidates if run.get("created_at", "") <= removed_at]
-              failed_candidates = [
-                  run
-                  for run in previous_queue_runs
-                  if run.get("conclusion") in {"failure", "cancelled", "timed_out", "action_required"}
-              ]
-              if failed_candidates:
-                  return max(failed_candidates, key=lambda run: run["created_at"])
-
-              if previous_queue_runs:
-                  return max(previous_queue_runs, key=lambda run: run["created_at"])
-
-              current_queue_runs = [run for run in candidates if run.get("head_branch") == queue_branch]
-              if current_queue_runs:
-                  return min(current_queue_runs, key=lambda run: run["created_at"])
-
-              return max(candidates, key=lambda run: run["created_at"], default=None)
+              return max(previous_queue_runs, key=lambda run: run["created_at"], default=None)
 
 
           def latest(events, event_type):
@@ -210,6 +217,7 @@ jobs:
           detector_workflow_url = f"{os.environ['SERVER_URL']}/{repo}/actions/runs/{os.environ['CURRENT_RUN_ID']}"
           merge_queue_run = query_merge_queue_workflow_run(repo, pr_number, queue_branch, latest_removal["createdAt"])
           merge_queue_run_url = (merge_queue_run or {}).get("html_url") or detector_workflow_url
+          head_commit_url = f"{os.environ['SERVER_URL']}/{repo}/commit/{current_head}"
 
           try:
               raw_mapping = json.loads(os.environ.get("GH_HANDLE_TO_SLACK_JSON") or "{}")
@@ -237,10 +245,11 @@ jobs:
           append_output("removed_by", actor.get("login"))
           append_output("enqueued_by", enqueuer_login)
           append_output("enqueued_by_mention", slack_id_for(enqueuer_login))
-          append_output("removed_at", latest_removal["createdAt"])
-          append_output("resubmitted_at", latest_add["createdAt"])
+          append_output("removed_at", format_timestamp(latest_removal["createdAt"]))
+          append_output("resubmitted_at", format_timestamp(latest_add["createdAt"]))
           append_output("head_commit", current_head)
-          append_output("head_committed_at", head_commit["committedDate"])
+          append_output("head_commit_url", head_commit_url)
+          append_output("head_committed_at", format_timestamp(head_commit["committedDate"]))
           append_output("merge_queue_workflow", merge_queue_run_url)
           append_output("detector_workflow", detector_workflow_url)
 
@@ -264,7 +273,8 @@ jobs:
               "Removed_By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued_By": ${{ toJson(steps.check.outputs.enqueued_by) }},
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
-              "Head_Commit": ${{ toJson(steps.check.outputs.head_commit) }},
+              "Head_Commit": ${{ toJson(steps.check.outputs.head_commit_url) }},
+              "Head_Commit_SHA": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},
               "Workflow": ${{ toJson(steps.check.outputs.detector_workflow) }},
               "Previous_Merge_Queue_Run": ${{ toJson(steps.check.outputs.merge_queue_workflow) }},

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -39,6 +39,14 @@ jobs:
                 author {
                   login
                 }
+                commits(last: 1) {
+                  nodes {
+                    commit {
+                      oid
+                      committedDate
+                    }
+                  }
+                }
                 timelineItems(
                   last: 50
                   itemTypes: [
@@ -62,9 +70,6 @@ jobs:
                       }
                       enqueuer {
                         login
-                      }
-                      beforeCommit {
-                        oid
                       }
                     }
                   }
@@ -139,14 +144,15 @@ jobs:
               finish_without_alert("The latest merge queue event is a removal, not this submission")
 
           current_head = pull_request["headRefOid"]
-          removed_head = (latest_removal.get("beforeCommit") or {}).get("oid")
-          if not removed_head:
-              finish_without_alert("The latest removal event does not include the PR head commit")
+          head_commit = pull_request["commits"]["nodes"][0]["commit"]
+          if current_head != head_commit["oid"]:
+              finish_without_alert("Could not confirm the PR head commit from the commit list")
 
-          if current_head != removed_head:
-              print("The PR head changed since the last merge queue removal")
+          if head_commit["committedDate"] > latest_removal["createdAt"]:
+              print("The PR head commit is newer than the last merge queue removal")
               print(f"Current head: {current_head}")
-              print(f"Removed head: {removed_head}")
+              print(f"Head committed at: {head_commit['committedDate']}")
+              print(f"Removed at: {latest_removal['createdAt']}")
               finish_without_alert("No unchanged resubmission detected")
 
           reason = latest_removal.get("reason") or "No reason provided"
@@ -156,6 +162,7 @@ jobs:
           print("PR was resubmitted after removal without new commits")
           print(f"Removal reason: {reason}")
           print(f"Head commit: {current_head}")
+          print(f"Head committed at: {head_commit['committedDate']}")
 
           append_output("resubmit", "true")
           append_output("pr_title", pull_request["title"])
@@ -167,6 +174,7 @@ jobs:
           append_output("removed_at", latest_removal["createdAt"])
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
+          append_output("head_committed_at", head_commit["committedDate"])
 
       - name: Notify Slack about unchanged merge queue resubmission
         if: steps.check.outputs.resubmit == 'true'
@@ -186,5 +194,6 @@ jobs:
               "Removed By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued By": ${{ toJson(steps.check.outputs.enqueued_by) }},
               "Head Commit": ${{ toJson(steps.check.outputs.head_commit) }},
+              "Head Committed At": ${{ toJson(steps.check.outputs.head_committed_at) }},
               "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -206,12 +206,12 @@ jobs:
               "Title": ${{ toJson(steps.check.outputs.pr_title) }},
               "Author": ${{ toJson(steps.check.outputs.pr_author) }},
               "Reason": ${{ toJson(steps.check.outputs.reason) }},
-              "Removed At": ${{ toJson(steps.check.outputs.removed_at) }},
-              "Resubmitted At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
-              "Removed By": ${{ toJson(steps.check.outputs.removed_by) }},
-              "Enqueued By": ${{ toJson(steps.check.outputs.enqueued_by) }},
+              "Removed_At": ${{ toJson(steps.check.outputs.removed_at) }},
+              "Resubmitted_At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
+              "Removed_By": ${{ toJson(steps.check.outputs.removed_by) }},
+              "Enqueued_By": ${{ toJson(steps.check.outputs.enqueued_by) }},
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
-              "Head Commit": ${{ toJson(steps.check.outputs.head_commit) }},
-              "Head Committed At": ${{ toJson(steps.check.outputs.head_committed_at) }},
+              "Head_Commit": ${{ toJson(steps.check.outputs.head_commit) }},
+              "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},
               "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -195,10 +195,10 @@ jobs:
 
       - name: Notify Slack about unchanged merge queue resubmission
         if: steps.check.outputs.resubmit == 'true'
-        uses: slackapi/slack-github-action@v1
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "repository": "${{ github.repository }}",

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -31,6 +31,7 @@ jobs:
           import re
           import subprocess
           import sys
+          import time
           import uuid
           from datetime import datetime, timezone
 
@@ -127,45 +128,51 @@ jobs:
               return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
 
 
-          def query_merge_queue_workflow_run(repo, pr_number, queue_branch, removed_at):
-              result = subprocess.run(
-                  [
-                      "gh",
-                      "api",
-                      f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
-                  ],
-                  check=True,
-                  capture_output=True,
-                  text=True,
-              )
-
+          def query_merge_queue_workflow_runs(repo, pr_number, queue_branch):
               pr_ref_pattern = re.compile(rf"(^|/)pr-{pr_number}-")
               candidates = []
-              for run in json.loads(result.stdout)["workflow_runs"]:
-                  if run.get("path") != ".github/workflows/event-merge-to-queue.yml":
-                      continue
+              for attempt in range(5):
+                  result = subprocess.run(
+                      [
+                          "gh",
+                          "api",
+                          f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
+                      ],
+                      check=True,
+                      capture_output=True,
+                      text=True,
+                  )
 
-                  head_branch = run.get("head_branch") or ""
-                  if not pr_ref_pattern.search(head_branch):
-                      continue
+                  candidates = []
+                  for run in json.loads(result.stdout)["workflow_runs"]:
+                      if run.get("path") != ".github/workflows/event-merge-to-queue.yml":
+                          continue
 
-                  candidates.append(run)
+                      head_branch = run.get("head_branch") or ""
+                      if not pr_ref_pattern.search(head_branch):
+                          continue
 
-              candidates.sort(key=lambda run: run["created_at"], reverse=True)
+                      candidates.append(run)
 
-              current_queue_run_index = next(
-                  (
-                      index
-                      for index, run in enumerate(candidates)
-                      if run.get("head_branch") == queue_branch
-                  ),
-                  None,
-              )
-              if current_queue_run_index is not None and current_queue_run_index + 1 < len(candidates):
-                  return candidates[current_queue_run_index + 1]
+                  candidates.sort(key=lambda run: run["created_at"], reverse=True)
+                  current_queue_run_index = next(
+                      (
+                          index
+                          for index, run in enumerate(candidates)
+                          if run.get("head_branch") == queue_branch
+                      ),
+                      None,
+                  )
+                  if current_queue_run_index is not None:
+                      previous_queue_run = None
+                      if current_queue_run_index + 1 < len(candidates):
+                          previous_queue_run = candidates[current_queue_run_index + 1]
+                      return candidates[current_queue_run_index], previous_queue_run
 
-              previous_queue_runs = [run for run in candidates if run.get("created_at", "") <= removed_at]
-              return max(previous_queue_runs, key=lambda run: run["created_at"], default=None)
+                  if attempt < 4:
+                      time.sleep(2)
+
+              return None, None
 
 
           def latest(events, event_type):
@@ -215,8 +222,24 @@ jobs:
           enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
           enqueuer_login = enqueuer.get("login") or ""
           detector_workflow_url = f"{os.environ['SERVER_URL']}/{repo}/actions/runs/{os.environ['CURRENT_RUN_ID']}"
-          merge_queue_run = query_merge_queue_workflow_run(repo, pr_number, queue_branch, latest_removal["createdAt"])
-          merge_queue_run_url = (merge_queue_run or {}).get("html_url") or detector_workflow_url
+          current_merge_queue_run, previous_merge_queue_run = query_merge_queue_workflow_runs(
+              repo, pr_number, queue_branch
+          )
+          if not current_merge_queue_run:
+              finish_without_alert("Could not find the current merge queue workflow run")
+
+          if (
+              previous_merge_queue_run
+              and previous_merge_queue_run.get("created_at", "") > latest_add["createdAt"]
+          ):
+              print("Previous merge queue workflow run is newer than the latest queue add event")
+              print(f"Latest queue add: {latest_add['createdAt']}")
+              print(f"Previous merge queue workflow run: {previous_merge_queue_run['created_at']}")
+              finish_without_alert(
+                  "This merge_group run is a queue revalidation for an existing queue add event"
+              )
+
+          merge_queue_run_url = (previous_merge_queue_run or {}).get("html_url") or detector_workflow_url
           head_commit_url = f"{os.environ['SERVER_URL']}/{repo}/commit/{current_head}"
 
           try:

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -1,119 +1,166 @@
-name: Detect Merge Queue Resubmission Without New Commits
+name: Detect Merge Queue Removal
 
 on:
-  merge_group:
-    types: [checks_requested]
+  workflow_run:
+    workflows: ["Merge a pull request"]
+    types: [completed]
 
 permissions:
   actions: read
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
-  detect-resubmit:
+  detect-removal:
+    name: Detect pull request removal from merge queue
     runs-on: ubuntu-slim
+    if: >
+      github.event.workflow_run.event == 'merge_group' &&
+      github.event.workflow_run.conclusion != 'success'
     steps:
-      - name: Check for resubmission without new commits
+      - name: Check whether GitHub removed the pull request from the queue
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-          BASE_SHA: ${{ github.event.merge_group.base_sha }}
-          PR_NUMBER: ${{ github.event.merge_group.head_ref }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          VALIDATION_RUN_CREATED_AT: ${{ github.event.workflow_run.created_at }}
+          VALIDATION_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          VALIDATION_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          # Extract PR number from head_ref (format: refs/pull/NUMBER/merge or gh-readonly-queue/main/pr-NUMBER-...)
-          if [[ "$PR_NUMBER" =~ refs/pull/([0-9]+)/merge ]]; then
-            PR_NUM="${BASH_REMATCH[1]}"
-          elif [[ "$PR_NUMBER" =~ pr-([0-9]+)- ]]; then
-            PR_NUM="${BASH_REMATCH[1]}"
+          if [[ "$HEAD_REF" =~ (^|/)pr-([0-9]+)- ]]; then
+            PR_NUM="${BASH_REMATCH[2]}"
           else
-            echo "Could not extract PR number from: $PR_NUMBER"
-            echo "resubmit=false" >> $GITHUB_OUTPUT
+            echo "Could not extract PR number from merge queue ref: $HEAD_REF"
+            echo "removed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Checking PR #$PR_NUM"
-          echo "Current HEAD SHA: $HEAD_SHA"
-          echo "Current BASE SHA: $BASE_SHA"
+          OWNER="${REPO%/*}"
+          REPO_NAME="${REPO#*/}"
 
-          # The merge queue creates a NEW temporary merge commit each time,
-          # so head_sha will be different even for the same PR commits.
-          # Hence, we should check the PR's actual head commit (before merge).
+          echo "Checking PR #$PR_NUM for a merge queue removal event"
+          echo "Validation run conclusion: $VALIDATION_RUN_CONCLUSION"
+          echo "Validation run URL: $VALIDATION_RUN_URL"
 
-          # Get the PR's actual head SHA (the last commit on the PR branch)
-          PR_HEAD_SHA=$(gh api "/repos/$REPO/pulls/$PR_NUM" --jq '.head.sha')
-          echo "PR's actual HEAD SHA: $PR_HEAD_SHA"
+          append_output() {
+            local name="$1"
+            local value="$2"
+            local delimiter="EOF_${name}_${RANDOM}_${RANDOM}"
 
-          # Get the list of previous workflow runs for this merge queue workflow
-          # Look for runs from the same PR that have failed/cancelled
-          echo "Searching for previous merge_group runs for PR #$PR_NUM..."
+            {
+              echo "$name<<$delimiter"
+              echo "$value"
+              echo "$delimiter"
+            } >> "$GITHUB_OUTPUT"
+          }
 
-          ALL_RUNS=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$REPO/actions/runs?event=merge_group&per_page=100" \
-            --jq ".workflow_runs[] | select(.id != $CURRENT_RUN_ID) | {id: .id, head_sha: .head_sha, conclusion: .conclusion, head_ref: .head_branch}" | jq -s '.')
+          # GitHub records the removal after it consumes the required-check result.
+          # Give the PR timeline a short window to catch up before querying it.
+          sleep 60
 
-          echo "Recent merge_group runs:"
-          echo "$ALL_RUNS" | jq -c '.[]'
+          RESPONSE=$(gh api graphql \
+            -f owner="$OWNER" \
+            -f repo="$REPO_NAME" \
+            -F number="$PR_NUM" \
+            -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    title
+                    url
+                    isInMergeQueue
+                    author {
+                      login
+                    }
+                    timelineItems(
+                      last: 20
+                      itemTypes: [
+                        ADDED_TO_MERGE_QUEUE_EVENT
+                        REMOVED_FROM_MERGE_QUEUE_EVENT
+                      ]
+                    ) {
+                      nodes {
+                        __typename
+                        ... on AddedToMergeQueueEvent {
+                          createdAt
+                          enqueuer {
+                            login
+                          }
+                        }
+                        ... on RemovedFromMergeQueueEvent {
+                          createdAt
+                          reason
+                          actor {
+                            login
+                          }
+                          enqueuer {
+                            login
+                          }
+                          beforeCommit {
+                            oid
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }')
 
-          # Look for previous runs from the same PR (by matching PR number in head_ref)
-          # Use regex anchors to ensure exact PR number match (e.g., pr-12- won't match pr-123-)
-          PREVIOUS_RUN_DATA=$(echo "$ALL_RUNS" | jq -c ".[] | select(.head_ref | test(\"(^|/)pr-${PR_NUM}-\")) | select(.conclusion == \"failure\" or .conclusion == \"cancelled\")" | head -1)
+          PR_DATA=$(echo "$RESPONSE" | jq -c '.data.repository.pullRequest')
+          LATEST_ADD_AT=$(echo "$PR_DATA" | jq -r '
+            [.timelineItems.nodes[] | select(.__typename == "AddedToMergeQueueEvent")]
+            | max_by(.createdAt).createdAt // empty')
+          LATEST_REMOVAL=$(echo "$PR_DATA" | jq -c '
+            [.timelineItems.nodes[] | select(.__typename == "RemovedFromMergeQueueEvent")]
+            | max_by(.createdAt) // empty')
 
-          if [[ -z "$PREVIOUS_RUN_DATA" ]]; then
-            echo "No previous failed/cancelled runs found for PR #$PR_NUM"
-            echo "resubmit=false" >> $GITHUB_OUTPUT
+          if [[ -z "$LATEST_REMOVAL" ]]; then
+            echo "No merge queue removal event found for PR #$PR_NUM"
+            echo "removed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PREVIOUS_RUN_ID=$(echo "$PREVIOUS_RUN_DATA" | jq -r '.id // empty')
-          echo "Found previous failed/cancelled run ID: $PREVIOUS_RUN_ID"
-
-          # Now check if the PR's head SHA has changed since that previous run
-          # Get the PR's head SHA at the time of the previous run by fetching the run details
-          PREVIOUS_RUN_DETAILS=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$REPO/actions/runs/$PREVIOUS_RUN_ID")
-
-          # Extract the PR head SHA from the previous run's jobs
-          # The merge queue creates a merge commit, but we need to check the actual PR commits
-          # We'll get the commit list from the previous run and find the PR's head commit
-          PREVIOUS_RUN_CREATED_AT=$(echo "$PREVIOUS_RUN_DETAILS" | jq -r '.created_at')
-          echo "Previous run was created at: $PREVIOUS_RUN_CREATED_AT"
-
-          # Get the PR's commit history and find what the head SHA was at the time of the previous run
-          # We'll check if the current PR head SHA existed before the previous run
-          COMMIT_DATE=$(gh api "/repos/$REPO/commits/$PR_HEAD_SHA" --jq '.commit.committer.date')
-          echo "Current PR HEAD commit date: $COMMIT_DATE"
-
-          # Compare dates: if the current PR head commit is newer than the previous run, there were new commits
-          if [[ "$COMMIT_DATE" > "$PREVIOUS_RUN_CREATED_AT" ]]; then
-            echo "New commits detected! Current HEAD ($PR_HEAD_SHA) was committed after the previous run."
-            echo "resubmit=false" >> $GITHUB_OUTPUT
+          REMOVED_AT=$(echo "$LATEST_REMOVAL" | jq -r '.createdAt')
+          if [[ -n "$LATEST_ADD_AT" && "$REMOVED_AT" < "$LATEST_ADD_AT" ]]; then
+            echo "Latest merge queue event is an add, not a removal"
+            echo "removed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Found previous failed/cancelled run for PR #$PR_NUM"
-          echo "Previous run ID: $PREVIOUS_RUN_ID"
-          echo "No new commits detected since the previous run!"
-          echo "This is a resubmission without new commits!"
-          echo "resubmit=true" >> $GITHUB_OUTPUT
-          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+          if [[ "$REMOVED_AT" < "$VALIDATION_RUN_CREATED_AT" ]]; then
+            echo "Latest removal predates this validation run"
+            echo "removed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          # Get PR details for the notification
-          PR_TITLE=$(gh api "/repos/$REPO/pulls/$PR_NUM" --jq '.title')
-          PR_URL=$(gh api "/repos/$REPO/pulls/$PR_NUM" --jq '.html_url')
-          PR_AUTHOR=$(gh api "/repos/$REPO/pulls/$PR_NUM" --jq '.user.login')
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          PR_URL=$(echo "$PR_DATA" | jq -r '.url')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // empty')
+          REASON=$(echo "$LATEST_REMOVAL" | jq -r '.reason // "No reason provided"')
+          ACTOR=$(echo "$LATEST_REMOVAL" | jq -r '.actor.login // empty')
+          ENQUEUER=$(echo "$LATEST_REMOVAL" | jq -r '.enqueuer.login // empty')
+          BEFORE_COMMIT=$(echo "$LATEST_REMOVAL" | jq -r '.beforeCommit.oid // empty')
 
-          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          echo "pr_author=$PR_AUTHOR" >> $GITHUB_OUTPUT
+          echo "GitHub removed PR #$PR_NUM from the merge queue"
+          echo "Removal reason: $REASON"
+          echo "Removal time: $REMOVED_AT"
+          echo "removed=true" >> "$GITHUB_OUTPUT"
+          append_output "pr_number" "$PR_NUM"
+          append_output "pr_title" "$PR_TITLE"
+          append_output "pr_url" "$PR_URL"
+          append_output "pr_author" "$PR_AUTHOR"
+          append_output "reason" "$REASON"
+          append_output "actor" "$ACTOR"
+          append_output "enqueuer" "$ENQUEUER"
+          append_output "removed_at" "$REMOVED_AT"
+          append_output "before_commit" "$BEFORE_COMMIT"
+          append_output "validation_run_url" "$VALIDATION_RUN_URL"
+          append_output "validation_run_conclusion" "$VALIDATION_RUN_CONCLUSION"
 
-      - name: Notify Slack about resubmission
-        if: steps.check.outputs.resubmit == 'true'
+      - name: Notify Slack about merge queue removal
+        if: steps.check.outputs.removed == 'true'
         uses: slackapi/slack-github-action@v1
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}
@@ -124,5 +171,10 @@ jobs:
               "PR": ${{ toJson(steps.check.outputs.pr_url) }},
               "Title": ${{ toJson(steps.check.outputs.pr_title) }},
               "Author": ${{ toJson(steps.check.outputs.pr_author) }},
-              "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "Reason": ${{ toJson(steps.check.outputs.reason) }},
+              "Removed At": ${{ toJson(steps.check.outputs.removed_at) }},
+              "Removed By": ${{ toJson(steps.check.outputs.actor) }},
+              "Enqueued By": ${{ toJson(steps.check.outputs.enqueuer) }},
+              "Validation Conclusion": ${{ toJson(steps.check.outputs.validation_run_conclusion) }},
+              "Validation Workflow": ${{ toJson(steps.check.outputs.validation_run_url) }}
             }

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -31,7 +31,6 @@ jobs:
           import re
           import subprocess
           import sys
-          import urllib.parse
           import uuid
 
           QUERY = """
@@ -119,33 +118,29 @@ jobs:
               return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
 
 
-          def query_previous_merge_group_run(repo, queue_branch, removed_at):
-              encoded_branch = urllib.parse.quote(queue_branch, safe="")
+          def query_merge_queue_workflow_run(repo, pr_number, queue_branch, removed_at):
               result = subprocess.run(
                   [
                       "gh",
                       "api",
-                      f"/repos/{repo}/actions/runs?event=merge_group&branch={encoded_branch}&per_page=20",
+                      f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
                   ],
                   check=True,
                   capture_output=True,
                   text=True,
               )
 
-              current_run_id = int(os.environ["CURRENT_RUN_ID"])
+              pr_ref_pattern = re.compile(rf"(^|/)pr-{pr_number}-")
               candidates = []
               for run in json.loads(result.stdout)["workflow_runs"]:
-                  if run["id"] == current_run_id:
+                  if run.get("path") != ".github/workflows/event-merge-to-queue.yml":
                       continue
 
-                  if run.get("name") == "Detect Merge Queue Resubmission Without New Commits":
+                  head_branch = run.get("head_branch") or ""
+                  if not pr_ref_pattern.search(head_branch):
                       continue
 
                   candidates.append(run)
-
-              current_queue_runs = [run for run in candidates if run.get("created_at", "") > removed_at]
-              if current_queue_runs:
-                  return min(current_queue_runs, key=lambda run: run["created_at"])
 
               previous_queue_runs = [run for run in candidates if run.get("created_at", "") <= removed_at]
               failed_candidates = [
@@ -156,7 +151,14 @@ jobs:
               if failed_candidates:
                   return max(failed_candidates, key=lambda run: run["created_at"])
 
-              return max(previous_queue_runs, key=lambda run: run["created_at"], default=None)
+              if previous_queue_runs:
+                  return max(previous_queue_runs, key=lambda run: run["created_at"])
+
+              current_queue_runs = [run for run in candidates if run.get("head_branch") == queue_branch]
+              if current_queue_runs:
+                  return min(current_queue_runs, key=lambda run: run["created_at"])
+
+              return max(candidates, key=lambda run: run["created_at"], default=None)
 
 
           def latest(events, event_type):
@@ -206,8 +208,8 @@ jobs:
           enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
           enqueuer_login = enqueuer.get("login") or ""
           detector_workflow_url = f"{os.environ['SERVER_URL']}/{repo}/actions/runs/{os.environ['CURRENT_RUN_ID']}"
-          previous_run = query_previous_merge_group_run(repo, queue_branch, latest_removal["createdAt"])
-          previous_run_url = (previous_run or {}).get("html_url") or detector_workflow_url
+          merge_queue_run = query_merge_queue_workflow_run(repo, pr_number, queue_branch, latest_removal["createdAt"])
+          merge_queue_run_url = (merge_queue_run or {}).get("html_url") or detector_workflow_url
 
           try:
               raw_mapping = json.loads(os.environ.get("GH_HANDLE_TO_SLACK_JSON") or "{}")
@@ -239,7 +241,7 @@ jobs:
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
           append_output("head_committed_at", head_commit["committedDate"])
-          append_output("previous_merge_queue_run", previous_run_url)
+          append_output("merge_queue_workflow", merge_queue_run_url)
           append_output("detector_workflow", detector_workflow_url)
 
       - name: Notify Slack about unchanged merge queue resubmission
@@ -264,7 +266,7 @@ jobs:
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
               "Head_Commit": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},
-              "Workflow": ${{ toJson(steps.check.outputs.previous_merge_queue_run) }},
-              "Previous_Merge_Queue_Run": ${{ toJson(steps.check.outputs.previous_merge_queue_run) }},
+              "Workflow": ${{ toJson(steps.check.outputs.detector_workflow) }},
+              "Previous_Merge_Queue_Run": ${{ toJson(steps.check.outputs.merge_queue_workflow) }},
               "Detector_Workflow": ${{ toJson(steps.check.outputs.detector_workflow) }}
             }

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -138,23 +138,25 @@ jobs:
                   if run["id"] == current_run_id:
                       continue
 
-                  if run.get("created_at", "") > removed_at:
-                      continue
-
                   if run.get("name") == "Detect Merge Queue Resubmission Without New Commits":
                       continue
 
                   candidates.append(run)
 
+              current_queue_runs = [run for run in candidates if run.get("created_at", "") > removed_at]
+              if current_queue_runs:
+                  return min(current_queue_runs, key=lambda run: run["created_at"])
+
+              previous_queue_runs = [run for run in candidates if run.get("created_at", "") <= removed_at]
               failed_candidates = [
                   run
-                  for run in candidates
+                  for run in previous_queue_runs
                   if run.get("conclusion") in {"failure", "cancelled", "timed_out", "action_required"}
               ]
               if failed_candidates:
                   return max(failed_candidates, key=lambda run: run["created_at"])
 
-              return max(candidates, key=lambda run: run["created_at"], default=None)
+              return max(previous_queue_runs, key=lambda run: run["created_at"], default=None)
 
 
           def latest(events, event_type):

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -210,7 +210,7 @@ jobs:
               "Resubmitted At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
               "Removed By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued By": ${{ toJson(steps.check.outputs.enqueued_by) }},
-              "Enqueued By Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
+              "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
               "Head Commit": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head Committed At": ${{ toJson(steps.check.outputs.head_committed_at) }},
               "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -216,7 +216,7 @@ jobs:
               slack_mapping = {}
 
           def slack_id_for(login):
-              return slack_mapping.get(login.lower(), "") if login else ""
+              return slack_mapping.get(login.lower(), login) if login else ""
 
 
           author_login = (pull_request.get("author") or {}).get("login") or ""

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -215,13 +215,29 @@ jobs:
           except (json.JSONDecodeError, AttributeError):
               slack_mapping = {}
 
-          slack_id = slack_mapping.get(enqueuer_login.lower())
-          if slack_id:
-              enqueued_by_mention = f"<@{slack_id}>"
-          elif enqueuer_login:
-              enqueued_by_mention = f"@{enqueuer_login}"
-          else:
-              enqueued_by_mention = ""
+          def normalize_slack_id(value):
+              value = str(value or "").strip()
+              if value.startswith("<@") and value.endswith(">"):
+                  value = value[2:-1]
+              return value.removeprefix("@")
+
+
+          def slack_id_for(login):
+              return normalize_slack_id(slack_mapping.get(login.lower())) if login else ""
+
+
+          def slack_mention_for(login):
+              slack_id = slack_id_for(login)
+              if slack_id:
+                  return f"<@{slack_id}>"
+              if login:
+                  return f"@{login}"
+              return ""
+
+
+          author_login = (pull_request.get("author") or {}).get("login") or ""
+          author_slack_id = slack_id_for(author_login)
+          enqueued_by_slack_id = slack_id_for(enqueuer_login)
 
           print("PR was resubmitted after removal without new commits")
           print(f"Removal reason: {reason}")
@@ -231,11 +247,14 @@ jobs:
           append_output("resubmit", "true")
           append_output("pr_title", pull_request["title"])
           append_output("pr_url", pull_request["url"])
-          append_output("pr_author", (pull_request.get("author") or {}).get("login"))
+          append_output("pr_author", author_login)
+          append_output("author_slack_id", author_slack_id)
+          append_output("author_mention", slack_mention_for(author_login))
           append_output("reason", reason)
           append_output("removed_by", actor.get("login"))
           append_output("enqueued_by", enqueuer_login)
-          append_output("enqueued_by_mention", enqueued_by_mention)
+          append_output("enqueued_by_slack_id", enqueued_by_slack_id)
+          append_output("enqueued_by_mention", slack_mention_for(enqueuer_login))
           append_output("removed_at", latest_removal["createdAt"])
           append_output("resubmitted_at", latest_add["createdAt"])
           append_output("head_commit", current_head)
@@ -257,11 +276,14 @@ jobs:
               "PR": ${{ toJson(steps.check.outputs.pr_url) }},
               "Title": ${{ toJson(steps.check.outputs.pr_title) }},
               "Author": ${{ toJson(steps.check.outputs.pr_author) }},
+              "Author_Slack_ID": ${{ toJson(steps.check.outputs.author_slack_id) }},
+              "Author_Mention": ${{ toJson(steps.check.outputs.author_mention) }},
               "Reason": ${{ toJson(steps.check.outputs.reason) }},
               "Removed_At": ${{ toJson(steps.check.outputs.removed_at) }},
               "Resubmitted_At": ${{ toJson(steps.check.outputs.resubmitted_at) }},
               "Removed_By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued_By": ${{ toJson(steps.check.outputs.enqueued_by) }},
+              "Enqueued_By_Slack_ID": ${{ toJson(steps.check.outputs.enqueued_by_slack_id) }},
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
               "Head_Commit": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current merge queue resubmission detector infers suspicious resubmissions from previous failed or cancelled merge_group workflow runs, which can produce false positives when queue order changes or a run is cancelled for reasons unrelated to an unchanged resubmission.
2. Change: The detector now runs on merge_group submission and queries the PR timeline for AddedToMergeQueueEvent and RemovedFromMergeQueueEvent. It reports only when the PR was previously removed from the merge queue, the latest queue event is the current add, and the current PR head commit is not newer than the latest removal. This uses the removal timestamp because GitHub's RemovedFromMergeQueueEvent.beforeCommit did not match the PR head SHA in live merge-queue testing.
3. Outcome: Slack notifications should represent actual unchanged resubmissions after queue removal instead of generic CI failures, cancellations, or queue reshuffles.

The Slack alert was also updated to use slackapi/slack-github-action@v3, fail visibly on Slack webhook errors, send plain Slack user IDs from GH_HANDLE_TO_SLACK_JSON, and include both the previous merge-queue validation run and the detector workflow link.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `.github/workflows/event-merge-queue-resubmit.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

Validation:
- Parsed workflow YAML with Python.
- Compiled the embedded Python workflow script.
- Ran `git diff --check`.
- Tested with real temporary merge queue PRs for first submission, unchanged resubmission, resubmission after new commit, queue advance after an earlier PR fails, queue jump/reorder, old removal events after new commits, and delayed detector execution after removal.
- Verified the simplified previous-run lookup resolves the prior merge queue validation run for PR #9553.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites merge-queue detection logic and Slack alerting in a CI workflow, which could suppress/trigger notifications incorrectly or fail the workflow if API assumptions change.
> 
> **Overview**
> Reworks the merge-queue resubmission detector to stop inferring “unchanged resubmits” from prior failed/cancelled `merge_group` runs, and instead query PR timeline events (`AddedToMergeQueueEvent`/`RemovedFromMergeQueueEvent`) plus the PR head commit timestamp to alert only when a PR is re-added after removal **without new commits**.
> 
> Updates the workflow to use a Python-based `gh api graphql` script, adds required `issues`/`pull-requests` permissions, and improves Slack alerting by upgrading to `slackapi/slack-github-action@v3`, failing on webhook errors, mapping GitHub handles to Slack IDs, and including richer context (removal reason/actor, enqueue info, commit/run links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7887eb26fd9f270e49455a3fa5c8da64b3221664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

