### PR TITLE
[MOD-15622] Fix suffix trie loops to iterate by rune count instead of byte length

### DIFF
--- a/src/suffix.c
+++ b/src/suffix.c
@@ -81,7 +81,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
 
   // Save string copy to all suffixes of it
   // If it exists, move to the next field
-  for (int j = 1; j < len - MIN_SUFFIX + 1; ++j) {
+  for (size_t j = 1; j + MIN_SUFFIX <= rlen; ++j) {
     TrieNode *trienode = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
 
     data = Suffix_GetData(trienode);
@@ -122,19 +122,29 @@ void deleteSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   rune *runes = runeBufFill(str, len, &buf, &rlen);
   char *oldTerm = NULL;
 
-  // iterate all matching terms and remove word
-  for (int j = 0; j < len - MIN_SUFFIX + 1; ++j) {
+  // Remove the full-word entry (always inserted by addSuffixTrie).
+  if (rlen > 0) {
+    TrieNode *node = Trie_GetNode(trie, runes, rlen, true, NULL);
+    suffixData *data = Suffix_GetData(node);
+    if (data) {
+      oldTerm = data->term;
+      data->term = NULL;
+      removeSuffix(str, len, data->array);
+      if (array_len(data->array) == 0) {
+        RS_LOG_ASSERT(!data->term, "array should contain a pointer to the string");
+        Trie_DeleteRunes(trie, runes, rlen);
+      }
+    }
+  }
+
+  // Remove suffix entries.
+  for (size_t j = 1; j + MIN_SUFFIX <= rlen; ++j) {
     TrieNode *node = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
     suffixData *data = Suffix_GetData(node);
     // suffix trie is shared between all text fields in index, even if they don't use it.
     // if the trie is owned by other fields and not any one containing this suffix,
     // then failure to find the suffix is not an error. just move along.
     if (!data) continue;
-    if (j == 0) {
-      // keep pointer to word string to free after it was found in al sub tokens.
-      oldTerm = data->term;
-      data->term = NULL;
-    }
     // remove from array
     removeSuffix(str, len, data->array);
     // if array is empty, remove the node

--- a/tests/pytests/test_multibyte_char_terms.py
+++ b/tests/pytests/test_multibyte_char_terms.py
@@ -764,6 +764,31 @@ def testLongTermWildcardQuery(env):
     res = env.cmd('FT.SEARCH', 'idx', f'@t:*{long_term.upper()}*', 'NOCONTENT', 'DIALECT', 2)
     env.assertEqual(res, [1, 'doc:1'])
 
+@skip(cluster=True)
+def testSingleRuneMultibyteSuffixTrie(env):
+    '''Test that a single multi-byte rune (rlen=1, len=3) is correctly
+    inserted and deleted from the suffix trie without leaking memory.
+    addSuffixTrie inserts the full-word entry unconditionally, so
+    deleteSuffixTrie must handle it even when rlen < MIN_SUFFIX.'''
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA', 't', 'TEXT', 'NOSTEM', 'WITHSUFFIXTRIE').ok()
+    conn = getConnectionByEnv(env)
+
+    # '中' is a single CJK rune (3 bytes UTF-8, 1 rune)
+    conn.execute_command('HSET', 'doc:1', 't', '中')
+
+    res = env.cmd('FT.SEARCH', 'idx', '中', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(res, [1, 'doc:1'])
+
+    # Delete the document; the suffix trie entry must be cleaned up
+    conn.execute_command('DEL', 'doc:1')
+
+    # Trigger GC to exercise deleteSuffixTrie on the single-rune term
+    forceInvokeGC(env, 'idx')
+
+    res = env.cmd('FT.SEARCH', 'idx', '中', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(res, [0])
+
 
 def testMultibyteTag(env):
     '''Test that multibyte characters are correctly converted to lowercase and

--- a/tests/pytests/test_multibyte_char_terms.py
+++ b/tests/pytests/test_multibyte_char_terms.py
@@ -744,6 +744,27 @@ def testLongTerms(env):
         res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx2')
         env.assertEqual(res, [f'+{long_term_lower[:148]}', long_term_lower])
 
+@skip(cluster=True)
+def testLongTermWildcardQuery(env):
+    '''Test that a wildcard (contains) query with >128 runes exercises the heap
+    allocation path in strToLowerRunes.'''
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA', 't', 'TEXT', 'NOSTEM', 'WITHSUFFIXTRIE').ok()
+    conn = getConnectionByEnv(env)
+
+    # 'б' is a single Cyrillic rune; 130 repetitions > SSO_MAX_LENGTH (128)
+    long_term = 'б' * 130
+    conn.execute_command('HSET', 'doc:1', 't', long_term)
+
+    # Contains query (*term*) calls strToLowerRunes at query time
+    res = env.cmd('FT.SEARCH', 'idx', f'@t:*{long_term}*', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(res, [1, 'doc:1'])
+
+    # Uppercase query — verifies case folding on the heap path
+    res = env.cmd('FT.SEARCH', 'idx', f'@t:*{long_term.upper()}*', 'NOCONTENT', 'DIALECT', 2)
+    env.assertEqual(res, [1, 'doc:1'])
+
+
 def testMultibyteTag(env):
     '''Test that multibyte characters are correctly converted to lowercase and
     that queries are case-insensitive using TAG fields'''


### PR DESCRIPTION
Multi-byte UTF-8 characters (e.g. CJK) caused addSuffixTrie and deleteSuffixTrie to iterate past valid rune positions,
creating spurious trie entries and leaking memory on index cleanup. Single-rune multi-byte terms (rlen=1, len=3) also failed to clean up the full-word entry on deletion.

This was found by adding a test filling a coverage gap in `strToLowerRunes` , see first commit.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches suffix trie insertion/deletion logic used by wildcard/contains queries; incorrect bounds or deletion behavior could impact query results or memory usage, but the change is small and covered by new regression tests.
> 
> **Overview**
> Fixes `addSuffixTrie`/`deleteSuffixTrie` to iterate suffixes by **rune count** (not byte length) to avoid walking past valid UTF-8 rune boundaries, which previously could create bogus trie nodes and leak memory.
> 
> `deleteSuffixTrie` now explicitly removes the *full-word* trie entry before removing suffix entries, ensuring single-rune multibyte terms (where `rlen < MIN_SUFFIX`) are cleaned up correctly.
> 
> Adds regression tests for (1) wildcard contains queries with >128 runes (exercising heap allocation in `strToLowerRunes`) and (2) inserting/deleting a single multibyte rune with `WITHSUFFIXTRIE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0153c7af5925fdbda0ed21a7d909f8680848c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->