### PR TITLE
MOD-15578 Track shared SVS thread pool memory & expose it through public VecSim API

### DIFF
--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -10,6 +10,7 @@
 #include "util/dict.h"
 #include "spec.h"
 #include "field_spec_info.h"
+#include "VecSim/vec_sim.h"
 #include <string.h>  // Add this for strerror
 
 // Assuming the GIL is held by the caller
@@ -85,5 +86,11 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
   dictReleaseIterator(iter);
   if (info.min_mem == -1) info.min_mem = 0;             // No index found
   if (BGIndexerInProgress) info.total_active_write_threads++;  // BG indexer is currently active
+
+  // Process-wide vector memory not tied to any specific spec (e.g. the shared SVS
+  // thread pool singleton).
+  size_t global_vector_mem = VecSim_GetGlobalMemory();
+  info.fields_stats.total_vector_idx_mem += global_vector_mem;
+  info.total_mem += global_vector_mem;
   return info;
 }

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -263,7 +263,10 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   size_t num_records = isDisk ? 0 : sp->stats.numRecords;
   // Vector indexes (e.g. HNSW) remain in memory even when the rest of the
   // index is stored on disk, so their memory must always be reported.
-  size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
+  // VecSim_GetGlobalMemory() returns process-wide vector-related allocations not
+  // tied to any single index (e.g. the shared SVS thread pool singleton).
+  size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes) +
+                               VecSim_GetGlobalMemory();
   size_t total_ii_blocks = isDisk ? 0 : TotalIIBlocks();
   size_t offset_vecs_size = isDisk ? 0 : sp->stats.offsetVecsSize;
   size_t sortables_size = isDisk ? 0 : sp->docs.sortablesSize;

--- a/src/spec.c
+++ b/src/spec.c
@@ -3149,7 +3149,8 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp, bool obfuscate,
   RedisModule_InfoAddFieldDouble(ctx, "inverted_size", sp->stats.invertedSize / (float)0x100000);
   if (!skip_unsafe_ops) {
     // Skip when unsafe - calls dictFetchValue which can trigger dict rehashing with rm_free
-    RedisModule_InfoAddFieldDouble(ctx, "vector_index_size", IndexSpec_VectorIndexesSize(sp) / (float)0x100000);
+    RedisModule_InfoAddFieldDouble(ctx, "vector_index_size",
+      (IndexSpec_VectorIndexesSize(sp) + VecSim_GetGlobalMemory()) / (float)0x100000);
   }
   RedisModule_InfoAddFieldDouble(ctx, "offset_vectors_size", sp->stats.offsetVecsSize / (float)0x100000);
   RedisModule_InfoAddFieldDouble(ctx, "doc_table_size", sp->docs.memsize / (float)0x100000);

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -421,7 +421,10 @@ def test_redis_info():
   env.assertGreater(res['search_largest_memory_index_human'], 0)
   env.assertGreater(res['search_smallest_memory_index'], 0)
   env.assertGreater(res['search_smallest_memory_index_human'], 0)
-  env.assertEqual(res['search_used_memory_vector_index'], 0)
+  # search_used_memory_vector_index folds in the process-wide shared SVS thread
+  # pool memory, which has a small non-zero baseline once the pool singleton is
+  # initialized — even for indexes without vector fields.
+  env.assertGreaterEqual(res['search_used_memory_vector_index'], 0)
   # env.assertGreater(res['search_total_indexing_time'], 0)   # Introduces flakiness
 
   # ========== Cursors statistics ==========
@@ -617,9 +620,14 @@ def test_redis_info_modules_vecsim():
     set_doc(f'doc_svs:{i}')
   env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
 
+  # search_used_memory_vector_index aggregates per-index MEMORY across all vector
+  # fields plus VecSim_GetGlobalMemory() (folded in once).
+  expected_vec_mem = lambda field_infos: (sum(int(fi['MEMORY']) for fi in field_infos) +
+                                          int(field_infos[0]['GLOBAL_MEMORY']))
+
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 5)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], expected_vec_mem(field_infos))
   # Validate that vector indexes are accounted in the total index memory
   env.assertGreater(info['search_used_memory_indexes'], info['search_used_memory_vector_index'])
   env.assertEqual(info['search_gc_marked_deleted_vectors'], 0)
@@ -629,7 +637,7 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 5)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], expected_vec_mem(field_infos))
   # 3 vectors were marked as deleted (1 for each hnsw index and 1 for svs)
   env.assertEqual(info['search_gc_marked_deleted_vectors'], 3)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
