### PR TITLE
refactor(query_term): store as Box<str>, drop trailing NUL

### DIFF
--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -45,7 +45,9 @@ static int func_matchedTerms(ExprEval *ctx, RSValue **argv, size_t argc, RSValue
         size_t len;
         const char *str = QueryTerm_GetStrAndLen(terms[i], &len);
         RS_ASSERT(len <= UINT32_MAX);
-        arr[i] = RSValue_NewBorrowedString(str, len);
+        // Copy: RSQueryTerm storage is not nul-terminated, so the
+        // borrowed-string contract (nul at str+len) doesn't hold.
+        arr[i] = RSValue_NewCopiedString(str, len);
       }
       RSValue *v = RSValue_NewArrayFromBuilder(arr, n);
       RSValue_MakeOwnReference(result, v);

--- a/src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs
@@ -18,9 +18,9 @@ use query_term::RSQueryTerm;
 
 /// Allocate a new [`RSQueryTerm`] from an [`RSToken`](ffi::RSToken).
 ///
-/// The term string is copied into a Rust-owned allocation (`Box<[u8]>`).
-/// Bytes are stored as-is without any UTF-8 conversion.
-/// The returned pointer must be freed with [`Term_Free`].
+/// The token bytes are validated as UTF-8 and copied into a Rust-owned
+/// allocation (`Box<str>`). The returned pointer must be freed with
+/// [`Term_Free`].
 ///
 /// # Safety
 ///
@@ -30,6 +30,12 @@ use query_term::RSQueryTerm;
 /// - If not NULL, `tok->str` must be a valid byte slice of `tok->len` bytes.
 /// - The returned pointer is heap-allocated and must be freed with
 ///   [`Term_Free`].
+///
+/// # Panics
+///
+/// Panics if `tok->str` is non-NULL and the byte slice is not valid UTF-8.
+/// The tokenizer pipeline (including libnu case-folding) is expected to
+/// always produce valid UTF-8.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewQueryTerm(tok: *const ffi::RSToken, id: c_int) -> *mut RSQueryTerm {
     debug_assert!(!tok.is_null(), "tok cannot be NULL");

