### PR TITLE
[test] MQ scenario 1 second advances

### DIFF
--- a/.github/mq-detector-test/scenario1-second-passes.txt
+++ b/.github/mq-detector-test/scenario1-second-passes.txt
@@ -1,0 +1,1 @@
+Scenario 1: second queued PR should advance after the first PR fails.


### PR DESCRIPTION
Temporary PR for merge queue detector testing.

Scenario 1: this PR enters the queue behind a failing PR, then should become first and revalidate after the first PR is removed.

Expected detector behavior: no unchanged-resubmission notification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single test marker file under `.github/` for merge-queue detector scenarios; no production code or runtime behavior changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/scenario1-second-passes.txt` containing the expected pass condition for merge-queue detector *Scenario 1* (second queued PR should advance after the first PR fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a82e8ffa079488ceac8896d240defe91db3841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->