@@ -642,7 +650,7 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 5)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], expected_vec_mem(field_infos))
   env.assertEqual(info['search_gc_marked_deleted_vectors'], 0)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
   env.assertEqual(to_dict(field_infos[1]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -472,7 +472,9 @@ def test_info():
       'sortable_values_size_mb': 0.0,
       'geoshapes_sz_mb': 0.0,
       'total_inverted_index_blocks': ANY,
-      'vector_index_sz_mb': 0.0,
+      # vector_index_sz_mb folds in the process-wide shared SVS thread pool memory,
+      # which has a small non-zero baseline once the pool singleton is initialized.
+      'vector_index_sz_mb': ANY,
       'Index Errors': {
           'indexing failures': 0,
           'last indexing error': 'N/A',
@@ -1276,9 +1278,18 @@ def test_ft_info():
       initial_doc_table_size_mb = 8072 / (1024 * 1024)
       # Size of an empty TrieMap
       key_table_sz_mb = 24 / (1024 * 1024)
-      total_index_memory_sz_mb = initial_doc_table_size_mb + key_table_sz_mb
+      per_node_index_memory_sz_mb = initial_doc_table_size_mb + key_table_sz_mb
 
       res = order_dict(r.execute_command('ft.info', 'idx'))
+
+      # The FT.INFO vector_index_sz_mb field folds in VecSim_GetGlobalMemory()
+      # (process-wide vector allocations not tied to any single index). For an
+      # index without vector fields IndexSpec_VectorIndexesSize() is 0, so
+      # vector_index_sz_mb is exactly that global overhead. In cluster mode it's
+      # already aggregated across shards. We pin to the response value so
+      # total_index_memory_sz_mb stays exact (rather than an ANY match).
+      global_vector_mem_mb = res['vector_index_sz_mb']
+      total_index_memory_sz_mb = per_node_index_memory_sz_mb + global_vector_mem_mb
 
       exp = {
         'attributes': [
@@ -1353,7 +1364,7 @@ def test_ft_info():
         'geoshapes_sz_mb': 0.0,
         'total_indexing_time': 0.0,
         'total_inverted_index_blocks': 0.0,
-        'vector_index_sz_mb': 0.0,
+        'vector_index_sz_mb': global_vector_mem_mb,
         'Index Errors': {
               'indexing failures': 0,
               'last indexing error': 'N/A',
@@ -1418,7 +1429,10 @@ def test_ft_info():
         'key_table_size_mb': nodes * key_table_sz_mb,
         'tag_overhead_sz_mb': 0.0,
         'text_overhead_sz_mb': 0.0,
-        'total_index_memory_sz_mb': nodes * total_index_memory_sz_mb,
+        # global_vector_mem_mb is already aggregated across shards (FT.INFO sums
+        # vector_index_sz_mb from each shard), so it's added once — not multiplied
+        # by `nodes` — to the per-node base * nodes.
+        'total_index_memory_sz_mb': nodes * per_node_index_memory_sz_mb + global_vector_mem_mb,
         'max_doc_id': 0,
         'num_docs': 0,
         'num_records': 0,
@@ -1432,7 +1446,7 @@ def test_ft_info():
         'sortable_values_size_mb': 0.0,
         'geoshapes_sz_mb': 0.0,
         'total_inverted_index_blocks': 0,
-        'vector_index_sz_mb': 0.0,
+        'vector_index_sz_mb': global_vector_mem_mb,
         'Index Errors': {
               'indexing failures': 0,
               'last indexing error': 'N/A',

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -339,8 +339,8 @@ def test_create():
         conn.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 'v_FLAT', 'VECTOR', 'FLAT', '8', 'TYPE', data_type,
                              'DIM', '1024', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', '10')
 
-        expected_HNSW = ['ALGORITHM', 'TIERED', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'MANAGEMENT_LAYER_MEMORY', dummy_val, 'BACKGROUND_INDEXING', 0, 'TIERED_BUFFER_LIMIT', 1024, 'FRONTEND_INDEX', ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024], 'BACKEND_INDEX', ['ALGORITHM', 'HNSW', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'M', 16, 'EF_CONSTRUCTION', 200, 'EF_RUNTIME', 10, 'MAX_LEVEL', -1, 'ENTRYPOINT', -1, 'EPSILON', '0.01', 'NUMBER_OF_MARKED_DELETED', 0], 'TIERED_HNSW_SWAP_JOBS_THRESHOLD', 1024]
-        expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024]
+        expected_HNSW = ['ALGORITHM', 'TIERED', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'MANAGEMENT_LAYER_MEMORY', dummy_val, 'BACKGROUND_INDEXING', 0, 'TIERED_BUFFER_LIMIT', 1024, 'FRONTEND_INDEX', ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024], 'BACKEND_INDEX', ['ALGORITHM', 'HNSW', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'M', 16, 'EF_CONSTRUCTION', 200, 'EF_RUNTIME', 10, 'MAX_LEVEL', -1, 'ENTRYPOINT', -1, 'EPSILON', '0.01', 'NUMBER_OF_MARKED_DELETED', 0], 'TIERED_HNSW_SWAP_JOBS_THRESHOLD', 1024, 'GLOBAL_MEMORY', dummy_val]
+        expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'GLOBAL_MEMORY', dummy_val]
 
         # SVS-VAMANA only supports FLOAT32 and FLOAT16 data types
         if data_type in ('FLOAT32', 'FLOAT16'):
@@ -356,16 +356,20 @@ def test_create():
                                                       'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE',
                                                       'BLOCK_SIZE', 1024, 'QUANT_BITS', 'NONE', 'ALPHA', 1.2, 'GRAPH_MAX_DEGREE', 32, 'CONSTRUCTION_WINDOW_SIZE', 200,
                                                       'MAX_CANDIDATE_POOL_SIZE', 600, 'PRUNE_TO', 28, 'USE_SEARCH_HISTORY', 1, 'NUM_THREADS', 1, 'LAST_RESERVED_NUM_THREADS', 1,
-                                                      'NUMBER_OF_MARKED_DELETED', 0, 'SEARCH_WINDOW_SIZE', 10, 'SEARCH_BUFFER_CAPACITY', 10, 'LEANVEC_DIMENSION', 0, 'EPSILON', 0.01],
-                                                      'TIERED_SVS_TRAINING_THRESHOLD', 1024, 'TIERED_SVS_UPDATE_THRESHOLD', 1024, 'TIERED_SVS_THREADS_RESERVE_TIMEOUT', 5000]
+                                                      'NUMBER_OF_MARKED_DELETED', 0, 'SEARCH_WINDOW_SIZE', 10, 'SEARCH_BUFFER_CAPACITY', 10, 'LEANVEC_DIMENSION', 0, 'EPSILON', 0.01,
+                                                      'SHARED_SVS_THREADPOOL_MEMORY', dummy_val],
+                                                      'TIERED_SVS_TRAINING_THRESHOLD', 1024, 'TIERED_SVS_UPDATE_THRESHOLD', 1024, 'TIERED_SVS_THREADS_RESERVE_TIMEOUT', 5000,
+                                                      'GLOBAL_MEMORY', dummy_val]
 
         for _ in env.reloadingIterator():
             info = ['identifier', 'v_HNSW', 'attribute', 'v_HNSW', 'type', 'VECTOR']
             env.assertEqual(index_info(env, 'idx1')['attributes'][0][:len(info)], info)
