### PR TITLE
[test] MQ past scenario 1 first fails

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/past-s1-first.txt
+++ b/.github/mq-detector-test/past-s1-first.txt
@@ -1,0 +1,1 @@
+Scenario 1 with history: first PR gets a past removal, then later fails again.

--- a/.github/mq-detector-test/past-s1-first.txt
+++ b/.github/mq-detector-test/past-s1-first.txt
@@ -1,1 +1,2 @@
 Scenario 1 with history: first PR gets a past removal, then later fails again.
+New commit after the past removal; this PR intentionally still fails.


### PR DESCRIPTION
Temporary PR for testing scenario 1 with a past removal event on the first failing PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds `.github/mq-detector-test` marker/fixture files used for merge-queue testing, with no runtime code changes.
> 
> **Overview**
> Adds two `.github/mq-detector-test` fixtures: a `fail-merge-queue` marker to intentionally trip mock merge-queue validation, and a `past-s1-first.txt` note documenting *scenario 1* where the first failing PR is removed in the past and later fails again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5214f4e279320e72b1f37699362f40f5b4a7b25f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->