### PR TITLE
[MOD-15595] union_trimmed: document why revalidate cannot be called

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -259,7 +259,7 @@ where
         // UnionTrimmed drains children sequentially, not in doc-id order,
         // so skip_to has no meaningful semantics. Panic to surface misuse
         // immediately rather than silently returning wrong results.
-        panic!(
+        unreachable!(
             "skip_to is not supported on UnionTrimmed — documents are not yielded in doc-id order"
         );
     }
@@ -269,9 +269,19 @@ where
         &mut self,
         _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // Trimmed unions run in a single, short-lived read path that does not
-        // interleave with GC cycles, so revalidation should never be called.
-        panic!(
+        // Revalidation is unreachable for trimmed unions in practice:
+        //
+        // `TrimUnionIterator` is only called for `Q_OPT_PARTIAL_RANGE`, which
+        // requires SORTBY on a numeric field. SORTBY always inserts an
+        // `RPSorter` into the result-processor pipeline, and `RPSorter` is an
+        // accumulator — it drains *all* upstream results (via `rpQueryItNext`)
+        // before emitting any rows. That drain happens entirely within the
+        // first `sendChunk` call while the spec read-lock is held
+        // (`sctx->flags != RS_CTX_UNSET`), so `handleSpecLockAndRevalidate`
+        // short-circuits and never calls `Revalidate`. Subsequent cursor reads
+        // only pull from the sorter's buffer; `rpQueryItNext` is not called
+        // again.
+        unreachable!(
             "revalidate is not supported on UnionTrimmed — trimmed unions are not subject to GC"
         );
     }


### PR DESCRIPTION
## Describe the changes in the pull request

Document why `UnionTrimmed::revalidate` cannot be called.

We could make this safer by either returning `Ok` or a new `RQEIteratorError::Unsupported`.
But then how would this map the C level? `validate` could return `ABORTED` and  `read`/`skip_to` return `EOF` but this could hide potential issues in the future so I'm not sure it's worth it. 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior remains a hard fail, with `panic!` replaced by `unreachable!` and expanded comments to explain why these code paths should never be hit.
> 
> **Overview**
> `UnionTrimmed` now treats `skip_to` and `revalidate` as *unreachable* rather than generic panics, keeping the same fail-fast behavior while better reflecting the intended invariants.
> 
> Adds detailed in-code rationale for why `revalidate` cannot be invoked for trimmed unions (due to the SORTBY/`RPSorter` drain path under a held spec read-lock), making future misuse easier to diagnose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8c8bf091afdebdedae04c3be92e6d602a0ebc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->