### PR TITLE
refactor(query_term): store as Box<str>, keep trailing NUL

### DIFF
--- a/src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs
@@ -18,9 +18,9 @@ use query_term::RSQueryTerm;
 
 /// Allocate a new [`RSQueryTerm`] from an [`RSToken`](ffi::RSToken).
 ///
-/// The term string is copied into a Rust-owned allocation (`Box<[u8]>`).
-/// Bytes are stored as-is without any UTF-8 conversion.
-/// The returned pointer must be freed with [`Term_Free`].
+/// The token bytes are validated as UTF-8 and copied into a Rust-owned
+/// allocation (`Box<str>`). The returned pointer must be freed with
+/// [`Term_Free`].
 ///
 /// # Safety
 ///
@@ -30,6 +30,12 @@ use query_term::RSQueryTerm;
 /// - If not NULL, `tok->str` must be a valid byte slice of `tok->len` bytes.
 /// - The returned pointer is heap-allocated and must be freed with
 ///   [`Term_Free`].
+///
+/// # Panics
+///
+/// Panics if `tok->str` is non-NULL and the byte slice is not valid UTF-8.
+/// The tokenizer pipeline (including libnu case-folding) is expected to
+/// always produce valid UTF-8.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewQueryTerm(tok: *const ffi::RSToken, id: c_int) -> *mut RSQueryTerm {
     debug_assert!(!tok.is_null(), "tok cannot be NULL");

