### PR TITLE
MOD-14813: Add `COLLECT` to `commands.json` and `command_info.c`

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1395,6 +1395,119 @@
                     "name": "random_sample",
                     "type": "pure-token",
                     "token": "RANDOM_SAMPLE"
+                  },
+                  {
+                    "name": "collect",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "fields",
+                        "type": "block",
+                        "arguments": [
+                          {
+                            "name": "fields_token",
+                            "type": "pure-token",
+                            "token": "FIELDS"
+                          },
+                          {
+                            "name": "fields_spec",
+                            "type": "oneof",
+                            "arguments": [
+                              {
+                                "name": "all",
+                                "type": "pure-token",
+                                "token": "*"
+                              },
+                              {
+                                "name": "explicit",
+                                "type": "block",
+                                "arguments": [
+                                  {
+                                    "name": "num_fields",
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "name": "field",
+                                    "type": "string",
+                                    "multiple": true
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               },
@@ -2471,6 +2584,120 @@
                     "name": "random_sample",
                     "type": "pure-token",
                     "token": "RANDOM_SAMPLE"
+                  },
+                  {
+                    "name": "collect",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "summary": "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "fields",
+                        "type": "block",
+                        "arguments": [
+                          {
+                            "name": "fields_token",
+                            "type": "pure-token",
+                            "token": "FIELDS"
+                          },
+                          {
+                            "name": "fields_spec",
+                            "type": "oneof",
+                            "arguments": [
+                              {
+                                "name": "all",
+                                "type": "pure-token",
+                                "token": "*"
+                              },
+                              {
+                                "name": "explicit",
+                                "type": "block",
+                                "arguments": [
+                                  {
+                                    "name": "num_fields",
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "name": "field",
+                                    "type": "string",
+                                    "multiple": true
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               },

--- a/commands.json
+++ b/commands.json
@@ -1440,39 +1440,29 @@
                     "type": "integer"
                   },
                   {
-                    "name": "fields",
-                    "type": "block",
+                    "name": "fields_clause",
+                    "type": "oneof",
                     "arguments": [
                       {
-                        "name": "fields_token",
-                        "type": "pure-token",
-                        "token": "FIELDS"
-                      },
-                      {
-                        "name": "fields_spec",
-                        "type": "oneof",
+                        "name": "fields",
+                        "type": "block",
                         "arguments": [
                           {
-                            "name": "all",
-                            "type": "pure-token",
-                            "token": "*"
+                            "name": "num_fields",
+                            "type": "integer",
+                            "token": "FIELDS"
                           },
                           {
-                            "name": "explicit",
-                            "type": "block",
-                            "arguments": [
-                              {
-                                "name": "num_fields",
-                                "type": "integer"
-                              },
-                              {
-                                "name": "field",
-                                "type": "string",
-                                "multiple": true
-                              }
-                            ]
+                            "name": "field",
+                            "type": "string",
+                            "multiple": true
                           }
                         ]
+                      },
+                      {
+                        "name": "fieldsall",
+                        "type": "pure-token",
+                        "token": "FIELDS *"
                       }
                     ]
                   },
@@ -2649,39 +2639,29 @@
                     "type": "integer"
                   },
                   {
-                    "name": "fields",
-                    "type": "block",
+                    "name": "fields_clause",
+                    "type": "oneof",
                     "arguments": [
                       {
-                        "name": "fields_token",
-                        "type": "pure-token",
-                        "token": "FIELDS"
-                      },
-                      {
-                        "name": "fields_spec",
-                        "type": "oneof",
+                        "name": "fields",
+                        "type": "block",
                         "arguments": [
                           {
-                            "name": "all",
-                            "type": "pure-token",
-                            "token": "*"
+                            "name": "num_fields",
+                            "type": "integer",
+                            "token": "FIELDS"
                           },
                           {
-                            "name": "explicit",
-                            "type": "block",
-                            "arguments": [
-                              {
-                                "name": "num_fields",
-                                "type": "integer"
-                              },
-                              {
-                                "name": "field",
-                                "type": "string",
-                                "multiple": true
-                              }
-                            ]
+                            "name": "field",
+                            "type": "string",
+                            "multiple": true
                           }
                         ]
+                      },
+                      {
+                        "name": "fieldsall",
+                        "type": "pure-token",
+                        "token": "FIELDS *"
                       }
                     ]
                   },

--- a/commands.json
+++ b/commands.json
@@ -1323,211 +1323,232 @@
           },
           {
             "name": "reduce",
-            "type": "block",
+            "type": "oneof",
             "optional": true,
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
-                "token": "REDUCE",
-                "type": "pure-token"
-              },
-              {
-                "name": "function",
-                "type": "oneof",
+                "name": "generic_reduce",
+                "type": "block",
+                "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
                 "arguments": [
                   {
-                    "name": "count",
-                    "type": "pure-token",
-                    "token": "COUNT"
+                    "name": "reduce",
+                    "token": "REDUCE",
+                    "type": "pure-token"
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
-                  },
-                  {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
-                  },
-                  {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
-                  },
-                  {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
-                  },
-                  {
-                    "name": "collect",
-                    "type": "block",
-                    "since": "8.8.0",
+                    "name": "function",
+                    "type": "oneof",
                     "arguments": [
                       {
-                        "name": "collect_token",
+                        "name": "count",
                         "type": "pure-token",
-                        "token": "COLLECT"
+                        "token": "COUNT"
                       },
                       {
-                        "name": "fields",
-                        "type": "block",
-                        "arguments": [
-                          {
-                            "name": "fields_token",
-                            "type": "pure-token",
-                            "token": "FIELDS"
-                          },
-                          {
-                            "name": "fields_spec",
-                            "type": "oneof",
-                            "arguments": [
-                              {
-                                "name": "all",
-                                "type": "pure-token",
-                                "token": "*"
-                              },
-                              {
-                                "name": "explicit",
-                                "type": "block",
-                                "arguments": [
-                                  {
-                                    "name": "num_fields",
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "name": "field",
-                                    "type": "string",
-                                    "multiple": true
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "name": "count_distinct",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCT"
                       },
                       {
-                        "name": "sortby",
-                        "type": "block",
-                        "optional": true,
-                        "arguments": [
-                          {
-                            "name": "sortby_token",
-                            "type": "pure-token",
-                            "token": "SORTBY"
-                          },
-                          {
-                            "name": "nargs",
-                            "type": "integer"
-                          },
-                          {
-                            "name": "key",
-                            "type": "block",
-                            "multiple": true,
-                            "arguments": [
-                              {
-                                "name": "field",
-                                "type": "string"
-                              },
-                              {
-                                "name": "order",
-                                "type": "oneof",
-                                "optional": true,
-                                "arguments": [
-                                  {
-                                    "name": "asc",
-                                    "type": "pure-token",
-                                    "token": "ASC"
-                                  },
-                                  {
-                                    "name": "desc",
-                                    "type": "pure-token",
-                                    "token": "DESC"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "name": "count_distinctish",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCTISH"
                       },
                       {
-                        "name": "limit",
-                        "type": "block",
-                        "optional": true,
-                        "arguments": [
-                          {
-                            "name": "limit_token",
-                            "type": "pure-token",
-                            "token": "LIMIT"
-                          },
-                          {
-                            "name": "offset",
-                            "type": "integer"
-                          },
-                          {
-                            "name": "count",
-                            "type": "integer"
-                          }
-                        ]
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                      },
+                      {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                      },
+                      {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                      },
+                      {
+                        "name": "avg",
+                        "type": "pure-token",
+                        "token": "AVG"
+                      },
+                      {
+                        "name": "stddev",
+                        "type": "pure-token",
+                        "token": "STDDEV"
+                      },
+                      {
+                        "name": "quantile",
+                        "type": "pure-token",
+                        "token": "QUANTILE"
+                      },
+                      {
+                        "name": "tolist",
+                        "type": "pure-token",
+                        "token": "TOLIST"
+                      },
+                      {
+                        "name": "first_value",
+                        "type": "pure-token",
+                        "token": "FIRST_VALUE"
+                      },
+                      {
+                        "name": "random_sample",
+                        "type": "pure-token",
+                        "token": "RANDOM_SAMPLE"
                       }
                     ]
+                  },
+                  {
+                    "name": "nargs",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "arg",
+                    "type": "string",
+                    "multiple": true
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
                   }
                 ]
               },
               {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
-              },
-              {
-                "name": "name",
-                "type": "string",
-                "token": "AS",
-                "optional": true
+                "name": "collect_reduce",
+                "type": "block",
+                "since": "8.8.0",
+                "arguments": [
+                  {
+                    "name": "reduce",
+                    "token": "REDUCE",
+                    "type": "pure-token"
+                  },
+                  {
+                    "name": "collect_token",
+                    "type": "pure-token",
+                    "token": "COLLECT"
+                  },
+                  {
+                    "name": "nargs",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "fields",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "fields_token",
+                        "type": "pure-token",
+                        "token": "FIELDS"
+                      },
+                      {
+                        "name": "fields_spec",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "all",
+                            "type": "pure-token",
+                            "token": "*"
+                          },
+                          {
+                            "name": "explicit",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "sortby",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "sortby_token",
+                        "type": "pure-token",
+                        "token": "SORTBY"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "key",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                          {
+                            "name": "field",
+                            "type": "string"
+                          },
+                          {
+                            "name": "order",
+                            "type": "oneof",
+                            "optional": true,
+                            "arguments": [
+                              {
+                                "name": "asc",
+                                "type": "pure-token",
+                                "token": "ASC"
+                              },
+                              {
+                                "name": "desc",
+                                "type": "pure-token",
+                                "token": "DESC"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "limit",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "limit_token",
+                        "type": "pure-token",
+                        "token": "LIMIT"
+                      },
+                      {
+                        "name": "offset",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "count",
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
+                  }
+                ]
               }
-            ],
-            "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results."
+            ]
           }
         ],
         "summary": "Groups results by specified fields, often used for aggregations."
@@ -2512,209 +2533,229 @@
           },
           {
             "name": "reduce",
-            "type": "block",
+            "type": "oneof",
             "optional": true,
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
-                "type": "pure-token",
-                "token": "REDUCE"
-              },
-              {
-                "name": "function",
-                "type": "oneof",
+                "name": "generic_reduce",
+                "type": "block",
                 "arguments": [
                   {
-                    "name": "count",
+                    "name": "reduce",
                     "type": "pure-token",
-                    "token": "COUNT"
+                    "token": "REDUCE"
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
-                  },
-                  {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
-                  },
-                  {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
-                  },
-                  {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
-                  },
-                  {
-                    "name": "collect",
-                    "type": "block",
-                    "since": "8.8.0",
-                    "summary": "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
+                    "name": "function",
+                    "type": "oneof",
                     "arguments": [
                       {
-                        "name": "collect_token",
+                        "name": "count",
                         "type": "pure-token",
-                        "token": "COLLECT"
+                        "token": "COUNT"
                       },
                       {
-                        "name": "fields",
-                        "type": "block",
-                        "arguments": [
-                          {
-                            "name": "fields_token",
-                            "type": "pure-token",
-                            "token": "FIELDS"
-                          },
-                          {
-                            "name": "fields_spec",
-                            "type": "oneof",
-                            "arguments": [
-                              {
-                                "name": "all",
-                                "type": "pure-token",
-                                "token": "*"
-                              },
-                              {
-                                "name": "explicit",
-                                "type": "block",
-                                "arguments": [
-                                  {
-                                    "name": "num_fields",
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "name": "field",
-                                    "type": "string",
-                                    "multiple": true
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "name": "count_distinct",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCT"
                       },
                       {
-                        "name": "sortby",
-                        "type": "block",
-                        "optional": true,
-                        "arguments": [
-                          {
-                            "name": "sortby_token",
-                            "type": "pure-token",
-                            "token": "SORTBY"
-                          },
-                          {
-                            "name": "nargs",
-                            "type": "integer"
-                          },
-                          {
-                            "name": "key",
-                            "type": "block",
-                            "multiple": true,
-                            "arguments": [
-                              {
-                                "name": "field",
-                                "type": "string"
-                              },
-                              {
-                                "name": "order",
-                                "type": "oneof",
-                                "optional": true,
-                                "arguments": [
-                                  {
-                                    "name": "asc",
-                                    "type": "pure-token",
-                                    "token": "ASC"
-                                  },
-                                  {
-                                    "name": "desc",
-                                    "type": "pure-token",
-                                    "token": "DESC"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "name": "count_distinctish",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCTISH"
                       },
                       {
-                        "name": "limit",
-                        "type": "block",
-                        "optional": true,
-                        "arguments": [
-                          {
-                            "name": "limit_token",
-                            "type": "pure-token",
-                            "token": "LIMIT"
-                          },
-                          {
-                            "name": "offset",
-                            "type": "integer"
-                          },
-                          {
-                            "name": "count",
-                            "type": "integer"
-                          }
-                        ]
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                      },
+                      {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                      },
+                      {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                      },
+                      {
+                        "name": "avg",
+                        "type": "pure-token",
+                        "token": "AVG"
+                      },
+                      {
+                        "name": "stddev",
+                        "type": "pure-token",
+                        "token": "STDDEV"
+                      },
+                      {
+                        "name": "quantile",
+                        "type": "pure-token",
+                        "token": "QUANTILE"
+                      },
+                      {
+                        "name": "tolist",
+                        "type": "pure-token",
+                        "token": "TOLIST"
+                      },
+                      {
+                        "name": "first_value",
+                        "type": "pure-token",
+                        "token": "FIRST_VALUE"
+                      },
+                      {
+                        "name": "random_sample",
+                        "type": "pure-token",
+                        "token": "RANDOM_SAMPLE"
                       }
                     ]
+                  },
+                  {
+                    "name": "nargs",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "arg",
+                    "type": "string",
+                    "multiple": true
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
                   }
                 ]
               },
               {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
-              },
-              {
-                "name": "name",
-                "type": "string",
-                "token": "AS",
-                "optional": true
+                "name": "collect_reduce",
+                "type": "block",
+                "since": "8.8.0",
+                "arguments": [
+                  {
+                    "name": "reduce",
+                    "type": "pure-token",
+                    "token": "REDUCE"
+                  },
+                  {
+                    "name": "collect_token",
+                    "type": "pure-token",
+                    "token": "COLLECT"
+                  },
+                  {
+                    "name": "nargs",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "fields",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "fields_token",
+                        "type": "pure-token",
+                        "token": "FIELDS"
+                      },
+                      {
+                        "name": "fields_spec",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "all",
+                            "type": "pure-token",
+                            "token": "*"
+                          },
+                          {
+                            "name": "explicit",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "sortby",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "sortby_token",
+                        "type": "pure-token",
+                        "token": "SORTBY"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "key",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                          {
+                            "name": "field",
+                            "type": "string"
+                          },
+                          {
+                            "name": "order",
+                            "type": "oneof",
+                            "optional": true,
+                            "arguments": [
+                              {
+                                "name": "asc",
+                                "type": "pure-token",
+                                "token": "ASC"
+                              },
+                              {
+                                "name": "desc",
+                                "type": "pure-token",
+                                "token": "DESC"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "limit",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "limit_token",
+                        "type": "pure-token",
+                        "token": "LIMIT"
+                      },
+                      {
+                        "name": "offset",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "count",
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
+                  }
+                ]
               }
             ]
           }

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1588,6 +1588,127 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
                     .token = "RANDOM_SAMPLE",
                     .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                   },
+                  {
+                    .name = "collect",
+                    .since = "8.8.0",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "collect_token",
+                        .token = "COLLECT",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "fields",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "fields_token",
+                            .token = "FIELDS",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "fields_spec",
+                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "all",
+                                .token = "*",
+                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                              },
+                              {
+                                .name = "explicit",
+                                .type = REDISMODULE_ARG_TYPE_BLOCK,
+                                .subargs = (RedisModuleCommandArg[]){
+                                  {
+                                    .name = "num_fields",
+                                    .type = REDISMODULE_ARG_TYPE_INTEGER,
+                                  },
+                                  {
+                                    .name = "field",
+                                    .type = REDISMODULE_ARG_TYPE_STRING,
+                                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                                  },
+                                  {0}
+                                },
+                              },
+                              {0}
+                            },
+                          },
+                          {0}
+                        },
+                      },
+                      {
+                        .name = "sortby",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "sortby_token",
+                            .token = "SORTBY",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "nargs",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "field",
+                                .type = REDISMODULE_ARG_TYPE_STRING,
+                              },
+                              {
+                                .name = "order",
+                                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                                .subargs = (RedisModuleCommandArg[]){
+                                  {
+                                    .name = "asc",
+                                    .token = "ASC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {
+                                    .name = "desc",
+                                    .token = "DESC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {0}
+                                },
+                              },
+                              {0}
+                            },
+                          },
+                          {0}
+                        },
+                      },
+                      {
+                        .name = "limit",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "limit_token",
+                            .token = "LIMIT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "offset",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "count",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {0}
+                        },
+                      },
+                      {0}
+                    },
+                  },
                   {0}
                 },
               },
@@ -2738,6 +2859,128 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .name = "random_sample",
                     .token = "RANDOM_SAMPLE",
                     .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "collect",
+                    .summary = "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
+                    .since = "8.8.0",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "collect_token",
+                        .token = "COLLECT",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "fields",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "fields_token",
+                            .token = "FIELDS",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "fields_spec",
+                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "all",
+                                .token = "*",
+                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                              },
+                              {
+                                .name = "explicit",
+                                .type = REDISMODULE_ARG_TYPE_BLOCK,
+                                .subargs = (RedisModuleCommandArg[]){
+                                  {
+                                    .name = "num_fields",
+                                    .type = REDISMODULE_ARG_TYPE_INTEGER,
+                                  },
+                                  {
+                                    .name = "field",
+                                    .type = REDISMODULE_ARG_TYPE_STRING,
+                                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                                  },
+                                  {0}
+                                },
+                              },
+                              {0}
+                            },
+                          },
+                          {0}
+                        },
+                      },
+                      {
+                        .name = "sortby",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "sortby_token",
+                            .token = "SORTBY",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "nargs",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "field",
+                                .type = REDISMODULE_ARG_TYPE_STRING,
+                              },
+                              {
+                                .name = "order",
+                                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                                .subargs = (RedisModuleCommandArg[]){
+                                  {
+                                    .name = "asc",
+                                    .token = "ASC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {
+                                    .name = "desc",
+                                    .token = "DESC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {0}
+                                },
+                              },
+                              {0}
+                            },
+                          },
+                          {0}
+                        },
+                      },
+                      {
+                        .name = "limit",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "limit_token",
+                            .token = "LIMIT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "offset",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "count",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {0}
+                        },
+                      },
+                      {0}
+                    },
                   },
                   {0}
                 },

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1633,41 +1633,30 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_INTEGER,
                   },
                   {
-                    .name = "fields",
-                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .name = "fields_clause",
+                    .type = REDISMODULE_ARG_TYPE_ONEOF,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "fields_token",
-                        .token = "FIELDS",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "fields_spec",
-                        .type = REDISMODULE_ARG_TYPE_ONEOF,
+                        .name = "fields",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "all",
-                            .token = "*",
-                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                            .name = "num_fields",
+                            .token = "FIELDS",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
                           },
                           {
-                            .name = "explicit",
-                            .type = REDISMODULE_ARG_TYPE_BLOCK,
-                            .subargs = (RedisModuleCommandArg[]){
-                              {
-                                .name = "num_fields",
-                                .type = REDISMODULE_ARG_TYPE_INTEGER,
-                              },
-                              {
-                                .name = "field",
-                                .type = REDISMODULE_ARG_TYPE_STRING,
-                                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-                              },
-                              {0}
-                            },
+                            .name = "field",
+                            .type = REDISMODULE_ARG_TYPE_STRING,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                           },
                           {0}
                         },
+                      },
+                      {
+                        .name = "fieldsall",
+                        .token = "FIELDS *",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {0}
                     },
@@ -2927,41 +2916,30 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_INTEGER,
                   },
                   {
-                    .name = "fields",
-                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .name = "fields_clause",
+                    .type = REDISMODULE_ARG_TYPE_ONEOF,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "fields_token",
-                        .token = "FIELDS",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "fields_spec",
-                        .type = REDISMODULE_ARG_TYPE_ONEOF,
+                        .name = "fields",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "all",
-                            .token = "*",
-                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                            .name = "num_fields",
+                            .token = "FIELDS",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
                           },
                           {
-                            .name = "explicit",
-                            .type = REDISMODULE_ARG_TYPE_BLOCK,
-                            .subargs = (RedisModuleCommandArg[]){
-                              {
-                                .name = "num_fields",
-                                .type = REDISMODULE_ARG_TYPE_INTEGER,
-                              },
-                              {
-                                .name = "field",
-                                .type = REDISMODULE_ARG_TYPE_STRING,
-                                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-                              },
-                              {0}
-                            },
+                            .name = "field",
+                            .type = REDISMODULE_ARG_TYPE_STRING,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                           },
                           {0}
                         },
+                      },
+                      {
+                        .name = "fieldsall",
+                        .token = "FIELDS *",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {0}
                     },

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1615,7 +1615,6 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
               },
               {
                 .name = "collect_reduce",
-                .summary = "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
                 .since = "8.8.0",
                 .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .subargs = (RedisModuleCommandArg[]){
@@ -2910,7 +2909,6 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
               },
               {
                 .name = "collect_reduce",
-                .summary = "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
                 .since = "8.8.0",
                 .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .subargs = (RedisModuleCommandArg[]){

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1515,193 +1515,157 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
           },
           {
             .name = "reduce",
-            .summary = "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
-            .type = REDISMODULE_ARG_TYPE_BLOCK,
+            .type = REDISMODULE_ARG_TYPE_ONEOF,
             .flags = REDISMODULE_CMD_ARG_OPTIONAL | REDISMODULE_CMD_ARG_MULTIPLE,
             .subargs = (RedisModuleCommandArg[]){
               {
-                .name = "reduce",
-                .token = "REDUCE",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-              },
-              {
-                .name = "function",
-                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                .name = "generic_reduce",
+                .summary = "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
+                .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .subargs = (RedisModuleCommandArg[]){
                   {
-                    .name = "count",
-                    .token = "COUNT",
+                    .name = "reduce",
+                    .token = "REDUCE",
                     .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                   },
                   {
-                    .name = "count_distinct",
-                    .token = "COUNT_DISTINCT",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "count_distinctish",
-                    .token = "COUNT_DISTINCTISH",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "sum",
-                    .token = "SUM",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "min",
-                    .token = "MIN",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "max",
-                    .token = "MAX",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "avg",
-                    .token = "AVG",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "stddev",
-                    .token = "STDDEV",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "quantile",
-                    .token = "QUANTILE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "tolist",
-                    .token = "TOLIST",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "first_value",
-                    .token = "FIRST_VALUE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "random_sample",
-                    .token = "RANDOM_SAMPLE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "collect",
-                    .since = "8.8.0",
-                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .name = "function",
+                    .type = REDISMODULE_ARG_TYPE_ONEOF,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "collect_token",
-                        .token = "COLLECT",
+                        .name = "count",
+                        .token = "COUNT",
                         .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {
-                        .name = "fields",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .subargs = (RedisModuleCommandArg[]){
-                          {
-                            .name = "fields_token",
-                            .token = "FIELDS",
-                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                          },
-                          {
-                            .name = "fields_spec",
-                            .type = REDISMODULE_ARG_TYPE_ONEOF,
-                            .subargs = (RedisModuleCommandArg[]){
-                              {
-                                .name = "all",
-                                .token = "*",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                              },
-                              {
-                                .name = "explicit",
-                                .type = REDISMODULE_ARG_TYPE_BLOCK,
-                                .subargs = (RedisModuleCommandArg[]){
-                                  {
-                                    .name = "num_fields",
-                                    .type = REDISMODULE_ARG_TYPE_INTEGER,
-                                  },
-                                  {
-                                    .name = "field",
-                                    .type = REDISMODULE_ARG_TYPE_STRING,
-                                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-                                  },
-                                  {0}
-                                },
-                              },
-                              {0}
-                            },
-                          },
-                          {0}
-                        },
+                        .name = "count_distinct",
+                        .token = "COUNT_DISTINCT",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {
-                        .name = "sortby",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .name = "count_distinctish",
+                        .token = "COUNT_DISTINCTISH",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "sum",
+                        .token = "SUM",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "min",
+                        .token = "MIN",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "max",
+                        .token = "MAX",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "avg",
+                        .token = "AVG",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "stddev",
+                        .token = "STDDEV",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "quantile",
+                        .token = "QUANTILE",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "tolist",
+                        .token = "TOLIST",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "first_value",
+                        .token = "FIRST_VALUE",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "random_sample",
+                        .token = "RANDOM_SAMPLE",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {0}
+                    },
+                  },
+                  {
+                    .name = "nargs",
+                    .type = REDISMODULE_ARG_TYPE_INTEGER,
+                  },
+                  {
+                    .name = "arg",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                  },
+                  {
+                    .name = "name",
+                    .token = "AS",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
+                  {0}
+                },
+              },
+              {
+                .name = "collect_reduce",
+                .summary = "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
+                .since = "8.8.0",
+                .type = REDISMODULE_ARG_TYPE_BLOCK,
+                .subargs = (RedisModuleCommandArg[]){
+                  {
+                    .name = "reduce",
+                    .token = "REDUCE",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "collect_token",
+                    .token = "COLLECT",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "nargs",
+                    .type = REDISMODULE_ARG_TYPE_INTEGER,
+                  },
+                  {
+                    .name = "fields",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "fields_token",
+                        .token = "FIELDS",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "fields_spec",
+                        .type = REDISMODULE_ARG_TYPE_ONEOF,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "sortby_token",
-                            .token = "SORTBY",
+                            .name = "all",
+                            .token = "*",
                             .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                           },
                           {
-                            .name = "nargs",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
-                          },
-                          {
-                            .name = "key",
+                            .name = "explicit",
                             .type = REDISMODULE_ARG_TYPE_BLOCK,
-                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                             .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "num_fields",
+                                .type = REDISMODULE_ARG_TYPE_INTEGER,
+                              },
                               {
                                 .name = "field",
                                 .type = REDISMODULE_ARG_TYPE_STRING,
-                              },
-                              {
-                                .name = "order",
-                                .type = REDISMODULE_ARG_TYPE_ONEOF,
-                                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                                .subargs = (RedisModuleCommandArg[]){
-                                  {
-                                    .name = "asc",
-                                    .token = "ASC",
-                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                  },
-                                  {
-                                    .name = "desc",
-                                    .token = "DESC",
-                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                  },
-                                  {0}
-                                },
+                                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                               },
                               {0}
                             },
-                          },
-                          {0}
-                        },
-                      },
-                      {
-                        .name = "limit",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                        .subargs = (RedisModuleCommandArg[]){
-                          {
-                            .name = "limit_token",
-                            .token = "LIMIT",
-                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                          },
-                          {
-                            .name = "offset",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
-                          },
-                          {
-                            .name = "count",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
                           },
                           {0}
                         },
@@ -1709,23 +1673,82 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
                       {0}
                     },
                   },
+                  {
+                    .name = "sortby",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "sortby_token",
+                        .token = "SORTBY",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "nargs",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {
+                        .name = "key",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "field",
+                            .type = REDISMODULE_ARG_TYPE_STRING,
+                          },
+                          {
+                            .name = "order",
+                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "asc",
+                                .token = "ASC",
+                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                              },
+                              {
+                                .name = "desc",
+                                .token = "DESC",
+                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                              },
+                              {0}
+                            },
+                          },
+                          {0}
+                        },
+                      },
+                      {0}
+                    },
+                  },
+                  {
+                    .name = "limit",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "limit_token",
+                        .token = "LIMIT",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "offset",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {
+                        .name = "count",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {0}
+                    },
+                  },
+                  {
+                    .name = "name",
+                    .token = "AS",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
                   {0}
                 },
