### PR TITLE
Refactor Pipeline Build Error Path

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1749,7 +1749,7 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
     };
     req->rootiter = NULL; // Ownership of the root iterator is now with the params.
     req->querySlots = NULL; // Ownership of the slot ranges is now with the params.
-    Pipeline_BuildQueryPart(&req->pipeline, &params);
+    Pipeline_BuildQueryPart(&req->pipeline, &params, status);
     if (QueryError_HasError(status)) {
       return REDISMODULE_ERR;
     }
@@ -1766,5 +1766,5 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
     .maxResultsLimit = IsSearch(req) ? req->maxSearchResults : req->maxAggregateResults,
     .language = req->searchopts.language,
   };
-  return Pipeline_BuildAggregationPart(&req->pipeline, &params, &req->stateflags);
+  return Pipeline_BuildAggregationPart(&req->pipeline, &params, &req->stateflags, status);
 }

--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -120,13 +120,10 @@ arrayof(char*) HybridRequest_BuildDistributedPipeline(HybridRequest *hreq,
     }
 
     RLookup_EnableOptions(tailLookup, RLOOKUP_OPT_ALLOWUNRESOLVED);
-    rc = HybridRequest_BuildMergePipeline(hreq, scoreKey, hybridParams);
+    rc = HybridRequest_BuildMergePipeline(hreq, scoreKey, hybridParams, status);
     RLookup_DisableOptions(tailLookup, RLOOKUP_OPT_ALLOWUNRESOLVED);
 
     if (rc != REDISMODULE_OK) {
-      // The error is set at the tail, copy it into status
-      QueryError_CloneFrom(&hreq->tailPipelineError, status);
-      QueryError_ClearError(&hreq->tailPipelineError);
       return NULL;
     }
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -205,7 +205,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
 
   // Set request flags from hybridParams
   hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
-  if (HybridRequest_BuildPipeline(hreq, &hybridParams, false) != REDISMODULE_OK) {
+  if (HybridRequest_BuildPipeline(hreq, &hybridParams, false, &hreq->tailPipelineError) != REDISMODULE_OK) {
     if (hybridParams.scoringCtx) {
       HybridScoringContext_Free(hybridParams.scoringCtx);
     }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -781,7 +781,7 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
     if (HybridRequest_BuildDepletionPipeline(hreq, hybridParams, depleteInBackground) != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
-  } else if (HybridRequest_BuildPipeline(hreq, hybridParams, depleteInBackground) != REDISMODULE_OK) {
+  } else if (HybridRequest_BuildPipeline(hreq, hybridParams, depleteInBackground, &hreq->tailPipelineError) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -125,7 +125,7 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req) {
   }
 }
 
-int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params) {
+int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params, QueryError *status) {
     // Array to collect upstream from each individual request pipeline
     arrayof(ResultProcessor*) upstreams = array_new(ResultProcessor *, req->nrequests);
     for (size_t i = 0; i < req->nrequests; i++) {
@@ -133,7 +133,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
         // In profile mode, the end processor must be RP_PROFILE (which wraps the depleter)
         if (IsProfile(req) && areq->pipeline.qctx.endProc->type != RP_PROFILE) {
             QueryError_SetWithoutUserDataFmt(
-                &req->tailPipelineError,
+                status,
                 QUERY_ERROR_CODE_GENERIC,
                 "Expected %s processor at end of pipeline, found %s",
                 RPTypeToString(RP_PROFILE),
@@ -164,11 +164,11 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     // Build the aggregation part of the tail pipeline for final result processing
     // This handles sorting, filtering, field loading, and output formatting of merged results
     uint32_t stateFlags = 0;
-    int rc = Pipeline_BuildAggregationPart(req->tailPipeline, &params->aggregationParams, &stateFlags);
+    int rc = Pipeline_BuildAggregationPart(req->tailPipeline, &params->aggregationParams, &stateFlags, status);
     return rc;
 }
 
-int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground) {
+int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground, QueryError *status) {
     // Build the depletion pipeline for extracting results from individual search requests
     if (HybridRequest_BuildDepletionPipeline(req, params, depleteInBackground) != REDISMODULE_OK) {
       return REDISMODULE_ERR;
@@ -185,13 +185,13 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
       HybridRequest_SynchronizeLookupKeys(req);
     }
 
-    const RLookupKey *scoreKey = OpenMergeScoreKey(tailLookup, params->aggregationParams.common.scoreAlias, &req->tailPipelineError);
-    if (QueryError_HasError(&req->tailPipelineError)) {
+    const RLookupKey *scoreKey = OpenMergeScoreKey(tailLookup, params->aggregationParams.common.scoreAlias, status);
+    if (QueryError_HasError(status)) {
       return REDISMODULE_ERR;
     }
 
     // Build the merge pipeline for combining and processing results from the depletion pipeline
-    return HybridRequest_BuildMergePipeline(req, scoreKey, params);
+    return HybridRequest_BuildMergePipeline(req, scoreKey, params, status);
 }
 
 /**

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -203,9 +203,10 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req);
  * @param req The HybridRequest containing the tail pipeline for merging
  * @param scoreKey The score key to use for writing the final score, could be null - won't write score in this case to the rlookup
  * @param params Pipeline parameters including aggregation settings and scoring context, this function takes ownership of the scoring context
+ * @param status Query error status to report any construction errors
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on failure
  */
-int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params);
+int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params, QueryError *status);
 
 /**
  * Build the complete hybrid search pipeline.
@@ -214,9 +215,10 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
  * @param req The HybridRequest to build the pipeline for
  * @param params Pipeline parameters including aggregation settings and scoring context, this function takes ownership of the scoring context
  * @param depleteInBackground Whether the pipeline should be built for asynchronous depletion
+ * @param status Query error status to report any construction errors
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on failure
  */
-int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground);
+int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground, QueryError *status);
 
 /**
  * Increment the reference count of the HybridRequest.

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -401,7 +401,7 @@ ResultProcessor *processLoadStep(PLN_LoadStep *loadStep, RLookup *lookup,
  * This creates the initial pipeline components that find matching documents and calculate
  * their relevance scores, providing the foundation for subsequent aggregation and filtering stages.
  */
