### PR TITLE
MOD-15579 Validate lazy SVS thread pool initialization in flow tests

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -272,6 +272,63 @@ def test_memory_info():
         env.execute_command('FLUSHALL')
 
 @skip(cluster=True)
+def test_svs_threadpool_lazy_init():
+    """Verify the shared SVS thread pool is not allocated until an SVS index is created.
+
+    With lazy init, VecSim_UpdateThreadPoolSize (called at module init via
+    workersThreadPool_CreatePool, and on every CONFIG SET WORKERS) only records
+    the requested size — OS threads are spawned on the first SVS index attach.
+
+    Observed via the GLOBAL_MEMORY field in FT.DEBUG VECSIM_INFO, which mirrors
+    VecSim_GetGlobalMemory() — currently sourced exclusively from the shared SVS
+    thread pool's allocation size.
+    """
+    workers = 4
+    env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {workers}')
+
+    # Create a non-SVS index — exercises FT.DEBUG VECSIM_INFO without involving
+    # SVS at all. GLOBAL_MEMORY (== shared SVS pool allocation) must equal the
+    # allocator's self-accounting baseline (sizeof(VecSimAllocator) — a single
+    # std::atomic_uint64_t, 8 bytes on standard platforms, see
+    # VecSimAllocator() ctor); no ThreadSlot allocations have happened yet.
+    # Threshold of 32 bytes leaves headroom for platform variation in
+    # sizeof(VecSimAllocator) but is well below the smallest realistic single
+    # ThreadSlot allocation (sizeof(svs::threads::Thread) + atomic<bool> +
+    # shared_ptr control block + allocation header).
+    create_vector_index(env, dim=4, alg='HNSW')
+    hnsw_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.assertTrue('GLOBAL_MEMORY' in hnsw_info,
+                   message=f"GLOBAL_MEMORY field must be present in VECSIM_INFO: {hnsw_info}")
+    hnsw_baseline = int(hnsw_info['GLOBAL_MEMORY'])
+    env.assertLess(hnsw_baseline, 32,
+                   message=f"GLOBAL_MEMORY exceeds the allocator self-accounting baseline — "
+                           f"suggests SVS thread slots were allocated despite no SVS index: "
+                           f"got {hnsw_baseline}, info={hnsw_info}")
+    env.execute_command('FT.DROPINDEX', DEFAULT_INDEX_NAME)
+
+    # Create an SVS index — first attach triggers the lazy thread spawn. The
+    # SHARED_SVS_THREADPOOL_MEMORY field appears in BACKEND_INDEX debug info
+    # and grows GLOBAL_MEMORY by the per-slot allocation tracked by the pool
+    # (workers - 1 ThreadSlots + the slots_ vector capacity).
+    create_vector_index(env, dim=4, alg='SVS-VAMANA')
+    debug_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    backend_info = get_tiered_backend_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.assertTrue('SHARED_SVS_THREADPOOL_MEMORY' in backend_info,
+                   message=f"BACKEND_INDEX debug info missing 'SHARED_SVS_THREADPOOL_MEMORY': "
+                           f"{backend_info}")
+    env.assertTrue('GLOBAL_MEMORY' in debug_info,
+                   message=f"GLOBAL_MEMORY field must be present in VECSIM_INFO: {debug_info}")
+    svs_pool_mem = int(backend_info['SHARED_SVS_THREADPOOL_MEMORY'])
+    env.assertGreater(svs_pool_mem, hnsw_baseline,
+                      message=f"SHARED_SVS_THREADPOOL_MEMORY should grow above the pre-attach "
+                              f"baseline ({hnsw_baseline}) after first SVS index creation with "
+                              f"WORKERS={workers}: got {svs_pool_mem}, backend_info={backend_info}")
+    env.assertEqual(int(debug_info['GLOBAL_MEMORY']), svs_pool_mem,
+                    message=f"GLOBAL_MEMORY should match SHARED_SVS_THREADPOOL_MEMORY: "
+                            f"debug_info={debug_info}")
+
+
+@skip(cluster=True)
 def test_svs_shared_threadpool_memory_info():
     """Verify shared SVS thread pool memory accounting:
       * FT.DEBUG VECSIM_INFO exposes it as SHARED_SVS_THREADPOOL_MEMORY inside
@@ -288,15 +345,18 @@ def test_svs_shared_threadpool_memory_info():
     All observations are validated before and after growing the worker pool, which
     physically resizes the shared SVS pool.
     """
-    initial_workers = 1
+    # Use 2+ initial workers so the first SVS index allocates at least one worker
+    # slot (pool size 1 = zero worker slots = zero allocator-tracked bytes, which
+    # would make 'pool memory > 0' assertions vacuous).
+    initial_workers = 2
     grown_workers = 4
     env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {initial_workers}')
     dim = 2
     debug_svs_pool_mem_field = 'SHARED_SVS_THREADPOOL_MEMORY'
 
-    # The shared SVS pool singleton is initialized at module init via
-    # workersThreadPool_CreatePool -> VecSim_UpdateThreadPoolSize, so the field is
-    # always present in the debug info once any SVS index exists.
+    # The shared SVS pool spawns OS threads lazily on first SVS index creation,
+    # using the size most recently passed to VecSim_UpdateThreadPoolSize (set at
+    # module init by workersThreadPool_CreatePool).
     create_vector_index(env, dim, alg='SVS-VAMANA')
 
     def measure():


### PR DESCRIPTION
Validating the lazy SVS thread pool init introduced in [VectorSimilarity#969](https://github.com/RedisAI/VectorSimilarity/pull/969). No RediSearch production changes — the integration contract with VecSim is unchanged.

- **New `test_svs_threadpool_lazy_init`**: with `WORKERS=4` at module init, asserts `GLOBAL_MEMORY` stays at the allocator's self-accounting baseline (`< 32` bytes) while only an HNSW index exists, then grows to a matching `SHARED_SVS_THREADPOOL_MEMORY` after the first `SVS-VAMANA` index is created.
- **Updated `test_svs_shared_threadpool_memory_info`**: `initial_workers` bumped from 1 to 2 so the first SVS index allocates at least one worker slot (pool size 1 = zero workers under the new semantics, which would make the existing "memory > 0" assertion vacuous). Comments updated.

#### Which additional issues this PR fixes

1. MOD-15579

#### Main objects this PR modified

1. `tests/pytests/test_vecsim_svs.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that may cause CI flakiness across platforms due to relying on memory accounting thresholds/fields, but no production logic is modified.
> 
> **Overview**
> Adds `test_svs_threadpool_lazy_init` to assert the shared SVS threadpool does **not** allocate/spawn until the first `SVS-VAMANA` index is created, using `FT.DEBUG VECSIM_INFO` `GLOBAL_MEMORY` and backend `SHARED_SVS_THREADPOOL_MEMORY`.
> 
> Updates `test_svs_shared_threadpool_memory_info` to start with `WORKERS>=2` and revises assumptions/comments to match the new *lazy thread spawn on first SVS index attach* behavior while keeping the resize/memory-invariant checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f188db898a276667b5bdee19280e5cf624a76d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->