-              },
-              {
-                .name = "nargs",
-                .type = REDISMODULE_ARG_TYPE_INTEGER,
-              },
-              {
-                .name = "arg",
-                .type = REDISMODULE_ARG_TYPE_STRING,
-                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-              },
-              {
-                .name = "name",
-                .token = "AS",
-                .type = REDISMODULE_ARG_TYPE_STRING,
-                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
               },
               {0}
             },
@@ -2788,193 +2811,156 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
           },
           {
             .name = "reduce",
-            .type = REDISMODULE_ARG_TYPE_BLOCK,
+            .type = REDISMODULE_ARG_TYPE_ONEOF,
             .flags = REDISMODULE_CMD_ARG_OPTIONAL | REDISMODULE_CMD_ARG_MULTIPLE,
             .subargs = (RedisModuleCommandArg[]){
               {
-                .name = "reduce",
-                .token = "REDUCE",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-              },
-              {
-                .name = "function",
-                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                .name = "generic_reduce",
+                .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .subargs = (RedisModuleCommandArg[]){
                   {
-                    .name = "count",
-                    .token = "COUNT",
+                    .name = "reduce",
+                    .token = "REDUCE",
                     .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                   },
                   {
-                    .name = "count_distinct",
-                    .token = "COUNT_DISTINCT",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "count_distinctish",
-                    .token = "COUNT_DISTINCTISH",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "sum",
-                    .token = "SUM",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "min",
-                    .token = "MIN",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "max",
-                    .token = "MAX",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "avg",
-                    .token = "AVG",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "stddev",
-                    .token = "STDDEV",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "quantile",
-                    .token = "QUANTILE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "tolist",
-                    .token = "TOLIST",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "first_value",
-                    .token = "FIRST_VALUE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "random_sample",
-                    .token = "RANDOM_SAMPLE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "collect",
-                    .summary = "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
-                    .since = "8.8.0",
-                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .name = "function",
+                    .type = REDISMODULE_ARG_TYPE_ONEOF,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "collect_token",
-                        .token = "COLLECT",
+                        .name = "count",
+                        .token = "COUNT",
                         .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {
-                        .name = "fields",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .subargs = (RedisModuleCommandArg[]){
-                          {
-                            .name = "fields_token",
-                            .token = "FIELDS",
-                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                          },
-                          {
-                            .name = "fields_spec",
-                            .type = REDISMODULE_ARG_TYPE_ONEOF,
-                            .subargs = (RedisModuleCommandArg[]){
-                              {
-                                .name = "all",
-                                .token = "*",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                              },
-                              {
-                                .name = "explicit",
-                                .type = REDISMODULE_ARG_TYPE_BLOCK,
-                                .subargs = (RedisModuleCommandArg[]){
-                                  {
-                                    .name = "num_fields",
-                                    .type = REDISMODULE_ARG_TYPE_INTEGER,
-                                  },
-                                  {
-                                    .name = "field",
-                                    .type = REDISMODULE_ARG_TYPE_STRING,
-                                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-                                  },
-                                  {0}
-                                },
-                              },
-                              {0}
-                            },
-                          },
-                          {0}
-                        },
+                        .name = "count_distinct",
+                        .token = "COUNT_DISTINCT",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {
-                        .name = "sortby",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .name = "count_distinctish",
+                        .token = "COUNT_DISTINCTISH",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "sum",
+                        .token = "SUM",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "min",
+                        .token = "MIN",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "max",
+                        .token = "MAX",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "avg",
+                        .token = "AVG",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "stddev",
+                        .token = "STDDEV",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "quantile",
+                        .token = "QUANTILE",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "tolist",
+                        .token = "TOLIST",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "first_value",
+                        .token = "FIRST_VALUE",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "random_sample",
+                        .token = "RANDOM_SAMPLE",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {0}
+                    },
+                  },
+                  {
+                    .name = "nargs",
+                    .type = REDISMODULE_ARG_TYPE_INTEGER,
+                  },
+                  {
+                    .name = "arg",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                  },
+                  {
+                    .name = "name",
+                    .token = "AS",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
+                  {0}
+                },
+              },
+              {
+                .name = "collect_reduce",
+                .summary = "Collects values from grouped documents into a structured list. Requires `search-enable-unstable-features` to be enabled.",
+                .since = "8.8.0",
+                .type = REDISMODULE_ARG_TYPE_BLOCK,
+                .subargs = (RedisModuleCommandArg[]){
+                  {
+                    .name = "reduce",
+                    .token = "REDUCE",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "collect_token",
+                    .token = "COLLECT",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "nargs",
+                    .type = REDISMODULE_ARG_TYPE_INTEGER,
+                  },
+                  {
+                    .name = "fields",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "fields_token",
+                        .token = "FIELDS",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "fields_spec",
+                        .type = REDISMODULE_ARG_TYPE_ONEOF,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "sortby_token",
-                            .token = "SORTBY",
+                            .name = "all",
+                            .token = "*",
                             .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                           },
                           {
-                            .name = "nargs",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
-                          },
-                          {
-                            .name = "key",
+                            .name = "explicit",
                             .type = REDISMODULE_ARG_TYPE_BLOCK,
-                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                             .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "num_fields",
+                                .type = REDISMODULE_ARG_TYPE_INTEGER,
+                              },
                               {
                                 .name = "field",
                                 .type = REDISMODULE_ARG_TYPE_STRING,
-                              },
-                              {
-                                .name = "order",
-                                .type = REDISMODULE_ARG_TYPE_ONEOF,
-                                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                                .subargs = (RedisModuleCommandArg[]){
-                                  {
-                                    .name = "asc",
-                                    .token = "ASC",
-                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                  },
-                                  {
-                                    .name = "desc",
-                                    .token = "DESC",
-                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                                  },
-                                  {0}
-                                },
+                                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                               },
                               {0}
                             },
-                          },
-                          {0}
-                        },
-                      },
-                      {
-                        .name = "limit",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                        .subargs = (RedisModuleCommandArg[]){
-                          {
-                            .name = "limit_token",
-                            .token = "LIMIT",
-                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                          },
-                          {
-                            .name = "offset",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
-                          },
-                          {
-                            .name = "count",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
                           },
                           {0}
                         },
@@ -2982,23 +2968,82 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                       {0}
                     },
                   },
+                  {
+                    .name = "sortby",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "sortby_token",
+                        .token = "SORTBY",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "nargs",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {
+                        .name = "key",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "field",
+                            .type = REDISMODULE_ARG_TYPE_STRING,
+                          },
+                          {
+                            .name = "order",
+                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "asc",
+                                .token = "ASC",
+                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                              },
+                              {
+                                .name = "desc",
+                                .token = "DESC",
+                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                              },
+                              {0}
+                            },
+                          },
+                          {0}
+                        },
+                      },
+                      {0}
+                    },
+                  },
+                  {
+                    .name = "limit",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "limit_token",
+                        .token = "LIMIT",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "offset",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {
+                        .name = "count",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {0}
+                    },
+                  },
+                  {
+                    .name = "name",
+                    .token = "AS",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
                   {0}
                 },
