### PR TITLE
[test] MQ scenario 2 first queued

### DIFF
--- a/.github/mq-detector-test/scenario2-first-passes.txt
+++ b/.github/mq-detector-test/scenario2-first-passes.txt
@@ -1,0 +1,1 @@
+Scenario 2: first queued PR should not notify when another PR jumps ahead.


### PR DESCRIPTION
Temporary PR for merge queue detector testing.

Scenario 2: this PR enters the queue first, then another PR jumps ahead.

Expected detector behavior: no unchanged-resubmission notification for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single text file used for merge-queue detector testing, with no production code or workflow logic changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/scenario2-first-passes.txt` to document/drive *merge queue detector* **Scenario 2**, where the first queued PR should **not** trigger an unchanged-resubmission notification if another PR jumps ahead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab78aedba33570fbe899e931cee9912ecc451c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->