### PR TITLE
[test] MQ failing PR ahead of past target

### DIFF
--- a/.github/mq-detector-test/fail-merge-queue
+++ b/.github/mq-detector-test/fail-merge-queue
@@ -1,0 +1,1 @@
+This marker intentionally fails the mock merge queue validation.

--- a/.github/mq-detector-test/past-ahead-fails.txt
+++ b/.github/mq-detector-test/past-ahead-fails.txt
@@ -1,0 +1,1 @@
+Failing PR that should be queued ahead of the past-removal target.


### PR DESCRIPTION
Temporary PR for testing a failing PR ahead of a PR that has a past removal and a newer head commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds test/marker files under `.github` with no impact on runtime code paths, aside from any CI/merge-queue checks that read these markers.
> 
> **Overview**
> Adds two new `.github/mq-detector-test/*` marker files to simulate a *failing* PR and ensure it is queued ahead of a past-removal target in merge-queue detector tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c88218b0413ff1740b98e96a1946035ade1f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->