### PR TITLE
[MOD-15009] ForkGC: Add recv-buffer support

### DIFF
--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -52,7 +52,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
   InvertedIndexGcDelta *delta = InvertedIndex_GcDelta_Read(&rd);
 
   if (delta == NULL) {
-    rm_free(empty_indicator);
+    FGC_freeBuffer(empty_indicator, ei_len);
     return FGC_CHILD_ERROR;
   }
 
@@ -89,7 +89,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
   FGC_updateStats(gc, sctx, 0, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);
 
 cleanup:
-  rm_free(empty_indicator);
+  FGC_freeBuffer(empty_indicator, ei_len);
   if (sp) {
     RedisSearchCtx_UnlockSpec(sctx);
     IndexSpecRef_Release(spec_ref);

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -68,7 +68,7 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
   delta = InvertedIndex_GcDelta_Read(&rd);
 
   if (delta == NULL) {
-    rm_free(rawFieldName);
+    FGC_freeBuffer(rawFieldName, fieldNameLen);
     return FGC_CHILD_ERROR;
   }
 
@@ -108,7 +108,7 @@ cleanup:
     IndexSpecRef_Release(spec_ref);
   }
   HiddenString_Free(fieldName, false);
-  rm_free(rawFieldName);
+  FGC_freeBuffer(rawFieldName, fieldNameLen);
   InvertedIndex_GcDelta_Free(delta);
 
   return status;

--- a/src/fork_gc/numeric.c
+++ b/src/fork_gc/numeric.c
@@ -63,7 +63,7 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     return FGC_DONE;
   }
   if (status != FGC_COLLECTED) {
-    rm_free(fieldName);
+    FGC_freeBuffer(fieldName, fieldNameLen);
     return status;
   }
 
@@ -165,7 +165,7 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     StrongRef spec_ref = IndexSpecRef_Promote(gc->index);
     IndexSpec *sp = StrongRef_Get(spec_ref);
     if (!sp) {
-      rm_free(fieldName);
+      FGC_freeBuffer(fieldName, fieldNameLen);
       return FGC_SPEC_DELETED;
     }
     RedisSearchCtx sctx2 = SEARCH_CTX_STATIC(gc->ctx, sp);
@@ -178,6 +178,6 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     IndexSpecRef_Release(spec_ref);
   }
 
-  rm_free(fieldName);
+  FGC_freeBuffer(fieldName, fieldNameLen);
   return status;
 }

--- a/src/fork_gc/pipe.c
+++ b/src/fork_gc/pipe.c
@@ -29,34 +29,6 @@ void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
   gc->stats.gcBlocksDenied += ignoredLastBlock ? 1 : 0;
 }
 
-int __attribute__((warn_unused_result))
-FGC_recvBuffer(ForkGC *fgc, void **buf, size_t *len) {
-  size_t temp_len;
-  if (FGC_recvFixed(fgc, &temp_len, sizeof temp_len) != REDISMODULE_OK) {
-    return REDISMODULE_ERR;
-  }
-  if (temp_len == SIZE_MAX) {
-    *len = temp_len;
-    *buf = RECV_BUFFER_EMPTY;
-    return REDISMODULE_OK;
-  }
-  if (temp_len == 0) {
-    *len = temp_len;
-    *buf = NULL;
-    return REDISMODULE_OK;
-  }
-
-  char *buf_data = rm_malloc(temp_len + 1);
-  buf_data[temp_len] = 0;
-  if (FGC_recvFixed(fgc, buf_data, temp_len) != REDISMODULE_OK) {
-    rm_free(buf_data);
-    return REDISMODULE_ERR;
-  }
-  *len = temp_len;
-  *buf = buf_data;
-  return REDISMODULE_OK;
-}
-
 // glue to use process pipe as writer for II GC delta info
 void pipe_write_cb(void *ctx, const void *buf, size_t len) {
   ForkGC *gc = ctx;

--- a/src/fork_gc/pipe.c
+++ b/src/fork_gc/pipe.c
@@ -47,21 +47,3 @@ void sendHeaderString(void* ptrCtx) {
   FGC_sendBuffer(ctx->gc, iov->iov_base, iov->iov_len);
 }
 
-// If anything other than FGC_COLLECTED is returned, it is an error or done
-FGCError recvFieldHeader(ForkGC *fgc, char **fieldName, size_t *fieldNameLen,
-                         uint64_t *id) {
-  if (FGC_recvBuffer(fgc, (void **)fieldName, fieldNameLen) != REDISMODULE_OK) {
-    return FGC_PARENT_ERROR;
-  }
-  if (*fieldName == RECV_BUFFER_EMPTY) {
-    *fieldName = NULL;
-    return FGC_DONE;
-  }
-
-  if (FGC_recvFixed(fgc, id, sizeof(*id)) != REDISMODULE_OK) {
-    rm_free(*fieldName);
-    *fieldName = NULL;
-    return FGC_PARENT_ERROR;
-  }
-  return FGC_COLLECTED;
-}

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -43,8 +43,6 @@ extern void *RECV_BUFFER_EMPTY;
 
 #define FGC_SEND_VAR(fgc, v) FGC_sendFixed(fgc, &v, sizeof v)
 
-int __attribute__((warn_unused_result)) FGC_recvBuffer(ForkGC *fgc, void **buf, size_t *len);
-
 //------------------------------------------------------------------------------
 // Pipe read/write callbacks for II GC
 //------------------------------------------------------------------------------

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -21,19 +21,6 @@
 #include <stdbool.h>
 #include <sys/uio.h>
 
-typedef enum {
-  // Terms have been collected
-  FGC_COLLECTED,
-  // No more terms remain
-  FGC_DONE,
-  // Pipe error, child probably crashed
-  FGC_CHILD_ERROR,
-  // Error on the parent
-  FGC_PARENT_ERROR,
-  // The spec was deleted
-  FGC_SPEC_DELETED,
-} FGCError;
-
 // Sentinel value indicating an empty/terminator buffer was received.
 extern void *RECV_BUFFER_EMPTY;
 
@@ -65,10 +52,6 @@ typedef struct {
 
 // Send an iovec-based header string over the pipe. Used by terms, missing_docs, existing_docs.
 void sendHeaderString(void *ptrCtx);
-
-// Receive a field header (field name + unique id). Used by numeric and tags.
-// Returns FGC_COLLECTED on success, FGC_DONE when no more fields, or an error.
-FGCError recvFieldHeader(ForkGC *fgc, char **fieldName, size_t *fieldNameLen, uint64_t *id);
 
 // Update index and GC stats after applying a delta.
 void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -181,10 +181,10 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
     InvertedIndex_GcDelta_Free(delta);
 
     if (tagVal) {
-      rm_free(tagVal);
+      FGC_freeBuffer(tagVal, tagValLen);
     }
   }
 
-  rm_free(fieldName);
+  FGC_freeBuffer(fieldName, fieldNameLen);
   return status;
 }

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -73,7 +73,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
   delta = InvertedIndex_GcDelta_Read(&rd);
 
   if (delta == NULL) {
-    rm_free(term);
+    FGC_freeBuffer(term, len);
     return FGC_CHILD_ERROR;
   }
 
