### PR TITLE
[Iterator Revalidation] [MOD-15507] Parametrize RSIndexResult via ref_mode::Ptr

### DIFF
--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -296,7 +296,11 @@ AddRecordOutcome InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, Forwar
                        .metrics = MetricsVec_New()};
 
   if (ent->vw) {
-    rec.data.term.borrowed.offsets.data = VVW_GetByteData(ent->vw);
+    // VVW_GetByteData returns `const uint8_t *`; the Rust side stores
+    // it as a `NonNull<u8>` (cheadergen emits the field as `uint8_t *`).
+    // We never write through this pointer; the cast is purely a typing
+    // adjustment to satisfy the strict C compiler.
+    rec.data.term.borrowed.offsets.data = (uint8_t *)VVW_GetByteData(ent->vw);
     rec.data.term.borrowed.offsets.len = VVW_GetByteLength(ent->vw);
   }
   return InvertedIndex_WriteEntryGeneric(idx, &rec);

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -20,7 +20,7 @@
 #include "stemmer.h"
 
 typedef struct RSQueryTerm RSQueryTerm;
-typedef struct RSIndexResult RSIndexResult;
+typedef struct RawIndexResult_Active RSIndexResult;
 typedef struct RSOffsetVector RSOffsetVector;
 typedef uint32_t RSTokenFlags;
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "enumflags2",
  "ffi",
  "query_term",
+ "ref_mode",
  "rqe_core",
  "thin_vec",
  "varint",
