### PR TITLE
[MOD-15397] Honor blocked-client timeout in Rust Query Iterators

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -612,6 +612,14 @@ static inline void AREQ_SetSkipTimeoutChecks(AREQ *req, bool skipTimeoutChecks) 
   }
 }
 
+// Returns the AREQ that iterator constructors should use to wire the
+// Blocked Client Timeout, or NULL if iterators should fall back to the
+// in-pipeline clock-based timeout. `skipTimeoutChecks` is set by
+// `AREQ_ApplyContext` exactly when the BC callback is the active source.
+static inline AREQ *AREQ_TimeoutAreqOrNull(AREQ *req) {
+  return (req && req->skipTimeoutChecks) ? req : NULL;
+}
+
 static inline bool RequestConfig_ApplyCoordinatorElapsedTime(RequestConfig *reqConfig,
                                                              rs_wall_clock_ns_t coordinatorElapsedTime) {
   // Only adjust the timeout for 'fail' and 'return-strict' policies.

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -562,6 +562,11 @@ static inline void AREQ_SetTimedOut(AREQ *req) {
 bool areq_timed_out(void *arg);
 #endif
 
+/* Non-inline named bridge over AREQ_TimedOut, invoked by Rust query
+ * iterators on the Blocked Client Timeout path. The named extern is a
+ * stable symbol that LTO can inline through. */
+bool AREQ_CheckTimedOut(AREQ *areq);
+
 /* True when this AREQ uses the BG-thread / timeout-callback claim handshake
  * around AggregateResults (TryClaim/Signal/Wait). Currently set only on the
  * coordinator AREQ under RETURN-STRICT; all other paths skip the protocol. */

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1363,7 +1363,7 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   // Setting the timeout context should be done in the same thread that executes the query.
   SearchCtx_UpdateTime(sctx, req->reqConfig.queryTimeoutMS);
 
-  req->rootiter = QAST_Iterate(ast, opts, sctx, AREQ_RequestFlags(req), status);
+  req->rootiter = QAST_Iterate(ast, opts, sctx, AREQ_RequestFlags(req), req, status);
 
   // check possible optimization after creation of QueryIterator tree
   if (IsOptimized(req)) {

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -149,6 +149,7 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 #define SYNC_POINT_AFTER_ITERATOR_START                 "AfterIteratorStart"
 #define SYNC_POINT_RPNET_REPLY_ADMITTED                 "RpnetReplyAdmitted"
 #define SYNC_POINT_RPNET_WAITING_FOR_REPLY              "RpnetWaitingForReply"
+#define SYNC_POINT_BEFORE_QI_TIMEOUT_CHECK              "BeforeQITimeoutCheck"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -43,7 +43,7 @@ int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelin
         }
 
         // Parse subquery: Convert AST to iterator tree
-        areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, &req->errors[i]);
+        areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, areq, &req->errors[i]);
 
         rs_wall_clock parseClock;
         if (isProfile) {

--- a/src/query.c
+++ b/src/query.c
@@ -989,7 +989,7 @@ static QueryIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
 
   t_docId maxDocId = q->sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec) : q->docTable->maxDocId;
   return NewNotIterator(child, maxDocId, qn->opts.weight, q->sctx->time.timeout,
-                        q->areq, q);
+                        q->bcTimeoutAreq, q);
 }
 
 static QueryIterator *Query_EvalOptionalNode(QueryEvalCtx *q, QueryNode *qn) {
@@ -1614,12 +1614,6 @@ int QAST_Parse(QueryAST *dst, const RedisSearchCtx *sctx, const RSSearchOptions 
 
 QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx,
                             uint32_t reqflags, struct AREQ *areq, QueryError *status) {
-  // Only wire BlockedClient timeout when it is actually active; otherwise
-  // fall back to the clock-based pipeline timeout
-  if (areq && !areq->skipTimeoutChecks) {
-    areq = NULL;
-  }
-
   QueryEvalCtx qectx = {
       .opts = opts,
       .numTokens = qast->numTokens,
@@ -1630,7 +1624,7 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
       .reqFlags = reqflags,
       .config = &qast->config,
       .notSubtree = false,
-      .areq = areq,
+      .bcTimeoutAreq = AREQ_TimeoutAreqOrNull(areq),
   };
   QueryIterator *root = Query_EvalNode(&qectx, qast->root);
   if (!root) {

--- a/src/query.c
+++ b/src/query.c
@@ -39,6 +39,7 @@
 #include "wildcard.h"
 #include "geometry/geometry_api.h"
 #include "iterators/hybrid_reader.h"
+#include "debug_commands.h"
 #include "iterators/optimizer_reader.h"
 #include "search_disk.h"
 #include "shard_window_ratio.h"
@@ -966,6 +967,18 @@ static QueryIterator *Query_EvalWildcardNode(QueryEvalCtx *q, QueryNode *qn) {
   return NewWildcardIterator(q, qn->opts.weight);
 }
 
+// Probe the Blocked Client Timeout flag for a query iterator. Called from
+// Rust via a direct `extern "C"` declaration when a NOT iterator is wired
+// to an AREQ; the sync point makes the check deterministically pauseable
+// in assert builds for race tests.
+bool AREQ_CheckTimedOut(AREQ *areq) {
+  RS_LOG_ASSERT(areq, "AREQ_CheckTimedOut called with NULL areq");
+#ifdef ENABLE_ASSERT
+  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_QI_TIMEOUT_CHECK, areq_timed_out, areq);
+#endif
+  return AREQ_TimedOut(areq);
+}
+
 static QueryIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_LOG_ASSERT(qn->type == QN_NOT, "query node type should be not")
   QueryIterator *child = NULL;
@@ -975,7 +988,8 @@ static QueryIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
   q->notSubtree = currently_notSubtree;
 
   t_docId maxDocId = q->sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec) : q->docTable->maxDocId;
-  return NewNotIterator(child, maxDocId, qn->opts.weight, q->sctx->time.timeout, q);
+  return NewNotIterator(child, maxDocId, qn->opts.weight, q->sctx->time.timeout,
+                        q->areq, q);
 }
 
 static QueryIterator *Query_EvalOptionalNode(QueryEvalCtx *q, QueryNode *qn) {
@@ -1599,7 +1613,7 @@ int QAST_Parse(QueryAST *dst, const RedisSearchCtx *sctx, const RSSearchOptions 
 }
 
 QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx,
-                            uint32_t reqflags, QueryError *status) {
+                            uint32_t reqflags, struct AREQ *areq, QueryError *status) {
   QueryEvalCtx qectx = {
       .opts = opts,
       .numTokens = qast->numTokens,
@@ -1610,6 +1624,7 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
       .reqFlags = reqflags,
       .config = &qast->config,
       .notSubtree = false,
+      .areq = areq,
   };
   QueryIterator *root = Query_EvalNode(&qectx, qast->root);
   if (!root) {

--- a/src/query.c
+++ b/src/query.c
@@ -1614,6 +1614,12 @@ int QAST_Parse(QueryAST *dst, const RedisSearchCtx *sctx, const RSSearchOptions 
 
 QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx,
                             uint32_t reqflags, struct AREQ *areq, QueryError *status) {
+  // Only wire BlockedClient timeout when it is actually active; otherwise
+  // fall back to the clock-based pipeline timeout
+  if (areq && !areq->skipTimeoutChecks) {
+    areq = NULL;
+  }
+
   QueryEvalCtx qectx = {
       .opts = opts,
       .numTokens = qast->numTokens,

--- a/src/query.h
+++ b/src/query.h
@@ -118,11 +118,15 @@ void SetFilterNode(QueryAST *q, QueryNode *filterNode);
  * @param sctx the search context. Note that this may be retained by the iterators
  *  for the remainder of the query.
  * @param reqflags Request (AGG/SEARCH) flags
+ * @param areq optional borrowed pointer to the owning request. When non-NULL,
+ *  iterators wire the Blocked Client Timeout callback against it; when NULL,
+ *  the Clock Based Timeout is used.
  * @param status error detail
  * @return an iterator.
  */
 QueryIterator *QAST_Iterate(QueryAST *ast, const RSSearchOptions *options,
-                            RedisSearchCtx *sctx, uint32_t reqflags, QueryError *status);
+                            RedisSearchCtx *sctx, uint32_t reqflags,
+                            struct AREQ *areq, QueryError *status);
 
 /**
  * Remove tag escape sequences and optionally lowercase a string.

--- a/src/query.h
+++ b/src/query.h
@@ -118,9 +118,10 @@ void SetFilterNode(QueryAST *q, QueryNode *filterNode);
  * @param sctx the search context. Note that this may be retained by the iterators
  *  for the remainder of the query.
  * @param reqflags Request (AGG/SEARCH) flags
- * @param areq optional borrowed pointer to the owning request. When non-NULL,
- *  iterators wire the Blocked Client Timeout callback against it; when NULL,
- *  the Clock Based Timeout is used.
+ * @param areq optional borrowed pointer to the owning request. Filtered
+ *  through `AREQ_TimeoutAreqOrNull`: when the request has `skipTimeoutChecks`
+ *  set, iterators wire the Blocked Client Timeout callback against it;
+ *  otherwise (including NULL `areq`) the Clock Based Timeout is used.
  * @param status error detail
  * @return an iterator.
  */

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -25,9 +25,10 @@ typedef struct QueryEvalCtx {
   uint32_t reqFlags;
   IteratorsConfig *config;
   bool notSubtree;
-  // Borrowed pointer to the owning request, when one exists. Used by
-  // iterator constructors that need to wire the blocked-client timeout
-  // callback (MOD-15397). NULL on paths without an AREQ (low-level C
-  // API and some tests); those fall back to the clock-based timeout.
-  struct AREQ *areq;
+  // AREQ to use for the Blocked Client Timeout dispatch. Non-NULL means
+  // iterators poll `AREQ_CheckTimedOut` against this request; NULL means
+  // iterators fall back to the in-pipeline clock-based timeout (low-level
+  // C API, tests, or any request whose `skipTimeoutChecks` is false).
+  // Set via `AREQ_TimeoutAreqOrNull` in `QAST_Iterate`.
+  struct AREQ *bcTimeoutAreq;
 } QueryEvalCtx;

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -12,6 +12,7 @@
 #include "util/timeout.h"
 
 struct MetricRequest;
+struct AREQ;
 
 typedef struct QueryEvalCtx {
   RedisSearchCtx *sctx;
@@ -24,4 +25,9 @@ typedef struct QueryEvalCtx {
   uint32_t reqFlags;
   IteratorsConfig *config;
   bool notSubtree;
+  // Borrowed pointer to the owning request, when one exists. Used by
+  // iterator constructors that need to wire the blocked-client timeout
+  // callback (MOD-15397). NULL on paths without an AREQ (low-level C
+  // API and some tests); those fall back to the clock-based timeout.
+  struct AREQ *areq;
 } QueryEvalCtx;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -9,7 +9,7 @@
 
 use std::ptr::NonNull;
 
-use ffi::{QueryIterator, t_docId, timespec};
+use ffi::{AREQ, QueryIterator, t_docId, timespec};
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
     NewWildcardIterator, RQEIterator,
@@ -17,11 +17,13 @@ use rqe_iterators::{
     interop::RQEIteratorWrapper,
     not::Not,
     not_optimized::NotOptimized,
-    not_reducer::{NewNotIterator, new_not_iterator},
+    not_reducer::{NewNotIterator, TIMEOUT_CHECK_GRANULARITY, new_not_iterator},
+    utils::{AnyTimeoutContext, NoTimeout, TimeoutContextBlockedClient, TimeoutContextClock},
 };
 
-type NotFfi<'index> = Not<'index, CRQEIterator>;
-type NotOptimizedFfi<'index> = NotOptimized<'index, NewWildcardIterator<'index>, CRQEIterator>;
+type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext>;
+type NotOptimizedFfi<'index> =
+    NotOptimized<'index, NewWildcardIterator<'index>, CRQEIterator, AnyTimeoutContext>;
 
 /// Enum holding both NOT iterator variants with concrete [`CRQEIterator`] child.
 ///
@@ -150,11 +152,63 @@ impl<'index> rqe_iterators::interop::ProfileChildren<'index> for NotIteratorEnum
 /// [`QueryIterator`] pointer.
 type NotIteratorWrapper<'index> = RQEIteratorWrapper<NotIteratorEnum<'index>>;
 
+/// Build the [`AnyTimeoutContext`] the iterator should use.
+///
+/// Selection rules:
+///
+/// * If `areq` is non-null, the Blocked Client Timeout path is used and
+///   `timeout` / `skipTimeoutChecks` are ignored.
+/// * Else if `skipTimeoutChecks` is set or `timeout` is the Redis sentinel
+///   (no deadline), [`AnyTimeoutContext::NoTimeout`] is returned and every
+///   timeout probe becomes a no-op.
+/// * Otherwise the Clock Based Timeout path is used.
+///
+/// # Safety
+///
+/// Caller must guarantee `q` and `q.sctx` are valid (FFI preconditions
+/// 3 and 4 of [`NewNotIterator`]). When `areq` is non-null, it must
+/// uphold the [`TimeoutContextBlockedClient::new`] safety contract for the
+/// lifetime of the returned context.
+unsafe fn build_timeout_context(
+    timeout: timespec,
+    areq: *mut AREQ,
+    q: NonNull<ffi::QueryEvalCtx>,
+) -> AnyTimeoutContext {
+    if !areq.is_null() {
+        // SAFETY: caller guarantees `areq` upholds the
+        // `TimeoutContextBlockedClient::new` contract.
+        let inner = unsafe { TimeoutContextBlockedClient::new(areq) };
+        return AnyTimeoutContext::BlockedClient(inner);
+    }
+
+    // SAFETY: caller guarantees q is valid (3).
+    let q_ref = unsafe { q.as_ref() };
+    // SAFETY: caller guarantees q.sctx is valid (4).
+    let sctx = unsafe { &*q_ref.sctx };
+    if sctx.time.skipTimeoutChecks {
+        return AnyTimeoutContext::NoTimeout(NoTimeout);
+    }
+    let Some(duration) = crate::timespec::duration_from_redis_timespec(timeout) else {
+        return AnyTimeoutContext::NoTimeout(NoTimeout);
+    };
+    AnyTimeoutContext::Clock(TimeoutContextClock::new(
+        duration,
+        TIMEOUT_CHECK_GRANULARITY,
+    ))
+}
+
 /// Creates a NOT iterator, choosing between non-optimized and optimized based
 /// on the query evaluation context.
 ///
 /// If the child is trivially reducible (empty or wildcard), a simplified
 /// iterator is returned directly.
+///
+/// `areq` selects the timeout source. When non-null, the Blocked Client
+/// Timeout path is used: every iterator timeout probe forwards to
+/// `AREQ_CheckTimedOut` and `timeout` / `skipTimeoutChecks` are ignored.
+/// When null, the Clock Based Timeout path is used: `timeout` is the
+/// deadline and `skipTimeoutChecks` (read from `q.sctx.time`) disables the
+/// check entirely.
 ///
 /// # Safety
 ///
@@ -170,46 +224,28 @@ type NotIteratorWrapper<'index> = RQEIteratorWrapper<NotIteratorEnum<'index>>;
 ///    [`SchemaRule`](ffi::SchemaRule).
 /// 7. When the optimized path is taken, the preconditions of
 ///    [`crate::wildcard::NewWildcardIterator_Optimized`] must hold.
+/// 8. When `areq` is non-null, it must satisfy the
+///    [`TimeoutContextBlockedClient::new`] safety contract and remain
+///    valid for the lifetime of the returned iterator.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewNotIterator(
     child: *mut QueryIterator,
     max_doc_id: t_docId,
     weight: f64,
     timeout: timespec,
+    areq: *mut AREQ,
     q: *mut ffi::QueryEvalCtx,
 ) -> *mut QueryIterator {
     let query = NonNull::new(q).expect("q must be non-null");
 
-    let (rust_timeout, skip_timeout_checks) = {
-        // SAFETY: caller guarantees q is valid (3).
-        let q_ref = unsafe { query.as_ref() };
-        // SAFETY: caller guarantees q.sctx is valid (4).
-        let sctx = unsafe { &*q_ref.sctx };
-        if sctx.time.skipTimeoutChecks {
-            (std::time::Duration::ZERO, true)
-        } else {
-            match crate::timespec::duration_from_redis_timespec(timeout) {
-                Some(d) => (d, false),
-                // Redis sentinel (no timeout) => skip timeout checks
-                None => (std::time::Duration::ZERO, true),
-            }
-        }
-    };
+    // SAFETY: caller upholds preconditions (3, 4, 8).
+    let timeout_ctx = unsafe { build_timeout_context(timeout, areq, query) };
 
     // Handle null child: reduce with Empty directly (always becomes wildcard).
     let Some(child_ptr) = NonNull::new(child) else {
         let empty = rqe_iterators::Empty;
         // SAFETY: caller guarantees preconditions (3–7).
-        let result = unsafe {
-            new_not_iterator(
-                empty,
-                max_doc_id,
-                weight,
-                rust_timeout,
-                skip_timeout_checks,
-                query,
-            )
-        };
+        let result = unsafe { new_not_iterator(empty, max_doc_id, weight, timeout_ctx, query) };
         return match result {
             NewNotIterator::ReducedWildcard(wc) => RQEIteratorWrapper::boxed_new(wc),
             NewNotIterator::ReducedEmpty(empty) => {
@@ -226,16 +262,7 @@ pub unsafe extern "C" fn NewNotIterator(
     let child = unsafe { CRQEIterator::new(child_ptr) };
 
     // SAFETY: caller guarantees preconditions (3–7).
-    let result = unsafe {
-        new_not_iterator(
-            child,
-            max_doc_id,
-            weight,
-            rust_timeout,
-            skip_timeout_checks,
-            query,
-        )
-    };
+    let result = unsafe { new_not_iterator(child, max_doc_id, weight, timeout_ctx, query) };
 
     match result {
         NewNotIterator::ReducedWildcard(wc) => RQEIteratorWrapper::boxed_new(wc),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -156,8 +156,8 @@ type NotIteratorWrapper<'index> = RQEIteratorWrapper<NotIteratorEnum<'index>>;
 ///
 /// Selection rules:
 ///
-/// * If `areq` is non-null, the Blocked Client Timeout path is used and
-///   `timeout` / `skipTimeoutChecks` are ignored.
+/// * If `bc_timeout_areq` is non-null, the Blocked Client Timeout path is
+///   used and `timeout` / `skipTimeoutChecks` are ignored.
 /// * Else if `skipTimeoutChecks` is set or `timeout` is the Redis sentinel
 ///   (no deadline), [`AnyTimeoutContext::NoTimeout`] is returned and every
 ///   timeout probe becomes a no-op.
@@ -166,15 +166,15 @@ type NotIteratorWrapper<'index> = RQEIteratorWrapper<NotIteratorEnum<'index>>;
 /// # Safety
 ///
 /// Caller must guarantee `q` and `q.sctx` are valid (FFI preconditions
-/// 3 and 4 of [`NewNotIterator`]). When `areq` is non-null, it must
-/// uphold the [`TimeoutContextBlockedClient::new`] safety contract for the
-/// lifetime of the returned context.
+/// 3 and 4 of [`NewNotIterator`]). When `bc_timeout_areq` is non-null, it
+/// must uphold the [`TimeoutContextBlockedClient::new`] safety contract for
+/// the lifetime of the returned context.
 unsafe fn build_timeout_context(
     timeout: timespec,
-    areq: *mut AREQ,
+    bc_timeout_areq: *mut AREQ,
     q: NonNull<ffi::QueryEvalCtx>,
 ) -> AnyTimeoutContext {
-    match NonNull::new(areq) {
+    match NonNull::new(bc_timeout_areq) {
         Some(areq) => {
             // SAFETY: caller guarantees `areq` upholds the
             // `TimeoutContextBlockedClient::new` contract.
@@ -206,12 +206,13 @@ unsafe fn build_timeout_context(
 /// If the child is trivially reducible (empty or wildcard), a simplified
 /// iterator is returned directly.
 ///
-/// `areq` selects the timeout source. When non-null, the Blocked Client
-/// Timeout path is used: every iterator timeout probe forwards to
+/// `bc_timeout_areq` selects the timeout source. When non-null, the Blocked
+/// Client Timeout path is used: every iterator timeout probe forwards to
 /// `AREQ_CheckTimedOut` and `timeout` / `skipTimeoutChecks` are ignored.
 /// When null, the Clock Based Timeout path is used: `timeout` is the
 /// deadline and `skipTimeoutChecks` (read from `q.sctx.time`) disables the
-/// check entirely.
+/// check entirely. The C caller is expected to pre-filter the owning
+/// request via `AREQ_TimeoutAreqOrNull` before passing it here.
 ///
 /// # Safety
 ///
@@ -227,7 +228,7 @@ unsafe fn build_timeout_context(
 ///    [`SchemaRule`](ffi::SchemaRule).
 /// 7. When the optimized path is taken, the preconditions of
 ///    [`crate::wildcard::NewWildcardIterator_Optimized`] must hold.
-/// 8. When `areq` is non-null, it must satisfy the
+/// 8. When `bc_timeout_areq` is non-null, it must satisfy the
 ///    [`TimeoutContextBlockedClient::new`] safety contract and remain
 ///    valid for the lifetime of the returned iterator.
 #[unsafe(no_mangle)]
@@ -236,13 +237,13 @@ pub unsafe extern "C" fn NewNotIterator(
     max_doc_id: t_docId,
     weight: f64,
     timeout: timespec,
-    areq: *mut AREQ,
+    bc_timeout_areq: *mut AREQ,
     q: *mut ffi::QueryEvalCtx,
 ) -> *mut QueryIterator {
     let query = NonNull::new(q).expect("q must be non-null");
 
     // SAFETY: caller upholds preconditions (3, 4, 8).
-    let timeout_ctx = unsafe { build_timeout_context(timeout, areq, query) };
+    let timeout_ctx = unsafe { build_timeout_context(timeout, bc_timeout_areq, query) };
 
     // Handle null child: reduce with Empty directly (always becomes wildcard).
     let Some(child_ptr) = NonNull::new(child) else {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -174,27 +174,30 @@ unsafe fn build_timeout_context(
     areq: *mut AREQ,
     q: NonNull<ffi::QueryEvalCtx>,
 ) -> AnyTimeoutContext {
-    if !areq.is_null() {
-        // SAFETY: caller guarantees `areq` upholds the
-        // `TimeoutContextBlockedClient::new` contract.
-        let inner = unsafe { TimeoutContextBlockedClient::new(areq) };
-        return AnyTimeoutContext::BlockedClient(inner);
+    match NonNull::new(areq) {
+        Some(areq) => {
+            // SAFETY: caller guarantees `areq` upholds the
+            // `TimeoutContextBlockedClient::new` contract.
+            let inner = unsafe { TimeoutContextBlockedClient::new(areq) };
+            AnyTimeoutContext::BlockedClient(inner)
+        }
+        None => {
+            // SAFETY: caller guarantees q is valid (3).
+            let q_ref = unsafe { q.as_ref() };
+            // SAFETY: caller guarantees q.sctx is valid (4).
+            let sctx = unsafe { &*q_ref.sctx };
+            if sctx.time.skipTimeoutChecks {
+                return AnyTimeoutContext::NoTimeout(NoTimeout);
+            }
+            match crate::timespec::duration_from_redis_timespec(timeout) {
+                Some(duration) => AnyTimeoutContext::Clock(TimeoutContextClock::new(
+                    duration,
+                    TIMEOUT_CHECK_GRANULARITY,
+                )),
+                None => AnyTimeoutContext::NoTimeout(NoTimeout),
+            }
+        }
     }
-
-    // SAFETY: caller guarantees q is valid (3).
-    let q_ref = unsafe { q.as_ref() };
-    // SAFETY: caller guarantees q.sctx is valid (4).
-    let sctx = unsafe { &*q_ref.sctx };
-    if sctx.time.skipTimeoutChecks {
-        return AnyTimeoutContext::NoTimeout(NoTimeout);
-    }
-    let Some(duration) = crate::timespec::duration_from_redis_timespec(timeout) else {
-        return AnyTimeoutContext::NoTimeout(NoTimeout);
-    };
-    AnyTimeoutContext::Clock(TimeoutContextClock::new(
-        duration,
-        TIMEOUT_CHECK_GRANULARITY,
-    ))
 }
 
 /// Creates a NOT iterator, choosing between non-optimized and optimized based

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -75,6 +75,10 @@ after_includes = """
 // In C, timespec is a struct tag, not a typedef. Rust's libc::timespec maps to
 // the bare name, so we introduce a typedef to make it valid C.
 typedef struct timespec timespec;
+// `AREQ` is forward-declared as a struct tag in `query.h` (above) but its
+// typedef lives in `aggregate/aggregate.h`. cheadergen emits `*mut ffi::AREQ`
+// as the bare `AREQ *`, so we surface the typedef here for the C compiler.
+typedef struct AREQ AREQ;
 """
 
 [header.module_init_ffi]

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -43,6 +43,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/aggregate/aggregate.h",
+        fns: &["AREQ_CheckTimedOut"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/aggregate/reducer.h",
         fns: &[],
         types: &["Reducer", "ReducerOptions"],
@@ -344,11 +350,17 @@ const PERMITTED_GENERATED_HEADERS: &[&str] = &[
     // contain `static inline` functions calling `QueryError_GetDisplayableError`
     // / `QueryError_SetCode` etc., so they need the function declarations.
     "query_error_ffi.h",
+    // `QEFlags` and the `QEFlag_*` named constants are required by
+    // `src/aggregate/aggregate.h` (pulled in for `AREQ_CheckTimedOut`).
+    "query_flags.h",
     // `QueryProcessingCtx` is embedded by value in `src/pipeline/pipeline.h`
     // and `src/aggregate/aggregate.h`. Brings `rs_wall_clock.h` into bindgen's
     // closure too, which is needed by `ffi::QueryProcessingCtx` (defined in
     // `ffi/src/lib.rs`).
     "result_processor_ffi.h",
+    // `RSValueType` and friends are required by `src/aggregate/aggregate.h`
+    // (pulled in transitively for `AREQ_CheckTimedOut`).
+    "value_ffi.h",
     // `enum IteratorType` is used by value in `src/iterators/iterator_api.h`.
     "rqe_iterator_type.h",
     // `src/rlookup.h` has `static inline` accessors that dereference

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -18,6 +18,10 @@
 // In C, timespec is a struct tag, not a typedef. Rust's libc::timespec maps to
 // the bare name, so we introduce a typedef to make it valid C.
 typedef struct timespec timespec;
+// `AREQ` is forward-declared as a struct tag in `query.h` (above) but its
+// typedef lives in `aggregate/aggregate.h`. cheadergen emits `*mut ffi::AREQ`
+// as the bare `AREQ *`, so we surface the typedef here for the C compiler.
+typedef struct AREQ AREQ;
 
 
 /**
@@ -585,30 +589,6 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
 double NumericInvIndIterator_GetProfileRangeMin(const QueryIterator *it);
 
 /**
- * Creates a NOT iterator, choosing between non-optimized and optimized based
- * on the query evaluation context.
- *
- * If the child is trivially reducible (empty or wildcard), a simplified
- * iterator is returned directly.
- *
- * # Safety
- *
- * 1. `child` must be null or a valid pointer to a [`QueryIterator`].
- *    A null `child` is treated as empty.
- * 2. When non-null, `child` must not be aliased.
- * 3. `q` must be a valid non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
- * 4. `q.sctx` must be a non-null pointer to a valid
- *    [`RedisSearchCtx`](ffi::RedisSearchCtx).
- * 5. `q.sctx.spec` must be a non-null pointer to a valid
- *    [`IndexSpec`](ffi::IndexSpec).
- * 6. `q.sctx.spec.rule`, when non-null, must point to a valid
- *    [`SchemaRule`](ffi::SchemaRule).
- * 7. When the optimized path is taken, the preconditions of
- *    [`crate::wildcard::NewWildcardIterator_Optimized`] must hold.
- */
-QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, QueryEvalCtx *q);
-
-/**
  * Get the metric type used by this metric iterator.
  *
  * # Safety
@@ -690,6 +670,40 @@ NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool cre
 const QueryIterator *GetUnionIteratorChild(const QueryIterator *it, size_t idx);
 
 /**
+ * Creates a NOT iterator, choosing between non-optimized and optimized based
+ * on the query evaluation context.
+ *
+ * If the child is trivially reducible (empty or wildcard), a simplified
+ * iterator is returned directly.
+ *
+ * `areq` selects the timeout source. When non-null, the Blocked Client
+ * Timeout path is used: every iterator timeout probe forwards to
+ * `AREQ_CheckTimedOut` and `timeout` / `skipTimeoutChecks` are ignored.
+ * When null, the Clock Based Timeout path is used: `timeout` is the
+ * deadline and `skipTimeoutChecks` (read from `q.sctx.time`) disables the
+ * check entirely.
+ *
+ * # Safety
+ *
+ * 1. `child` must be null or a valid pointer to a [`QueryIterator`].
+ *    A null `child` is treated as empty.
+ * 2. When non-null, `child` must not be aliased.
+ * 3. `q` must be a valid non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
+ * 4. `q.sctx` must be a non-null pointer to a valid
+ *    [`RedisSearchCtx`](ffi::RedisSearchCtx).
+ * 5. `q.sctx.spec` must be a non-null pointer to a valid
+ *    [`IndexSpec`](ffi::IndexSpec).
+ * 6. `q.sctx.spec.rule`, when non-null, must point to a valid
+ *    [`SchemaRule`](ffi::SchemaRule).
+ * 7. When the optimized path is taken, the preconditions of
+ *    [`crate::wildcard::NewWildcardIterator_Optimized`] must hold.
+ * 8. When `areq` is non-null, it must satisfy the
+ *    [`TimeoutContextBlockedClient::new`] safety contract and remain
+ *    valid for the lifetime of the returned iterator.
+ */
+QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, AREQ *areq, QueryEvalCtx *q);
+
+/**
  * Returns the [`QueryNodeType`] stored in the union iterator.
  *
  * # Safety
@@ -735,17 +749,6 @@ QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct 
 const char *GetUnionIteratorQueryString(const QueryIterator *it);
 
 /**
- * Get the child pointer of a NOT iterator, or NULL if there is no child.
- *
- * # Safety
- *
- * 1. `it` must be a valid non-null pointer to a non-reduced NOT iterator
- *    created via [`NewNotIterator()`]. Must not be called on a reduced
- *    (wildcard/empty) iterator returned by [`NewNotIterator()`].
- */
-const QueryIterator *GetNotIteratorChild(const QueryIterator *it);
-
-/**
  * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
  * sequential read mode.
  *
@@ -755,6 +758,17 @@ const QueryIterator *GetNotIteratorChild(const QueryIterator *it);
  *    created via [`NewUnionIterator`].
  */
 void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
+
+/**
+ * Get the child pointer of a NOT iterator, or NULL if there is no child.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-null pointer to a non-reduced NOT iterator
+ *    created via [`NewNotIterator()`]. Must not be called on a reduced
+ *    (wildcard/empty) iterator returned by [`NewNotIterator()`].
+ */
+const QueryIterator *GetNotIteratorChild(const QueryIterator *it);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -676,12 +676,13 @@ const QueryIterator *GetUnionIteratorChild(const QueryIterator *it, size_t idx);
  * If the child is trivially reducible (empty or wildcard), a simplified
  * iterator is returned directly.
  *
- * `areq` selects the timeout source. When non-null, the Blocked Client
- * Timeout path is used: every iterator timeout probe forwards to
+ * `bc_timeout_areq` selects the timeout source. When non-null, the Blocked
+ * Client Timeout path is used: every iterator timeout probe forwards to
  * `AREQ_CheckTimedOut` and `timeout` / `skipTimeoutChecks` are ignored.
  * When null, the Clock Based Timeout path is used: `timeout` is the
  * deadline and `skipTimeoutChecks` (read from `q.sctx.time`) disables the
- * check entirely.
+ * check entirely. The C caller is expected to pre-filter the owning
+ * request via `AREQ_TimeoutAreqOrNull` before passing it here.
  *
  * # Safety
  *
@@ -697,11 +698,11 @@ const QueryIterator *GetUnionIteratorChild(const QueryIterator *it, size_t idx);
  *    [`SchemaRule`](ffi::SchemaRule).
  * 7. When the optimized path is taken, the preconditions of
  *    [`crate::wildcard::NewWildcardIterator_Optimized`] must hold.
- * 8. When `areq` is non-null, it must satisfy the
+ * 8. When `bc_timeout_areq` is non-null, it must satisfy the
  *    [`TimeoutContextBlockedClient::new`] safety contract and remain
  *    valid for the lifetime of the returned iterator.
  */
-QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, AREQ *areq, QueryEvalCtx *q);
+QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, AREQ *bc_timeout_areq, QueryEvalCtx *q);
 
 /**
  * Returns the [`QueryNodeType`] stored in the union iterator.

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -7,6 +7,20 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+// Pull in the `redisearch_rs` aggregator crate (and its transitive `*_ffi`
+// crates) when building the lib test binary, so that C symbols implemented in
+// Rust (e.g. `NewNotIterator`, `QueryError_SetError`) are available to the
+// linker. This is required because `rqe_iterators` calls
+// `ffi::AREQ_CheckTimedOut` (defined in `query.c.o`), which transitively
+// references symbols provided by those Rust-implemented C wrappers.
+// The companion `mock_or_stub_missing_redis_c_symbols!()` invocation provides
+// the OpenSSL/DocIdMeta stubs that the coord/hiredis objects also drag in.
+// Integration tests apply the same pattern in `tests/integration/main.rs`.
+#[cfg(test)]
+extern crate redisearch_rs;
+#[cfg(test)]
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 use std::sync::OnceLock;
 
 use ffi::t_docId;

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -7,19 +7,15 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-// Pull in the `redisearch_rs` aggregator crate (and its transitive `*_ffi`
-// crates) when building the lib test binary, so that C symbols implemented in
-// Rust (e.g. `NewNotIterator`, `QueryError_SetError`) are available to the
-// linker. This is required because `rqe_iterators` calls
-// `ffi::AREQ_CheckTimedOut` (defined in `query.c.o`), which transitively
-// references symbols provided by those Rust-implemented C wrappers.
-// The companion `mock_or_stub_missing_redis_c_symbols!()` invocation provides
-// the OpenSSL/DocIdMeta stubs that the coord/hiredis objects also drag in.
-// Integration tests apply the same pattern in `tests/integration/main.rs`.
+// Stub `AREQ_CheckTimedOut` for lib unit tests so the linker doesn't pull
+// `query.c.o` (and its C/coord/SSL transitive closure) from
+// `libredisearch_all.a`. The flag is only ever set by Redis on the main
+// thread, which doesn't exist here. Integration tests use the real symbol.
 #[cfg(test)]
-extern crate redisearch_rs;
-#[cfg(test)]
-redis_mock::mock_or_stub_missing_redis_c_symbols!();
+#[unsafe(no_mangle)]
+unsafe extern "C" fn AREQ_CheckTimedOut(_areq: *mut ffi::AREQ) -> bool {
+    false
+}
 
 use std::sync::OnceLock;
 

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -9,8 +9,6 @@
 
 //! Supporting types for [`Not`].
 
-use std::time::Duration;
-
 use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 
@@ -24,7 +22,14 @@ use index_spec::IndexSpecReadGuard;
 ///
 /// Yields all document IDs from 1 to `max_doc_id` (inclusive) that are **not**
 /// present in the child iterator.
-pub struct Not<'index, I> {
+///
+/// # Type parameters
+///
+/// * `'index` - The lifetime of the index being iterated over.
+/// * `I` - The child iterator type whose results are negated.
+/// * `TC` - The [`TimeoutContext`] implementation. The variant is chosen at
+///   construction time and monomorphized into the hot path.
+pub struct Not<'index, I, TC> {
     /// The child iterator whose results are negated.
     child: MaybeEmpty<I>,
     /// The maximum document ID to iterate up to (inclusive).
@@ -35,24 +40,26 @@ pub struct Not<'index, I> {
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
     result: RSIndexResult<'index>,
-    /// Tracks the execution deadline for this iterator.
+    /// Tracks the execution deadline for this iterator. Pass
+    /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
+    /// entirely; monomorphization collapses the no-op context to dead code.
     ///
-    /// Uses an amortized check to minimize overhead in hot paths. The timeout
-    /// is absolute for the iterator's lifetime and does not reset upon rewinding.
-    timeout_ctx: Option<TimeoutContext>,
+    /// The timeout is absolute for the iterator's lifetime and does not
+    /// reset upon rewinding.
+    timeout_ctx: TC,
 }
 
-impl<'index, I> Not<'index, I>
+impl<'index, I, TC> Not<'index, I, TC>
 where
     I: RQEIterator<'index>,
+    TC: TimeoutContext,
 {
-    pub fn new(
-        child: I,
-        max_doc_id: t_docId,
-        weight: f64,
-        timeout: Duration,
-        skip_timeout_checks: bool,
-    ) -> Self {
+    /// Build a new [`Not`] iterator.
+    ///
+    /// `timeout_ctx` is the [`TimeoutContext`] implementation to use. Pass
+    /// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
+    /// entirely on this iterator's hot path.
+    pub fn new(child: I, max_doc_id: t_docId, weight: f64, timeout_ctx: TC) -> Self {
         Self {
             child: MaybeEmpty::new(child),
             max_doc_id,
@@ -61,15 +68,7 @@ where
                 .weight(weight)
                 .field_mask(RS_FIELDMASK_ALL)
                 .build(),
-            // The `limit` of 5_000 determines the granularity of the timeout check.
-            // Each time [`TimeoutContext::check_timeout`] is called (during `read` / `skip_to`),
-            // the internal counter goes up. When it reaches this `limit` of 5_000 it will
-            // reset that counter and do the actual (OS) expensive timeout check.
-            timeout_ctx: if skip_timeout_checks {
-                None
-            } else {
-                Some(TimeoutContext::new(timeout, 5_000, false))
-            },
+            timeout_ctx,
         }
     }
 
@@ -77,13 +76,9 @@ where
     /// we also mark this iterator as EOF.
     ///
     /// Returns error [`RQEIteratorError::TimedOut`] if the deadline has been reached or exceeded.
-    ///
-    /// In case no timeout is enforced it will just return `Ok(())`.
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        let Some(result) = self.timeout_ctx.as_mut().map(|ctx| ctx.check_timeout()) else {
-            return Ok(());
-        };
+        let result = self.timeout_ctx.check_timeout();
         if matches!(result, Err(RQEIteratorError::TimedOut)) {
             // NOTE: this is not done for optimized version of NOT iterator in C
             self.forced_eof = true;
@@ -92,13 +87,9 @@ where
     }
 
     /// Wrapper around [`TimeoutContext::reset_counter`] to reset the timeout counter.
-    ///
-    /// Does nothing when no timeout is enforced.
     #[inline(always)]
-    const fn reset_timeout(&mut self) {
-        if let Some(ctx) = self.timeout_ctx.as_mut() {
-            ctx.reset_counter();
-        }
+    fn reset_timeout(&mut self) {
+        self.timeout_ctx.reset_counter();
     }
 
     /// Get a shared reference to the _child_ iterator
@@ -108,9 +99,10 @@ where
     }
 }
 
-impl<'index, I> RQEIterator<'index> for Not<'index, I>
+impl<'index, I, TC> RQEIterator<'index> for Not<'index, I, TC>
 where
     I: RQEIterator<'index>,
+    TC: TimeoutContext,
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -274,7 +266,10 @@ pub trait NotIterator<'index>: RQEIterator<'index> {
     fn child(&self) -> Option<&dyn RQEIterator<'index>>;
 }
 
-impl<'index> NotIterator<'index> for Not<'index, Box<dyn RQEIterator<'index> + 'index>> {
+impl<'index, TC> NotIterator<'index> for Not<'index, Box<dyn RQEIterator<'index> + 'index>, TC>
+where
+    TC: TimeoutContext,
+{
     fn child(&self) -> Option<&dyn RQEIterator<'index>> {
         self.child
             .as_ref()
@@ -282,7 +277,11 @@ impl<'index> NotIterator<'index> for Not<'index, Box<dyn RQEIterator<'index> + '
     }
 }
 
-impl<'index> crate::interop::ProfileChildren<'index> for Not<'index, crate::c2rust::CRQEIterator> {
+impl<'index, TC> crate::interop::ProfileChildren<'index>
+    for Not<'index, crate::c2rust::CRQEIterator, TC>
+where
+    TC: TimeoutContext + 'index,
+{
     fn profile_children(self) -> Self {
         Not {
             child: self.child.map(crate::c2rust::CRQEIterator::into_profiled),

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -9,8 +9,6 @@
 
 //! Supporting types for [`NotOptimized`].
 
-use std::time::Duration;
-
 use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 
@@ -19,9 +17,6 @@ use crate::{
     WildcardIterator, maybe_empty::MaybeEmpty, not::NotIterator, utils::TimeoutContext,
 };
 use index_spec::IndexSpecReadGuard;
-
-/// Check the clock every this many loop iterations to amortize syscall cost.
-const TIMEOUT_CHECK_GRANULARITY: u32 = 5_000;
 
 /// An optimized NOT iterator that uses a wildcard inverted index iterator.
 ///
@@ -40,7 +35,9 @@ const TIMEOUT_CHECK_GRANULARITY: u32 = 5_000;
 /// * `'index` - The lifetime of the index being iterated over.
 /// * `W` - The wildcard iterator type, must implement [`WildcardIterator`].
 /// * `I` - The child iterator type whose results are negated.
-pub struct NotOptimized<'index, W, I> {
+/// * `TC` - The [`TimeoutContext`] implementation. Chosen at construction
+///   time and monomorphized into the hot path.
+pub struct NotOptimized<'index, W, I, TC> {
     /// The wildcard iterator over all existing documents.
     wcii: W,
     /// The child iterator whose results are negated.
@@ -51,14 +48,17 @@ pub struct NotOptimized<'index, W, I> {
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
     result: RSIndexResult<'index>,
-    /// Tracks the execution deadline for this iterator.
-    timeout_ctx: Option<TimeoutContext>,
+    /// Tracks the execution deadline for this iterator. Pass
+    /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
+    /// entirely; monomorphization collapses the no-op context to dead code.
+    timeout_ctx: TC,
 }
 
-impl<'index, W, I> NotOptimized<'index, W, I>
+impl<'index, W, I, TC> NotOptimized<'index, W, I, TC>
 where
     W: WildcardIterator<'index>,
     I: RQEIterator<'index>,
+    TC: TimeoutContext,
 {
     /// Create a new optimized NOT iterator.
     ///
@@ -66,14 +66,10 @@ where
     /// `child` is the iterator whose documents will be excluded.
     /// `max_doc_id` is the upper bound for document IDs.
     /// `weight` is the score weight applied to every returned result.
-    /// `timeout` controls the amortized timeout. Pass [`None`] to skip timeout checks.
-    pub fn new(
-        wcii: W,
-        child: I,
-        max_doc_id: t_docId,
-        weight: f64,
-        timeout: Option<Duration>,
-    ) -> Self {
+    /// `timeout_ctx` is the [`TimeoutContext`] implementation to use; pass
+    /// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
+    /// entirely.
+    pub fn new(wcii: W, child: I, max_doc_id: t_docId, weight: f64, timeout_ctx: TC) -> Self {
         Self {
             wcii,
             child: MaybeEmpty::new(child),
@@ -83,18 +79,14 @@ where
                 .weight(weight)
                 .field_mask(RS_FIELDMASK_ALL)
                 .build(),
-            timeout_ctx: timeout.map(|t| TimeoutContext::new(t, TIMEOUT_CHECK_GRANULARITY, false)),
+            timeout_ctx,
         }
     }
 
     /// Wrapper around [`TimeoutContext::check_timeout`].
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        if let Some(ctx) = self.timeout_ctx.as_mut() {
-            ctx.check_timeout()
-        } else {
-            Ok(())
-        }
+        self.timeout_ctx.check_timeout()
     }
 
     /// Advance the wildcard iterator and set [`forced_eof`](Self::forced_eof)
@@ -177,10 +169,11 @@ where
     }
 }
 
-impl<'index, W, I> RQEIterator<'index> for NotOptimized<'index, W, I>
+impl<'index, W, I, TC> RQEIterator<'index> for NotOptimized<'index, W, I, TC>
 where
     W: WildcardIterator<'index>,
     I: RQEIterator<'index>,
+    TC: TimeoutContext,
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -343,18 +336,22 @@ where
     }
 }
 
-impl<'index, W> NotIterator<'index>
-    for NotOptimized<'index, W, Box<dyn RQEIterator<'index> + 'index>>
+impl<'index, W, TC> NotIterator<'index>
+    for NotOptimized<'index, W, Box<dyn RQEIterator<'index> + 'index>, TC>
 where
     W: crate::WildcardIterator<'index>,
+    TC: TimeoutContext,
 {
     fn child(&self) -> Option<&dyn RQEIterator<'index>> {
         NotOptimized::child(self).map(|c| &**c as &dyn RQEIterator<'index>)
     }
 }
 
-impl<'index, W: crate::WildcardIterator<'index> + 'index> crate::interop::ProfileChildren<'index>
-    for NotOptimized<'index, W, crate::c2rust::CRQEIterator>
+impl<'index, W, TC> crate::interop::ProfileChildren<'index>
+    for NotOptimized<'index, W, crate::c2rust::CRQEIterator, TC>
+where
+    W: crate::WildcardIterator<'index> + 'index,
+    TC: TimeoutContext + 'index,
 {
     fn profile_children(self) -> Self {
         NotOptimized {

--- a/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
@@ -10,7 +10,7 @@
 //! Reducer logic for creating the right NOT iterator variant,
 //! with short-circuit reductions applied before construction.
 
-use std::{ptr::NonNull, time::Duration};
+use std::ptr::NonNull;
 
 use ffi::t_docId;
 
@@ -18,10 +18,14 @@ use crate::{
     Empty, IteratorType, NewWildcardIterator, RQEIterator,
     not::Not,
     not_optimized::NotOptimized,
+    utils::TimeoutContext,
     wildcard::{
         new_wildcard_iterator, new_wildcard_iterator_on_disk, new_wildcard_iterator_optimized,
     },
 };
+
+/// Check the clock every this many loop iterations to amortize syscall cost.
+pub const TIMEOUT_CHECK_GRANULARITY: u32 = 5_000;
 
 /// The result of [`not_iterator_reducer`].
 ///
@@ -85,15 +89,20 @@ where
 }
 
 /// The result of [`new_not_iterator`].
-pub enum NewNotIterator<'index, I> {
+///
+/// Generic over the [`TimeoutContext`] implementation chosen by the caller
+/// (typically [`AnyTimeoutContext`](crate::utils::AnyTimeoutContext) at the
+/// FFI boundary, or [`TimeoutContextClock`](crate::utils::TimeoutContextClock)
+/// in tests).
+pub enum NewNotIterator<'index, I, TC> {
     /// The child is empty → NOT matches everything → wildcard.
     ReducedWildcard(NewWildcardIterator<'index>),
     /// The child is a wildcard → NOT matches nothing → empty.
     ReducedEmpty(Empty),
     /// Non-optimized path: sequential NOT iterator.
-    Not(Not<'index, I>),
+    Not(Not<'index, I, TC>),
     /// Optimized path (`index_all` or disk index): wildcard-backed NOT iterator.
-    NotOptimized(NotOptimized<'index, NewWildcardIterator<'index>, I>),
+    NotOptimized(NotOptimized<'index, NewWildcardIterator<'index>, I, TC>),
 }
 
 /// Construct a NOT iterator, choosing between [`Not`] (sequential) and
@@ -102,6 +111,13 @@ pub enum NewNotIterator<'index, I> {
 /// If the child is trivially reducible (empty or wildcard), the reducer is
 /// applied first and a simplified iterator is returned directly as
 /// [`NewNotIterator::ReducedWildcard`] or [`NewNotIterator::ReducedEmpty`].
+///
+/// `timeout_ctx` is handed to the constructed iterator unchanged. Pass
+/// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
+/// entirely; the caller is otherwise responsible for picking the right
+/// concrete type (typically
+/// [`AnyTimeoutContext`](crate::utils::AnyTimeoutContext) at the FFI
+/// boundary).
 ///
 /// # Safety
 ///
@@ -116,16 +132,16 @@ pub enum NewNotIterator<'index, I> {
 /// 5. All preconditions of [`new_wildcard_iterator`] must hold (it may be
 ///    called both on the optimized path and by the reducer when the child is
 ///    empty).
-pub unsafe fn new_not_iterator<'index, I>(
+pub unsafe fn new_not_iterator<'index, I, TC>(
     child: I,
     max_doc_id: t_docId,
     weight: f64,
-    timeout: Duration,
-    skip_timeout_checks: bool,
+    timeout_ctx: TC,
     query: NonNull<ffi::QueryEvalCtx>,
-) -> NewNotIterator<'index, I>
+) -> NewNotIterator<'index, I, TC>
 where
     I: RQEIterator<'index> + 'index,
+    TC: TimeoutContext,
 {
     // SAFETY: Caller guarantees the preconditions for `new_wildcard_iterator`
     // (used by the reducer when the child is empty).
@@ -174,19 +190,9 @@ where
             child,
             max_doc_id,
             weight,
-            if skip_timeout_checks {
-                None
-            } else {
-                Some(timeout)
-            },
+            timeout_ctx,
         ))
     } else {
-        NewNotIterator::Not(Not::new(
-            child,
-            max_doc_id,
-            weight,
-            timeout,
-            skip_timeout_checks,
-        ))
+        NewNotIterator::Not(Not::new(child, max_doc_id, weight, timeout_ctx))
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
@@ -16,4 +16,6 @@ mod timeout;
 #[doc(inline)]
 pub use self::owned_slice::OwnedSlice;
 pub use min_heap::{DocIdMinHeap, HeapEntry};
-pub use timeout::TimeoutContext;
+pub use timeout::{
+    AnyTimeoutContext, NoTimeout, TimeoutContext, TimeoutContextBlockedClient, TimeoutContextClock,
+};

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -7,7 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::time::{Duration, Instant};
+use std::{
+    ptr::NonNull,
+    time::{Duration, Instant},
+};
 
 use ffi::{AREQ, AREQ_CheckTimedOut};
 
@@ -115,7 +118,7 @@ impl TimeoutContext for TimeoutContextClock {
 /// counter keeps the hot path branch-free.
 pub struct TimeoutContextBlockedClient {
     /// [`AREQ`] pointer forwarded verbatim to [`AREQ_CheckTimedOut`].
-    areq: *mut AREQ,
+    areq: NonNull<AREQ>,
 }
 
 impl TimeoutContextBlockedClient {
@@ -123,13 +126,13 @@ impl TimeoutContextBlockedClient {
     ///
     /// # Safety
     ///
-    /// * `areq` must be a non-null pointer to a valid [`AREQ`] (as defined in
+    /// * `areq` must point to a valid [`AREQ`] (as defined in
     ///   `src/aggregate/aggregate.h`).
     /// * The pointee must outlive every iterator that holds this context.
     /// * The `RequestSyncCtx::timedOut` flag inside the [`AREQ`] must be safe
     ///   to read with relaxed semantics from any thread.
     #[inline(always)]
-    pub unsafe fn new(areq: *mut AREQ) -> Self {
+    pub const unsafe fn new(areq: NonNull<AREQ>) -> Self {
         Self { areq }
     }
 }
@@ -142,7 +145,7 @@ impl TimeoutContext for TimeoutContextBlockedClient {
         // SAFETY: constructor contract guarantees `self.areq` is valid and
         // thread-safe to probe; `AREQ_CheckTimedOut` performs a relaxed
         // atomic load and does not unwind.
-        let timed_out = unsafe { AREQ_CheckTimedOut(self.areq) };
+        let timed_out = unsafe { AREQ_CheckTimedOut(self.areq.as_ptr()) };
         if timed_out {
             Err(RQEIteratorError::TimedOut)
         } else {

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -9,49 +9,83 @@
 
 use std::time::{Duration, Instant};
 
+use ffi::{AREQ, AREQ_CheckTimedOut};
+
 use crate::RQEIteratorError;
 
-/// A utility for performing amortized timeout checks in high-frequency loops.
+/// Abstraction over the different ways a query iterator can detect that the
+/// surrounding query has run out of time.
+///
+/// Three implementations exist:
+/// * [`NoTimeout`] — zero-sized no-op used when the query has no deadline.
+/// * [`TimeoutContextClock`] — Clock Based Timeout: amortized clock check
+///   used when no Blocked Client Timeout is in play.
+/// * [`TimeoutContextBlockedClient`] — Blocked Client Timeout: reads the
+///   AREQ atomic flag (set by the Blocked Client Timeout main-thread
+///   callback) via the [`AREQ_CheckTimedOut`] C symbol.
+///
+/// Iterators are generic over this trait so the dispatch is monomorphized
+/// in the hot path.
+pub trait TimeoutContext {
+    /// Report whether the query has timed out.
+    ///
+    /// Returns [`RQEIteratorError::TimedOut`] when the deadline has been
+    /// reached (or, for externally-signalled variants, when the signal has
+    /// flipped). Otherwise returns `Ok(())`.
+    ///
+    /// Implementations are allowed (and encouraged) to amortize the actual
+    /// check across many calls.
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError>;
+
+    /// Hook invoked by callers after a unit of useful work has been
+    /// completed, so amortized implementations can reset their internal
+    /// counter without losing accuracy.
+    ///
+    /// The default implementation is a no-op, which is the right behavior
+    /// for variants that do not maintain any internal counter (such as
+    /// [`NoTimeout`] and [`TimeoutContextBlockedClient`]).
+    fn reset_counter(&mut self) {}
+}
+
+/// Amortized clock-based [`TimeoutContext`].
 ///
 /// In "hot paths" (like index scanning or large iterations), calling the system clock
 /// on every iteration is computationally expensive. This context uses a counter to
 /// only perform a real clock check every `limit` iterations, significantly reducing
 /// syscall overhead while still ensuring eventual termination.
-pub struct TimeoutContext {
+pub struct TimeoutContextClock {
     /// The absolute point in time after which the operation is considered timed out.
     deadline: Instant,
     /// The number of times `check_timeout` has been called since the last clock check.
     counter: u32,
     /// The threshold at which a real clock check is performed (the amortized frequency).
-    /// When set to `u32::MAX`, timeout checks are effectively skipped.
     limit: u32,
 }
 
-impl TimeoutContext {
-    /// Creates a new [`TimeoutContext`] that expires after the given `duration`.
+impl TimeoutContextClock {
+    /// Creates a new [`TimeoutContextClock`] that expires after the given `duration`.
     ///
     /// The `limit` determines the granularity of the check. A higher limit
     /// improves performance but increases the potential delay between the
     /// actual timeout and when it is detected.
     ///
-    /// If `skip_timeout_checks` is `true`, `limit` is set to `u32::MAX` to effectively
-    /// skip timeout checks (the counter will never reach the limit in practice).
+    /// To skip timeout checks entirely, use [`NoTimeout`] instead of
+    /// constructing this context.
     #[inline(always)]
-    pub fn new(duration: Duration, limit: u32, skip_timeout_checks: bool) -> Self {
+    pub fn new(duration: Duration, limit: u32) -> Self {
         Self {
             deadline: Instant::now() + duration,
             counter: 0,
-            // Use u32::MAX to effectively skip timeout checks
-            limit: if skip_timeout_checks { u32::MAX } else { limit },
+            limit,
         }
     }
+}
 
+impl TimeoutContext for TimeoutContextClock {
     /// Increments the internal counter and, if the `limit` is reached, checks if
     /// the current time has passed the `deadline`.
-    ///
-    /// Returns error [`RQEIteratorError::TimedOut`] if the deadline has been reached or exceeded.
     #[inline(always)]
-    pub fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
         self.counter += 1;
         if self.counter >= self.limit {
             self.counter = 0;
@@ -63,9 +97,174 @@ impl TimeoutContext {
         Ok(())
     }
 
-    /// Reset the internal counter.
     #[inline(always)]
-    pub const fn reset_counter(&mut self) {
+    fn reset_counter(&mut self) {
         self.counter = 0;
     }
+}
+
+/// [`TimeoutContext`] backed by the Blocked Client Timeout flag on an [`AREQ`].
+///
+/// The struct stores a pointer to the [`AREQ`] and on every
+/// [`TimeoutContext::check_timeout`] call forwards directly to the
+/// [`AREQ_CheckTimedOut`] C symbol.
+///
+/// Unlike [`TimeoutContextClock`] this variant does **not** amortize calls:
+/// the cost of a relaxed atomic load through the named extern is already
+/// in the same order of magnitude as a counter bump, and avoiding the
+/// counter keeps the hot path branch-free.
+pub struct TimeoutContextBlockedClient {
+    /// [`AREQ`] pointer forwarded verbatim to [`AREQ_CheckTimedOut`].
+    areq: *mut AREQ,
+}
+
+impl TimeoutContextBlockedClient {
+    /// Build a new context wrapping `areq`.
+    ///
+    /// # Safety
+    ///
+    /// * `areq` must be a non-null pointer to a valid [`AREQ`] (as defined in
+    ///   `src/aggregate/aggregate.h`).
+    /// * The pointee must outlive every iterator that holds this context.
+    /// * The `RequestSyncCtx::timedOut` flag inside the [`AREQ`] must be safe
+    ///   to read with relaxed semantics from any thread.
+    #[inline(always)]
+    pub unsafe fn new(areq: *mut AREQ) -> Self {
+        Self { areq }
+    }
+}
+
+impl TimeoutContext for TimeoutContextBlockedClient {
+    /// Probe the AREQ timed-out flag via [`AREQ_CheckTimedOut`] and translate
+    /// its `bool` reply into the iterator-level [`Result`].
+    #[inline(always)]
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        // SAFETY: constructor contract guarantees `self.areq` is valid and
+        // thread-safe to probe; `AREQ_CheckTimedOut` performs a relaxed
+        // atomic load and does not unwind.
+        let timed_out = unsafe { AREQ_CheckTimedOut(self.areq) };
+        if timed_out {
+            Err(RQEIteratorError::TimedOut)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Zero-sized no-op [`TimeoutContext`].
+///
+/// Used by callers that want to opt out of timeout checks entirely without
+/// having to wrap the context in an [`Option`]. Because the type has no
+/// fields and every method is a no-op, monomorphizing an iterator over
+/// `NoTimeout` collapses the entire timeout machinery to dead code that
+/// the optimizer removes from the hot path.
+pub struct NoTimeout;
+
+impl TimeoutContext for NoTimeout {
+    #[inline(always)]
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        Ok(())
+    }
+}
+
+/// Type-erased [`TimeoutContext`] wrapping the concrete variants.
+///
+/// Used at the FFI boundary so the iterator type does not depend on which
+/// timeout source the C side selected for a given query. The variant is
+/// fixed at construction time: each call to [`check_timeout`] adds a single
+/// well-predicted branch on top of the inner variant's own work.
+///
+/// [`check_timeout`]: TimeoutContext::check_timeout
+pub enum AnyTimeoutContext {
+    /// No timeout source: every probe is a no-op.
+    NoTimeout(NoTimeout),
+    /// Clock Based Timeout: amortized clock check.
+    Clock(TimeoutContextClock),
+    /// Blocked Client Timeout: relaxed atomic load against the AREQ flag.
+    BlockedClient(TimeoutContextBlockedClient),
+}
+
+impl TimeoutContext for AnyTimeoutContext {
+    #[inline(always)]
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        match self {
+            Self::NoTimeout(c) => c.check_timeout(),
+            Self::Clock(c) => c.check_timeout(),
+            Self::BlockedClient(c) => c.check_timeout(),
+        }
+    }
+
+    #[inline(always)]
+    fn reset_counter(&mut self) {
+        match self {
+            Self::NoTimeout(c) => c.reset_counter(),
+            Self::Clock(c) => c.reset_counter(),
+            Self::BlockedClient(c) => c.reset_counter(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clock_context_does_not_time_out_within_deadline() {
+        let mut ctx = TimeoutContextClock::new(Duration::from_secs(60), 1);
+        for _ in 0..1_000 {
+            assert!(ctx.check_timeout().is_ok());
+        }
+    }
+
+    #[test]
+    fn clock_context_times_out_after_deadline() {
+        let mut ctx = TimeoutContextClock::new(Duration::from_nanos(1), 1);
+        // Spin until the (very short) deadline passes; in practice the
+        // first call already crosses it on every platform we run on.
+        for _ in 0..1_000 {
+            if ctx.check_timeout().is_err() {
+                return;
+            }
+        }
+        panic!("clock context never timed out");
+    }
+
+    #[test]
+    fn clock_context_amortizes_via_limit() {
+        let mut ctx = TimeoutContextClock::new(Duration::from_nanos(1), 100);
+        // With `limit = 100` the first 99 calls must not even probe the
+        // clock, so they must all succeed regardless of the deadline.
+        for _ in 0..99 {
+            assert!(ctx.check_timeout().is_ok());
+        }
+    }
+
+    #[test]
+    fn clock_context_reset_counter_delays_next_check() {
+        let mut ctx = TimeoutContextClock::new(Duration::from_nanos(1), 4);
+        // Three increments bring the counter to 3 (below `limit`).
+        for _ in 0..3 {
+            assert!(ctx.check_timeout().is_ok());
+        }
+        // Reset back to 0; the next three calls must again avoid the
+        // clock check and report Ok.
+        ctx.reset_counter();
+        for _ in 0..3 {
+            assert!(ctx.check_timeout().is_ok());
+        }
+    }
+
+    #[test]
+    fn any_timeout_context_dispatches_to_clock_variant() {
+        let inner = TimeoutContextClock::new(Duration::from_secs(60), 1);
+        let mut ctx = AnyTimeoutContext::Clock(inner);
+        assert!(ctx.check_timeout().is_ok());
+        ctx.reset_counter();
+        assert!(ctx.check_timeout().is_ok());
+    }
+
+    // The `BlockedClient` variant is a thin wrapper around the C symbol
+    // `AREQ_CheckTimedOut` (declared above as `unsafe extern "C"`); its
+    // dispatch is covered end-to-end by `tests/pytests/test_blocked_client_timeout.py`
+    // because exercising it from Rust requires a real AREQ.
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -12,15 +12,20 @@ use std::time::Duration;
 use ffi::t_docId;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    id_list::IdListSorted, not::Not,
+    id_list::IdListSorted,
+    not::Not,
+    utils::{NoTimeout, TimeoutContextClock},
 };
+
+/// Granularity used by the production reducer; tests reuse it for parity.
+const CLOCK_CHECK_GRANULARITY: u32 = 5_000;
 
 use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
 
 #[test]
 fn type_() {
     let child = IdListSorted::new(vec![2, 4, 6]);
-    let it = Not::new(child, 10, 1.0, Duration::ZERO, true);
+    let it = Not::new(child, 10, 1.0, NoTimeout);
     assert_eq!(it.type_(), IteratorType::Not);
 }
 
@@ -28,7 +33,7 @@ fn type_() {
 #[test]
 fn initial_state() {
     let child = IdListSorted::new(vec![2, 4, 6]);
-    let it = Not::new(child, 10, 1.0, Duration::ZERO, true);
+    let it = Not::new(child, 10, 1.0, NoTimeout);
 
     // Before first read, cursor is at 0 and we are not at EOF.
     assert_eq!(it.last_doc_id(), 0);
@@ -41,7 +46,12 @@ fn initial_state() {
 #[test]
 fn read_skips_child_docs() {
     let child_ids = vec![2, 4, 7];
-    let mut it = Not::new(IdListSorted::new(child_ids), 10, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(
+        IdListSorted::new(child_ids),
+        10,
+        1.0,
+        NoTimeout,
+    );
 
     // Child has [2, 4, 7]; complement in [1..=10] is [1, 3, 5, 6, 8, 9, 10].
     let expected = vec![1, 3, 5, 6, 8, 9, 10];
@@ -66,7 +76,12 @@ fn read_skips_child_docs() {
 #[test]
 fn read_with_empty_child_behaves_like_wildcard() {
     // When the child is empty, NOT should yield all doc IDs in [1, max_doc_id]
-    let mut it = Not::new(IdListSorted::new(vec![]), 5, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(
+        IdListSorted::new(vec![]),
+        5,
+        1.0,
+        NoTimeout,
+    );
 
     for expected_id in 1u64..=5 {
         let result = it.read();
@@ -90,8 +105,7 @@ fn read_with_child_covering_full_range_yields_no_docs() {
         IdListSorted::new(vec![1, 2, 3, 4, 5]),
         5,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // Child already produces 1..=5, so there is no doc left for NOT to return.
@@ -111,8 +125,7 @@ fn skip_to_honours_child_membership() {
         IdListSorted::new(vec![2, 4, 7]),
         10,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // 5 is not in child {2, 4, 7}, so NOT must return Found(5).
@@ -156,8 +169,7 @@ fn skip_to_child_doc_at_max_docid_returns_none() {
         IdListSorted::new(vec![2, 5, 10]),
         10,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // Read first to position before the skip
@@ -180,8 +192,7 @@ fn skip_to_child_ahead_returns_found() {
         IdListSorted::new(vec![5, 10]),
         15,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // Read once to advance child to doc_id=5
@@ -203,7 +214,12 @@ fn skip_to_child_ahead_returns_found() {
 // skip_to when child is at EOF: Case 1 - child.at_eof()
 #[test]
 fn skip_to_child_at_eof_returns_found() {
-    let mut it = Not::new(IdListSorted::new(vec![1, 2]), 10, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(
+        IdListSorted::new(vec![1, 2]),
+        10,
+        1.0,
+        NoTimeout,
+    );
 
     // Exhaust the child by reading past its docs
     while let Some(doc) = it.read().unwrap() {
@@ -231,8 +247,7 @@ fn skip_to_child_last_doc_when_at_eof_excludes_it() {
         IdListSorted::new(vec![5, 10]),
         15,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // Read up to doc 9 to exhaust the child
@@ -264,8 +279,7 @@ fn skip_to_past_max_docid_returns_none_and_sets_eof() {
         IdListSorted::new(vec![2, 4, 7]),
         10,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // 11 > max_doc_id=10, so there is no valid target and we end at EOF.
@@ -284,8 +298,7 @@ fn rewind_resets_state() {
         IdListSorted::new(vec![2, 4, 7]),
         10,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // For child [2, 4, 7] and max_doc_id=10, the first two NOT results are 1 and 3.
@@ -311,7 +324,7 @@ fn rewind_resets_state() {
 fn revalidate_child_ok_preserves_exclusions() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let child = Mock::new([2, 4]);
-    let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 5, 1.0, NoTimeout);
 
     let status = it
         .revalidate(&*mock_ctx.spec_read())
@@ -334,7 +347,7 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Abort);
-    let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 5, 1.0, NoTimeout);
 
     let status = it
         .revalidate(&*mock_ctx.spec_read())
@@ -357,7 +370,7 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Move);
-    let mut it = Not::new(child, 5, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 5, 1.0, NoTimeout);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
     let status = it
@@ -381,7 +394,7 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let child = Mock::new([5, 10]);
     let mut data = child.data();
-    let mut it = Not::new(child, 15, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 15, 1.0, NoTimeout);
 
     // Read first doc (1) - child will be at 5, NOT at 1
     let doc = it.read().expect("read() failed").expect("expected doc");
@@ -415,7 +428,7 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let child = Mock::new([8, 15]);
     let mut data = child.data();
-    let mut it = Not::new(child, 20, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 20, 1.0, NoTimeout);
 
     // Skip to 3 - child will be at 8, NOT at 3
     let outcome = it
@@ -459,7 +472,7 @@ fn read_propagates_child_timeout() {
     let mut data = child.data();
     // Set child to return timeout error when it reaches EOF
     data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
-    let mut it = Not::new(child, 6, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 6, 1.0, NoTimeout);
 
     // Read docs that are NOT in child: [1, 2, 4, 6]
     // Child has [3, 5]. When NOT reads doc 6, child.read() is called to check
@@ -492,7 +505,7 @@ fn skip_to_propagates_child_timeout() {
     let mut data = child.data();
     // Set child to return timeout error when it reaches EOF
     data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
-    let mut it = Not::new(child, 10, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(child, 10, 1.0, NoTimeout);
 
     // skip_to(7) - child has [2,4,6], child.last_doc_id()=0 < 7, so we call
     // child.skip_to(7) which will go past child's last doc (6) and hit EOF,
@@ -512,8 +525,7 @@ fn skip_to_at_eof_returns_none() {
         IdListSorted::new(vec![1, 2, 3, 4, 5]),
         5,
         1.0,
-        Duration::ZERO,
-        true,
+        NoTimeout,
     );
 
     // Exhaust the iterator - child covers full range so NOT produces nothing
@@ -534,7 +546,12 @@ fn skip_to_at_eof_returns_none() {
 #[test]
 fn skip_to_child_behind_child_skip_returns_eof() {
     // Child has [2], max_doc_id=10
-    let mut it = Not::new(IdListSorted::new(vec![2]), 10, 1.0, Duration::ZERO, true);
+    let mut it = Not::new(
+        IdListSorted::new(vec![2]),
+        10,
+        1.0,
+        NoTimeout,
+    );
 
     // Read first doc (1) to advance child to position 2
     let doc = it.read().unwrap().unwrap();
@@ -568,7 +585,12 @@ fn read_timeout_via_timeout_ctx() {
     // Set child to return timeout error when it reaches EOF
     data.add_delay_since_index(1, Duration::from_micros(100));
 
-    let mut it = Not::new(child, 10_000, 1.0, Duration::from_micros(50), false);
+    let mut it = Not::new(
+        child,
+        10_000,
+        1.0,
+        TimeoutContextClock::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
+    );
 
     let result = it.read();
     assert!(
@@ -585,7 +607,12 @@ fn skip_to_timeout_via_timeout_ctx() {
     // Set child to return timeout error when it reaches EOF
     data.add_delay_since_index(1, Duration::from_micros(100));
 
-    let mut it = Not::new(child, 10_000, 1.0, Duration::from_micros(50), false);
+    let mut it = Not::new(
+        child,
+        10_000,
+        1.0,
+        TimeoutContextClock::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
+    );
 
     for idx in 1..=4_999 {
         let outcome = it

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -46,12 +46,7 @@ fn initial_state() {
 #[test]
 fn read_skips_child_docs() {
     let child_ids = vec![2, 4, 7];
-    let mut it = Not::new(
-        IdListSorted::new(child_ids),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(child_ids), 10, 1.0, NoTimeout);
 
     // Child has [2, 4, 7]; complement in [1..=10] is [1, 3, 5, 6, 8, 9, 10].
     let expected = vec![1, 3, 5, 6, 8, 9, 10];
@@ -76,12 +71,7 @@ fn read_skips_child_docs() {
 #[test]
 fn read_with_empty_child_behaves_like_wildcard() {
     // When the child is empty, NOT should yield all doc IDs in [1, max_doc_id]
-    let mut it = Not::new(
-        IdListSorted::new(vec![]),
-        5,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![]), 5, 1.0, NoTimeout);
 
     for expected_id in 1u64..=5 {
         let result = it.read();
@@ -101,12 +91,7 @@ fn read_with_empty_child_behaves_like_wildcard() {
 // Child covers full range: NOT should be empty and report EOF.
 #[test]
 fn read_with_child_covering_full_range_yields_no_docs() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![1, 2, 3, 4, 5]),
-        5,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeout);
 
     // Child already produces 1..=5, so there is no doc left for NOT to return.
     let res = it.read().expect("read() must not error");
@@ -121,12 +106,7 @@ fn read_with_child_covering_full_range_yields_no_docs() {
 // skip_to on ids below, between and inside child: Found vs NotFound semantics.
 #[test]
 fn skip_to_honours_child_membership() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![2, 4, 7]),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeout);
 
     // 5 is not in child {2, 4, 7}, so NOT must return Found(5).
     let outcome = it.skip_to(5).expect("skip_to(5) must not error");
@@ -165,12 +145,7 @@ fn skip_to_honours_child_membership() {
 #[test]
 fn skip_to_child_doc_at_max_docid_returns_none() {
     // Child has doc 10, which is also max_doc_id
-    let mut it = Not::new(
-        IdListSorted::new(vec![2, 5, 10]),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![2, 5, 10]), 10, 1.0, NoTimeout);
 
     // Read first to position before the skip
     let doc = it.read().unwrap().unwrap();
@@ -188,12 +163,7 @@ fn skip_to_child_doc_at_max_docid_returns_none() {
 // skip_to when child is ahead of docId: Case 1 - child.last_doc_id() > doc_id
 #[test]
 fn skip_to_child_ahead_returns_found() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![5, 10]),
-        15,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![5, 10]), 15, 1.0, NoTimeout);
 
     // Read once to advance child to doc_id=5
     let doc = it.read().unwrap().unwrap();
@@ -214,12 +184,7 @@ fn skip_to_child_ahead_returns_found() {
 // skip_to when child is at EOF: Case 1 - child.at_eof()
 #[test]
 fn skip_to_child_at_eof_returns_found() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![1, 2]),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![1, 2]), 10, 1.0, NoTimeout);
 
     // Exhaust the child by reading past its docs
     while let Some(doc) = it.read().unwrap() {
@@ -243,12 +208,7 @@ fn skip_to_child_at_eof_returns_found() {
 // skip_to to child's last doc when child is at EOF: should exclude it
 #[test]
 fn skip_to_child_last_doc_when_at_eof_excludes_it() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![5, 10]),
-        15,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![5, 10]), 15, 1.0, NoTimeout);
 
     // Read up to doc 9 to exhaust the child
     while let Some(doc) = it.read().unwrap() {
@@ -275,12 +235,7 @@ fn skip_to_child_last_doc_when_at_eof_excludes_it() {
 // skip_to past max_doc_id: should return None and move to EOF.
 #[test]
 fn skip_to_past_max_docid_returns_none_and_sets_eof() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![2, 4, 7]),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeout);
 
     // 11 > max_doc_id=10, so there is no valid target and we end at EOF.
     let res = it.skip_to(11).expect("skip_to(11) must not error");
@@ -294,12 +249,7 @@ fn skip_to_past_max_docid_returns_none_and_sets_eof() {
 // rewind should restore the initial state and read sequence.
 #[test]
 fn rewind_resets_state() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![2, 4, 7]),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeout);
 
     // For child [2, 4, 7] and max_doc_id=10, the first two NOT results are 1 and 3.
     for expected in [1u64, 3] {
@@ -521,12 +471,7 @@ fn skip_to_propagates_child_timeout() {
 // skip_to when already at EOF should return None immediately.
 #[test]
 fn skip_to_at_eof_returns_none() {
-    let mut it = Not::new(
-        IdListSorted::new(vec![1, 2, 3, 4, 5]),
-        5,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeout);
 
     // Exhaust the iterator - child covers full range so NOT produces nothing
     assert!(it.read().unwrap().is_none());
@@ -546,12 +491,7 @@ fn skip_to_at_eof_returns_none() {
 #[test]
 fn skip_to_child_behind_child_skip_returns_eof() {
     // Child has [2], max_doc_id=10
-    let mut it = Not::new(
-        IdListSorted::new(vec![2]),
-        10,
-        1.0,
-        NoTimeout,
-    );
+    let mut it = Not::new(IdListSorted::new(vec![2]), 10, 1.0, NoTimeout);
 
     // Read first doc (1) to advance child to position 2
     let doc = it.read().unwrap().unwrap();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -11,7 +11,13 @@ use std::time::Duration;
 
 use ffi::t_docId;
 use index_result::RSIndexResult;
-use rqe_iterators::{RQEIterator, RQEIteratorError, SkipToOutcome, not_optimized::NotOptimized};
+use rqe_iterators::{
+    RQEIterator, RQEIteratorError, SkipToOutcome, not_optimized::NotOptimized,
+    utils::{NoTimeout, TimeoutContextClock},
+};
+
+/// Granularity used by the production reducer; tests reuse it for parity.
+const CLOCK_CHECK_GRANULARITY: u32 = 5_000;
 
 use crate::utils::{Mock, MockIteratorError, MockVec, WildcardHelper};
 
@@ -38,7 +44,7 @@ fn read_test(wc_ids: Vec<t_docId>, child_ids: Vec<t_docId>, max_doc_id: t_docId)
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(child_ids);
-    let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, NoTimeout);
 
     let mut actual = Vec::new();
     while let Ok(Some(doc)) = it.read() {
@@ -80,7 +86,7 @@ fn read_continuous_child_empty_wc() {
     let wc_helper = WildcardHelper::new(&[]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![1, 2, 3]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
 }
@@ -141,7 +147,7 @@ fn skip_to_beyond_max_returns_eof() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     assert!(it.skip_to(11).unwrap().is_none());
     assert!(it.at_eof());
@@ -155,7 +161,7 @@ fn skip_to_found_in_wc_not_in_child() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4, 6, 8, 10]);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
 
     let outcome = it.skip_to(3).unwrap();
     match outcome {
@@ -173,7 +179,7 @@ fn skip_to_in_child_returns_not_found() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4, 6, 8, 10]);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
 
     let outcome = it.skip_to(2).unwrap();
     match outcome {
@@ -191,7 +197,7 @@ fn skip_to_not_in_wc_returns_not_found() {
     let wc_helper = WildcardHelper::new(&[5, 10, 15, 20]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![10]);
-    let mut it = NotOptimized::new(wcii, child, 25, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 25, 1.0, NoTimeout);
 
     // Skip to 7: not in wcii, wcii advances to 10. 10 is in child, so advance
     // further to 15 which is valid.
@@ -213,7 +219,7 @@ fn skip_to_all_test(wc_ids: Vec<t_docId>, child_ids: Vec<t_docId>, max_doc_id: t
         let wc_helper = WildcardHelper::new(&wc_ids);
         let wcii = wc_helper.create_wildcard();
         let child = MockVec::new(child_ids.clone());
-        let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, None);
+        let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, NoTimeout);
 
         let expected_id = expected.iter().find(|&&eid| eid >= id);
         let is_exact = expected.contains(&id);
@@ -269,7 +275,7 @@ fn skip_to_sequential() {
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(child_ids);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
 
     // Skip to each expected result sequentially.
     for &eid in &expected {
@@ -291,7 +297,7 @@ fn num_estimated_returns_wcii_estimate() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
     assert_eq!(it.num_estimated(), 5);
 }
 
@@ -304,7 +310,7 @@ fn rewind_resets_state() {
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(child_ids);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
 
     for pass in 0..5 {
         for j in 0..=pass.min(expected.len() - 1) {
@@ -322,7 +328,7 @@ fn initial_state() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     assert_eq!(it.last_doc_id(), 0);
     assert!(!it.at_eof());
@@ -334,7 +340,7 @@ fn current_always_returns_some() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     // Before any read.
     assert!(it.current().is_some());
@@ -355,7 +361,7 @@ fn skip_to_case2_eof() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![1, 2, 3]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     let outcome = it.skip_to(1).unwrap();
     assert!(outcome.is_none());
@@ -372,7 +378,7 @@ fn skip_to_case2_not_found() {
     let wc_helper = WildcardHelper::new(&[1, 3, 5, 7]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![3, 5]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     let doc = it.read().unwrap().unwrap();
     assert_eq!(doc.doc_id, 1);
@@ -396,7 +402,7 @@ fn skip_to_case2_exhausted() {
     let wc_helper = WildcardHelper::new(&[1, 3, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![3, 5]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     let doc = it.read().unwrap().unwrap();
     assert_eq!(doc.doc_id, 1);
@@ -416,7 +422,7 @@ fn skip_to_case1_child_exhausted() {
     let wc_helper = WildcardHelper::new(&[1, 3, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     // Consume docs to exhaust the child iterator.
     let doc = it.read().unwrap().unwrap();
@@ -451,7 +457,7 @@ fn child_timeout_on_first_read() {
     let mut child_data = child.data();
     child_data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
 
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
     let rc = it.read();
     assert!(
         matches!(rc, Err(RQEIteratorError::TimedOut)),
@@ -467,7 +473,7 @@ fn child_timeout_on_subsequent_read() {
     let wcii = wc_helper.create_wildcard();
     let child = Mock::new([2, 4, 6]);
     let mut child_data = child.data();
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
 
     // Read first result: 1 (not in child).
     let doc = it.read().unwrap().unwrap();
@@ -499,7 +505,7 @@ fn child_timeout_on_skip_to() {
     let mut child_data = child.data();
     child_data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
 
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, None);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
 
     let rc = it.skip_to(1);
     assert!(
@@ -522,7 +528,13 @@ fn read_timeout_via_timeout_ctx() {
     let mut child_data = child.data();
     child_data.add_delay_since_index(1, Duration::from_micros(100));
 
-    let mut it = NotOptimized::new(wcii, child, 10_000, 1.0, Some(Duration::from_micros(50)));
+    let mut it = NotOptimized::new(
+        wcii,
+        child,
+        10_000,
+        1.0,
+        TimeoutContextClock::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
+    );
 
     let result = it.read();
     assert!(
@@ -565,6 +577,7 @@ mod revalidate {
             '_,
             rqe_iterators::inverted_index::Wildcard<'_, DocIdsOnly>,
             Mock<'_, { CHILD_IDS.len() }>,
+            NoTimeout,
         >,
         crate::utils::MockData,
     ) {
@@ -572,7 +585,7 @@ mod revalidate {
         let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
         let child = Mock::new(CHILD_IDS);
         let child_data = child.data();
-        let it = NotOptimized::new(wcii, child, 100, 1.0, None);
+        let it = NotOptimized::new(wcii, child, 100, 1.0, NoTimeout);
         (it, child_data)
     }
 
@@ -765,7 +778,7 @@ mod revalidate {
         let child = Mock::<1>::new([100]); // child won't match
         let mut child_data = child.data();
         child_data.set_revalidate_result(MockRevalidateResult::Ok);
-        let mut it = NotOptimized::new(wcii, child, 200, 1.0, None);
+        let mut it = NotOptimized::new(wcii, child, 200, 1.0, NoTimeout);
 
         // Read the single document.
         let doc = it.read().unwrap().unwrap();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 use ffi::t_docId;
 use index_result::RSIndexResult;
 use rqe_iterators::{
-    RQEIterator, RQEIteratorError, SkipToOutcome, not_optimized::NotOptimized,
+    RQEIterator, RQEIteratorError, SkipToOutcome,
+    not_optimized::NotOptimized,
     utils::{NoTimeout, TimeoutContextClock},
 };
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -214,8 +214,7 @@ fn weight_is_propagated() {
     let weight = 0.42;
 
     // SAFETY: MockContext guarantees valid FFI structures.
-    let result =
-        unsafe { new_not_iterator(child, 5, weight, NoTimeout, ctx.qctx()) };
+    let result = unsafe { new_not_iterator(child, 5, weight, NoTimeout, ctx.qctx()) };
 
     let NewNotIterator::Not(mut it) = result else {
         panic!("Expected Not variant");

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -9,12 +9,11 @@
 
 //! Tests for [`new_not_iterator`].
 
-use std::time::Duration;
-
 use ffi::t_docId;
 use rqe_iterators::{
     Empty, IteratorType, RQEIterator, SkipToOutcome, Wildcard,
     not_reducer::{NewNotIterator, new_not_iterator},
+    utils::NoTimeout,
 };
 use rqe_iterators_test_utils::MockContext;
 
@@ -26,13 +25,13 @@ fn call_new_not_iterator<'a, I>(
     child: I,
     max_doc_id: t_docId,
     ctx: &'a MockContext,
-) -> NewNotIterator<'a, I>
+) -> NewNotIterator<'a, I, NoTimeout>
 where
     I: RQEIterator<'a> + 'a,
 {
     // SAFETY: `MockContext` guarantees valid FFI structures for the lifetime
-    // of the context.
-    unsafe { new_not_iterator(child, max_doc_id, 1.0, Duration::ZERO, true, ctx.qctx()) }
+    // of the context. `NoTimeout` disables timeout checks at zero runtime cost.
+    unsafe { new_not_iterator(child, max_doc_id, 1.0, NoTimeout, ctx.qctx()) }
 }
 
 // ---------------------------------------------------------------------------
@@ -215,7 +214,8 @@ fn weight_is_propagated() {
     let weight = 0.42;
 
     // SAFETY: MockContext guarantees valid FFI structures.
-    let result = unsafe { new_not_iterator(child, 5, weight, Duration::ZERO, true, ctx.qctx()) };
+    let result =
+        unsafe { new_not_iterator(child, 5, weight, NoTimeout, ctx.qctx()) };
 
     let NewNotIterator::Not(mut it) = result else {
         panic!("Expected Not variant");

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profilable.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profilable.rs
@@ -7,14 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::time::Duration;
-
 use rqe_iterators::{
     Intersection, RQEIterator, Wildcard,
     not::Not,
     optional::Optional,
     profile::Profile,
     union::{Union, UnionQuickFlat},
+    utils::NoTimeout,
 };
 
 use crate::utils::Mock;
@@ -43,7 +42,7 @@ fn leaf_wraps_self() {
 #[test]
 fn not_wraps_child_and_self() {
     let child = Mock::new([2, 4]);
-    let not = Not::new(child, 5, 1.0, Duration::ZERO, true);
+    let not = Not::new(child, 5, 1.0, NoTimeout);
     let mut profiled = Profile::new(not);
 
     assert_eq!(profiled.counters().read, 0);
@@ -70,7 +69,7 @@ fn not_wraps_child_and_self() {
 #[test]
 fn not_empty_child() {
     let child = Mock::new([]);
-    let not = Not::new(child, 3, 1.0, Duration::ZERO, true);
+    let not = Not::new(child, 3, 1.0, NoTimeout);
     let mut profiled = Profile::new(not);
 
     for expected in 1..=3 {
@@ -246,7 +245,7 @@ fn leaf_skip_to() {
 #[test]
 fn not_skip_to() {
     let child = Mock::new([3, 7]);
-    let not = Not::new(child, 10, 1.0, Duration::ZERO, true);
+    let not = Not::new(child, 10, 1.0, NoTimeout);
     let mut profiled = Profile::new(not);
 
     // skip_to(5): doc 5 is not in child {3,7}, so NOT yields it.
@@ -259,7 +258,7 @@ fn not_skip_to() {
 #[test]
 fn not_rewind() {
     let child = Mock::new([2]);
-    let not = Not::new(child, 5, 1.0, Duration::ZERO, true);
+    let not = Not::new(child, 5, 1.0, NoTimeout);
     let mut profiled = Profile::new(not);
 
     let _ = profiled.read().unwrap(); // doc 1

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
@@ -12,7 +12,9 @@
 use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
-use rqe_iterators::{RQEIterator, empty::Empty, id_list::IdListSorted, not::Not};
+use rqe_iterators::{
+    RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeout,
+};
 
 #[derive(Default)]
 pub struct Bencher;
@@ -23,11 +25,10 @@ impl Bencher {
 
     const MAX_DOC_ID: u64 = 1_000_000;
 
-    /// Duration is irrelevant since we skip timeout checks in benchmarks.
-    const NOT_ITERATOR_TIMEOUT: Duration = Duration::ZERO;
-
-    /// Skip timeout checks in benchmarks to avoid any overhead.
-    const SKIP_TIMEOUT_CHECKS: bool = true;
+    /// Disable timeout checks in benchmarks: [`NoTimeout`] is a zero-sized
+    /// no-op so the iterator's `check_timeout` path is dead code after
+    /// monomorphization.
+    const TIMEOUT_CTX: NoTimeout = NoTimeout;
 
     fn benchmark_group<'a>(
         &self,
@@ -55,15 +56,7 @@ impl Bencher {
         // Rust implementation
         group.bench_function("Rust", |b| {
             b.iter_batched_ref(
-                || {
-                    Not::new(
-                        Empty,
-                        Self::MAX_DOC_ID,
-                        1.0,
-                        Self::NOT_ITERATOR_TIMEOUT,
-                        Self::SKIP_TIMEOUT_CHECKS,
-                    )
-                },
+                || Not::new(Empty, Self::MAX_DOC_ID, 1.0, Self::TIMEOUT_CTX),
                 |it| {
                     while let Ok(Some(current)) = it.read() {
                         black_box(current);
@@ -90,8 +83,7 @@ impl Bencher {
                         IdListSorted::new(data),
                         Self::MAX_DOC_ID,
                         1.0,
-                        Self::NOT_ITERATOR_TIMEOUT,
-                        Self::SKIP_TIMEOUT_CHECKS,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {
@@ -114,15 +106,7 @@ impl Bencher {
         // Rust implementation
         group.bench_function("Rust", |b| {
             b.iter_batched_ref(
-                || {
-                    Not::new(
-                        Empty,
-                        Self::MAX_DOC_ID,
-                        1.0,
-                        Self::NOT_ITERATOR_TIMEOUT,
-                        Self::SKIP_TIMEOUT_CHECKS,
-                    )
-                },
+                || Not::new(Empty, Self::MAX_DOC_ID, 1.0, Self::TIMEOUT_CTX),
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + step) {
                         black_box(current);
@@ -149,8 +133,7 @@ impl Bencher {
                         IdListSorted::new(data),
                         Self::MAX_DOC_ID,
                         1.0,
-                        Self::NOT_ITERATOR_TIMEOUT,
-                        Self::SKIP_TIMEOUT_CHECKS,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {
@@ -179,8 +162,7 @@ impl Bencher {
                         IdListSorted::new(data),
                         Self::MAX_DOC_ID,
                         1.0,
-                        Self::NOT_ITERATOR_TIMEOUT,
-                        Self::SKIP_TIMEOUT_CHECKS,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
@@ -12,9 +12,7 @@
 use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
-use rqe_iterators::{
-    RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeout,
-};
+use rqe_iterators::{RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeout};
 
 #[derive(Default)]
 pub struct Bencher;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -14,7 +14,7 @@ use std::{hint::black_box, time::Duration};
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 use rqe_iterators::{
     RQEIterator, empty::Empty, id_list::IdListSorted, not_optimized::NotOptimized,
-    wildcard::new_wildcard_iterator_optimized,
+    utils::NoTimeout, wildcard::new_wildcard_iterator_optimized,
 };
 use rqe_iterators_test_utils::TestContext;
 
@@ -49,6 +49,10 @@ impl Bencher {
     const SPARSE_STEP: usize = 200;
     /// Step size for skip_to() calls.
     const SKIP_TO_STEP: u64 = 100;
+    /// Disable timeout checks in benchmarks: [`NoTimeout`] is a zero-sized
+    /// no-op so the iterator's `check_timeout` path is dead code after
+    /// monomorphization.
+    const TIMEOUT_CTX: NoTimeout = NoTimeout;
 
     fn benchmark_group<'a>(
         &self,
@@ -90,7 +94,7 @@ impl Bencher {
                 || {
                     // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
                     let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
-                    NotOptimized::new(wc, Empty, Self::MAX_DOC_ID, Self::WEIGHT, None)
+                    NotOptimized::new(wc, Empty, Self::MAX_DOC_ID, Self::WEIGHT, Self::TIMEOUT_CTX)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.read() {
@@ -119,7 +123,7 @@ impl Bencher {
                         IdListSorted::new(Self::dense_child()),
                         Self::MAX_DOC_ID,
                         Self::WEIGHT,
-                        None,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {
@@ -149,7 +153,7 @@ impl Bencher {
                         IdListSorted::new(Self::sparse_child()),
                         Self::MAX_DOC_ID,
                         Self::WEIGHT,
-                        None,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {
@@ -174,7 +178,7 @@ impl Bencher {
                 || {
                     // SAFETY: context has index_all=true and existingDocs wired by TestContext::wildcard.
                     let wc = unsafe { new_wildcard_iterator_optimized(context.sctx, Self::WEIGHT) };
-                    NotOptimized::new(wc, Empty, Self::MAX_DOC_ID, Self::WEIGHT, None)
+                    NotOptimized::new(wc, Empty, Self::MAX_DOC_ID, Self::WEIGHT, Self::TIMEOUT_CTX)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
@@ -204,7 +208,7 @@ impl Bencher {
                         IdListSorted::new(Self::sparse_child()),
                         Self::MAX_DOC_ID,
                         Self::WEIGHT,
-                        None,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {
@@ -235,7 +239,7 @@ impl Bencher {
                         IdListSorted::new(Self::dense_child()),
                         Self::MAX_DOC_ID,
                         Self::WEIGHT,
-                        None,
+                        Self::TIMEOUT_CTX,
                     )
                 },
                 |it| {

--- a/tests/cpptests/llapi_test_helpers.cpp
+++ b/tests/cpptests/llapi_test_helpers.cpp
@@ -228,7 +228,7 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
     goto end;
   }
 
-  it->internal = QAST_Iterate(&it->qast, &options, &it->sctx, 0, &status);
+  it->internal = QAST_Iterate(&it->qast, &options, &it->sctx, 0, NULL, &status);
   RS_ASSERT(it->internal);
 
   IndexSpec_GetStats(sp, &it->scargs.indexStats);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -292,7 +292,7 @@ TEST_F(IndexTest, testNot) {
   MockQueryEvalCtx mockQctx(16, 16);
   irs[0] = NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1);
   MockQueryEvalCtx mockQctx2(10, 10);
-  irs[1] = NewNotIterator(NewInvIndIterator_TermQuery(w2, &mockQctx2.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w2), 1, {0}, NULL, NULL, &ctx->qctx);
+  irs[1] = NewNotIterator(NewInvIndIterator_TermQuery(w2, &mockQctx2.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w2), 1, {0}, NULL, &ctx->qctx);
 
   QueryIterator *ui = NewIntersectionIterator(irs, 2, -1, 0, 1);
   int expected[] = {1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16};
@@ -314,7 +314,7 @@ TEST_F(IndexTest, testPureNot) {
   auto ctx = std::make_unique<MockQueryEvalCtx>();
   FieldMaskOrIndex f = {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL};
   MockQueryEvalCtx mockQctx(10, 10);
-  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w) + 5, 1, {0}, NULL, NULL, &ctx->qctx);
+  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w) + 5, 1, {0}, NULL, &ctx->qctx);
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -292,7 +292,7 @@ TEST_F(IndexTest, testNot) {
   MockQueryEvalCtx mockQctx(16, 16);
   irs[0] = NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1);
   MockQueryEvalCtx mockQctx2(10, 10);
-  irs[1] = NewNotIterator(NewInvIndIterator_TermQuery(w2, &mockQctx2.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w2), 1, {0}, &ctx->qctx);
+  irs[1] = NewNotIterator(NewInvIndIterator_TermQuery(w2, &mockQctx2.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w2), 1, {0}, NULL, NULL, &ctx->qctx);
 
   QueryIterator *ui = NewIntersectionIterator(irs, 2, -1, 0, 1);
   int expected[] = {1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16};
@@ -314,7 +314,7 @@ TEST_F(IndexTest, testPureNot) {
   auto ctx = std::make_unique<MockQueryEvalCtx>();
   FieldMaskOrIndex f = {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL};
   MockQueryEvalCtx mockQctx(10, 10);
-  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w) + 5, 1, {0}, &ctx->qctx);
+  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w) + 5, 1, {0}, NULL, NULL, &ctx->qctx);
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,

--- a/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
@@ -139,7 +139,7 @@ bool SetupHybridIteratorTest(RedisModuleCtx *ctx,
     AREQ *vecReq = testCtx->hybridReq->requests[VECTOR_REQUEST_INDEX];
     testCtx->rootiter = QAST_Iterate(&vecReq->ast, &vecReq->searchopts,
                                       AREQ_SearchCtx(vecReq), vecReq->reqflags,
-                                      &testCtx->iterError);
+                                      vecReq, &testCtx->iterError);
 
     if (!QueryError_IsOk(&testCtx->iterError) || !testCtx->rootiter) return false;
     if (testCtx->rootiter->type != HYBRID_ITERATOR) return false;

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -163,7 +163,7 @@ TEST_F(QueryTest, testDiskVectorQueryRestrictions) {
   ASSERT_FALSE(QueryError_HasError(&iterErr)) << QueryError_GetUserError(&iterErr);
 
   // Disk-backed pre-filtered KNN requires explicit HYBRID_POLICY during iteration setup.
-  QueryIterator *it = QAST_Iterate(&ast, &opts, &ctx, 0, &iterErr);
+  QueryIterator *it = QAST_Iterate(&ast, &opts, &ctx, 0, NULL, &iterErr);
   ASSERT_NE(it, nullptr);
   ASSERT_TRUE(QueryError_HasError(&iterErr));
   ASSERT_NE(strstr(QueryError_GetUserError(&iterErr), "require explicit HYBRID_POLICY"), nullptr)
@@ -203,7 +203,7 @@ TEST_F(QueryTest, testDiskVectorQueryRestrictions) {
 
   // Query attributes syntax without HYBRID_POLICY still raises the same error.
   QueryIterator *it_missing_attrs =
-      QAST_Iterate(&ast_missing_attrs, &opts_missing_attrs, &ctx, 0, &iterErrMissingAttrs);
+      QAST_Iterate(&ast_missing_attrs, &opts_missing_attrs, &ctx, 0, NULL, &iterErrMissingAttrs);
   ASSERT_NE(it_missing_attrs, nullptr);
   ASSERT_TRUE(QueryError_HasError(&iterErrMissingAttrs));
   ASSERT_NE(strstr(QueryError_GetUserError(&iterErrMissingAttrs), "require explicit HYBRID_POLICY"), nullptr)
@@ -236,7 +236,7 @@ TEST_F(QueryTest, testDiskVectorQueryRestrictions) {
   ASSERT_FALSE(QueryError_HasError(&iterErrAttrs)) << QueryError_GetUserError(&iterErrAttrs);
 
   // Query attributes syntax also satisfies the explicit HYBRID_POLICY requirement.
-  QueryIterator *it_attrs = QAST_Iterate(&ast_attrs, &opts_attrs, &ctx, 0, &iterErrAttrs);
+  QueryIterator *it_attrs = QAST_Iterate(&ast_attrs, &opts_attrs, &ctx, 0, NULL, &iterErrAttrs);
   ASSERT_NE(it_attrs, nullptr);
   ASSERT_FALSE(QueryError_HasError(&iterErrAttrs)) << QueryError_GetUserError(&iterErrAttrs);
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4491,6 +4491,69 @@ class TestShardTimeout:
 
         env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
 
+    def test_shard_timeout_qi_not_iterator(self):
+        """MOD-15397: the Rust NOT iterator's per-iterator timeout callback
+        receives the blocked-client timeout signal under FAIL + WORKERS.
+
+        Arms ``BeforeQITimeoutCheck``, runs ``FT.SEARCH idx -hello1`` so the
+        Rust ``NotIterator``'s ``check_timeout`` parks at the sync point, then
+        fires ``CLIENT UNBLOCK ... TIMEOUT`` to flip the AREQ timed-out flag.
+        The sync-point predicate (``AREQ_TimedOut``) releases the wait, the
+        iterator returns ``Timeout``, and the query reports the timeout error.
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+        sync_point = 'BeforeQITimeoutCheck'
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'fail').ok()
+
+        before_info = info_modules_to_dict(env)
+        base_err_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC])
+
+        env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+        env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+        try:
+            query_args = ['FT.SEARCH', 'idx', '-hello1']
+            t_query = threading.Thread(
+                target=run_cmd_expect_timeout,
+                args=(env, query_args),
+                daemon=True
+            )
+            t_query.start()
+
+            blocked_client_id = wait_for_blocked_query_client(env, 'FT.SEARCH')
+
+            # Worker must reach the QI timeout check (proves the callback was
+            # installed and the iterator's check_timeout was called).
+            wait_for_condition(
+                lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+                f'Worker never reached {sync_point}'
+            )
+
+            # Fire blocked-client timeout: main-thread callback sets
+            # AREQ.timedOut; the sync-point predicate releases the wait and
+            # the iterator's check_timeout returns Timeout.
+            env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+            wait_for_client_unblocked(env, blocked_client_id)
+        finally:
+            # Disarm the sync point. The predicate may have already released
+            # the worker, but the point itself stays armed until signalled
+            # or cleared, which would block subsequent tests.
+            env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+
+        # Standalone uses coord metrics for shard-side timeouts.
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC],
+                        str(base_err_coord + 1),
+                        message="Coord timeout error should be +1 after QI sync-point timeout")
+
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy).ok()
+
     def _test_fail_timeout_before_store_impl(self, query_args, cmd_name=None):
         """Test timeout occurring before storing results (reply_callback path) in standalone."""
         env = self.env


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Under `FAIL` / `RETURN-STRICT` with `WORKERS > 0`, query execution runs on background worker threads while the main thread receives the Redis blocked-client timeout. The C-side `RPQueryIterator` already consults `AREQ.timedOut` (set by the main-thread blocked-client callback) on every probe, but Rust Query Iterators (currently `NotIterator`) only had a clock-based `TimeoutContext`. With `skipTimeoutChecks=true` (the FAIL/RETURN-STRICT + workers configuration), the clock check is intentionally suppressed and the Rust iterator therefore had **no timeout source at all** — a long-running NOT subtree could not be interrupted by a client timeout.

2. **Change**:
   - Introduce a `TimeoutContext` trait in `rqe_iterators::utils::timeout`. Rename the existing struct to `TimeoutContextClock` and add a new `TimeoutContextBlockedClientCallback` variant holding an `extern "C" fn(*mut c_void) -> bool` plus user-data pointer.
   - Plumb the callback variant through the `NotIterator` (and `not_optimized`) FFI constructors. Selection happens at iterator construction.
   - On the C side, register `not_iterator_timeout_cb` (delegates to `AREQ_TimedOutRelaxed`) whenever `q->areq` is set. `skipTimeoutChecks` only suppresses clock checks and is **orthogonal** to the blocked-client signal — under FAIL/RETURN-STRICT + workers the callback becomes the only timeout source.
   - `QueryEvalCtx` gains an `areq` field; `QAST_Iterate` gains a matching `struct AREQ *` parameter, threaded through from `aggregate_exec.c` and `hybrid_request.c`. Low-level paths (`redisearch_api.c`, cpptests) pass `NULL`.
   - Add `SYNC_POINT_BEFORE_QI_TIMEOUT_CHECK` (`"BeforeQITimeoutCheck"`) and wrap `not_iterator_timeout_cb` with `SyncPoint_WaitUntil(...)` under `#ifdef ENABLE_ASSERT`. The wait predicate (`AREQ_TimedOut`) releases the parked worker the moment the main-thread callback flips the flag — zero overhead in release builds.
   - Add flow test `TestShardTimeout::test_shard_timeout_qi_not_iterator` that arms the sync point, runs `FT.SEARCH idx -hello1`, asserts `IS_WAITING` (proves the QI callback was reached), fires `CLIENT UNBLOCK ... TIMEOUT`, and verifies the coordinator timeout-error metric increments.

3. **Outcome**: Rust Query Iterators now honor the Redis blocked-client timeout under all timeout policies, matching the C `RPQueryIterator` behavior. The `BeforeQITimeoutCheck` sync point gives flow tests a deterministic way to assert that a timeout signal travelled through the QI path.

#### Which additional issues this PR fixes

1. MOD-15397
2. Stacked on top of #9601 (MOD-15396) — please review/merge that one first.

#### Main objects this PR modified

1. `rqe_iterators::utils::timeout::TimeoutContext` (new trait), `TimeoutContextClock` (renamed), `TimeoutContextBlockedClientCallback` (new)
2. `NotIterator` / `not_optimized` FFI constructors (`iterators_ffi`)
3. `Query_EvalNotNode`, `not_iterator_timeout_cb`, `not_iter_areq_timed_out` (C, `src/query.c`)
4. `QueryEvalCtx::areq`, `QAST_Iterate` signature (`src/query.h`, `src/query_ctx.h`)
5. `SYNC_POINT_BEFORE_QI_TIMEOUT_CHECK` (`src/debug_commands.h`)
6. `TestShardTimeout::test_shard_timeout_qi_not_iterator` (`tests/pytests/test_blocked_client_timeout.py`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

User impact: long-running queries with NOT subtrees, executed under `FAIL` / `RETURN-STRICT` with `WORKERS > 0`, now correctly observe Redis blocked-client timeouts (`CLIENT UNBLOCK ... TIMEOUT`) and return promptly instead of running until natural completion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query timeout behavior on the hot NOT iterator path under FAIL/RETURN-STRICT with workers; incorrect wiring could miss timeouts or false-positive, but scope is limited to iterator timeout plumbing and is covered by a new sync-point flow test.
> 
> **Overview**
> Rust **NOT** iterators can now honor the **blocked-client** timeout when worker threads run the query with clock-based checks disabled (`skipTimeoutChecks`). The C side threads the owning **`AREQ`** through **`QAST_Iterate`** into **`QueryEvalCtx`**, selects it via **`AREQ_TimeoutAreqOrNull`**, and passes it into **`NewNotIterator`**. The Rust FFI builds an **`AnyTimeoutContext`** (no-op, amortized clock, or **`AREQ_CheckTimedOut`** on the request’s relaxed **`timedOut`** flag).
> 
> **`Not`** / **`NotOptimized`** / the reducer are generic over **`TimeoutContext`** instead of optional duration + skip flags. **`AREQ_CheckTimedOut`** is a stable C symbol (assert builds can park at **`BeforeQITimeoutCheck`** for race tests). Call sites in aggregate/hybrid execution pass the real **`AREQ`**; tests and low-level APIs pass **`NULL`**. A flow test arms that sync point on **`FT.SEARCH … -hello1`**, unblocks with **`CLIENT UNBLOCK … TIMEOUT`**, and checks timeout metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07461a6887ddc6cd331cece999cfef8803d6214f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->