### PR TITLE
[MOD-15575] Minimize the bindgen-generated FFI surface

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -28,6 +28,14 @@ struct HeaderAllowlist {
 /// Bindgen inputs. Each entry both feeds clang and constrains which symbols
 /// bindgen emits. Sorted alphabetically by `path` for easy scanning.
 const HEADERS: &[HeaderAllowlist] = &[
+    // RSE: `ThrottleCB` and `VecSimParamsDisk` are consumed by the disk
+    // vector-index API exposed through `src/search_disk_api.h`.
+    HeaderAllowlist {
+        path: "deps/VectorSimilarity/src/VecSim/vec_sim_common.h",
+        fns: &[],
+        types: &["ThrottleCB", "VecSimParamsDisk"],
+        vars: &[],
+    },
     HeaderAllowlist {
         path: "deps/geohash/geohash.h",
         fns: &[],
@@ -132,7 +140,9 @@ const HEADERS: &[HeaderAllowlist] = &[
     HeaderAllowlist {
         path: "src/redismodule.h",
         fns: &[],
-        types: &["RedisModuleString"],
+        // RSE: `RedisModuleIO` is referenced by the RDB save/load entry points
+        // in `src/search_disk_api.h`.
+        types: &["RedisModuleIO", "RedisModuleString"],
         vars: &[
             "REDISMODULE_ERR",
             "REDISMODULE_OK",
@@ -145,7 +155,14 @@ const HEADERS: &[HeaderAllowlist] = &[
             "RedisModule_GetDetachedThreadSafeContext",
             "RedisModule_GetThreadSafeContext",
             "RedisModule_InfoAddFieldCString",
+            // RSE: u64 field writer used by `redisearch_disk`'s
+            // `RedisModuleInfoCtx`-backed INFO sink.
+            "RedisModule_InfoAddFieldULongLong",
             "RedisModule_InfoAddSection",
+            // RSE: open/close pair for nested dict fields, used by the same
+            // INFO sink in `redisearch_disk`.
+            "RedisModule_InfoBeginDictField",
+            "RedisModule_InfoEndDictField",
             "RedisModule_Log",
             "RedisModule_ReplySetArrayLength",
             "RedisModule_ReplySetMapLength",
@@ -187,6 +204,30 @@ const HEADERS: &[HeaderAllowlist] = &[
         path: "src/search_ctx.h",
         fns: &["NewSearchCtxC", "SearchCtx_Free"],
         types: &[],
+        vars: &[],
+    },
+    // RSE: the entire disk API struct family lives in this header and is
+    // consumed by `redisearch_disk` to bridge from C into the Rust storage
+    // layer. None of these symbols are referenced by RediSearch itself.
+    HeaderAllowlist {
+        path: "src/search_disk_api.h",
+        fns: &[],
+        types: &[
+            "AllocateDMDCallback",
+            "AllocateKeyCallback",
+            "AsyncPollResult",
+            "AsyncReadResult",
+            "BasicDiskAPI",
+            "DocTableDiskAPI",
+            "IndexDiskAPI",
+            "MetricsDiskAPI",
+            "RedisSearchDisk",
+            "RedisSearchDiskAPI",
+            "RedisSearchDiskAsyncReadPool",
+            "RedisSearchDiskRdbState",
+            "SearchDiskCompactionCallbacks",
+            "VectorDiskAPI",
+        ],
         vars: &[],
     },
     HeaderAllowlist {

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -9,9 +9,257 @@
 
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use build_utils::{repository_root, rerun_if_c_changes};
+
+/// One C header bindgen consumes, plus the FFI symbols Rust code reaches
+/// for from that file. The build script verifies at startup that every
+/// listed symbol appears in the file at `path` — typos and upstream renames
+/// fail the build with a clear error instead of leaking into bindings.
+struct HeaderAllowlist {
+    /// Repository-relative path, e.g. `src/buffer/buffer.h`.
+    path: &'static str,
+    fns: &'static [&'static str],
+    types: &'static [&'static str],
+    vars: &'static [&'static str],
+}
+
+/// Bindgen inputs. Each entry both feeds clang and constrains which symbols
+/// bindgen emits. Sorted alphabetically by `path` for easy scanning.
+const HEADERS: &[HeaderAllowlist] = &[
+    HeaderAllowlist {
+        path: "deps/geohash/geohash.h",
+        fns: &[],
+        types: &[],
+        vars: &["GEO_LAT_MAX", "GEO_LAT_MIN", "GEO_LONG_MAX", "GEO_LONG_MIN"],
+    },
+    HeaderAllowlist {
+        path: "deps/hiredis/sds.h",
+        fns: &["sdscatlen"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/aggregate/reducer.h",
+        fns: &[],
+        types: &["Reducer", "ReducerOptions"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/buffer/buffer.h",
+        fns: &["Buffer_Free", "Buffer_Grow"],
+        types: &["BufferReader", "BufferWriter"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/config.h",
+        fns: &[],
+        types: &[],
+        vars: &["RM_SCAN_KEY_API_FIX", "RSGlobalConfig"],
+    },
+    HeaderAllowlist {
+        path: "src/doc_table.h",
+        fns: &["DMD_Free", "DocTable_Exists"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/fork_gc.h",
+        fns: &[],
+        types: &["ForkGC"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/forward_index.h",
+        fns: &["InvertedIndex_WriteForwardIndexEntry"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/iterators/iterator_api.h",
+        fns: &[],
+        types: &["QueryIterator"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/json.h",
+        fns: &[],
+        types: &[],
+        vars: &["RedisJSONAPI_MIN_API_VER", "japi", "japi_ver"],
+    },
+    HeaderAllowlist {
+        path: "src/numeric_filter.h",
+        fns: &["NewNumericFilter"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/obfuscation/hidden.h",
+        fns: &[
+            "HiddenString_CompareC",
+            "HiddenString_Free",
+            "HiddenString_GetUnsafe",
+            "NewHiddenString",
+        ],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/obfuscation/obfuscation_api.h",
+        fns: &["Obfuscate_Number", "Obfuscate_Text"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/query.h",
+        fns: &[],
+        types: &["QueryEvalCtx"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/redis_index.h",
+        fns: &["Redis_OpenInvertedIndex"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/redisearch.h",
+        fns: &[],
+        types: &["RSToken"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/redismodule.h",
+        fns: &[],
+        types: &["RedisModuleString"],
+        vars: &[
+            "REDISMODULE_ERR",
+            "REDISMODULE_OK",
+            "REDISMODULE_POSTPONED_ARRAY_LEN",
+            "REDISMODULE_POSTPONED_LEN",
+            "RedisModule_Alloc",
+            "RedisModule_Free",
+            "RedisModule_FreeString",
+            "RedisModule_FreeThreadSafeContext",
+            "RedisModule_GetDetachedThreadSafeContext",
+            "RedisModule_GetThreadSafeContext",
+            "RedisModule_InfoAddFieldCString",
+            "RedisModule_InfoAddSection",
+            "RedisModule_Log",
+            "RedisModule_ReplySetArrayLength",
+            "RedisModule_ReplySetMapLength",
+            "RedisModule_ReplyWithArray",
+            "RedisModule_ReplyWithDouble",
+            "RedisModule_ReplyWithEmptyArray",
+            "RedisModule_ReplyWithLongLong",
+            "RedisModule_ReplyWithMap",
+            "RedisModule_ReplyWithSimpleString",
+            "RedisModule_ReplyWithStringBuffer",
+            "RedisModule_StringPtrLen",
+        ],
+    },
+    HeaderAllowlist {
+        path: "src/result_processor.h",
+        fns: &["RPProfile_IncrementCount"],
+        types: &["RPStatus"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/rlookup_load_document.h",
+        fns: &["loadIndividualKeys", "sdslen_rust"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/rules.h",
+        fns: &["SchemaPrefixes_Free"],
+        types: &[],
+        vars: &["SchemaPrefixes_g"],
+    },
+    HeaderAllowlist {
+        path: "src/score_explain.h",
+        fns: &["SEDestroy"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/search_ctx.h",
+        fns: &["NewSearchCtxC", "SearchCtx_Free"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/spec.h",
+        fns: &[
+            "IndexSpec_AcquireWriteLock",
+            "IndexSpec_DecrementNumTerms",
+            "IndexSpec_DecrementTrieTermCount",
+            "IndexSpec_GetFieldWithLength",
+            "IndexSpec_ParseC",
+            "IndexSpec_ReleaseWriteLock",
+            "IndexSpec_RemoveFromGlobals",
+            "IndexSpecCache_Decref",
+            "Indexes_Init",
+            "Spec_AddToDict",
+        ],
+        types: &[],
+        vars: &["isCrdt", "specDict_g", "specIdDict_g"],
+    },
+    HeaderAllowlist {
+        path: "src/stopwords.h",
+        fns: &["StopWordList_FreeGlobals"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/tag_index.h",
+        fns: &["TagIndex_Ensure", "TagIndex_OpenIndex"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/trie/trie.h",
+        fns: &["Trie_DecrementNumDocs"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/ttl_table/ttl_table.h",
+        fns: &[
+            "TimeToLiveTable_Add",
+            "TimeToLiveTable_VerifyDocAndField",
+            "TimeToLiveTable_VerifyDocAndFieldMask",
+            "TimeToLiveTable_VerifyDocAndWideFieldMask",
+            "TimeToLiveTable_VerifyInit",
+        ],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/util/arr/arr.h",
+        fns: &["array_free", "array_len_func", "array_new_sz"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/util/dict/dict.h",
+        fns: &[
+            "RS_dictAdd",
+            "RS_dictDelete",
+            "RS_dictFetchValue",
+            "RS_dictRelease",
+        ],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/util/references.h",
+        fns: &["StrongRef_Get"],
+        types: &[],
+        vars: &[],
+    },
+];
 
 /// Generated headers (from `src/redisearch_rs/headers/`) that bindgen is allowed
 /// to consume transitively. Every entry is an explicit decision: each new entry
@@ -66,40 +314,52 @@ const PERMITTED_GENERATED_HEADERS: &[&str] = &[
     "varint_ffi.h",
 ];
 
+/// Types defined in Rust (re-exported from their owning crate in
+/// `ffi/src/lib.rs`). Blocklisted so bindgen doesn't emit a conflicting
+/// opaque stub when it sees a forward reference.
+const BLOCKLIST_TYPES: &[&str] = &[
+    "IteratorType",
+    "QueryNodeType",
+    "QueryProcessingCtx", // defined directly in `ffi/src/lib.rs`
+    "RSQueryTerm",
+    "RSTokenFlags",
+];
+
+/// cheadergen-produced headers whose types are provided from the owning
+/// Rust crate via `pub use` in `ffi/src/lib.rs`, not from bindgen's output.
+const BLOCKLIST_FILES: &[&str] = &[
+    ".*/document_rs.h",
+    ".*/numeric_range_tree.h",
+    ".*/query_node_type.h",
+    ".*/query_term.h",
+    ".*/query_term_ffi.h",
+    ".*/rqe_iterator_type.h",
+    ".*/rqe_iterators.h",
+];
+
 fn main() {
     let root =
         repository_root().expect("Could not find repository root for static library linking");
+    let src = root.join("src");
+    let deps = root.join("deps");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    // Construct the correct folder path based on OS and architecture
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-
-    // There are several symbols exposed by the C code that we don't
-    // actually invoke (either directly or indirectly) in our benchmarks.
-    // We provide a definition for the ones we need (e.g. Redis' allocation functions),
-    // but we don't want to be forced to add dummy definitions for the ones we don't rely on.
-    // We prefer to fail at runtime if we try to use a symbol that's undefined.
-    // This is the default linker behaviour on macOS. On other platforms, the default
-    // configuration is stricter: it exits with an error if any symbol is undefined.
-    // We intentionally relax it here.
-    if target_os != "macos" {
+    // On non-macOS platforms the default linker rejects undefined symbols.
+    // Several symbols exposed by the C code aren't actually invoked from our
+    // benchmarks; relax the check so we don't have to ship dummy definitions.
+    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "macos" {
         println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
     }
 
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    // Stage the explicitly permitted generated headers into an OUT_DIR
-    // subdirectory and put only that subdirectory on bindgen's include path.
-    // Generated headers not on the allowlist are unreachable from bindgen's
-    // clang invocation, so a malformed regeneration of an unlisted header
-    // cannot wedge the build.
+    // Stage permitted generated headers into an OUT_DIR subdirectory and put
+    // only that subdirectory on bindgen's clang include path. Generated
+    // headers not on the allowlist are unreachable from bindgen, so a
+    // malformed regeneration of an unlisted header cannot wedge the build.
     let permitted_dir = out_dir.join("permitted_generated_headers");
     fs::create_dir_all(&permitted_dir).expect("create permitted_generated_headers");
+    let cheadergen_dir = src.join("redisearch_rs").join("headers");
     for hdr in PERMITTED_GENERATED_HEADERS {
-        let src_path = root
-            .join("src")
-            .join("redisearch_rs")
-            .join("headers")
-            .join(hdr);
+        let src_path = cheadergen_dir.join(hdr);
         let dst_path = permitted_dir.join(hdr);
         fs::copy(&src_path, &dst_path).unwrap_or_else(|e| {
             panic!("copy {} -> {}: {e}", src_path.display(), dst_path.display())
@@ -107,128 +367,100 @@ fn main() {
         println!("cargo:rerun-if-changed={}", src_path.display());
     }
 
-    let includes = {
-        let src = root.join("src");
-        let deps = root.join("deps");
-
-        let inverted_index = src.join("inverted_index");
-        let vecsim = deps.join("VectorSimilarity").join("src");
-        let buffer = src.join("buffer");
-        let ttl_table = src.join("ttl_table");
-        let trie = src.join("trie");
-        let rmalloc = deps.join("rmalloc");
-
-        [
-            src,
-            deps,
-            permitted_dir,
-            inverted_index,
-            vecsim,
-            buffer,
-            ttl_table,
-            trie,
-            rmalloc,
-        ]
-    };
-
-    let src = root.join("src");
-    let deps = root.join("deps");
-    let headers = [
-        src.join("redismodule.h"),
-        deps.join("hiredis").join("sds.h"),
-        deps.join("rmutil").join("vector.h"),
-        src.join("aggregate").join("reducer.h"),
-        src.join("buffer/buffer.h"),
-        src.join("config.h"),
-        src.join("doc_table.h"),
-        src.join("fork_gc.h"),
-        src.join("forward_index.h"),
-        src.join("geo_index.h"),
-        deps.join("geohash").join("geohash.h"),
-        src.join("index_result").join("index_result.h"),
-        src.join("json.h"),
-        src.join("obfuscation").join("hidden.h"),
-        src.join("obfuscation").join("obfuscation_api.h"),
-        src.join("query.h"),
-        src.join("redis_index.h"),
-        src.join("redisearch.h"),
-        src.join("result_processor.h"),
-        src.join("rlookup.h"),
-        src.join("rlookup_load_document.h"),
-        src.join("rules.h"),
-        src.join("score_explain.h"),
-        src.join("search_ctx.h"),
-        src.join("search_disk.h"),
-        src.join("search_disk_api.h"),
-        src.join("search_result.h"),
-        src.join("sortable.h"),
-        src.join("spec.h"),
-        src.join("stopwords.h"),
-        src.join("numeric_filter.h"),
-        src.join("tag_index.h"),
-        src.join("trie").join("trie_node.h"),
-        src.join("trie").join("trie.h"),
-        src.join("ttl_table").join("ttl_table.h"),
-        src.join("util").join("arr").join("arr.h"),
-        src.join("util").join("dict").join("dict.h"),
-        src.join("util").join("references.h"),
+    let includes = [
+        src.clone(),
+        deps.clone(),
+        permitted_dir,
+        src.join("inverted_index"),
+        deps.join("VectorSimilarity").join("src"),
+        src.join("buffer"),
+        src.join("ttl_table"),
+        src.join("trie"),
+        deps.join("rmalloc"),
     ];
 
     let mut bindings = bindgen::Builder::default();
+    for entry in HEADERS {
+        let abs = root.join(entry.path);
+        verify_symbols(&abs, entry);
+        bindings = bindings.header(abs.display().to_string());
+        println!("cargo:rerun-if-changed={}", abs.display());
 
-    for header in headers {
-        bindings = bindings
-            .header(header.display().to_string())
-            .allowlist_file(header.display().to_string());
-
-        println!("cargo:rerun-if-changed={}", header.display());
+        for func in entry.fns {
+            bindings = bindings.allowlist_function(func);
+        }
+        for ty in entry.types {
+            bindings = bindings.allowlist_type(ty);
+        }
+        for var in entry.vars {
+            bindings = bindings.allowlist_var(var);
+        }
     }
-    for include in includes {
+    for include in &includes {
         bindings = bindings.clang_arg(format!("-I{}", include.display()));
-        // Re-run the build script if any of the C files in the included
-        // directory changes
-        let _ = rerun_if_c_changes(&include);
+        let _ = rerun_if_c_changes(include);
     }
-
-    // Required so `<stdio.h>` declares `asprintf`/`vasprintf` (used by
-    // `deps/rmalloc/rmalloc.h`) when bindgen parses the headers with clang.
+    // `_GNU_SOURCE` makes `<stdio.h>` declare `asprintf`/`vasprintf`, which
+    // `deps/rmalloc/rmalloc.h` uses.
     bindings = bindings.clang_arg("-D_GNU_SOURCE");
 
+    for ty in BLOCKLIST_TYPES {
+        bindings = bindings.blocklist_type(ty);
+    }
+    for file in BLOCKLIST_FILES {
+        bindings = bindings.blocklist_file(file);
+    }
+
     bindings
-        .blocklist_file(".*/document_rs.h")
-        // numeric_range_tree.h is generated by Rust (cheadergen) and those types
-        // are provided by the numeric_range_tree_ffi crate, not parsed from C
-        .blocklist_file(".*/numeric_range_tree.h")
-        // Provided by the query_term crate, not parsed from C
-        .blocklist_file(".*/query_term_ffi.h")
-        .blocklist_file(".*/query_term.h")
-        // IteratorType is defined in Rust (rqe_iterator_type crate);
-        // cheadergen generates rqe_iterator_type.h which is included by
-        // iterator_api.h. We blocklist the generated header so bindgen
-        // doesn't re-parse it, and re-export the Rust type from lib.rs.
-        .blocklist_file(".*/rqe_iterator_type.h")
-        // QueryNodeType is defined in Rust (query_node_type crate);
-        // cheadergen generates query_node_type.h which is included by
-        // query_node.h. We blocklist the generated header so bindgen
-        // doesn't re-parse it, and re-export the Rust type from lib.rs.
-        .blocklist_file(".*/query_node_type.h")
-        .blocklist_file(".*/rqe_iterators.h")
-        // Suppress bindgen's opaque-struct fallbacks for types it sees
-        // referenced (in allowlisted headers) but whose definitions live in
-        // the blocklisted Rust-generated headers above. The Rust side
-        // re-exports these from their owning crates.
-        .blocklist_type("RSQueryTerm")
-        .blocklist_type("RSTokenFlags")
-        .blocklist_type("IteratorType")
-        .blocklist_type("QueryNodeType")
-        // QueryProcessingCtx is defined directly in the `ffi` crate
-        // (`ffi/src/lib.rs`). Without this blocklist, bindgen would emit a
-        // conflicting opaque struct from its forward reference in
-        // `result_processor.h`.
-        .blocklist_type("QueryProcessingCtx")
-        .allowlist_file(".*/types_ffi.h")
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+}
+
+/// Verify that every symbol claimed in `entry` actually appears (as a
+/// whole identifier) in the file at `abs`. Catches typos and upstream
+/// renames at `cargo build` time.
+fn verify_symbols(abs: &Path, entry: &HeaderAllowlist) {
+    let content = fs::read_to_string(abs)
+        .unwrap_or_else(|e| panic!("ffi build.rs: read {}: {e}", abs.display()));
+    let check = |sym: &str, kind: &str| {
+        if !contains_word(&content, sym) {
+            panic!(
+                "ffi build.rs: {kind} `{sym}` claimed to be in `{}` but not found",
+                entry.path,
+            );
+        }
+    };
+    for f in entry.fns {
+        check(f, "function");
+    }
+    for t in entry.types {
+        check(t, "type");
+    }
+    for v in entry.vars {
+        check(v, "variable");
+    }
+}
+
+/// True when `sym` appears in `haystack` surrounded by non-identifier
+/// characters (so `Buffer` doesn't match inside `BufferReader`).
+fn contains_word(haystack: &str, sym: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let mut start = 0;
+    while let Some(idx) = haystack[start..].find(sym) {
+        let pos = start + idx;
+        let end = pos + sym.len();
+        let left_ok = pos == 0 || !is_ident_byte(bytes[pos - 1]);
+        let right_ok = end == bytes.len() || !is_ident_byte(bytes[end]);
+        if left_ok && right_ok {
+            return true;
+        }
+        start = pos + 1;
+    }
+    false
+}
+
+const fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
 }


### PR DESCRIPTION
## Describe the changes in the pull request

~Stacked on top of #9572~.

Trims the bindgen output in the `ffi` crate to what Rust code actually references. Previously `ffi/build.rs` allowlisted *files*, which made bindgen emit every function, type, and constant declared in each of 38 input headers. This PR replaces that with explicit module-scoped per-symbol allowlists.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `ffi` build script and bindgen configuration, so mistakes in the new allowlists/blocklists can break compilation or omit required FFI symbols across platforms.
> 
> **Overview**
> **Minimizes the bindgen-generated FFI surface** by replacing the previous per-header `allowlist_file` approach with an explicit per-header *per-symbol* allowlist (`HEADERS`) for functions, types, and variables.
> 
> Adds build-time validation (`verify_symbols` + `contains_word`) that every allowlisted symbol actually exists in its source header, and centralizes bindgen blocklisting via `BLOCKLIST_TYPES`/`BLOCKLIST_FILES` while keeping the existing generated-header staging/`rerun-if-changed` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbf6f401e4e965285dc4f92f7a063c0b6524cd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->