### PR TITLE
Retry CI build/lint on transient sccache startup timeouts

### DIFF
--- a/.github/actions/retry-on-sccache-timeout/action.yml
+++ b/.github/actions/retry-on-sccache-timeout/action.yml
@@ -1,28 +1,27 @@
 name: Retry on sccache timeout
 description: |
-  Run a command, retrying only when it fails with a transient sccache server
-  startup timeout (e.g. when the GitHub Actions cache backend is briefly
-  unreachable). On the final attempt, sccache is configured with verbose
-  logging (`SCCACHE_LOG=debug`) and run without its background daemon
-  (`SCCACHE_NO_DAEMON=1`) so that any persistent failure surfaces with
-  maximum diagnostic information.
-
-  See MOD-15568.
+  Runs a command with retry logic, but only retries when the failure matches a
+  transient sccache server startup timeout (the GitHub Actions cache backend
+  briefly unreachable). Any other failure is surfaced immediately so real
+  errors are not masked. On the final attempt, sccache is configured with
+  verbose logging (SCCACHE_LOG=debug) and run without its background daemon
+  (SCCACHE_NO_DAEMON=1) so that a persistent failure surfaces with maximum
+  diagnostic information.
 
 inputs:
   command:
-    description: "The command to run."
+    description: "The command to run"
     required: true
   working_directory:
-    description: "Working directory to run the command from."
+    description: "Working directory to run the command from"
     required: false
     default: "."
-  max_attempts:
-    description: "Maximum number of attempts (initial run + retries)."
+  max_retries:
+    description: "Maximum number of retry attempts"
     required: false
     default: "3"
   retry_delay:
-    description: "Delay in seconds between attempts."
+    description: "Delay in seconds between retries"
     required: false
     default: "30"
 
@@ -33,36 +32,35 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       env:
         COMMAND: ${{ inputs.command }}
-        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        MAX_RETRIES: ${{ inputs.max_retries }}
         RETRY_DELAY: ${{ inputs.retry_delay }}
       run: |
-        # Pattern that identifies a transient sccache backend startup failure
-        # that is safe to retry. Keep narrow: any other failure is treated as
-        # a real error and surfaced immediately.
+        # Narrow pattern: only retry on this exact transient error.
         SCCACHE_TIMEOUT_PATTERN='sccache: error: Timed out waiting for server startup'
 
         LOG_FILE=$(mktemp)
         trap 'rm -f "$LOG_FILE"' EXIT
 
+        SUCCESS=0
         EXIT_CODE=0
-        for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-          echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+        for i in $(seq 1 "$MAX_RETRIES"); do
+          echo "::group::Attempt $i of $MAX_RETRIES"
 
           # Last attempt: enable verbose sccache logging and disable the
-          # background server so that any persistent failure is captured with
-          # maximum diagnostic information (per MOD-15568 review feedback).
-          if [ "$attempt" -eq "$MAX_ATTEMPTS" ] && [ "$MAX_ATTEMPTS" -gt 1 ]; then
+          # background server so that any persistent failure surfaces with
+          # maximum diagnostic information.
+          if [ "$i" -eq "$MAX_RETRIES" ] && [ "$MAX_RETRIES" -gt 1 ]; then
             echo "Final attempt: enabling SCCACHE_LOG=debug and SCCACHE_NO_DAEMON=1"
             export SCCACHE_LOG=debug
             export SCCACHE_NO_DAEMON=1
-            # Stop any sccache server already started by previous attempts so
-            # the no-daemon mode actually takes effect for child processes.
+            # Stop any sccache server started by earlier attempts so no-daemon
+            # mode actually takes effect for child processes.
             "${SCCACHE_PATH:-sccache}" --stop-server >/dev/null 2>&1 || true
           fi
 
-          # Run the command, mirroring its output to a log file so we can
-          # inspect it afterwards for known transient error patterns.
-          # Use `set +e` so we can capture the exit code without aborting.
+          # Mirror output to a log file so we can inspect it afterwards for
+          # the known transient pattern. `set +e` lets us capture the exit
+          # code of the eval without aborting under `set -e`.
           set +e
           eval "$COMMAND" 2>&1 | tee "$LOG_FILE"
           EXIT_CODE=${PIPESTATUS[0]}
@@ -71,24 +69,17 @@ runs:
           echo "::endgroup::"
 
           if [ "$EXIT_CODE" -eq 0 ]; then