@@ -113,8 +113,10 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
 
     if (!Trie_Delete(sctx->spec->terms, term, len)) {
       const char* name = IndexSpec_FormatName(sctx->spec, RSGlobalConfig.hideUserDataFromLog);
-      RedisModule_Log(sctx->redisCtx, "warning", "RedisSearch fork GC: deleting a term '%s' from"
-                      " trie in index '%s' failed", RSGlobalConfig.hideUserDataFromLog ? Obfuscate_Text(term) : term, name);
+      const char* term_str = RSGlobalConfig.hideUserDataFromLog ? Obfuscate_Text(term) : term;
+      int term_display_len = RSGlobalConfig.hideUserDataFromLog ? (int)strlen(term_str) : (int)len;
+      RedisModule_Log(sctx->redisCtx, "warning", "RedisSearch fork GC: deleting a term '%.*s' from"
+                      " trie in index '%s' failed", term_display_len, term_str, name);
     }
     sctx->spec->stats.scoring.numTerms--;
     sctx->spec->stats.termsSize -= len;
@@ -131,7 +133,7 @@ cleanup:
     RedisSearchCtx_UnlockSpec(sctx);
     IndexSpecRef_Release(spec_ref);
   }
-  rm_free(term);
+  FGC_freeBuffer(term, len);
 
   InvertedIndex_GcDelta_Free(delta);
   return status;

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -25,23 +25,25 @@ use tracing_log_error::log_error;
 mod util;
 
 /// Status code returned by Fork GC parent-side pipe-receive operations.
+#[cheadergen::config(export)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[expect(
-    non_camel_case_types,
-    reason = "variant names must match the C enum constants"
-)]
 pub enum FGCError {
     /// Data has been collected; more may follow.
-    FGC_COLLECTED = 0,
+    #[cheadergen(rename = "FGC_COLLECTED")]
+    Collected = 0,
     /// No more data remains; iteration is complete.
-    FGC_DONE = 1,
+    #[cheadergen(rename = "FGC_DONE")]
+    Done = 1,
     /// Pipe error — the child process likely crashed.
-    FGC_CHILD_ERROR = 2,
+    #[cheadergen(rename = "FGC_CHILD_ERROR")]
+    ChildError = 2,
     /// Error on the parent side.
-    FGC_PARENT_ERROR = 3,
+    #[cheadergen(rename = "FGC_PARENT_ERROR")]
+    ParentError = 3,
     /// The index spec was deleted.
-    FGC_SPEC_DELETED = 4,
+    #[cheadergen(rename = "FGC_SPEC_DELETED")]
+    SpecDeleted = 4,
 }
 
 /// Write exactly `len` bytes from `buff` to the FGC pipe.