-              },
-              {
-                .name = "nargs",
-                .type = REDISMODULE_ARG_TYPE_INTEGER,
-              },
-              {
-                .name = "arg",
-                .type = REDISMODULE_ARG_TYPE_STRING,
-                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-              },
-              {
-                .name = "name",
-                .token = "AS",
-                .type = REDISMODULE_ARG_TYPE_STRING,
-                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
               },
               {0}
             },


### PR DESCRIPTION
## Describe the changes in the pull request

Adds the full `COLLECT` reducer description (introduced in 8.8.0) to `commands.json` and `src/command_info/command_info.c` so the new subcommand is exposed through `COMMAND DOCS` / `COMMAND INFO` and the Redis client autocomplete metadata.

Also restructures the `REDUCE` schema for `FT.AGGREGATE` and `FT.HYBRID` into a `oneof` of two variants — `generic_reduce` (the existing `COUNT`/`SUM`/... family) and `collect_reduce` (`COLLECT` with `<nargs>` ahead of `FIELDS`/`[SORTBY]`/`[LIMIT]`/`[AS <name>]`) — so the documented token order matches what `RDCRCollect_New` actually parses. The generated `src/command_info/command_info.c` is refreshed by `srcutil/gen_command_info.py`.

#### Which additional issues this PR fixes
1. MOD-14813

#### Main objects this PR modified
1. `commands.json`
2. `src/command_info/command_info.c` (auto-generated from `commands.json`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates command documentation/autocomplete metadata only, but could affect clients that consume `COMMAND DOCS`/`COMMAND INFO` schemas for parsing or completion.
> 
> **Overview**
> Exposes the `COLLECT` reducer (since 8.8.0) in `FT.AGGREGATE` and `FT.HYBRID` command metadata so it appears in `COMMAND DOCS`/`COMMAND INFO` and client autocomplete.
> 
> Restructures the `GROUPBY ... REDUCE` argument schema into a `oneof` with **two variants**—`generic_reduce` for existing reducers and `collect_reduce` for `REDUCE COLLECT <nargs> FIELDS ... [SORTBY ...] [LIMIT ...] [AS ...]`—so the documented token order matches the actual parser; regenerates `src/command_info/command_info.c` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cef7b8ece5a7694ce873687e0cf14dd78b44496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->