### PR TITLE
[MOD-5245] add FT.ALIASLIST command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -470,6 +470,19 @@
     "since": "1.0.0",
     "group": "search"
   },
+  "FT.ALIASLIST": {
+    "summary": "Lists all aliases for the index",
+    "complexity": "O(N) where N is the number of aliases",
+    "arguments": [
+      {
+        "name": "index",
+        "type": "string",
+        "summary": "Specifies the name of the index. The index must be created using `FT.CREATE`."
+      }
+    ],
+    "since": "8.8.0",
+    "group": "search"
+  },
   "FT.TAGVALS": {
     "summary": "Returns the distinct tags indexed in a Tag field",
     "complexity": "O(N)",

--- a/commands.json
+++ b/commands.json
@@ -480,7 +480,7 @@
         "summary": "Specifies the name of the index. The index must be created using `FT.CREATE`."
       }
     ],
-    "since": "8.8.0",
+    "since": "8.10.0",
     "group": "search"
   },
   "FT.TAGVALS": {

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -543,6 +543,26 @@ int SetFtAliasdelInfo(RedisModuleCommand *cmd) {
   return RedisModule_SetCommandInfo(cmd, &info);
 }
 
+// Info for FT.ALIASLIST
+int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
+  const RedisModuleCommandInfo info = {
+    .version = REDISMODULE_COMMAND_INFO_VERSION,
+    .summary = "Lists all aliases for the index",
+    .complexity = "O(N) where N is the number of aliases",
+    .args = (RedisModuleCommandArg[]){
+      {
+        .name = "index",
+        .summary = "Specifies the name of the index. The index must be created using `FT.CREATE`.",
+        .type = REDISMODULE_ARG_TYPE_STRING,
+      },
+      {0}
+    },
+    .arity = -2,
+    .since = "8.8.0",
+  };
+  return RedisModule_SetCommandInfo(cmd, &info);
+}
+
 // Info for FT.TAGVALS
 int SetFtTagvalsInfo(RedisModuleCommand *cmd) {
   const RedisModuleCommandInfo info = {

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -558,7 +558,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       {0}
     },
     .arity = -2,
-    .since = "8.8.0",
+    .since = "8.10.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -557,7 +557,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = -2,
+    .arity = 2,
     .since = "8.10.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);

--- a/src/command_info/command_info.h
+++ b/src/command_info/command_info.h
@@ -17,6 +17,7 @@ int SetFtDropindexInfo(RedisModuleCommand *cmd);
 int SetFtAliasaddInfo(RedisModuleCommand *cmd);
 int SetFtAliasupdateInfo(RedisModuleCommand *cmd);
 int SetFtAliasdelInfo(RedisModuleCommand *cmd);
+int SetFtAliaslistInfo(RedisModuleCommand *cmd);
 int SetFtTagvalsInfo(RedisModuleCommand *cmd);
 int SetFtSugaddInfo(RedisModuleCommand *cmd);
 int SetFtSuggetInfo(RedisModuleCommand *cmd);

--- a/src/commands.h
+++ b/src/commands.h
@@ -121,6 +121,7 @@ bool IsEnterprise();
 #define RS_DICT_DUMP "FT.DICTDUMP"
 #define RS_SYNDUMP_CMD "FT.SYNDUMP"
 #define RS_INDEX_LIST_CMD "FT._LIST"
+#define RS_ALIASLIST_CMD "FT.ALIASLIST"
 #define RS_SYNADD_CMD "FT.SYNADD" // Deprecated, always returns an error
 
 // Read commands always use the internal "_FT" prefix

--- a/src/module.c
+++ b/src/module.c
@@ -1174,6 +1174,10 @@ int AliasListCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
   }
 
+  if (!checkEnterpriseACL(ctx, sp)) {
+    return RedisModule_ReplyWithError(ctx, NOPERM_ERR);
+  }
+
   CurrentThread_SetIndexSpec(sp->own_ref);
 
   size_t count = array_len(sp->aliases);

