### PR TITLE
[test] MQ past target behind failing PR

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,1 +1,0 @@
-This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/past-target.txt
+++ b/.github/mq-detector-test/past-target.txt
@@ -1,0 +1,1 @@
+Past-removal target PR. It will later be placed behind a failing PR.

--- a/.github/mq-detector-test/past-target.txt
+++ b/.github/mq-detector-test/past-target.txt
@@ -1,1 +1,2 @@
 Past-removal target PR. It will later be placed behind a failing PR.
+New commit after the past removal; this PR should now pass mock MQ validation.


### PR DESCRIPTION
Temporary PR for testing a past removal followed by a new commit, then queueing behind another failing PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a test-only text fixture under `.github/` with no impact on runtime code paths.
> 
> **Overview**
> Adds `.github/mq-detector-test/past-target.txt` as a test fixture describing a past-removal target followed by a new commit, intended to make the mock MQ validation pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c346951dec532a341457494e488789c123b4f7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->