### PR TITLE
[MOD-14866] Port QAST string helper functions to Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1180,7 +1180,7 @@ static QueryIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
  * @param caseSensitive A flag indicating whether the conversion to lowercase
  * should be performed. If true, the string remains case-sensitive.
  */
-static void tag_strtolower(char **pstr, size_t *len, int caseSensitive) {
+void tag_strtolower(char **pstr, size_t *len, int caseSensitive) {
   size_t length = *len;
   char *str = *pstr;
   char *origStr = str;

--- a/src/query.h
+++ b/src/query.h
@@ -125,6 +125,14 @@ QueryIterator *QAST_Iterate(QueryAST *ast, const RSSearchOptions *options,
                             RedisSearchCtx *sctx, uint32_t reqflags, QueryError *status);
 
 /**
+ * Remove tag escape sequences and optionally lowercase a string.
+ * @param pstr pointer to the string (may be reallocated if lowercasing produces a longer result)
+ * @param len pointer to the string length (updated on output)
+ * @param caseSensitive if non-zero, skip lowercasing
+ */
+void tag_strtolower(char **pstr, size_t *len, int caseSensitive);
+
+/**
  * Expand the query using a pre-registered expander. Query expansion possibly
  * modifies or adds additional search terms to the query.
  * @param q the query

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -115,7 +115,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/query.h",
-        fns: &[],
+        fns: &["tag_strtolower"],
         types: &["QueryEvalCtx"],
         vars: &[],
     },

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -301,6 +301,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/util/strconv.h",
+        fns: &["unicode_tolower_fn"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/wildcard/wildcard.h",
         fns: &["Wildcard_RemoveEscape"],
         types: &[],

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -12,6 +12,16 @@
 //! These are pure-Rust replacements for C helpers that were previously
 //! implemented using `libnu` for Unicode operations.
 
+/// Convert a UTF-8 string to lowercase per-character, without
+/// context-dependent casing rules.
+///
+/// Unlike [`str::to_lowercase`], this lowercases each [`char`] independently
+/// (via [`char::to_lowercase`]), which matches the behaviour of the C
+/// `unicode_tolower` function backed by libnu.
+pub fn unicode_tolower(s: &str) -> String {
+    s.chars().flat_map(char::to_lowercase).collect()
+}
+
 /// Maximum number of runes (lowercased codepoints) allowed in a single
 /// conversion, matching the C `MAX_RUNESTR_LEN` constant.
 pub const MAX_RUNE_STR_LEN: usize = 1024;

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -12,6 +12,8 @@
 //! These are pure-Rust replacements for C helpers that were previously
 //! implemented using `libnu` for Unicode operations.
 
+use std::borrow::Cow;
+
 /// Convert a UTF-8 string to lowercase per-character, without
 /// context-dependent casing rules.
 ///
@@ -51,4 +53,63 @@ pub fn str_to_lower_runes(s: &str) -> Result<Vec<u16>, RuneStrTooLong> {
         return Err(RuneStrTooLong { len: runes.len() });
     }
     Ok(runes)
+}
+
+/// Equivalent to C `isspace()` in the POSIX/C locale.
+///
+/// Rust's [`u8::is_ascii_whitespace`] excludes vertical tab (`\x0B`), so we
+/// match the C definition explicitly.
+const fn is_c_space(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b'\x0B' | b'\x0C')
+}
+
+/// Remove tag escape sequences and optionally convert to lowercase.
+///
+/// 1. Strips backslash escapes that precede ASCII punctuation or whitespace.
+/// 2. If `case_sensitive` is `false`, converts the result to lowercase using
+///    [`unicode_tolower`] (per-character, no context-dependent rules).
+pub fn tag_strtolower(s: &str, case_sensitive: bool) -> Cow<'_, str> {
+    let bytes = s.as_bytes();
+    // Only `\` before ASCII punctuation or C-locale whitespace counts as
+    // an escape; `\` before a letter (e.g. `\n` as two literal bytes) is
+    // kept verbatim—matching the original C `tag_strtolower` behaviour.
+    let has_escape = bytes
+        .windows(2)
+        .any(|w| w[0] == b'\\' && (w[1].is_ascii_punctuation() || is_c_space(w[1])));
+
+    if case_sensitive && !has_escape {
+        return Cow::Borrowed(s);
+    }
+
+    if !has_escape {
+        return Cow::Owned(unicode_tolower(s));
+    }
+
+    let mut result = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            if next.is_ascii_punctuation() || is_c_space(next) {
+                result.push(next);
+                i += 2;
+                continue;
+            }
+        }
+        result.push(bytes[i]);
+        i += 1;
+    }
+
+    // SAFETY: removing `\` (0x5C, a single-byte ASCII character) before
+    // another ASCII byte (punctuation or whitespace) cannot break a
+    // multi-byte UTF-8 sequence, so the output is valid UTF-8 whenever
+    // the input is.
+    let unescaped =
+        String::from_utf8(result).expect("invalid UTF-8 after removing escape characters");
+
+    if case_sensitive {
+        Cow::Owned(unescaped)
+    } else {
+        Cow::Owned(unicode_tolower(&unescaped))
+    }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
@@ -8,4 +8,5 @@
 */
 
 mod str_to_lower_runes;
+mod tag_strtolower;
 mod unicode_tolower;

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
@@ -8,3 +8,4 @@
 */
 
 mod str_to_lower_runes;
+mod unicode_tolower;

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/tag_strtolower.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/tag_strtolower.rs
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use query_eval::string_utils::tag_strtolower;
+
+#[test]
+fn unescape_punct() {
+    assert_eq!(tag_strtolower("hello\\!world", false), "hello!world");
+}
+
+#[test]
+fn unescape_space() {
+    assert_eq!(tag_strtolower("hello\\ world", false), "hello world");
+}
+
+#[test]
+fn no_unescape_alpha() {
+    assert_eq!(tag_strtolower("hello\\nworld", false), "hello\\nworld");
+}
+
+#[test]
+fn case_sensitive() {
+    assert_eq!(tag_strtolower("Hello\\!World", true), "Hello!World");
+}
+
+#[test]
+fn case_insensitive() {
+    assert_eq!(tag_strtolower("Hello\\!World", false), "hello!world");
+}
+
+#[test]
+fn empty() {
+    assert_eq!(tag_strtolower("", false), "");
+}
+
+#[test]
+fn trailing_backslash() {
+    assert_eq!(tag_strtolower("abc\\", false), "abc\\");
+}
+
+#[test]
+fn unescape_vertical_tab() {
+    // Vertical tab (0x0B) is whitespace per C isspace() — must be unescaped.
+    assert_eq!(tag_strtolower("hello\\\x0Bworld", false), "hello\x0Bworld");
+}
+
+#[test]
+fn consecutive_escapes() {
+    // `\\!` = bytes [0x5C, 0x5C, 0x21]: first `\` is removed (next is
+    // punct `\`), second `\` and `!` are kept — matches C behavior.
+    assert_eq!(tag_strtolower("\\\\!", false), "\\!");
+}
+
+#[test]
+fn escaped_backslash_before_alpha() {
+    // `\\n` = bytes [0x5C, 0x5C, 0x6E]: first `\` removed (next is punct
+    // `\`), second `\` kept, `n` is not punct/space so kept verbatim.
+    assert_eq!(tag_strtolower("\\\\n", false), "\\n");
+}
+
+#[test]
+fn sigma_lowercased_per_character() {
+    // Per-character lowercasing: Σ always maps to σ (no context-dependent
+    // final-sigma rule), matching the C `unicode_tolower` behaviour.
+    assert_eq!(tag_strtolower("ΣΣΣΣΣ", false), "σσσσσ");
+    assert_eq!(tag_strtolower("ΝΕΑΝΊΑΣ", false), "νεανίασ");
+}
+
+#[test]
+fn case_insensitive_matches_unicode_tolower() {
+    use query_eval::string_utils::unicode_tolower;
+
+    for s in ["ΣΣΣΣΣ", "ΝΕΑΝΊΑΣ", "Straße", "HELLO", "σίγμα"] {
+        assert_eq!(
+            tag_strtolower(s, false),
+            unicode_tolower(s),
+            "tag_strtolower({s:?}, false) != unicode_tolower",
+        );
+    }
+}
+
+// Compare Rust tag_strtolower against C tag_strtolower via FFI.
+// The C function may rm_free/rm_malloc *pstr, so input must be
+// allocated with the Redis allocator.
+#[cfg(not(miri))]
+mod ffi_comparison {
+    use proptest::prelude::*;
+    use query_eval::string_utils::tag_strtolower;
+    use std::ffi::c_void;
+
+    /// Call C `tag_strtolower` via FFI and return the resulting string.
+    fn c_tag_strtolower(s: &str, case_sensitive: bool) -> String {
+        // SAFETY: extern are initialized by the test harness (mock allocator).
+        let rm_alloc = unsafe { ffi::RedisModule_Alloc.expect("Redis allocator not available") };
+        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
+
+        // Allocate with rm_malloc: C code may rm_free this pointer.
+        let buf_len = s.len() + 1; // +1 for null terminator
+        // SAFETY: `buf_len` is non-zero; allocator is initialized by the test harness.
+        let buf = unsafe { rm_alloc(buf_len) }.cast::<u8>();
+        assert!(!buf.is_null());
+        // SAFETY: `buf` is a valid allocation of `buf_len` bytes.
+        unsafe {
+            std::ptr::copy_nonoverlapping(s.as_ptr(), buf, s.len());
+            *buf.add(s.len()) = 0; // null terminator
+        }
+
+        let mut ptr = buf.cast::<std::os::raw::c_char>();
+        let mut len = s.len();
+        // SAFETY: `ptr` is a valid rm_malloc'd, null-terminated buffer.
+        // `tag_strtolower` may rm_free and replace `ptr`.
+        unsafe {
+            ffi::tag_strtolower(&mut ptr, &mut len, if case_sensitive { 1 } else { 0 });
+        }
+
+        // SAFETY: `ptr` (possibly reallocated) is valid for `len` bytes.
+        let result = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) }.to_vec();
+        // SAFETY: `ptr` was allocated by `rm_malloc` (via `tag_strtolower` or the original alloc).
+        unsafe { rm_free(ptr.cast::<c_void>()) };
+
+        String::from_utf8(result).expect("C tag_strtolower result must be valid UTF-8")
+    }
+
+    fn assert_tag_matches_c(s: &str, case_sensitive: bool) {
+        let c_result = c_tag_strtolower(s, case_sensitive);
+        let rust_result = tag_strtolower(s, case_sensitive);
+        assert_eq!(
+            rust_result, c_result,
+            "mismatch for input {:?} (case_sensitive={}): rust={:?}, c={:?}",
+            s, case_sensitive, rust_result, c_result,
+        );
+    }
+
+    #[test]
+    fn ffi_unescape_case_sensitive_shrinks_in_place() {
+        // Escape removal shortens the string without reallocating. The
+        // dealloc must use the original allocation size, not the shorter
+        // output length.
+        assert_tag_matches_c("hello\\!world", true);
+        assert_tag_matches_c("a\\!b\\!c\\!d", true);
+    }
+
+    #[test]
+    fn ffi_unescape_punct() {
+        assert_tag_matches_c("hello\\!world", false);
+    }
+
+    #[test]
+    fn ffi_unescape_space() {
+        assert_tag_matches_c("hello\\ world", false);
+    }
+
+    #[test]
+    fn ffi_no_unescape_alpha() {
+        assert_tag_matches_c("hello\\nworld", false);
+    }
+
+    #[test]
+    fn ffi_case_sensitive() {
+        assert_tag_matches_c("Hello\\!World", true);
+    }
+
+    #[test]
+    fn ffi_case_insensitive() {
+        assert_tag_matches_c("Hello\\!World", false);
+    }
+
+    #[test]
+    fn ffi_empty() {
+        assert_tag_matches_c("", false);
+    }
+
+    #[test]
+    fn ffi_trailing_backslash() {
+        assert_tag_matches_c("abc\\", false);
+    }
+
+    #[test]
+    fn ffi_consecutive_escapes() {
+        assert_tag_matches_c("\\\\!", false);
+    }
+
+    /// Generate BMP strings biased toward backslashes and punctuation.
+    fn tag_input_bmp() -> impl Strategy<Value = String> {
+        let ch = prop_oneof![
+            3 => Just('\\'),
+            2 => (0x20u32..=0x2Fu32).prop_filter_map("ascii punct", |cp| char::from_u32(cp)),
+            3 => (0x41u32..=0x7Au32).prop_filter_map("ascii alpha", |cp| char::from_u32(cp)),
+            2 => (0x00C0u32..=0xD7FFu32).prop_filter_map("BMP", |cp| char::from_u32(cp)),
+        ];
+        proptest::collection::vec(ch, 1..100)
+            .prop_map(|chars| chars.into_iter().collect::<String>())
+    }
+
+    proptest! {
+        #[test]
+        fn ffi_matches_rust_sensitive(s in tag_input_bmp()) {
+            assert_tag_matches_c(&s, true);
+        }
+
+        #[test]
+        fn ffi_matches_rust_insensitive(s in tag_input_bmp()) {
+            assert_tag_matches_c(&s, false);
+        }
+    }
+}
+
+#[cfg(not(miri))]
+mod proptest_checks {
+    use proptest::prelude::*;
+    use query_eval::string_utils::{tag_strtolower, unicode_tolower};
+
+    /// Generate ASCII strings biased toward backslashes and punctuation.
+    fn tag_input() -> impl Strategy<Value = String> {
+        let byte = prop_oneof![
+            3 => Just(b'\\'),
+            2 => 0x20..=0x2Fu8, // punctuation/space range
+            5 => 0x41..=0x7Au8, // alphanumeric range
+        ];
+        proptest::collection::vec(byte, 0..100).prop_map(|v| String::from_utf8(v).unwrap())
+    }
+
+    proptest! {
+        #[test]
+        fn case_insensitive_is_lowercase(s in tag_input()) {
+            let result = tag_strtolower(&s, false);
+            assert_eq!(
+                result,
+                result.to_lowercase(),
+                "case-insensitive result not lowercase for input {:?}",
+                s
+            );
+        }
+
+        #[test]
+        fn case_sensitive_then_lower_eq_case_insensitive(s in tag_input()) {
+            let sensitive = tag_strtolower(&s, true);
+            let then_lower = unicode_tolower(&sensitive);
+            let insensitive = tag_strtolower(&s, false);
+            assert_eq!(
+                then_lower, insensitive,
+                "unicode_tolower(tag_strtolower(s, true)) != tag_strtolower(s, false) for {:?}",
+                s
+            );
+        }
+    }
+}

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/unicode_tolower.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/unicode_tolower.rs
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Verify that [`query_eval::string_utils::unicode_tolower`] matches the FFI
+//! `unicode_tolower_fn` for all BMP codepoints.
+
+#[cfg(not(miri))]
+mod ffi_comparison {
+    use proptest::prelude::*;
+    use std::ffi::c_void;
+
+    /// Call C `unicode_tolower_fn` and return the lowercased string.
+    fn c_unicode_tolower(s: &str) -> String {
+        if s.is_empty() {
+            return String::new();
+        }
+        let mut buf = s.as_bytes().to_vec();
+        buf.push(0); // guard against off-by-one reads in C
+        let mut len = s.len();
+        // SAFETY: `buf` is a valid mutable buffer of at least `len` bytes.
+        // `unicode_tolower_fn` either writes in-place (returns NULL) or
+        // returns a new `rm_malloc`'d buffer. `len` is updated to the
+        // output length.
+        let ret = unsafe { ffi::unicode_tolower_fn(buf.as_mut_ptr().cast(), &mut len) };
+        if ret.is_null() {
+            // Result written in-place into `buf`.
+            String::from_utf8(buf[..len].to_vec())
+                .expect("C unicode_tolower in-place result must be valid UTF-8")
+        } else {
+            // Result in newly allocated buffer.
+            // SAFETY: `ret` is a valid `rm_malloc`'d buffer of `len` bytes.
+            let result = unsafe { std::slice::from_raw_parts(ret.cast::<u8>(), len) }.to_vec();
+            // SAFETY: `ret` was allocated by `rm_malloc` (via `unicode_tolower_fn`).
+            unsafe {
+                (ffi::RedisModule_Free.expect("Redis allocator not available"))(
+                    ret.cast::<c_void>(),
+                );
+            }
+            String::from_utf8(result)
+                .expect("C unicode_tolower allocated result must be valid UTF-8")
+        }
+    }
+
+    fn assert_tolower_matches_c(s: &str) {
+        let c_result = c_unicode_tolower(s);
+        let rust_result = query_eval::string_utils::unicode_tolower(s);
+        assert_eq!(
+            rust_result, c_result,
+            "mismatch for input {:?}: rust={:?}, c={:?}",
+            s, rust_result, c_result,
+        );
+    }
+
+    #[test]
+    fn ffi_ascii() {
+        assert_tolower_matches_c("HELLO");
+    }
+
+    #[test]
+    fn ffi_empty() {
+        assert_tolower_matches_c("");
+    }
+
+    #[test]
+    fn ffi_already_lower() {
+        assert_tolower_matches_c("hello");
+    }
+
+    #[test]
+    fn ffi_mixed() {
+        assert_tolower_matches_c("Hello World 123!");
+    }
+
+    #[test]
+    fn ffi_unicode() {
+        assert_tolower_matches_c("Straße");
+    }
+
+    #[test]
+    fn ffi_greek_sigma() {
+        assert_tolower_matches_c("ΣΩΚΡΆΤΗΣ");
+    }
+
+    /// Generate BMP strings for exhaustive comparison.
+    fn bmp_string() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            (0x0001u32..=0xD7FFu32).prop_filter_map("valid BMP char", |cp| char::from_u32(cp)),
+            1..100,
+        )
+        .prop_map(|chars| chars.into_iter().collect::<String>())
+    }
+
+    proptest! {
+        #[test]
+        fn ffi_matches_rust(s in bmp_string()) {
+            assert_tolower_matches_c(&s);
+        }
+    }
+}