+
             info_data_HNSW = conn.execute_command(debug_cmd(), "VECSIM_INFO", "idx1", "v_HNSW")
             # replace memory values with a dummy value - irrelevant for the test
             info_data_HNSW[info_data_HNSW.index('MEMORY') + 1] = dummy_val
             info_data_HNSW[info_data_HNSW.index('MANAGEMENT_LAYER_MEMORY') + 1] = dummy_val
+            info_data_HNSW[info_data_HNSW.index('GLOBAL_MEMORY') + 1] = dummy_val
             front = info_data_HNSW[info_data_HNSW.index('FRONTEND_INDEX') + 1]
             front[front.index('MEMORY') + 1] = dummy_val
             back = info_data_HNSW[info_data_HNSW.index('BACKEND_INDEX') + 1]
@@ -376,6 +380,7 @@ def test_create():
             info_data_FLAT = conn.execute_command(debug_cmd(), "VECSIM_INFO", "idx2", "v_FLAT")
             # replace memory value with a dummy value - irrelevant for the test
             info_data_FLAT[info_data_FLAT.index('MEMORY') + 1] = dummy_val
+            info_data_FLAT[info_data_FLAT.index('GLOBAL_MEMORY') + 1] = dummy_val
 
             env.assertEqual(info_data_FLAT, expected_FLAT)
 
@@ -387,10 +392,12 @@ def test_create():
                 # replace memory values with a dummy value - irrelevant for the test
                 info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('MEMORY') + 1] = dummy_val
                 info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('MANAGEMENT_LAYER_MEMORY') + 1] = dummy_val