--- a/src/module.c
+++ b/src/module.c
@@ -1142,7 +1142,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
   }
   int rc = 0;
   if (aliasAddCommon(ctx, argv, argc, &status, false) != REDISMODULE_OK) {
-    // Add back the previous index. this shouldn't fail
+    // Add back the previous index. This shouldn't fail
     if (spOrig) {
       QueryError e2 = QueryError_Default();
       IndexAlias_Add(alias, Orig_ref, 0, &e2);
@@ -1155,6 +1155,37 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
   }
   HiddenString_Free(alias, false);
   return rc;
+}
+
+// FT.ALIASLIST <index>
+// Returns all aliases for the given index.
+// Only accepts index names, not aliases (INDEXSPEC_LOAD_NOALIAS).
+int AliasListCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  IndexLoadOptions lOpts = {.nameR = argv[1],
+                            .flags = INDEXSPEC_LOAD_NOALIAS | INDEXSPEC_LOAD_KEY_RSTRING};
+  StrongRef ref = IndexSpec_LoadUnsafeEx(&lOpts);
+  IndexSpec *sp = StrongRef_Get(ref);
+  if (!sp) {
+    const char *idx = RedisModule_StringPtrLen(argv[1], NULL);
+    return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
+  }
+
+  CurrentThread_SetIndexSpec(sp->own_ref);
+
+  size_t count = array_len(sp->aliases);
+  RedisModule_ReplyWithSet(ctx, count);
+  for (size_t i = 0; i < count; i++) {
+    size_t len;
+    const char *alias = HiddenString_GetUnsafe(sp->aliases[i], &len);
+    RedisModule_ReplyWithStringBuffer(ctx, alias, len);
+  }
+
+  CurrentThread_ClearIndexSpec();
+  return REDISMODULE_OK;
 }
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -1775,6 +1806,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
     DEFINE_COMMAND(CMD_FOR_ENV(RS_ALIASUPDATE),        AliasUpdateCommand,            "write deny-oom",   SetFtAliasupdateInfo,         SET_COMMAND_INFO,       "",  true, indexOnlyCmdArgs, !enterprise),
     DEFINE_COMMAND(CMD_FOR_ENV(RS_ALIASDEL),           AliasDelCommand,               "write",            SetFtAliasdelInfo,            SET_COMMAND_INFO,       "",  true, indexOnlyCmdArgs, !enterprise),
     DEFINE_COMMAND(CMD_FOR_ENV(RS_ALIASDEL_IF_X),      AliasDelIfExCommand,           "write",            SetFtAliasdelInfo,            SET_COMMAND_INFO,       "",  true, indexOnlyCmdArgs, !enterprise),
+    DEFINE_COMMAND(RS_ALIASLIST_CMD,                   AliasListCommand,              "readonly",         SetFtAliaslistInfo,           SET_COMMAND_INFO,       "",  true, indexOnlyCmdArgs, false),
 
     // Suggestion commands key specs should be 1, 1, 1
     DEFINE_COMMAND(RS_SUGADD_CMD,     DiskDisabledCmd(RSSuggestAddCommand), "write deny-oom", SetFtSugaddInfo, SET_COMMAND_INFO, "write", true, indexSugCmdArgs, false),
@@ -3997,7 +4029,6 @@ int TagValsCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   if (argc < 3) {
     return RedisModule_WrongArity(ctx);
   } else if (!SearchCluster_Ready()) {
-    // Check that the cluster state is valid
     return RedisModule_ReplyWithError(ctx, CLUSTERDOWN_ERR);
   }
   RS_AutoMemory(ctx);
@@ -4012,12 +4043,12 @@ int TagValsCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
   MRCommand_SetProtocol(&cmd, ctx);
-  /* Replace our own FT command with _FT. command */
   MRCommand_SetPrefix(&cmd, "_FT");
 
   MR_Fanout(MR_CreateCtx(ctx, 0, NULL, NumShards), uniqueStringsReducer, cmd, true);
   return REDISMODULE_OK;
 }
+
 
 int InfoCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc != 2) {

--- a/src/module.c
+++ b/src/module.c
@@ -1174,7 +1174,7 @@ int AliasListCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
   }
 
