### PR TITLE
[MOD-15588] interior NUL bytes in INDEXMISSING field names

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2615,11 +2615,19 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, StrongRef sp_ref,
   char* name = NULL;
   size_t len = 0;
   LoadStringBufferAlloc_IOErrors(rdb, name, &len, true, goto fail);
+  if (memchr(name, '\0', len)) {
+    rm_free(name);
+    goto fail;
+  }
   f->fieldName = NewHiddenString(name, len, false);
   f->fieldPath = f->fieldName;
   if (encver >= INDEX_JSON_VERSION) {
     if (LoadUnsigned_IOError(rdb, goto fail) == 1) {
       LoadStringBufferAlloc_IOErrors(rdb, name, &len, true, goto fail);
+      if (memchr(name, '\0', len)) {
+        rm_free(name);
+        goto fail;
+      }
       f->fieldPath = NewHiddenString(name, len, false);
     }
   }

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -1,4 +1,5 @@
 from common import *
+from redis.client import NEVER_DECODE
 import json
 import faker
 
@@ -620,3 +621,66 @@ def testMissingWithParams():
                   'NOCONTENT',
                   'PARAMS', '2', 'val', 'hello')
     env.assertEqual(res, [0])
+
+
+@skip(cluster=True)
+def test_missing_field_name_with_interior_nul(env):
+    """Verify that a schema restored with a field name containing an interior
+    NUL byte does not crash the server. The Rust Missing iterator converts the
+    HiddenString field name into a CString, which panics on interior NUL bytes.
+    RDB/schema-restore data is length-based, so it can smuggle NUL bytes past
+    the normal FT.CREATE path (which uses strlen). This test injects a poisoned
+    field name via _FT._RESTOREIFNX and verifies the server stays alive through
+    document indexing and querying."""
+
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a TAG field that indexes missing values.
+    # Use a distinctive field name so we can find and replace it in the
+    # serialized binary blob.
+    field_name = 'nultest_field'
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               field_name, 'TAG', 'INDEXMISSING').ok()
+
+    # Add a document missing the field to populate missingFieldDict.
+    conn.execute_command('HSET', 'doc1', 'other', 'value')
+
+    # Verify the normal ismissing query path works.
+    res = env.cmd('FT.SEARCH', 'idx', f'ismissing(@{field_name})', 'NOCONTENT')
+    env.assertEqual(res, [1, 'doc1'])
+
+    # Mark as internal client so we can use the internal DUMP/RESTORE commands.
+    env.cmd('DEBUG', 'MARK-INTERNAL-CLIENT')
+
+    # Dump the schema as a binary blob (same format as RDB persistence).
+    dump, encode = env.cmd(debug_cmd(), 'DUMP_SCHEMA', 'idx', NEVER_DECODE=True)
+
+    # Verify the field name appears in the dump.
+    env.assertTrue(field_name.encode() in dump,
+                   message="field name not found in schema dump")
+
+    # Drop the original index.
+    env.cmd('FT.DROPINDEX', 'idx')
+
+    # Poison the dump: replace the field name with one containing an interior
+    # NUL byte. The replacement has the same length so all offsets and length
+    # encodings in the binary blob remain valid.
+    poisoned_name = b'nulte\x00t_field'
+    env.assertEqual(len(poisoned_name), len(field_name.encode()),
+                    message="poisoned name must be same length as original")
+
+    # The field name appears twice in the dump: once as fieldName and once as
+    # fieldPath (they share the same value when no separate JSON path is set).
+    poisoned_dump = dump.replace(field_name.encode(), poisoned_name)
+    env.assertNotEqual(dump, poisoned_dump,
+                       message="dump should have been modified")
+
+    # Restore the poisoned schema. The server must not crash regardless of
+    # whether the restore succeeds or is rejected by RDB load validation.
+    try:
+        env.cmd('_FT._RESTOREIFNX', 'SCHEMA', encode, poisoned_dump)
+    except Exception:
+        pass
+
+    # Verify the server is still alive.
+    env.expect('PING').equal(True)

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -675,12 +675,13 @@ def test_missing_field_name_with_interior_nul(env):
     env.assertNotEqual(dump, poisoned_dump,
                        message="dump should have been modified")
 
-    # Restore the poisoned schema. The server must not crash regardless of
-    # whether the restore succeeds or is rejected by RDB load validation.
-    try:
-        env.cmd('_FT._RESTOREIFNX', 'SCHEMA', encode, poisoned_dump)
-    except Exception:
-        pass
+    # Restore the poisoned schema. The RDB loader rejects field names with
+    # interior NUL bytes.
+    env.expect('_FT._RESTOREIFNX', 'SCHEMA', encode, poisoned_dump).error().contains('Failed to deserialize schema')
+
+    # Verify no index was created from the poisoned dump.
+    idx_list = env.cmd('FT._LIST')
+    env.assertEqual(idx_list, [])
 
     # Verify the server is still alive.
     env.expect('PING').equal(True)


### PR DESCRIPTION
  A security report identified that `Missing::new` (`missing.rs:110`) panics via
  `CString::new(bytes).expect(...)` when a field name contains an interior NUL
  byte. Since `HiddenString` is length-based, crafted RDB or schema-restore data
  could smuggle such a field name past the normal `FT.CREATE` path (which uses
  `strlen`).

  ### The issue is not triggerable in practice

  The Ragel query lexer (`lexer.rl:124`) defines field name tokens as
  `(any - (punct | cntrl | space | escape))`, which excludes NUL (a control
  character). This means no `ismissing(@field)` query a client can construct will
  ever resolve to a field whose name contains interior NUL bytes, so the panic
  path in `Missing::new` is unreachable.

  ### Changes

  The two changes below are **not required for safety** but harden the code as
  defense in depth:

  1. **Flow test**
     Injects a poisoned field name (with interior NUL) via `_FT._RESTOREIFNX
     SCHEMA` and verifies the server doesn't crash. Passes with or without the fixes.

  2. **C-side validation** 
     Rejects field names with interior NUL bytes in `FieldSpec_RdbLoad` before
     they enter `HiddenString`. Stops bad data at the boundary.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches schema/RDB deserialization for field specs, so a bug could break loading/restoring indexes or alter failure behavior for corrupted data; scope is small and adds coverage via a new flow test.
> 
> **Overview**
> **Schema/RDB loading is hardened against poisoned field names.** `FieldSpec_RdbLoad` now validates `fieldName` and (when present) `fieldPath` buffers and fails deserialization if they contain interior `\0` bytes before constructing `HiddenString`s.
> 
> **Adds a defensive regression test.** New `test_missing_field_name_with_interior_nul` dumps an index schema, injects an interior-NUL field name into the binary blob, and asserts `_FT._RESTOREIFNX SCHEMA` is rejected and the server remains healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98315050eeae927c4605efbbb6f88e28ec818525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->