### PR TITLE
[test] MQ past scenario 1 second advances

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,1 +1,0 @@
-This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/past-s1-second.txt
+++ b/.github/mq-detector-test/past-s1-second.txt
@@ -1,0 +1,1 @@
+Scenario 1 with history: second PR gets a past removal, then later passes.

--- a/.github/mq-detector-test/past-s1-second.txt
+++ b/.github/mq-detector-test/past-s1-second.txt
@@ -1,1 +1,2 @@
 Scenario 1 with history: second PR gets a past removal, then later passes.
+New commit after the past removal; this PR should pass after the first PR is kicked.


### PR DESCRIPTION
Temporary PR for testing scenario 1 with a past removal event on the second advancing PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new test/fixture text file under `.github` with no code or workflow logic changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/past-s1-second.txt`, a new two-line fixture/marker file used for merge-queue detector testing of *past scenario 1* (second PR sees a past removal, then later passes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cfaf045799afe2b149badda429e3de7131f55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->