-  if (!checkEnterpriseACL(ctx, sp)) {
+  if (!ACLUserMayAccessIndex(ctx, sp)) {
     return RedisModule_ReplyWithError(ctx, NOPERM_ERR);
   }
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3757,6 +3757,37 @@ def testAliasAddIfNX(env):
 def testAliasDelIfX(env):
     env.expect('FT._ALIASDELIFX a1').ok()
 
+def test_alias_list(env):
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'text')
+
+    # No aliases initially
+    env.expect('ft.aliaslist', 'idx').equal([])
+
+    # Add some aliases
+    env.cmd('ft.aliasAdd', 'alias1', 'idx')
+    env.cmd('ft.aliasAdd', 'alias2', 'idx')
+
+    # List should contain both aliases
+    res = env.cmd('ft.aliaslist', 'idx')
+    env.assertEqual(sorted(res), sorted(['alias1', 'alias2']))
+
+    # Delete one alias
+    env.cmd('ft.aliasDel', 'alias1')
+    env.expect('ft.aliaslist', 'idx').equal(['alias2'])
+
+    # Error on non-existent index
+    env.expect('ft.aliaslist', 'nonexistent').error().contains('SEARCH_INDEX_NOT_FOUND Index not found: nonexistent')
+
+    # Error on alias name (not index name) - aliases cannot be used
+    # The INDEXSPEC_LOAD_NOALIAS flag ensures we only accept actual index names
+    env.expect('ft.aliaslist', 'alias2').error().contains('SEARCH_INDEX_NOT_FOUND Index not found: alias2')
+
+    # Wrong arity - no arguments
+    env.expect('ft.aliaslist').error().contains('wrong number of arguments')
+
+    # Wrong arity - too many arguments
+    env.expect('ft.aliaslist', 'idx', 'extra').error().contains('wrong number of arguments')
+
 def testEmptyDoc(env):
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE idx SCHEMA t TEXT').ok()

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -28,7 +28,7 @@ def test_acl_search_commands(env):
         'FT._ALIASDELIFX', 'FT._CREATEIFNX', 'FT._ALIASADDIFNX', 'FT._ALTERIFNX',
         'FT._DROPINDEXIFX', 'FT.DROPINDEX', 'FT.TAGVALS', 'FT._DROPIFX',
         'FT.DROP', 'FT.GET', 'FT.SYNADD', 'FT.ADD', 'FT.MGET', 'FT.DEL',
-        '_FT.CONFIG', '_FT.DEBUG', 'FT.SAFEADD'
+        '_FT.CONFIG', '_FT.DEBUG', 'FT.SAFEADD', 'FT.ALIASLIST'
     ]
     if not env.isCluster():
         commands.append('FT.CONFIG')

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -225,6 +225,7 @@ def test_acl_key_permissions_validation(env):
         ['FT.SPELLCHECK', no_perm_index, 'name'],
         ['FT.ALIASADD', 'myAlias', no_perm_index],
         ['FT.ALIASUPDATE', 'myAlias', no_perm_index],
+        ['FT.ALIASLIST', no_perm_index],
         ['FT.ALTER', no_perm_index, 'SCHEMA', 'ADD', 'n2', 'NUMERIC', 'SORTABLE'],
         ['FT.EXPLAIN', no_perm_index, '*'],
         ['FT.EXPLAINCLI', no_perm_index, '*'],

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -380,6 +380,7 @@ def test_WriteCommandsOnReplica():
     ['FT.SPELLCHECK', 'idx', 'held' ],
     ['FT.SUGGET', 'h:sug{3}', 'hello'],
     ['FT.SUGLEN', 'h:sug{3}'],
+    ['FT.ALIASLIST', 'idx'],
   ]
 
   # Run read and write commands on the master - should not raise RO exception


### PR DESCRIPTION
## Describe the changes in the pull request

Adds the `FT.ALIASLIST` command, which lists all aliases currently defined on the server (each alias plus the index it points to).

1. **Current:** Aliases can be created, updated and deleted via `FT.ALIASADD` / `FT.ALIASUPDATE` / `FT.ALIASDEL`, but there is no way to enumerate them.
2. **Change:** Introduce a new read-only command `FT.ALIASLIST` returning the list of `(alias, index)` pairs.
3. **Outcome:** Users (and the coordinator) can introspect the set of aliases.

This is a re-push of #8538 (by @pierrelambert) so CI can run with full credentials. The fork-PR CI is failing on a pre-existing issue with `vars.SCCACHE_*` not being available to fork-triggered workflows (unrelated to this change). Authorship of the commit is preserved.

#### Which additional issues this PR fixes
1. MOD-5245
2. Supersedes #8538

#### Main objects this PR modified
1. `src/module.c` — command registration and handler for `FT.ALIASLIST`
2. `src/command_info/command_info.{c,h}`, `src/commands.h`, `commands.json` — command metadata
3. `tests/pytests/test.py`, `test_acl.py`, `test_replicate.py` — tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

New user-facing command `FT.ALIASLIST` for listing index aliases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new read-only command and associated metadata/tests; risk is low but involves command registration and ACL checks for index access.
> 
> **Overview**
> Adds a new read-only `FT.ALIASLIST <index>` command that returns the aliases defined for a specific index, rejecting alias names as input and enforcing ACL access checks.
> 
> Registers the command (`src/module.c`, `src/commands.h`) and exposes it via command metadata (`commands.json`, generated `command_info.*`). Updates pytests to cover behavior, ACL category listing, and replication/read-only semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add8184bfb64b4799f99c4852a8d53202d2f10dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->