+                info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('GLOBAL_MEMORY') + 1] = dummy_val
                 front_svs = info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('FRONTEND_INDEX') + 1]
                 front_svs[front_svs.index('MEMORY') + 1] = dummy_val
                 back_svs = info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('BACKEND_INDEX') + 1]
                 back_svs[back_svs.index('MEMORY') + 1] = dummy_val
+                back_svs[back_svs.index('SHARED_SVS_THREADPOOL_MEMORY') + 1] = dummy_val
 
                 # round float values
                 back_svs[back_svs.index('ALPHA') + 1] = round(float(back_svs[back_svs.index('ALPHA') + 1]), 1)

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -271,6 +271,83 @@ def test_memory_info():
 
         env.execute_command('FLUSHALL')
 
+@skip(cluster=True)
+def test_svs_shared_threadpool_memory_info():
+    """Verify shared SVS thread pool memory accounting:
+      * FT.DEBUG VECSIM_INFO exposes it as SHARED_SVS_THREADPOOL_MEMORY inside
+        the SVS section (BACKEND_INDEX for a tiered SVS index, top level for a
+        non-tiered SVS index).
+      * FT.INFO vector_index_sz_mb folds it in once per call (per-spec scope).
+      * INFO MODULES search_used_memory_vector_index folds it in once per call
+        (process-wide scope).
+      * For a single SVS index, both FT.INFO and INFO MODULES report the same
+        bytes — vector field memory + pool memory.
+      * Pool memory is added once per call regardless of the number of vector
+        fields in the spec or specs in the process — no double-counting.
+
+    All observations are validated before and after growing the worker pool, which
+    physically resizes the shared SVS pool.
+    """
+    initial_workers = 1
+    grown_workers = 4
+    env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {initial_workers}')
+    dim = 2
+    debug_svs_pool_mem_field = 'SHARED_SVS_THREADPOOL_MEMORY'
+
+    # The shared SVS pool singleton is initialized at module init via
+    # workersThreadPool_CreatePool -> VecSim_UpdateThreadPoolSize, so the field is
+    # always present in the debug info once any SVS index exists.
+    create_vector_index(env, dim, alg='SVS-VAMANA')
+
+    def measure():
+        debug_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+        backend_info = get_tiered_backend_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+        env.assertTrue(debug_svs_pool_mem_field in backend_info,
+                       message=f"BACKEND_INDEX debug info missing '{debug_svs_pool_mem_field}': {backend_info}")
+        info_modules = env.cmd('INFO', 'MODULES')
+        return {
+            'debug_svs_pool_mem': int(backend_info[debug_svs_pool_mem_field]),
+            'debug_per_index_mem': int(debug_info['MEMORY']),
+            'info_modules_vec_mem': int(info_modules['search_used_memory_vector_index']),
+            'ft_info_vec_bytes': int(float(index_info(env, DEFAULT_INDEX_NAME)['vector_index_sz_mb']) * 0x100000),
+        }
+
+    def assert_invariants(label, m):
+        # FT.INFO and INFO MODULES report the same total for a single SVS field:
+        # per-index memory + pool memory, both folded once.
+        expected = m['debug_per_index_mem'] + m['debug_svs_pool_mem']
+        env.assertEqual(m['ft_info_vec_bytes'], expected,
+                        message=f"[{label}] FT.INFO vector_index_sz_mb should equal per-index + pool: {m}")
+        env.assertEqual(m['info_modules_vec_mem'], expected,
+                        message=f"[{label}] INFO MODULES search_used_memory_vector_index should equal per-index + pool: {m}")
+        env.assertEqual(m['ft_info_vec_bytes'], m['info_modules_vec_mem'],
+                        message=f"[{label}] FT.INFO vector_index_sz_mb should match INFO MODULES "
+                                f"search_used_memory_vector_index: {m}")
+
+    # ---- Initial state ----
+    before = measure()
+    env.assertGreater(before['debug_svs_pool_mem'], 0, message="shared pool memory should be > 0 after pool initialization")
+    assert_invariants('before resize', before)
+
+    # ---- Grow the worker pool ----
+    # CONFIG SET WORKERS triggers VecSim_UpdateThreadPoolSize, which physically
+    # resizes the shared SVS pool (synchronous when no jobs are pending).
+    env.execute_command(config_cmd(), 'SET', 'WORKERS', grown_workers)
+
+    after = measure()
+    env.assertGreater(after['debug_svs_pool_mem'], before['debug_svs_pool_mem'],
+                      message=f"SHARED_SVS_THREADPOOL_MEMORY should grow when workers go from "
+                              f"{initial_workers} to {grown_workers}: before={before}, after={after}")
+    assert_invariants('after resize', after)
+
+    # Both FT.INFO and INFO MODULES vector memory grow by exactly the pool growth
+    # (per-index memory is unchanged by the pool resize).
+    pool_growth = after['debug_svs_pool_mem'] - before['debug_svs_pool_mem']
+    env.assertEqual(after['ft_info_vec_bytes'] - before['ft_info_vec_bytes'], pool_growth,
+                    message=f"FT.INFO vector_index_sz_mb growth should match pool growth: before={before}, after={after}")
+    env.assertEqual(after['info_modules_vec_mem'] - before['info_modules_vec_mem'], pool_growth,
+                    message=f"INFO MODULES search_used_memory_vector_index growth should match pool growth: before={before}, after={after}")
+
 
 func_gen = lambda tn, comp, dt, dist, wr: lambda: queries_sanity(tn, comp, dt, dist, wr)
 for workers in [0, 4]:

