### PR TITLE
MOD-15584 fix: denial-of-service crash in `RSSortingVector_PutStrNormalize`

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -426,7 +426,9 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
       if (is_normalized) {
           RSSortingVector_PutStr(&aCtx->sv, fs->sortIdx, c);
       } else {
-          RSSortingVector_PutStrNormalize(&aCtx->sv, fs->sortIdx, c);
+          if (!RSSortingVector_PutStrNormalize(&aCtx->sv, fs->sortIdx, c, status)) {
+              return -1;
+          }
       }
     } else if (field->multisv) {
       RSSortingVector_PutRSVal(&aCtx->sv, fs->sortIdx, field->multisv);
@@ -763,7 +765,9 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
       if (is_normalized) {
           RSSortingVector_PutStr(&aCtx->sv, fs->sortIdx, str);
       } else {
-          RSSortingVector_PutStrNormalize(&aCtx->sv, fs->sortIdx, str);
+          if (!RSSortingVector_PutStrNormalize(&aCtx->sv, fs->sortIdx, str, status)) {
+              return -1;
+          }
       }
     } else if (field->multisv) {
       RSSortingVector_PutRSVal(&aCtx->sv, fs->sortIdx, field->multisv);
@@ -783,7 +787,9 @@ FIELD_PREPROCESSOR(tagPreprocessor) {
         if (is_normalized) {
             RSSortingVector_PutStr(&aCtx->sv, fs->sortIdx, str);
         } else {
-            RSSortingVector_PutStrNormalize(&aCtx->sv, fs->sortIdx, str);
+            if (!RSSortingVector_PutStrNormalize(&aCtx->sv, fs->sortIdx, str, status)) {
+                return -1;
+            }
         }
       } else if (field->multisv) {
         RSSortingVector_PutRSVal(&aCtx->sv, fs->sortIdx, field->multisv);
@@ -1098,7 +1104,9 @@ static void AddDocumentCtx_UpdateNoIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx 
           if (is_normalized) {
               RSSortingVector_PutStr(&md->sortVector, idx, str);
           } else {
-              RSSortingVector_PutStrNormalize(&md->sortVector, idx, str);
+              if (!RSSortingVector_PutStrNormalize(&md->sortVector, idx, str, &aCtx->status)) {
+                BAIL("Invalid UTF8");
+              }
           }
 
           break;

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
  "cheadergen",
  "ffi",
  "libc",
+ "query_error",
  "sorting_vector",
  "thin_vec",
  "value",

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/Cargo.toml
@@ -20,6 +20,7 @@ thin_vec.workspace = true
 value.workspace = true
 value_ffi = { path = "../value_ffi" }
 workspace_hack.workspace = true
+query_error.workspace = true
 
 
 [lints]

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
@@ -8,6 +8,8 @@
 */
 
 use libc::size_t;
+use query_error::opaque::OpaqueQueryError;
+use query_error::{QueryError, QueryErrorCode};
 use sorting_vector::RSSortingVector;
 use std::slice;
 use std::{
@@ -116,15 +118,18 @@ pub unsafe extern "C" fn RSSortingVector_PutStr(
 
 /// Puts a string at the given index in the sorting vector, the string is normalized before being set.
 ///
+/// Returns `true` if the string was successfully normalized and added to the sorting vector.
+/// Returns `false` is the string was malformed and was not inserted; the `QueryError` has been set to reflect this.
+///
 /// # Panics
 ///
-/// - Panics if the provided string is invalid UTF-8
 /// - Panics if the `idx` is out of bounds for the vector.
 ///
 /// # Safety
 ///
 /// 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or equivalent.
 /// 2. `str` must be a [valid], non-null pointer to a C string (null-terminated).
+/// 3. `status` must have been created by `QueryError_Default`.
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
@@ -132,19 +137,28 @@ pub unsafe extern "C" fn RSSortingVector_PutStrNormalize(
     vec: Option<NonNull<RSSortingVector>>,
     idx: libc::size_t,
     str: *const c_char,
-) {
+    status: Option<NonNull<OpaqueQueryError>>,
+) -> bool {
     // Safety: The caller must ensure that the pointer is valid (1.)
     let vec = unsafe { vec.expect("vec must not be null").as_mut() };
 
     // Safety: The caller must ensure str points to a valid C string (2.)
     let str = unsafe { CStr::from_ptr(str) };
 
-    let str = str.to_str().expect("value is invalid UTF-8");
+    // Safety: The caller must ensure status points to a valid query error (3.)
+    let status = unsafe { QueryError::from_opaque_non_null(status.unwrap()) };
+
+    let Ok(str) = str.to_str() else {
+        status.set_code_and_message(QueryErrorCode::BadVal, Some(c"Invalid UTF-8".to_owned()));
+        return false;
+    };
 
     vec.try_insert_string_normalize(idx, str)
         .unwrap_or_else(|_| {
             panic!("Index out of bounds: {} >= {}", idx, vec.len());
         });
+
+    true
 }
 
 /// Puts a value at the given index in the sorting vector. If a out of bounds occurs it returns silently.

--- a/src/redisearch_rs/headers/sorting_vector_ffi.h
+++ b/src/redisearch_rs/headers/sorting_vector_ffi.h
@@ -14,6 +14,14 @@
  */
 typedef struct RSValue RSValue;
 
+/**
+ * An opaque query error which can be passed by value to C.
+ *
+ * The size and alignment of this struct must match the Rust `QueryError`
+ * structure exactly.
+ */
+typedef struct QueryError QueryError;
+
 #define RS_SORTABLES_MAX 1024
 
 #ifdef __cplusplus
@@ -72,19 +80,22 @@ void RSSortingVector_PutStr(RSSortingVector *vec, size_t idx, const char *str);
 /**
  * Puts a string at the given index in the sorting vector, the string is normalized before being set.
  *
+ * Returns `true` if the string was successfully normalized and added to the sorting vector.
+ * Returns `false` is the string was malformed and was not inserted; the `QueryError` has been set to reflect this.
+ *
  * # Panics
  *
- * - Panics if the provided string is invalid UTF-8
  * - Panics if the `idx` is out of bounds for the vector.
  *
  * # Safety
  *
  * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or equivalent.
  * 2. `str` must be a [valid], non-null pointer to a C string (null-terminated).
+ * 3. `status` must have been created by `QueryError_Default`.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RSSortingVector_PutStrNormalize(RSSortingVector *vec, size_t idx, const char *str);
+bool RSSortingVector_PutStrNormalize(RSSortingVector *vec, size_t idx, const char *str, struct QueryError *status);
 
 /**
  * Puts a value at the given index in the sorting vector. If a out of bounds occurs it returns silently.

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -2,9 +2,11 @@
 
 from cmath import inf
 from email import message
-from includes import *
+
 from common import *
+from includes import *
 from RLTest import Env
+
 
 def check_order(env, item1, item2, asc=True):
     if not asc:
@@ -13,11 +15,11 @@ def check_order(env, item1, item2, asc=True):
     try:
         item1 = float(item1)
     except:
-        item1 = -inf if '-inf' in item1 else inf
+        item1 = -inf if "-inf" in item1 else inf
     try:
         item1 = float(item1)
     except:
-        item2 = -inf if '-inf' in item2 else inf
+        item2 = -inf if "-inf" in item2 else inf
 
     if float(item1) > float(item2):
         env.assertTrue(float(item1) <= float(item2))
@@ -27,50 +29,53 @@ def check_order(env, item1, item2, asc=True):
 
 # check order within returned results
 def check_sortby(env, query, params, msg=None):
-    cmds = ['ft.search', 'ft.aggregate']
+    cmds = ["ft.search", "ft.aggregate"]
     idx = 2 if query[0] == cmds[0] else 1
-    msg = cmds[idx % 2] + ' limit %d %d : ' % (params[1], params[2]) + msg
+    msg = cmds[idx % 2] + " limit %d %d : " % (params[1], params[2]) + msg
 
-    sort_order = ['ASC', 'DESC']
+    sort_order = ["ASC", "DESC"]
     for sort in range(len(sort_order)):
         print_err = False
         res = env.cmd(*query, sort_order[sort], *params)
 
         # put all `n` values into a list
-        res_list = [to_dict(n)['n'] for n in res[idx::idx]]
-        err_msg = msg + ' : ' + sort_order[sort] + f' : len={len(res_list)}'
+        res_list = [to_dict(n)["n"] for n in res[idx::idx]]
+        err_msg = msg + " : " + sort_order[sort] + f" : len={len(res_list)}"
 
         for i in range(len(res_list) - 1):
-            if not check_order(env, res_list[i], res_list[i+1], sort_order[sort] == sort_order[0]):
+            if not check_order(
+                env, res_list[i], res_list[i + 1], sort_order[sort] == sort_order[0]
+            ):
                 print_err = True
 
         if print_err:
             if (len(res)) < 100:
                 env.debugPrint(str(res), force=TEST_DEBUG)
                 env.debugPrint(str(res_list), force=TEST_DEBUG)
-                input('stop')
+                input("stop")
 
         env.assertFalse(print_err, message=err_msg)
+
 
 # check ASC vs DESC
 # number of result must be less than limit
 def compare_asc_desc(env, query, params, msg=None):
-    asc_res = env.cmd(*query, 'ASC', *params)[1:]
-    desc_res = env.cmd(*query, 'DESC', *params)[1:]
-    #env.debugPrint(str(asc_res), force=TEST_DEBUG)
-    #env.debugPrint(str(desc_res), force=TEST_DEBUG)
+    asc_res = env.cmd(*query, "ASC", *params)[1:]
+    desc_res = env.cmd(*query, "DESC", *params)[1:]
+    # env.debugPrint(str(asc_res), force=TEST_DEBUG)
+    # env.debugPrint(str(desc_res), force=TEST_DEBUG)
 
     desc_res.reverse()
     cmp_res = []
     for i, j in zip(desc_res[0::2], desc_res[1::2]):
         cmp_res.extend([j, i])
-    #env.debugPrint(str(cmp_res), force=TEST_DEBUG)
+    # env.debugPrint(str(cmp_res), force=TEST_DEBUG)
 
     failed = False
-    for i in range(1,len(asc_res),2):
+    for i in range(1, len(asc_res), 2):
         if asc_res[i][1] != cmp_res[i][1]:
             env.assertEqual(asc_res[i][1], cmp_res[i][1], message=query)
-    env.assertFalse(failed, message = query)
+    env.assertFalse(failed, message=query)
 
 
 def testSortby(env):
@@ -79,58 +84,118 @@ def testSortby(env):
     else:
         repeat = 10000
     conn = getConnectionByEnv(env)
-    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT', 'tag', 'TAG')
-    env.cmd('FT.CREATE', 'idx_sortable', 'SCHEMA', 'n', 'NUMERIC', 'SORTABLE', 't', 'TEXT', 'tag', 'TAG')
+    env.cmd("FT.CREATE", "idx", "SCHEMA", "n", "NUMERIC", "t", "TEXT", "tag", "TAG")
+    env.cmd(
+        "FT.CREATE",
+        "idx_sortable",
+        "SCHEMA",
+        "n",
+        "NUMERIC",
+        "SORTABLE",
+        "t",
+        "TEXT",
+        "tag",
+        "TAG",
+    )
 
-    words = ['hello', 'world', 'foo', 'bar', 'baz']
+    words = ["hello", "world", "foo", "bar", "baz"]
     for i in range(0, repeat, len(words)):
         for j in range(len(words)):
-            conn.execute_command('hset', i + j, 't', words[j], 'tag', words[j], 'n', i % 1000 + j)
+            conn.execute_command(
+                "hset", i + j, "t", words[j], "tag", words[j], "n", i % 1000 + j
+            )
 
     # with inf values
     for j in range(len(words)):
-        conn.execute_command('hset', repeat + j, 't', words[j], 'tag', words[j], 'n', 'inf')
+        conn.execute_command(
+            "hset", repeat + j, "t", words[j], "tag", words[j], "n", "inf"
+        )
     for j in range(len(words)):
-        conn.execute_command('hset', repeat + 5 + j, 't', words[j], 'tag', words[j], 'n', '+inf')
+        conn.execute_command(
+            "hset", repeat + 5 + j, "t", words[j], "tag", words[j], "n", "+inf"
+        )
     for j in range(len(words)):
-        conn.execute_command('hset', repeat + 10 + j, 't', words[j], 'tag', words[j], 'n', '-inf')
+        conn.execute_command(
+            "hset", repeat + 10 + j, "t", words[j], "tag", words[j], "n", "-inf"
+        )
 
-    limits = [[0, 5], [0, 30], [0, 150], [5, 5], [20, 30], [100, 10], [500, 100], [5000, 1000], [9900, 1010], [0, 100000]]
-    ranges = [['-5', '105'], ['0', '3'], ['30', '60'], ['-10', '5'], ['950', '1100'], ['2000', '3000'],
-              ['42', '42'], ['-inf', '+inf'], ['-inf', '100'], ['990', 'inf']]
-    params = ['limit', 0 , 0]
+    limits = [
+        [0, 5],
+        [0, 30],
+        [0, 150],
+        [5, 5],
+        [20, 30],
+        [100, 10],
+        [500, 100],
+        [5000, 1000],
+        [9900, 1010],
+        [0, 100000],
+    ]
+    ranges = [
+        ["-5", "105"],
+        ["0", "3"],
+        ["30", "60"],
+        ["-10", "5"],
+        ["950", "1100"],
+        ["2000", "3000"],
+        ["42", "42"],
+        ["-inf", "+inf"],
+        ["-inf", "100"],
+        ["990", "inf"],
+    ]
+    params = ["limit", 0, 0]
 
     for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]
             for j in range(len(ranges)):
-                numRange = str(f'@n:[{ranges[j][0]} {ranges[j][1]}]')
+                numRange = str(f"@n:[{ranges[j][0]} {ranges[j][1]}]")
 
                 ### (1) TEXT and range with sort ###
-                check_sortby(env, ['ft.search', 'idx', 'foo ' + numRange, 'SORTBY', 'n'], params, 'case 1 ' + numRange)
+                check_sortby(
+                    env,
+                    ["ft.search", "idx", "foo " + numRange, "SORTBY", "n"],
+                    params,
+                    "case 1 " + numRange,
+                )
 
                 ### (3) TAG and range with sort ###
-                check_sortby(env, ['ft.search', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 'n'], params, 'case 3 ' + numRange)
+                check_sortby(
+                    env,
+                    ["ft.search", "idx", "@tag:{foo} " + numRange, "SORTBY", "n"],
+                    params,
+                    "case 3 " + numRange,
+                )
 
                 ### (5) numeric range with sort ###
-                check_sortby(env, ['ft.search', 'idx', numRange, 'SORTBY', 'n'], params, 'case 5 ' + numRange)
+                check_sortby(
+                    env,
+                    ["ft.search", "idx", numRange, "SORTBY", "n"],
+                    params,
+                    "case 5 " + numRange,
+                )
 
             ### (7) filter with sort ###
             # Search only minimal number of ranges
-            check_sortby(env, ['ft.search', 'idx', 'foo', 'SORTBY', 'n'], params, 'case 7')
+            check_sortby(
+                env, ["ft.search", "idx", "foo", "SORTBY", "n"], params, "case 7"
+            )
 
             ### (9) no sort, no score, with sortby ###
             # Search only minimal number of ranges
-            check_sortby(env, ['ft.search', 'idx', '@tag:{foo}', 'SORTBY', 'n'], params, 'case 9')
+            check_sortby(
+                env, ["ft.search", "idx", "@tag:{foo}", "SORTBY", "n"], params, "case 9"
+            )
 
             ### (11) wildcard with sort ###
             # Search only minimal number of ranges
-            check_sortby(env, ['ft.search', 'idx', '*', 'SORTBY', 'n'], params, 'case 11')
-
+            check_sortby(
+                env, ["ft.search", "idx", "*", "SORTBY", "n"], params, "case 11"
+            )
 
     # update parameters for ft.aggregate
-    params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
+    params = ["limit", 0, 0, "LOAD", 4, "@__key", "@n", "@t", "@tag"]
 
     for _ in env.reloadingIterator():
         for i in range(len(limits)):
@@ -138,36 +203,110 @@ def testSortby(env):
             params[2] = limits[i][1]
 
             for j in range(len(ranges)):
-                numRange = f'@n:[{ranges[j][0]} {ranges[j][1]}]'
+                numRange = f"@n:[{ranges[j][0]} {ranges[j][1]}]"
 
                 ### (1) TEXT and range with sort ###
-                check_sortby(env, ['ft.aggregate', 'idx', 'foo ' + numRange, 'SORTBY', 2, '@n'], params, 'case 1 ' + numRange)
+                check_sortby(
+                    env,
+                    ["ft.aggregate", "idx", "foo " + numRange, "SORTBY", 2, "@n"],
+                    params,
+                    "case 1 " + numRange,
+                )
 
                 ### (3) TAG and range with sort ###
-                check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 2, '@n'], params, 'case 3 ' + numRange)
+                check_sortby(
+                    env,
+                    [
+                        "ft.aggregate",
+                        "idx",
+                        "@tag:{foo} " + numRange,
+                        "SORTBY",
+                        2,
+                        "@n",
+                    ],
+                    params,
+                    "case 3 " + numRange,
+                )
 
                 ### (5) numeric range with sort ###
-                check_sortby(env, ['ft.aggregate', 'idx', numRange, 'SORTBY', 2, '@n'], params, 'case 5 ' + numRange)
+                check_sortby(
+                    env,
+                    ["ft.aggregate", "idx", numRange, "SORTBY", 2, "@n"],
+                    params,
+                    "case 5 " + numRange,
+                )
 
             ### (7) filter with sort ###
             # aggregate only minimal number of ranges
-            check_sortby(env, ['ft.aggregate', 'idx', 'foo', 'SORTBY', 2, '@n'], params, 'case 7')
+            check_sortby(
+                env, ["ft.aggregate", "idx", "foo", "SORTBY", 2, "@n"], params, "case 7"
+            )
 
             ### (9) no sort, no score, with sortby ###
             # aggregate only minimal number of ranges
-            check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo}', 'SORTBY', 2, '@n'], params, 'case 9')
+            check_sortby(
+                env,
+                ["ft.aggregate", "idx", "@tag:{foo}", "SORTBY", 2, "@n"],
+                params,
+                "case 9",
+            )
 
             ### (11) wildcard with sort ###
             # aggregate only minimal number of ranges
-            check_sortby(env, ['ft.aggregate', 'idx', '*', 'SORTBY', 2, '@n'], params, 'case 11')
+            check_sortby(
+                env, ["ft.aggregate", "idx", "*", "SORTBY", 2, "@n"], params, "case 11"
+            )
 
     # with inf values
-    params = ['limit', 0, 100, 'return', 1, 'n']
-    compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[995 inf]', 'SORTBY', 'n'], params)
-    compare_asc_desc(env, ['ft.search', 'idx', '@n:[999 inf]', 'SORTBY', 'n'], params)
-    compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf 5]', 'SORTBY', 'n'], params)
-    compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf 1]', 'SORTBY', 'n'], params)
+    params = ["limit", 0, 100, "return", 1, "n"]
+    compare_asc_desc(
+        env, ["ft.search", "idx", "foo @n:[995 inf]", "SORTBY", "n"], params
+    )
+    compare_asc_desc(env, ["ft.search", "idx", "@n:[999 inf]", "SORTBY", "n"], params)
+    compare_asc_desc(
+        env, ["ft.search", "idx", "foo @n:[-inf 5]", "SORTBY", "n"], params
+    )
+    compare_asc_desc(env, ["ft.search", "idx", "@n:[-inf 1]", "SORTBY", "n"], params)
     params[2] = 10015
-    compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf inf]', 'SORTBY', 'n'], params)
-    compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf inf]', 'SORTBY', 'n'], params)
+    compare_asc_desc(
+        env, ["ft.search", "idx", "foo @n:[-inf inf]", "SORTBY", "n"], params
+    )
+    compare_asc_desc(env, ["ft.search", "idx", "@n:[-inf inf]", "SORTBY", "n"], params)
 
+
+@skip(cluster=True)
+def testSortableInvalidUtf8DoesNotCrash(env):
+    # regression test for denial-of-service report
+    # a schema that is TEXT SORTABLE _must_ be UTF8 for searching to work correctly
+    # and storing malformed document is technically user-error, but it may happen in practice
+    # and we must make sure to not crash because of it
+    conn = getConnectionByEnv(env)
+    env.expect("FT.CREATE", "idx", "SCHEMA", "t", "TEXT", "SORTABLE").ok()
+    conn.execute_command("HSET", "doc1", "t", "foo")
+    conn.execute_command("HSET", "doc2", "t", b"\xff")
+
+    # the malformed input will result in an indexing error
+    errors = index_errors(env, "idx")
+    env.assertEqual(errors["indexing failures"], 1)
+    env.assertContains("Invalid UTF-8", errors["last indexing error"])
+    env.assertEqual(errors["last indexing error key"], "doc2")
+
+    # and the offeding document is not included in search results
+    env.expect("FT.SEARCH", "idx", "*", "NOCONTENT").equal([1, "doc1"])
+
+
+@skip(cluster=True)
+def testSortableTagInvalidUtf8DoesNotCrash(env):
+    conn = getConnectionByEnv(env)
+    env.expect("FT.CREATE", "idx_tag", "SCHEMA", "tag", "TAG", "SORTABLE").ok()
+    conn.execute_command("HSET", "doc1", "tag", "foo")
+    conn.execute_command("HSET", "doc2", "tag", b"\xff")
+
+    # the malformed input will result in an indexing error
+    errors = index_errors(env, "idx_tag")
+    env.assertEqual(errors["indexing failures"], 1)
+    env.assertContains("Invalid UTF-8", errors["last indexing error"])
+    env.assertEqual(errors["last indexing error key"], "doc2")
+
+    # and the offeding document is not included in search results
+    env.expect("FT.SEARCH", "idx_tag", "*", "NOCONTENT").equal([1, "doc1"])


### PR DESCRIPTION
This change fixes a potential denial-of-service crash in `RSSortingVector_PutStrNormalize`.

When we execute a search against a `TEXT` and `SORTABLE` schema field that ends up (down the line) calling into `RSSortingVector_PutStrNormalize` to produce a normalized (and therefore sortable) string. 

When being called on a HSET field that actually contains binary data (invalid UTF8) the previous C version would simply corrupt the "string" through its naive and broken case-folding implementation, leading to garbage being stored and searched but _not_ a crash.

The current Rust version (correctly) rejects invalid UTF8 but does so by panicking, which leads to a potential denial-of-service vulnerability where attacker controlled strings are searched using a `TEXT SORTABLE` schema index.

This change fixes this crash by writing to the `QueryError` and returning `-1` from the preprocessor, marking the document as "having failed to index". This is the most correct behavior, but it does mean a technically breaking change. I don't think callers were relying on this since the sorting was nonsensical to begin with, but we'll need to confirm this is acceptable.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document indexing and a public C/Rust FFI signature; behavior changes from crash to failed index for invalid UTF-8 on sortable text/tag fields.
> 
> **Overview**
> **`RSSortingVector_PutStrNormalize`** no longer **panics** on invalid UTF-8. It takes a **`QueryError`**, returns **`bool`**, and records **"Invalid UTF-8"** when normalization cannot run.
> 
> **C indexing** (`document.c`) checks that return value in fulltext, geo, tag, and partial-update sortable paths and **fails the document** (preprocessor error / bail) instead of crashing.
> 
> **Regression tests** in `test_sortby.py` cover **`TEXT SORTABLE`** and **`TAG SORTABLE`** with binary field values: one indexing failure, the bad key excluded from **`FT.SEARCH`**.
> 
> This replaces attacker-triggerable DoS with **failed indexing** for malformed sortable strings (behavior change vs silently storing garbage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f218d360a6e1cb050c99049e15247baad8bfc618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->