### PR TITLE
[MOD-15585] Ensure MetricsVec is correctly initialized as empty when building RSIndexResult instances from C

### DIFF
--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <sys/param.h>
 #include "rmalloc.h"
+#include "metrics.h"
 
 typedef struct {
   KHTableEntry khBase;
@@ -286,7 +287,8 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntr
                        .data.term.borrowed.tag = RSTermRecord_Borrowed,
                        .docId = ent->docId,
                        .freq = ent->freq,
-                       .fieldMask = ent->fieldMask};
+                       .fieldMask = ent->fieldMask,
+                       .metrics = MetricsVec_New()};
 
   if (ent->vw) {
     rec.data.term.borrowed.offsets.data = VVW_GetByteData(ent->vw);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -23,6 +23,7 @@
 #include "info/global_stats.h"
 #include "gc.h"
 #include "doc_id_meta.h"
+#include "metrics.h"
 
 extern RedisModuleCtx *RSDummyContext;
 
@@ -386,7 +387,8 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     }
     // Add docId to inverted index
     t_docId docId = aCtx->doc->docId;
-    RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
+    RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
+                         .metrics = MetricsVec_New()};
     aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
   }
   dictReleaseIterator(iter);
@@ -406,7 +408,8 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   }
 
   t_docId docId = aCtx->doc->docId;
-  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
+  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
+                       .metrics = MetricsVec_New()};
   aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
 }
 

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -15,6 +15,19 @@
 use ffi::RLookupKey;
 use inverted_index::{MetricsSlice, MetricsVec, RSIndexResult};
 
+/// Creates an empty metrics collection. Does not allocate.
+///
+/// Use this to initialize the `metrics` field when constructing an
+/// `RSIndexResult` in place on the C side. Zero-initialization (e.g.
+/// designated initializers, `memset`, `calloc`) produces an invalid
+/// `MetricsVec` because the underlying `ThinVec` represents the empty
+/// state with a non-null sentinel pointer to a static header — not
+/// `NULL`.
+#[unsafe(no_mangle)]
+pub const extern "C" fn MetricsVec_New() -> MetricsVec<'static> {
+    MetricsVec::new()
+}
+
 /// Moves all metrics from `child` into `parent`, leaving `child` empty.
 ///
 /// # Safety

--- a/src/redisearch_rs/headers/metrics.h
+++ b/src/redisearch_rs/headers/metrics.h
@@ -60,6 +60,18 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Creates an empty metrics collection. Does not allocate.
+ *
+ * Use this to initialize the `metrics` field when constructing an
+ * `RSIndexResult` in place on the C side. Zero-initialization (e.g.
+ * designated initializers, `memset`, `calloc`) produces an invalid
+ * `MetricsVec` because the underlying `ThinVec` represents the empty
+ * state with a non-null sentinel pointer to a static header — not
+ * `NULL`.
+ */
+MetricsVec MetricsVec_New(void);
+
+/**
  * Moves all metrics from `child` into `parent`, leaving `child` empty.
  *
  * # Safety

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -19,6 +19,7 @@
 #include "rmutil/rm_assert.h"
 #include "resp3.h"
 #include "redisearch_rs/headers/iterators_rs.h"
+#include "metrics.h"
 #include "search_disk.h"
 #include "spec.h"
 
@@ -206,7 +207,8 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // the inverted index (if a new inverted index was created)
 static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
   size_t sz;
-  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
+  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
+                       .metrics = MetricsVec_New()};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
   return InvertedIndex_WriteEntryGeneric(iv, &rec) + sz;
 }


### PR DESCRIPTION
## Describe the changes in the pull request

`NULL` is a not a valid value for a `ThinVec` field.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indexing write paths by changing how `RSIndexResult` is constructed, but the change is small and limited to correctly initializing the metrics vector to avoid invalid `ThinVec` state.
> 
> **Overview**
> Fixes a C/Rust FFI correctness bug where C-side `RSIndexResult` construction could leave the `metrics` field in an invalid state (zeroed `ThinVec`).
> 
> Adds an exported `MetricsVec_New()` helper and uses it when creating `RSIndexResult` records in `forward_index.c`, `indexer.c` (missing-field and existing-docs virtual records), and `tag_index.c`, ensuring `metrics` is always a valid empty collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd766d53f15b5bd9316582059556e317ed2011a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->