### PR TITLE
[MOD-15569][MOD-15570][MOD-15571] Skip flaky vecsim tests until 2026-06-12

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1892,9 +1892,11 @@ def test_create_multi_value_json():
                        '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',).ok()
             env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "vec"))['IS_MULTI_VALUE'], 0, message=f'{algo}, {path}')
 
-@skip_until("2026-06-12", reason="Flaky test, see MOD-15571")
 @skip(no_json=True)
 def test_index_multi_value_json():
+    # Flaky under coverage (MOD-15571); skip only on coverage runs until the date below.
+    if CODE_COVERAGE:
+        skipTestUntil("2026-06-12", reason="Flaky test under coverage, see MOD-15571")
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
     dim = 4

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1892,6 +1892,7 @@ def test_create_multi_value_json():
                        '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',).ok()
             env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "vec"))['IS_MULTI_VALUE'], 0, message=f'{algo}, {path}')
 
+@skip_until("2026-06-12", reason="Flaky test, see MOD-15571")
 @skip(no_json=True)
 def test_index_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -274,12 +274,13 @@ def test_memory_info():
 
 
 func_gen = lambda tn, comp, dt, dist, wr: lambda: queries_sanity(tn, comp, dt, dist, wr)
-# (compression_type, data_type, metric, workers) tuples that are flaky on coverage Coordinator
-# and are temporarily skipped via skip_until. See MOD-15569 / MOD-15570.
+# (compression_type, data_type, metric, workers) tuples that are flaky on the
+# coverage (Coordinator-only) job and are temporarily skipped via skip_until.
+# Only applied when running under coverage; see MOD-15569 / MOD-15570.
 QUERIES_SANITY_SKIP_UNTIL = {
-    ('LVQ8', 'FLOAT16', 'IP', 0): ('2026-06-12', 'Flaky test, see MOD-15570'),
-    ('LVQ8', 'FLOAT16', 'IP', 4): ('2026-06-12', 'Flaky test, see MOD-15569'),
-}
+    ('LVQ8', 'FLOAT16', 'IP', 0): ('2026-06-12', 'Flaky test under coverage, see MOD-15570'),
+    ('LVQ8', 'FLOAT16', 'IP', 4): ('2026-06-12', 'Flaky test under coverage, see MOD-15569'),
+} if CODE_COVERAGE else {}
 for workers in [0, 4]:
     name_suffix = "_async" if workers else ""
     # Create SVS VAMANA index with all compression flavors

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -8,6 +8,7 @@ from vecsim_utils import *
 from common import (
     getConnectionByEnv,
     skip,
+    skip_until,
     assertInfoField,
     index_info,
     to_dict,
@@ -273,6 +274,12 @@ def test_memory_info():
 
 
 func_gen = lambda tn, comp, dt, dist, wr: lambda: queries_sanity(tn, comp, dt, dist, wr)
+# (compression_type, data_type, metric, workers) tuples that are flaky on coverage Coordinator
+# and are temporarily skipped via skip_until. See MOD-15569 / MOD-15570.
+QUERIES_SANITY_SKIP_UNTIL = {
+    ('LVQ8', 'FLOAT16', 'IP', 0): ('2026-06-12', 'Flaky test, see MOD-15570'),
+    ('LVQ8', 'FLOAT16', 'IP', 4): ('2026-06-12', 'Flaky test, see MOD-15569'),
+}
 for workers in [0, 4]:
     name_suffix = "_async" if workers else ""
     # Create SVS VAMANA index with all compression flavors
@@ -283,7 +290,12 @@ for workers in [0, 4]:
             metrics = VECSIM_DISTANCE_METRICS if EXTENDED_PYTESTS else ['IP']
             for metric in metrics:
                 test_name = f"test_queries_sanity_{compression_type}_{data_type}_{metric}" + name_suffix
-                globals()[test_name] = func_gen(test_name, compression_type, data_type, metric, workers)
+                test_func = func_gen(test_name, compression_type, data_type, metric, workers)
+                skip_spec = QUERIES_SANITY_SKIP_UNTIL.get((compression_type, data_type, metric, workers))
+                if skip_spec is not None:
+                    skip_date, skip_reason = skip_spec
+                    test_func = skip_until(skip_date, reason=skip_reason)(test_func)
+                globals()[test_name] = test_func
 
 '''
 This test validates SVS-VAMANA tiered indexing across all datatype, metric, and compression combinations.


### PR DESCRIPTION
## Describe the changes in the pull request

Three vecsim tests have been timing out on the coverage (Coordinator-only) job (Ubuntu Latest x86_64, Redis 3cd4642), most recently in [run 25733757789 / job 75565488354](https://github.com/RediSearch/RediSearch/actions/runs/25733757789/job/75565488354?pr=9443) on a PR (#9443) that does not touch any vector or JSON code, so the failures are reproducing on master.

1. **Current**: The following tests are killed by RLTest after the per-test timeout, leaving the run with Total Tests Failed: 3:
   - test_vecsim_svs:test_queries_sanity_LVQ8_FLOAT16_IP ([MOD-15570])
   - test_vecsim_svs:test_queries_sanity_LVQ8_FLOAT16_IP_async ([MOD-15569])
   - test_vecsim:test_index_multi_value_json ([MOD-15571])

   The two test_queries_sanity_LVQ8_FLOAT16_IP* tests are dynamically generated from a loop in test_vecsim_svs.py, so they cannot be decorated directly. test_index_multi_value_json already has a @skip(no_json=True) decorator that we want to keep.

2. **Change**: Skip each of the three tests via @skip_until("2026-06-12", reason="Flaky test, see MOD-...") for one month (today is 2026-05-12) while the underlying timeouts are investigated.
   - For test_vecsim_svs.py, a small QUERIES_SANITY_SKIP_UNTIL table maps (compression, dtype, metric, workers) tuples to (date, reason). Inside the existing test-generation loop the produced function is wrapped with skip_until(...) only for the listed tuples, leaving every other generated test untouched.
   - For test_vecsim.py, @skip_until(...) is stacked on top of the existing @skip(no_json=True) so the original platform skip semantics are preserved automatically once the date passes.

3. **Outcome**: CI stops being interrupted by these three flakes. After 2026-06-12 the skip_until decorators become no-ops and the tests resume their previous behavior automatically - guaranteeing they are reconsidered rather than silently disabled forever.

#### Which additional issues this PR fixes
1. MOD-15569
2. MOD-15570
3. MOD-15571

#### Main objects this PR modified
1. tests/pytests/test_vecsim_svs.py - import skip_until; add QUERIES_SANITY_SKIP_UNTIL table and wrap the matching generated tests in the existing test-generation loop.
2. tests/pytests/test_vecsim.py - add @skip_until("2026-06-12", reason="Flaky test, see MOD-15571") above test_index_multi_value_json.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

[MOD-15569]: https://redislabs.atlassian.net/browse/MOD-15569
[MOD-15570]: https://redislabs.atlassian.net/browse/MOD-15570
[MOD-15571]: https://redislabs.atlassian.net/browse/MOD-15571

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that temporarily skip a small set of known-flaky VecSim tests under coverage runs, without touching production code paths.
> 
> **Overview**
> Reduces coverage-job flakiness by temporarily skipping `test_index_multi_value_json` when `CODE_COVERAGE` is enabled until `2026-06-12`.
> 
> For dynamically generated SVS query sanity tests, adds a small tuple→(date,reason) skip table and wraps only the two known-flaky `LVQ8/FLOAT16/IP` variants (sync and async workers) with `skip_until`, leaving all other generated tests unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76dedbc8eaa6c4012ee0bf48a0fb7e774215c2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->