### PR TITLE
Trie - Remove dead TRIE_32BIT_RUNES compile flag

### DIFF
--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -15,13 +15,10 @@
 extern "C" {
 #endif
 
-/* Internally, the trie works with 16/32 bit "Runes", i.e. fixed width unicode
- * characters. 16 bit should be fine for most use cases */
-#ifdef TRIE_32BIT_RUNES
-typedef uint32_t rune;
-#else  // default - 16 bit runes
+/* Internally, the trie works with 16-bit "Runes", i.e. fixed-width Unicode
+ * characters limited to the Basic Multilingual Plane (U+0000..U+FFFF).
+ * Codepoints above U+FFFF are truncated on conversion. */
 typedef uint16_t rune;
-#endif
 
 #define RUNE_STATIC_ALLOC_SIZE 127
 typedef struct {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `src/trie/rune_util.h` exposes a `TRIE_32BIT_RUNES` compile-time flag that switches the `rune` typedef between `uint16_t` (default) and `uint32_t`. The flag is not defined anywhere in the build system, CI workflows, or sources — only the 16-bit default has ever been compiled. The Rust port (`c_trie_rs`) is also locked to `u16`.
2. **Change**: Drop the `#ifdef` and replace it with an unconditional `typedef uint16_t rune`. Update the comment to document the resulting BMP-only limitation explicitly.
3. **Outcome**: Removes a dead build-time switch that, if ever enabled, would silently change `TrieNode` on-disk layout (because `sizeof(rune)` is baked into node sizing). C and Rust trie implementations now agree on a single rune width by construction.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `src/trie/rune_util.h` — `rune` typedef.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused compile-time flag and makes the `rune` width unconditionally `uint16_t`; behavior only changes for any out-of-tree builds that previously relied on `TRIE_32BIT_RUNES`.
> 
> **Overview**
> The trie `rune` type is now **fixed to 16-bit** by removing the dead `TRIE_32BIT_RUNES` compile-time switch in `src/trie/rune_util.h`.
> 
> The header comment is updated to explicitly document the *BMP-only* limitation and that codepoints above `U+FFFF` are truncated during conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895a402cdf47a12ce287e82ba03246610b4222ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->