--- a/src/util/strconv.c
+++ b/src/util/strconv.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "strconv.h"
+
+char *unicode_tolower_fn(char *encoded, size_t *inout_len) {
+  return unicode_tolower(encoded, inout_len);
+}

--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -217,4 +217,7 @@ static char *rm_normalize(const char *s, size_t len) {
   return ret;
 }
 
+// Non-static wrapper around unicode_tolower for FFI testing.
+char *unicode_tolower_fn(char *encoded, size_t *inout_len);
+
 #endif


### PR DESCRIPTION
## Describe the changes in the pull request

Re-implementing string helper methods that will be used when porting QAST to Rust.

I validated them by adding ffi and swapping the C implementations. This change is not part of this PR as that would add extra C string <-> Rust string conversions which would likely degrade performances.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query/tag string normalization semantics (escaping + Unicode lowercasing) and exposes C helpers via FFI, so subtle behaviour mismatches could affect search results despite extensive cross-language tests.
> 
> **Overview**
> Adds pure-Rust implementations of the QAST string helpers `unicode_tolower` (per-character Unicode lowercasing) and `tag_strtolower` (tag unescape + optional lowercasing) for use in the Rust query evaluator.
> 
> Makes the C `tag_strtolower` symbol public and adds an exported wrapper `unicode_tolower_fn` so Rust integration tests can compare Rust output against the existing C/libnu behaviour via bindgen allowlisted FFI, with new integration + proptest coverage for edge cases (e.g., escapes, C-locale whitespace, Greek sigma casing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4137878edbfe6eacd274797bf7ac19e017504d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->