@@ -1508,6 +1509,7 @@ dependencies = [
  "ffi",
  "generational_slab",
  "hyperloglog",
+ "index_result",
  "inverted_index",
  "inverted_index_ffi",
  "numeric_range_tree",
@@ -3196,9 +3198,12 @@ dependencies = [
 name = "types_ffi"
 version = "0.0.1"
 dependencies = [
+ "cheadergen",
+ "ffi",
  "field",
  "index_result",
  "inverted_index",
+ "ref_mode",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn RSYieldableMetric_Concat<'a>(
 ///    (or null).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ResultMetrics_Add(
-    r: *mut RSIndexResult<'_>,
+    r: *mut RSIndexResult,
     key: *const RLookupKey,
     val: f64,
 ) {
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn ResultMetrics_Add(
 ///
 /// 1. `r` must point to a valid `RSIndexResult` and cannot be null.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn ResultMetrics_Reset(r: *mut RSIndexResult<'_>) {
+pub unsafe extern "C" fn ResultMetrics_Reset(r: *mut RSIndexResult) {
     debug_assert!(!r.is_null(), "result must not be null");
 
     // SAFETY: caller guarantees validity (1).
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn ResultMetrics_Reset(r: *mut RSIndexResult<'_>) {
 ///
 /// 1. `r` must point to a valid `RSIndexResult` and cannot be null.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_ResetAggregate(r: *mut RSIndexResult<'_>) {
+pub unsafe extern "C" fn IndexResult_ResetAggregate(r: *mut RSIndexResult) {
     debug_assert!(!r.is_null(), "result must not be null");
 
     // SAFETY: caller guarantees validity (1).

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 cheadergen.workspace = true
 numeric_range_tree.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 inverted_index_ffi = { path = "../inverted_index_ffi" }
 generational_slab.workspace = true

--- a/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
@@ -16,7 +16,10 @@ workspace = true
 
 
 [dependencies]
+cheadergen.workspace = true
+ffi.workspace = true
 field.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
+ref_mode.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -13,7 +13,6 @@ use ref_mode::{SharedPtr, Suspended};
 
 use std::{ffi::c_char, mem, ptr};
 
-use ffi::t_fieldMask;
 use index_result::{
     RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSQueryTerm, RSTermRecord,
 };

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -9,8 +9,11 @@
 
 //! This module contains pure Rust types that we want to expose to C code.
 
+use ref_mode::{SharedPtr, Suspended};
+
 use std::{ffi::c_char, mem, ptr};
 
+use ffi::t_fieldMask;
 use index_result::{
     RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSQueryTerm, RSTermRecord,
 };
@@ -599,7 +602,7 @@ pub struct AggregateRecordsSlice {
 /// - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_GetData(
-    offsets: *const RSOffsetSlice<'_>,
+    offsets: *const RSOffsetSlice,
     len: *mut u32,
 ) -> *const c_char {
     debug_assert!(!offsets.is_null(), "offsets must not be null");
@@ -610,7 +613,10 @@ pub unsafe extern "C" fn RSOffsetVector_GetData(
 
     // SAFETY: Caller is to ensure `len` is non-null and point to a valid u32 memory.
     unsafe { len.write(offsets.len) };
-    offsets.data.cast::<c_char>()
+    offsets
+        .data
+        .map_or(ptr::null(), |p| p.as_raw())
+        .cast::<c_char>()
 }
 
 /// Set the offsets array on an offset vector.
@@ -627,7 +633,7 @@ pub unsafe extern "C" fn RSOffsetVector_GetData(
 /// - if `data` is NULL then `len` should be 0.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_SetData(
-    offsets: *mut RSOffsetSlice<'_>,
+    offsets: *mut RSOffsetSlice,
     data: *const c_char,
     len: u32,
 ) {
@@ -640,7 +646,13 @@ pub unsafe extern "C" fn RSOffsetVector_SetData(
     // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid offset vector.
     let offsets = unsafe { &mut *offsets };
 
-    offsets.data = data.cast::<u8>();
+    // SAFETY: Caller guarantees `data` points to a valid array of `len` bytes
+    // for the lifetime of the offset slice (or `data` is null and `len == 0`).
+    offsets.data = std::ptr::NonNull::new(data.cast::<u8>() as *mut u8).map(|nn| {
+        // SAFETY: caller guarantees the buffer is alive and unaliased
+        // for reads for the lifetime of `offsets`.
+        unsafe { SharedPtr::<Suspended, _>::from_non_null(nn).into_active() }
+    });
     offsets.len = len;
 }
 
@@ -679,7 +691,7 @@ pub unsafe extern "C" fn RSOffsetVector_FreeData(offsets: *mut RSOffsetVector) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_CopyData(
     dest: *mut RSOffsetVector,
-    src: *const RSOffsetSlice<'_>,
+    src: *const RSOffsetSlice,
 ) {
     debug_assert!(!dest.is_null(), "offsets must not be null");
     debug_assert!(!src.is_null(), "offsets must not be null");
@@ -701,7 +713,7 @@ pub unsafe extern "C" fn RSOffsetVector_CopyData(
 /// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
 ///   and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSOffsetVector_Len(offsets: *const RSOffsetSlice<'_>) -> u32 {
+pub unsafe extern "C" fn RSOffsetVector_Len(offsets: *const RSOffsetSlice) -> u32 {
     debug_assert!(!offsets.is_null(), "offsets must not be null");
 
     // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid offset vector.

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -75,6 +75,25 @@ after_includes = """
 // We can't include redisearch.h directly: it transitively includes this header.
 typedef struct RSDocumentMetadata_s RSDocumentMetadata;
 """
+trailer = """
+/* Backward-compatible aliases for the variant tag enumerators. cheadergen
+ * mangles them with the underlying generic+instantiation name; the C codebase
+ * uses the unsuffixed forms. */
+#define RSResultData_Union        RawResultData_Active_Union
+#define RSResultData_Intersection RawResultData_Active_Intersection
+#define RSResultData_Term         RawResultData_Active_Term
+#define RSResultData_Virtual      RawResultData_Active_Virtual
+#define RSResultData_Numeric      RawResultData_Active_Numeric
+#define RSResultData_Metric       RawResultData_Active_Metric
+#define RSResultData_HybridMetric RawResultData_Active_HybridMetric
+
+#define RSAggregateResult_Borrowed RawAggregateResult_Active_Borrowed
+#define RSAggregateResult_Owned    RawAggregateResult_Active_Owned
+
+#define RSTermRecord_Borrowed   RawTermRecord_Active_Borrowed
+#define RSTermRecord_Owned      RawTermRecord_Active_Owned
+#define RSTermRecord_FullyOwned RawTermRecord_Active_FullyOwned
+"""
 
 [header.inverted_index_ffi]
 includes = ["config.h", "search_ctx.h", "spec.h"]

--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -26,38 +26,175 @@ typedef struct RSQueryTerm RSQueryTerm;
 typedef struct RLookupKey RLookupKey;
 
 /**
+ * The [`Active`] instantiation of [`RawOffsetSlice`]: a borrowed view whose data
+ * pointer is a live `&'a [u8]`.
+ */
+typedef struct RSOffsetVector RSOffsetSlice;
+
+#ifndef SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
+#define SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
+/**
+ * A pointer to `T` whose validity semantics depend on the [`Ref`] mode `Rf`.
+ *
+ * Internally this is a [`NonNull<T>`]. The `Rf` type parameter controls
+ * which constructors and methods are available:
+ *
+ * - [`Active<'a>`]: built from a reference via
+ *   [`SharedPtr::<Active>::from_ref`], with safe access via
+ *   [`SharedPtr::get`].
+ * - [`Suspended`]: built from a raw [`NonNull<T>`] via
+ *   [`SharedPtr::<Suspended>::from_non_null`]; inert (no safe access).
+ *   Upgrade to [`Active`] with the unsafe
+ *   [`SharedPtr::<Suspended>::into_active`] once validity is
+ *   re-established.
+ *
+ * `SharedPtr` only ever exposes shared (immutable) access to its
+ * referent; there is no mutable counterpart.
+ *
+ * `#[repr(transparent)]` ensures `SharedPtr<Rf, T>` has the same layout
+ * as `NonNull<T>` regardless of `Rf`, enabling zero-cost transmutation
+ * between `Active` and `Suspended` instantiations of containing
+ * `#[repr(C)]` structs. The `NonNull<T>` niche makes
+ * `Option<SharedPtr<Rf, T>>` pointer-sized as well.
+ */
+typedef RLookupKey *SharedPtr_Active__RLookupKey;
+#endif /* SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED */
+
+#ifndef RAWMETRICENTRY_ACTIVE_DEFINED
+#define RAWMETRICENTRY_ACTIVE_DEFINED
+/**
+ * A single metric: a borrowed key and a numeric value.
+ *
+ * The `R: Ref` parameter controls how the key reference is stored:
+ * in [`Active<'a>`] mode it is a valid `&'a RLookupKey`, in
+ * [`ref_mode::Suspended`] mode it is an inert raw pointer.
+ *
+ * `key` is `Option<SharedPtr<R, RLookupKey>>` so "no key" is encoded as
+ * `None`. `SharedPtr` wraps `NonNull` so the niche optimization keeps the C
+ * ABI as a nullable `RLookupKey *`.
+ */
+typedef struct RawMetricEntry_Active {
+  /**
+   * Borrowed reference to the lookup key that identifies this metric,
+   * or `None` when the metric has no associated key.
+   */
+  SharedPtr_Active__RLookupKey key;
+  /**
+   * The metric value (e.g. vector distance, score).
+   */
+  double value;
+} RawMetricEntry_Active;
+#endif /* RAWMETRICENTRY_ACTIVE_DEFINED */
+
+/**
+ * The [`Active`] instantiation of [`RawMetricEntry`].
+ */
+typedef struct RawMetricEntry_Active MetricEntry;
+
+#ifndef SHAREDPTR_ACTIVE__RSQUERYTERM_DEFINED
+#define SHAREDPTR_ACTIVE__RSQUERYTERM_DEFINED
+/**
+ * A pointer to `T` whose validity semantics depend on the [`Ref`] mode `Rf`.
+ *
+ * Internally this is a [`NonNull<T>`]. The `Rf` type parameter controls
+ * which constructors and methods are available:
+ *
+ * - [`Active<'a>`]: built from a reference via
+ *   [`SharedPtr::<Active>::from_ref`], with safe access via
+ *   [`SharedPtr::get`].
+ * - [`Suspended`]: built from a raw [`NonNull<T>`] via
+ *   [`SharedPtr::<Suspended>::from_non_null`]; inert (no safe access).
+ *   Upgrade to [`Active`] with the unsafe
+ *   [`SharedPtr::<Suspended>::into_active`] once validity is
+ *   re-established.
+ *
+ * `SharedPtr` only ever exposes shared (immutable) access to its
+ * referent; there is no mutable counterpart.
+ *
+ * `#[repr(transparent)]` ensures `SharedPtr<Rf, T>` has the same layout
+ * as `NonNull<T>` regardless of `Rf`, enabling zero-cost transmutation
+ * between `Active` and `Suspended` instantiations of containing
+ * `#[repr(C)]` structs. The `NonNull<T>` niche makes
+ * `Option<SharedPtr<Rf, T>>` pointer-sized as well.
+ */
+typedef struct RSQueryTerm *SharedPtr_Active__RSQueryTerm;
+#endif /* SHAREDPTR_ACTIVE__RSQUERYTERM_DEFINED */
+
+#ifndef SHAREDPTR_ACTIVE__U8_DEFINED
+#define SHAREDPTR_ACTIVE__U8_DEFINED
+/**
+ * A pointer to `T` whose validity semantics depend on the [`Ref`] mode `Rf`.
+ *
+ * Internally this is a [`NonNull<T>`]. The `Rf` type parameter controls
+ * which constructors and methods are available:
+ *
+ * - [`Active<'a>`]: built from a reference via
+ *   [`SharedPtr::<Active>::from_ref`], with safe access via
+ *   [`SharedPtr::get`].
+ * - [`Suspended`]: built from a raw [`NonNull<T>`] via
+ *   [`SharedPtr::<Suspended>::from_non_null`]; inert (no safe access).
+ *   Upgrade to [`Active`] with the unsafe
+ *   [`SharedPtr::<Suspended>::into_active`] once validity is
+ *   re-established.
+ *
+ * `SharedPtr` only ever exposes shared (immutable) access to its
+ * referent; there is no mutable counterpart.
+ *
+ * `#[repr(transparent)]` ensures `SharedPtr<Rf, T>` has the same layout
+ * as `NonNull<T>` regardless of `Rf`, enabling zero-cost transmutation
+ * between `Active` and `Suspended` instantiations of containing
+ * `#[repr(C)]` structs. The `NonNull<T>` niche makes
+ * `Option<SharedPtr<Rf, T>>` pointer-sized as well.
+ */
+typedef uint8_t *SharedPtr_Active__u8;
+#endif /* SHAREDPTR_ACTIVE__U8_DEFINED */
+
+#ifndef RSOFFSETVECTOR_DEFINED
+#define RSOFFSETVECTOR_DEFINED
+/**
  * Borrowed view of the encoded offsets of a term in a document. You can read the offsets by
  * iterating over it with RSIndexResult_IterateOffsets.
  *
  * This is a borrowed, `Copy` type — it does not own the data and will not free it on drop.
  * Use [`RSOffsetVector`] for owned offset data.
+ *
+ * The `R: Ref` parameter selects between [`Active<'index>`] mode (the data
+ * pointer is a valid `&'index [u8]`) and [`ref_mode::Suspended`] mode (the
+ * data pointer may be stale).
+ *
+ * `data` is `Option<SharedPtr<R, u8>>` so the empty slice can be represented
+ * with a null pointer. Thanks to `NonNull`'s niche, the in-memory layout
+ * is still a bare `*const u8` followed by a `u32`.
  */
 typedef struct RSOffsetVector {
   /**
-   * Pointer to the borrowed offset data.
+   * Pointer to the borrowed offset data, or `None` for the empty slice.
    */
-  const uint8_t *data;
+  SharedPtr_Active__u8 data;
   uint32_t len;
 } RSOffsetVector;
+#endif /* RSOFFSETVECTOR_DEFINED */
 
+#ifndef RAWTERMRECORD_ACTIVE_DEFINED
+#define RAWTERMRECORD_ACTIVE_DEFINED
 /**
  * Represents a single record of a document inside a term in the inverted index
  */
-enum RSTermRecord_Tag
+enum RawTermRecord_Active_Tag
 #ifdef __cplusplus
   : uint8_t
 #endif // __cplusplus
  {
-  RSTermRecord_Borrowed,
-  RSTermRecord_Owned,
-  RSTermRecord_FullyOwned,
+  RawTermRecord_Active_Borrowed,
+  RawTermRecord_Active_Owned,
+  RawTermRecord_Active_FullyOwned,
 };
 #ifndef __cplusplus
-typedef uint8_t RSTermRecord_Tag;
+typedef uint8_t RawTermRecord_Active_Tag;
 #endif // __cplusplus
 
-typedef struct RSTermRecord_Borrowed_Body {
-  RSTermRecord_Tag tag;
+typedef struct RawTermRecord_Active_Borrowed_Body {
+  RawTermRecord_Active_Tag tag;
   /**
    * The term that brought up this record.
    *
@@ -71,30 +208,32 @@ typedef struct RSTermRecord_Borrowed_Body {
   /**
    * The encoded offsets in which the term appeared in the document
    *
-   * A decoder can choose to borrow this data from the index block, hence the `'index` lifetime.
+   * A decoder can choose to borrow this data from the index block, hence the `R`
+   * parameter (which carries the index lifetime in [`Active`] mode).
    */
   struct RSOffsetVector offsets;
-} RSTermRecord_Borrowed_Body;
+} RawTermRecord_Active_Borrowed_Body;
 
-typedef struct RSTermRecord_Owned_Body {
-  RSTermRecord_Tag tag;
+typedef struct RawTermRecord_Active_Owned_Body {
+  RawTermRecord_Active_Tag tag;
   /**
    * The term that brought up this record.
    *
-   * It borrows the term from another record.
-   * The name of the variant, `Owned`, refers to the `offsets` field.
+   * It borrows the term from another record. `None` encodes "no
+   * term"; thanks to `NonNull`'s niche, `Option<SharedPtr<R, RSQueryTerm>>`
+   * has the same C ABI as a nullable `*const RSQueryTerm`.
    */
-  const struct RSQueryTerm *term;
+  SharedPtr_Active__RSQueryTerm term;
   /**
    * The encoded offsets in which the term appeared in the document
    *
    * The owned version owns a copy of the offsets data, which is freed on drop.
    */
   RSOffsetVector offsets;
-} RSTermRecord_Owned_Body;
+} RawTermRecord_Active_Owned_Body;
 
-typedef struct RSTermRecord_FullyOwned_Body {
-  RSTermRecord_Tag tag;
+typedef struct RawTermRecord_Active_FullyOwned_Body {
+  RawTermRecord_Active_Tag tag;
   /**
    * The term that brought up this record.
    *
@@ -111,30 +250,23 @@ typedef struct RSTermRecord_FullyOwned_Body {
    * (e.g. reading from a disk page that may be evicted).
    */
   RSOffsetVector offsets;
-} RSTermRecord_FullyOwned_Body;
+} RawTermRecord_Active_FullyOwned_Body;
 
-typedef union RSTermRecord {
-  RSTermRecord_Tag tag;
-  struct RSTermRecord_Borrowed_Body borrowed;
-  struct RSTermRecord_Owned_Body owned;
-  struct RSTermRecord_FullyOwned_Body fullyowned;
-} RSTermRecord;
+typedef union RawTermRecord_Active {
+  RawTermRecord_Active_Tag tag;
+  struct RawTermRecord_Active_Borrowed_Body borrowed;
+  struct RawTermRecord_Active_Owned_Body owned;
+  struct RawTermRecord_Active_FullyOwned_Body fullyowned;
+} RawTermRecord_Active;
+#endif /* RAWTERMRECORD_ACTIVE_DEFINED */
 
 /**
- * A single metric: a borrowed key and a numeric value.
+ * The [`Active`] instantiation of [`RawTermRecord`].
  */
-typedef struct MetricEntry {
-  /**
-   * Borrowed reference to the lookup key that identifies this metric.
-   * `None` when the metric has no associated key.
-   */
-  const RLookupKey *key;
-  /**
-   * The metric value (e.g. vector distance, score).
-   */
-  double value;
-} MetricEntry;
+typedef union RawTermRecord_Active RSTermRecord;
 
+#ifndef RAWMETRICSSLICE_ACTIVE_DEFINED
+#define RAWMETRICSSLICE_ACTIVE_DEFINED
 /**
  * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
  *
@@ -142,38 +274,41 @@ typedef struct MetricEntry {
  * from C. The pointed-to data is valid as long as the originating
  * [`MetricsVec`] is not mutated or dropped.
  */
-typedef struct MetricsSlice {
+typedef struct RawMetricsSlice_Active {
   /**
    * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
    * when `len == 0`.
    */
-  const struct MetricEntry *data;
+  const struct RawMetricEntry_Active *data;
   /**
    * Number of entries.
    */
   size_t len;
-} MetricsSlice;
+} RawMetricsSlice_Active;
+#endif /* RAWMETRICSSLICE_ACTIVE_DEFINED */
 
-#ifndef THINVEC_BOX_RSINDEXRESULT__U16_DEFINED
-#define THINVEC_BOX_RSINDEXRESULT__U16_DEFINED
+#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_Box_RSIndexResult__u16 {
+typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
   struct Header_u16 *ptr;
-} ThinVec_Box_RSIndexResult__u16;
-#endif /* THINVEC_BOX_RSINDEXRESULT__U16_DEFINED */
+} ThinVec_Box_RawIndexResult_Active__u16;
+#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
 
-#ifndef THINVEC_METRICENTRY__U64_DEFINED
-#define THINVEC_METRICENTRY__U64_DEFINED
+#ifndef THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
+#define THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_MetricEntry__u64 {
+typedef struct ThinVec_RawMetricEntry_Active__u64 {
   struct Header_u64 *ptr;
-} ThinVec_MetricEntry__u64;
-#endif /* THINVEC_METRICENTRY__U64_DEFINED */
+} ThinVec_RawMetricEntry_Active__u64;
+#endif /* THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED */
 
+#ifndef RAWMETRICSVEC_ACTIVE_DEFINED
+#define RAWMETRICSVEC_ACTIVE_DEFINED
 /**
  * A dynamically-sized collection of [`MetricEntry`] values.
  *
@@ -183,39 +318,50 @@ typedef struct ThinVec_MetricEntry__u64 {
  * `repr(transparent)` over `ThinVec` means this type is pointer-sized
  * and can be embedded directly in `repr(C)` structs.
  */
-typedef struct ThinVec_MetricEntry__u64 MetricsVec;
+typedef struct ThinVec_RawMetricEntry_Active__u64 RawMetricsVec_Active;
+#endif /* RAWMETRICSVEC_ACTIVE_DEFINED */
 
-#ifndef THINVEC_RSINDEXRESULT__U16_DEFINED
-#define THINVEC_RSINDEXRESULT__U16_DEFINED
+/**
+ * The [`Active`] instantiation of [`RawMetricsVec`].
+ */
+typedef RawMetricsVec_Active MetricsVec;
+
+#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_RSIndexResult__u16 {
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
   struct Header_u16 *ptr;
-} ThinVec_RSIndexResult__u16;
-#endif /* THINVEC_RSINDEXRESULT__U16_DEFINED */
+} ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
+#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
 
-#ifndef SMALLTHINVEC_BOX_RSINDEXRESULT_DEFINED
-#define SMALLTHINVEC_BOX_RSINDEXRESULT_DEFINED
+/**
+ * The [`Active`] instantiation of [`RawMetricsSlice`].
+ */
+typedef struct RawMetricsSlice_Active MetricsSlice;
+
+#ifndef SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
+#define SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
 /**
  * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
  *
  * This is useful when you know the vector will never exceed 65,535 elements
  * and want to minimize header overhead (4 bytes instead of 16).
  */
-typedef struct ThinVec_Box_RSIndexResult__u16 SmallThinVec_Box_RSIndexResult;
-#endif /* SMALLTHINVEC_BOX_RSINDEXRESULT_DEFINED */
+typedef struct ThinVec_Box_RawIndexResult_Active__u16 SmallThinVec_Box_RawIndexResult_Active;
+#endif /* SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED */
 
-#ifndef SMALLTHINVEC_RSINDEXRESULT_DEFINED
-#define SMALLTHINVEC_RSINDEXRESULT_DEFINED
+#ifndef SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
+#define SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED
 /**
  * A [`ThinVec`] with `u16` capacity, supporting up to 65,535 elements.
  *
  * This is useful when you know the vector will never exceed 65,535 elements
  * and want to minimize header overhead (4 bytes instead of 16).
  */
-typedef struct ThinVec_RSIndexResult__u16 SmallThinVec_RSIndexResult;
-#endif /* SMALLTHINVEC_RSINDEXRESULT_DEFINED */
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 SmallThinVec_SharedPtr_Active__RawIndexResult_Active;
+#endif /* SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED */
 
 #ifndef BITFLAGS_RSRESULTKIND__U8_DEFINED
 #define BITFLAGS_RSRESULTKIND__U8_DEFINED
@@ -337,6 +483,8 @@ typedef uint8_t BitFlags_RSResultKind__u8;
 
 typedef BitFlags_RSResultKind__u8 RSResultKindMask;
 
+#ifndef RAWAGGREGATERESULT_ACTIVE_DEFINED
+#define RAWAGGREGATERESULT_ACTIVE_DEFINED
 /**
  * Represents an aggregate array of values in an index record.
  *
@@ -345,122 +493,141 @@ typedef BitFlags_RSResultKind__u8 RSResultKindMask;
  * the `ThinVec` which needs to exist in Rust's memory space to ensure its memory is
  * managed correctly.
  */
-enum RSAggregateResult_Tag
+enum RawAggregateResult_Active_Tag
 #ifdef __cplusplus
   : uint8_t
 #endif // __cplusplus
  {
-  RSAggregateResult_Borrowed,
-  RSAggregateResult_Owned,
+  RawAggregateResult_Active_Borrowed,
+  RawAggregateResult_Active_Owned,
 };
 #ifndef __cplusplus
-typedef uint8_t RSAggregateResult_Tag;
+typedef uint8_t RawAggregateResult_Active_Tag;
 #endif // __cplusplus
 
-typedef struct RSAggregateResult_Borrowed_Body {
-  RSAggregateResult_Tag tag;
+typedef struct RawAggregateResult_Active_Borrowed_Body {
+  RawAggregateResult_Active_Tag tag;
   /**
    * The records making up this aggregate result
    *
-   * The `RSAggregateResult` is part of a union in [`super::result_data::RSResultData`], so it needs to have a
-   * known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
-   * own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
+   * The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so
+   * it needs to have a known size. The std `Vec` won't have this since it is not
+   * `#[repr(C)]`, so we use our own `ThinVec` type which is `#[repr(C)]` and has a known
+   * size instead.
    *
-   * This requires `'index` on the reference because adding a new lifetime will cause the
-   * type to be `ThinVec<&'refs RSIndexResult<'index, 'refs>>` which will require
-   * `'index: 'refs` else it would mean the `'index` can be cleaned up while some reference
-   * will still try to access it (ie a dangling pointer). Now the decoders will never return
-   * any aggregate results so `'refs == 'static` when decoding. Because of the requirement
-   * above, this means `'index: 'static` which is just incorrect since the index data will
-   * never be `'static` when decoding.
+   * Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
+   * equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
+   * an inert raw pointer that survives lock release/reacquire cycles.
    */
-  SmallThinVec_RSIndexResult records;
+  SmallThinVec_SharedPtr_Active__RawIndexResult_Active records;
   /**
    * A map of the aggregate kind of the underlying records
    */
   RSResultKindMask kind_mask;
-} RSAggregateResult_Borrowed_Body;
+} RawAggregateResult_Active_Borrowed_Body;
 
-typedef struct RSAggregateResult_Owned_Body {
-  RSAggregateResult_Tag tag;
+typedef struct RawAggregateResult_Active_Owned_Body {
+  RawAggregateResult_Active_Tag tag;
   /**
    * The records making up this aggregate result
    *
-   * The `RSAggregateResult` is part of a union in [`super::result_data::RSResultData`], so it needs to have a
+   * The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so it needs to have a
    * known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
    * own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
    */
-  SmallThinVec_Box_RSIndexResult records;
+  SmallThinVec_Box_RawIndexResult_Active records;
   /**
    * A map of the aggregate kind of the underlying records
    */
   RSResultKindMask kind_mask;
-} RSAggregateResult_Owned_Body;
+} RawAggregateResult_Active_Owned_Body;
 
-typedef union RSAggregateResult {
-  RSAggregateResult_Tag tag;
-  struct RSAggregateResult_Borrowed_Body borrowed;
-  struct RSAggregateResult_Owned_Body owned;
-} RSAggregateResult;
+typedef union RawAggregateResult_Active {
+  RawAggregateResult_Active_Tag tag;
+  struct RawAggregateResult_Active_Borrowed_Body borrowed;
+  struct RawAggregateResult_Active_Owned_Body owned;
+} RawAggregateResult_Active;
+#endif /* RAWAGGREGATERESULT_ACTIVE_DEFINED */
 
+#ifndef RAWRESULTDATA_ACTIVE_DEFINED
+#define RAWRESULTDATA_ACTIVE_DEFINED
 /**
  * Holds the actual data of an ['IndexResult']
  *
  * These enum values should stay in sync with [`RSResultKind`], so that the C union generated matches
  * the bitflags on [`super::kind::RSResultKindMask`]
  *
- * The `'index` lifetime is linked to the `IndexBlock` (in the `inverted_index` crate) when
- * decoding borrows from the block.
+ * The `R: Ref` parameter selects between [`Active<'index>`] mode (data references are valid for
+ * `'index`) and [`ref_mode::Suspended`] mode (data references are inert raw pointers).
  */
-enum RSResultData_Tag
+enum RawResultData_Active_Tag
 #ifdef __cplusplus
   : uint8_t
 #endif // __cplusplus
  {
-  RSResultData_Union = 1,
-  RSResultData_Intersection = 2,
-  RSResultData_Term = 4,
-  RSResultData_Virtual = 8,
-  RSResultData_Numeric = 16,
-  RSResultData_Metric = 32,
-  RSResultData_HybridMetric = 64,
+  RawResultData_Active_Union = 1,
+  RawResultData_Active_Intersection = 2,
+  RawResultData_Active_Term = 4,
+  RawResultData_Active_Virtual = 8,
+  RawResultData_Active_Numeric = 16,
+  RawResultData_Active_Metric = 32,
+  RawResultData_Active_HybridMetric = 64,
 };
 #ifndef __cplusplus
-typedef uint8_t RSResultData_Tag;
+typedef uint8_t RawResultData_Active_Tag;
 #endif // __cplusplus
 
-typedef union RSResultData {
-  RSResultData_Tag tag;
+typedef union RawResultData_Active {
+  RawResultData_Active_Tag tag;
   struct {
-    RSResultData_Tag union__tag;
-    union RSAggregateResult union_;
+    RawResultData_Active_Tag union__tag;
+    union RawAggregateResult_Active union_;
   };
   struct {
-    RSResultData_Tag intersection_tag;
-    union RSAggregateResult intersection;
+    RawResultData_Active_Tag intersection_tag;
+    union RawAggregateResult_Active intersection;
   };
   struct {
-    RSResultData_Tag term_tag;
-    union RSTermRecord term;
+    RawResultData_Active_Tag term_tag;
+    union RawTermRecord_Active term;
   };
   struct {
-    RSResultData_Tag numeric_tag;
+    RawResultData_Active_Tag numeric_tag;
     double numeric;
   };
   struct {
-    RSResultData_Tag metric_tag;
+    RawResultData_Active_Tag metric_tag;
     double metric;
   };
   struct {
-    RSResultData_Tag hybridmetric_tag;
-    union RSAggregateResult hybridmetric;
+    RawResultData_Active_Tag hybridmetric_tag;
+    union RawAggregateResult_Active hybridmetric;
   };
-} RSResultData;
+} RawResultData_Active;
+#endif /* RAWRESULTDATA_ACTIVE_DEFINED */
 
 /**
- * The result of an inverted index
+ * The [`Active`] instantiation of [`RawResultData`].
  */
-typedef struct RSIndexResult {
+typedef union RawResultData_Active RSResultData;
+
+/**
+ * The [`Active`] instantiation of [`RawAggregateResult`].
+ */
+typedef union RawAggregateResult_Active RSAggregateResult;
+
+#ifndef RAWINDEXRESULT_ACTIVE_DEFINED
+#define RAWINDEXRESULT_ACTIVE_DEFINED
+/**
+ * The result of an inverted index
+ *
+ * The `R: Ref` parameter selects between [`Active<'index>`] mode (the
+ * data references inside this result are valid for `'index` and the
+ * inverted index read lock is held) and [`ref_mode::Suspended`] mode
+ * (the data references are inert raw pointers that survive lock
+ * release/reacquire cycles).
+ */
+typedef struct RawIndexResult_Active {
   /**
    * The document ID of the result
    */
@@ -480,16 +647,43 @@ typedef struct RSIndexResult {
   /**
    * The actual data of the result
    */
-  union RSResultData data;
+  union RawResultData_Active data;
   /**
    * Holds an array of metrics yielded by the different iterators in the AST.
    *
    * Backed by [`ThinVec`](thin_vec::ThinVec) — pointer-sized, no
    * allocation when empty.
    */
-  MetricsVec metrics;
+  RawMetricsVec_Active metrics;
   /**
    * Relative weight for scoring calculations. This is derived from the result's iterator weight
    */
   double weight;
-} RSIndexResult;
+} RawIndexResult_Active;
+#endif /* RAWINDEXRESULT_ACTIVE_DEFINED */
+
+/**
+ * The [`Active`] instantiation of [`RawIndexResult`].
+ *
+ * This is the only mode that crosses the C boundary today; the suspended
+ * counterpart is forthcoming.
+ */
+typedef struct RawIndexResult_Active RSIndexResult;
+/* Backward-compatible aliases for the variant tag enumerators. cheadergen
+ * mangles them with the underlying generic+instantiation name; the C codebase
+ * uses the unsuffixed forms. */
+#define RSResultData_Union        RawResultData_Active_Union
+#define RSResultData_Intersection RawResultData_Active_Intersection
+#define RSResultData_Term         RawResultData_Active_Term
+#define RSResultData_Virtual      RawResultData_Active_Virtual
+#define RSResultData_Numeric      RawResultData_Active_Numeric
+#define RSResultData_Metric       RawResultData_Active_Metric
+#define RSResultData_HybridMetric RawResultData_Active_HybridMetric
+
+#define RSAggregateResult_Borrowed RawAggregateResult_Active_Borrowed
+#define RSAggregateResult_Owned    RawAggregateResult_Active_Owned
+
+#define RSTermRecord_Borrowed   RawTermRecord_Active_Borrowed
+#define RSTermRecord_Owned      RawTermRecord_Active_Owned
+#define RSTermRecord_FullyOwned RawTermRecord_Active_FullyOwned
+

--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -31,6 +31,82 @@ typedef struct RLookupKey RLookupKey;
  */
 typedef struct RSOffsetVector RSOffsetSlice;
 
+#ifndef RAWMETRICSSLICE_ACTIVE_DEFINED
+#define RAWMETRICSSLICE_ACTIVE_DEFINED
+/**
+ * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
+ *
+ * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
+ * from C. The pointed-to data is valid as long as the originating
+ * [`MetricsVec`] is not mutated or dropped.
+ */
+typedef struct RawMetricsSlice_Active {
+  /**
+   * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
+   * when `len == 0`.
+   */
+  const struct RawMetricEntry_Active *data;
+  /**
+   * Number of entries.
+   */
+  size_t len;
+} RawMetricsSlice_Active;
+#endif /* RAWMETRICSSLICE_ACTIVE_DEFINED */
+
+#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
+/**
+ * See the crate's top level documentation for a description of this type.
+ */
+typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
+  struct Header_u16 *ptr;
+} ThinVec_Box_RawIndexResult_Active__u16;
+#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
+
+#ifndef THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
+#define THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
+/**
+ * See the crate's top level documentation for a description of this type.
+ */
+typedef struct ThinVec_RawMetricEntry_Active__u64 {
+  struct Header_u64 *ptr;
+} ThinVec_RawMetricEntry_Active__u64;
+#endif /* THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED */
+
+#ifndef RAWMETRICSVEC_ACTIVE_DEFINED
+#define RAWMETRICSVEC_ACTIVE_DEFINED
+/**
+ * A dynamically-sized collection of [`MetricEntry`] values.
+ *
+ * Backed by a [`ThinVec`] — a single-pointer vec that stores len/cap in
+ * the allocation header. `MetricsVec::new()` does not allocate.
+ *
+ * `repr(transparent)` over `ThinVec` means this type is pointer-sized
+ * and can be embedded directly in `repr(C)` structs.
+ */
+typedef struct ThinVec_RawMetricEntry_Active__u64 RawMetricsVec_Active;
+#endif /* RAWMETRICSVEC_ACTIVE_DEFINED */
+
+/**
+ * The [`Active`] instantiation of [`RawMetricsVec`].
+ */
+typedef RawMetricsVec_Active MetricsVec;
+
+#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
+#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
+/**
+ * See the crate's top level documentation for a description of this type.
+ */
+typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
+  struct Header_u16 *ptr;
+} ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
+#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
+
+/**
+ * The [`Active`] instantiation of [`RawMetricsSlice`].
+ */
+typedef struct RawMetricsSlice_Active MetricsSlice;
+
 #ifndef SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
 #define SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
 /**
@@ -264,82 +340,6 @@ typedef union RawTermRecord_Active {
  * The [`Active`] instantiation of [`RawTermRecord`].
  */
 typedef union RawTermRecord_Active RSTermRecord;
-
-#ifndef RAWMETRICSSLICE_ACTIVE_DEFINED
-#define RAWMETRICSSLICE_ACTIVE_DEFINED
-/**
- * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
- *
- * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
- * from C. The pointed-to data is valid as long as the originating
- * [`MetricsVec`] is not mutated or dropped.
- */
-typedef struct RawMetricsSlice_Active {
-  /**
-   * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
-   * when `len == 0`.
-   */
-  const struct RawMetricEntry_Active *data;
-  /**
-   * Number of entries.
-   */
-  size_t len;
-} RawMetricsSlice_Active;
-#endif /* RAWMETRICSSLICE_ACTIVE_DEFINED */
-
-#ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
-#define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
-/**
- * See the crate's top level documentation for a description of this type.
- */
-typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
-  struct Header_u16 *ptr;
-} ThinVec_Box_RawIndexResult_Active__u16;
-#endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
-
-#ifndef THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
-#define THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
-/**
- * See the crate's top level documentation for a description of this type.
- */
-typedef struct ThinVec_RawMetricEntry_Active__u64 {
-  struct Header_u64 *ptr;
-} ThinVec_RawMetricEntry_Active__u64;
-#endif /* THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED */
-
-#ifndef RAWMETRICSVEC_ACTIVE_DEFINED
-#define RAWMETRICSVEC_ACTIVE_DEFINED
-/**
- * A dynamically-sized collection of [`MetricEntry`] values.
- *
- * Backed by a [`ThinVec`] — a single-pointer vec that stores len/cap in
- * the allocation header. `MetricsVec::new()` does not allocate.
- *
- * `repr(transparent)` over `ThinVec` means this type is pointer-sized
- * and can be embedded directly in `repr(C)` structs.
- */
-typedef struct ThinVec_RawMetricEntry_Active__u64 RawMetricsVec_Active;
-#endif /* RAWMETRICSVEC_ACTIVE_DEFINED */
-
-/**
- * The [`Active`] instantiation of [`RawMetricsVec`].
- */
-typedef RawMetricsVec_Active MetricsVec;
-
-#ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
-#define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
-/**
- * See the crate's top level documentation for a description of this type.
- */
-typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
-  struct Header_u16 *ptr;
-} ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
-#endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
-
-/**
- * The [`Active`] instantiation of [`RawMetricsSlice`].
- */
-typedef struct RawMetricsSlice_Active MetricsSlice;
 
 #ifndef SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
 #define SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -14,11 +14,6 @@
 #include "rqe_core.h"
 
 /**
- * The result of an inverted index
- */
-typedef struct RSIndexResult RSIndexResult;
-
-/**
  * An opaque inverted index reader structure. The actual implementation is determined at runtime
  * based on the index type and filter provided when creating the reader. This allows us to have a
  * single interface for all index reader types while still being able to optimize the storage
@@ -67,6 +62,14 @@ typedef struct II_GCCallback {
    */
   void (*call)(void *ctx);
 } II_GCCallback;
+
+/**
+ * The [`Active`] instantiation of [`RawIndexResult`].
+ *
+ * This is the only mode that crosses the C boundary today; the suspended
+ * counterpart is forthcoming.
+ */
+typedef struct RawIndexResult_Active RSIndexResult;
 
 /**
  * The mask of flags that determine the index storage type. This includes all flags that affect
@@ -141,7 +144,7 @@ struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
  */
-struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record);
+struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const RSIndexResult *record);
 
 /**
  * Return the number of blocks in the inverted index.
@@ -437,7 +440,7 @@ bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedInde
  * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
  * - `res` must be a valid pointer to an `RSIndexResult` instance.
  */
-bool IndexReader_Next(struct IndexReader *ir, struct RSIndexResult *res);
+bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
 
 /**
  * Skip the internal block of the inverted index reader to the block that may contain the given
@@ -464,7 +467,7 @@ bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
  * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
  * - `res` must be a valid pointer to an `RSIndexResult` instance.
  */
-bool IndexReader_Seek(struct IndexReader *ir, t_docId doc_id, struct RSIndexResult *res);
+bool IndexReader_Seek(struct IndexReader *ir, t_docId doc_id, RSIndexResult *res);
 
 /**
  * Check if the index reader can return multiple entries for the same document ID.

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -46,7 +46,7 @@ void RSYieldableMetric_Concat(MetricsVec *parent, MetricsVec *child);
  * 2. `key` must be a valid `*const RLookupKey` that outlives the result
  *    (or null).
  */
-void ResultMetrics_Add(struct RSIndexResult *r, const RLookupKey *key, double val);
+void ResultMetrics_Add(RSIndexResult *r, const RLookupKey *key, double val);
 
 /**
  * Clears all entries from the result's metrics collection.
@@ -55,7 +55,7 @@ void ResultMetrics_Add(struct RSIndexResult *r, const RLookupKey *key, double va
  *
  * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
  */
-void ResultMetrics_Reset(struct RSIndexResult *r);
+void ResultMetrics_Reset(RSIndexResult *r);
 
 /**
  * Resets aggregate-specific fields on an `RSIndexResult`: doc_id, freq,
@@ -65,7 +65,7 @@ void ResultMetrics_Reset(struct RSIndexResult *r);
  *
  * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
  */
-void IndexResult_ResetAggregate(struct RSIndexResult *r);
+void IndexResult_ResetAggregate(RSIndexResult *r);
 
 /**
  * Returns a read-only slice view of the metrics collection for zero-copy
@@ -77,7 +77,7 @@ void IndexResult_ResetAggregate(struct RSIndexResult *r);
  * 2. The returned slice borrows from the `MetricsVec`; the caller must
  *    not mutate or free the `MetricsVec` while the slice is in use.
  */
-struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
+MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
 
 /**
  * Finds the first metric whose key matches `key` (pointer equality) and

--- a/src/redisearch_rs/headers/search_result_rs.h
+++ b/src/redisearch_rs/headers/search_result_rs.h
@@ -22,9 +22,12 @@ typedef const RSDocumentMetadata *OwnedDocumentMetadata;
 
 
 /**
- * The result of an inverted index
+ * The [`Active`] instantiation of [`RawIndexResult`].
+ *
+ * This is the only mode that crosses the C boundary today; the suspended
+ * counterpart is forthcoming.
  */
-typedef struct RSIndexResult RSIndexResult;
+typedef struct RawIndexResult_Active RSIndexResult;
 
 #ifndef BITFLAGS_SEARCHRESULTFLAG__U8_DEFINED
 #define BITFLAGS_SEARCHRESULTFLAG__U8_DEFINED
@@ -166,7 +169,7 @@ typedef struct SearchResult {
    */
   RSScoreExplain *_score_explain;
   OwnedDocumentMetadata _document_metadata;
-  const struct RSIndexResult *_index_result;
+  const RSIndexResult *_index_result;
   struct RLookupRow _row_data;
   SearchResultFlags _flags;
 } SearchResult;

--- a/src/redisearch_rs/headers/types_ffi.h
+++ b/src/redisearch_rs/headers/types_ffi.h
@@ -25,6 +25,32 @@ typedef struct NumericFilter NumericFilter;
  */
 typedef struct RSQueryTerm RSQueryTerm;
 
+#ifndef RSOFFSETVECTOR_DEFINED
+#define RSOFFSETVECTOR_DEFINED
+/**
+ * Borrowed view of the encoded offsets of a term in a document. You can read the offsets by
+ * iterating over it with RSIndexResult_IterateOffsets.
+ *
+ * This is a borrowed, `Copy` type — it does not own the data and will not free it on drop.
+ * Use [`RSOffsetVector`] for owned offset data.
+ *
+ * The `R: Ref` parameter selects between [`Active<'index>`] mode (the data
+ * pointer is a valid `&'index [u8]`) and [`ref_mode::Suspended`] mode (the
+ * data pointer may be stale).
+ *
+ * `data` is `Option<SharedPtr<R, u8>>` so the empty slice can be represented
+ * with a null pointer. Thanks to `NonNull`'s niche, the in-memory layout
+ * is still a bare `*const u8` followed by a `u32`.
+ */
+typedef struct RSOffsetVector {
+  /**
+   * Pointer to the borrowed offset data, or `None` for the empty slice.
+   */
+  SharedPtr_Active__u8 data;
+  uint32_t len;
+} RSOffsetVector;
+#endif /* RSOFFSETVECTOR_DEFINED */
+
 /**
  * A view over the records stored inside an [`RSAggregateResult`].
  *
@@ -33,7 +59,7 @@ typedef struct RSQueryTerm RSQueryTerm;
  * C->Rust FFI calls.
  */
 typedef struct AggregateRecordsSlice {
-  const struct RSIndexResult *const *ptr;
+  const RSIndexResult *const *ptr;
   size_t len;
 } AggregateRecordsSlice;
 
@@ -55,29 +81,29 @@ bool NumericFilter_Match(const struct NumericFilter *filter, double value);
  * Allocate a new intersect result with a given capacity and weight. This result should be freed
  * using [`IndexResult_Free`].
  */
-struct RSIndexResult *NewIntersectResult(size_t cap, double weight);
+RSIndexResult *NewIntersectResult(size_t cap, double weight);
 
 /**
  * Allocate a new union result with a given capacity and weight. This result should be freed using
  * [`IndexResult_Free`].
  */
-struct RSIndexResult *NewUnionResult(size_t cap, double weight);
+RSIndexResult *NewUnionResult(size_t cap, double weight);
 
 /**
  * Allocate a new virtual result with a given weight and field mask. This result should be freed
  * using [`IndexResult_Free`].
  */
-struct RSIndexResult *NewVirtualResult(double weight, t_fieldMask field_mask);
+RSIndexResult *NewVirtualResult(double weight, t_fieldMask field_mask);
 
 /**
  * Allocate a new numeric result. This result should be freed using [`IndexResult_Free`].
  */
-struct RSIndexResult *NewNumericResult(void);
+RSIndexResult *NewNumericResult(void);
 
 /**
  * Allocate a new metric result. This result should be freed using [`IndexResult_Free`].
  */
-struct RSIndexResult *NewMetricResult(void);
+RSIndexResult *NewMetricResult(void);
 
 /**
  * Allocate a new hybrid result. This result should be freed using [`IndexResult_Free`].
@@ -85,7 +111,7 @@ struct RSIndexResult *NewMetricResult(void);
  * This constructor is only used by the hydrid reader which will pushed owned copies to it.
  * Therefore, this also returns an owned `RSIndexResult`.
  */
-struct RSIndexResult *NewHybridResult(void);
+RSIndexResult *NewHybridResult(void);
 
 /**
  * Allocate a new token record with a given term and weight. This result should be freed using
@@ -96,7 +122,7 @@ struct RSIndexResult *NewHybridResult(void);
  * `term` must be a heap-allocated `RSQueryTerm` (e.g. created by `NewQueryTerm`) and the
  * caller transfers ownership — it must not be freed separately.
  */
-struct RSIndexResult *NewTokenRecord(struct RSQueryTerm *term, double weight);
+RSIndexResult *NewTokenRecord(struct RSQueryTerm *term, double weight);
 
 /**
  * Free an index result's internal allocations and also free the result itself.
@@ -114,7 +140,7 @@ struct RSIndexResult *NewTokenRecord(struct RSQueryTerm *term, double weight);
  *   - [`NewTokenRecord`]
  *   - [`IndexResult_DeepCopy`]
  */
-void IndexResult_Free(struct RSIndexResult *result);
+void IndexResult_Free(RSIndexResult *result);
 
 /**
  * Create a deep copy of the results that is totally thread safe. This is very slow so use it with
@@ -126,7 +152,7 @@ void IndexResult_Free(struct RSIndexResult *result);
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-struct RSIndexResult *IndexResult_DeepCopy(const struct RSIndexResult *source);
+RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *source);
 
 /**
  * Check if the result is an aggregate result.
@@ -136,7 +162,7 @@ struct RSIndexResult *IndexResult_DeepCopy(const struct RSIndexResult *source);
  * The following invariants must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-bool IndexResult_IsAggregate(const struct RSIndexResult *result);
+bool IndexResult_IsAggregate(const RSIndexResult *result);
 
 /**
  * Get the numeric value of the result if it is a numeric result. If the result is not numeric,
@@ -147,7 +173,7 @@ bool IndexResult_IsAggregate(const struct RSIndexResult *result);
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-double IndexResult_NumValue(const struct RSIndexResult *result);
+double IndexResult_NumValue(const RSIndexResult *result);
 
 /**
  * Set the numeric value of the result if it is a numeric result. If the result is not numeric,
@@ -158,7 +184,7 @@ double IndexResult_NumValue(const struct RSIndexResult *result);
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-void IndexResult_SetNumValue(struct RSIndexResult *result, double value);
+void IndexResult_SetNumValue(RSIndexResult *result, double value);
 
 /**
  * Get the query term from a result if it is a term result. If the result is not a term, then
@@ -169,7 +195,7 @@ void IndexResult_SetNumValue(struct RSIndexResult *result, double value);
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-struct RSQueryTerm *IndexResult_QueryTermRef(const struct RSIndexResult *result);
+struct RSQueryTerm *IndexResult_QueryTermRef(const RSIndexResult *result);
 
 /**
  * Get the term offsets from a result if it is a term result. If the result is not a term, then
@@ -180,7 +206,7 @@ struct RSQueryTerm *IndexResult_QueryTermRef(const struct RSIndexResult *result)
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-const struct RSOffsetVector *IndexResult_TermOffsetsRef(const struct RSIndexResult *result);
+const RSOffsetSlice *IndexResult_TermOffsetsRef(const RSIndexResult *result);
 
 /**
  * Get the aggregate result reference if the result is an aggregate result. If the result is
@@ -191,7 +217,7 @@ const struct RSOffsetVector *IndexResult_TermOffsetsRef(const struct RSIndexResu
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-const union RSAggregateResult *IndexResult_AggregateRef(const struct RSIndexResult *result);
+const RSAggregateResult *IndexResult_AggregateRef(const RSIndexResult *result);
 
 /**
  * Get the aggregate result reference without performing a runtime check
@@ -207,7 +233,7 @@ const union RSAggregateResult *IndexResult_AggregateRef(const struct RSIndexResu
  * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
  * 2. `result`'s data payload must be of the aggregate kind
  */
-const union RSAggregateResult *IndexResult_AggregateRefUnchecked(const struct RSIndexResult *result);
+const RSAggregateResult *IndexResult_AggregateRefUnchecked(const RSIndexResult *result);
 
 /**
  * Get a mutable aggregate result reference without performing a runtime check
@@ -223,7 +249,7 @@ const union RSAggregateResult *IndexResult_AggregateRefUnchecked(const struct RS
  * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
  * 2. `result`'s data payload must be of the aggregate kind
  */
-union RSAggregateResult *IndexResult_AggregateRefMutUnchecked(struct RSIndexResult *result);
+RSAggregateResult *IndexResult_AggregateRefMutUnchecked(RSIndexResult *result);
 
 /**
  * Reset the result if it is an aggregate result. This will clear the children vector
@@ -234,7 +260,7 @@ union RSAggregateResult *IndexResult_AggregateRefMutUnchecked(struct RSIndexResu
  * The following invariant must be upheld when calling this function:
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-void IndexResult_AggregateReset(struct RSIndexResult *result);
+void IndexResult_AggregateReset(RSIndexResult *result);
 
 /**
  * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
@@ -245,7 +271,7 @@ void IndexResult_AggregateReset(struct RSIndexResult *result);
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
-const struct RSIndexResult *AggregateResult_Get(const union RSAggregateResult *agg, size_t index);
+const RSIndexResult *AggregateResult_Get(const RSAggregateResult *agg, size_t index);
 
 /**
  * Get the result at the specified index in the aggregate result, without checking bounds.
@@ -256,7 +282,7 @@ const struct RSIndexResult *AggregateResult_Get(const union RSAggregateResult *a
  * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  * 2. `index` must be lower than the length of the aggregate result children vector.
  */
-const struct RSIndexResult *AggregateResult_GetUnchecked(const union RSAggregateResult *agg, size_t index);
+const RSIndexResult *AggregateResult_GetUnchecked(const RSAggregateResult *agg, size_t index);
 
 /**
  * Get a mutable result at the specified index in the aggregate result, without checking bounds.
@@ -268,7 +294,7 @@ const struct RSIndexResult *AggregateResult_GetUnchecked(const union RSAggregate
  * 2. `index` must be lower than the length of the aggregate result children vector.
  * 3. `agg` must be of the `Owned` variant.
  */
-struct RSIndexResult *AggregateResult_GetMutUnchecked(union RSAggregateResult *agg, size_t index);
+RSIndexResult *AggregateResult_GetMutUnchecked(RSAggregateResult *agg, size_t index);
 
 /**
  * Get the element count of the aggregate result.
@@ -278,7 +304,7 @@ struct RSIndexResult *AggregateResult_GetMutUnchecked(union RSAggregateResult *a
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
-size_t AggregateResult_NumChildren(const union RSAggregateResult *agg);
+size_t AggregateResult_NumChildren(const RSAggregateResult *agg);
 
 /**
  * Get the capacity of the aggregate result.
@@ -288,7 +314,7 @@ size_t AggregateResult_NumChildren(const union RSAggregateResult *agg);
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
-size_t AggregateResult_Capacity(const union RSAggregateResult *agg);
+size_t AggregateResult_Capacity(const RSAggregateResult *agg);
 
 /**
  * Get the kind mask of the aggregate result.
@@ -298,14 +324,14 @@ size_t AggregateResult_Capacity(const union RSAggregateResult *agg);
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
-uint8_t AggregateResult_KindMask(const union RSAggregateResult *agg);
+uint8_t AggregateResult_KindMask(const RSAggregateResult *agg);
 
 /**
  * Create a new aggregate result with the specified capacity. This function will make the result
  * in Rust memory, but the ownership ends up being transferred to C's memory space. This ownership
  * should return to Rust to free up any heap memory using [`AggregateResult_Free`].
  */
-union RSAggregateResult AggregateResult_New(size_t cap);
+RSAggregateResult AggregateResult_New(size_t cap);
 
 /**
  * Take ownership of a `RSAggregateResult` to free any heap memory it owns. This function will not
@@ -315,7 +341,7 @@ union RSAggregateResult AggregateResult_New(size_t cap);
  *
  * The `agg` parameter should have been created with [`AggregateResult_New`].
  */
-void AggregateResult_Free(union RSAggregateResult agg);
+void AggregateResult_Free(RSAggregateResult agg);
 
 /**
  * Add a child to a result if it is an aggregate result.
@@ -336,7 +362,7 @@ void AggregateResult_Free(union RSAggregateResult agg);
  * - `parent` must point to a valid `RSIndexResult` and cannot be NULL.
  * - `child` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-void AggregateResult_AddChild(struct RSIndexResult *parent, struct RSIndexResult *child);
+void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child);
 
 /**
  * Get a view of the records stored inside the aggregate result.
@@ -345,7 +371,7 @@ void AggregateResult_AddChild(struct RSIndexResult *parent, struct RSIndexResult
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
-struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const union RSAggregateResult *agg);
+struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const RSAggregateResult *agg);
 
 /**
  * Retrieve the offsets array from an offset vector.
@@ -360,7 +386,7 @@ struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const union RSAggre
  *   and cannot be NULL.
  * - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
  */
-const char *RSOffsetVector_GetData(const struct RSOffsetVector *offsets, uint32_t *len);
+const char *RSOffsetVector_GetData(const RSOffsetSlice *offsets, uint32_t *len);
 
 /**
  * Set the offsets array on an offset vector.
@@ -376,7 +402,7 @@ const char *RSOffsetVector_GetData(const struct RSOffsetVector *offsets, uint32_
  * - `data` must point to an array of `len` offsets.
  * - if `data` is NULL then `len` should be 0.
  */
-void RSOffsetVector_SetData(struct RSOffsetVector *offsets, const char *data, uint32_t len);
+void RSOffsetVector_SetData(RSOffsetSlice *offsets, const char *data, uint32_t len);
 
 /**
  * Free the data inside an offset vector.
@@ -404,7 +430,7 @@ void RSOffsetVector_FreeData(RSOffsetVector *offsets);
  *   and cannot be NULL.
  * - `src` data should point to a valid array of `src.len` offsets.
  */
-void RSOffsetVector_CopyData(RSOffsetVector *dest, const struct RSOffsetVector *src);
+void RSOffsetVector_CopyData(RSOffsetVector *dest, const RSOffsetSlice *src);
 
 /**
  * Retrieve the number of offsets in an offset vector.
@@ -415,7 +441,7 @@ void RSOffsetVector_CopyData(RSOffsetVector *dest, const struct RSOffsetVector *
  * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
  *   and cannot be NULL.
  */
-uint32_t RSOffsetVector_Len(const struct RSOffsetVector *offsets);
+uint32_t RSOffsetVector_Len(const RSOffsetSlice *offsets);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/index_result/Cargo.toml
+++ b/src/redisearch_rs/index_result/Cargo.toml
@@ -11,6 +11,7 @@ enumflags2.workspace = true
 ffi.workspace = true
 rqe_core.workspace = true
 query_term.workspace = true
+ref_mode.workspace = true
 thin_vec.workspace = true
 varint.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -7,9 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use ref_mode::{Active, Ref, SharedPtr};
 use thin_vec::SmallThinVec;
 
-use super::core::RSIndexResult;
+use super::core::{RSIndexResult, RawIndexResult};
 use super::kind::RSResultKindMask;
 
 /// Represents an aggregate array of values in an index record.
@@ -19,24 +20,21 @@ use super::kind::RSResultKindMask;
 /// the `ThinVec` which needs to exist in Rust's memory space to ensure its memory is
 /// managed correctly.
 #[cheadergen::config(prefix_with_name)]
+#[derive(Debug)]
 #[repr(u8)]
-#[derive(Debug, PartialEq)]
-pub enum RSAggregateResult<'index> {
+pub enum RawAggregateResult<R: Ref> {
     Borrowed {
         /// The records making up this aggregate result
         ///
-        /// The `RSAggregateResult` is part of a union in [`super::result_data::RSResultData`], so it needs to have a
-        /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
-        /// own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
+        /// The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so
+        /// it needs to have a known size. The std `Vec` won't have this since it is not
+        /// `#[repr(C)]`, so we use our own `ThinVec` type which is `#[repr(C)]` and has a known
+        /// size instead.
         ///
-        /// This requires `'index` on the reference because adding a new lifetime will cause the
-        /// type to be `ThinVec<&'refs RSIndexResult<'index, 'refs>>` which will require
-        /// `'index: 'refs` else it would mean the `'index` can be cleaned up while some reference
-        /// will still try to access it (ie a dangling pointer). Now the decoders will never return
-        /// any aggregate results so `'refs == 'static` when decoding. Because of the requirement
-        /// above, this means `'index: 'static` which is just incorrect since the index data will
-        /// never be `'static` when decoding.
-        records: SmallThinVec<&'index RSIndexResult<'index>>,
+        /// Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
+        /// equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
+        /// an inert raw pointer that survives lock release/reacquire cycles.
+        records: SmallThinVec<SharedPtr<R, RawIndexResult<R>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -44,17 +42,56 @@ pub enum RSAggregateResult<'index> {
     Owned {
         /// The records making up this aggregate result
         ///
-        /// The `RSAggregateResult` is part of a union in [`super::result_data::RSResultData`], so it needs to have a
+        /// The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so it needs to have a
         /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
         /// own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
-        records: SmallThinVec<Box<RSIndexResult<'index>>>,
+        records: SmallThinVec<Box<RawIndexResult<R>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
     },
 }
 
-impl<'index> RSAggregateResult<'index> {
+/// The [`Active`] instantiation of [`RawAggregateResult`].
+#[cheadergen::config(export)]
+pub type RSAggregateResult<'a> = RawAggregateResult<Active<'a>>;
+
+// Manual (rather than derived) because the `Borrowed` variant stores
+// `SharedPtr<R, RawIndexResult<R>>`, which only implements `PartialEq` in `Active`
+// mode. Restricted to the `Active` alias accordingly.
+impl<'a> PartialEq for RSAggregateResult<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Borrowed {
+                    records: a,
+                    kind_mask: ma,
+                },
+                Self::Borrowed {
+                    records: b,
+                    kind_mask: mb,
+                },
+            ) => {
+                ma == mb
+                    && a.len() == b.len()
+                    && a.iter().zip(b.iter()).all(|(x, y)| x.get() == y.get())
+            }
+            (
+                Self::Owned {
+                    records: a,
+                    kind_mask: ma,
+                },
+                Self::Owned {
+                    records: b,
+                    kind_mask: mb,
+                },
+            ) => ma == mb && a == b,
+            _ => false,
+        }
+    }
+}
+
+impl<R: Ref> RawAggregateResult<R> {
     /// Create a new empty aggregate result (of the borrowed kind) with the given capacity
     pub fn borrowed_with_capacity(cap: usize) -> Self {
         Self::Borrowed {
@@ -74,37 +111,55 @@ impl<'index> RSAggregateResult<'index> {
     /// The number of results in this aggregate result
     pub fn len(&self) -> usize {
         match self {
-            RSAggregateResult::Borrowed { records, .. } => records.len(),
-            RSAggregateResult::Owned { records, .. } => records.len(),
+            Self::Borrowed { records, .. } => records.len(),
+            Self::Owned { records, .. } => records.len(),
         }
     }
 
     /// Check whether this aggregate result is empty
     pub fn is_empty(&self) -> bool {
         match self {
-            RSAggregateResult::Borrowed { records, .. } => records.is_empty(),
-            RSAggregateResult::Owned { records, .. } => records.is_empty(),
+            Self::Borrowed { records, .. } => records.is_empty(),
+            Self::Owned { records, .. } => records.is_empty(),
         }
     }
 
     /// The capacity of the aggregate result
     pub fn capacity(&self) -> usize {
         match self {
-            RSAggregateResult::Borrowed { records, .. } => records.capacity(),
-            RSAggregateResult::Owned { records, .. } => records.capacity(),
+            Self::Borrowed { records, .. } => records.capacity(),
+            Self::Owned { records, .. } => records.capacity(),
         }
     }
 
     /// The current type mask of the aggregate result
     pub const fn kind_mask(&self) -> RSResultKindMask {
         match self {
-            RSAggregateResult::Borrowed { kind_mask, .. } => *kind_mask,
-            RSAggregateResult::Owned { kind_mask, .. } => *kind_mask,
+            Self::Borrowed { kind_mask, .. } => *kind_mask,
+            Self::Owned { kind_mask, .. } => *kind_mask,
         }
     }
 
+    /// Reset the aggregate result, clearing the children vector and resetting the kind mask.
+    pub fn reset(&mut self) {
+        match self {
+            Self::Borrowed {
+                records, kind_mask, ..
+            } => {
+                records.clear();
+                *kind_mask = RSResultKindMask::empty();
+            }
+            Self::Owned { records, kind_mask } => {
+                records.clear();
+                *kind_mask = RSResultKindMask::empty();
+            }
+        }
+    }
+}
+
+impl<'a> RSAggregateResult<'a> {
     /// Get an iterator over the children of this aggregate result
-    pub const fn iter(&'index self) -> RSAggregateResultIter<'index> {
+    pub const fn iter(&'a self) -> RSAggregateResultIter<'a> {
         RSAggregateResultIter {
             agg: self,
             index: 0,
@@ -112,10 +167,10 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// Get the child at the given index, if it exists.
-    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'index>> {
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a>> {
         match self {
-            RSAggregateResult::Borrowed { records, .. } => records.get(index).copied(),
-            RSAggregateResult::Owned { records, .. } => records.get(index).map(AsRef::as_ref),
+            Self::Borrowed { records, .. } => records.get(index).map(|p| p.get()),
+            Self::Owned { records, .. } => records.get(index).map(AsRef::as_ref),
         }
     }
 
@@ -124,9 +179,19 @@ impl<'index> RSAggregateResult<'index> {
     /// # Safety
     ///
     /// 1. The index must be within the bounds of the children vector.
-    pub unsafe fn get_unchecked(&self, index: usize) -> &RSIndexResult<'index> {
+    pub unsafe fn get_unchecked(&self, index: usize) -> &RSIndexResult<'a> {
         match self {
-            RSAggregateResult::Borrowed { records, .. } => {
+            Self::Borrowed { records, .. } => {
+                debug_assert!(
+                    index < records.len(),
+                    "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
+                    records.len()
+                );
+                // SAFETY:
+                // - Thanks to precondition 1., we know that the index is within bounds.
+                unsafe { records.get_unchecked(index) }.get()
+            }
+            Self::Owned { records, .. } => {
                 debug_assert!(
                     index < records.len(),
                     "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
@@ -135,32 +200,6 @@ impl<'index> RSAggregateResult<'index> {
                 // SAFETY:
                 // - Thanks to precondition 1., we know that the index is within bounds.
                 unsafe { records.get_unchecked(index) }
-            }
-            RSAggregateResult::Owned { records, .. } => {
-                debug_assert!(
-                    index < records.len(),
-                    "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
-                    records.len()
-                );
-                // SAFETY:
-                // - Thanks to precondition 1., we know that the index is within bounds.
-                unsafe { records.get_unchecked(index) }
-            }
-        }
-    }
-
-    /// Reset the aggregate result, clearing the children vector and resetting the kind mask.
-    pub fn reset(&mut self) {
-        match self {
-            RSAggregateResult::Borrowed {
-                records, kind_mask, ..
-            } => {
-                records.clear();
-                *kind_mask = RSResultKindMask::empty();
-            }
-            RSAggregateResult::Owned { records, kind_mask } => {
-                records.clear();
-                *kind_mask = RSResultKindMask::empty();
             }
         }
     }
@@ -170,16 +209,16 @@ impl<'index> RSAggregateResult<'index> {
     /// # Safety
     /// The given `child` has to stay valid for the lifetime of this aggregate result. Else reading
     /// the child with [`Self::get()`] will cause undefined behavior.
-    pub fn push_borrowed(&mut self, child: &'index RSIndexResult<'index>) {
+    pub fn push_borrowed(&mut self, child: &'a RSIndexResult<'a>) {
         match self {
-            RSAggregateResult::Borrowed {
+            Self::Borrowed {
                 records, kind_mask, ..
             } => {
-                records.push(child);
+                records.push(SharedPtr::from_ref(child));
 
                 *kind_mask |= child.kind();
             }
-            RSAggregateResult::Owned { .. } => {
+            Self::Owned { .. } => {
                 panic!("Cannot push a borrowed child to an owned aggregate result");
             }
         }
@@ -189,24 +228,24 @@ impl<'index> RSAggregateResult<'index> {
     ///
     /// The returned aggregate result will have the same lifetime as the original one,
     /// since it may borrow terms from the original result.
-    pub fn to_owned<'a>(&'a self) -> RSAggregateResult<'a> {
+    pub fn to_owned(&'a self) -> RSAggregateResult<'a> {
         match self {
-            RSAggregateResult::Borrowed { records, kind_mask } => {
+            Self::Borrowed { records, kind_mask } => {
                 let mut new_records = SmallThinVec::with_capacity(records.len());
 
                 new_records.extend(
                     records
                         .iter()
-                        .map(|c| RSIndexResult::to_owned(c))
+                        .map(|c| RSIndexResult::to_owned(c.get()))
                         .map(Box::new),
                 );
 
-                RSAggregateResult::Owned {
+                Self::Owned {
                     records: new_records,
                     kind_mask: *kind_mask,
                 }
             }
-            RSAggregateResult::Owned { records, kind_mask } => {
+            Self::Owned { records, kind_mask } => {
                 let mut new_records = SmallThinVec::with_capacity(records.len());
 
                 new_records.extend(
@@ -216,7 +255,7 @@ impl<'index> RSAggregateResult<'index> {
                         .map(Box::new),
                 );
 
-                RSAggregateResult::Owned {
+                Self::Owned {
                     records: new_records,
                     kind_mask: *kind_mask,
                 }
@@ -225,12 +264,12 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// Add a heap owned child to the aggregate result and update the kind mask
-    pub fn push_boxed(&mut self, child: Box<RSIndexResult<'index>>) {
+    pub fn push_boxed(&mut self, child: Box<RSIndexResult<'a>>) {
         match self {
-            RSAggregateResult::Borrowed { .. } => {
+            Self::Borrowed { .. } => {
                 panic!("Cannot push a borrowed child to an owned aggregate result");
             }
-            RSAggregateResult::Owned { records, kind_mask } => {
+            Self::Owned { records, kind_mask } => {
                 *kind_mask |= child.kind();
                 records.push(child);
             }
@@ -238,12 +277,12 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// Get a mutable reference to the child at the given index, if it exists
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut RSIndexResult<'index>> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut RSIndexResult<'a>> {
         match self {
-            RSAggregateResult::Borrowed { .. } => {
+            Self::Borrowed { .. } => {
                 panic!("Cannot get a mutable reference to a borrowed aggregate result");
             }
-            RSAggregateResult::Owned { records, .. } => records.get_mut(index).map(AsMut::as_mut),
+            Self::Owned { records, .. } => records.get_mut(index).map(AsMut::as_mut),
         }
     }
 
@@ -253,9 +292,9 @@ impl<'index> RSAggregateResult<'index> {
     ///
     /// 1. The index must be within the bounds of the children vector.
     /// 2. The aggregate result must be of the `Owned` variant.
-    pub unsafe fn get_mut_unchecked(&mut self, index: usize) -> &mut RSIndexResult<'index> {
+    pub unsafe fn get_mut_unchecked(&mut self, index: usize) -> &mut RSIndexResult<'a> {
         match self {
-            RSAggregateResult::Borrowed { .. } => {
+            Self::Borrowed { .. } => {
                 debug_assert!(
                     false,
                     "Safety violation: trying to get a mutable reference from a borrowed aggregate result"
@@ -263,7 +302,7 @@ impl<'index> RSAggregateResult<'index> {
                 // SAFETY: Thanks to precondition 2., we'll never reach this statement.
                 unsafe { std::hint::unreachable_unchecked() }
             }
-            RSAggregateResult::Owned { records, .. } => {
+            Self::Owned { records, .. } => {
                 debug_assert!(
                     index < records.len(),
                     "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
@@ -277,13 +316,13 @@ impl<'index> RSAggregateResult<'index> {
 }
 
 /// An iterator over the results in an [`RSAggregateResult`].
-pub struct RSAggregateResultIter<'index> {
-    agg: &'index RSAggregateResult<'index>,
+pub struct RSAggregateResultIter<'a> {
+    agg: &'a RSAggregateResult<'a>,
     index: usize,
 }
 
-impl<'index> Iterator for RSAggregateResultIter<'index> {
-    type Item = &'index RSIndexResult<'index>;
+impl<'a> Iterator for RSAggregateResultIter<'a> {
+    type Item = &'a RSIndexResult<'a>;
 
     /// Get the next item in the iterator
     ///

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -13,51 +13,52 @@ use std::ptr;
 
 use ffi::RSDocumentMetadata;
 use query_term::RSQueryTerm;
+use ref_mode::{Active, Ref, SharedPtr};
 use rqe_core::{DocId, FieldMask, RS_FIELDMASK_ALL};
 
-use super::aggregate::RSAggregateResult;
+use super::aggregate::RawAggregateResult;
 use super::kind::RSResultKind;
-use super::metrics::MetricsVec;
-use super::offsets::{RSOffsetSlice, RSOffsetVector};
-use super::result_data::RSResultData;
-use super::term_record::RSTermRecord;
+use super::metrics::{MetricsVec, RawMetricsVec};
+use super::offsets::{RSOffsetVector, RawOffsetSlice};
+use super::result_data::RawResultData;
+use super::term_record::RawTermRecord;
 
-/// Builder for creating [`RSIndexResult`] instances.
+/// Builder for creating [`RawIndexResult`] instances.
 ///
-/// Constructed via `RSIndexResult::build_*` methods. For the
-/// [`RSResultKind::Term`] kind, [`RSIndexResult::build_term`] returns a
-/// specialized [`RSTermResultBuilder`] with additional setters for
+/// Constructed via `RawIndexResult::build_*` methods. For the
+/// [`RSResultKind::Term`] kind, [`RawIndexResult::build_term`] returns a
+/// specialized [`RawTermResultBuilder`] with additional setters for
 /// term-specific fields.
-pub struct RSIndexResultBuilder<'index> {
+pub struct RawIndexResultBuilder<R: Ref> {
     doc_id: DocId,
     field_mask: FieldMask,
     freq: u32,
-    data: RSResultData<'index>,
+    data: RawResultData<R>,
     weight: f64,
 }
 
-/// Specialized builder for creating [`RSIndexResult`] instances of the
+/// Specialized builder for creating [`RawIndexResult`] instances of the
 /// [`RSResultKind::Term`] kind.
 ///
-/// Created via [`RSIndexResult::build_term`]. Use [`Self::borrowed_record`]
+/// Created via [`RawIndexResult::build_term`]. Use [`Self::borrowed_record`]
 /// or [`Self::owned_record`] to set the term record data before calling
 /// [`Self::build`].
-pub struct RSTermResultBuilder<'index> {
+pub struct RawTermResultBuilder<R: Ref> {
     doc_id: DocId,
     field_mask: FieldMask,
     freq: u32,
     weight: f64,
-    record: TermBuilderRecord<'index>,
+    record: TermBuilderRecord<R>,
 }
 
 /// Internal enum holding the term record data for the builder.
-enum TermBuilderRecord<'index> {
+enum TermBuilderRecord<R: Ref> {
     Borrowed {
         term: Option<Box<RSQueryTerm>>,
-        offsets: RSOffsetSlice<'index>,
+        offsets: RawOffsetSlice<R>,
     },
     Owned {
-        term: Option<&'index RSQueryTerm>,
+        term: Option<SharedPtr<R, RSQueryTerm>>,
         offsets: RSOffsetVector,
     },
     FullyOwned {
@@ -66,7 +67,7 @@ enum TermBuilderRecord<'index> {
     },
 }
 
-impl<'index> RSIndexResultBuilder<'index> {
+impl<R: Ref> RawIndexResultBuilder<R> {
     /// Set the document ID of this record
     pub const fn doc_id(mut self, doc_id: DocId) -> Self {
         self.doc_id = doc_id;
@@ -97,7 +98,7 @@ impl<'index> RSIndexResultBuilder<'index> {
             doc_id: 0,
             field_mask: 0,
             freq: 0,
-            data: RSResultData::Virtual,
+            data: RawResultData::Virtual,
             weight: 0.0,
         }
     }
@@ -108,7 +109,7 @@ impl<'index> RSIndexResultBuilder<'index> {
             doc_id: 0,
             field_mask: RS_FIELDMASK_ALL,
             freq: 1,
-            data: RSResultData::Numeric(num),
+            data: RawResultData::Numeric(num),
             weight: 1.0,
         }
     }
@@ -119,7 +120,7 @@ impl<'index> RSIndexResultBuilder<'index> {
             doc_id: 0,
             field_mask: RS_FIELDMASK_ALL,
             freq: 0,
-            data: RSResultData::Metric(0f64),
+            data: RawResultData::Metric(0f64),
             weight: 1.0,
         }
     }
@@ -130,7 +131,7 @@ impl<'index> RSIndexResultBuilder<'index> {
             doc_id: 0,
             field_mask: 0,
             freq: 0,
-            data: RSResultData::Intersection(RSAggregateResult::borrowed_with_capacity(cap)),
+            data: RawResultData::Intersection(RawAggregateResult::borrowed_with_capacity(cap)),
             weight: 0.0,
         }
     }
@@ -141,7 +142,7 @@ impl<'index> RSIndexResultBuilder<'index> {
             doc_id: 0,
             field_mask: 0,
             freq: 0,
-            data: RSResultData::Union(RSAggregateResult::borrowed_with_capacity(cap)),
+            data: RawResultData::Union(RawAggregateResult::borrowed_with_capacity(cap)),
             weight: 0.0,
         }
     }
@@ -152,27 +153,27 @@ impl<'index> RSIndexResultBuilder<'index> {
             doc_id: 0,
             field_mask: 0,
             freq: 0,
-            data: RSResultData::HybridMetric(RSAggregateResult::owned_with_capacity(2)),
+            data: RawResultData::HybridMetric(RawAggregateResult::owned_with_capacity(2)),
             weight: 1.0,
         }
     }
 
-    /// Build the final [`RSIndexResult`]
+    /// Build the final [`RawIndexResult`]
     #[inline]
-    pub fn build(self) -> RSIndexResult<'index> {
-        RSIndexResult {
+    pub fn build(self) -> RawIndexResult<R> {
+        RawIndexResult {
             doc_id: self.doc_id,
             dmd: ptr::null(),
             field_mask: self.field_mask,
             freq: self.freq,
             data: self.data,
-            metrics: MetricsVec::new(),
+            metrics: RawMetricsVec::new(),
             weight: self.weight,
         }
     }
 }
 
-impl<'index> RSTermResultBuilder<'index> {
+impl<R: Ref> RawTermResultBuilder<R> {
     /// Create a new term result builder
     const fn new() -> Self {
         Self {
@@ -182,7 +183,7 @@ impl<'index> RSTermResultBuilder<'index> {
             weight: 0.0,
             record: TermBuilderRecord::Borrowed {
                 term: None,
-                offsets: RSOffsetSlice::empty(),
+                offsets: RawOffsetSlice::empty(),
             },
         }
     }
@@ -213,12 +214,12 @@ impl<'index> RSTermResultBuilder<'index> {
 
     /// Set the term record data with borrowed offsets and an optional query term.
     ///
-    /// Produces an [`RSTermRecord::Borrowed`] variant.
+    /// Produces an [`RawTermRecord::Borrowed`] variant.
     #[inline]
     pub fn borrowed_record(
         mut self,
         term: Option<Box<RSQueryTerm>>,
-        offsets: RSOffsetSlice<'index>,
+        offsets: RawOffsetSlice<R>,
     ) -> Self {
         self.record = TermBuilderRecord::Borrowed { term, offsets };
         self
@@ -226,12 +227,12 @@ impl<'index> RSTermResultBuilder<'index> {
 
     /// Set the term record data with owned offsets and an optional borrowed query term.
     ///
-    /// Produces an [`RSTermRecord::Owned`] variant. Use this when the offset
+    /// Produces an [`RawTermRecord::Owned`] variant. Use this when the offset
     /// data does not live long enough to be borrowed by the result.
     #[inline]
     pub fn owned_record(
         mut self,
-        term: Option<&'index RSQueryTerm>,
+        term: Option<SharedPtr<R, RSQueryTerm>>,
         offsets: RSOffsetVector,
     ) -> Self {
         self.record = TermBuilderRecord::Owned { term, offsets };
@@ -241,7 +242,7 @@ impl<'index> RSTermResultBuilder<'index> {
     /// Set the term record data with an owned query term (wrapped in a
     /// [`Box`]) and owned offsets.
     ///
-    /// Produces an [`RSTermRecord::FullyOwned`] variant. Use this when the
+    /// Produces an [`RawTermRecord::FullyOwned`] variant. Use this when the
     /// offsets do not live long enough to be borrowed by the result, but the
     /// caller still wants the record to own the query term (as with
     /// [`Self::borrowed_record`]). This is the right choice for readers that
@@ -256,37 +257,43 @@ impl<'index> RSTermResultBuilder<'index> {
         self
     }
 
-    /// Build the final [`RSIndexResult`]
+    /// Build the final [`RawIndexResult`]
     #[inline]
-    pub fn build(self) -> RSIndexResult<'index> {
+    pub fn build(self) -> RawIndexResult<R> {
         let data = match self.record {
             TermBuilderRecord::Borrowed { term, offsets } => {
-                RSResultData::Term(RSTermRecord::Borrowed { term, offsets })
+                RawResultData::Term(RawTermRecord::Borrowed { term, offsets })
             }
             TermBuilderRecord::Owned { term, offsets } => {
-                RSResultData::Term(RSTermRecord::Owned { term, offsets })
+                RawResultData::Term(RawTermRecord::Owned { term, offsets })
             }
             TermBuilderRecord::FullyOwned { term, offsets } => {
-                RSResultData::Term(RSTermRecord::FullyOwned { term, offsets })
+                RawResultData::Term(RawTermRecord::FullyOwned { term, offsets })
             }
         };
-        RSIndexResult {
+        RawIndexResult {
             doc_id: self.doc_id,
             dmd: ptr::null(),
             field_mask: self.field_mask,
             freq: self.freq,
             data,
-            metrics: MetricsVec::new(),
+            metrics: RawMetricsVec::new(),
             weight: self.weight,
         }
     }
 }
 
 /// The result of an inverted index
+///
+/// The `R: Ref` parameter selects between [`Active<'index>`] mode (the
+/// data references inside this result are valid for `'index` and the
+/// inverted index read lock is held) and [`ref_mode::Suspended`] mode
+/// (the data references are inert raw pointers that survive lock
+/// release/reacquire cycles).
+#[cheadergen::config(rename_all = "camelCase")]
+#[derive(Debug)]
 #[repr(C)]
-#[derive(Debug, PartialEq)]
-#[cheadergen::config(export, rename_all = "camelCase")]
-pub struct RSIndexResult<'index> {
+pub struct RawIndexResult<R: Ref> {
     /// The document ID of the result
     pub doc_id: DocId,
 
@@ -300,48 +307,100 @@ pub struct RSIndexResult<'index> {
     pub freq: u32,
 
     /// The actual data of the result
-    data: RSResultData<'index>,
+    pub(super) data: RawResultData<R>,
 
     /// Holds an array of metrics yielded by the different iterators in the AST.
     ///
     /// Backed by [`ThinVec`](thin_vec::ThinVec) — pointer-sized, no
     /// allocation when empty.
-    pub metrics: MetricsVec<'index>,
+    pub metrics: RawMetricsVec<R>,
 
     /// Relative weight for scoring calculations. This is derived from the result's iterator weight
     pub weight: f64,
 }
 
-impl Default for RSIndexResult<'_> {
+/// The [`Active`] instantiation of [`RawIndexResult`].
+///
+/// This is the only mode that crosses the C boundary today; the suspended
+/// counterpart is forthcoming.
+#[cheadergen::config(export)]
+pub type RSIndexResult<'a> = RawIndexResult<Active<'a>>;
+
+impl<'a> PartialEq for RSIndexResult<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            doc_id,
+            dmd,
+            field_mask,
+            freq,
+            data,
+            metrics,
+            weight,
+        } = self;
+        let Self {
+            doc_id: o_doc_id,
+            dmd: o_dmd,
+            field_mask: o_field_mask,
+            freq: o_freq,
+            data: o_data,
+            metrics: o_metrics,
+            weight: o_weight,
+        } = other;
+        doc_id == o_doc_id
+            && dmd == o_dmd
+            && field_mask == o_field_mask
+            && freq == o_freq
+            && data == o_data
+            && metrics == o_metrics
+            && weight == o_weight
+    }
+}
+
+impl<'a> Default for RSIndexResult<'a> {
     fn default() -> Self {
         Self::build_virt().build()
     }
 }
 
-impl<'index> RSIndexResult<'index> {
+impl<R: Ref> RawIndexResult<R> {
     /// Create a builder for a virtual index result
-    pub const fn build_virt() -> RSIndexResultBuilder<'index> {
-        RSIndexResultBuilder::virt()
+    pub const fn build_virt() -> RawIndexResultBuilder<R> {
+        RawIndexResultBuilder::virt()
     }
 
     /// Create a builder for a numeric index result with the given number
-    pub const fn build_numeric(num: f64) -> RSIndexResultBuilder<'index> {
-        RSIndexResultBuilder::numeric(num)
+    pub const fn build_numeric(num: f64) -> RawIndexResultBuilder<R> {
+        RawIndexResultBuilder::numeric(num)
     }
 
     /// Create a builder for a metric index result
-    pub const fn build_metric() -> RSIndexResultBuilder<'index> {
-        RSIndexResultBuilder::metric()
+    pub const fn build_metric() -> RawIndexResultBuilder<R> {
+        RawIndexResultBuilder::metric()
     }
 
     /// Create a builder for an intersection index result with the given capacity
-    pub fn build_intersect(cap: usize) -> RSIndexResultBuilder<'index> {
-        RSIndexResultBuilder::intersect(cap)
+    pub fn build_intersect(cap: usize) -> RawIndexResultBuilder<R> {
+        RawIndexResultBuilder::intersect(cap)
     }
 
     /// Create a builder for a union index result with the given capacity
-    pub fn build_union(cap: usize) -> RSIndexResultBuilder<'index> {
-        RSIndexResultBuilder::union(cap)
+    pub fn build_union(cap: usize) -> RawIndexResultBuilder<R> {
+        RawIndexResultBuilder::union(cap)
+    }
+
+    /// Create a builder for a hybrid metric index result
+    pub fn build_hybrid_metric() -> RawIndexResultBuilder<R> {
+        RawIndexResultBuilder::hybrid_metric()
+    }
+
+    /// Create a specialized builder for a term index result
+    pub const fn build_term() -> RawTermResultBuilder<R> {
+        RawTermResultBuilder::new()
+    }
+
+    /// Get the kind of this index result
+    pub const fn kind(&self) -> RSResultKind {
+        self.data.kind()
     }
 
     /// Reset an aggregate result for reuse, clearing children, frequency,
@@ -350,25 +409,16 @@ impl<'index> RSIndexResult<'index> {
         self.doc_id = 0;
         self.freq = 0;
         self.field_mask = 0;
-        if let Some(agg) = self.as_aggregate_mut() {
-            agg.reset();
+        match &mut self.data {
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => agg.reset(),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => {}
         }
         self.metrics.reset();
-    }
-
-    /// Create a builder for a hybrid metric index result
-    pub fn build_hybrid_metric() -> RSIndexResultBuilder<'index> {
-        RSIndexResultBuilder::hybrid_metric()
-    }
-
-    /// Create a specialized builder for a term index result
-    pub const fn build_term() -> RSTermResultBuilder<'index> {
-        RSTermResultBuilder::new()
-    }
-
-    /// Get the kind of this index result
-    pub const fn kind(&self) -> RSResultKind {
-        self.data.kind()
     }
 
     /// Get the numeric value of this record without checking its kind. The caller must ensure
@@ -380,18 +430,18 @@ impl<'index> RSIndexResult<'index> {
     pub unsafe fn as_numeric_unchecked(&self) -> f64 {
         debug_assert!(
             self.is_numeric(),
-            "Invariant violation: `as_numeric_unchecked` was invoked on a non-numeric `RSIndexResult` \
+            "Invariant violation: `as_numeric_unchecked` was invoked on a non-numeric `RawIndexResult` \
              instance that didn't actually contain a numeric. It was a {}",
             self.kind()
         );
 
         match &self.data {
-            RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => *numeric,
-            RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::HybridMetric(_) => {
+            RawResultData::Numeric(numeric) | RawResultData::Metric(numeric) => *numeric,
+            RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::HybridMetric(_) => {
                 // SAFETY: unreachable because of safety condition 1
                 unsafe { std::hint::unreachable_unchecked() }
             }
@@ -408,18 +458,18 @@ impl<'index> RSIndexResult<'index> {
     pub unsafe fn as_numeric_unchecked_mut(&mut self) -> &mut f64 {
         debug_assert!(
             self.is_numeric(),
-            "Invariant violation: `as_numeric_unchecked_mut` was invoked on a non-numeric `RSIndexResult` \
+            "Invariant violation: `as_numeric_unchecked_mut` was invoked on a non-numeric `RawIndexResult` \
              instance that didn't actually contain a numeric. It was a {}",
             self.kind()
         );
 
         match &mut self.data {
-            RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => numeric,
-            RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::HybridMetric(_) => {
+            RawResultData::Numeric(numeric) | RawResultData::Metric(numeric) => numeric,
+            RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::HybridMetric(_) => {
                 // SAFETY: unreachable because of safety condition 1
                 unsafe { std::hint::unreachable_unchecked() }
             }
@@ -430,12 +480,12 @@ impl<'index> RSIndexResult<'index> {
     /// `None`.
     pub const fn as_numeric(&self) -> Option<f64> {
         match &self.data {
-            RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => Some(*numeric),
-            RSResultData::HybridMetric(_)
-            | RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Term(_)
-            | RSResultData::Virtual => None,
+            RawResultData::Numeric(numeric) | RawResultData::Metric(numeric) => Some(*numeric),
+            RawResultData::HybridMetric(_)
+            | RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Term(_)
+            | RawResultData::Virtual => None,
         }
     }
 
@@ -443,12 +493,12 @@ impl<'index> RSIndexResult<'index> {
     /// returns `None`.
     pub const fn as_numeric_mut(&mut self) -> Option<&mut f64> {
         match &mut self.data {
-            RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => Some(numeric),
-            RSResultData::HybridMetric(_)
-            | RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Term(_)
-            | RSResultData::Virtual => None,
+            RawResultData::Numeric(numeric) | RawResultData::Metric(numeric) => Some(numeric),
+            RawResultData::HybridMetric(_)
+            | RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Term(_)
+            | RawResultData::Virtual => None,
         }
     }
 
@@ -459,22 +509,22 @@ impl<'index> RSIndexResult<'index> {
     /// # Safety
     ///
     /// 1. `Self::is_term()` must return `true` for `self`.
-    pub unsafe fn as_term_unchecked_mut(&mut self) -> &mut RSTermRecord<'index> {
+    pub unsafe fn as_term_unchecked_mut(&mut self) -> &mut RawTermRecord<R> {
         debug_assert!(
             self.is_term(),
-            "Invariant violation: `as_term_unchecked_mut` was invoked on a non-term `RSIndexResult` \
+            "Invariant violation: `as_term_unchecked_mut` was invoked on a non-term `RawIndexResult` \
              instance that didn't actually contain a term. It was a {}",
             self.kind()
         );
 
         match &mut self.data {
-            RSResultData::Term(term) => term,
-            RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_)
-            | RSResultData::HybridMetric(_) => {
+            RawResultData::Term(term) => term,
+            RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_)
+            | RawResultData::HybridMetric(_) => {
                 // SAFETY: unreachable because of safety condition 1
                 unsafe { std::hint::unreachable_unchecked() }
             }
@@ -483,29 +533,29 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as a term record if possible. If the record is not term, returns
     /// `None`.
-    pub const fn as_term(&self) -> Option<&RSTermRecord<'index>> {
+    pub const fn as_term(&self) -> Option<&RawTermRecord<R>> {
         match &self.data {
-            RSResultData::Term(term) => Some(term),
-            RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_)
-            | RSResultData::HybridMetric(_) => None,
+            RawResultData::Term(term) => Some(term),
+            RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_)
+            | RawResultData::HybridMetric(_) => None,
         }
     }
 
     /// Get this record as a mutable term record if possible. If the record is not term, returns
     /// `None`.
-    pub const fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'index>> {
+    pub const fn as_term_mut(&mut self) -> Option<&mut RawTermRecord<R>> {
         match &mut self.data {
-            RSResultData::Term(term) => Some(term),
-            RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_)
-            | RSResultData::HybridMetric(_) => None,
+            RawResultData::Term(term) => Some(term),
+            RawResultData::Union(_)
+            | RawResultData::Intersection(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_)
+            | RawResultData::HybridMetric(_) => None,
         }
     }
 
@@ -515,7 +565,7 @@ impl<'index> RSIndexResult<'index> {
     /// # Safety
     ///
     /// 1. `Self::is_aggregate` must return `true` for `self`.
-    pub unsafe fn as_aggregate_unchecked(&self) -> Option<&RSAggregateResult<'index>> {
+    pub unsafe fn as_aggregate_unchecked(&self) -> Option<&RawAggregateResult<R>> {
         debug_assert!(
             self.is_aggregate(),
             "Invariant violation: `as_aggregate_unchecked` was invoked on an `IndexResult` \
@@ -523,13 +573,13 @@ impl<'index> RSIndexResult<'index> {
             self.kind()
         );
         match &self.data {
-            RSResultData::Union(agg)
-            | RSResultData::Intersection(agg)
-            | RSResultData::HybridMetric(agg) => Some(agg),
-            RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => {
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => Some(agg),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => {
                 // SAFETY:
                 // - Thanks to safety precondition 1., we'll never reach this statement.
                 unsafe { std::hint::unreachable_unchecked() }
@@ -539,29 +589,29 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as an aggregate result if possible. If the record is not an aggregate,
     /// returns `None`.
-    pub const fn as_aggregate(&self) -> Option<&RSAggregateResult<'index>> {
+    pub const fn as_aggregate(&self) -> Option<&RawAggregateResult<R>> {
         match &self.data {
-            RSResultData::Union(agg)
-            | RSResultData::Intersection(agg)
-            | RSResultData::HybridMetric(agg) => Some(agg),
-            RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => None,
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => Some(agg),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => None,
         }
     }
 
     /// Get this record as a mutable aggregate result if possible. If the record is not an
     /// aggregate, returns `None`.
-    pub const fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'index>> {
+    pub const fn as_aggregate_mut(&mut self) -> Option<&mut RawAggregateResult<R>> {
         match &mut self.data {
-            RSResultData::Union(agg)
-            | RSResultData::Intersection(agg)
-            | RSResultData::HybridMetric(agg) => Some(agg),
-            RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => None,
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => Some(agg),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => None,
         }
     }
 
@@ -571,7 +621,7 @@ impl<'index> RSIndexResult<'index> {
     /// # Safety
     ///
     /// 1. `Self::is_aggregate` must return `true` for `self`.
-    pub unsafe fn as_aggregate_mut_unchecked(&mut self) -> Option<&mut RSAggregateResult<'index>> {
+    pub unsafe fn as_aggregate_mut_unchecked(&mut self) -> Option<&mut RawAggregateResult<R>> {
         debug_assert!(
             self.is_aggregate(),
             "Invariant violation: `as_aggregate_mut_unchecked` was invoked on an `IndexResult` \
@@ -579,13 +629,13 @@ impl<'index> RSIndexResult<'index> {
             self.kind()
         );
         match &mut self.data {
-            RSResultData::Union(agg)
-            | RSResultData::Intersection(agg)
-            | RSResultData::HybridMetric(agg) => Some(agg),
-            RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => {
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => Some(agg),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => {
                 // SAFETY:
                 // - Thanks to safety precondition 1., we'll never reach this statement.
                 unsafe { std::hint::unreachable_unchecked() }
@@ -597,7 +647,9 @@ impl<'index> RSIndexResult<'index> {
     pub const fn is_aggregate(&self) -> bool {
         matches!(
             self.data,
-            RSResultData::Intersection(_) | RSResultData::Union(_) | RSResultData::HybridMetric(_)
+            RawResultData::Intersection(_)
+                | RawResultData::Union(_)
+                | RawResultData::HybridMetric(_)
         )
     }
 
@@ -605,15 +657,45 @@ impl<'index> RSIndexResult<'index> {
     const fn is_numeric(&self) -> bool {
         matches!(
             self.data,
-            RSResultData::Numeric(_) | RSResultData::Metric(_)
+            RawResultData::Numeric(_) | RawResultData::Metric(_)
         )
     }
 
     /// True if this is a term kind
     pub const fn is_term(&self) -> bool {
-        matches!(self.data, RSResultData::Term(_))
+        matches!(self.data, RawResultData::Term(_))
     }
 
+    /// Returns a mutable reference to the metrics collection.
+    pub const fn metrics_mut(&mut self) -> &mut RawMetricsVec<R> {
+        &mut self.metrics
+    }
+
+    /// Returns a reference to the metrics collection.
+    pub const fn metrics_ref(&self) -> &RawMetricsVec<R> {
+        &self.metrics
+    }
+
+    /// Is this result some copy type
+    pub const fn is_copy(&self) -> bool {
+        match self.data {
+            RawResultData::Union(RawAggregateResult::Owned { .. })
+            | RawResultData::Intersection(RawAggregateResult::Owned { .. })
+            | RawResultData::HybridMetric(RawAggregateResult::Owned { .. })
+            | RawResultData::Term(RawTermRecord::Owned { .. })
+            | RawResultData::Term(RawTermRecord::FullyOwned { .. }) => true,
+            RawResultData::Union(RawAggregateResult::Borrowed { .. })
+            | RawResultData::Intersection(RawAggregateResult::Borrowed { .. })
+            | RawResultData::HybridMetric(RawAggregateResult::Borrowed { .. })
+            | RawResultData::Term(RawTermRecord::Borrowed { .. })
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => false,
+        }
+    }
+}
+
+impl<'a> RSIndexResult<'a> {
     /// Returns `true` when the term positions in this result satisfy the given
     /// proximity constraints.
     ///
@@ -643,24 +725,6 @@ impl<'index> RSIndexResult<'index> {
         debug_assert_eq!(self.data, other.data);
     }
 
-    /// Is this result some copy type
-    pub const fn is_copy(&self) -> bool {
-        match self.data {
-            RSResultData::Union(RSAggregateResult::Owned { .. })
-            | RSResultData::Intersection(RSAggregateResult::Owned { .. })
-            | RSResultData::HybridMetric(RSAggregateResult::Owned { .. })
-            | RSResultData::Term(RSTermRecord::Owned { .. })
-            | RSResultData::Term(RSTermRecord::FullyOwned { .. }) => true,
-            RSResultData::Union(RSAggregateResult::Borrowed { .. })
-            | RSResultData::Intersection(RSAggregateResult::Borrowed { .. })
-            | RSResultData::HybridMetric(RSAggregateResult::Borrowed { .. })
-            | RSResultData::Term(RSTermRecord::Borrowed { .. })
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => false,
-        }
-    }
-
     /// If this is an aggregate result, then add a child to it. Also updates the following of this
     /// record:
     /// - `doc_id` is set to the child's doc_id (inherits, not accumulated)
@@ -680,8 +744,8 @@ impl<'index> RSIndexResult<'index> {
     /// from this result will cause undefined behaviour.
     pub fn push_borrowed(
         &mut self,
-        child: &'index RSIndexResult<'index>,
-        mut child_metrics: MetricsVec<'index>,
+        child: &'a RSIndexResult<'a>,
+        mut child_metrics: MetricsVec<'a>,
     ) {
         debug_assert!(
             child.metrics.is_empty(),
@@ -706,23 +770,23 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get a child at the given index if this is an aggregate record. Returns `None` if this is not
     /// an aggregate record or if the index is out-of-bounds.
-    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'index>> {
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a>> {
         match &self.data {
-            RSResultData::Union(agg)
-            | RSResultData::Intersection(agg)
-            | RSResultData::HybridMetric(agg) => agg.get(index),
-            RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => None,
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => agg.get(index),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => None,
         }
     }
 
     /// Create an owned copy of this index result, allocating new memory for the contained data.
     ///
     /// The returned result may borrow the term data from the original result.
-    pub fn to_owned<'a>(&'a self) -> RSIndexResult<'a> {
-        RSIndexResult {
+    pub fn to_owned(&'a self) -> RSIndexResult<'a> {
+        RawIndexResult {
             doc_id: self.doc_id,
             dmd: self.dmd,
             field_mask: self.field_mask,
@@ -742,7 +806,7 @@ impl<'index> RSIndexResult<'index> {
     ///
     /// If this is not an aggregate result, then nothing happens. Use [`Self::is_aggregate()`] first
     /// to make sure this is an aggregate result.
-    pub fn push_boxed(&mut self, mut child: Box<RSIndexResult<'index>>) {
+    pub fn push_boxed(&mut self, mut child: Box<RSIndexResult<'a>>) {
         if !self.is_aggregate() {
             return;
         }
@@ -761,27 +825,17 @@ impl<'index> RSIndexResult<'index> {
         }
     }
 
-    /// Returns a mutable reference to the metrics collection.
-    pub const fn metrics_mut(&mut self) -> &mut MetricsVec<'index> {
-        &mut self.metrics
-    }
-
-    /// Returns a reference to the metrics collection.
-    pub const fn metrics_ref(&self) -> &MetricsVec<'index> {
-        &self.metrics
-    }
-
     /// Get a mutable reference to the child at the given index, if it is an aggregate record.
     /// `None` is returned if this is not an aggregate record or if the index is out-of-bounds.
     pub fn get_mut(&mut self, index: usize) -> Option<&mut Self> {
         match &mut self.data {
-            RSResultData::Union(agg)
-            | RSResultData::Intersection(agg)
-            | RSResultData::HybridMetric(agg) => agg.get_mut(index),
-            RSResultData::Term(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_) => None,
+            RawResultData::Union(agg)
+            | RawResultData::Intersection(agg)
+            | RawResultData::HybridMetric(agg) => agg.get_mut(index),
+            RawResultData::Term(_)
+            | RawResultData::Virtual
+            | RawResultData::Numeric(_)
+            | RawResultData::Metric(_) => None,
         }
     }
 }

--- a/src/redisearch_rs/index_result/src/core/proximity.rs
+++ b/src/redisearch_rs/index_result/src/core/proximity.rs
@@ -13,7 +13,7 @@
 use std::io::Cursor;
 
 use super::super::kind::{RSResultKind, RSResultKindMask};
-use super::super::result_data::RSResultData;
+use super::super::result_data::RawResultData;
 use super::RSIndexResult;
 
 /// A lazy iterator over the term-position offsets stored inside an [`RSIndexResult`].
@@ -69,10 +69,10 @@ impl OffsetIter<'_> {
 }
 
 /// Returns `true` if `result` contributes meaningful term-position offsets.
-fn has_offsets(result: &RSIndexResult<'_>) -> bool {
+fn has_offsets(result: &RSIndexResult) -> bool {
     match &result.data {
-        RSResultData::Term(rec) => !rec.offsets().is_empty(),
-        RSResultData::Intersection(agg) | RSResultData::Union(agg) => {
+        RawResultData::Term(rec) => !rec.offsets().is_empty(),
+        RawResultData::Intersection(agg) | RawResultData::Union(agg) => {
             // Skip aggregates that consist only of virtual or purely numeric
             // (Numeric | Metric) results, as neither carries offset data.
             let mask = agg.kind_mask();
@@ -80,10 +80,10 @@ fn has_offsets(result: &RSIndexResult<'_>) -> bool {
             let numeric_only: RSResultKindMask = RSResultKind::Numeric | RSResultKind::Metric;
             mask != virtual_only && mask != numeric_only
         }
-        RSResultData::Virtual
-        | RSResultData::Numeric(_)
-        | RSResultData::Metric(_)
-        | RSResultData::HybridMetric(_) => false,
+        RawResultData::Virtual
+        | RawResultData::Numeric(_)
+        | RawResultData::Metric(_)
+        | RawResultData::HybridMetric(_) => false,
     }
 }
 
@@ -93,17 +93,17 @@ fn has_offsets(result: &RSIndexResult<'_>) -> bool {
 /// - Intersection / Union with 1 child → recurse into that child directly.
 /// - Intersection / Union with N children → k-way merge of child iterators.
 /// - Everything else → [`OffsetIter::Empty`].
-fn iterate_offsets<'a>(result: &'a RSIndexResult<'_>) -> OffsetIter<'a> {
+fn iterate_offsets<'a>(result: &'a RSIndexResult) -> OffsetIter<'a> {
     match &result.data {
-        RSResultData::Term(rec) => OffsetIter::Term {
+        RawResultData::Term(rec) => OffsetIter::Term {
             cursor: Cursor::new(rec.offsets()),
             last: 0,
         },
-        RSResultData::Virtual
-        | RSResultData::Numeric(_)
-        | RSResultData::Metric(_)
-        | RSResultData::HybridMetric(_) => OffsetIter::Empty,
-        RSResultData::Intersection(agg) | RSResultData::Union(agg) => {
+        RawResultData::Virtual
+        | RawResultData::Numeric(_)
+        | RawResultData::Metric(_)
+        | RawResultData::HybridMetric(_) => OffsetIter::Empty,
+        RawResultData::Intersection(agg) | RawResultData::Union(agg) => {
             let n = agg.len();
             if n == 1 {
                 // optimisation: single child → delegate directly.
@@ -260,7 +260,7 @@ fn array_max(arr: &[u32]) -> (u32, usize) {
 /// is trivially `true` for every input and the call is pointless; callers are
 /// expected to short-circuit that case before invoking this function.
 pub(super) fn is_within_range<'a>(
-    ir: &'a RSIndexResult<'_>,
+    ir: &'a RSIndexResult,
     max_slop: Option<u32>,
     in_order: bool,
 ) -> bool {
@@ -271,7 +271,7 @@ pub(super) fn is_within_range<'a>(
     );
 
     let agg = match &ir.data {
-        RSResultData::Intersection(agg) | RSResultData::Union(agg) => agg,
+        RawResultData::Intersection(agg) | RawResultData::Union(agg) => agg,
         _ => return true,
     };
 
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn single_child_union_delegates_to_child_iter() {
-        use crate::{RSAggregateResult, RSIndexResult, RSOffsetSlice, RSResultData};
+        use crate::{RSAggregateResult, RSIndexResult, RSOffsetSlice};
         use std::ptr;
 
         // delta bytes [2, 3, 5] → cumulative positions [2, 5, 10]
@@ -491,7 +491,7 @@ mod tests {
             dmd: ptr::null(),
             field_mask: 0,
             freq: 0,
-            data: RSResultData::Union(agg),
+            data: RawResultData::Union(agg),
             metrics: crate::MetricsVec::new(),
             weight: 0.0,
         };

--- a/src/redisearch_rs/index_result/src/lib.rs
+++ b/src/redisearch_rs/index_result/src/lib.rs
@@ -17,10 +17,12 @@ mod term_record;
 
 pub use query_term::RSQueryTerm;
 
-pub use self::core::RSIndexResult;
-pub use aggregate::{RSAggregateResult, RSAggregateResultIter};
+pub use self::core::{RSIndexResult, RawIndexResult, RawIndexResultBuilder, RawTermResultBuilder};
+pub use aggregate::{RSAggregateResult, RSAggregateResultIter, RawAggregateResult};
 pub use kind::{RSResultKind, RSResultKindMask};
-pub use metrics::{MetricEntry, MetricsSlice, MetricsVec};
-pub use offsets::{RSOffsetSlice, RSOffsetVector};
-pub use result_data::RSResultData;
-pub use term_record::RSTermRecord;
+pub use metrics::{
+    MetricEntry, MetricsSlice, MetricsVec, RawMetricEntry, RawMetricsSlice, RawMetricsVec,
+};
+pub use offsets::{RSOffsetSlice, RSOffsetVector, RawOffsetSlice};
+pub use result_data::{RSResultData, RawResultData};
+pub use term_record::{RSTermRecord, RawTermRecord};

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -16,26 +16,47 @@
 //! `MetricsVec` is `repr(transparent)` and can be embedded directly in
 //! `repr(C)` structs like [`super::RSIndexResult`].
 use ffi::RLookupKey;
+use ref_mode::{Active, Ref, SharedPtr};
+use std::ptr;
 use thin_vec::ThinVec;
 
 /// A single metric: a borrowed key and a numeric value.
+///
+/// The `R: Ref` parameter controls how the key reference is stored:
+/// in [`Active<'a>`] mode it is a valid `&'a RLookupKey`, in
+/// [`ref_mode::Suspended`] mode it is an inert raw pointer.
+///
+/// `key` is `Option<SharedPtr<R, RLookupKey>>` so "no key" is encoded as
+/// `None`. `SharedPtr` wraps `NonNull` so the niche optimization keeps the C
+/// ABI as a nullable `RLookupKey *`.
+#[derive(Debug)]
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
-#[cheadergen::config(export)]
-pub struct MetricEntry<'a> {
-    /// Borrowed reference to the lookup key that identifies this metric.
-    /// `None` when the metric has no associated key.
-    pub key: Option<&'a RLookupKey>,
+pub struct RawMetricEntry<R: Ref> {
+    /// Borrowed reference to the lookup key that identifies this metric,
+    /// or `None` when the metric has no associated key.
+    pub key: Option<SharedPtr<R, RLookupKey>>,
 
     /// The metric value (e.g. vector distance, score).
     pub value: f64,
+}
+
+/// The [`Active`] instantiation of [`RawMetricEntry`].
+#[cheadergen::config(export)]
+pub type MetricEntry<'a> = RawMetricEntry<Active<'a>>;
+
+impl<R: Ref> Copy for RawMetricEntry<R> {}
+
+impl<R: Ref> Clone for RawMetricEntry<R> {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl<'a> MetricEntry<'a> {
     /// Creates a metric entry with an associated key.
     pub const fn with_key(key: &'a RLookupKey, value: f64) -> Self {
         Self {
-            key: Some(key),
+            key: Some(SharedPtr::from_ref(key)),
             value,
         }
     }
@@ -47,9 +68,14 @@ impl<'a> MetricEntry<'a> {
 
     /// Returns the key reference, or `None` if the metric has no key.
     pub const fn key(&self) -> Option<&'a RLookupKey> {
-        self.key
+        match self.key {
+            Some(k) => Some(k.get()),
+            None => None,
+        }
     }
+}
 
+impl<R: Ref> RawMetricEntry<R> {
     /// Returns the metric value.
     pub const fn value(&self) -> f64 {
         self.value
@@ -61,12 +87,21 @@ impl<'a> MetricEntry<'a> {
     }
 }
 
-impl PartialEq for MetricEntry<'_> {
+// Manual `PartialEq` (rather than derived) because `RLookupKey` is an opaque
+// FFI type without a `PartialEq` impl, and we want identity-based key
+// comparison anyway: two metric entries refer to "the same key" when their
+// pointers match, regardless of the key's content. Restricted to the
+// `Active` instantiation since [`Suspended`] pointers may be stale.
+impl<'a> PartialEq for MetricEntry<'a> {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(
-            self.key.map_or(std::ptr::null(), |k| k as *const _),
-            other.key.map_or(std::ptr::null(), |k| k as *const _),
-        ) && self.value == other.value
+        let Self { key, value } = self;
+        let Self {
+            key: o_key,
+            value: o_value,
+        } = other;
+        let lhs = key.map_or(ptr::null(), |p| p.as_raw());
+        let rhs = o_key.map_or(ptr::null(), |p| p.as_raw());
+        ptr::eq(lhs, rhs) && value == o_value
     }
 }
 
@@ -77,10 +112,30 @@ impl PartialEq for MetricEntry<'_> {
 ///
 /// `repr(transparent)` over `ThinVec` means this type is pointer-sized
 /// and can be embedded directly in `repr(C)` structs.
+#[derive(Debug)]
 #[repr(transparent)]
-#[derive(Clone, PartialEq, Debug)]
-pub struct MetricsVec<'a> {
-    inner: ThinVec<MetricEntry<'a>>,
+pub struct RawMetricsVec<R: Ref> {
+    inner: ThinVec<RawMetricEntry<R>>,
+}
+
+/// The [`Active`] instantiation of [`RawMetricsVec`].
+pub type MetricsVec<'a> = RawMetricsVec<Active<'a>>;
+
+impl<R: Ref> Clone for RawMetricsVec<R> {
+    fn clone(&self) -> Self {
+        let Self { inner } = self;
+        Self {
+            inner: inner.clone(),
+        }
+    }
+}
+
+impl<'a> PartialEq for MetricsVec<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        let Self { inner } = self;
+        let Self { inner: o_inner } = other;
+        inner.as_slice() == o_inner.as_slice()
+    }
 }
 
 /// A read-only, C-visible slice view over the entries of a [`MetricsVec`].
@@ -89,31 +144,24 @@ pub struct MetricsVec<'a> {
 /// from C. The pointed-to data is valid as long as the originating
 /// [`MetricsVec`] is not mutated or dropped.
 #[repr(C)]
-pub struct MetricsSlice<'a> {
+pub struct RawMetricsSlice<R: Ref> {
     /// Pointer to the first [`MetricEntry`].  May be dangling (but not null)
     /// when `len == 0`.
-    pub data: *const MetricEntry<'a>,
+    pub data: *const RawMetricEntry<R>,
 
     /// Number of entries.
     pub len: usize,
 }
 
-impl<'a> MetricsVec<'a> {
+/// The [`Active`] instantiation of [`RawMetricsSlice`].
+pub type MetricsSlice<'a> = RawMetricsSlice<Active<'a>>;
+
+impl<R: Ref> RawMetricsVec<R> {
     /// Creates an empty metrics collection. Does not allocate.
     pub const fn new() -> Self {
         Self {
             inner: ThinVec::new(),
         }
-    }
-
-    /// Appends a metric entry with an associated key.
-    pub fn push_with_key(&mut self, key: &'a RLookupKey, value: f64) {
-        self.inner.push(MetricEntry::with_key(key, value));
-    }
-
-    /// Appends a metric entry without an associated key.
-    pub fn push_without_key(&mut self, value: f64) {
-        self.inner.push(MetricEntry::without_key(value));
     }
 
     /// Moves all entries from `other` into `self`, leaving `other` empty.
@@ -137,9 +185,9 @@ impl<'a> MetricsVec<'a> {
     }
 
     /// Returns a C-compatible slice view for zero-copy iteration.
-    pub fn as_metrics_slice(&self) -> MetricsSlice<'a> {
+    pub fn as_metrics_slice(&self) -> RawMetricsSlice<R> {
         let slice = self.inner.as_slice();
-        MetricsSlice {
+        RawMetricsSlice {
             data: slice.as_ptr(),
             len: slice.len(),
         }
@@ -147,32 +195,45 @@ impl<'a> MetricsVec<'a> {
 
     /// Returns a reference to the entry at `index`, or `None` if out of
     /// bounds.
-    pub fn get(&self, index: usize) -> Option<&MetricEntry<'a>> {
+    pub fn get(&self, index: usize) -> Option<&RawMetricEntry<R>> {
         self.inner.as_slice().get(index)
     }
 
     /// Returns a mutable reference to the entry at `index`, or `None` if
     /// out of bounds.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut MetricEntry<'a>> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut RawMetricEntry<R>> {
         self.inner.as_mut_slice().get_mut(index)
     }
 
     /// Returns an iterator over the entries.
-    pub fn iter(&self) -> impl Iterator<Item = &MetricEntry<'a>> {
+    pub fn iter(&self) -> impl Iterator<Item = &RawMetricEntry<R>> {
         self.inner.as_slice().iter()
     }
 
     /// Finds the first entry whose key matches `key` (pointer equality)
     /// and returns a mutable reference to it.
-    pub fn find_by_key_mut(&mut self, key: &RLookupKey) -> Option<&mut MetricEntry<'a>> {
+    pub fn find_by_key_mut(&mut self, key: &RLookupKey) -> Option<&mut RawMetricEntry<R>> {
+        let needle = key as *const RLookupKey;
         self.inner
             .as_mut_slice()
             .iter_mut()
-            .find(|e| e.key.is_some_and(|k| std::ptr::eq(k, key)))
+            .find(|e| e.key.is_some_and(|p| ptr::eq(p.as_raw(), needle)))
     }
 }
 
-impl Default for MetricsVec<'_> {
+impl<'a> MetricsVec<'a> {
+    /// Appends a metric entry with an associated key.
+    pub fn push_with_key(&mut self, key: &'a RLookupKey, value: f64) {
+        self.inner.push(MetricEntry::with_key(key, value));
+    }
+
+    /// Appends a metric entry without an associated key.
+    pub fn push_without_key(&mut self, value: f64) {
+        self.inner.push(MetricEntry::without_key(value));
+    }
+}
+
+impl<R: Ref> Default for RawMetricsVec<R> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/redisearch_rs/index_result/src/offsets.rs
+++ b/src/redisearch_rs/index_result/src/offsets.rs
@@ -58,13 +58,25 @@ impl<R: Ref> Debug for RawOffsetSlice<R> {
         let Some(data) = self.data else {
             return write!(f, "RSOffsetSlice(null)");
         };
-        // SAFETY: `len` is guaranteed to be a valid length for the data pointer
-        // when the slice was constructed from a valid `&[u8]` source. Debug
-        // output for `Suspended` instances may be stale; callers must ensure
-        // the underlying memory is still valid before using this impl.
-        let offsets = unsafe { std::slice::from_raw_parts(data.as_raw(), self.len as usize) };
-
-        write!(f, "RSOffsetSlice {offsets:?}")
+        if R::is_active() {
+            // SAFETY: `R::is_active()` returns `true` only for the [`Active`]
+            // instantiation of the sealed [`Ref`] trait. Every constructor of
+            // `RawOffsetSlice<Active<'_>>` (see [`RSOffsetSlice::from_slice`]
+            // and [`RSOffsetVector::as_slice`]) retains slice-wide provenance
+            // for the full `len` bytes and ties them to the carrying
+            // lifetime, so reconstructing a `&[u8]` of that length here is
+            // valid for reads with no aliasing mutable references.
+            let offsets =
+                unsafe { std::slice::from_raw_parts(data.as_raw(), self.len as usize) };
+            write!(f, "RSOffsetSlice {offsets:?}")
+        } else {
+            // Suspended: the pointer may be stale, so we cannot dereference
+            // it. Print the raw address and length instead.
+            f.debug_struct("RSOffsetSlice")
+                .field("data", &data.as_raw())
+                .field("len", &self.len)
+                .finish()
+        }
     }
 }
 

--- a/src/redisearch_rs/index_result/src/offsets.rs
+++ b/src/redisearch_rs/index_result/src/offsets.rs
@@ -7,104 +7,125 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{alloc::Layout, borrow::Borrow, fmt::Debug, marker::PhantomData, ptr};
+use std::{alloc::Layout, borrow::Borrow, fmt::Debug, ptr};
+
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 
 /// Borrowed view of the encoded offsets of a term in a document. You can read the offsets by
 /// iterating over it with RSIndexResult_IterateOffsets.
 ///
 /// This is a borrowed, `Copy` type — it does not own the data and will not free it on drop.
 /// Use [`RSOffsetVector`] for owned offset data.
+///
+/// The `R: Ref` parameter selects between [`Active<'index>`] mode (the data
+/// pointer is a valid `&'index [u8]`) and [`ref_mode::Suspended`] mode (the
+/// data pointer may be stale).
+///
+/// `data` is `Option<SharedPtr<R, u8>>` so the empty slice can be represented
+/// with a null pointer. Thanks to `NonNull`'s niche, the in-memory layout
+/// is still a bare `*const u8` followed by a `u32`.
 #[cheadergen::config(rename = "RSOffsetVector")]
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct RSOffsetSlice<'index> {
-    /// Pointer to the borrowed offset data.
-    pub data: *const u8,
+pub struct RawOffsetSlice<R: Ref> {
+    /// Pointer to the borrowed offset data, or `None` for the empty slice.
+    pub data: Option<SharedPtr<R, u8>>,
     pub len: u32,
-    /// The data pointer does not carry a lifetime, so use a `PhantomData` to track it instead.
-    _phantom: PhantomData<&'index ()>,
 }
 
-impl PartialEq for RSOffsetSlice<'_> {
+/// The [`Active`] instantiation of [`RawOffsetSlice`]: a borrowed view whose data
+/// pointer is a live `&'a [u8]`.
+#[cheadergen::config(export)]
+pub type RSOffsetSlice<'a> = RawOffsetSlice<Active<'a>>;
+
+impl<R: Ref> Copy for RawOffsetSlice<R> {}
+
+impl<R: Ref> Clone for RawOffsetSlice<R> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a> PartialEq for RSOffsetSlice<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.as_bytes() == other.as_bytes()
     }
 }
 
-impl Eq for RSOffsetSlice<'_> {}
+impl<'a> Eq for RSOffsetSlice<'a> {}
 
-impl Debug for RSOffsetSlice<'_> {
+impl<R: Ref> Debug for RawOffsetSlice<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.data.is_null() {
+        let Some(data) = self.data else {
             return write!(f, "RSOffsetSlice(null)");
-        }
-        // SAFETY: `len` is guaranteed to be a valid length for the data pointer.
-        let offsets = unsafe { std::slice::from_raw_parts(self.data, self.len as usize) };
+        };
+        // SAFETY: `len` is guaranteed to be a valid length for the data pointer
+        // when the slice was constructed from a valid `&[u8]` source. Debug
+        // output for `Suspended` instances may be stale; callers must ensure
+        // the underlying memory is still valid before using this impl.
+        let offsets = unsafe { std::slice::from_raw_parts(data.as_raw(), self.len as usize) };
 
         write!(f, "RSOffsetSlice {offsets:?}")
     }
 }
 
-impl AsRef<[u8]> for RSOffsetSlice<'_> {
+impl<'a> AsRef<[u8]> for RSOffsetSlice<'a> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl Borrow<[u8]> for RSOffsetSlice<'_> {
+impl<'a> Borrow<[u8]> for RSOffsetSlice<'a> {
     fn borrow(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'index> RSOffsetSlice<'index> {
+impl<'a> RSOffsetSlice<'a> {
     /// Create an offset slice borrowing from the given byte slice.
     ///
     /// # Panics
     ///
     /// Panics if `bytes.len() > u32::MAX as usize`.
-    pub fn from_slice(bytes: &'index [u8]) -> Self {
+    pub fn from_slice(bytes: &'a [u8]) -> Self {
         assert!(
             bytes.len() <= u32::MAX as usize,
             "offset slice length exceeds u32::MAX"
         );
+        // Match the C ABI of the historic `RSOffsetVector`: empty slices
+        // are represented as `data = null, len = 0`. Non-empty slices
+        // carry a real pointer.
+        let data = if bytes.is_empty() {
+            None
+        } else {
+            Some(SharedPtr::from_ref(&bytes[0]))
+        };
         Self {
-            data: bytes.as_ptr(),
+            data,
             len: bytes.len() as u32,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl RSOffsetSlice<'_> {
-    /// Create a new, empty offset slice.
-    pub const fn empty() -> Self {
-        Self {
-            data: ptr::null(),
-            len: 0,
-            _phantom: PhantomData,
         }
     }
 
     /// Return the offset data as a byte slice.
-    pub const fn as_bytes(&self) -> &[u8] {
-        if self.data.is_null() {
-            &[]
-        } else {
-            // SAFETY: We checked that data is not NULL and `len` is guaranteed to be a valid
-            // length for the data pointer.
-            unsafe { std::slice::from_raw_parts(self.data, self.len as usize) }
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        match self.data {
+            None => &[],
+            Some(data) => {
+                // SAFETY: By the `Active<'a>` invariant on the wrapping
+                // `SharedPtr<Active<'a>, u8>`, it points to memory valid for
+                // reads of `len` bytes for the lifetime `'a`.
+                unsafe { std::slice::from_raw_parts(data.as_raw(), self.len as usize) }
+            }
         }
     }
 
     /// Create an owned copy of this offset slice, allocating new memory for the data.
     pub fn to_owned(&self) -> RSOffsetVector {
         let data = if self.len > 0 {
-            debug_assert!(!self.data.is_null(), "data must not be null");
+            let src = self.data.expect("non-empty slice must have a data pointer");
             let layout = Layout::array::<u8>(self.len as usize).unwrap();
             // SAFETY: we just checked that len > 0
-            let data = unsafe { std::alloc::alloc(layout) };
-            if data.is_null() {
+            let dst = unsafe { std::alloc::alloc(layout) };
+            if dst.is_null() {
                 std::alloc::handle_alloc_error(layout)
             };
             // SAFETY:
@@ -113,9 +134,9 @@ impl RSOffsetSlice<'_> {
             // - The destination buffer is valid for writes of `src.len` elements
             //   since it was just allocated with capacity `src.len`.
             // - The source buffer is valid for reads of `src.len` elements as a call invariant.
-            unsafe { std::ptr::copy_nonoverlapping(self.data, data, self.len as usize) };
+            unsafe { std::ptr::copy_nonoverlapping(src.as_raw(), dst, self.len as usize) };
 
-            data
+            dst
         } else {
             ptr::null_mut()
         };
@@ -127,13 +148,22 @@ impl RSOffsetSlice<'_> {
     }
 }
 
+impl<R: Ref> RawOffsetSlice<R> {
+    /// Create a new, empty offset slice.
+    pub const fn empty() -> Self {
+        Self { data: None, len: 0 }
+    }
+}
+
 /// Owned encoded offsets of a term in a document.
 ///
 /// This type owns the data and will free it on drop. Use [`RSOffsetSlice`] for borrowed offset
 /// data.
 ///
-/// The `#[repr(C)]` layout is identical to [`RSOffsetSlice`] (minus the zero-sized `PhantomData`),
-/// so a `&RSOffsetVector` can be safely cast to `&RSOffsetSlice<'_>`.
+/// The `#[repr(C)]` layout is identical to [`RSOffsetSlice`] — both store a
+/// nullable `*const u8` followed by a `u32`. The borrowed slice's
+/// `Option<SharedPtr<R, u8>>` field collapses to a bare pointer thanks to
+/// `NonNull`'s niche.
 #[repr(C)]
 #[cheadergen::config(skip)]
 pub struct RSOffsetVector {
@@ -186,10 +216,19 @@ impl RSOffsetVector {
 
     /// Return a borrowed view of this owned offset vector.
     pub const fn as_slice<'a>(&'a self) -> RSOffsetSlice<'a> {
+        let data = if self.data.is_null() {
+            None
+        } else {
+            // SAFETY: `self.data` is non-null (we just checked above).
+            let nn = unsafe { std::ptr::NonNull::new_unchecked(self.data) };
+            // SAFETY: `self.data` lives for `'a` (tied to the `&'a self`
+            // borrow) and we hold a shared `&'a self`, so the pointer is
+            // valid for reads and unaliased for `'a`.
+            Some(unsafe { SharedPtr::<Suspended, _>::from_non_null(nn).into_active() })
+        };
         RSOffsetSlice {
-            data: self.data,
+            data,
             len: self.len,
-            _phantom: PhantomData,
         }
     }
 

--- a/src/redisearch_rs/index_result/src/offsets.rs
+++ b/src/redisearch_rs/index_result/src/offsets.rs
@@ -66,8 +66,7 @@ impl<R: Ref> Debug for RawOffsetSlice<R> {
             // for the full `len` bytes and ties them to the carrying
             // lifetime, so reconstructing a `&[u8]` of that length here is
             // valid for reads with no aliasing mutable references.
-            let offsets =
-                unsafe { std::slice::from_raw_parts(data.as_raw(), self.len as usize) };
+            let offsets = unsafe { std::slice::from_raw_parts(data.as_raw(), self.len as usize) };
             write!(f, "RSOffsetSlice {offsets:?}")
         } else {
             // Suspended: the pointer may be stale, so we cannot dereference

--- a/src/redisearch_rs/index_result/src/offsets.rs
+++ b/src/redisearch_rs/index_result/src/offsets.rs
@@ -97,7 +97,18 @@ impl<'a> RSOffsetSlice<'a> {
         let data = if bytes.is_empty() {
             None
         } else {
-            Some(SharedPtr::from_ref(&bytes[0]))
+            // Retag through the *whole* slice and then cast to a `u8`
+            // pointer. Going through `SharedPtr::from_ref(&bytes[0])`
+            // would retag only the first byte under Stacked Borrows, so
+            // the subsequent `as_bytes()` / `Debug` calls — which read
+            // `len` bytes through the same `SharedPtr` — would trip the
+            // borrow stack on `bytes[1..]`. The slice retag preserves
+            // provenance over all `len` bytes for the lifetime `'a`.
+            let nn = std::ptr::NonNull::from_ref(bytes).cast::<u8>();
+            // SAFETY: `bytes` is a `&'a [u8]` that is non-empty, so `nn`
+            // is non-null and valid for reads of `bytes.len()` bytes for
+            // the lifetime `'a`, with no aliasing mutable references.
+            Some(unsafe { SharedPtr::<Suspended, _>::from_non_null(nn).into_active::<'a>() })
         };
         Self {
             data,

--- a/src/redisearch_rs/index_result/src/result_data.rs
+++ b/src/redisearch_rs/index_result/src/result_data.rs
@@ -7,55 +7,78 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use super::aggregate::RSAggregateResult;
+use ref_mode::{Active, Ref};
+
+use super::aggregate::RawAggregateResult;
 use super::kind::RSResultKind;
-use super::term_record::RSTermRecord;
+use super::term_record::RawTermRecord;
 
 /// Holds the actual data of an ['IndexResult']
 ///
 /// These enum values should stay in sync with [`RSResultKind`], so that the C union generated matches
 /// the bitflags on [`super::kind::RSResultKindMask`]
 ///
-/// The `'index` lifetime is linked to the `IndexBlock` (in the `inverted_index` crate) when
-/// decoding borrows from the block.
-#[repr(u8)]
-#[derive(Debug, PartialEq)]
+/// The `R: Ref` parameter selects between [`Active<'index>`] mode (data references are valid for
+/// `'index`) and [`ref_mode::Suspended`] mode (data references are inert raw pointers).
 #[cheadergen::config(prefix_with_name)]
-pub enum RSResultData<'index> {
-    Union(RSAggregateResult<'index>) = 1,
-    Intersection(RSAggregateResult<'index>) = 2,
-    Term(RSTermRecord<'index>) = 4,
+#[derive(Debug)]
+#[repr(u8)]
+pub enum RawResultData<R: Ref> {
+    Union(RawAggregateResult<R>) = 1,
+    Intersection(RawAggregateResult<R>) = 2,
+    Term(RawTermRecord<R>) = 4,
     Virtual = 8,
     Numeric(f64) = 16,
     Metric(f64) = 32,
-    HybridMetric(RSAggregateResult<'index>) = 64,
+    HybridMetric(RawAggregateResult<R>) = 64,
 }
 
-impl RSResultData<'_> {
-    pub const fn kind(&self) -> RSResultKind {
-        match self {
-            RSResultData::Union(_) => RSResultKind::Union,
-            RSResultData::Intersection(_) => RSResultKind::Intersection,
-            RSResultData::Term(_) => RSResultKind::Term,
-            RSResultData::Virtual => RSResultKind::Virtual,
-            RSResultData::Numeric(_) => RSResultKind::Numeric,
-            RSResultData::Metric(_) => RSResultKind::Metric,
-            RSResultData::HybridMetric(_) => RSResultKind::HybridMetric,
+/// The [`Active`] instantiation of [`RawResultData`].
+#[cheadergen::config(export)]
+pub type RSResultData<'a> = RawResultData<Active<'a>>;
+
+impl<'a> PartialEq for RSResultData<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Union(a), Self::Union(b)) => a == b,
+            (Self::Intersection(a), Self::Intersection(b)) => a == b,
+            (Self::Term(a), Self::Term(b)) => a == b,
+            (Self::Virtual, Self::Virtual) => true,
+            (Self::Numeric(a), Self::Numeric(b)) => a == b,
+            (Self::Metric(a), Self::Metric(b)) => a == b,
+            (Self::HybridMetric(a), Self::HybridMetric(b)) => a == b,
+            _ => false,
         }
     }
+}
 
+impl<R: Ref> RawResultData<R> {
+    pub const fn kind(&self) -> RSResultKind {
+        match self {
+            Self::Union(_) => RSResultKind::Union,
+            Self::Intersection(_) => RSResultKind::Intersection,
+            Self::Term(_) => RSResultKind::Term,
+            Self::Virtual => RSResultKind::Virtual,
+            Self::Numeric(_) => RSResultKind::Numeric,
+            Self::Metric(_) => RSResultKind::Metric,
+            Self::HybridMetric(_) => RSResultKind::HybridMetric,
+        }
+    }
+}
+
+impl<'a> RSResultData<'a> {
     /// Create an owned copy of this result data, allocating new memory for the contained data.
     ///
     /// The returned data may borrow the term from the original data.
-    pub fn to_owned<'a>(&'a self) -> RSResultData<'a> {
+    pub fn to_owned(&'a self) -> RSResultData<'a> {
         match self {
-            Self::Union(agg) => RSResultData::Union(agg.to_owned()),
-            Self::Intersection(agg) => RSResultData::Intersection(agg.to_owned()),
-            Self::Term(term) => RSResultData::Term(term.to_owned()),
-            Self::Virtual => RSResultData::Virtual,
-            Self::Numeric(num) => RSResultData::Numeric(*num),
-            Self::Metric(num) => RSResultData::Metric(*num),
-            Self::HybridMetric(agg) => RSResultData::HybridMetric(agg.to_owned()),
+            Self::Union(agg) => Self::Union(agg.to_owned()),
+            Self::Intersection(agg) => Self::Intersection(agg.to_owned()),
+            Self::Term(term) => Self::Term(term.to_owned()),
+            Self::Virtual => Self::Virtual,
+            Self::Numeric(num) => Self::Numeric(*num),
+            Self::Metric(num) => Self::Metric(*num),
+            Self::HybridMetric(agg) => Self::HybridMetric(agg.to_owned()),
         }
     }
 }

--- a/src/redisearch_rs/index_result/src/term_record.rs
+++ b/src/redisearch_rs/index_result/src/term_record.rs
@@ -7,16 +7,16 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::fmt::Debug;
-
 use query_term::RSQueryTerm;
+use ref_mode::{Active, Ref, SharedPtr};
 
-use super::offsets::{RSOffsetSlice, RSOffsetVector};
+use super::offsets::{RSOffsetSlice, RSOffsetVector, RawOffsetSlice};
 
 /// Represents a single record of a document inside a term in the inverted index
 #[cheadergen::config(prefix_with_name)]
+#[derive(Debug)]
 #[repr(u8)]
-pub enum RSTermRecord<'index> {
+pub enum RawTermRecord<R: Ref> {
     Borrowed {
         /// The term that brought up this record.
         ///
@@ -29,15 +29,17 @@ pub enum RSTermRecord<'index> {
 
         /// The encoded offsets in which the term appeared in the document
         ///
-        /// A decoder can choose to borrow this data from the index block, hence the `'index` lifetime.
-        offsets: RSOffsetSlice<'index>,
+        /// A decoder can choose to borrow this data from the index block, hence the `R`
+        /// parameter (which carries the index lifetime in [`Active`] mode).
+        offsets: RawOffsetSlice<R>,
     },
     Owned {
         /// The term that brought up this record.
         ///
-        /// It borrows the term from another record.
-        /// The name of the variant, `Owned`, refers to the `offsets` field.
-        term: Option<&'index RSQueryTerm>,
+        /// It borrows the term from another record. `None` encodes "no
+        /// term"; thanks to `NonNull`'s niche, `Option<SharedPtr<R, RSQueryTerm>>`
+        /// has the same C ABI as a nullable `*const RSQueryTerm`.
+        term: Option<SharedPtr<R, RSQueryTerm>>,
 
         /// The encoded offsets in which the term appeared in the document
         ///
@@ -61,68 +63,73 @@ pub enum RSTermRecord<'index> {
     },
 }
 
-impl PartialEq for RSTermRecord<'_> {
+/// The [`Active`] instantiation of [`RawTermRecord`].
+#[cheadergen::config(export)]
+pub type RSTermRecord<'a> = RawTermRecord<Active<'a>>;
+
+// Manual (rather than derived) because the `Owned` variant stores
+// `Option<SharedPtr<R, RSQueryTerm>>`, which only implements `PartialEq` in
+// `Active` mode. Compares the dereferenced query term and the byte view of
+// the offsets so equality is well-defined across variants.
+impl<'a> PartialEq for RSTermRecord<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.query_term() == other.query_term() && self.offsets() == other.offsets()
     }
 }
 
-impl Eq for RSTermRecord<'_> {}
+impl<'a> Eq for RSTermRecord<'a> {}
 
-impl<'index> RSTermRecord<'index> {
+impl<R: Ref> RawTermRecord<R> {
     /// Create a new term record without term pointer and offsets.
     pub const fn new() -> Self {
         Self::Borrowed {
             term: None,
-            offsets: RSOffsetSlice::empty(),
+            offsets: RawOffsetSlice::empty(),
         }
     }
 
+    /// Is this term record borrowed or owned?
+    pub const fn is_copy(&self) -> bool {
+        matches!(self, Self::Owned { .. } | Self::FullyOwned { .. })
+    }
+}
+
+impl<'a> RSTermRecord<'a> {
     /// Create a new borrowed term record with the given term and offsets.
-    pub const fn with_term(
-        term: Box<RSQueryTerm>,
-        offsets: RSOffsetSlice<'index>,
-    ) -> RSTermRecord<'index> {
+    pub const fn with_term(term: Box<RSQueryTerm>, offsets: RSOffsetSlice<'a>) -> RSTermRecord<'a> {
         Self::Borrowed {
             term: Some(term),
             offsets,
         }
     }
 
-    /// Is this term record borrowed or owned?
-    pub const fn is_copy(&self) -> bool {
-        matches!(
-            self,
-            RSTermRecord::Owned { .. } | RSTermRecord::FullyOwned { .. }
-        )
-    }
-
     /// Get the offsets of this term record as a byte slice.
     pub const fn offsets(&self) -> &[u8] {
         match self {
-            RSTermRecord::Borrowed { offsets, .. } => offsets.as_bytes(),
-            RSTermRecord::Owned { offsets, .. } => offsets.as_bytes(),
-            RSTermRecord::FullyOwned { offsets, .. } => offsets.as_bytes(),
+            Self::Borrowed { offsets, .. } => offsets.as_bytes(),
+            Self::Owned { offsets, .. } => offsets.as_bytes(),
+            Self::FullyOwned { offsets, .. } => offsets.as_bytes(),
         }
     }
 
     /// Get a reference to the query term of this term record, if one is set.
     pub fn query_term(&self) -> Option<&RSQueryTerm> {
         match self {
-            RSTermRecord::Borrowed { term, .. } => term.as_deref(),
-            RSTermRecord::Owned { term, .. } => *term,
-            RSTermRecord::FullyOwned { term, .. } => term.as_deref(),
+            Self::Borrowed { term, .. } => term.as_deref(),
+            Self::Owned { term, .. } => term.map(|p| p.get()),
+            Self::FullyOwned { term, .. } => term.as_deref(),
         }
     }
 
     /// Create an owned copy of this term record, allocating new memory for the offsets, but reusing the term.
-    pub fn to_owned<'a>(&'a self) -> RSTermRecord<'a> {
-        RSTermRecord::Owned {
-            term: self.query_term(),
+    pub fn to_owned(&'a self) -> RSTermRecord<'a> {
+        let term = self.query_term().map(SharedPtr::from_ref);
+        Self::Owned {
+            term,
             offsets: match self {
-                RSTermRecord::Borrowed { offsets, .. } => offsets.to_owned(),
-                RSTermRecord::Owned { offsets, .. } => offsets.as_slice().to_owned(),
-                RSTermRecord::FullyOwned { offsets, .. } => offsets.as_slice().to_owned(),
+                Self::Borrowed { offsets, .. } => offsets.to_owned(),
+                Self::Owned { offsets, .. } => offsets.as_slice().to_owned(),
+                Self::FullyOwned { offsets, .. } => offsets.as_slice().to_owned(),
             },
         }
     }
@@ -132,16 +139,16 @@ impl<'index> RSTermRecord<'index> {
     /// For the `Owned` and `FullyOwned` variants the slice is copied into a
     /// fresh allocation, so the input does not need to satisfy any lifetime
     /// relationship beyond the call itself.
-    pub fn set_offsets(&mut self, offsets: RSOffsetSlice<'index>) {
+    pub fn set_offsets(&mut self, offsets: RSOffsetSlice<'a>) {
         match self {
-            RSTermRecord::Borrowed { offsets: o, .. } => {
+            Self::Borrowed { offsets: o, .. } => {
                 *o = offsets;
             }
-            RSTermRecord::Owned { offsets: o, .. } => {
+            Self::Owned { offsets: o, .. } => {
                 // Assign the new owned copy; the old value is auto-dropped, freeing old data.
                 *o = offsets.to_owned();
             }
-            RSTermRecord::FullyOwned { offsets: o, .. } => {
+            Self::FullyOwned { offsets: o, .. } => {
                 *o = offsets.to_owned();
             }
         }
@@ -151,59 +158,37 @@ impl<'index> RSTermRecord<'index> {
     /// [`RSOffsetVector`].
     ///
     /// Unlike [`Self::set_offsets`], this method does not tie the input to the
-    /// record's `'index` lifetime, since an [`RSOffsetVector`] owns its data.
+    /// record's `'a` lifetime, since an [`RSOffsetVector`] owns its data.
     /// This is the method to use from decoders that borrow their source bytes
-    /// with a lifetime shorter than `'index` (for example, a disk-backed block
+    /// with a lifetime shorter than `'a` (for example, a disk-backed block
     /// that may be replaced on the next read).
     ///
     /// # Panics
     ///
-    /// Panics if the record is in the [`RSTermRecord::Borrowed`] variant,
+    /// Panics if the record is in the [`Self::Borrowed`] variant,
     /// which stores an [`RSOffsetSlice`] rather than an owned vector. Callers
     /// that need to call this method should construct the record via
-    /// [`RSTermResultBuilder::fully_owned_record`](super::core::RSTermResultBuilder::fully_owned_record)
-    /// or [`RSTermResultBuilder::owned_record`](super::core::RSTermResultBuilder::owned_record).
+    /// [`RawTermResultBuilder::fully_owned_record`](super::core::RawTermResultBuilder::fully_owned_record)
+    /// or [`RawTermResultBuilder::owned_record`](super::core::RawTermResultBuilder::owned_record).
     pub fn set_offsets_owned(&mut self, offsets: RSOffsetVector) {
         match self {
-            RSTermRecord::Borrowed { .. } => {
+            Self::Borrowed { .. } => {
                 panic!(
                     "set_offsets_owned called on RSTermRecord::Borrowed; \
                      construct the record with fully_owned_record or owned_record instead"
                 );
             }
-            RSTermRecord::Owned { offsets: o, .. } => {
+            Self::Owned { offsets: o, .. } => {
                 *o = offsets;
             }
-            RSTermRecord::FullyOwned { offsets: o, .. } => {
+            Self::FullyOwned { offsets: o, .. } => {
                 *o = offsets;
             }
         }
     }
 }
 
-impl Debug for RSTermRecord<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RSTermRecord::Borrowed { offsets, .. } => f
-                .debug_struct("RSTermRecord(Borrowed)")
-                .field("term", &self.query_term())
-                .field("offsets", offsets)
-                .finish(),
-            RSTermRecord::Owned { offsets, .. } => f
-                .debug_struct("RSTermRecord(Owned)")
-                .field("term", &self.query_term())
-                .field("offsets", offsets)
-                .finish(),
-            RSTermRecord::FullyOwned { offsets, .. } => f
-                .debug_struct("RSTermRecord(FullyOwned)")
-                .field("term", &self.query_term())
-                .field("offsets", offsets)
-                .finish(),
-        }
-    }
-}
-
-impl Default for RSTermRecord<'_> {
+impl<R: Ref> Default for RawTermRecord<R> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/redisearch_rs/inverted_index/src/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/full.rs
@@ -35,7 +35,7 @@ pub struct Full;
 ///
 /// record must have `result_type` set to `RSResultType::Term`.
 #[inline(always)]
-pub const fn offsets<'a>(record: &'a RSIndexResult<'_>) -> &'a [u8] {
+pub const fn offsets<'a>(record: &'a RSIndexResult) -> &'a [u8] {
     // SAFETY: caller ensured the proper result_type.
     let term = record.as_term().unwrap();
 

--- a/src/redisearch_rs/inverted_index/src/tests/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index_result.rs
@@ -12,7 +12,7 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn synced_discriminants() {
-    let tests = [
+    let tests: [(RSResultData, RSResultKind); 7] = [
         (
             RSResultData::Union(RSAggregateResult::borrowed_with_capacity(0)),
             RSResultKind::Union,

--- a/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
@@ -105,7 +105,7 @@ fn entry_with_key_not_equal_to_keyless_entry() {
 
 #[test]
 fn new_vec_is_empty() {
-    let v: MetricsVec<'_> = MetricsVec::new();
+    let v: MetricsVec = MetricsVec::new();
     assert!(v.is_empty());
     assert_eq!(v.len(), 0);
     assert!(v.get(0).is_none());
@@ -114,7 +114,7 @@ fn new_vec_is_empty() {
 
 #[test]
 fn default_matches_new() {
-    let v: MetricsVec<'_> = MetricsVec::default();
+    let v: MetricsVec = MetricsVec::default();
     assert!(v.is_empty());
     assert_eq!(v.len(), 0);
     assert_eq!(v, MetricsVec::new());
@@ -309,7 +309,7 @@ fn as_metrics_slice_matches_entries() {
 
 #[test]
 fn as_metrics_slice_on_empty_vec_has_zero_len() {
-    let v: MetricsVec<'_> = MetricsVec::new();
+    let v: MetricsVec = MetricsVec::new();
     let slice = v.as_metrics_slice();
     // `data` may be a dangling-but-non-null sentinel for an empty ThinVec —
     // we don't constrain its value, only that `len == 0` so consumers cannot

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -51,7 +51,7 @@ impl NumericIndex {
     ///
     /// Panics if the underlying write fails. This should never happen with
     /// in-memory inverted indexes, so a panic indicates a bug.
-    pub fn add_record(&mut self, record: &RSIndexResult<'_>) -> inverted_index::AddRecordOutcome {
+    pub fn add_record(&mut self, record: &RSIndexResult) -> inverted_index::AddRecordOutcome {
         let result = match self {
             NumericIndex::Uncompressed(idx) => idx.add_record(record),
             NumericIndex::Compressed(idx) => idx.add_record(record),

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -92,7 +92,7 @@ impl NumericRangeNode {
         let mut majority_hll = Hll::new();
         let mut last_block_hll = Hll::new();
 
-        let mut repair_fn = |res: &RSIndexResult<'_>, ctx: &inverted_index::RepairContext<'_>| {
+        let mut repair_fn = |res: &RSIndexResult, ctx: &inverted_index::RepairContext<'_>| {
             // SAFETY: We know this is a numeric index result
             let value = unsafe { res.as_numeric_unchecked() };
             let target = if ctx.block_idx == last_block_idx {

--- a/src/redisearch_rs/ref_mode/src/lib.rs
+++ b/src/redisearch_rs/ref_mode/src/lib.rs
@@ -54,6 +54,20 @@ mod sealed {
 /// The `fmt::Debug` supertrait lets containing types derive `Debug` without
 /// requiring an explicit `where R: Debug` bound at every use site.
 pub trait Ref: sealed::Sealed + fmt::Debug {
+    /// Returns `true` iff this [`Ref`] mode is [`Active`].
+    ///
+    /// Sealed-trait dispatch lets generic code branch between [`Active`] and
+    /// [`Suspended`] at runtime without resorting to specialization. Since
+    /// the value is statically determined per instantiation, the compiler
+    /// monomorphises the branch away.
+    ///
+    /// The intended use is gating an `unsafe` operation that is only sound
+    /// when the [`Active`] invariant holds — e.g. dereferencing a pointer
+    /// stored in a generic [`SharedPtr<Self, _>`]-bearing struct.
+    fn is_active() -> bool
+    where
+        Self: Sized;
+
     /// Format a [`SharedPtr`] of this mode for `Debug`.
     ///
     /// In [`Active`] mode the pointer is dereferenced and the pointee's
@@ -82,6 +96,10 @@ pub struct Active<'a>(PhantomData<&'a ()>);
 
 impl sealed::Sealed for Active<'_> {}
 impl Ref for Active<'_> {
+    fn is_active() -> bool {
+        true
+    }
+
     fn fmt_ptr<T: ?Sized + fmt::Debug>(
         ptr: &SharedPtr<Self, T>,
         f: &mut fmt::Formatter<'_>,
@@ -103,6 +121,10 @@ pub struct Suspended;
 
 impl sealed::Sealed for Suspended {}
 impl Ref for Suspended {
+    fn is_active() -> bool {
+        false
+    }
+
     fn fmt_ptr<T: ?Sized + fmt::Debug>(
         ptr: &SharedPtr<Self, T>,
         f: &mut fmt::Formatter<'_>,

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -8,6 +8,7 @@
 */
 // TODO: remove once we have compound iterators written in Rust that leverage
 //   this shim.
+
 use ffi::{
     IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND, IteratorStatus_ITERATOR_OK,
     IteratorStatus_ITERATOR_TIMEOUT, IteratorType, QueryIterator, ValidateStatus_VALIDATE_ABORTED,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -204,7 +204,7 @@ impl QueryIterator {
     #[inline(always)]
     pub fn current(&self) -> Option<&RSIndexResult<'static>> {
         let current = unsafe { (*self.0).current };
-        unsafe { current.cast::<RSIndexResult>().as_ref() }
+        unsafe { current.cast::<RSIndexResult<'static>>().as_ref() }
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -453,7 +453,7 @@ impl TestContext {
 
         // Populate with virtual records for each document ID
         for doc_id in doc_ids {
-            let record = RSIndexResult::build_virt().doc_id(doc_id).build();
+            let record: RSIndexResult = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
             unsafe {
                 inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
@@ -518,7 +518,7 @@ impl TestContext {
 
         // Populate with virtual records for each document ID
         for doc_id in doc_ids {
-            let record = RSIndexResult::build_virt().doc_id(doc_id).build();
+            let record: RSIndexResult = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
             unsafe {
                 inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
@@ -608,7 +608,7 @@ impl TestContext {
         // pointer is actually a Rust opaque InvertedIndex despite the C type.
         let ii_opaque: *mut inverted_index::opaque::InvertedIndex = ii_ptr.cast();
         for doc_id in doc_ids {
-            let record = RSIndexResult::build_virt().doc_id(doc_id).build();
+            let record: RSIndexResult = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii_opaque is a valid pointer created via TagIndex_OpenIndex
             // which delegates to NewInvertedIndex_Ex (Rust FFI).
             unsafe {


### PR DESCRIPTION
## Describe the changes in the pull request

Allow `RSIndexResult` to hold references which are either active (&) or inactive (raw pointer).
To minimise churn, we rename the generic types to `Raw*` (e.g. `RawRSIndexResult`) and use the previous names to describe the active variants.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query/index result memory layout and C/Rust FFI at scale, but behavior for today's Active-only C path is intended to stay ABI-compatible with explicit casts and compatibility macros.
> 
> **Overview**
> **`RSIndexResult` and related index-result types are generalized** with `ref_mode` (`Active` vs `Suspended`): Rust types are renamed to `Raw*` (e.g. `RawIndexResult`, `RawResultData`, `RawTermRecord`) and **`RSIndexResult` is the `Active` alias** used at the C boundary today.
> 
> **Borrowed fields** (offset bytes, query terms, metric keys, aggregate children) now use **`SharedPtr<R, T>`** instead of raw pointers or `&'a` in the generic layout, so the same `repr(C)` structs can later hold **inert pointers** across index lock release/reacquire while **`Active`** keeps current lifetime semantics.
> 
> **Generated C headers** (`index_result_rs.h`, `types_ffi.h`, etc.) reflect the new mangled names; **`cheadergen.toml` adds trailer `#define`s** so existing C code keeps **`RSResultData_Term`**, **`RSTermRecord_Borrowed`**, and similar enum tags. **`redisearch.h`** typedefs `RSIndexResult` to `RawIndexResult_Active`.
> 
> **FFI** drops lifetime parameters on `*mut RSIndexResult` (`metrics_ffi`, `types_ffi`); **`RSOffsetVector_SetData` / `GetData`** bridge C buffers via `SharedPtr::<Suspended>::from_non_null` → `into_active`. **`forward_index.c`** casts `VVW_GetByteData` to `uint8_t *` for the emitted field type.
> 
> **Dependencies**: `index_result` and `types_ffi` pull in `ref_mode`; `ref_mode` gains **`Ref::is_active()`** for safe vs suspended debug/deref paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fbfa4ddbe8aaed8f2e5a3926984215ce2fea5dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->