### PR TITLE
[MOD-15589] Drop index_result re-export from inverted_index root

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "buffer",
  "criterion",
  "ffi",
+ "index_result",
  "inverted_index",
  "itertools 0.14.0",
  "query_term",
@@ -1102,6 +1103,7 @@ version = "0.0.1"
 dependencies = [
  "cheadergen",
  "ffi",
+ "index_result",
  "inverted_index",
  "libc",
  "rmp-serde",
@@ -1115,6 +1117,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "field",
+ "index_result",
  "index_spec",
  "inverted_index",
  "inverted_index_ffi",
@@ -1295,6 +1298,7 @@ name = "metrics_ffi"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "index_result",
  "inverted_index",
  "workspace_hack",
 ]
@@ -1416,6 +1420,7 @@ dependencies = [
  "ffi",
  "generational_slab",
  "hyperloglog",
+ "index_result",
  "insta",
  "inverted_index",
  "numeric_range_tree",
@@ -2110,6 +2115,7 @@ dependencies = [
  "field",
  "geo",
  "idf",
+ "index_result",
  "index_spec",
  "inverted_index",
  "libc",
@@ -2145,6 +2151,7 @@ dependencies = [
  "criterion",
  "ffi",
  "field",
+ "index_result",
  "inverted_index",
  "inverted_index_ffi",
  "iterators_ffi",
@@ -2164,6 +2171,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "field",
+ "index_result",
  "index_spec",
  "inverted_index",
  "inverted_index_ffi",
@@ -2334,6 +2342,7 @@ dependencies = [
  "document_metadata",
  "enumflags2",
  "ffi",
+ "index_result",
  "inverted_index",
  "rlookup",
  "workspace_hack",
@@ -2862,6 +2871,7 @@ name = "types_ffi"
 version = "0.0.1"
 dependencies = [
  "field",
+ "index_result",
  "inverted_index",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 cheadergen.workspace = true
 ffi.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 libc.workspace = true
 rmp-serde.workspace = true

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -21,11 +21,12 @@ use ffi::{
 };
 
 use fork_gc::{InvertedIndexGCCallback, InvertedIndexGCReader, InvertedIndexGCWriter};
+use index_result::RSIndexResult;
 pub use inverted_index::opaque::InvertedIndex;
 use inverted_index::{
     EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader, FilterMaskReader,
     FilterNumericReader, GcApplyInfo, GcScanDelta, IndexBlock, IndexReader as _, NumericFilter,
-    RSIndexResult, ReadFilter,
+    ReadFilter,
     debug::{BlockSummary, Summary},
     doc_ids_only::DocIdsOnly,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -23,6 +23,7 @@ bench = false
 ffi.workspace = true
 libc.workspace = true
 field.workspace = true
+index_result.workspace = true
 index_spec.workspace = true
 inverted_index.workspace = true
 inverted_index_ffi = { path = "../inverted_index_ffi" }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -8,7 +8,7 @@
 */
 
 use ffi::{QueryIterator, t_docId};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{id_list::IdList, utils::OwnedSlice};
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -10,8 +10,9 @@
 use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use index_result::RSIndexResult;
 use inverted_index::{
-    IndexReader, RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
+    IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
 use rqe_iterators::{
     FieldExpirationChecker, IteratorType, interop::RQEIteratorWrapper, inverted_index::Missing,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -64,14 +64,14 @@ impl<'index> NumericIterator<'index> {
 
 impl<'index> rqe_iterators::RQEIterator<'index> for NumericIterator<'index> {
     #[inline(always)]
-    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+    fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
         self.iterator.current()
     }
 
     #[inline(always)]
     fn read(
         &mut self,
-    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
+    ) -> Result<Option<&mut index_result::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
     {
         self.iterator.read()
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -10,9 +10,9 @@
 use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use index_result::{RSIndexResult, RSQueryTerm};
 use inverted_index::{
-    IndexReader, RSIndexResult, RSQueryTerm, doc_ids_only::DocIdsOnly,
-    raw_doc_ids_only::RawDocIdsOnly, t_docId,
+    IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
 use rqe_iterators::{
     FieldExpirationChecker, IteratorType, interop::RQEIteratorWrapper, inverted_index::Tag,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -10,10 +10,11 @@
 use std::ptr::NonNull;
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use index_result::{RSIndexResult, RSQueryTerm};
 use inverted_index::{
-    FilterMaskReader, IndexReader, IndexReaderCore, RSIndexResult, RSQueryTerm, TermReader,
-    doc_ids_only::DocIdsOnly, fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only,
-    full, offsets_only, raw_doc_ids_only::RawDocIdsOnly, t_docId,
+    FilterMaskReader, IndexReader, IndexReaderCore, TermReader, doc_ids_only::DocIdsOnly,
+    fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only, full, offsets_only,
+    raw_doc_ids_only::RawDocIdsOnly, t_docId,
 };
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{FieldExpirationChecker, inverted_index::Term};

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/wildcard.rs
@@ -9,9 +9,8 @@
 
 use std::fmt::Debug;
 
-use inverted_index::{
-    RSIndexResult, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId,
-};
+use index_result::RSIndexResult;
+use inverted_index::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly, t_docId};
 use rqe_iterators::{IteratorType, interop::RQEIteratorWrapper, inverted_index::Wildcard};
 
 /// Wrapper around different II wildcard iterator encoding types to avoid generics in FFI code.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -49,7 +49,7 @@ impl<'index> NotIteratorEnum<'index> {
 // Delegate `RQEIterator` to the inner variant.
 impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
-    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+    fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
         match self {
             Self::Not(it) => it.current(),
             Self::NotOptimized(it) => it.current(),
@@ -59,7 +59,7 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
     fn read(
         &mut self,
-    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
+    ) -> Result<Option<&mut index_result::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
     {
         match self {
             Self::Not(it) => it.read(),

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 
 [dependencies]
 ffi.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -13,7 +13,7 @@
 //! `headers/metrics_ffi.h`.
 
 use ffi::RLookupKey;
-use inverted_index::{MetricsSlice, MetricsVec, RSIndexResult};
+use index_result::{MetricsSlice, MetricsVec, RSIndexResult};
 
 /// Creates an empty metrics collection. Does not allocate.
 ///

--- a/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
@@ -17,5 +17,6 @@ workspace = true
 
 [dependencies]
 field.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -11,10 +11,10 @@
 
 use std::{ffi::c_char, mem, ptr};
 
-use inverted_index::{
-    NumericFilter, RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSQueryTerm,
-    RSTermRecord, t_fieldMask,
+use index_result::{
+    RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSQueryTerm, RSTermRecord,
 };
+use inverted_index::{NumericFilter, t_fieldMask};
 
 pub use inverted_index::{
     ReadFilter,

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -102,29 +102,6 @@ typedef struct IIBlockSummary {
 } IIBlockSummary;
 
 /**
- * Information about the result of applying a garbage collection scan to the index
- */
-typedef struct II_GCScanStats {
-  /**
-   * The number of bytes that were freed
-   */
-  size_t bytes_freed;
-  /**
-   * The number of bytes that were allocated
-   */
-  size_t bytes_allocated;
-  /**
-   * The number of entries that were removed from the index including duplicates
-   */
-  size_t entries_removed;
-  /**
-   * Whether or not we ignored the last block in the index, since it changed
-   * compared to the time we performed the scan
-   */
-  bool ignored_last_block;
-} II_GCScanStats;
-
-/**
  * Filter to apply when reading from an index. Entries which don't match the filter will not be
  * returned by the reader.
  */
@@ -161,3 +138,26 @@ typedef union IndexDecoderCtx {
     const struct NumericFilter *numeric;
   };
 } IndexDecoderCtx;
+
+/**
+ * Information about the result of applying a garbage collection scan to the index
+ */
+typedef struct II_GCScanStats {
+  /**
+   * The number of bytes that were freed
+   */
+  size_t bytes_freed;
+  /**
+   * The number of bytes that were allocated
+   */
+  size_t bytes_allocated;
+  /**
+   * The number of entries that were removed from the index including duplicates
+   */
+  size_t entries_removed;
+  /**
+   * Whether or not we ignored the last block in the index, since it changed
+   * compared to the time we performed the scan
+   */
+  bool ignored_last_block;
+} II_GCScanStats;

--- a/src/redisearch_rs/inverted_index/src/codec/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/doc_ids_only.rs
@@ -12,7 +12,8 @@ use std::io::{Cursor, Seek, Write};
 use ffi::t_docId;
 use varint::VarintEncode;
 
-use crate::{Decoder, DocIdsDecoder, Encoder, RSIndexResult, TermDecoder};
+use crate::{Decoder, DocIdsDecoder, Encoder, TermDecoder};
+use index_result::RSIndexResult;
 
 /// Encode and decode only the delta document ID of a record, without any other data.
 /// The delta is encoded using [varint encoding](varint).

--- a/src/redisearch_rs/inverted_index/src/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/fields_offsets.rs
@@ -14,9 +14,10 @@ use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, TermDecoder,
+    Decoder, Encoder, TermDecoder,
     full::{decode_term_record_offsets, offsets},
 };
+use index_result::RSIndexResult;
 
 /// Encode and decode the delta, field mask and offsets of a term record.
 ///

--- a/src/redisearch_rs/inverted_index/src/codec/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/fields_only.rs
@@ -13,7 +13,8 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult, TermDecoder};
+use crate::{Decoder, Encoder, TermDecoder};
+use index_result::RSIndexResult;
 
 /// Encode and decode the delta and field mask of a record.
 ///

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_fields.rs
@@ -13,7 +13,8 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult, TermDecoder};
+use crate::{Decoder, Encoder, TermDecoder};
+use index_result::RSIndexResult;
 
 /// Encode and decode the delta, frequency and field mask of a record.
 ///

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_offsets.rs
@@ -13,9 +13,10 @@ use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, TermDecoder,
+    Decoder, Encoder, TermDecoder,
     full::{decode_term_record_offsets, offsets},
 };
+use index_result::RSIndexResult;
 
 /// Encode and decode the delta, frequency, and offsets of a term record.
 ///

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_only.rs
@@ -12,7 +12,8 @@ use std::io::{Cursor, Seek, Write};
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
-use crate::{Decoder, Encoder, RSIndexResult, TermDecoder};
+use crate::{Decoder, Encoder, TermDecoder};
+use index_result::RSIndexResult;
 
 /// Encode and decode only the delta and frequencies of a record, without any other data.
 /// The delta and frequency are encoded using [qint encoding](qint).

--- a/src/redisearch_rs/inverted_index/src/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/full.rs
@@ -13,7 +13,8 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult, RSOffsetSlice, TermDecoder};
+use crate::{Decoder, Encoder, TermDecoder};
+use index_result::{RSIndexResult, RSOffsetSlice};
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
 ///

--- a/src/redisearch_rs/inverted_index/src/codec/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/mod.rs
@@ -22,7 +22,8 @@ use std::io::{Cursor, Seek, Write};
 
 use ffi::t_docId;
 
-use crate::{IndexBlock, RSIndexResult};
+use crate::IndexBlock;
+use index_result::RSIndexResult;
 
 /// Trait used to correctly derive the delta needed for different encoders
 pub trait IdDelta

--- a/src/redisearch_rs/inverted_index/src/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/numeric.rs
@@ -144,7 +144,8 @@ use std::io::{Cursor, IoSlice, Read, Write};
 
 use ffi::t_docId;
 
-use crate::{Decoder, Encoder, IdDelta, NumericDecoder, RSIndexResult};
+use crate::{Decoder, Encoder, IdDelta, NumericDecoder};
+use index_result::RSIndexResult;
 
 /// Trait to convert various types to byte representations for numeric encoding
 trait ToBytes<const N: usize> {

--- a/src/redisearch_rs/inverted_index/src/codec/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/offsets_only.rs
@@ -13,9 +13,10 @@ use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, TermDecoder,
+    Decoder, Encoder, TermDecoder,
     full::{decode_term_record_offsets, offsets},
 };
+use index_result::RSIndexResult;
 
 /// Encode and decode the offsets of a term record.
 ///

--- a/src/redisearch_rs/inverted_index/src/codec/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/raw_doc_ids_only.rs
@@ -11,7 +11,8 @@ use std::io::{Cursor, Seek, Write};
 
 use ffi::t_docId;
 
-use crate::{Decoder, DocIdsDecoder, Encoder, IndexBlock, RSIndexResult, TermDecoder};
+use crate::{Decoder, DocIdsDecoder, Encoder, IndexBlock, TermDecoder};
+use index_result::RSIndexResult;
 
 /// Encode and decode only the raw document ID delta without any compression.
 ///

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -10,8 +10,9 @@
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
-use crate::{BlockCapacity, DecodedBy, Decoder, Encoder, IndexBlock, InvertedIndex, RSIndexResult};
+use crate::{BlockCapacity, DecodedBy, Decoder, Encoder, IndexBlock, InvertedIndex};
 use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use index_result::RSIndexResult;
 use smallvec::SmallVec;
 use thin_vec::{Header, ThinVec};
 

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -16,11 +16,12 @@ use thin_vec::ThinVec;
 
 use super::unique_id::IndexUniqueId;
 use crate::{
-    BlockCapacity, Encoder, IdDelta, RSIndexResult,
+    BlockCapacity, Encoder, IdDelta,
     controlled_cursor::ControlledCursor,
     debug::{BlockSummary, Summary},
 };
 use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue, t_docId};
+use index_result::RSIndexResult;
 
 /// An inverted index is a data structure that maps terms to their occurrences in documents. It is
 /// used to efficiently search for documents that contain specific terms.

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -8,11 +8,12 @@
 */
 
 use crate::{
-    DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex, RSIndexResult,
+    DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
 use ffi::{IndexFlags, t_docId};
+use index_result::RSIndexResult;
 
 /// A wrapper around the inverted index to track the total number of entries in the index.
 /// Unlike [`InvertedIndex::unique_docs()`], this counts all entries, including duplicates.

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -9,11 +9,11 @@
 
 use crate::{
     DecodedBy, Encoder, FilterMaskReader, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
-    RSIndexResult,
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
 use ffi::{IndexFlags, IndexFlags_Index_StoreFieldFlags, t_docId, t_fieldMask};
+use index_result::RSIndexResult;
 
 /// A wrapper around the inverted index which tracks the fields for all the records in the index
 /// using a mask. This makes is easy to know if the index has any records for a specific field.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -25,14 +25,6 @@ pub use index::*;
 // Re-export GC types.
 pub use gc::{GcApplyInfo, GcScanDelta};
 
-// Re-export result types from the `index_result` crate so existing
-// `use inverted_index::RSIndexResult` imports keep working.
-pub use index_result::{
-    MetricEntry, MetricsSlice, MetricsVec, RSAggregateResult, RSAggregateResultIter, RSIndexResult,
-    RSOffsetSlice, RSOffsetVector, RSQueryTerm, RSResultData, RSResultKind, RSResultKindMask,
-    RSTermRecord,
-};
-
 // Re-export reader types.
 pub use reader::{IndexReader, IndexReaderCore, NumericFilter, NumericReader, TermReader};
 

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -11,10 +11,11 @@ use std::{io::Cursor, sync::atomic};
 
 use super::{IndexReader, NumericReader, TermReader};
 use crate::{
-    DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, RSIndexResult,
-    TermDecoder, index::unique_id::IndexUniqueId, opaque::OpaqueEncoding,
+    DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, TermDecoder,
+    index::unique_id::IndexUniqueId, opaque::OpaqueEncoding,
 };
 use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue, t_docId};
+use index_result::RSIndexResult;
 
 /// Reader that is able to read the records from an [`InvertedIndex`]
 pub struct IndexReaderCore<'index, E> {

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -9,10 +9,10 @@
 
 use super::{IndexReader, IndexReaderCore, TermReader};
 use crate::{
-    DecodedBy, Decoder, HasInnerIndex, InvertedIndex, RSIndexResult, TermDecoder,
-    opaque::OpaqueEncoding,
+    DecodedBy, Decoder, HasInnerIndex, InvertedIndex, TermDecoder, opaque::OpaqueEncoding,
 };
 use ffi::{IndexFlags, t_docId, t_fieldMask};
+use index_result::RSIndexResult;
 
 /// A reader that filters out records that do not match a given field mask. It is used to
 /// filter records in an index based on their field mask, allowing only those that match the

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -8,8 +8,9 @@
 */
 
 use super::{IndexReader, IndexReaderCore, NumericFilter, NumericReader};
-use crate::{DecodedBy, Decoder, InvertedIndex, RSIndexResult};
+use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{GeoFilter, IndexFlags, t_docId};
+use index_result::RSIndexResult;
 
 // Manually define some C functions, because we'll create a circular dependency if we use the FFI
 // crate to make them automatically.

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -12,8 +12,8 @@ mod field_mask;
 mod geo;
 mod numeric;
 
-use crate::RSIndexResult;
 use ffi::{IndexFlags, t_docId, t_fieldMask};
+use index_result::RSIndexResult;
 
 pub use self::core::*;
 pub use field_mask::FilterMaskReader;

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -10,8 +10,9 @@
 use std::ffi::c_void;
 
 use super::{IndexReader, IndexReaderCore, NumericReader};
-use crate::{DecodedBy, Decoder, InvertedIndex, RSIndexResult};
+use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{FieldSpec, IndexFlags, t_docId};
+use index_result::RSIndexResult;
 
 /// Filter details to apply to numeric values
 #[derive(Debug)]

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -12,9 +12,9 @@
 use ffi::t_fieldMask;
 use query_term::RSQueryTerm;
 
-use crate::{RSIndexResult, RSOffsetSlice};
+use index_result::{RSIndexResult, RSOffsetSlice};
 
-/// Wrapper around `inverted_index::RSIndexResult` ensuring the offsets
+/// Wrapper around `index_result::RSIndexResult` ensuring the offsets
 /// pointer used internally stays valid for the duration of the test or bench.
 #[derive(Debug)]
 pub struct TestTermRecord<'index> {

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -14,9 +14,10 @@ use std::{
 
 use crate::{
     Decoder, Encoder, EntriesTrackingIndex, GcApplyInfo, GcScanDelta, IdDelta, IndexBlock,
-    InvertedIndex, RSIndexResult, gc::BlockGcScanResult, gc::RepairType,
+    InvertedIndex, gc::BlockGcScanResult, gc::RepairType,
 };
 use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 use smallvec::smallvec;
 use thin_vec::medium_thin_vec;

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 
 use crate::{
     Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex, GcScanDelta, IdDelta,
-    IndexBlock, InvertedIndex, RSIndexResult,
+    IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
     gc::BlockGcScanResult,
     gc::RepairType,
@@ -20,6 +20,7 @@ use ffi::{
     IndexFlags_Index_DocIdsOnly, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreNumeric, t_docId,
 };
+use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 
 use super::Dummy;

--- a/src/redisearch_rs/inverted_index/src/tests/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index_result.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::{RSAggregateResult, RSResultData, RSResultKind, RSTermRecord};
+use index_result::{RSAggregateResult, RSResultData, RSResultKind, RSTermRecord};
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/mod.rs
@@ -9,7 +9,9 @@
 
 use std::io::{Cursor, Read};
 
-use crate::{Encoder, RSIndexResult};
+use ::index_result::RSIndexResult;
+
+use crate::Encoder;
 
 mod gc;
 mod index;

--- a/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
@@ -10,12 +10,11 @@
 use std::io::{Cursor, Read};
 use std::sync::atomic;
 
-use crate::{
-    Decoder, Encoder, IndexBlock, IndexReader, InvertedIndex, NumericReader, RSIndexResult,
-};
+use crate::{Decoder, Encoder, IndexBlock, IndexReader, InvertedIndex, NumericReader};
 use ffi::{
     IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreTermOffsets, IndexFlags_Index_WideSchema,
 };
+use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 use thin_vec::medium_thin_vec;
 

--- a/src/redisearch_rs/inverted_index/src/tests/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/field_mask.rs
@@ -7,7 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::{FilterMaskReader, IndexReader, RSIndexResult};
+use crate::{FilterMaskReader, IndexReader};
+use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/geo.rs
@@ -9,8 +9,9 @@
 
 use std::ptr;
 
-use crate::{FilterGeoReader, IndexReader, NumericFilter, RSIndexResult};
+use crate::{FilterGeoReader, IndexReader, NumericFilter};
 use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter};
+use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/numeric.rs
@@ -9,7 +9,8 @@
 
 use std::ptr;
 
-use crate::{FilterNumericReader, IndexReader, NumericFilter, RSIndexResult};
+use crate::{FilterNumericReader, IndexReader, NumericFilter};
+use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/doc_ids_only.rs
@@ -9,7 +9,8 @@
 
 use std::io::Cursor;
 
-use inverted_index::{Decoder, Encoder, RSIndexResult, doc_ids_only::DocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, doc_ids_only::DocIdsOnly};
 
 #[test]
 fn test_encode_doc_ids_only() {

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
@@ -10,8 +10,9 @@
 use std::io::Cursor;
 
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
     test_utils::{TermRecordCompare, TestTermRecord},
 };
@@ -163,7 +164,7 @@ fn test_encode_fields_offsets_field_mask_overflow() {
     let buf = [0u8; 100];
     let mut cursor = Cursor::new(buf);
 
-    let record = inverted_index::RSIndexResult::build_term()
+    let record = index_result::RSIndexResult::build_term()
         .field_mask(u32::MAX as t_fieldMask + 1)
         .build();
     let _res = FieldsOffsets::encode(&mut cursor, 0, &record);
@@ -174,7 +175,7 @@ fn test_encode_fields_offsets_output_too_small() {
     // Not enough space in the buffer to write the encoded data.
     let buf = [0u8; 3];
     let mut cursor = Cursor::new(buf);
-    let record = inverted_index::RSIndexResult::build_term().build();
+    let record = index_result::RSIndexResult::build_term().build();
 
     let res = FieldsOffsets::encode(&mut cursor, 0, &record);
     assert_eq!(res.is_err(), true);

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/fields_only.rs
@@ -10,8 +10,9 @@
 use std::io::Cursor;
 
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     fields_only::{FieldsOnly, FieldsOnlyWide},
 };
 
@@ -62,7 +63,7 @@ fn test_encode_fields_only() {
 
     for (delta, field_mask, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
-        let record = inverted_index::RSIndexResult::build_term()
+        let record = index_result::RSIndexResult::build_term()
             .doc_id(doc_id)
             .field_mask(field_mask)
             .build();
@@ -126,7 +127,7 @@ fn test_encode_fields_only_wide() {
 
     for (delta, field_mask, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
-        let record = inverted_index::RSIndexResult::build_term()
+        let record = index_result::RSIndexResult::build_term()
             .doc_id(doc_id)
             .field_mask(field_mask)
             .build();

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_fields.rs
@@ -10,8 +10,9 @@
 use std::io::Cursor;
 
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     freqs_fields::{FreqsFields, FreqsFieldsWide},
 };
 

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_offsets.rs
@@ -9,8 +9,9 @@
 
 use std::io::Cursor;
 
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     freqs_offsets::FreqsOffsets,
     test_utils::{TermRecordCompare, TestTermRecord},
 };
@@ -71,7 +72,7 @@ fn test_encode_freqs_offsets_output_too_small() {
     // Not enough space in the buffer to write the encoded data.
     let buf = [0u8; 1];
     let mut cursor = Cursor::new(buf);
-    let record = inverted_index::RSIndexResult::build_term().build();
+    let record = index_result::RSIndexResult::build_term().build();
 
     let res = FreqsOffsets::encode(&mut cursor, 0, &record);
     assert_eq!(res.is_err(), true);

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_only.rs
@@ -9,7 +9,8 @@
 
 use std::io::Cursor;
 
-use inverted_index::{Decoder, Encoder, RSIndexResult, freqs_only::FreqsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, freqs_only::FreqsOnly};
 
 /// Helper to encode a sequence of (delta, freq) records using FreqsOnly.
 fn encode_freqs_only(records: &[(u32, u32)]) -> Vec<u8> {

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
@@ -10,8 +10,9 @@
 use std::io::Cursor;
 
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     full::{Full, FullWide},
     test_utils::{TermRecordCompare, TestTermRecord},
 };

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
@@ -7,8 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, IdDelta, RSIndexResult,
+    Decoder, Encoder, IdDelta,
     numeric::{Numeric, NumericDelta, NumericFloatCompression},
 };
 use pretty_assertions::assert_eq;

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/offsets_only.rs
@@ -9,8 +9,9 @@
 
 use std::io::Cursor;
 
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     offsets_only::OffsetsOnly,
     test_utils::{TermRecordCompare, TestTermRecord},
 };
@@ -69,7 +70,7 @@ fn test_encode_offsets_only_output_too_small() {
     // Not enough space in the buffer to write the encoded data.
     let buf = [0u8; 1];
     let mut cursor = Cursor::new(buf);
-    let record = inverted_index::RSIndexResult::build_term().build();
+    let record = index_result::RSIndexResult::build_term().build();
 
     let res = OffsetsOnly::encode(&mut cursor, 0, &record);
     assert_eq!(res.is_err(), true);

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/raw_doc_ids_only.rs
@@ -9,7 +9,8 @@
 
 use std::io::Cursor;
 
-use inverted_index::{Decoder, Encoder, RSIndexResult, raw_doc_ids_only::RawDocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, raw_doc_ids_only::RawDocIdsOnly};
 
 #[test]
 fn test_encode_raw_doc_ids_only() {
@@ -53,7 +54,7 @@ fn test_encode_raw_doc_ids_only_output_too_small() {
     // Not enough space in the buffer to write the encoded data.
     let buf = [0u8; 1];
     let mut cursor = Cursor::new(buf);
-    let record = inverted_index::RSIndexResult::build_virt().build();
+    let record = index_result::RSIndexResult::build_virt().build();
 
     let res = RawDocIdsOnly::encode(&mut cursor, 0, &record);
     assert_eq!(res.is_err(), true);

--- a/src/redisearch_rs/inverted_index/tests/integration/index.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index.rs
@@ -8,9 +8,8 @@
 */
 
 use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
-use inverted_index::{
-    IndexBlock, IndexReader, InvertedIndex, RSIndexResult, doc_ids_only::DocIdsOnly,
-};
+use index_result::RSIndexResult;
+use inverted_index::{IndexBlock, IndexReader, InvertedIndex, doc_ids_only::DocIdsOnly};
 
 #[test]
 #[cfg_attr(miri, ignore = "Too slow to be run under miri.")]

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -8,7 +8,7 @@
 */
 
 use ffi::RS_FIELDMASK_ALL;
-use inverted_index::{
+use index_result::{
     MetricsVec, RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSResultKind,
     RSResultKindMask,
 };

--- a/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
@@ -16,7 +16,7 @@
 //! irrelevant — only their addresses matter.
 
 use ffi::RLookupKey;
-use inverted_index::{MetricEntry, MetricsVec};
+use index_result::{MetricEntry, MetricsVec};
 use std::ptr;
 
 /// Builds a zero-initialized `RLookupKey` suitable for pointer-identity tests.

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 buffer.workspace = true
 criterion.workspace = true
 ffi.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 query_term.workspace = true
 itertools.workspace = true

--- a/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
@@ -14,7 +14,8 @@ use criterion::{
     measurement::WallTime,
 };
 use ffi::IndexFlags_Index_DocIdsOnly;
-use inverted_index::{IndexBlock, InvertedIndex, RSIndexResult, numeric::Numeric};
+use index_result::RSIndexResult;
+use inverted_index::{IndexBlock, InvertedIndex, numeric::Numeric};
 
 fn benchmark_garbage_collection(c: &mut Criterion) {
     let mut group = c.benchmark_group("GC");

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
@@ -10,7 +10,8 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use inverted_index::{Decoder, Encoder, RSIndexResult, doc_ids_only::DocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, doc_ids_only::DocIdsOnly};
 
 pub struct Bencher {
     test_values: Vec<TestValue>,

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -11,8 +11,9 @@ use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
     test_utils::TestTermRecord,
 };

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
@@ -11,8 +11,9 @@ use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     fields_only::{FieldsOnly, FieldsOnlyWide},
 };
 use itertools::Itertools;

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
@@ -11,8 +11,9 @@ use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     freqs_fields::{FreqsFields, FreqsFieldsWide},
 };
 use itertools::Itertools;

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_offsets.rs
@@ -10,9 +10,8 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use inverted_index::{
-    Decoder, Encoder, RSIndexResult, freqs_offsets::FreqsOffsets, test_utils::TestTermRecord,
-};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, freqs_offsets::FreqsOffsets, test_utils::TestTermRecord};
 use itertools::Itertools;
 
 pub struct Bencher {

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
@@ -10,7 +10,8 @@
 use std::{hint::black_box, io::Cursor};
 
 use criterion::{BatchSize, Criterion};
-use inverted_index::{Decoder, Encoder, RSIndexResult, freqs_only::FreqsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, freqs_only::FreqsOnly};
 use itertools::Itertools;
 
 pub struct Bencher {
@@ -39,7 +40,7 @@ impl Bencher {
             .into_iter()
             .cartesian_product(deltas)
             .map(|(freq, delta)| {
-                let record = inverted_index::RSIndexResult::build_virt()
+                let record = index_result::RSIndexResult::build_virt()
                     .doc_id(100)
                     .frequency(freq)
                     .build();
@@ -67,7 +68,7 @@ impl Bencher {
                 || Cursor::new(Vec::with_capacity(buffer_size)),
                 |mut buffer| {
                     for test in &self.test_values {
-                        let record = inverted_index::RSIndexResult::build_virt()
+                        let record = index_result::RSIndexResult::build_virt()
                             .doc_id(100)
                             .frequency(test.freq)
                             .build();

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
@@ -11,8 +11,9 @@ use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
 use ffi::t_fieldMask;
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, RSIndexResult,
+    Decoder, Encoder,
     full::{Full, FullWide},
     test_utils::TestTermRecord,
 };

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -10,8 +10,9 @@
 use std::{collections::HashMap, hint::black_box, io::Cursor};
 
 use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion, measurement::Measurement};
+use index_result::RSIndexResult;
 use inverted_index::{
-    Decoder, Encoder, IdDelta, RSIndexResult,
+    Decoder, Encoder, IdDelta,
     numeric::{Numeric, NumericDelta},
 };
 use itertools::Itertools;
@@ -170,7 +171,7 @@ fn generate_test_values() -> Vec<BenchGroup> {
                     .into_iter()
                     // We need to find the actual resulting output for the decoding benchmarks
                     .map(|value| {
-                        let record = inverted_index::RSIndexResult::build_numeric(value).build();
+                        let record = index_result::RSIndexResult::build_numeric(value).build();
                         let mut buffer = Cursor::new(Vec::new());
                         let _grew_size = Numeric::encode(
                             &mut buffer,
@@ -238,7 +239,7 @@ fn encode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input: &BenchGroup)
                 },
                 |mut buffer| {
                     for (value, delta, _) in values {
-                        let record = inverted_index::RSIndexResult::build_numeric(*value).build();
+                        let record = index_result::RSIndexResult::build_numeric(*value).build();
 
                         let grew_size = Numeric::encode(
                             &mut buffer,

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
@@ -10,9 +10,8 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use inverted_index::{
-    Decoder, Encoder, RSIndexResult, offsets_only::OffsetsOnly, test_utils::TestTermRecord,
-};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, offsets_only::OffsetsOnly, test_utils::TestTermRecord};
 use itertools::Itertools;
 
 pub struct Bencher {

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/raw_doc_ids_only.rs
@@ -10,7 +10,8 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use inverted_index::{Decoder, Encoder, RSIndexResult, raw_doc_ids_only::RawDocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{Decoder, Encoder, raw_doc_ids_only::RawDocIdsOnly};
 
 pub struct Bencher {
     test_values: Vec<TestValue>,

--- a/src/redisearch_rs/numeric_range_tree/Cargo.toml
+++ b/src/redisearch_rs/numeric_range_tree/Cargo.toml
@@ -25,6 +25,7 @@ build_utils = { path = "../build_utils" }
 cheadergen.workspace = true
 ffi.workspace = true
 hyperloglog.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 redis_reply.workspace = true
 generational_slab.workspace = true

--- a/src/redisearch_rs/numeric_range_tree/src/debug.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/debug.rs
@@ -12,7 +12,8 @@
 //! This module provides functions to dump tree state for debugging purposes.
 //! These are used by the FT.DEBUG commands (NUMIDX_SUMMARY, DUMP_NUMIDX, DUMP_NUMIDXTREE).
 
-use inverted_index::{IndexReader, RSIndexResult};
+use index_result::RSIndexResult;
+use inverted_index::IndexReader;
 use redis_reply::{ArrayBuilder, MapBuilder, RedisModuleCtx, Replier};
 
 use crate::{NodeIndex, NumericIndex, NumericRange, NumericRangeNode, NumericRangeTree};

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -13,8 +13,9 @@
 //! compressed and uncompressed numeric storage in inverted indexes.
 
 use ffi::IndexFlags_Index_StoreNumeric;
+use index_result::RSIndexResult;
 use inverted_index::{
-    EntriesTrackingIndex, IndexBlock, IndexReader, IndexReaderCore, NumericReader, RSIndexResult,
+    EntriesTrackingIndex, IndexBlock, IndexReader, IndexReaderCore, NumericReader,
     debug::Summary,
     numeric::{Numeric, NumericFloatCompression},
 };

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -15,7 +15,8 @@
 
 use ffi::t_docId;
 use hyperloglog::{HyperLogLog6, WyHasher};
-use inverted_index::{IndexReader as _, RSIndexResult};
+use index_result::RSIndexResult;
+use inverted_index::IndexReader as _;
 
 use crate::index::{NumericIndex, NumericIndexReader};
 

--- a/src/redisearch_rs/numeric_range_tree/src/test_utils.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/test_utils.rs
@@ -12,7 +12,8 @@
 //! Gated behind the `test_utils` feature so that production builds do not
 //! include these utilities.
 
-use inverted_index::{Encoder, IndexBlock, RSIndexResult, numeric::Numeric};
+use index_result::RSIndexResult;
+use inverted_index::{Encoder, IndexBlock, numeric::Numeric};
 
 use crate::{NodeGcDelta, NodeIndex, NumericRangeNode, NumericRangeTree};
 

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -15,7 +15,8 @@
 
 use std::collections::HashMap;
 
-use inverted_index::{GcApplyInfo, GcScanDelta, IndexBlock, RSIndexResult};
+use index_result::RSIndexResult;
+use inverted_index::{GcApplyInfo, GcScanDelta, IndexBlock};
 
 use super::{NumericRangeTree, TrimEmptyLeavesResult};
 use crate::NumericRangeNode;

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -14,7 +14,8 @@
 //! splitting and AVL-like rebalancing on the way back up.
 
 use ffi::t_docId;
-use inverted_index::{IndexReader as _, RSIndexResult};
+use index_result::RSIndexResult;
+use inverted_index::IndexReader as _;
 
 use super::{AddResult, CheckedCount, NumericRangeTree};
 use crate::arena::{NodeArena, NodeIndex};
@@ -317,7 +318,7 @@ impl NumericRangeTree {
 
         // Redistribute entries to children
         let mut reader = parent_range.reader();
-        let mut result = inverted_index::RSIndexResult::build_numeric(0.0).build();
+        let mut result = index_result::RSIndexResult::build_numeric(0.0).build();
         while reader.next_record(&mut result).unwrap_or(false) {
             // SAFETY: We know the result contains numeric data
             let entry_value = unsafe { result.as_numeric_unchecked() };

--- a/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
@@ -13,7 +13,8 @@
 //! after every mutation (`add`, `trim_empty_leaves`) to catch structural
 //! violations early.
 
-use inverted_index::{IndexReader, NumericFilter, RSIndexResult};
+use index_result::RSIndexResult;
+use inverted_index::{IndexReader, NumericFilter};
 
 use super::{AddResult, CheckedCount, NumericRangeTree, TreeStats, TrimEmptyLeavesResult};
 use crate::NumericRange;

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -20,6 +20,7 @@ geo.workspace = true
 rqe_iterator_type.workspace = true
 field.workspace = true
 idf.workspace = true
+index_result.workspace = true
 index_spec.workspace = true
 inverted_index.workspace = true
 libc.workspace = true

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -18,8 +18,8 @@ use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, interop::RQEIteratorWrapper,
     intersection::Intersection,
 };
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 use std::{
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -10,8 +10,8 @@
 //! Supporting types for [`Empty`].
 
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 

--- a/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
@@ -15,7 +15,7 @@ use std::ptr::NonNull;
 
 use ffi::{IndexFlags_Index_WideSchema, RS_INVALID_FIELD_INDEX, RedisSearchCtx};
 use field::{FieldFilterContext, FieldMaskOrIndex};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 /// Trait for checking if a document has expired.
 ///

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -10,8 +10,8 @@
 //! Supporting types for [`IdList`].
 
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 use std::cmp::Ordering;
 
 use crate::{

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -13,7 +13,7 @@ use ffi::{
     ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK,
     t_docId,
 };
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -16,8 +16,8 @@
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
 ///
@@ -294,7 +294,7 @@ where
     /// Explore removing the unsafe code by using one of the following alternatives (as suggested in the PR):
     ///
     /// - Store owned copies instead of borrowed references (memory/perf tradeoff)
-    /// - Restructure [`RSAggregateResult`](inverted_index::RSAggregateResult) to not require `'index` on stored references
+    /// - Restructure [`RSAggregateResult`](index_result::RSAggregateResult) to not require `'index` on stored references
     /// - Use a different aggregate pattern that doesn't store child references
     fn build_aggregate_result(&mut self, doc_id: t_docId) {
         // Reset all per-document accumulating fields before building the new aggregate.

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -8,8 +8,9 @@
 */
 
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{IndexReader, RSIndexResult};
+use inverted_index::IndexReader;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -13,10 +13,9 @@ use std::{
 };
 
 use ffi::{RedisSearchCtx, t_docId, t_fieldIndex};
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{
-    DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
-};
+use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
 
 use crate::{
     ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -15,9 +15,10 @@ use crate::{
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 use ffi::{FieldType_INDEXFLD_T_GEO, FieldType_INDEXFLD_T_NUMERIC, IndexFlags, t_docId};
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
-    FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader, RSIndexResult,
+    FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -10,10 +10,10 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, TagIndex, t_docId};
+use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
-    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RSIndexResult, RSOffsetSlice,
-    opaque::OpaqueEncoding,
+    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, opaque::OpaqueEncoding,
 };
 use query_term::RSQueryTerm;
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -10,8 +10,9 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, t_docId};
+use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{RSIndexResult, RSOffsetSlice, TermReader};
+use inverted_index::TermReader;
 use query_term::RSQueryTerm;
 
 use crate::{

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -8,10 +8,9 @@
 */
 
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{
-    DecodedBy, DocIdsDecoder, IndexReaderCore, RSIndexResult, opaque::OpaqueEncoding,
-};
+use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -13,7 +13,8 @@ use ffi::t_docId;
 use index_spec::IndexSpecReadGuard;
 use thiserror::Error;
 
-use ::inverted_index::{RSIndexResult, t_fieldMask};
+use ::inverted_index::t_fieldMask;
+use index_result::RSIndexResult;
 use query_term::RSQueryTerm;
 
 pub mod c2rust;

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -10,8 +10,8 @@
 //! Helper wrapping either [`Empty`] or the provided [`RQEIterator`].
 
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty,

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -14,8 +14,8 @@ use crate::{
     utils::OwnedSlice,
 };
 use ffi::{RLookupKey, RLookupKeyHandle, t_docId};
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 
 /// The different types of metrics.
 /// At the moment, only vector distance is supported.

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -10,7 +10,7 @@
 //! Supporting types for [`Optional`].
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use std::cmp;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -15,7 +15,7 @@
 //! results accordingly.
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, maybe_empty::MaybeEmpty,

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant};
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use ffi::t_docId;
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::RSIndexResult;
 
 /// Profile counters collected during query execution.
 ///

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -10,7 +10,7 @@
 //! Flat array variant of the union iterator with O(n) min-finding.
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use index_spec::IndexSpecReadGuard;

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -10,7 +10,7 @@
 //! Heap variant of the union iterator with O(log n) min-finding.
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::utils::DocIdMinHeap;
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -24,7 +24,7 @@
 use std::ffi::c_char;
 
 use ffi::{QueryNodeType, t_docId};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -46,7 +46,7 @@
 //! accessible even though they are inactive.
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use index_spec::IndexSpecReadGuard;

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -12,9 +12,10 @@
 use std::ptr::NonNull;
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
+use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
-use inverted_index::{DocIdsDecoder, RSIndexResult, opaque};
+use inverted_index::{DocIdsDecoder, opaque};
 
 use crate::IteratorType;
 use crate::{

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -8,7 +8,7 @@
 */
 
 use crate::id_cases;
-use inverted_index::RSResultKind;
+use index_result::RSResultKind;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome,
     id_list::{IdListSorted, IdListUnsorted},

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -10,7 +10,8 @@
 //! Tests for the missing-field inverted index iterator.
 
 use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
-use inverted_index::{RSIndexResult, doc_ids_only::DocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::doc_ids_only::DocIdsOnly;
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Missing};
 use rqe_iterators_test_utils::MockContext;
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -10,8 +10,9 @@
 use std::ptr::{self, NonNull};
 
 use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, IndexFlags_Index_StoreNumeric, t_docId};
+use index_result::RSIndexResult;
 use inverted_index::{
-    FilterNumericReader, IndexReader, InvertedIndex, NumericFilter, NumericReader, RSIndexResult,
+    FilterNumericReader, IndexReader, InvertedIndex, NumericFilter, NumericReader,
 };
 use rqe_iterators::{
     IteratorType, NoOpChecker, RQEIterator, RQEValidateStatus, SkipToOutcome,
@@ -703,7 +704,8 @@ mod from_tree {
 mod variant {
     use ffi::IndexFlags_Index_StoreNumeric;
     use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-    use inverted_index::{NumericFilter, RSIndexResult};
+    use index_result::RSIndexResult;
+    use inverted_index::NumericFilter;
     use numeric_range_tree::NumericIndex;
     use rqe_iterators::{FieldExpirationChecker, NumericIteratorVariant};
     use rqe_iterators_test_utils::MockContext;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -10,7 +10,8 @@
 //! Tests for the tag inverted index iterator.
 
 use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
-use inverted_index::{RSIndexResult, doc_ids_only::DocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::doc_ids_only::DocIdsOnly;
 use query_term::RSQueryTerm;
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Tag};
 use rqe_iterators_test_utils::MockContext;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -14,7 +14,8 @@ use ffi::{
     t_docId, t_fieldMask,
 };
 use field::FieldMaskOrIndex;
-use inverted_index::{FilterMaskReader, RSIndexResult, RSOffsetSlice, full::Full};
+use index_result::{RSIndexResult, RSOffsetSlice};
+use inverted_index::{FilterMaskReader, full::Full};
 use query_term::RSQueryTerm;
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Term};
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -13,9 +13,8 @@ use ffi::{
     t_docId,
 };
 use field::FieldMaskOrIndex;
-use inverted_index::{
-    DecodedBy, Encoder, InvertedIndex, RSIndexResult, RSResultKind, test_utils::TermRecordCompare,
-};
+use index_result::{RSIndexResult, RSResultKind};
+use inverted_index::{DecodedBy, Encoder, InvertedIndex, test_utils::TermRecordCompare};
 use numeric_range_tree::NumericIndex;
 use rqe_iterators::{ExpirationChecker, RQEIterator, RQEValidateStatus, SkipToOutcome};
 use rqe_iterators_test_utils::MockContext;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -10,7 +10,8 @@
 //! Tests for the wildcard inverted index iterator.
 
 use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
-use inverted_index::{RSIndexResult, doc_ids_only::DocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::doc_ids_only::DocIdsOnly;
 use rqe_iterators::{IteratorType, RQEIterator, inverted_index::Wildcard};
 
 use crate::inverted_index::utils::BaseTest;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -13,16 +13,16 @@ use rqe_iterators::{
 };
 
 #[derive(Default)]
-struct Infinite<'index>(inverted_index::RSIndexResult<'index>);
+struct Infinite<'index>(index_result::RSIndexResult<'index>);
 
 impl<'index> RQEIterator<'index> for Infinite<'index> {
-    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+    fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
         Some(&mut self.0)
     }
 
     fn read(
         &mut self,
-    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, RQEIteratorError> {
+    ) -> Result<Option<&mut index_result::RSIndexResult<'index>>, RQEIteratorError> {
         self.0.doc_id += 1;
         Ok(Some(&mut self.0))
     }
@@ -145,9 +145,7 @@ fn skip_to_not_empty() {
         assert_eq!(
             outcome,
             Some(SkipToOutcome::Found(
-                &mut inverted_index::RSIndexResult::build_virt()
-                    .doc_id(id)
-                    .build()
+                &mut index_result::RSIndexResult::build_virt().doc_id(id).build()
             ))
         );
         assert_eq!(it.last_doc_id(), id);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -64,7 +64,7 @@ fn score_variant_cannot_skip() {
 
 mod metrics_tests {
     use crate::id_cases;
-    use inverted_index::RSResultKind;
+    use index_result::RSResultKind;
     use rqe_iterators::{RQEIterator, SkipToOutcome, metric::MetricSortedById};
     use rstest_reuse::apply;
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -10,7 +10,7 @@
 use std::time::Duration;
 
 use ffi::t_docId;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use rqe_iterators::{RQEIterator, RQEIteratorError, SkipToOutcome, not_optimized::NotOptimized};
 
 use crate::utils::{Mock, MockIteratorError, MockVec, WildcardHelper};

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -905,7 +905,7 @@ mod optional_iterator_non_sequential_reads {
     struct ReadStepIterator<'index, const N: usize> {
         read_steps: [t_docId; N],
         read_step: usize,
-        result: inverted_index::RSIndexResult<'index>,
+        result: index_result::RSIndexResult<'index>,
     }
 
     impl<'index, const N: usize> ReadStepIterator<'index, N> {
@@ -913,22 +913,20 @@ mod optional_iterator_non_sequential_reads {
             Self {
                 read_steps,
                 read_step: 0,
-                result: inverted_index::RSIndexResult::build_numeric(42.).build(),
+                result: index_result::RSIndexResult::build_numeric(42.).build(),
             }
         }
     }
 
     impl<'index, const N: usize> RQEIterator<'index> for ReadStepIterator<'index, N> {
-        fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+        fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
             Some(&mut self.result)
         }
 
         fn read(
             &mut self,
-        ) -> Result<
-            Option<&mut inverted_index::RSIndexResult<'index>>,
-            rqe_iterators::RQEIteratorError,
-        > {
+        ) -> Result<Option<&mut index_result::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
+        {
             if self.at_eof() {
                 return Ok(None);
             }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -8,7 +8,8 @@
 */
 
 use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
-use inverted_index::{InvertedIndex, RSIndexResult, RSResultKind, doc_ids_only::DocIdsOnly};
+use index_result::{RSIndexResult, RSResultKind};
+use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 use rqe_iterators::{
     RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, inverted_index::Wildcard,
     optional_optimized::OptionalOptimized,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -9,7 +9,7 @@
 
 use std::ptr::NonNull;
 
-use inverted_index::RSResultKind;
+use index_result::RSResultKind;
 use rqe_iterators::{
     RQEIterator,
     empty::Empty,
@@ -100,7 +100,8 @@ mod optional_reducer_tests {
     #[test]
     fn shortcircuit_2_inverted_index_wildcard_child_returned_as_passthrough() {
         use ffi::IndexFlags_Index_DocIdsOnly;
-        use inverted_index::{InvertedIndex, RSIndexResult, doc_ids_only::DocIdsOnly};
+        use index_result::RSIndexResult;
+        use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
         use rqe_iterators::{IteratorType, inverted_index::Wildcard as InvIdxWildcard};
 
         const MAX_DOC_ID: ffi::t_docId = 1000;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -10,7 +10,7 @@
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use ffi::{RS_FIELDMASK_ALL, t_docId};
-use inverted_index::{RSIndexResult, RSOffsetSlice};
+use index_result::{RSIndexResult, RSOffsetSlice};
 use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 
 /// Test iterator used in unit tests that expect an [`RQEIterator`]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use mock_enterprise_iterators::{MOCK_DISK_WILDCARD_TOP_ID, init_enter
 pub(crate) use mock_iterator::{Mock, MockData, MockIteratorError, MockRevalidateResult, MockVec};
 pub(crate) use wildcard_helper::WildcardHelper;
 
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use rqe_iterators::{IteratorType, RQEIterator, RQEIteratorError, SkipToOutcome};
 
 /// A mock iterator that produces results with a specific `t_fieldMask`.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
@@ -8,7 +8,8 @@
 */
 
 use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
-use inverted_index::{InvertedIndex, RSIndexResult, doc_ids_only::DocIdsOnly};
+use index_result::RSIndexResult;
+use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 
 /// Holds an [`InvertedIndex`] so a
 /// [`Wildcard`](rqe_iterators::inverted_index::Wildcard) iterator can be

--- a/src/redisearch_rs/rqe_iterators_bencher/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators_bencher/Cargo.toml
@@ -24,6 +24,7 @@ build_utils = { path = "../build_utils" }
 criterion.workspace = true
 ffi.workspace = true
 field.workspace = true
+index_result.workspace = true
 query_term.workspace = true
 inverted_index.workspace = true
 inverted_index_ffi = { version = "0.0.1", path = "../c_entrypoint/inverted_index_ffi" }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
@@ -22,7 +22,8 @@ use ffi::{
     IndexFlags, IndexFlags_Index_StoreByteOffsets, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets, IteratorStatus_ITERATOR_OK,
 };
-use inverted_index::{InvertedIndex, RSIndexResult, RSOffsetSlice, full::Full};
+use index_result::{RSIndexResult, RSOffsetSlice};
+use inverted_index::{InvertedIndex, full::Full};
 use query_term::RSQueryTerm;
 use rqe_iterators::{
     Intersection, NoOpChecker, RQEIterator, id_list::IdListSorted, inverted_index::Term,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/numeric.rs
@@ -11,7 +11,8 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use inverted_index::{IndexReader, RSIndexResult};
+use index_result::RSIndexResult;
+use inverted_index::IndexReader;
 use rqe_iterators::{FieldExpirationChecker, RQEIterator, SkipToOutcome, inverted_index::Numeric};
 use rqe_iterators_test_utils::TestContext;
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
@@ -12,7 +12,8 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
-use inverted_index::{RSQueryTerm, doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding};
+use index_result::RSQueryTerm;
+use inverted_index::{doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding};
 use rqe_iterators::{RQEIterator, SkipToOutcome, inverted_index::Tag};
 use rqe_iterators_test_utils::TestContext;
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/term.rs
@@ -10,9 +10,9 @@
 use std::{hint::black_box, marker::PhantomData};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
+use index_result::{RSIndexResult, RSOffsetSlice};
 use inverted_index::{
-    DecodedBy, Encoder, HasInnerIndex, InvertedIndex, RSIndexResult, RSOffsetSlice, TermDecoder,
-    opaque::OpaqueEncoding,
+    DecodedBy, Encoder, HasInnerIndex, InvertedIndex, TermDecoder, opaque::OpaqueEncoding,
 };
 use query_term::RSQueryTerm;
 use rqe_iterators::{NoOpChecker, RQEIterator, SkipToOutcome, inverted_index::Term};

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -13,7 +13,7 @@ pub use ffi::{
     IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_OK,
     RedisModule_Alloc, RedisModule_Free, ValidateStatus, t_docId,
 };
-use inverted_index::{RSIndexResult, RSQueryTerm};
+use index_result::{RSIndexResult, RSQueryTerm};
 use iterators_ffi::intersection::NewIntersectionIterator;
 use std::{ffi::c_void, ptr};
 
@@ -258,7 +258,7 @@ impl InvertedIndex {
         term: Option<Box<RSQueryTerm>>,
         offsets: &[u8],
     ) {
-        let offsets = inverted_index::RSOffsetSlice::from_slice(offsets);
+        let offsets = index_result::RSOffsetSlice::from_slice(offsets);
         let record = RSIndexResult::build_term()
             .borrowed_record(term, offsets)
             .doc_id(doc_id)

--- a/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 ffi.workspace = true
 field.workspace = true
+index_result.workspace = true
 index_spec.workspace = true
 inverted_index = { workspace = true, features = ["test_utils"] }
 inverted_index_ffi = { path = "../c_entrypoint/inverted_index_ffi", features = [

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -39,7 +39,7 @@ fn unique_index_name(prefix: &str) -> String {
     format!("{prefix}_{id}")
 }
 use field::FieldMaskOrIndex;
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use numeric_range_tree::{NumericIndex, NumericRangeTree};
 use query_error::QueryError;
 

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 
 [dependencies]
 ffi.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 rlookup.workspace = true
 enumflags2.workspace = true

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -8,7 +8,7 @@
 */
 
 use enumflags2::{BitFlags, bitflags};
-use inverted_index::RSIndexResult;
+use index_result::RSIndexResult;
 use rlookup::RLookupRow;
 use std::ptr::NonNull;
 


### PR DESCRIPTION
## Describe the changes in the pull request

Clean-up workspace references to RSIndexResult in preparation for its parametrisation via `ref_mode::Ptr`.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This removes `index_result` type re-exports from `inverted_index`, requiring widespread import/dependency updates and potentially breaking downstream code that relied on `inverted_index::RSIndexResult` and related symbols.
> 
> **Overview**
> Drops `index_result` type re-exports from the `inverted_index` crate root, forcing call sites to depend on and import `index_result` directly (e.g., `RSIndexResult`, `RSQueryTerm`, metrics/offset/result enums).
> 
> Updates multiple Rust crates (FFI entrypoints, iterators, numeric range tree, search results, tests, and benchers) to add `index_result` as an explicit dependency and to replace `inverted_index::…` result-type imports with `index_result::…`.
> 
> Regenerates/adjusts headers so `II_GCScanStats` is emitted after `IndexDecoderCtx` (no field changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea369b952eb5b9db27fa25cfc285698bbee3163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->