@@ -213,16 +215,16 @@ pub unsafe extern "C" fn recvFieldHeader(
 
     let frame = match reader.recv_buffer() {
         Ok(frame) => frame,
-        Err(_) => return FGCError::FGC_PARENT_ERROR,
+        Err(_) => return FGCError::ParentError,
     };
 
     if matches!(frame, RecvFrame::Terminator) {
-        return FGCError::FGC_DONE;
+        return FGCError::Done;
     }
 
     let mut id_bytes = [0u8; size_of::<u64>()];
     if reader.recv_fixed(&mut id_bytes).is_err() {
-        return FGCError::FGC_PARENT_ERROR;
+        return FGCError::ParentError;
     }
 
     let (name_ptr, name_len) = util::frame_into_c_buffer(frame);
@@ -232,5 +234,6 @@ pub unsafe extern "C" fn recvFieldHeader(
     unsafe { *field_name_len = name_len };
     // SAFETY: caller guarantees (3).
     unsafe { *id = u64::from_ne_bytes(id_bytes) };
-    FGCError::FGC_COLLECTED
+
+    FGCError::Collected
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -180,10 +180,9 @@ pub unsafe extern "C" fn FGC_recvBuffer(
     let (ptr, payload_len) = util::frame_into_c_buffer(frame);
 
     // SAFETY: caller guarantees (2).
-    unsafe {
-        *buf = ptr;
-        *len = payload_len;
-    }
+    unsafe { *buf = ptr };
+    // SAFETY: caller guarantees (2).
+    unsafe { *len = payload_len };
 
     ffi::REDISMODULE_OK as c_int
 }
@@ -227,11 +226,11 @@ pub unsafe extern "C" fn recvFieldHeader(
     }
 
     let (name_ptr, name_len) = util::frame_into_c_buffer(frame);
-    // SAFETY: caller guarantees (2) and (3).
-    unsafe {
-        *field_name = name_ptr.cast();
-        *field_name_len = name_len;
-        *id = u64::from_ne_bytes(id_bytes);
-    }
+    // SAFETY: caller guarantees (2).
+    unsafe { *field_name = name_ptr.cast() };
+    // SAFETY: caller guarantees (2).
+    unsafe { *field_name_len = name_len };
+    // SAFETY: caller guarantees (3).
+    unsafe { *id = u64::from_ne_bytes(id_bytes) };
     FGCError::FGC_COLLECTED
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn FGC_recvBuffer(
     let frame = match fgc.reader().recv_buffer() {
         Ok(frame) => frame,
         Err(e) => {
-            log_error!(e, level: Level::WARN, "ForkGC pipe read error");
+            log_error!(e, level: Level::WARN, "ForkGC pipe read error: failed to read frame");
             return ffi::REDISMODULE_ERR as c_int;
         }
     };
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn recvFieldHeader(
     let frame = match reader.recv_buffer() {
         Ok(frame) => frame,
         Err(e) => {
-            log_error!(e, level: Level::WARN, "ForkGC pipe read error");
+            log_error!(e, level: Level::WARN, "ForkGC pipe read error: failed to read frame for field header");
             return FGCError::ParentError;
         }
     };
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn recvFieldHeader(
 
     let mut id_bytes = [0u8; size_of::<u64>()];
     if let Err(e) = reader.recv_fixed(&mut id_bytes) {
-        log_error!(e, level: Level::WARN, "ForkGC pipe read error");
+        log_error!(e, level: Level::WARN, "ForkGC pipe read error: failed to read id for field header");
         return FGCError::ParentError;
     };
 

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -182,7 +182,10 @@ pub unsafe extern "C" fn FGC_recvBuffer(
 
     let frame = match fgc.reader().recv_buffer() {
         Ok(frame) => frame,
-        Err(_) => return ffi::REDISMODULE_ERR as c_int,
+        Err(e) => {
+            log_error!(e, level: Level::WARN, "ForkGC pipe read error");
+            return ffi::REDISMODULE_ERR as c_int;
+        }
     };
 
     let (ptr, payload_len) = util::frame_into_c_buffer(frame);
@@ -220,7 +223,10 @@ pub unsafe extern "C" fn recvFieldHeader(
 
     let (frame, id) = match fgc.reader().recv_buffer_and_id() {
         Ok((frame, id)) => (frame, id),
-        Err(_) => return FGCError::ParentError,
+        Err(e) => {
+            log_error!(e, level: Level::WARN, "ForkGC pipe read error");
+            return FGCError::ParentError;
+        }
     };
 
     if matches!(frame, RecvFrame::Terminator) {

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -22,6 +22,8 @@ use fork_gc::{ForkGC, io_result_ext::IoResultExt};
 use tracing::Level;
 use tracing_log_error::log_error;
 
+mod util;
+
 /// Write exactly `len` bytes from `buff` to the FGC pipe.
 ///
 /// On error, logs the failure and terminates the child process via
@@ -120,4 +122,48 @@ pub unsafe extern "C" fn FGC_recvFixed(
             ffi::REDISMODULE_ERR as c_int
         }
     }
+}
+
+/// Read a length-prefixed buffer frame from the FGC pipe.
+///
+/// On receipt of a `SIZE_MAX` length prefix, writes `SIZE_MAX` to
+/// `*len` and the `RECV_BUFFER_EMPTY` sentinel pointer to `*buf`. On a
+/// zero-length prefix, writes `0` and a null pointer. Otherwise
+/// allocates `len + 1` bytes (NUL-terminated) via the module allocator,
+/// reads the payload, and stores the pointer in `*buf`; the caller is
+/// responsible for releasing it with `rm_free`.
+///
+/// On read error (timeout, short stream, ...), returns `REDISMODULE_ERR`
+/// and leaves `*buf` / `*len` unchanged.
+///
+/// # Safety
+///
+/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an
+///    open, readable file descriptor.
+/// 2. `buf` and `len` must point to writable `void*` and `size_t`
+///    locations respectively.
+#[unsafe(no_mangle)]
+#[must_use]
+pub unsafe extern "C" fn FGC_recvBuffer(
+    fgc: *mut ffi::ForkGC,
+    buf: *mut *mut c_void,
+    len: *mut usize,
+) -> c_int {
+    // SAFETY: caller guarantees (1).
+    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+
+    let frame = match fgc.reader().recv_buffer() {
+        Ok(frame) => frame,
+        Err(_) => return ffi::REDISMODULE_ERR as c_int,
+    };
+
+    let (ptr, payload_len) = util::frame_into_c_buffer(frame);
+
+    // SAFETY: caller guarantees (2).
+    unsafe {
+        *buf = ptr;
+        *len = payload_len;
+    }
+
+    ffi::REDISMODULE_OK as c_int
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -15,10 +15,7 @@
 //! delegates everything else — including Redis-specific failure
 //! handling — to the `fork_gc` crate.
 
-use std::{
-    ffi::{c_char, c_int, c_void},
-    slice,
-};
+use std::ffi::{c_char, c_int, c_void};
 
 use fork_gc::{ForkGC, io_result_ext::IoResultExt, reader::RecvFrame};
 
@@ -209,21 +206,20 @@ pub unsafe extern "C" fn FGC_recvBuffer(
 ///    readable file descriptor.
 /// 2. `field_name` and `field_name_len` must point to writable `char*` and
 ///    `size_t` locations respectively.
-/// 3. `id` must point to a writable `uint64_t` location.
+/// 3. `id_ptr` must point to a writable `uint64_t` location.
 #[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn recvFieldHeader(
     fgc: *mut ffi::ForkGC,
     field_name: *mut *mut c_char,
     field_name_len: *mut usize,
-    id: *mut u64,
+    id_ptr: *mut u64,
 ) -> FGCError {
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
-    let mut reader = fgc.reader();
 
-    let frame = match reader.recv_buffer() {
-        Ok(frame) => frame,
+    let (frame, id) = match fgc.reader().recv_buffer_and_id() {
+        Ok((frame, id)) => (frame, id),
         Err(_) => return FGCError::ParentError,
     };
 
@@ -231,18 +227,14 @@ pub unsafe extern "C" fn recvFieldHeader(
         return FGCError::Done;
     }
 
-    let mut id_bytes = [0u8; size_of::<u64>()];
-    if reader.recv_fixed(&mut id_bytes).is_err() {
-        return FGCError::ParentError;
-    }
-
     let (name_ptr, name_len) = util::frame_into_c_buffer(frame);
+
     // SAFETY: caller guarantees (2).
     unsafe { *field_name = name_ptr.cast() };
     // SAFETY: caller guarantees (2).
     unsafe { *field_name_len = name_len };
     // SAFETY: caller guarantees (3).
-    unsafe { *id = u64::from_ne_bytes(id_bytes) };
+    unsafe { *id_ptr = id };
 
     FGCError::Collected
 }
@@ -261,6 +253,8 @@ pub unsafe extern "C" fn FGC_freeBuffer(buf: *mut c_void, len: usize) {
     if buf.is_null() || buf == unsafe { RECV_BUFFER_EMPTY } {
         return;
     }
+
+    let ptr = std::ptr::slice_from_raw_parts_mut(buf.cast::<u8>(), len);
     // SAFETY: caller guarantees (1).
-    drop(unsafe { Box::from_raw(slice::from_raw_parts_mut(buf.cast::<u8>(), len)) });
+    drop(unsafe { Box::from_raw(ptr) });
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -15,7 +15,10 @@
 //! delegates everything else — including Redis-specific failure
 //! handling — to the `fork_gc` crate.
 
-use std::ffi::{c_char, c_int, c_void};
+use std::{
+    ffi::{c_char, c_int, c_void},
+    slice,
+};
 
 use fork_gc::{ForkGC, io_result_ext::IoResultExt, reader::RecvFrame};
 
@@ -23,6 +26,13 @@ use tracing::Level;
 use tracing_log_error::log_error;
 
 mod util;
+
+// Sentinel pointer defined in `src/fork_gc/pipe.c`, compared by pointer
+// identity in C callers (e.g. `recvFieldHeader`) to detect end-of-stream
+// frames returned through `FGC_recvBuffer`'s `buf` out-parameter.
+unsafe extern "C" {
+    static RECV_BUFFER_EMPTY: *mut c_void;
+}
 
 /// Status code returned by Fork GC parent-side pipe-receive operations.
 #[cheadergen::config(export)]
@@ -150,10 +160,9 @@ pub unsafe extern "C" fn FGC_recvFixed(
 ///
 /// On receipt of a `SIZE_MAX` length prefix, writes `SIZE_MAX` to
 /// `*len` and the `RECV_BUFFER_EMPTY` sentinel pointer to `*buf`. On a
-/// zero-length prefix, writes `0` and a null pointer. Otherwise
-/// allocates `len + 1` bytes (NUL-terminated) via the module allocator,
-/// reads the payload, and stores the pointer in `*buf`; the caller is
-/// responsible for releasing it with `rm_free`.
+/// zero-length prefix, writes `0` and a null pointer. Otherwise leaks a
+/// boxed payload slice, writing its pointer and length to `*buf` / `*len`;
+/// the caller is responsible for releasing it with [`FGC_freeBuffer`].
 ///
 /// On read error (timeout, short stream, ...), returns `REDISMODULE_ERR`
 /// and leaves `*buf` / `*len` unchanged.
@@ -236,4 +245,22 @@ pub unsafe extern "C" fn recvFieldHeader(
     unsafe { *id = u64::from_ne_bytes(id_bytes) };
 
     FGCError::Collected
+}
+
+/// Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
+///
+/// No-ops for the `RECV_BUFFER_EMPTY` sentinel and null pointers.
+///
+/// # Safety
+///
+/// 1. `buf` and `len` must be the pointer and length returned by a prior call to
+///    [`FGC_recvBuffer`] or [`recvFieldHeader`], and must not have been freed before.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn FGC_freeBuffer(buf: *mut c_void, len: usize) {
+    // SAFETY: `RECV_BUFFER_EMPTY` is a static defined in `pipe.c`.
+    if buf.is_null() || buf == unsafe { RECV_BUFFER_EMPTY } {
+        return;
+    }
+    // SAFETY: caller guarantees (1).
+    drop(unsafe { Box::from_raw(slice::from_raw_parts_mut(buf.cast::<u8>(), len)) });
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -15,14 +15,34 @@
 //! delegates everything else — including Redis-specific failure
 //! handling — to the `fork_gc` crate.
 
-use std::ffi::{c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 
-use fork_gc::{ForkGC, io_result_ext::IoResultExt};
+use fork_gc::{ForkGC, io_result_ext::IoResultExt, reader::RecvFrame};
 
 use tracing::Level;
 use tracing_log_error::log_error;
 
 mod util;
+
+/// Status code returned by Fork GC parent-side pipe-receive operations.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(
+    non_camel_case_types,
+    reason = "variant names must match the C enum constants"
+)]
+pub enum FGCError {
+    /// Data has been collected; more may follow.
+    FGC_COLLECTED = 0,
+    /// No more data remains; iteration is complete.
+    FGC_DONE = 1,
+    /// Pipe error — the child process likely crashed.
+    FGC_CHILD_ERROR = 2,
+    /// Error on the parent side.
+    FGC_PARENT_ERROR = 3,
+    /// The index spec was deleted.
+    FGC_SPEC_DELETED = 4,
+}
 
 /// Write exactly `len` bytes from `buff` to the FGC pipe.
 ///
@@ -166,4 +186,52 @@ pub unsafe extern "C" fn FGC_recvBuffer(
     }
 
     ffi::REDISMODULE_OK as c_int
+}
+
+/// Receive a field header (field name + unique id).
+///
+/// Returns `FGC_COLLECTED` on success, `FGC_DONE` when no more fields remain,
+/// or an error variant on pipe failure.
+///
+/// # Safety
+///
+/// 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+///    readable file descriptor.
+/// 2. `field_name` and `field_name_len` must point to writable `char*` and
+///    `size_t` locations respectively.
+/// 3. `id` must point to a writable `uint64_t` location.
+#[unsafe(no_mangle)]
+#[must_use]
+pub unsafe extern "C" fn recvFieldHeader(
+    fgc: *mut ffi::ForkGC,
+    field_name: *mut *mut c_char,
+    field_name_len: *mut usize,
+    id: *mut u64,
+) -> FGCError {
+    // SAFETY: caller guarantees (1).
+    let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let mut reader = fgc.reader();
+
+    let frame = match reader.recv_buffer() {
+        Ok(frame) => frame,
+        Err(_) => return FGCError::FGC_PARENT_ERROR,
+    };
+
+    if matches!(frame, RecvFrame::Terminator) {
+        return FGCError::FGC_DONE;
+    }
+
+    let mut id_bytes = [0u8; size_of::<u64>()];
+    if reader.recv_fixed(&mut id_bytes).is_err() {
+        return FGCError::FGC_PARENT_ERROR;
+    }
+
+    let (name_ptr, name_len) = util::frame_into_c_buffer(frame);
+    // SAFETY: caller guarantees (2) and (3).
+    unsafe {
+        *field_name = name_ptr.cast();
+        *field_name_len = name_len;
+        *id = u64::from_ne_bytes(id_bytes);
+    }
+    FGCError::FGC_COLLECTED
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -220,9 +220,10 @@ pub unsafe extern "C" fn recvFieldHeader(
 ) -> FGCError {
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(fgc) };
+    let mut reader = fgc.reader();
 
-    let (frame, id) = match fgc.reader().recv_buffer_and_id() {
-        Ok((frame, id)) => (frame, id),
+    let frame = match reader.recv_buffer() {
+        Ok(frame) => frame,
         Err(e) => {
             log_error!(e, level: Level::WARN, "ForkGC pipe read error");
             return FGCError::ParentError;
@@ -233,7 +234,14 @@ pub unsafe extern "C" fn recvFieldHeader(
         return FGCError::Done;
     }
 
+    let mut id_bytes = [0u8; size_of::<u64>()];
+    if let Err(e) = reader.recv_fixed(&mut id_bytes) {
+        log_error!(e, level: Level::WARN, "ForkGC pipe read error");
+        return FGCError::ParentError;
+    };
+
     let (name_ptr, name_len) = util::frame_into_c_buffer(frame);
+    let id = u64::from_ne_bytes(id_bytes);
 
     // SAFETY: caller guarantees (2).
     unsafe { *field_name = name_ptr.cast() };

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{ffi::c_void, ptr};
+
+use fork_gc::reader::RecvFrame;
+
+use ffi::RedisModule_Alloc;
+
+// Sentinel pointer defined in `src/fork_gc/pipe.c`, compared by pointer
+// identity in C callers (e.g. `recvFieldHeader`) to detect end-of-stream
+// frames returned through `FGC_recvBuffer`'s `buf` out-parameter.
+unsafe extern "C" {
+    static RECV_BUFFER_EMPTY: *mut c_void;
+}
+
+/// Consume the frame, producing the `(buf, len)` pair that the C
+/// `FGC_recvBuffer` API exposes through its out-parameters.
+///
+/// - [`RecvFrame::Terminator`] → `(RECV_BUFFER_EMPTY, usize::MAX)`.
+/// - [`RecvFrame::Empty`] → `(null, 0)`.
+/// - [`RecvFrame::Data`] → the payload is copied into a fresh
+///   `len + 1`-byte, NUL-terminated allocation via `RedisModule_Alloc`.
+///   Ownership of the pointer is transferred to the caller, which is
+///   expected to release it with the Redis module allocator's `rm_free`.
+pub(crate) fn frame_into_c_buffer(frame: RecvFrame) -> (*mut c_void, usize) {
+    match frame {
+        RecvFrame::Terminator => {
+            // SAFETY: `RECV_BUFFER_EMPTY` is a static pointer defined in `pipe.c`.
+            (unsafe { RECV_BUFFER_EMPTY }, usize::MAX)
+        }
+        RecvFrame::Empty => (ptr::null_mut(), 0),
+        RecvFrame::Data(data) => {
+            let len = data.len();
+            // SAFETY: `RedisModule_Alloc` is initialized before any module
+            // code runs; the Redis module loader sets up the API table
+            // before calling `RedisModule_OnLoad`.
+            let alloc = unsafe { RedisModule_Alloc.unwrap() };
+            // Allocate `len + 1` with a trailing NUL so C callers can treat
+            // the result as a C string, matching the original
+            // `rm_malloc(len + 1); buf[len] = 0;` shape.
+            //
+            // SAFETY: `len + 1 > 0`, so this satisfies the allocator's
+            // non-zero-size requirement.
+            let ptr = unsafe { alloc(len + 1) }.cast::<u8>();
+            assert!(!ptr.is_null(), "RedisModule_Alloc returned NULL");
+            // SAFETY: `ptr` is non-null and points to `len + 1` writable
+            // bytes we just allocated; `data` is a valid slice of `len`
+            // bytes; the regions do not overlap.
+            unsafe {
+                ptr::copy_nonoverlapping(data.as_ptr(), ptr, len);
+                ptr.add(len).write(0);
+            }
+            (ptr.cast(), len)
+        }
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
@@ -53,10 +53,13 @@ pub(crate) fn frame_into_c_buffer(frame: RecvFrame) -> (*mut c_void, usize) {
             // SAFETY: `ptr` is non-null and points to `len + 1` writable
             // bytes we just allocated; `data` is a valid slice of `len`
             // bytes; the regions do not overlap.
-            unsafe {
-                ptr::copy_nonoverlapping(data.as_ptr(), ptr, len);
-                ptr.add(len).write(0);
-            }
+            unsafe { ptr::copy_nonoverlapping(data.as_ptr(), ptr, len) };
+            // SAFETY: `ptr` points to `len + 1` bytes; `len` is a valid
+            // offset into that allocation.
+            let nul = unsafe { ptr.add(len) };
+            // SAFETY: `nul` points to the byte just past the payload,
+            // which is within the allocation.
+            unsafe { nul.write(0) };
             (ptr.cast(), len)
         }
     }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
@@ -11,55 +11,24 @@ use std::{ffi::c_void, ptr};
 
 use fork_gc::reader::RecvFrame;
 
-use ffi::RedisModule_Alloc;
-
-// Sentinel pointer defined in `src/fork_gc/pipe.c`, compared by pointer
-// identity in C callers (e.g. `recvFieldHeader`) to detect end-of-stream
-// frames returned through `FGC_recvBuffer`'s `buf` out-parameter.
-unsafe extern "C" {
-    static RECV_BUFFER_EMPTY: *mut c_void;
-}
-
 /// Consume the frame, producing the `(buf, len)` pair that the C
 /// `FGC_recvBuffer` API exposes through its out-parameters.
 ///
 /// - [`RecvFrame::Terminator`] → `(RECV_BUFFER_EMPTY, usize::MAX)`.
 /// - [`RecvFrame::Empty`] → `(null, 0)`.
-/// - [`RecvFrame::Data`] → the payload is copied into a fresh
-///   `len + 1`-byte, NUL-terminated allocation via `RedisModule_Alloc`.
-///   Ownership of the pointer is transferred to the caller, which is
-///   expected to release it with the Redis module allocator's `rm_free`.
+/// - [`RecvFrame::Data`] → leaks the boxed payload, transferring ownership
+///   to the caller. The caller is responsible for releasing it with
+///   [`super::FGC_freeBuffer`].
 pub(crate) fn frame_into_c_buffer(frame: RecvFrame) -> (*mut c_void, usize) {
     match frame {
         RecvFrame::Terminator => {
             // SAFETY: `RECV_BUFFER_EMPTY` is a static pointer defined in `pipe.c`.
-            (unsafe { RECV_BUFFER_EMPTY }, usize::MAX)
+            (unsafe { super::RECV_BUFFER_EMPTY }, usize::MAX)
         }
         RecvFrame::Empty => (ptr::null_mut(), 0),
         RecvFrame::Data(data) => {
             let len = data.len();
-            // SAFETY: `RedisModule_Alloc` is initialized before any module
-            // code runs; the Redis module loader sets up the API table
-            // before calling `RedisModule_OnLoad`.
-            let alloc = unsafe { RedisModule_Alloc.unwrap() };
-            // Allocate `len + 1` with a trailing NUL so C callers can treat
-            // the result as a C string, matching the original
-            // `rm_malloc(len + 1); buf[len] = 0;` shape.
-            //
-            // SAFETY: `len + 1 > 0`, so this satisfies the allocator's
-            // non-zero-size requirement.
-            let ptr = unsafe { alloc(len + 1) }.cast::<u8>();
-            assert!(!ptr.is_null(), "RedisModule_Alloc returned NULL");
-            // SAFETY: `ptr` is non-null and points to `len + 1` writable
-            // bytes we just allocated; `data` is a valid slice of `len`
-            // bytes; the regions do not overlap.
-            unsafe { ptr::copy_nonoverlapping(data.as_ptr(), ptr, len) };
-            // SAFETY: `ptr` points to `len + 1` bytes; `len` is a valid
-            // offset into that allocation.
-            let nul = unsafe { ptr.add(len) };
-            // SAFETY: `nul` points to the byte just past the payload,
-            // which is within the allocation.
-            unsafe { nul.write(0) };
+            let ptr = Box::into_raw(data) as *mut u8;
             (ptr.cast(), len)
         }
     }

--- a/src/redisearch_rs/fork_gc/src/reader.rs
+++ b/src/redisearch_rs/fork_gc/src/reader.rs
@@ -67,7 +67,7 @@ impl<R: Read> Reader<R> {
 /// The three variants correspond to the three possible length prefixes
 /// of the Fork GC buffer protocol: `usize::MAX` (end of stream), `0`
 /// (empty), or a positive payload length.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RecvFrame {
     /// End-of-stream sentinel — the writer called
     /// [`Writer::send_terminator`](crate::writer::Writer::send_terminator).

--- a/src/redisearch_rs/fork_gc/src/reader.rs
+++ b/src/redisearch_rs/fork_gc/src/reader.rs
@@ -60,6 +60,25 @@ impl<R: Read> Reader<R> {
         self.recv_fixed(&mut data)?;
         Ok(RecvFrame::Data(data))
     }
+
+    /// Read a length-prefixed buffer frame followed by a native-endian `u64` field id.
+    ///
+    /// Extends [`recv_buffer`](Self::recv_buffer) with a trailing id read.
+    /// On [`RecvFrame::Terminator`] the id is not present on the wire; `0` is
+    /// returned as a placeholder and the caller should discard it.
+    pub fn recv_buffer_and_id(&mut self) -> io::Result<(RecvFrame, u64)> {
+        let frame = self.recv_buffer()?;
+
+        if matches!(frame, RecvFrame::Terminator) {
+            return Ok((frame, 0));
+        }
+
+        let mut id_bytes = [0u8; size_of::<u64>()];
+        self.recv_fixed(&mut id_bytes)?;
+        let id = u64::from_ne_bytes(id_bytes);
+
+        Ok((frame, id))
+    }
 }
 
 /// A frame decoded by [`Reader::recv_buffer`].

--- a/src/redisearch_rs/fork_gc/src/reader.rs
+++ b/src/redisearch_rs/fork_gc/src/reader.rs
@@ -60,25 +60,6 @@ impl<R: Read> Reader<R> {
         self.recv_fixed(&mut data)?;
         Ok(RecvFrame::Data(data))
     }
-
-    /// Read a length-prefixed buffer frame followed by a native-endian `u64` field id.
-    ///
-    /// Extends [`recv_buffer`](Self::recv_buffer) with a trailing id read.
-    /// On [`RecvFrame::Terminator`] the id is not present on the wire; `0` is
-    /// returned as a placeholder and the caller should discard it.
-    pub fn recv_buffer_and_id(&mut self) -> io::Result<(RecvFrame, u64)> {
-        let frame = self.recv_buffer()?;
-
-        if matches!(frame, RecvFrame::Terminator) {
-            return Ok((frame, 0));
-        }
-
-        let mut id_bytes = [0u8; size_of::<u64>()];
-        self.recv_fixed(&mut id_bytes)?;
-        let id = u64::from_ne_bytes(id_bytes);
-
-        Ok((frame, id))
-    }
 }
 
 /// A frame decoded by [`Reader::recv_buffer`].

--- a/src/redisearch_rs/fork_gc/src/reader.rs
+++ b/src/redisearch_rs/fork_gc/src/reader.rs
@@ -32,4 +32,49 @@ impl<R: Read> Reader<R> {
     pub fn recv_fixed(&mut self, buf: &mut [u8]) -> io::Result<()> {
         self.reader.read_exact(buf)
     }
+
+    /// Read a length-prefixed buffer frame.
+    ///
+    /// Counterpart of [`PipeWriter::send_buffer`] and
+    /// [`PipeWriter::send_terminator`]. Reads a native-endian `size_t`
+    /// prefix, then:
+    ///
+    /// - `usize::MAX` → [`RecvFrame::Terminator`] (end-of-stream
+    ///   sentinel; no payload follows).
+    /// - `0` → [`RecvFrame::Empty`] (no payload).
+    /// - otherwise → [`RecvFrame::Data`] containing exactly that many
+    ///   payload bytes.
+    pub fn recv_buffer(&mut self) -> io::Result<RecvFrame> {
+        let mut len_bytes = [0u8; size_of::<usize>()];
+        self.recv_fixed(&mut len_bytes)?;
+        let len = usize::from_ne_bytes(len_bytes);
+
+        if len == usize::MAX {
+            return Ok(RecvFrame::Terminator);
+        }
+        if len == 0 {
+            return Ok(RecvFrame::Empty);
+        }
+
+        let mut data = vec![0u8; len].into_boxed_slice();
+        self.recv_fixed(&mut data)?;
+        Ok(RecvFrame::Data(data))
+    }
+}
+
+/// A frame decoded by [`PipeReader::recv_buffer`].
+///
+/// The three variants correspond to the three possible length prefixes
+/// of the Fork GC buffer protocol: `usize::MAX` (end of stream), `0`
+/// (empty), or a positive payload length.
+#[derive(Debug)]
+pub enum RecvFrame {
+    /// End-of-stream sentinel — the writer called
+    /// [`PipeWriter::send_terminator`].
+    Terminator,
+    /// Zero-length frame — the writer called
+    /// [`PipeWriter::send_buffer`] with an empty slice.
+    Empty,
+    /// A frame carrying `data.len()` payload bytes.
+    Data(Box<[u8]>),
 }

--- a/src/redisearch_rs/fork_gc/src/reader.rs
+++ b/src/redisearch_rs/fork_gc/src/reader.rs
@@ -35,8 +35,8 @@ impl<R: Read> Reader<R> {
 
     /// Read a length-prefixed buffer frame.
     ///
-    /// Counterpart of [`PipeWriter::send_buffer`] and
-    /// [`PipeWriter::send_terminator`]. Reads a native-endian `size_t`
+    /// Counterpart of [`Writer::send_buffer`](crate::writer::Writer::send_buffer) and
+    /// [`Writer::send_terminator`](crate::writer::Writer::send_terminator). Reads a native-endian `size_t`
     /// prefix, then:
     ///
     /// - `usize::MAX` → [`RecvFrame::Terminator`] (end-of-stream
@@ -62,7 +62,7 @@ impl<R: Read> Reader<R> {
     }
 }
 
-/// A frame decoded by [`PipeReader::recv_buffer`].
+/// A frame decoded by [`Reader::recv_buffer`].
 ///
 /// The three variants correspond to the three possible length prefixes
 /// of the Fork GC buffer protocol: `usize::MAX` (end of stream), `0`
@@ -70,10 +70,10 @@ impl<R: Read> Reader<R> {
 #[derive(Debug)]
 pub enum RecvFrame {
     /// End-of-stream sentinel — the writer called
-    /// [`PipeWriter::send_terminator`].
+    /// [`Writer::send_terminator`](crate::writer::Writer::send_terminator).
     Terminator,
     /// Zero-length frame — the writer called
-    /// [`PipeWriter::send_buffer`] with an empty slice.
+    /// [`Writer::send_buffer`](crate::writer::Writer::send_buffer) with an empty slice.
     Empty,
     /// A frame carrying `data.len()` payload bytes.
     Data(Box<[u8]>),

--- a/src/redisearch_rs/fork_gc/tests/reader.rs
+++ b/src/redisearch_rs/fork_gc/tests/reader.rs
@@ -45,7 +45,7 @@ fn recv_buffer_reads_length_prefixed_payload() {
     bytes.extend_from_slice(b"hello");
     let mut pr = Reader::from_reader(Cursor::new(bytes));
     match pr.recv_buffer().unwrap() {
-        RecvFrame::Data(d) => assert_eq!(d, b"hello"),
+        RecvFrame::Data(d) => assert_eq!(&*d, b"hello"),
         other => panic!("expected Data, got {other:?}"),
     }
 }
@@ -75,7 +75,7 @@ fn recv_buffer_roundtrips_through_send_buffer() {
     }
     let mut pr = Reader::from_reader(Cursor::new(sink));
     match pr.recv_buffer().unwrap() {
-        RecvFrame::Data(d) => assert_eq!(d, b"round trip"),
+        RecvFrame::Data(d) => assert_eq!(&*d, b"round trip"),
         other => panic!("expected Data, got {other:?}"),
     }
 }

--- a/src/redisearch_rs/fork_gc/tests/reader.rs
+++ b/src/redisearch_rs/fork_gc/tests/reader.rs
@@ -7,7 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use fork_gc::reader::Reader;
+use fork_gc::reader::{Reader, RecvFrame};
+use fork_gc::writer::Writer;
 use std::io::{self, Cursor};
 
 #[test]
@@ -35,4 +36,56 @@ fn recv_fixed_reads_less_bytes_than_are_available() {
     let mut buf = [0u8; 5];
     pr.recv_fixed(&mut buf).unwrap();
     assert_eq!(&buf, b"hello");
+}
+
+#[test]
+fn recv_buffer_reads_length_prefixed_payload() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&5usize.to_ne_bytes());
+    bytes.extend_from_slice(b"hello");
+    let mut pr = Reader::from_reader(Cursor::new(bytes));
+    match pr.recv_buffer().unwrap() {
+        RecvFrame::Data(d) => assert_eq!(d, b"hello"),
+        other => panic!("expected Data, got {other:?}"),
+    }
+}
+
+#[test]
+fn recv_buffer_detects_terminator() {
+    let bytes = usize::MAX.to_ne_bytes().to_vec();
+    let mut pr = Reader::from_reader(Cursor::new(bytes));
+    assert!(matches!(pr.recv_buffer().unwrap(), RecvFrame::Terminator));
+}
+
+#[test]
+fn recv_buffer_detects_empty() {
+    let bytes = 0usize.to_ne_bytes().to_vec();
+    let mut pr = Reader::from_reader(Cursor::new(bytes));
+    assert!(matches!(pr.recv_buffer().unwrap(), RecvFrame::Empty));
+}
+
+#[test]
+fn recv_buffer_roundtrips_through_send_buffer() {
+    // Emit a `send_buffer` frame into a Vec, then parse it back with
+    // `recv_buffer` — the two sides agree on the wire format.
+    let mut sink: Vec<u8> = Vec::new();
+    {
+        let mut pw = Writer::from_writer(&mut sink);
+        pw.send_buffer(b"round trip").unwrap();
+    }
+    let mut pr = Reader::from_reader(Cursor::new(sink));
+    match pr.recv_buffer().unwrap() {
+        RecvFrame::Data(d) => assert_eq!(d, b"round trip"),
+        other => panic!("expected Data, got {other:?}"),
+    }
+}
+
+#[test]
+fn recv_buffer_eof_on_truncated_payload() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&5usize.to_ne_bytes());
+    bytes.extend_from_slice(b"hi"); // short
+    let mut pr = Reader::from_reader(Cursor::new(bytes));
+    let err = pr.recv_buffer().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/fork_gc/tests/reader.rs
+++ b/src/redisearch_rs/fork_gc/tests/reader.rs
@@ -8,7 +8,6 @@
 */
 
 use fork_gc::reader::{Reader, RecvFrame};
-use fork_gc::writer::Writer;
 use std::io::{self, Cursor};
 
 #[test]
@@ -65,22 +64,6 @@ fn recv_buffer_detects_empty() {
 }
 
 #[test]
-fn recv_buffer_roundtrips_through_send_buffer() {
-    // Emit a `send_buffer` frame into a Vec, then parse it back with
-    // `recv_buffer` — the two sides agree on the wire format.
-    let mut sink: Vec<u8> = Vec::new();
-    {
-        let mut pw = Writer::from_writer(&mut sink);
-        pw.send_buffer(b"round trip").unwrap();
-    }
-    let mut pr = Reader::from_reader(Cursor::new(sink));
-    match pr.recv_buffer().unwrap() {
-        RecvFrame::Data(d) => assert_eq!(&*d, b"round trip"),
-        other => panic!("expected Data, got {other:?}"),
-    }
-}
-
-#[test]
 fn recv_buffer_eof_on_truncated_payload() {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&5usize.to_ne_bytes());
@@ -88,4 +71,29 @@ fn recv_buffer_eof_on_truncated_payload() {
     let mut pr = Reader::from_reader(Cursor::new(bytes));
     let err = pr.recv_buffer().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn recv_buffer_and_id_reads_frame_and_id() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&10usize.to_ne_bytes());
+    bytes.extend_from_slice(b"field_name");
+    bytes.extend_from_slice(&42u64.to_ne_bytes());
+    let mut pr = Reader::from_reader(Cursor::new(bytes));
+    let (frame, id) = pr.recv_buffer_and_id().unwrap();
+    match frame {
+        RecvFrame::Data(d) => assert_eq!(&*d, b"field_name"),
+        other => panic!("expected Data, got {other:?}"),
+    }
+    assert_eq!(id, 42);
+}
+
+#[test]
+fn recv_buffer_and_id_on_terminator_returns_zero_id() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&usize::MAX.to_ne_bytes());
+    let mut pr = Reader::from_reader(Cursor::new(bytes));
+    let (frame, id) = pr.recv_buffer_and_id().unwrap();
+    assert!(matches!(frame, RecvFrame::Terminator));
+    assert_eq!(id, 0);
 }

--- a/src/redisearch_rs/fork_gc/tests/reader.rs
+++ b/src/redisearch_rs/fork_gc/tests/reader.rs
@@ -72,28 +72,3 @@ fn recv_buffer_eof_on_truncated_payload() {
     let err = pr.recv_buffer().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
-
-#[test]
-fn recv_buffer_and_id_reads_frame_and_id() {
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(&10usize.to_ne_bytes());
-    bytes.extend_from_slice(b"field_name");
-    bytes.extend_from_slice(&42u64.to_ne_bytes());
-    let mut pr = Reader::from_reader(Cursor::new(bytes));
-    let (frame, id) = pr.recv_buffer_and_id().unwrap();
-    match frame {
-        RecvFrame::Data(d) => assert_eq!(&*d, b"field_name"),
-        other => panic!("expected Data, got {other:?}"),
-    }
-    assert_eq!(id, 42);
-}
-
-#[test]
-fn recv_buffer_and_id_on_terminator_returns_zero_id() {
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(&usize::MAX.to_ne_bytes());
-    let mut pr = Reader::from_reader(Cursor::new(bytes));
-    let (frame, id) = pr.recv_buffer_and_id().unwrap();
-    assert!(matches!(frame, RecvFrame::Terminator));
-    assert_eq!(id, 0);
-}

--- a/src/redisearch_rs/fork_gc/tests/roundtrip.rs
+++ b/src/redisearch_rs/fork_gc/tests/roundtrip.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use fork_gc::reader::{Reader, RecvFrame};
+use fork_gc::writer::Writer;
+use std::io::Cursor;
+
+#[test]
+fn send_buffer_roundtrips_to_recv_buffer_data_frame() {
+    let mut sink: Vec<u8> = Vec::new();
+    {
+        let mut pw = Writer::from_writer(&mut sink);
+        pw.send_buffer(b"round trip").unwrap();
+    }
+    let mut pr = Reader::from_reader(Cursor::new(sink));
+    match pr.recv_buffer().unwrap() {
+        RecvFrame::Data(d) => assert_eq!(&*d, b"round trip"),
+        other => panic!("expected Data, got {other:?}"),
+    }
+}
+
+#[test]
+fn send_terminator_roundtrips_to_recv_buffer_terminator_frame() {
+    let mut sink: Vec<u8> = Vec::new();
+    {
+        let mut pw = Writer::from_writer(&mut sink);
+        pw.send_terminator().unwrap();
+    }
+    let mut pr = Reader::from_reader(Cursor::new(sink));
+    let frame = pr.recv_buffer().unwrap();
+    assert!(matches!(frame, RecvFrame::Terminator));
+}
+
+#[test]
+fn send_buffer_empty_roundtrips_to_recv_buffer_empty_frame() {
+    let mut sink: Vec<u8> = Vec::new();
+    {
+        let mut pw = Writer::from_writer(&mut sink);
+        pw.send_buffer(&[]).unwrap();
+    }
+    let mut pr = Reader::from_reader(Cursor::new(sink));
+    let frame = pr.recv_buffer().unwrap();
+    assert!(matches!(frame, RecvFrame::Empty));
+}

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -133,9 +133,9 @@ int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
  *    readable file descriptor.
  * 2. `field_name` and `field_name_len` must point to writable `char*` and
  *    `size_t` locations respectively.
- * 3. `id` must point to a writable `uint64_t` location.
+ * 3. `id_ptr` must point to a writable `uint64_t` location.
  */
-enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_name_len, uint64_t *id);
+enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_name_len, uint64_t *id_ptr);
 
 /**
  * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -9,6 +9,32 @@
 #include <stdlib.h>
 #include "fork_gc.h"
 
+/**
+ * Status code returned by Fork GC parent-side pipe-receive operations.
+ */
+typedef enum FGCError {
+  /**
+   * Data has been collected; more may follow.
+   */
+  FGC_COLLECTED = 0,
+  /**
+   * No more data remains; iteration is complete.
+   */
+  FGC_DONE = 1,
+  /**
+   * Pipe error — the child process likely crashed.
+   */
+  FGC_CHILD_ERROR = 2,
+  /**
+   * Error on the parent side.
+   */
+  FGC_PARENT_ERROR = 3,
+  /**
+   * The index spec was deleted.
+   */
+  FGC_SPEC_DELETED = 4,
+} FGCError;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -95,6 +121,22 @@ int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
  *    locations respectively.
  */
 int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
+
+/**
+ * Receive a field header (field name + unique id).
+ *
+ * Returns `FGC_COLLECTED` on success, `FGC_DONE` when no more fields remain,
+ * or an error variant on pipe failure.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+ *    readable file descriptor.
+ * 2. `field_name` and `field_name_len` must point to writable `char*` and
+ *    `size_t` locations respectively.
+ * 3. `id` must point to a writable `uint64_t` location.
+ */
+enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_name_len, uint64_t *id);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -105,10 +105,9 @@ int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
  *
  * On receipt of a `SIZE_MAX` length prefix, writes `SIZE_MAX` to
  * `*len` and the `RECV_BUFFER_EMPTY` sentinel pointer to `*buf`. On a
- * zero-length prefix, writes `0` and a null pointer. Otherwise
- * allocates `len + 1` bytes (NUL-terminated) via the module allocator,
- * reads the payload, and stores the pointer in `*buf`; the caller is
- * responsible for releasing it with `rm_free`.
+ * zero-length prefix, writes `0` and a null pointer. Otherwise leaks a
+ * boxed payload slice, writing its pointer and length to `*buf` / `*len`;
+ * the caller is responsible for releasing it with [`FGC_freeBuffer`].
  *
  * On read error (timeout, short stream, ...), returns `REDISMODULE_ERR`
  * and leaves `*buf` / `*len` unchanged.
@@ -137,6 +136,18 @@ int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
  * 3. `id` must point to a writable `uint64_t` location.
  */
 enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_name_len, uint64_t *id);
+
+/**
+ * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
+ *
+ * No-ops for the `RECV_BUFFER_EMPTY` sentinel and null pointers.
+ *
+ * # Safety
+ *
+ * 1. `buf` and `len` must be the pointer and length returned by a prior call to
+ *    [`FGC_recvBuffer`] or [`recvFieldHeader`], and must not have been freed before.
+ */
+void FGC_freeBuffer(void *buf, size_t len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -74,6 +74,28 @@ void FGC_sendTerminator(ForkGC *fgc);
  */
 int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
 
+/**
+ * Read a length-prefixed buffer frame from the FGC pipe.
+ *
+ * On receipt of a `SIZE_MAX` length prefix, writes `SIZE_MAX` to
+ * `*len` and the `RECV_BUFFER_EMPTY` sentinel pointer to `*buf`. On a
+ * zero-length prefix, writes `0` and a null pointer. Otherwise
+ * allocates `len + 1` bytes (NUL-terminated) via the module allocator,
+ * reads the payload, and stores the pointer in `*buf`; the caller is
+ * responsible for releasing it with `rm_free`.
+ *
+ * On read error (timeout, short stream, ...), returns `REDISMODULE_ERR`
+ * and leaves `*buf` / `*len` unchanged.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an
+ *    open, readable file descriptor.
+ * 2. `buf` and `len` must point to writable `void*` and `size_t`
+ *    locations respectively.
+ */
+int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
## Describe the changes in the pull request

- Implement `recv_buffer` in Rust using the existing `recv_fixed` for timout based read operations.
- Migrate over `FGC_recvBuffer` and `recvFieldHeader` which use this `recv_buffer`.
- Move over `FGCError` to Rust.
- C functions calling `FGC_recvBuffer` and `recvFieldHeader` now free their buffers with `FGC_freeBuffer`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fork-GC parent/child pipe protocol and buffer lifetime across many index kinds; behavior should match prior C but mistakes could leak memory or mis-handle stream termination.
> 
> **Overview**
> Fork GC **parent-side pipe reads** for length-prefixed buffers move from C into Rust: `Reader::recv_buffer` / `RecvFrame` mirror the existing writer protocol, and **`fork_gc_ffi`** exposes `FGC_recvBuffer`, `recvFieldHeader`, `FGC_freeBuffer`, and **`FGCError`** (generated into `fork_gc_ffi.h`). The C implementations are removed from `pipe.c` / `pipe.h`.
> 
> Parent handlers for **terms, tags, numeric, missing docs, and existing docs** now release pipe payloads with **`FGC_freeBuffer(buf, len)`** instead of `rm_free`, matching boxed ownership from the FFI layer. **Terms** logging uses **`%.*s`** with the correct length when user data is obfuscated.
> 
> Tests cover **`recv_buffer`** edge cases and **writer/reader roundtrips**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1467afdbaccb4e1989cdd37ba63fe7cb56ef55e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->