--- a/src/redisearch_rs/headers/query_term_ffi.h
+++ b/src/redisearch_rs/headers/query_term_ffi.h
@@ -26,9 +26,9 @@ extern "C" {
 /**
  * Allocate a new [`RSQueryTerm`] from an [`RSToken`](ffi::RSToken).
  *
- * The term string is copied into a Rust-owned allocation (`Box<[u8]>`).
- * Bytes are stored as-is without any UTF-8 conversion.
- * The returned pointer must be freed with [`Term_Free`].
+ * The token bytes are validated as UTF-8 and copied into a Rust-owned
+ * allocation (`Box<str>`). The returned pointer must be freed with
+ * [`Term_Free`].
  *
  * # Safety
  *
@@ -38,6 +38,12 @@ extern "C" {
  * - If not NULL, `tok->str` must be a valid byte slice of `tok->len` bytes.
  * - The returned pointer is heap-allocated and must be freed with
  *   [`Term_Free`].
+ *
+ * # Panics
+ *
+ * Panics if `tok->str` is non-NULL and the byte slice is not valid UTF-8.
+ * The tokenizer pipeline (including libnu case-folding) is expected to
+ * always produce valid UTF-8.
  */
 struct RSQueryTerm *NewQueryTerm(const RSToken *tok, int id);
 

--- a/src/redisearch_rs/query_term/src/lib.rs
+++ b/src/redisearch_rs/query_term/src/lib.rs
@@ -33,8 +33,13 @@ pub type RSTokenFlags = u32;
 ///
 #[derive(PartialEq)]
 pub struct RSQueryTerm {
-    /// The term string as raw bytes, or `None` if the token had a null string pointer.
-    str_: Option<Box<[u8]>>,
+    /// The term string, or `None` if the token had a null string pointer.
+    ///
+    /// Storage includes a trailing nul byte so the pointer can be handed
+    /// directly to C consumers that expect a nul-terminated string (e.g.
+    /// `RSValue_NewBorrowedString`). The trailing nul is sliced off by
+    /// [`as_str`](RSQueryTerm::as_str) / [`as_bytes`](RSQueryTerm::as_bytes).
+    str_: Option<Box<str>>,
     /// Inverse document frequency of the term in the index.
     ///
     /// See <https://en.wikipedia.org/wiki/Tf%E2%80%93idf>.
@@ -48,33 +53,37 @@ pub struct RSQueryTerm {
 }
 
 impl RSQueryTerm {
-    /// Create a new [`RSQueryTerm`] from a UTF-8 string slice, copying it into
-    /// a Rust-owned allocation (`Box<[u8]>`).
+    /// Create a new [`RSQueryTerm`] from a string slice, copying it into a
+    /// Rust-owned allocation (`Box<str>`).
     ///
     /// The resulting term has `idf = 1.0` and `bm25_idf = 0.0`.
     pub fn new(s: &str, id: i32, flags: RSTokenFlags) -> Box<Self> {
-        Self::new_bytes(s.as_bytes(), id, flags)
-    }
-
-    /// Create a new [`RSQueryTerm`] from a raw byte slice, copying it into a
-    /// Rust-owned allocation (`Box<[u8]>`).
-    ///
-    /// Bytes are stored as-is without any UTF-8 validation or conversion.
-    /// This is intended for the FFI path, where the C tokenizer may produce
-    /// byte sequences that are not valid UTF-8 (e.g. after case-folding
-    /// applied to some Unicode codepoints).
-    pub fn new_bytes(s: &[u8], id: i32, flags: RSTokenFlags) -> Box<Self> {
-        let mut buf = Vec::with_capacity(s.len() + 1);
-        buf.extend_from_slice(s);
-        buf.push(0); // add nul-terminator because this string ends up in RsValue which requires that.
+        let mut buf = String::with_capacity(s.len() + 1);
+        buf.push_str(s);
+        buf.push('\0'); // nul-terminator: term string is handed to C consumers (RSValue_NewBorrowedString).
 
         Box::new(Self {
-            str_: Some(buf.into_boxed_slice()),
+            str_: Some(buf.into_boxed_str()),
             idf: 1.0,
             id,
             flags,
             bm25_idf: 0.0,
         })
+    }
+
+    /// Create a new [`RSQueryTerm`] from a raw byte slice, validating it as
+    /// UTF-8 and copying it into a Rust-owned allocation (`Box<str>`).
+    ///
+    /// Intended for the FFI path, where the C tokenizer hands us raw bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s` is not valid UTF-8. The upstream tokenizer (including
+    /// libnu case-folding) is expected to always produce valid UTF-8; invalid
+    /// input indicates a bug in the tokenizer pipeline.
+    pub fn new_bytes(s: &[u8], id: i32, flags: RSTokenFlags) -> Box<Self> {
+        let s = std::str::from_utf8(s).expect("RSQueryTerm bytes must be valid UTF-8");
+        Self::new(s, id, flags)
     }
 
     /// Create a new [`RSQueryTerm`] with a null string pointer.
@@ -119,7 +128,7 @@ impl RSQueryTerm {
 
     /// Get the term string length in bytes.
     pub fn len(&self) -> usize {
-        self.as_bytes().map_or(0, <[u8]>::len)
+        self.as_str().map_or(0, str::len)
     }
 
     /// Check if the term string is empty (null or zero length).
@@ -127,9 +136,16 @@ impl RSQueryTerm {
         self.len() == 0
     }
 
+    /// Get the term as a string slice, if the string is non-null.
+    pub fn as_str(&self) -> Option<&str> {
+        // The trailing byte is always `\0` (a single-byte UTF-8 scalar), so
+        // `len() - 1` is guaranteed to be a valid char boundary.
+        self.str_.as_deref().map(|s| &s[0..(s.len() - 1)])
+    }
+
     /// Get the term as a byte slice, if the string is non-null.
     pub fn as_bytes(&self) -> Option<&[u8]> {
-        self.str_.as_deref().map(|s| &s[0..(s.len() - 1)])
+        self.as_str().map(str::as_bytes)
     }
 }
 
@@ -140,7 +156,7 @@ impl Eq for RSQueryTerm {}
 impl fmt::Debug for RSQueryTerm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSQueryTerm")
-            .field("str", &self.as_bytes().map(String::from_utf8_lossy))
+            .field("str", &self.as_str())
             .field("idf", &self.idf)
             .field("id", &self.id)
             .field("flags", &self.flags)
@@ -190,11 +206,39 @@ mod tests {
     }
 
     #[test]
-    fn new_bytes_accepts_non_utf8() {
-        // 0xFF and 0xFE are not valid UTF-8; new_bytes must not panic and
-        // must store the bytes as-is without any replacement.
-        let term = RSQueryTerm::new_bytes(&[0xFF, 0xFE], 1, 0);
-        assert!(!term.is_empty());
-        assert_eq!(term.as_bytes(), Some(&[0xFF, 0xFEu8][..]));
+    #[should_panic(expected = "RSQueryTerm bytes must be valid UTF-8")]
+    fn new_bytes_panics_on_non_utf8() {
+        // 0xFF and 0xFE are not valid UTF-8; new_bytes must reject them.
+        let _ = RSQueryTerm::new_bytes(&[0xFF, 0xFE], 1, 0);
+    }
+
+    #[test]
+    fn new_bytes_accepts_valid_utf8() {
+        let term = RSQueryTerm::new_bytes("héllo".as_bytes(), 1, 0);
+        assert_eq!(term.as_str(), Some("héllo"));
+        assert_eq!(term.len(), "héllo".len());
+    }
+
+    #[test]
+    fn new_bytes_accepts_multibyte_utf8() {
+        let term = RSQueryTerm::new_bytes("日本語".as_bytes(), 1, 0);
+        assert_eq!(term.as_str(), Some("日本語"));
+        assert_eq!(term.as_bytes(), Some("日本語".as_bytes()));
+    }
+
+    #[test]
+    fn new_accepts_empty_string() {
+        let term = RSQueryTerm::new("", 1, 0);
+        assert!(term.is_empty());
+        assert_eq!(term.as_str(), Some(""));
+    }
+
+    #[test]
+    fn nul_terminator_not_included_in_accessors() {
+        // The trailing \0 is for C consumers — Rust accessors must hide it.
+        let term = RSQueryTerm::new("abc", 1, 0);
+        assert_eq!(term.len(), 3);
+        assert_eq!(term.as_str(), Some("abc"));
+        assert_eq!(term.as_bytes(), Some(&b"abc"[..]));
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `RSQueryTerm.str_` stores `Option<Box<[u8]>>` (raw bytes). Construction via `new_bytes()` accepted arbitrary, possibly invalid UTF-8, which then propagated into the rest of the query engine. `Debug` had to use `from_utf8_lossy` to print the field.
2. **Change**: Switch internal storage to `Option<Box<str>>` and validate UTF-8 at the FFI boundary in `new_bytes()` (panics on invalid input). `new(&str)` now builds a `String` directly with a trailing `'\0'` so the pointer can be handed to C consumers (e.g. `RSValue_NewBorrowedString`) without a copy. Added `as_str()`; `as_bytes()` delegates to it. Replaced the `new_bytes_accepts_non_utf8` test with `new_bytes_panics_on_non_utf8`, plus added coverage for valid UTF-8, multibyte UTF-8, empty strings, and trailing-nul stripping.
3. **Outcome**: The invariant "the string inside `RSQueryTerm` is valid UTF-8" is enforced at construction. Invalid bytes from the tokenizer/case-folder are now treated as a programming error and surfaced immediately, rather than silently flowing through the engine. No FFI ABI change: `QueryTerm_GetStrAndLen` still returns `*const c_char` + length, and `Box<str>` shares `Box<[u8]>`'s fat-pointer layout; the auto-regenerated `query_term.h` only reflects updated documentation.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `src/redisearch_rs/query_term/src/lib.rs` — storage type, constructors, accessors, tests
2. `src/redisearch_rs/c_entrypoint/query_term_ffi/src/lib.rs` — FFI accessor updated to delegate through `as_str()`
3. `src/redisearch_rs/headers/query_term_ffi.h` — auto-regenerated (doc-only diff)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-term string invariants and can panic at the C/Rust boundary if the tokenizer ever emits non-UTF-8, but the public FFI shape is unchanged.
> 
> **Overview**
> **`RSQueryTerm`** now stores the term text as **`Option<Box<str>>`** instead of raw bytes, with a trailing **`'\0'`** kept in the allocation for C callers (e.g. borrowed string values) while **`as_str()`** / **`as_bytes()`** expose only the logical term length.
> 
> **`new_bytes()`** (used from **`NewQueryTerm`**) **validates UTF-8** and **panics** on invalid input, replacing the previous behavior of accepting arbitrary byte sequences. **`new()`** builds the string directly; **`Debug`** uses **`as_str()`** instead of lossy UTF-8 decoding. Tests were updated to expect panic on invalid UTF-8 and to cover multibyte/empty strings and NUL stripping. Auto-generated **`query_term_ffi.h`** docs reflect the new contract; **no C ABI change** is intended for **`QueryTerm_GetStrAndLen`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dda5f6950dca52a5990ce3562f1421aa1585e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->