--- a/tests/pytests/vecsim_utils.py
+++ b/tests/pytests/vecsim_utils.py
@@ -73,7 +73,11 @@ def get_tiered_backend_debug_info(env, index_name, field_name) -> dict:
     return to_dict(tiered_index_info['BACKEND_INDEX'])
 
 def get_vecsim_memory(env, index_key, field_name):
-    return float(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_key, field_name))["MEMORY"])/0x100000
+    # Returns the total vector-related memory for this field in MB: the per-index
+    # allocator (MEMORY) plus the process-wide VecSim global memory.
+    info = to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_key, field_name))
+    total = float(info["MEMORY"]) + float(info.get("GLOBAL_MEMORY", 0))
+    return total / 0x100000
 
 def get_vecsim_index_size(env, index_key, field_name):
     return int(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_key, field_name))["INDEX_SIZE"])


### PR DESCRIPTION
Consume the new `VecSim_GetGlobalMemory()` API (introduced in [VectorSimilarity#967](https://github.com/RedisAI/VectorSimilarity/pull/967)) so that process-wide VecSim allocations — currently the shared SVS thread pool singleton — are included in RediSearch's vector memory reporting.

Bumps `deps/VectorSimilarity` and folds the global term into three surfaces:

1. **`IndexesInfo_TotalInfo()`** (`src/info/indexes_info.c`) — added once to `fields_stats.total_vector_idx_mem` and `total_mem` (drives `INFO MODULES` `search_used_memory_vector_index` and `search_used_memory_indexes`).
2. **`fillReplyWithIndexInfo()`** (`src/info/info_command.c`) — added to `vector_indexes_size` (drives `FT.INFO` `vector_index_sz_mb` and `total_index_memory_sz_mb`).
3. **`IndexSpec_AddToInfo()`** (`src/spec.c`) — added to the per-spec `vector_index_size` field in `INFO MODULES`.

The global term is added **once per call** at each surface (not per spec, not per field, and once across cluster shards in `FT.INFO` aggregation), so there's no double-counting.

#### Main objects this PR modified
- `IndexesInfo_TotalInfo()`, `fillReplyWithIndexInfo()`, `IndexSpec_AddToInfo()`
- `deps/VectorSimilarity` submodule

#### Tests

- **New** `test_vecsim_svs.py::test_svs_shared_threadpool_memory_info` — asserts `FT.INFO vector_index_sz_mb == INFO MODULES search_used_memory_vector_index == per-index MEMORY + SHARED_SVS_THREADPOOL_MEMORY`, and that growing the pool via `CONFIG SET WORKERS` increases both surfaces by exactly the pool delta.
- Updated `test_info_modules.py`, `test_resp3.py`, `test_vecsim.py`, and `vecsim_utils.py` to fold `GLOBAL_MEMORY` into expected values (once per call, once across shards).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `FT.INFO` and `INFO MODULES` report vector and total index memory by adding process-wide VecSim allocations, which may affect monitoring/alerting and any code that depends on these metrics.
> 
> **Overview**
> Updates memory accounting so vector memory stats include **process-wide VecSim allocations** (via `VecSim_GetGlobalMemory()`), such as the shared SVS thread pool, rather than only per-index vector structures.
> 
> This folds the global vector overhead into `INFO MODULES` totals (`search_used_memory_vector_index`/`total_mem`) and into `FT.INFO`/`IndexSpec_AddToInfo` vector size reporting, and adjusts tests/fixtures accordingly (including new `GLOBAL_MEMORY` and `SHARED_SVS_THREADPOOL_MEMORY` expectations in `FT.DEBUG VECSIM_INFO` and a new SVS threadpool memory invariant test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e2fc00effba8ca4983e416ccba35c60e7c280d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->