-void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params) {
+void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params, QueryError *status) {
   IndexSpecCache *cache = IndexSpec_GetSpecCache(params->common.sctx->spec);
   RS_LOG_ASSERT(cache, "IndexSpec_GetSpecCache failed")
   RLookup *first = AGPLN_GetLookup(&pipeline->ap, NULL, AGPLN_GETLOOKUP_FIRST);
@@ -418,7 +418,7 @@ void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params) {
   // Load results metrics according to their RLookup key.
   // We need this RP only if metricRequests is not empty.
   if (params->ast->metricRequests) {
-    rp = getAdditionalMetricsRP(params->common.sctx, params->ast, first, pipeline->qctx.err);
+    rp = getAdditionalMetricsRP(params->common.sctx, params->ast, first, status);
     if (!rp) {
       return;
     }
@@ -455,7 +455,7 @@ void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params) {
       if (params->common.scoreAlias) {
         scoreKey = RLookup_GetKey_Write(first, params->common.scoreAlias, RLOOKUP_F_NOFLAGS);
         if (!scoreKey) {
-          QueryError_SetWithUserDataFmt(pipeline->qctx.err, QUERY_ERROR_CODE_DUP_FIELD, "Could not create score alias, name already exists in query", "%s", params->common.scoreAlias);
+          QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_DUP_FIELD, "Could not create score alias, name already exists in query", "%s", params->common.scoreAlias);
           return;
         }
       } else {
@@ -536,12 +536,11 @@ error:
   return REDISMODULE_ERR;
 }
 
-int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineParams *params, uint32_t *outStateFlags) {
+int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineParams *params, uint32_t *outStateFlags, QueryError *status) {
   AGGPlan *pln = &pipeline->ap;
   ResultProcessor *rp = NULL, *rpUpstream = pipeline->qctx.endProc;
   RedisSearchCtx *sctx = params->common.sctx;
   int requestFlags = params->common.reqflags;
-  QueryError *status = pipeline->qctx.err;
 
   // If we have a JSON spec, and an "old" API version (DIALECT < 3), we don't store all the data of a multi-value field
   // in the SV as we want to return it, so we need to load and override all requested return fields that are SV source.

--- a/src/pipeline/pipeline_construction.h
+++ b/src/pipeline/pipeline_construction.h
@@ -7,14 +7,16 @@ extern "C" {
 
 /** Build the document search and scoring part of the pipeline.
  *  This creates the initial pipeline components that execute the query against
- *  the index to find matching documents and calculate their relevance scores. */
-void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params);
+ *  the index to find matching documents and calculate their relevance scores.
+ *  Construction errors are reported into `status`. */
+void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params, QueryError *status);
 
 /** Build the result processing and output formatting part of the pipeline.
  *  This creates pipeline components that process search results through operations
  *  like filtering, sorting, grouping, field loading, and output formatting.
- *  There is a hidden assumption that the pipeline already contains at least one result processor to be used as an upstream */
-int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineParams *params, uint32_t *outStateFlags);
+ *  There is a hidden assumption that the pipeline already contains at least one result processor to be used as an upstream.
+ *  Construction errors are reported into `status`. */
+int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineParams *params, uint32_t *outStateFlags, QueryError *status);
 
 bool hasQuerySortby(const AGGPlan *pln);
 

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -168,7 +168,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   }
 
   // Build the pipeline using the parsed hybrid parameters
-  rc = HybridRequest_BuildPipeline(hybridReq, cmd.hybridParams, true);
+  rc = HybridRequest_BuildPipeline(hybridReq, cmd.hybridParams, true, status);
   if (rc != REDISMODULE_OK) {
     HybridRequest_DecrRef(hybridReq);
     return nullptr;


### PR DESCRIPTION
Right now, we use the QueryStatus inside the query objects during pipeline construction.
It makes more sense to separate the build error from the execution error.
Refactoring the different pipeline construction functions to receive a query status pointer and work with it instead of using query object error variable.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pipeline construction and hybrid merge planning by changing function signatures and error propagation paths, which could alter which errors are surfaced or when pipeline build aborts. Behavior should be largely equivalent but regressions are possible around hybrid tail/score-alias and pipeline build failures.
> 
> **Overview**
> Refactors pipeline construction to **stop relying on per-pipeline `qctx.err` during build** and instead thread an explicit `QueryError *status` through `Pipeline_BuildQueryPart` and `Pipeline_BuildAggregationPart` (and their call sites).
> 
> Hybrid pipeline building is updated to pass the caller-provided status through `HybridRequest_BuildPipeline`/`HybridRequest_BuildMergePipeline`, and coordinator distributed hybrid planning no longer clones errors from `tailPipelineError` after merge-pipeline build failures (error is now expected to be set directly). Tests are updated to use the new function signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5878a94e459b8acf85eaf48f03df6aecb747d06f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->