### PR TITLE
[test] MQ scenario 1 first fails

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/scenario1-first-fails.txt
+++ b/.github/mq-detector-test/scenario1-first-fails.txt
@@ -1,0 +1,1 @@
+Scenario 1: first queued PR intentionally fails mock merge queue validation.


### PR DESCRIPTION
Temporary PR for merge queue detector testing.

Scenario 1: this PR enters the queue first and intentionally fails mock merge queue validation using `.github/mq-detector-test/fail-merge-queue`.

Expected detector behavior: no unchanged-resubmission notification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds test marker text files under `.github/` with no runtime code changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/fail-merge-queue` and `.github/mq-detector-test/scenario1-first-fails.txt` as **merge-queue detector test fixtures** to intentionally trigger a mock merge-queue validation failure for *scenario 1 (first queued PR fails)*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f4d0f7e7863a02bdee605267f4244342bcc6b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->