### PR TITLE
strconv: remove unused strtolower()

### DIFF
--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -80,15 +80,6 @@ static int ParseBoolean(const char *arg, int *res) {
   return 0;
 }
 
-static char *strtolower(char *str) {
-  char *p = str;
-  while (*p) {
-    *p = tolower(*p);
-    p++;
-  }
-  return str;
-}
-
 static char *rm_strndup_unescape(const char *s, size_t len) {
   char *ret = rm_strndup(s, len);
   char *dst = ret;


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes an unused internal helper without changing any call sites or runtime behavior.
> 
> **Overview**
> Removes the unused `strtolower()` helper from `src/util/strconv.h`, leaving normalization/lowercasing to the existing unicode-based path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6dc4b19fe3b1c612d86d35c4e1f26f181efa88c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->