### PR TITLE
[test] MQ scenario 2 second jumps

### DIFF
--- a/.github/mq-detector-test/scenario2-second-jumps.txt
+++ b/.github/mq-detector-test/scenario2-second-jumps.txt
@@ -1,0 +1,1 @@
+Scenario 2: second queued PR jumps ahead and should not notify either PR.


### PR DESCRIPTION
Temporary PR for merge queue detector testing.

Scenario 2: this PR is enqueued with jump=true after another PR is already queued.

Expected detector behavior: no unchanged-resubmission notification for either PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single test scenario marker text file under `.github` with no code or runtime behavior changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/scenario2-second-jumps.txt` to represent merge-queue detector *Scenario 2* where a second queued PR jumps ahead and should not trigger unchanged-resubmission notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e767b463304fcede01619c85af73ef054ae8ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->