### PR TITLE
[MOD-14918][DO NOT MERGE] Verify ASAN fix against redis/unstable

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,10 +12,11 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert when 8.4 is released
+    # TEMP for MOD-14918 verification: pinned to redis/unstable to reproduce
+    # the ASAN __cxa_throw NULL-interceptor crash. Do NOT merge this branch.
     runs-on: ubuntu-slim
     outputs:
-      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
+      tag: unstable
     steps:
       - run: echo "Dummy step to set output"
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -154,6 +154,24 @@ setup_clang_sanitizer() {
 		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:verbosity=0"
 		export LSAN_OPTIONS="suppressions=$ROOT/tests/memcheck/asan.supp:print_suppressions=0:verbosity=0"
 		# :use_tls=0
+
+		# Preload libstdc++ so ASAN's __cxa_throw interceptor can resolve the
+		# real symbol at process init. Redis no longer links libstdc++ (upstream
+		# commit 670993a, "Replace fast_float C++ library with pure C
+		# implementation"), so ASAN's interceptor lookup runs before any C++
+		# runtime is mapped and stores NULL. The RediSearch module brings
+		# libstdc++ in via dlopen, but by then the interceptor has already
+		# captured NULL, and the first C++ throw aborts the process with:
+		#   AddressSanitizer: CHECK failed: asan_interceptors.cpp:458
+		#   "((__interception::real___cxa_throw)) != (0)"
+		# See MOD-14918.
+		if [[ $OS != macos ]] && command -v g++ &> /dev/null; then
+			local libstdcxx
+			libstdcxx=$(g++ -print-file-name=libstdc++.so.6 2> /dev/null)
+			if [[ -n $libstdcxx && -e $libstdcxx ]]; then
+				export LD_PRELOAD="${libstdcxx}${LD_PRELOAD:+:$LD_PRELOAD}"
+			fi
+		fi
 	fi
 }
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -155,6 +155,23 @@ setup_clang_sanitizer() {
 		export LSAN_OPTIONS="suppressions=$ROOT/tests/memcheck/asan.supp:print_suppressions=0:verbosity=0"
 		# :use_tls=0
 
+		# Preload libstdc++ so ASAN's __cxa_throw interceptor can resolve the
+		# real symbol at process init. Redis no longer links libstdc++ (upstream
+		# commit 670993a, "Replace fast_float C++ library with pure C
+		# implementation"), so ASAN's interceptor lookup runs before any C++
+		# runtime is mapped and stores NULL. The RediSearch module brings
+		# libstdc++ in via dlopen, but by then the interceptor has already
+		# captured NULL, and the first C++ throw aborts the process with:
+		#   AddressSanitizer: CHECK failed: asan_interceptors.cpp:458
+		#   "((__interception::real___cxa_throw)) != (0)"
+		# See MOD-14918.
+		if [[ $OS != macos ]] && command -v g++ &> /dev/null; then
+			local libstdcxx
+			libstdcxx=$(g++ -print-file-name=libstdc++.so.6 2> /dev/null)
+			if [[ -n $libstdcxx && -e $libstdcxx ]]; then
+				export LD_PRELOAD="${libstdcxx}${LD_PRELOAD:+:$LD_PRELOAD}"
+			fi
+		fi
 	fi
 }
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -154,24 +154,6 @@ setup_clang_sanitizer() {
 		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:verbosity=0"
 		export LSAN_OPTIONS="suppressions=$ROOT/tests/memcheck/asan.supp:print_suppressions=0:verbosity=0"
 		# :use_tls=0
-
-		# Preload libstdc++ so ASAN's __cxa_throw interceptor can resolve the
-		# real symbol at process init. Redis no longer links libstdc++ (upstream
-		# commit 670993a, "Replace fast_float C++ library with pure C
-		# implementation"), so ASAN's interceptor lookup runs before any C++
-		# runtime is mapped and stores NULL. The RediSearch module brings
-		# libstdc++ in via dlopen, but by then the interceptor has already
-		# captured NULL, and the first C++ throw aborts the process with:
-		#   AddressSanitizer: CHECK failed: asan_interceptors.cpp:458
-		#   "((__interception::real___cxa_throw)) != (0)"
-		# See MOD-14918.
-		if [[ $OS != macos ]] && command -v g++ &> /dev/null; then
-			local libstdcxx
-			libstdcxx=$(g++ -print-file-name=libstdc++.so.6 2> /dev/null)
-			if [[ -n $libstdcxx && -e $libstdcxx ]]; then
-				export LD_PRELOAD="${libstdcxx}${LD_PRELOAD:+:$LD_PRELOAD}"
-			fi
-		fi
 	fi
 }
 


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** This branch exists only to verify the MOD-14918 fix in PR #9620 against `redis/unstable`. It will be force-closed after results are in.

## Purpose

PR #9620 adds an `LD_PRELOAD libstdc++.so.6` workaround so ASAN's `__cxa_throw` interceptor resolves to a real symbol when the host (`redis-server`) no longer links the C++ runtime. The pinned Redis SHA used by the regular pull-request CI predates that change, so the bug doesn't reproduce there and the workaround can't be validated by the standard pipeline.

This branch flips both knobs needed to actually exercise the fix:

1. `event-pull_request.yml` `tag:` is bumped from `3cd464263b03b425ffae2e23db24df3dc9346871` → `unstable`.
2. The branch is opened **non-draft** so the ASAN job runs (the gate in `event-pull_request.yml:48` requires non-draft).

## Verification protocol

Two CI runs, on the same branch, in sequence:

| Step | HEAD state | Expected ASAN result | What it proves |
|------|------------|----------------------|----------------|
| **1. Negative control** *(this commit)* | redis = `unstable`, **no preload** | ASAN aborts: `CHECK failed: asan_interceptors.cpp:458 "((__interception::real___cxa_throw)) != (0)"` on the previously-failing tests | Bug actually reproduces against `unstable` in CI |
| **2. Positive run** *(pushed after step 1 finishes)* | redis = `unstable`, preload restored from PR #9620 | ASAN matrix passes | The preload fixes the crash |

If step 1 doesn't crash, our model of the bug is wrong and PR #9620 needs more thought. If step 2 doesn't pass, the preload is necessary but not sufficient and there's another throw site we haven't accounted for.

## After verification

- Both runs' outcomes will be summarized in a comment on PR #9620.
- This PR will be closed and the branch deleted.
- The actual fix lives in PR #9620; nothing from this branch ships.

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=atlassian&utm_medium=jira_issue&utm_campaign=jira)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI workflow inputs and the sanitizer test harness, which can change what Redis version is exercised and how processes are launched during ASAN runs. Runtime impact is limited to CI/test environments but could cause platform-specific preload issues if misdetected.
> 
> **Overview**
> Updates PR CI to use `redis/unstable` (instead of a pinned SHA) to reproduce an ASAN crash scenario, with prominent *TEMP/DO NOT MERGE* annotations in `event-pull_request.yml`.
> 
> Extends `tests/pytests/runtests.sh` so address-sanitizer runs on non-macOS attempt to locate `libstdc++.so.6` via `g++` and prepend it to `LD_PRELOAD`, ensuring ASAN’s `__cxa_throw` interceptor resolves correctly when the host `redis-server` doesn’t link the C++ runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb6f91cade19918214eb09b279bf5f64b8718be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->