### PR TITLE
[test] MQ past scenario 2 second jumps

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,1 +1,0 @@
-This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/past-s2-second.txt
+++ b/.github/mq-detector-test/past-s2-second.txt
@@ -1,1 +1,2 @@
 Scenario 2 with history: jumping PR gets a past removal before the jump test.
+New commit after the past removal; this PR should not notify when it jumps.

--- a/.github/mq-detector-test/past-s2-second.txt
+++ b/.github/mq-detector-test/past-s2-second.txt
@@ -1,0 +1,1 @@
+Scenario 2 with history: jumping PR gets a past removal before the jump test.


### PR DESCRIPTION
Temporary PR for testing jump scenario with a past removal event on the jumping PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone test marker text file under `.github/` with no code or workflow logic changes.
> 
> **Overview**
> Adds `.github/mq-detector-test/past-s2-second.txt`, a new fixture describing *scenario 2 with history* where a jumping PR had a prior removal event and should not trigger a notification on jump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4de43ef759d45ff94e7ef88735c666e96eb97a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->