### PR TITLE
[test] MQ past scenario 2 first queued

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,1 +1,0 @@
-This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/past-s2-first.txt
+++ b/.github/mq-detector-test/past-s2-first.txt
@@ -1,1 +1,2 @@
 Scenario 2 with history: first PR gets a past removal, then later participates in jump test.
+New commit after the past removal; this PR should not notify when another PR jumps.

--- a/.github/mq-detector-test/past-s2-first.txt
+++ b/.github/mq-detector-test/past-s2-first.txt
@@ -1,0 +1,1 @@
+Scenario 2 with history: first PR gets a past removal, then later participates in jump test.


### PR DESCRIPTION
Temporary PR for testing jump scenario with a past removal event on the first PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only a test/fixture text file under `.github` with no code or workflow logic changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/past-s2-first.txt`, a new fixture describing a merge-queue detector test case where the first PR has a prior removal event and should *not* trigger a notification when another PR later jumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc7eaf48d7cda7e4f4f5700ea7aa144c7b5cc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->