### PR TITLE
[8.6-rse][MOD-6411] Parse FT.CREATE arguments via ArgsCursor instead of up-fro…

### DIFF
--- a/src/obfuscation/hidden_unicode.c
+++ b/src/obfuscation/hidden_unicode.c
@@ -13,6 +13,10 @@ HiddenUnicodeString *NewHiddenUnicodeString(const char *name) {
   return (HiddenUnicodeString*)sdsnew(name);
 }
 
+HiddenUnicodeString *NewHiddenUnicodeStringWithLen(const char *name, size_t len) {
+  return (HiddenUnicodeString*)sdsnewlen(name, len);
+}
+
 void HiddenUnicodeString_Free(const HiddenUnicodeString *hn) {
   sds value = (sds)hn;
   sdsfree(value);

--- a/src/obfuscation/hidden_unicode.h
+++ b/src/obfuscation/hidden_unicode.h
@@ -23,6 +23,9 @@ typedef struct HiddenUnicodeString HiddenUnicodeString;
 // Creates a new hidden unicode string from a sds string
 // name must have been created using sdsnew, takes ownership by default
 HiddenUnicodeString *NewHiddenUnicodeString(const char *name);
+// Creates a new hidden unicode string from a buffer of known length, avoiding
+// a strlen scan when the caller already knows the length
+HiddenUnicodeString *NewHiddenUnicodeStringWithLen(const char *name, size_t len);
 // Freeds a hidden unicode string
 void HiddenUnicodeString_Free(const HiddenUnicodeString *value);
 // Compares two hidden unicode strings

--- a/src/rules.c
+++ b/src/rules.c
@@ -431,10 +431,11 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver, QueryError
   SchemaRule *rule = NULL;
   IndexSpec *sp = NULL;
 
+  uint64_t nprefixes_u64 = 0;
   int ret = REDISMODULE_OK;
   args.type = LoadStringBuffer_IOError(rdb, &len, goto cleanup);
 
-  uint64_t nprefixes_u64 = LoadUnsigned_IOError(rdb, goto cleanup);
+  nprefixes_u64 = LoadUnsigned_IOError(rdb, goto cleanup);
   RS_ASSERT(MAX_SCHEMA_PREFIXES <= UINT32_MAX);
   if (unlikely(nprefixes_u64 > MAX_SCHEMA_PREFIXES)) {
     QueryError_SetWithoutUserDataFmt(

--- a/src/rules.c
+++ b/src/rules.c
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "rules.h"
+#include "spec.h"
+#include "util/likely.h"
 #include "rlookup_load_document.h"
 #include "aggregate/expr/expression.h"
 #include "aggregate/expr/exprast.h"
@@ -125,6 +127,14 @@ static SchemaRule *SchemaRule_CreateInternal(SchemaRuleArgs *args, ArgsCursor *p
 
   if (prefixes_ac) {
     size_t nprefixes = AC_NumRemaining(prefixes_ac);
+    RS_ASSERT(MAX_SCHEMA_PREFIXES <= SIZE_MAX);
+    if (unlikely(nprefixes > MAX_SCHEMA_PREFIXES)) {
+      QueryError_SetWithoutUserDataFmt(
+          status, QUERY_ERROR_CODE_LIMIT,
+          "Number of prefixes (%zu) exceeds maximum allowed (%d)",
+          nprefixes, MAX_SCHEMA_PREFIXES);
+      goto error;
+    }
     rule->prefixes = array_new(HiddenUnicodeString*, nprefixes);
     for (size_t i = 0; i < nprefixes; ++i) {
       size_t prefix_len = 0;
@@ -132,6 +142,13 @@ static SchemaRule *SchemaRule_CreateInternal(SchemaRuleArgs *args, ArgsCursor *p
       array_append(rule->prefixes, NewHiddenUnicodeStringWithLen(prefix, prefix_len));
     }
   } else {
+    if (unlikely(args->nprefixes > MAX_SCHEMA_PREFIXES)) {
+      QueryError_SetWithoutUserDataFmt(
+          status, QUERY_ERROR_CODE_LIMIT,
+          "Number of prefixes (%d) exceeds maximum allowed (%d)",
+          args->nprefixes, MAX_SCHEMA_PREFIXES);
+      goto error;
+    }
     rule->prefixes = array_new(HiddenUnicodeString*, args->nprefixes);
     for (int i = 0; i < args->nprefixes; ++i) {
       array_append(rule->prefixes, NewHiddenUnicodeString(args->prefixes[i]));
@@ -417,7 +434,17 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver, QueryError
   int ret = REDISMODULE_OK;
   args.type = LoadStringBuffer_IOError(rdb, &len, goto cleanup);
 
-  args.nprefixes = LoadUnsigned_IOError(rdb, goto cleanup);
+  uint64_t nprefixes_u64 = LoadUnsigned_IOError(rdb, goto cleanup);
+  RS_ASSERT(MAX_SCHEMA_PREFIXES <= UINT32_MAX);
+  if (unlikely(nprefixes_u64 > MAX_SCHEMA_PREFIXES)) {
+    QueryError_SetWithoutUserDataFmt(
+        status, QUERY_ERROR_CODE_LIMIT,
+        "RDB Load: Number of prefixes (%llu) exceeds maximum allowed (%d)",
+        (unsigned long long)nprefixes_u64, MAX_SCHEMA_PREFIXES);
+    ret = REDISMODULE_ERR;
+    goto cleanup;
+  }
+  args.nprefixes = (unsigned int)nprefixes_u64;
   if (args.nprefixes <= RULEARGS_INITIAL_NUM_PREFIXES_ON_STACK) {
     args.prefixes = (const char **)prefixes;
     memset(args.prefixes, 0, args.nprefixes * sizeof(*args.prefixes));

--- a/src/rules.c
+++ b/src/rules.c
@@ -83,7 +83,11 @@ void LegacySchemaRulesArgs_Free(RedisModuleCtx *ctx) {
   legacySpecRules = NULL;
 }
 
-SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *status) {
+// Shared body for SchemaRule_Create / SchemaRule_CreateWithPrefixesAC. The
+// prefix list is taken from `prefixes_ac` if non-NULL, otherwise from
+// `args->prefixes` (count `args->nprefixes`). The cursor, if used, is consumed.
+static SchemaRule *SchemaRule_CreateInternal(SchemaRuleArgs *args, ArgsCursor *prefixes_ac,
+                                             StrongRef ref, QueryError *status) {
   SchemaRule *rule = rm_calloc(1, sizeof(*rule));
 
   if (DocumentType_Parse(args->type, &rule->type, status) == REDISMODULE_ERR) {
@@ -119,10 +123,19 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
     rule->lang_default = DEFAULT_LANGUAGE;
   }
 
-  rule->prefixes = array_new(HiddenUnicodeString*, args->nprefixes);
-  for (int i = 0; i < args->nprefixes; ++i) {
-    HiddenUnicodeString* p = NewHiddenUnicodeString(args->prefixes[i]);
-    array_append(rule->prefixes, p);
+  if (prefixes_ac) {
+    size_t nprefixes = AC_NumRemaining(prefixes_ac);
+    rule->prefixes = array_new(HiddenUnicodeString*, nprefixes);
+    for (size_t i = 0; i < nprefixes; ++i) {
+      size_t prefix_len = 0;
+      const char *prefix = AC_GetStringNC(prefixes_ac, &prefix_len);
+      array_append(rule->prefixes, NewHiddenUnicodeStringWithLen(prefix, prefix_len));
+    }
+  } else {
+    rule->prefixes = array_new(HiddenUnicodeString*, args->nprefixes);
+    for (int i = 0; i < args->nprefixes; ++i) {
+      array_append(rule->prefixes, NewHiddenUnicodeString(args->prefixes[i]));
+    }
   }
 
   if (rule->filter_exp_str) {
@@ -154,6 +167,15 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
 error:
   SchemaRule_Free(rule);
   return NULL;
+}
+
+SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *status) {
+  return SchemaRule_CreateInternal(args, NULL, ref, status);
+}
+
+SchemaRule *SchemaRule_CreateWithPrefixesAC(SchemaRuleArgs *args, ArgsCursor *prefixes_ac,
+                                            StrongRef ref, QueryError *status) {
+  return SchemaRule_CreateInternal(args, prefixes_ac, ref, status);
 }
 
 /*.

--- a/src/rules.h
+++ b/src/rules.h
@@ -28,6 +28,9 @@ extern "C" {
 #define RULE_TYPE_HASH "HASH"
 #define RULE_TYPE_JSON "JSON"
 
+#define MAX_SCHEMA_PREFIXES 1000000
+
+
 struct RSExpr;
 struct IndexSpec;
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -17,6 +17,7 @@
 #include "redisearch.h"
 #include "util/references.h"
 #include "obfuscation/hidden_unicode.h"
+#include "rmutil/args.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,6 +72,12 @@ void SchemaRuleArgs_Free(SchemaRuleArgs *args);
 void LegacySchemaRulesArgs_Free(RedisModuleCtx *ctx);
 
 SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef spec_ref, QueryError *status);
+
+/* Same as SchemaRule_Create, but the prefixes are read from an ArgsCursor
+ * instead of `args->prefixes`/`args->nprefixes`. The cursor must contain at
+ * least one prefix. The cursor is consumed (advanced) by this function. */
+SchemaRule *SchemaRule_CreateWithPrefixesAC(SchemaRuleArgs *args, ArgsCursor *prefixes_ac,
+                                            StrongRef spec_ref, QueryError *status);
 void SchemaRule_FilterFields(struct IndexSpec *sp);
 void SchemaRule_Free(SchemaRule *);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -312,6 +312,10 @@ arrayof(FieldSpec *) IndexSpec_GetFieldsByMask(const IndexSpec *sp, t_fieldMask 
 
 //---------------------------------------------------------------------------------------------
 
+// Forward declaration
+static StrongRef IndexSpec_ParseFromArgCursor(RedisModuleCtx *ctx, const HiddenString *name,
+                                           ArgsCursor *ac_in, QueryError *status);
+
 /*
 * Parse an index spec from redis command arguments.
 * Returns REDISMODULE_ERR if there's a parsing error.
@@ -322,13 +326,9 @@ arrayof(FieldSpec *) IndexSpec_GetFieldsByMask(const IndexSpec *sp, t_fieldMask 
 */
 StrongRef IndexSpec_ParseRedisArgs(RedisModuleCtx *ctx, const HiddenString *name,
                                     RedisModuleString **argv, int argc, QueryError *status) {
-
-  const char *args[argc];
-  for (int i = 0; i < argc; i++) {
-    args[i] = RedisModule_StringPtrLen(argv[i], NULL);
-  }
-
-  return IndexSpec_Parse(ctx, name, args, argc, status);
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, argv, argc);
+  return IndexSpec_ParseFromArgCursor(ctx, name, &ac, status);
 }
 
 arrayof(FieldSpec *) getFieldsByType(IndexSpec *spec, FieldType type) {
@@ -1744,17 +1744,17 @@ void handleBadArguments(IndexSpec *spec, const char *badarg, QueryError *status,
 /* The format currently is FT.CREATE {index} [NOOFFSETS] [NOFIELDS]
     SCHEMA {field} [TEXT [WEIGHT {weight}]] | [NUMERIC]
   */
-StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const char **argv, int argc, QueryError *status) {
+
+static StrongRef IndexSpec_ParseFromArgCursor(RedisModuleCtx *ctx, const HiddenString *name,
+                                           ArgsCursor *ac, QueryError *status) {
   IndexSpec *spec = NewIndexSpec(name);
   StrongRef spec_ref = StrongRef_New(spec, (RefManager_Free)IndexSpec_Free);
   spec->own_ref = spec_ref;
 
   IndexSpec_MakeKeyless(spec);
 
-  ArgsCursor ac = {0};
   ArgsCursor acStopwords = {0};
 
-  ArgsCursor_InitCString(&ac, argv, argc);
   long long timeout = -1;
   int dummy;
   size_t dummy2;
@@ -1794,7 +1794,7 @@ StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const c
     {.name = NULL}
   };
   ACArgSpec *argopts = isSpecOnDiskForValidation(spec) ? flex_argopts : non_flex_argopts;
-  rc = AC_ParseArgSpec(&ac, argopts, &errarg);
+  rc = AC_ParseArgSpec(ac, argopts, &errarg);
   invalid_flex_on_type = isSpecOnDiskForValidation(spec) && rule_args.type && (strcasecmp(rule_args.type, RULE_TYPE_HASH) != 0);
   if (rc != AC_OK) {
     if (rc != AC_ERR_ENOENT) {
@@ -1820,15 +1820,13 @@ StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const c
   spec->timeout = timeout * 1000;  // convert to ms
 
   if (rule_prefixes.argc > 0) {
-    rule_args.nprefixes = rule_prefixes.argc;
-    rule_args.prefixes = (const char **)rule_prefixes.objs;
+    spec->rule = SchemaRule_CreateWithPrefixesAC(&rule_args, &rule_prefixes, spec_ref, status);
   } else {
     rule_args.nprefixes = 1;
     static const char *empty_prefix[] = {""};
     rule_args.prefixes = empty_prefix;
+    spec->rule = SchemaRule_Create(&rule_args, spec_ref, status);
   }
-
-  spec->rule = SchemaRule_Create(&rule_args, spec_ref, status);
   if (!spec->rule) {
     goto failure;
   }
@@ -1855,13 +1853,13 @@ StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const c
     if (spec->stopwords) {
       StopWordList_Unref(spec->stopwords);
     }
-    spec->stopwords = NewStopWordListCStr((const char **)acStopwords.objs, acStopwords.argc);
+    spec->stopwords = NewStopWordListAC(&acStopwords);
     spec->flags |= Index_HasCustomStopwords;
   }
 
-  if (!AC_AdvanceIfMatch(&ac, SPEC_SCHEMA_STR)) {
-    if (AC_NumRemaining(&ac)) {
-      const char *badarg = AC_GetStringNC(&ac, NULL);
+  if (!AC_AdvanceIfMatch(ac, SPEC_SCHEMA_STR)) {
+    if (AC_NumRemaining(ac)) {
+      const char *badarg = AC_GetStringNC(ac, NULL);
       handleBadArguments(spec, badarg, status, non_flex_argopts);
     } else {
       QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No schema found");
@@ -1869,7 +1867,7 @@ StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const c
     goto failure;
   }
 
-  if (!IndexSpec_AddFieldsInternal(spec, spec_ref, &ac, status, 1)) {
+  if (!IndexSpec_AddFieldsInternal(spec, spec_ref, ac, status, 1)) {
     goto failure;
   }
 
@@ -1892,7 +1890,9 @@ failure:  // on failure free the spec fields array and return an error
 
 StrongRef IndexSpec_ParseC(RedisModuleCtx *ctx, const char *name, const char **argv, int argc, QueryError *status) {
   HiddenString *hidden = NewHiddenString(name, strlen(name), true);
-  return IndexSpec_Parse(ctx, hidden, argv, argc, status);
+  ArgsCursor ac = {0};
+  ArgsCursor_InitCString(&ac, argv, argc);
+  return IndexSpec_ParseFromArgCursor(ctx, hidden, &ac, status);
 }
 
 static void RSIndexStats_FromScoringStats(const ScoringIndexStats *scoring, RSIndexStats *stats) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -536,9 +536,10 @@ int IndexSpec_Deserialize(const RedisModuleString *serialized, int encver);
 void IndexSpec_StartGC(StrongRef spec_ref, IndexSpec *sp, GCPolicy gcPolicy);
 void IndexSpec_StartGCFromSpec(StrongRef spec_ref, IndexSpec *sp, uint32_t gcPolicy);
 
-/* Same as above but with ordinary strings, to allow unit testing */
-StrongRef IndexSpec_Parse(RedisModuleCtx *ctx, const HiddenString *name, const char **argv, int argc, QueryError *status);
-// Calls IndexSpec_Parse after wrapping name with a hidden string
+/* Same as IndexSpec_Parse, but takes a NUL-terminated C-string name and wraps it in a HiddenString
+ * internally. Intended for unit tests only.
+ * Do not use in production or new code: the wrapping requires an extra strlen() over the name,
+ * which IndexSpec_Parse avoids by taking a HiddenString directly. */
 StrongRef IndexSpec_ParseC(RedisModuleCtx *ctx, const char *name, const char **argv, int argc, QueryError *status);
 
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);

--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -70,40 +70,67 @@ int StopWordList_Contains(const StopWordList *sl, const char *term, size_t len) 
   return ret;
 }
 
-StopWordList *NewStopWordListCStr(const char **strs, size_t len) {
-  if (len == 0 && __empty_stopwords) {
-    return __empty_stopwords;
+// Lowercase `s` and add it to the stopword list's trie. The input is copied,
+// so the caller retains ownership of `s`. `slen` is the byte length of `s`.
+static void StopWordList_AddInternal(StopWordList *sl, const char *s, size_t slen) {
+  char *t = rm_strndup(s, slen);
+  RS_ASSERT(t);
+
+  // convert multi-byte characters to lowercase
+  char *dst = unicode_tolower(t, &slen);
+  if (dst) {
+    rm_free(t);
+    t = dst;
+  } else {
+    // No memory allocation, just ensure null termination
+    t[slen] = '\0';
   }
-  if (len > MAX_STOPWORDLIST_SIZE) {
-    len = MAX_STOPWORDLIST_SIZE;
+
+  TrieMap_Add(sl->m, t, slen, NULL, NULL);
+  rm_free(t);
+}
+
+static StopWordList *StopWordList_NewEmpty(size_t expected_len) {
+  if (expected_len == 0 && __empty_stopwords) {
+    return __empty_stopwords;
   }
   StopWordList *sl = rm_malloc(sizeof(*sl));
   sl->refcount = 1;
   sl->m = NewTrieMap();
+  if (expected_len == 0) {
+    __empty_stopwords = sl;
+  }
+  return sl;
+}
+
+StopWordList *NewStopWordListCStr(const char **strs, size_t len) {
+  if (len > MAX_STOPWORDLIST_SIZE) {
+    len = MAX_STOPWORDLIST_SIZE;
+  }
+  StopWordList *sl = StopWordList_NewEmpty(len);
+  if (len == 0) {
+    return sl;
+  }
 
   for (size_t i = 0; i < len; i++) {
-
-    char *t = rm_strdup(strs[i]);
-    if (t == NULL) {
-      break;
-    }
-    size_t tlen = strlen(t);
-
-    // convert multi-byte characters to lowercase
-    char *dst = unicode_tolower(t, &tlen);
-    if (dst) {
-        rm_free(t);
-        t = dst;
-    } else {
-      // No memory allocation, just ensure null termination
-      t[tlen] = '\0';
-    }
-
-    TrieMap_Add(sl->m, t, tlen, NULL, NULL);
-    rm_free(t);
+    StopWordList_AddInternal(sl, strs[i], strlen(strs[i]));
   }
+  return sl;
+}
+
+StopWordList *NewStopWordListAC(ArgsCursor *ac) {
+  size_t len = AC_NumRemaining(ac);
+  if (len > MAX_STOPWORDLIST_SIZE) {
+    len = MAX_STOPWORDLIST_SIZE;
+  }
+  StopWordList *sl = StopWordList_NewEmpty(len);
   if (len == 0) {
-    __empty_stopwords = sl;
+    return sl;
+  }
+  for (size_t i = 0; i < len; i++) {
+    size_t slen = 0;
+    const char *s = AC_GetStringNC(ac, &slen);
+    StopWordList_AddInternal(sl, s, slen);
   }
   return sl;
 }

--- a/src/stopwords.h
+++ b/src/stopwords.h
@@ -11,6 +11,7 @@
 
 #include "reply.h"
 #include "redismodule.h"
+#include "rmutil/args.h"
 
 #include <stdlib.h>
 
@@ -37,6 +38,11 @@ void StopWordList_FreeGlobals(void);
 
 /* Create a new stopword list from a list of NULL-terminated C strings */
 struct StopWordList *NewStopWordListCStr(const char **strs, size_t len);
+
+/* Create a new stopword list by consuming the remaining arguments of an
+ * ArgsCursor. Works with any ArgsCursor type (CString, RString, SDS) and
+ * avoids materializing an intermediate const char ** buffer. */
+struct StopWordList *NewStopWordListAC(ArgsCursor *ac);
 
 /* Free a stopword list's memory */
 void StopWordList_Unref(struct StopWordList *sl);

--- a/tests/cpptests/test_cpp_rules.cpp
+++ b/tests/cpptests/test_cpp_rules.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "gtest/gtest.h"
+#include "common.h"
+#include "index_utils.h"
+#include "rules.h"
+#include "redisearch_api.h"
+#include "obfuscation/hidden_unicode.h"
+#include "rmutil/args.h"
+#include "util/arr.h"
+
+class SchemaRuleTest : public ::testing::Test {};
+
+// SchemaRule_CreateWithPrefixesAC reads prefixes from an ArgsCursor and consumes
+// it fully, producing a rule whose prefix list matches the cursor contents.
+TEST_F(SchemaRuleTest, testCreateFromACPrefixes) {
+  auto ism = RediSearch_CreateIndex("idx_rule_ac", NULL);
+  ASSERT_NE(ism, nullptr);
+
+  const char *prefix_strs[] = {"users:", "products:", "orders:"};
+  const int nprefixes = sizeof(prefix_strs) / sizeof(prefix_strs[0]);
+
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, prefix_strs, nprefixes);
+
+  SchemaRuleArgs args = {0};
+  args.type = "HASH";
+
+  QueryError status = QueryError_Default();
+  SchemaRule *rule = SchemaRule_CreateWithPrefixesAC(&args, &ac, {ism}, &status);
+  ASSERT_NE(rule, nullptr) << QueryError_GetUserError(&status);
+  ASSERT_FALSE(QueryError_HasError(&status));
+
+  ASSERT_EQ((int)array_len(rule->prefixes), nprefixes);
+  for (int i = 0; i < nprefixes; i++) {
+    size_t len = 0;
+    const char *got = HiddenUnicodeString_GetUnsafe(rule->prefixes[i], &len);
+    ASSERT_STREQ(got, prefix_strs[i]);
+  }
+  // The cursor should be fully consumed.
+  ASSERT_EQ(AC_NumRemaining(&ac), 0u);
+
+  get_spec(ism)->rule = rule;
+  Spec_AddToDict(ism);
+  freeSpec(ism);
+}
+
+// The AC and the C-array constructors must produce the same prefix list when
+// fed equivalent inputs.
+TEST_F(SchemaRuleTest, testCreateFromACEquivalentToCArray) {
+  const char *prefix_strs[] = {"a:", "b:"};
+  const int nprefixes = sizeof(prefix_strs) / sizeof(prefix_strs[0]);
+
+  auto ism_arr = RediSearch_CreateIndex("idx_rule_arr", NULL);
+  ASSERT_NE(ism_arr, nullptr);
+  SchemaRuleArgs args_arr = {0};
+  args_arr.type = "HASH";
+  args_arr.prefixes = prefix_strs;
+  args_arr.nprefixes = nprefixes;
+  QueryError s_arr = QueryError_Default();
+  SchemaRule *rule_arr = SchemaRule_Create(&args_arr, {ism_arr}, &s_arr);
+  ASSERT_NE(rule_arr, nullptr) << QueryError_GetUserError(&s_arr);
+
+  auto ism_ac = RediSearch_CreateIndex("idx_rule_ac2", NULL);
+  ASSERT_NE(ism_ac, nullptr);
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, prefix_strs, nprefixes);
+  SchemaRuleArgs args_ac = {0};
+  args_ac.type = "HASH";
+  QueryError s_ac = QueryError_Default();
+  SchemaRule *rule_ac = SchemaRule_CreateWithPrefixesAC(&args_ac, &ac, {ism_ac}, &s_ac);
+  ASSERT_NE(rule_ac, nullptr) << QueryError_GetUserError(&s_ac);
+
+  ASSERT_EQ(array_len(rule_arr->prefixes), array_len(rule_ac->prefixes));
+  for (int i = 0; i < nprefixes; i++) {
+    ASSERT_EQ(HiddenUnicodeString_Compare(rule_arr->prefixes[i], rule_ac->prefixes[i]), 0);
+  }
+  ASSERT_EQ(rule_arr->type, rule_ac->type);
+
+  get_spec(ism_arr)->rule = rule_arr;
+  Spec_AddToDict(ism_arr);
+  freeSpec(ism_arr);
+  get_spec(ism_ac)->rule = rule_ac;
+  Spec_AddToDict(ism_ac);
+  freeSpec(ism_ac);
+}
+
+// An AC with no remaining args produces a rule with an empty prefix list.
+TEST_F(SchemaRuleTest, testCreateFromACEmpty) {
+  auto ism = RediSearch_CreateIndex("idx_rule_ac_empty", NULL);
+  ASSERT_NE(ism, nullptr);
+
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, NULL, 0);
+
+  SchemaRuleArgs args = {0};
+  args.type = "HASH";
+
+  QueryError status = QueryError_Default();
+  SchemaRule *rule = SchemaRule_CreateWithPrefixesAC(&args, &ac, {ism}, &status);
+  ASSERT_NE(rule, nullptr) << QueryError_GetUserError(&status);
+  ASSERT_EQ(array_len(rule->prefixes), 0u);
+
+  get_spec(ism)->rule = rule;
+  Spec_AddToDict(ism);
+  freeSpec(ism);
+}
+
+// Bad args (invalid document type) must surface as an error and return NULL,
+// regardless of which constructor variant is used.
+TEST_F(SchemaRuleTest, testCreateFromACInvalidType) {
+  auto ism = RediSearch_CreateIndex("idx_rule_ac_bad", NULL);
+  ASSERT_NE(ism, nullptr);
+
+  const char *prefix_strs[] = {"x:"};
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, prefix_strs, 1);
+
+  SchemaRuleArgs args = {0};
+  args.type = "BOGUS";
+
+  QueryError status = QueryError_Default();
+  SchemaRule *rule = SchemaRule_CreateWithPrefixesAC(&args, &ac, {ism}, &status);
+  ASSERT_EQ(rule, nullptr);
+  ASSERT_TRUE(QueryError_HasError(&status));
+  QueryError_ClearError(&status);
+
+  freeSpec(ism);
+}

--- a/tests/cpptests/test_cpp_rules.cpp
+++ b/tests/cpptests/test_cpp_rules.cpp
@@ -113,6 +113,49 @@ TEST_F(SchemaRuleTest, testCreateFromACEmpty) {
   freeSpec(ism);
 }
 
+// Exceeding MAX_SCHEMA_PREFIXES via the AC path must return NULL with an error
+// without touching the (potentially fake) prefix pointers.
+TEST_F(SchemaRuleTest, testCreateFromACTooManyPrefixes) {
+  auto ism = RediSearch_CreateIndex("idx_rule_ac_overlimit", NULL);
+  ASSERT_NE(ism, nullptr);
+
+  ArgsCursor ac = {};
+  ac.argc = MAX_SCHEMA_PREFIXES + 1;  // fake count; the check fires before iteration
+
+  SchemaRuleArgs args = {0};
+  args.type = "HASH";
+
+  QueryError status = QueryError_Default();
+  SchemaRule *rule = SchemaRule_CreateWithPrefixesAC(&args, &ac, {ism}, &status);
+  ASSERT_EQ(rule, nullptr);
+  ASSERT_TRUE(QueryError_HasError(&status));
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_LIMIT);
+  QueryError_ClearError(&status);
+
+  freeSpec(ism);
+}
+
+// Exceeding MAX_SCHEMA_PREFIXES via the C-array path must return NULL with an
+// error without dereferencing the (NULL) prefix array.
+TEST_F(SchemaRuleTest, testCreateFromCArrayTooManyPrefixes) {
+  auto ism = RediSearch_CreateIndex("idx_rule_arr_overlimit", NULL);
+  ASSERT_NE(ism, nullptr);
+
+  SchemaRuleArgs args = {0};
+  args.type = "HASH";
+  args.nprefixes = MAX_SCHEMA_PREFIXES + 1;  // check fires before iteration
+  args.prefixes = nullptr;
+
+  QueryError status = QueryError_Default();
+  SchemaRule *rule = SchemaRule_Create(&args, {ism}, &status);
+  ASSERT_EQ(rule, nullptr);
+  ASSERT_TRUE(QueryError_HasError(&status));
+  ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_LIMIT);
+  QueryError_ClearError(&status);
+
+  freeSpec(ism);
+}
+
 // Bad args (invalid document type) must surface as an error and return NULL,
 // regardless of which constructor variant is used.
 TEST_F(SchemaRuleTest, testCreateFromACInvalidType) {

--- a/tests/ctests/test_stopwords.c
+++ b/tests/ctests/test_stopwords.c
@@ -9,6 +9,7 @@
 #include "test_util.h"
 #include <rmalloc.h>
 #include <stopwords.h>
+#include <rmutil/args.h>
 
 void RMUTil_InitAlloc();
 
@@ -51,9 +52,48 @@ int testDefaultStopwords() {
   return 0;
 }
 
+int testStopwordListAC() {
+
+  // Same inputs as testStopwordList, but consumed via an ArgsCursor.
+  const char *terms[] = {"foo", "bar", "שלום", "Hello", "WORLD"};
+  const char *test_terms[] = {"foo", "bar", "שלום", "hello", "world"};
+  const size_t nterms = sizeof(terms) / sizeof(const char *);
+
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, terms, nterms);
+
+  StopWordList *sl = NewStopWordListAC(&ac);
+  ASSERT(sl != NULL);
+  // The cursor should have been fully consumed.
+  ASSERT_EQUAL(0, AC_NumRemaining(&ac));
+
+  for (int i = 0; i < sizeof(test_terms) / sizeof(const char *); i++) {
+    ASSERT(StopWordList_Contains(sl, test_terms[i], strlen(test_terms[i])));
+  }
+
+  ASSERT(!StopWordList_Contains(sl, "asdfasdf", strlen("asdfasdf")));
+  StopWordList_Free(sl);
+  return 0;
+}
+
+int testStopwordListACEmpty() {
+
+  // An empty cursor should produce a non-NULL (cached, empty) list.
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, NULL, 0);
+
+  StopWordList *sl = NewStopWordListAC(&ac);
+  ASSERT(sl != NULL);
+  ASSERT(!StopWordList_Contains(sl, "foo", 3));
+  StopWordList_Free(sl);
+  return 0;
+}
+
 TEST_MAIN({
   RMUTil_InitAlloc();
   TESTFUNC(testStopwordList);
+  TESTFUNC(testStopwordListAC);
+  TESTFUNC(testStopwordListACEmpty);
   TESTFUNC(testDefaultStopwords);
   StopWordList_FreeGlobals();
 });

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -144,6 +144,18 @@ def test_MOD_865(env):
   env.expect(*args_list).error().contains('Duplicate field in schema - txt')
   env.expect('FT.DROPINDEX', 'idx')
 
+def test_MOD_6411(env):
+  # FT.CREATE used to crash on a stack overflow when the argument list was
+  # large enough (the parser allocated a VLA of `const char *` on the stack).
+  # The parser now consumes RedisModuleString ** directly through ArgsCursor,
+  # so an oversized field list is rejected with the standard schema-limit
+  # error instead of crashing the server.
+  args_list = ['FT.CREATE', 'idx', 'SCHEMA']
+  for i in range(100000):
+    args_list.extend([f'field{i}', 'NUMERIC', 'SORTABLE'])
+  env.expect(*args_list).error().contains('Schema is limited to 1024 fields')
+  env.expect('FT.DROPINDEX', 'idx')
+
 def test_issue1826(env):
   # Stopword query is case sensitive.
   conn = getConnectionByEnv(env)


### PR DESCRIPTION
Backport #9427 to 8.6-rse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `FT.CREATE`/index-spec parsing and schema rule construction, so mistakes could break index creation or RDB loading; changes are guarded with explicit limits and expanded test coverage.
> 
> **Overview**
> Reworks `FT.CREATE` parsing to consume arguments directly via `ArgsCursor` (instead of building a stack-based `const char *` array), preventing stack overflows on very large command argument lists and keeping error behavior consistent.
> 
> Adds a shared `SchemaRule_CreateInternal` plus `SchemaRule_CreateWithPrefixesAC`, introduces `MAX_SCHEMA_PREFIXES` enforcement (including during RDB load), and adds `NewHiddenUnicodeStringWithLen` to avoid extra `strlen` scans when prefixes come with known lengths.
> 
> Extends stopwords construction with `NewStopWordListAC` to build lists directly from an `ArgsCursor`, and adds new C/C++/Python tests covering cursor consumption, prefix-limit errors, stopwords AC behavior, and the MOD-6411 regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff125cb31929bb72b83481db33b9ef4df3c6ebfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->