### PR TITLE
build.sh: capture coverage data even when Python tests fail

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -843,12 +843,13 @@ run_unit_tests() {
   UNIT_TEST_RESULT=$?
   if [[ $UNIT_TEST_RESULT -eq 0 ]]; then
     echo "All unit tests passed!"
-    if [[ $COV == 1 ]]; then
-      capture_coverage unit
-    fi
   else
     echo "Some unit tests failed. Check the test logs above for details."
     HAS_FAILURES=1
+  fi
+
+  if [[ $COV == 1 ]]; then
+    capture_coverage unit
   fi
 }
 
@@ -1035,17 +1036,18 @@ run_python_tests() {
   PYTHON_TEST_RESULT=$?
   if [[ $PYTHON_TEST_RESULT -eq 0 ]]; then
     echo "All Python tests passed!"
-    if [[ $COV == 1 ]]; then
-      if [[ "$REDIS_STANDALONE" == "1" ]]; then
-        DEPLOYMENT_TYPE="standalone"
-      else
-        DEPLOYMENT_TYPE="coordinator"
-      fi
-      capture_coverage flow_$DEPLOYMENT_TYPE
-    fi
   else
     echo "Some Python tests failed. Check the test logs above for details."
     HAS_FAILURES=1
+  fi
+
+  if [[ $COV == 1 ]]; then
+    if [[ "$REDIS_STANDALONE" == "1" ]]; then
+      DEPLOYMENT_TYPE="standalone"
+    else
+      DEPLOYMENT_TYPE="coordinator"
+    fi
+    capture_coverage flow_$DEPLOYMENT_TYPE
   fi
 }
 


### PR DESCRIPTION
Move capture_coverage out of the test-success branch so gcov data is collected regardless of test results. Previously, any test failure would skip coverage capture entirely.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script control-flow change that only affects when `capture_coverage` runs; main risk is producing/overwriting coverage artifacts even on failing test runs.
> 
> **Overview**
> Ensures coverage artifacts are captured even when tests fail by moving `capture_coverage` out of the success-only branches in `run_unit_tests` and `run_python_tests`.
> 
> Python coverage capture still differentiates output naming based on `REDIS_STANDALONE` (standalone vs coordinator), but now runs whenever `COV=1` regardless of test result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a491ba3612ac32f4d6f8cfb9b5609f3d1952dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->