-            echo "Command succeeded on attempt $attempt"
-            exit 0
-          fi
-
-          echo "Command failed on attempt $attempt with exit code $EXIT_CODE"
-
-          if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-            echo "Reached maximum attempts ($MAX_ATTEMPTS); giving up."
+            echo "Command succeeded"
+            SUCCESS=1
             break
           fi
 
-          if grep -qF "$SCCACHE_TIMEOUT_PATTERN" "$LOG_FILE"; then
-            echo "Detected transient sccache startup timeout; retrying in $RETRY_DELAY seconds..."
+          if [ "$i" -lt "$MAX_RETRIES" ] && grep -qF "$SCCACHE_TIMEOUT_PATTERN" "$LOG_FILE"; then
+            echo "Command failed with transient sccache startup timeout, retrying in $RETRY_DELAY seconds..."
             sleep "$RETRY_DELAY"
           else
-            echo "Failure does not match a known transient sccache pattern; not retrying."
             break
           fi
         done
 
-        exit "$EXIT_CODE"
+        [ $SUCCESS -eq 1 ] || exit "$EXIT_CODE"

--- a/.github/actions/retry-on-sccache-timeout/action.yml
+++ b/.github/actions/retry-on-sccache-timeout/action.yml
@@ -1,0 +1,94 @@
+name: Retry on sccache timeout
+description: |
+  Run a command, retrying only when it fails with a transient sccache server
+  startup timeout (e.g. when the GitHub Actions cache backend is briefly
+  unreachable). On the final attempt, sccache is configured with verbose
+  logging (`SCCACHE_LOG=debug`) and run without its background daemon
+  (`SCCACHE_NO_DAEMON=1`) so that any persistent failure surfaces with
+  maximum diagnostic information.
+
+  See MOD-15568.
+
+inputs:
+  command:
+    description: "The command to run."
+    required: true
+  working_directory:
+    description: "Working directory to run the command from."
+    required: false
+    default: "."
+  max_attempts:
+    description: "Maximum number of attempts (initial run + retries)."
+    required: false
+    default: "3"
+  retry_delay:
+    description: "Delay in seconds between attempts."
+    required: false
+    default: "30"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash -l -eo pipefail {0}
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        COMMAND: ${{ inputs.command }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        RETRY_DELAY: ${{ inputs.retry_delay }}
+      run: |
+        # Pattern that identifies a transient sccache backend startup failure
+        # that is safe to retry. Keep narrow: any other failure is treated as
+        # a real error and surfaced immediately.
+        SCCACHE_TIMEOUT_PATTERN='sccache: error: Timed out waiting for server startup'
+
+        LOG_FILE=$(mktemp)
+        trap 'rm -f "$LOG_FILE"' EXIT
+
+        EXIT_CODE=0
+        for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+          echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+
+          # Last attempt: enable verbose sccache logging and disable the
+          # background server so that any persistent failure is captured with
+          # maximum diagnostic information (per MOD-15568 review feedback).
+          if [ "$attempt" -eq "$MAX_ATTEMPTS" ] && [ "$MAX_ATTEMPTS" -gt 1 ]; then
+            echo "Final attempt: enabling SCCACHE_LOG=debug and SCCACHE_NO_DAEMON=1"
+            export SCCACHE_LOG=debug
+            export SCCACHE_NO_DAEMON=1
+            # Stop any sccache server already started by previous attempts so
+            # the no-daemon mode actually takes effect for child processes.
+            "${SCCACHE_PATH:-sccache}" --stop-server >/dev/null 2>&1 || true
+          fi
+
+          # Run the command, mirroring its output to a log file so we can
+          # inspect it afterwards for known transient error patterns.
+          # Use `set +e` so we can capture the exit code without aborting.
+          set +e
+          eval "$COMMAND" 2>&1 | tee "$LOG_FILE"
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "::endgroup::"
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "Command succeeded on attempt $attempt"
+            exit 0
+          fi
+
+          echo "Command failed on attempt $attempt with exit code $EXIT_CODE"
+
+          if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "Reached maximum attempts ($MAX_ATTEMPTS); giving up."
+            break
+          fi
+
+          if grep -qF "$SCCACHE_TIMEOUT_PATTERN" "$LOG_FILE"; then
+            echo "Detected transient sccache startup timeout; retrying in $RETRY_DELAY seconds..."
+            sleep "$RETRY_DELAY"
+          else
+            echo "Failure does not match a known transient sccache pattern; not retrying."
+            break
+          fi
+        done
+
+        exit "$EXIT_CODE"

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -87,7 +87,12 @@ jobs:
       - name: Lint
         id: lint
         continue-on-error: true
-        run: make lint
+        # Wrapped in retry-on-sccache-timeout so that transient sccache server
+        # startup failures (GHA cache backend briefly unreachable) do not fail
+        # the whole merge queue job. See MOD-15568.
+        uses: ./.github/actions/retry-on-sccache-timeout
+        with:
+          command: make lint
 
       - name: Generated files
         id: git-diff

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -89,7 +89,7 @@ jobs:
         continue-on-error: true
         # Wrapped in retry-on-sccache-timeout so that transient sccache server
         # startup failures (GHA cache backend briefly unreachable) do not fail
-        # the whole merge queue job. See MOD-15568.
+        # the whole job.
         uses: ./.github/actions/retry-on-sccache-timeout
         with:
           command: make lint

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -345,7 +345,7 @@ jobs:
       - name: Build
         # Wrapped in retry-on-sccache-timeout so that transient sccache server
         # startup failures (GHA cache backend briefly unreachable) do not fail
-        # the whole merge queue job. See MOD-15568.
+        # the whole job.
         uses: ./.github/actions/retry-on-sccache-timeout
         env:
           SAN: ${{ inputs.san }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -343,11 +343,16 @@ jobs:
           echo "Artifact name: ${ARTIFACT_NAME}"
           echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
       - name: Build
+        # Wrapped in retry-on-sccache-timeout so that transient sccache server
+        # startup failures (GHA cache backend briefly unreachable) do not fail
+        # the whole merge queue job. See MOD-15568.
+        uses: ./.github/actions/retry-on-sccache-timeout
         env:
           SAN: ${{ inputs.san }}
           REDIS_VER: ${{ inputs.redis-ref }}
           ENABLE_ASSERT: 1
-        run: make build TESTS=1
+        with:
+          command: make build TESTS=1
       - name: Validate glibc version
         if: runner.os == 'Linux' && inputs.platform != 'ubuntu:focal'
         uses: ./.github/actions/validate-glibc-version


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current**: The merge queue Rust build (`make build TESTS=1`) and lint (`make lint`) steps occasionally fail when sccache cannot reach the GitHub Actions cache backend at startup, aborting compilation with `sccache: error: Timed out waiting for server startup`. This is a transient infrastructure issue, but it fails the whole job and forces a manual re-run of the entire merge queue.
2. **Change**: Add a small composite action (`./.github/actions/retry-on-sccache-timeout`) that runs a command and only retries when its captured output contains that specific transient pattern. Any other failure is surfaced immediately, so real bugs are not masked. The wrapper is applied to the two Rust build entry points used by the merge queue:
   - `task-test.yml` `Build` step (`make build TESTS=1`)
   - `task-lint.yml` `Lint` step (`make lint`)

   The **final attempt** is run with `SCCACHE_LOG=debug` and `SCCACHE_NO_DAEMON=1`, and any pre-existing sccache server is stopped first, so that a persistent failure is captured with maximum diagnostic information instead of just the same one-line timeout.

   Inputs (`command`, `working_directory`, `max_retries`, `retry_delay`), shell, env-propagation pattern and log wording are aligned with the existing `./.github/actions/retry-command` action and the `SETUP_RETRY_LOOP` env-var pattern already in use, so the new wrapper reads the same as the rest of the CI.
3. **Outcome**: Transient `sccache: error: Timed out waiting for server startup` failures in the merge queue no longer fail the job on first occurrence. Retry behaviour is observable in the CI logs (each attempt is wrapped in a `::group::` annotation). Persistent failures still fail the job clearly, with verbose sccache diagnostics on the last attempt. Only the failed step is re-run, not the entire workflow.

#### Which additional issues this PR fixes
1. _N/A_

#### Main objects this PR modified
1. `.github/actions/retry-on-sccache-timeout/action.yml` (new composite action)
2. `.github/workflows/task-test.yml` (`Build` step uses the new action)
3. `.github/workflows/task-lint.yml` (`Lint` step uses the new action)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change: no user-facing behaviour, commands, or APIs are affected.