--- a/src/redisearch_rs/headers/query_term_ffi.h
+++ b/src/redisearch_rs/headers/query_term_ffi.h
@@ -26,9 +26,9 @@ extern "C" {
 /**
  * Allocate a new [`RSQueryTerm`] from an [`RSToken`](ffi::RSToken).
  *
- * The term string is copied into a Rust-owned allocation (`Box<[u8]>`).
- * Bytes are stored as-is without any UTF-8 conversion.
- * The returned pointer must be freed with [`Term_Free`].
+ * The token bytes are validated as UTF-8 and copied into a Rust-owned
+ * allocation (`Box<str>`). The returned pointer must be freed with
+ * [`Term_Free`].
  *
  * # Safety
  *
@@ -38,6 +38,12 @@ extern "C" {
  * - If not NULL, `tok->str` must be a valid byte slice of `tok->len` bytes.
  * - The returned pointer is heap-allocated and must be freed with
  *   [`Term_Free`].
+ *
+ * # Panics
+ *
+ * Panics if `tok->str` is non-NULL and the byte slice is not valid UTF-8.
+ * The tokenizer pipeline (including libnu case-folding) is expected to
+ * always produce valid UTF-8.
  */
 struct RSQueryTerm *NewQueryTerm(const RSToken *tok, int id);
 

--- a/src/redisearch_rs/query_term/src/lib.rs
+++ b/src/redisearch_rs/query_term/src/lib.rs
@@ -34,11 +34,6 @@ pub type RSTokenFlags = u32;
 #[derive(PartialEq)]
 pub struct RSQueryTerm {
     /// The term string, or `None` if the token had a null string pointer.
-    ///
-    /// Storage includes a trailing nul byte so the pointer can be handed
-    /// directly to C consumers that expect a nul-terminated string (e.g.
-    /// `RSValue_NewBorrowedString`). The trailing nul is sliced off by
-    /// [`as_str`](RSQueryTerm::as_str) / [`as_bytes`](RSQueryTerm::as_bytes).
     str_: Option<Box<str>>,
     /// Inverse document frequency of the term in the index.
     ///
@@ -58,12 +53,8 @@ impl RSQueryTerm {
     ///
     /// The resulting term has `idf = 1.0` and `bm25_idf = 0.0`.
     pub fn new(s: &str, id: i32, flags: RSTokenFlags) -> Box<Self> {
-        let mut buf = String::with_capacity(s.len() + 1);
-        buf.push_str(s);
-        buf.push('\0'); // nul-terminator: term string is handed to C consumers (RSValue_NewBorrowedString).
-
         Box::new(Self {
-            str_: Some(buf.into_boxed_str()),
+            str_: Some(Box::from(s)),
             idf: 1.0,
             id,
             flags,
@@ -138,9 +129,7 @@ impl RSQueryTerm {
 
     /// Get the term as a string slice, if the string is non-null.
     pub fn as_str(&self) -> Option<&str> {
-        // The trailing byte is always `\0` (a single-byte UTF-8 scalar), so
-        // `len() - 1` is guaranteed to be a valid char boundary.
-        self.str_.as_deref().map(|s| &s[0..(s.len() - 1)])
+        self.str_.as_deref()
     }
 
     /// Get the term as a byte slice, if the string is non-null.
@@ -234,8 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn nul_terminator_not_included_in_accessors() {
-        // The trailing \0 is for C consumers — Rust accessors must hide it.
+    fn storage_has_no_trailing_nul() {
         let term = RSQueryTerm::new("abc", 1, 0);
         assert_eq!(term.len(), 3);
         assert_eq!(term.as_str(), Some("abc"));

--- a/src/redisearch_rs/query_term/src/lib.rs
+++ b/src/redisearch_rs/query_term/src/lib.rs
@@ -33,8 +33,13 @@ pub type RSTokenFlags = u32;
 ///
 #[derive(PartialEq)]
 pub struct RSQueryTerm {
-    /// The term string as raw bytes, or `None` if the token had a null string pointer.
-    str_: Option<Box<[u8]>>,
+    /// The term string, or `None` if the token had a null string pointer.
+    ///
+    /// Storage includes a trailing nul byte so the pointer can be handed
+    /// directly to C consumers that expect a nul-terminated string (e.g.
+    /// `RSValue_NewBorrowedString`). The trailing nul is sliced off by
+    /// [`as_str`](RSQueryTerm::as_str) / [`as_bytes`](RSQueryTerm::as_bytes).
+    str_: Option<Box<str>>,
     /// Inverse document frequency of the term in the index.
     ///
     /// See <https://en.wikipedia.org/wiki/Tf%E2%80%93idf>.
@@ -48,33 +53,37 @@ pub struct RSQueryTerm {
 }
 
 impl RSQueryTerm {
-    /// Create a new [`RSQueryTerm`] from a UTF-8 string slice, copying it into
-    /// a Rust-owned allocation (`Box<[u8]>`).
+    /// Create a new [`RSQueryTerm`] from a string slice, copying it into a
+    /// Rust-owned allocation (`Box<str>`).
     ///
     /// The resulting term has `idf = 1.0` and `bm25_idf = 0.0`.
     pub fn new(s: &str, id: i32, flags: RSTokenFlags) -> Box<Self> {
-        Self::new_bytes(s.as_bytes(), id, flags)
-    }
-
-    /// Create a new [`RSQueryTerm`] from a raw byte slice, copying it into a
-    /// Rust-owned allocation (`Box<[u8]>`).
-    ///
-    /// Bytes are stored as-is without any UTF-8 validation or conversion.
-    /// This is intended for the FFI path, where the C tokenizer may produce
-    /// byte sequences that are not valid UTF-8 (e.g. after case-folding
-    /// applied to some Unicode codepoints).
-    pub fn new_bytes(s: &[u8], id: i32, flags: RSTokenFlags) -> Box<Self> {
-        let mut buf = Vec::with_capacity(s.len() + 1);
-        buf.extend_from_slice(s);
-        buf.push(0); // add nul-terminator because this string ends up in RsValue which requires that.
+        let mut buf = String::with_capacity(s.len() + 1);
+        buf.push_str(s);
+        buf.push('\0'); // nul-terminator: term string is handed to C consumers (RSValue_NewBorrowedString).
 
         Box::new(Self {
-            str_: Some(buf.into_boxed_slice()),
+            str_: Some(buf.into_boxed_str()),
             idf: 1.0,
             id,
             flags,
             bm25_idf: 0.0,
         })
+    }
+
+    /// Create a new [`RSQueryTerm`] from a raw byte slice, validating it as
+    /// UTF-8 and copying it into a Rust-owned allocation (`Box<str>`).
+    ///
+    /// Intended for the FFI path, where the C tokenizer hands us raw bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s` is not valid UTF-8. The upstream tokenizer (including
+    /// libnu case-folding) is expected to always produce valid UTF-8; invalid
+    /// input indicates a bug in the tokenizer pipeline.
+    pub fn new_bytes(s: &[u8], id: i32, flags: RSTokenFlags) -> Box<Self> {
+        let s = std::str::from_utf8(s).expect("RSQueryTerm bytes must be valid UTF-8");
+        Self::new(s, id, flags)
     }
 
     /// Create a new [`RSQueryTerm`] with a null string pointer.
@@ -119,7 +128,7 @@ impl RSQueryTerm {
 
     /// Get the term string length in bytes.
     pub fn len(&self) -> usize {
-        self.as_bytes().map_or(0, <[u8]>::len)
+        self.as_str().map_or(0, str::len)
     }
 
     /// Check if the term string is empty (null or zero length).
@@ -127,9 +136,16 @@ impl RSQueryTerm {
         self.len() == 0
     }
 
+    /// Get the term as a string slice, if the string is non-null.
+    pub fn as_str(&self) -> Option<&str> {
+        // The trailing byte is always `\0` (a single-byte UTF-8 scalar), so
+        // `len() - 1` is guaranteed to be a valid char boundary.
+        self.str_.as_deref().map(|s| &s[0..(s.len() - 1)])
+    }
+
     /// Get the term as a byte slice, if the string is non-null.
     pub fn as_bytes(&self) -> Option<&[u8]> {
-        self.str_.as_deref().map(|s| &s[0..(s.len() - 1)])
+        self.as_str().map(str::as_bytes)
     }
 }
 
@@ -140,7 +156,7 @@ impl Eq for RSQueryTerm {}
 impl fmt::Debug for RSQueryTerm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSQueryTerm")
-            .field("str", &self.as_bytes().map(String::from_utf8_lossy))
+            .field("str", &self.as_str())
             .field("idf", &self.idf)
             .field("id", &self.id)
             .field("flags", &self.flags)
@@ -190,11 +206,39 @@ mod tests {
     }
 
     #[test]
-    fn new_bytes_accepts_non_utf8() {
-        // 0xFF and 0xFE are not valid UTF-8; new_bytes must not panic and
-        // must store the bytes as-is without any replacement.
-        let term = RSQueryTerm::new_bytes(&[0xFF, 0xFE], 1, 0);
-        assert!(!term.is_empty());
-        assert_eq!(term.as_bytes(), Some(&[0xFF, 0xFEu8][..]));
+    #[should_panic(expected = "RSQueryTerm bytes must be valid UTF-8")]
+    fn new_bytes_panics_on_non_utf8() {
+        // 0xFF and 0xFE are not valid UTF-8; new_bytes must reject them.
+        let _ = RSQueryTerm::new_bytes(&[0xFF, 0xFE], 1, 0);
+    }
+
+    #[test]
+    fn new_bytes_accepts_valid_utf8() {
+        let term = RSQueryTerm::new_bytes("héllo".as_bytes(), 1, 0);
+        assert_eq!(term.as_str(), Some("héllo"));
+        assert_eq!(term.len(), "héllo".len());
+    }
+
+    #[test]
+    fn new_bytes_accepts_multibyte_utf8() {
+        let term = RSQueryTerm::new_bytes("日本語".as_bytes(), 1, 0);
+        assert_eq!(term.as_str(), Some("日本語"));
+        assert_eq!(term.as_bytes(), Some("日本語".as_bytes()));
+    }
+
+    #[test]
+    fn new_accepts_empty_string() {
+        let term = RSQueryTerm::new("", 1, 0);
+        assert!(term.is_empty());
+        assert_eq!(term.as_str(), Some(""));
+    }
+
+    #[test]
+    fn nul_terminator_not_included_in_accessors() {
+        // The trailing \0 is for C consumers — Rust accessors must hide it.
+        let term = RSQueryTerm::new("abc", 1, 0);
+        assert_eq!(term.len(), 3);
+        assert_eq!(term.as_str(), Some("abc"));
+        assert_eq!(term.as_bytes(), Some(&b"abc"[..]));
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `RSQueryTerm` stores its term as `Option<Box<[u8]>>` with a trailing NUL byte, so the raw pointer can be handed to C consumers that want a C-string. The byte slice carries no UTF-8 guarantee, so readers must use `from_utf8_lossy` and similar fallbacks. The NUL is paid for by every term even though only one consumer (`MatchedTerms` reducer's `RSValue_NewBorrowedString` call) actually needs it.

2. **Change:** Two-step refactor of `RSQueryTerm`'s internal storage:
   - Commit 1 (`980dc4f4`): switch storage to `Option<Box<str>>` and validate UTF-8 at the FFI boundary (`new_bytes()` panics on invalid UTF-8). Tokenizer + libnu case-folding are expected to produce valid UTF-8; treat violations as a programming error. Keeps the trailing NUL for now.
   - Commit 2 (`dea518ff`): drop the trailing NUL from storage. The lone consumer that needed NUL termination (`MatchedTerms` in `src/aggregate/functions/string.c`) is switched from `RSValue_NewBorrowedString` to `RSValue_NewCopiedString`, which allocates a `Box<CStr>` and adds the NUL itself.

3. **Outcome:**
   - One byte saved per `RSQueryTerm` across all queries.
   - Cleaner accessor: `as_str()` is `self.str_.as_deref()`; `Debug` no longer needs `from_utf8_lossy`.
   - Cost: one extra alloc+memcpy per term emitted by the `MatchedTerms` reducer — paid only by queries that use it.
   - No FFI ABI change: `QueryTerm_GetStrAndLen` still returns `*const c_char` + length; `Box<str>` shares `Box<[u8]>`'s fat-pointer layout. Autogenerated `query_term.h` only reflects updated doc comments.

#### Which additional issues this PR fixes

N/A — internal refactor.

#### Main objects this PR modified

1. `src/redisearch_rs/query_term/src/lib.rs` — storage type, constructors, accessors, tests.
2. `src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs` — FFI accessor.
3. `src/redisearch_rs/headers/query_term_ffi.h` — autogenerated, doc-only changes.
4. `src/aggregate/functions/string.c` — `MatchedTerms` reducer switched to `RSValue_NewCopiedString`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UTF-8 validation at the FFI boundary can panic if the tokenizer ever emits invalid bytes; matched_terms pays extra allocations only when used.
> 
> **Overview**
> **`RSQueryTerm`** now keeps the term text in **`Box<str>`** (validated UTF-8) instead of a raw byte buffer with a trailing NUL. The FFI path **`new_bytes` / `NewQueryTerm`** rejects invalid UTF-8 (panic, documented as a tokenizer bug). Accessors use **`as_str()`**; storage no longer pads for C-string consumers.
> 
> The **`matched_terms`** aggregate function switches from **`RSValue_NewBorrowedString`** to **`RSValue_NewCopiedString`** because term bytes are length-delimited and not NUL-terminated at `str+len`. That trades a per-term copy only when that reducer runs, for one byte saved per term in normal query evaluation.
> 
> Autogenerated **`query_term_ffi.h`** comments reflect the new contract; **`QueryTerm_GetStrAndLen`** still exposes pointer + length (unchanged ABI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8358441ce59964bd6887d342873fef57979c7a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->