### PR TITLE
[8.6-rse][MOD-14930] refactor expire handling without full reindexing (#9356)

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1127,6 +1127,11 @@ DEBUG_COMMAND(setMonitorExpiration) {
     return RedisModule_ReplyWithError(ctx, "Can't set both fields and not-fields");
   }
 
+  // Note: enabling these per-spec flags only takes effect when
+  // RSGlobalConfig.monitorExpiration is also true. The keyspace-notification
+  // fast path (Indexes_UpdateMatchingDocExpiration) early-returns on the
+  // global flag, so a spec-level override to "on" is a no-op while the
+  // global config is "off".
   if (options.docs || options.notDocs) {
     sp->monitorDocumentExpiration = options.docs && !options.notDocs;
   }

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -242,8 +242,16 @@ static inline int64_t expirationTimePointToNs(t_expirationTimePoint t) {
 // iterators use `t->ttl == NULL` as their per-spec gate. Takes ownership of
 // `sortedFieldWithExpiration` either by handing it to the table or freeing it
 // when there are no field-level entries to register.
+//
+// The store on `expirationTimeNs` is a relaxed atomic so the EXPIRE/PERSIST
+// fast path in `Indexes_UpdateMatchingDocExpiration` can run under the spec
+// read lock concurrently with FT.SEARCH workers; readers in
+// `DocTable_IsDocExpired` pair it with a relaxed atomic load. Callers that
+// pass a non-empty `sortedFieldWithExpiration` (e.g. `Indexer_Add`) still
+// hold the write lock — the atomic store is a no-op in that case but keeps
+// a single source of truth for the field write.
 void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expirationTimePoint ttl, arrayof(FieldExpiration) sortedFieldWithExpiration) {
-  dmd->expirationTimeNs = expirationTimePointToNs(ttl);
+  __atomic_store_n(&dmd->expirationTimeNs, expirationTimePointToNs(ttl), __ATOMIC_RELAXED);
   if (array_len(sortedFieldWithExpiration) > 0) {
     TimeToLiveTable_VerifyInit(&t->ttl, t->maxSize);
     TimeToLiveTable_Add(t->ttl, dmd->id, sortedFieldWithExpiration);
@@ -253,18 +261,24 @@ void DocTable_UpdateExpiration(DocTable *t, RSDocumentMetadata* dmd, t_expiratio
 }
 
 bool DocTable_IsDocExpired(DocTable* t, const RSDocumentMetadata* dmd, struct timespec* expirationPoint) {
-  if (dmd->expirationTimeNs == 0) {
+  // Relaxed atomic load: pairs with the relaxed store in DocTable_UpdateExpiration
+  // so reader/writer concurrency under the spec read lock is well-defined under
+  // the C abstract machine. Ordering relative to other index mutations is not
+  // required — the value is a self-contained timestamp compared against `now`.
+  int64_t exp = __atomic_load_n(&dmd->expirationTimeNs, __ATOMIC_RELAXED);
+  if (exp == 0) {
     return false;
   }
-  return dmd->expirationTimeNs <= expirationTimePointToNs(*expirationPoint);
+  return exp <= expirationTimePointToNs(*expirationPoint);
 }
 
 void DocTable_ClearExpirationData(DocTable *t) {
   // Walk every DMD: doc-level TTL lives inline on the DMD (not in the TTL
   // table), and field-level TTL is only present for docs that are also in
   // the table. Either may be set, so a single sweep over all DMDs is the
-  // simplest correct path.
-  DOCTABLE_FOREACH(t, dmd->expirationTimeNs = 0);
+  // simplest correct path. Caller holds the write lock (see header), but use
+  // the relaxed atomic store to match the access pattern everywhere else.
+  DOCTABLE_FOREACH(t, __atomic_store_n(&dmd->expirationTimeNs, 0, __ATOMIC_RELAXED));
   TimeToLiveTable_Destroy(&t->ttl);
 }
 

--- a/src/document.h
+++ b/src/document.h
@@ -148,6 +148,11 @@ typedef struct {
 // We don't allow any lazy expiration to happen here
 #define DOCUMENT_OPEN_KEY_QUERY_FLAGS REDISMODULE_READ | REDISMODULE_OPEN_KEY_NOEFFECTS | REDISMODULE_OPEN_KEY_NOEXPIRE | REDISMODULE_OPEN_KEY_ACCESS_EXPIRED | REDISMODULE_OPEN_KEY_ACCESS_TRIMMED
 
+// Returns the absolute expiration time of an already-opened key as a
+// t_expirationTimePoint, or {0,0} if the key has no TTL. Wraps
+// RedisModule_GetAbsExpire so callers share a single ms->timespec conversion.
+t_expirationTimePoint GetKeyExpirationTime(RedisModuleKey *openedKey);
+
 void Document_AddField(Document *d, const char *fieldname, RedisModuleString *fieldval,
                        uint32_t typemask);
 

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -118,15 +118,13 @@ static inline timespec timespecFromMilliseconds(int64_t totalMilliseconds) {
   return result;
 }
 
-static inline t_expirationTimePoint getDocExpirationTime(RedisModuleCtx* ctx, RedisModuleKey *openedKey) {
-  t_expirationTimePoint zero = {.tv_sec = 0, .tv_nsec = 0};
+t_expirationTimePoint GetKeyExpirationTime(RedisModuleKey *openedKey) {
   mstime_t totalMilliseconds = RedisModule_GetAbsExpire(openedKey);
   if (totalMilliseconds == REDISMODULE_NO_EXPIRE) {
+    t_expirationTimePoint zero = {.tv_sec = 0, .tv_nsec = 0};
     return zero;
   }
-
-  t_expirationTimePoint result = timespecFromMilliseconds(totalMilliseconds);
-  return result;
+  return timespecFromMilliseconds(totalMilliseconds);
 }
 
 int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError *status) {
@@ -191,7 +189,7 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError
   }
 
   if (spec->monitorDocumentExpiration) {
-    doc->docExpirationTime = getDocExpirationTime(sctx->redisCtx, k);
+    doc->docExpirationTime = GetKeyExpirationTime(k);
   }
   rv = REDISMODULE_OK;
 done:
@@ -230,7 +228,7 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, QueryError
   }
 
   if (spec->monitorDocumentExpiration) {
-    doc->docExpirationTime = getDocExpirationTime(sctx->redisCtx, k);
+    doc->docExpirationTime = GetKeyExpirationTime(k);
   }
 
   RedisModule_CloseKey(k);

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -181,6 +181,18 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
 
     case expire_cmd:
     case persist_cmd:
+      // EXPIRE/PERSIST only change the key's TTL; the document content,
+      // schema-rule filters and inverted indexes are all unaffected. In the
+      // in-memory flow we only need to refresh the doc-level expiration on
+      // the matching DMDs. Disk-backed indexes still take the full reindex
+      // path until they grow an equivalent fast path.
+      if (SearchDisk_IsEnabled()) {
+        Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
+      } else {
+        Indexes_UpdateMatchingDocExpiration(ctx, key, getDocTypeFromString(key));
+      }
+      break;
+
     case restore_cmd:
     case copy_to_cmd:
       Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);

--- a/src/spec.c
+++ b/src/spec.c
@@ -4152,6 +4152,77 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
   Indexes_SpecOpsIndexingCtxFree(specs);
 }
 
+void Indexes_UpdateMatchingDocExpiration(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type) {
+  if (type == DocumentType_Unsupported || !RSGlobalConfig.monitorExpiration) {
+    return;
+  }
+
+  // Find all indexes that match the key's name prefix. runFilters=false:
+  // EXPIRE/PERSIST do not change field values, so a doc's schema-rule FILTER
+  // outcome cannot have flipped since the last write. The DocTable lookup
+  // below (DocTable_BorrowByKeyR) is the only discriminator we need — it
+  // returns the existing DMD when the doc is currently indexed, and NULL
+  // otherwise. Re-evaluating the filter here would re-read hash/JSON fields
+  // on the main thread for a result the loop would ignore.
+  SpecOpIndexingCtx *specs = Indexes_FindMatchingSchemaRules(ctx, key, type, false, NULL);
+
+  // EXPIRE/PERSIST notifications fire for every key in the keyspace. When no
+  // spec prefix matches we have nothing to update, so skip the OpenKey/TTL
+  // read entirely — that overhead would otherwise be paid on every event.
+  if (array_len(specs->specsOps) == 0) {
+    Indexes_SpecOpsIndexingCtxFree(specs);
+    return;
+  }
+
+  RedisModuleKey *kp = RedisModule_OpenKey(ctx, key, DOCUMENT_OPEN_KEY_INDEXING_FLAGS);
+  RS_ASSERT(kp);
+  t_expirationTimePoint ttl = GetKeyExpirationTime(kp);
+  RedisModule_CloseKey(kp);
+
+  for (size_t i = 0; i < array_len(specs->specsOps); ++i) {
+    SpecOpCtx *specOp = &specs->specsOps[i];
+    IndexSpec *spec = specOp->spec;
+    // Skip TTL update for specs that opted out of doc-level TTL tracking,
+    // matching the gate in Document_LoadSchemaFieldHash/Json. Otherwise
+    // DocTable_IsDocExpired could drop rows for an index that doesn't
+    // monitor TTLs.
+    //
+    // No spec lock needed: monitorDocumentExpiration is only written from
+    // main-thread callbacks (spec init, FT.CONFIG SET, FT.DEBUG
+    // MONITOR_EXPIRATION), and this keyspace-notification callback also
+    // runs on the main thread, so the Redis event loop serializes them.
+    // The spec write lock guards index data against background workers,
+    // not main-thread config flags (same pattern as the load path).
+    if (!spec->monitorDocumentExpiration) {
+      continue;
+    }
+    RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
+    // Read lock is sufficient: the only mutation is the relaxed atomic store on
+    // `dmd->expirationTimeNs` inside DocTable_UpdateExpiration (paired with a
+    // relaxed atomic load in DocTable_IsDocExpired). The DMD chain traversal
+    // and refcount manipulation in DocTable_BorrowByKeyR / DMD_Return are
+    // explicitly documented as safe under either lock mode (doc_table.c, near
+    // DocTable_GetOwn). Concurrent writers cannot race here because keyspace
+    // notifications all dispatch on the Redis main thread, so this callback is
+    // serialized against itself and against other notification-driven writers
+    // by the event loop, not by the spec lock.
+    RedisSearchCtx_LockSpecRead(&sctx);
+    const RSDocumentMetadata *cdmd = DocTable_BorrowByKeyR(&spec->docs, key);
+    if (cdmd) {
+      // Reuse the canonical setter so the doc-level write goes through the
+      // same path as Indexer_Add (indexer.c) and the timespec->ns conversion
+      // assertion in expirationTimePointToNs runs. Pass NULL for the field
+      // expirations: EXPIRE/PERSIST do not affect HEXPIRE state, so the
+      // existing per-spec TTL table entries must be preserved untouched.
+      DocTable_UpdateExpiration(&spec->docs, (RSDocumentMetadata *)cdmd, ttl, NULL);
+      DMD_Return(cdmd);
+    }
+    RedisSearchCtx_UnlockSpec(&sctx);
+  }
+
+  Indexes_SpecOpsIndexingCtxFree(specs);
+}
+
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
                                            DocumentType type,
                                            RedisModuleString **hashFields) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -744,6 +744,12 @@ size_t Indexes_Count();
 void Indexes_Propagate(RedisModuleCtx *ctx);
 void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type,
                                            RedisModuleString **hashFields);
+// Fast path for keyspace events that only change the document-level TTL
+// (EXPIRE/PERSIST): re-reads the key's absolute expiration and writes it
+// directly onto the matching DMDs, without re-running schema-rule filters or
+// re-indexing the document. In-memory flow only; callers must fall back to
+// Indexes_UpdateMatchingWithSchemaRules for disk-backed indexes.
+void Indexes_UpdateMatchingDocExpiration(RedisModuleCtx *ctx, RedisModuleString *key, DocumentType type);
 void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *key,
                                            DocumentType type,
                                            RedisModuleString **hashFields);

--- a/tests/benchmarks/search-expire-doc-50-50-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-50-50-10-milliseconds.yml
@@ -1,0 +1,39 @@
+version: 0.2
+name: "search-expire-doc-50-50-10-milliseconds"
+description: |
+  High write-ratio variant of search-expire-doc-10-milliseconds. Splits load
+  50/50 between FT.SEARCH and PEXPIRE so the doc-expiration fast path
+  dominates the workload — any throughput delta from
+  Indexes_UpdateMatchingDocExpiration (or any regression in the
+  notification-routing branch in OnKeySpaceNotification) shows up well above
+  the variance floor.
+
+  Active expiration is disabled so keys stay in the dataset and every PEXPIRE
+  is a pure TTL-only metadata update. Search side is a deterministic
+  catch-all to keep latency tight and re-triggers stable (>1000 QPS).
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "PEXPIRE fast path under high write ratio 50-50 signal amplification for regression detection"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-50-50-10ms"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 * NOCONTENT LIMIT 0 1' --command-ratio 50 --command 'PEXPIRE __key__ 10' --command-ratio 50"

--- a/tests/benchmarks/search-expire-doc-json-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-json-10-milliseconds.yml
@@ -1,0 +1,38 @@
+version: 0.2
+name: "search-expire-doc-json-10-milliseconds"
+description: |
+  TTL table benchmark for document expiration on JSON documents. Mirrors
+  search-expire-doc-10-milliseconds but stores docs as JSON so the JSON
+  branch of the doc-expiration fast path is exercised
+  (Document_LoadSchemaFieldJson uses the same GetKeyExpirationTime helper
+  as the hash branch after PR #9356).
+
+  Active expiration is disabled so every PEXPIRE is a TTL-only metadata
+  update on the matching DMD; the 10K-doc dataset keeps memory pressure low
+  and re-trigger variance tight. Higher per-thread concurrency (-c 32) is
+  used to drive throughput well above 1000 QPS on the smaller dataset.
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "PEXPIRE fast path on JSON documents covers Document_LoadSchemaFieldJson side of GetKeyExpirationTime"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "10K-singlevalue-numeric-json-expire-doc-10ms"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/10K-singlevalue-numeric-json/10K-singlevalue-numeric-json.redisjson.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - 'FT.CREATE idx:single ON JSON PREFIX 1 doc:single SCHEMA $.numericInt1 AS numericInt1 NUMERIC $.numericFloat1 AS numericFloat1 NUMERIC $.numericInt2 AS numericInt2 NUMERIC $.numericFloat2 AS numericFloat2 NUMERIC $.numericInt3 AS numericInt3 NUMERIC $.numericFloat3 AS numericFloat3 NUMERIC $.numericInt4 AS numericInt4 NUMERIC $.numericFloat4 AS numericFloat4 NUMERIC $.numericInt5 AS numericInt5 NUMERIC $.numericFloat5 AS numericFloat5 NUMERIC $.numericInt6 AS numericInt6 NUMERIC $.numericFloat6 AS numericFloat6 NUMERIC $.numericInt7 AS numericInt7 NUMERIC $.numericFloat7 AS numericFloat7 NUMERIC $.numericInt8 AS numericInt8 NUMERIC $.numericFloat8 AS numericFloat8 NUMERIC $.numericInt9 AS numericInt9 NUMERIC $.numericFloat9 AS numericFloat9 NUMERIC $.numericInt10 AS numericInt10 NUMERIC $.numericFloat10 AS numericFloat10 NUMERIC'
+  - check:
+      keyspacelen: 10000
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 4 --hide-histogram --key-prefix 'doc:single' --key-minimum 1 --key-maximum 10000 --command 'FT.SEARCH idx:single * NOCONTENT LIMIT 0 1' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"

--- a/tests/benchmarks/search-expire-doc-multi-index-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-multi-index-10-milliseconds.yml
@@ -1,0 +1,46 @@
+version: 0.2
+name: "search-expire-doc-multi-index-10-milliseconds"
+description: |
+  TTL table benchmark for document expiration when multiple indexes share the
+  same key prefix. Three FT indexes on the idx10: prefix all monitor doc-level
+  expiration, so every PEXPIRE notification is fanned out across all three
+  specs.
+
+  Under the old reindex path this means N (=3) full re-tokenizations and
+  inverted-index rewrites per PEXPIRE; under the fast path
+  (Indexes_UpdateMatchingDocExpiration) this collapses to N short
+  DocTable_UpdateExpiration calls. Active expiration is disabled so docs
+  remain in the dataset and the per-spec write-lock fan-out is the dominant
+  observable.
+
+  Search side uses a deterministic catch-all on idx10_a so re-triggers on the
+  same branch produce stable throughput (>1000 QPS); the optimization signal
+  comes from the PEXPIRE × 3-index fan-out.
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "EXPIRE PEXPIRE fast path with N greater than 1 matching indexes amplifies the per-spec metadata-update vs full-reindex delta"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-multi-index-10ms"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - '"FT.CREATE" "idx10_a" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+      - '"FT.CREATE" "idx10_b" "PREFIX" "1" "idx10:" "SCHEMA" "field2" "TEXT" "field3" "TEXT"'
+      - '"FT.CREATE" "idx10_c" "PREFIX" "1" "idx10:" "SCHEMA" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC"'
+  - dataset_load_timeout_secs: 240
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10_a * NOCONTENT LIMIT 0 1' --command-ratio 95 --command 'PEXPIRE __key__ 10' --command-ratio 5"

--- a/tests/benchmarks/search-expire-write-read-concurrent.yml
+++ b/tests/benchmarks/search-expire-write-read-concurrent.yml
@@ -1,0 +1,35 @@
+version: 0.2
+name: "search-expire-write-read-concurrent"
+description: |
+  TTL table benchmark for document expiration and persist notifications.
+  This variant covers the write path (EXPIRE/PERSIST), not the read path.s
+
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 16 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'EXPIRE __key__ 1000000' --command-ratio 30 --command 'PERSIST __key__' --command-ratio 30 --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"' --command-ratio 40"

--- a/tests/benchmarks/search-persist-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-persist-doc-1000-seconds.yml
@@ -1,0 +1,43 @@
+version: 0.2
+name: "search-persist-doc-1000-seconds"
+description: |
+  TTL table benchmark exercising the PERSIST keyspace-notification path on
+  indexed hash documents. Each PERSIST clears the key's absolute expiration;
+  in the in-memory flow this is routed through the doc-expiration fast path
+  (Indexes_UpdateMatchingDocExpiration) instead of a full reindex.
+
+  Keeps both the SET-TTL (EXPIRE) and CLEAR-TTL (PERSIST) branches busy with
+  symmetric ratios (5%/5%) on top of a search-dominant load. Active expiration
+  is disabled and TTL=1000s so the dataset never evicts during the 180s test;
+  every notification is a pure metadata update on the matching DMD, which is
+  the property we want to keep stable across re-triggers.
+
+  Search side uses a deterministic catch-all (`FT.SEARCH idx10 * NOCONTENT
+  LIMIT 0 1`) to keep query latency tight (low variance) and push throughput
+  well above 1000 QPS.
+
+metadata:
+  component: "search"
+  group: "expire-persist"
+  use_case: "PERSIST keyspace-notification fast path on indexed hashes in-memory flow"
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-persist-doc-1000s"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - init_commands:
+      - '"DEBUG" "SET-ACTIVE-EXPIRE" "0"'
+      - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 16 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'FT.SEARCH idx10 * NOCONTENT LIMIT 0 1' --command-ratio 90 --command 'EXPIRE __key__ 1000' --command-ratio 5 --command 'PERSIST __key__' --command-ratio 5"

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -278,10 +278,11 @@ def test_expire_aggregate(env):
     # This test ensures that the flag indicating expiration is cleared and the search result struct is ready to be reused.
     res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@t')
     # The result count is not accurate in aggregation, because WITHOUTCOUNT is the default
-    env.assertEqual(res, [1, ['t', 'arr'], ['t', 'bar']])
+    # Accept both orders, since docID did not advance
+    env.assertEqual([res[0], sorted(res[1:])], [1, sorted([['t', 'arr'], ['t', 'bar']])])
     # Test using WITHCOUNT
     res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', 1, '@t')
-    env.assertEqual(res, [2, ['t', 'arr'], ['t', 'bar']])
+    env.assertEqual([res[0], sorted(res[1:])], [2, sorted([['t', 'arr'], ['t', 'bar']])])
 
 
 
@@ -569,6 +570,126 @@ def testLazyVectorFieldExpiration(env):
     # also we expect that the ismissing inverted index to contain document 1 since it had an active expiration
     env.expect('FT.SEARCH', 'idx', 'ismissing(@v)', 'NOCONTENT', 'DIALECT', '3').equal([1, 'doc:1'])
 
+def _setup_non_matching_indexes(env):
+    # Shared setup for the EXPIRE/PEXPIRE/PERSIST scenarios. Three distinct
+    # ways an index can fail to match the key are exercised:
+    #   - idx_other_prefix: PREFIX excludes the key entirely, so the spec is
+    #                       not returned by FindMatchingSchemaRules.
+    #   - idx_filter_skip:  PREFIX matches but the FILTER excludes the doc, so
+    #                       FindMatchingSchemaRules tags the op as SpecOp_Del.
+    #   - idx_no_monitor:   PREFIX matches but monitorDocumentExpiration is
+    #                       disabled, so the spec is skipped on the fast path.
+    # Only idx_match should reflect TTL changes via DocTable_UpdateExpiration.
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+
+    env.expect('FT.CREATE', 'idx_match', 'ON', 'HASH',
+               'PREFIX', '1', 'doc:',
+               'SCHEMA', 'x', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx_other_prefix', 'ON', 'HASH',
+               'PREFIX', '1', 'other:',
+               'SCHEMA', 'x', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx_filter_skip', 'ON', 'HASH',
+               'PREFIX', '1', 'doc:',
+               'FILTER', '@n == 100',
+               'SCHEMA', 'x', 'TEXT', 'n', 'NUMERIC').ok()
+    env.expect('FT.CREATE', 'idx_no_monitor', 'ON', 'HASH',
+               'PREFIX', '1', 'doc:',
+               'SCHEMA', 'x', 'TEXT').ok()
+
+    # Disable doc-level expiration tracking on idx_no_monitor; the other specs
+    # keep the default monitorDocumentExpiration=true.
+    env.cmd(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx_no_monitor', 'not-documents')
+
+    # n=1 fails the FILTER on idx_filter_skip but the PREFIX still selects
+    # these hashes for the keyspace-notification path.
+    conn.execute_command('HSET', 'doc:1', 'x', 'hello', 'n', '1')
+    conn.execute_command('HSET', 'doc:2', 'x', 'hello', 'n', '1')
+    # other:1 belongs only to idx_other_prefix.
+    conn.execute_command('HSET', 'other:1', 'x', 'hello')
+
+    # Sanity check: every index returns the docs it is supposed to before
+    # any TTL command fires.
+    env.expect('FT.SEARCH', 'idx_match', '@x:hello', 'NOCONTENT') \
+        .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+    env.expect('FT.SEARCH', 'idx_no_monitor', '@x:hello', 'NOCONTENT') \
+        .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+    env.expect('FT.SEARCH', 'idx_other_prefix', '@x:hello', 'NOCONTENT') \
+        .equal([1, 'other:1'])
+    env.expect('FT.SEARCH', 'idx_filter_skip', '*', 'NOCONTENT').equal([0])
+
+    return conn
+
+
+def _assert_non_matching_indexes_unchanged(env):
+    # Indexes that did not match doc:1 must keep their pre-TTL view of the
+    # data regardless of which TTL command fired.
+    #
+    # idx_no_monitor: spec opted out, so the fast path skipped it and the
+    # DocTable entry for doc:1 was never tagged. Active expiration is off,
+    # so the underlying hash is still present and doc:1 remains visible.
+    env.expect('FT.SEARCH', 'idx_no_monitor', '@x:hello', 'NOCONTENT') \
+        .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+    # idx_other_prefix: doc:1 was never selected by this index's PREFIX, and
+    # other:1 has no TTL of its own.
+    env.expect('FT.SEARCH', 'idx_other_prefix', '@x:hello', 'NOCONTENT') \
+        .equal([1, 'other:1'])
+    # idx_filter_skip: the FILTER excludes every doc, so the index stays
+    # empty and the SpecOp_Del branch in the fast path is exercised.
+    env.expect('FT.SEARCH', 'idx_filter_skip', '*', 'NOCONTENT').equal([0])
+
+
+def _run_key_expiration_with_non_matching_indexes(env, expire_cmd, ttl_arg, sleep_secs):
+    # Cover the full-key TTL case when several indexes coexist but only
+    # idx_match is affected by an EXPIRE/PEXPIRE notification.
+    conn = _setup_non_matching_indexes(env)
+
+    conn.execute_command(expire_cmd, 'doc:1', ttl_arg)
+    # https://www.kernel.org/doc/html/latest/core-api/timekeeping.html (CLOCK_REALTIME_COARSE may be off by 10ms)
+    time.sleep(sleep_secs)
+
+    # idx_match: monitorDocumentExpiration=true, so DocTable_UpdateExpiration
+    # ran for doc:1 and DocTable_IsDocExpired now filters it out at search.
+    env.expect('FT.SEARCH', 'idx_match', '@x:hello', 'NOCONTENT').equal([1, 'doc:2'])
+
+    _assert_non_matching_indexes_unchanged(env)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def testKeyExpirationWithNonMatchingIndexes(env):
+    # PEXPIRE granularity: TTL of 1ms, expires almost immediately.
+    _run_key_expiration_with_non_matching_indexes(env, 'PEXPIRE', '1', 0.015)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def testKeyExpirationWithNonMatchingIndexesExpire(env):
+    # EXPIRE (seconds) granularity: same scenario, but the keyspace
+    # notification arrives via the seconds-based path.
+    _run_key_expiration_with_non_matching_indexes(env, 'EXPIRE', '1', 1.05)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def testKeyPersistWithNonMatchingIndexes(env):
+    # PERSIST shares the expire_cmd branch in src/notifications.c, so it
+    # also flows through Indexes_UpdateMatchingDocExpiration. Verify that
+    # clearing the TTL on doc:1 propagates to idx_match's DocTable entry
+    # so the doc remains visible past the original PEXPIRE deadline, while
+    # the non-matching indexes keep their pre-TTL view.
+    conn = _setup_non_matching_indexes(env)
+
+    conn.execute_command('PEXPIRE', 'doc:1', '1')
+    # PERSIST runs synchronously on the main thread before the sleep, so it
+    # clears the DocTable expiration recorded by the PEXPIRE notification.
+    conn.execute_command('PERSIST', 'doc:1')
+    time.sleep(0.015)
+
+    # idx_match: PERSIST cleared the DocTable TTL, so DocTable_IsDocExpired
+    # returns false and doc:1 is still visible.
+    env.expect('FT.SEARCH', 'idx_match', '@x:hello', 'NOCONTENT') \
+        .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+
+    _assert_non_matching_indexes_unchanged(env)
+
 
 @skip(redis_less_than='7.3')
 def testLastFieldNoExpiration(env):
@@ -715,3 +836,82 @@ def test_ttl_table_collision_chain():
     res = env.cmd('FT.SEARCH', 'idx', f'@n:[1 {N}]', 'NOCONTENT', 'LIMIT', '0', str(N))
     returned = sorted(int(d.split(':')[1]) for d in res[1:])
     env.assertEqual(returned, expected)
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_wide_schema_field_expiration(env):
+    # Indexes with >32 text fields are auto-promoted to wide schema encoding.
+    # We use also field index >= 64 to trigger high half loop iteration
+    N_FIELDS = 70
+
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+
+    schema = list(chain.from_iterable((f'f{i}', 'TEXT') for i in range(N_FIELDS)))
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', *schema)
+
+    hello_kv = list(chain.from_iterable((f'f{i}', 'hello') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:plain', *hello_kv)
+    conn.execute_command('HSET', 'doc:short', *hello_kv)
+    conn.execute_command('HPEXPIRE', 'doc:short', '1', 'FIELDS', '1', 'f5')
+
+    kv_scan = list(chain.from_iterable(
+        (f'f{i}', 'needle' if i in (3, 67) else 'filler') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:scan', *kv_scan)
+    conn.execute_command('HPEXPIRE', 'doc:scan', '1', 'FIELDS', '2', 'f3', 'f67')
+
+    conn.execute_command('HSET', 'doc:docexp', *hello_kv)
+    conn.execute_command('EXPIRE', 'doc:docexp', '30000')
+
+    kv_lowexp = list(chain.from_iterable(
+        (f'f{i}', 'tophalf' if i == 67 else 'other') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:lowexp', *kv_lowexp)
+    conn.execute_command('HPEXPIRE', 'doc:lowexp', '1', 'FIELDS', '1', 'f5')
+
+    kv_below = list(chain.from_iterable(
+        (f'f{i}', 'below' if i == 3 else 'other') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:below', *kv_below)
+    conn.execute_command('HPEXPIRE', 'doc:below', '1', 'FIELDS', '1', 'f50')
+
+    kv_live = list(chain.from_iterable(
+        (f'f{i}', 'alive' if i == 3 else 'other') for i in range(N_FIELDS)))
+    conn.execute_command('HSET', 'doc:live', *kv_live)
+    conn.execute_command('HEXPIRE', 'doc:live', '30000', 'FIELDS', '1', 'f3')
+
+    waitForIndex(env, 'idx')
+
+    time.sleep(0.050)
+
+    # Match because:
+    # - "doc:plain" has no expiration
+    # - "doc:docexp" has a long doc expiration time
+    # - "doc:short" has f5 expired but not the others
+    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT').apply(sort_document_names) \
+        .equal([3, 'doc:docexp', 'doc:plain', 'doc:short'])
+    # Not match because:
+    # - "doc:scan" f3 and f67 were expired
+    env.expect('FT.SEARCH', 'idx', 'needle', 'NOCONTENT').equal([0])
+    # Match because:
+    # - "doc:lowexp" f67 matches so the f5 expiration is not considered
+    env.expect('FT.SEARCH', 'idx', 'tophalf', 'NOCONTENT').equal([1, 'doc:lowexp'])
+    # Match because:
+    # - "doc:below" f3 matches so the f50 expiration is not considered
+    env.expect('FT.SEARCH', 'idx', 'below', 'NOCONTENT').equal([1, 'doc:below'])
+    # Match because:
+    # - "doc:live" f3 matches and it is not expired yet
+    env.expect('FT.SEARCH', 'idx', 'alive', 'NOCONTENT').equal([1, 'doc:live'])
+
+@skip(cluster=True)
+def test_expire_past_timestamp_removes_doc(env):
+    env.cmd('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('HSET', 'doc:1', 't', 'hello').equal(1)
+    env.expect('HSET', 'doc:2', 't', 'world').equal(1)
+    waitForIndex(env, 'idx')
+
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').apply(sort_document_names).equal(
+        [2, 'doc:1', 'doc:2'])
+
+    env.expect('EXPIREAT', 'doc:1', '1').equal(1)
+
+    env.expect('EXISTS', 'doc:1').equal(0)
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal([1, 'doc:2'])

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -293,12 +293,16 @@ def expireDocs(isSortable, iter1_expected_without_sortby, iter1_expected_with_so
             'SORTABLE ' if isSortable else '', 'without' if i == 0 else 'with')
         # First iteration
         expected_res = iter1_expected_without_sortby if i == 0 else iter1_expected_with_sortby
+        # Accept both orders, since docID did not advance: pair up (name, fields)
+        # entries and compare as unordered sets.
+        def to_pairs(r):
+            return [r[0], sorted(zip(r[1::2], r[2::2]))]
         # Opening the key should fail on both slave and master should and the result should be marked with
         # a null value.
         res = slave.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
-        env.assertEqual(res, expected_res, message=(msg + " slave"))
+        env.assertEqual(to_pairs(res), to_pairs(expected_res), message=(msg + " slave"))
         res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
-        env.assertEqual(res, expected_res, message=(msg + " master"))
+        env.assertEqual(to_pairs(res), to_pairs(expected_res), message=(msg + " master"))
 
         # Cancel lazy expire to allow the deletion of the key
         master.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '1')


### PR DESCRIPTION
Backport #9356 to 8.6-rse

## Backport notes

**1 conflict resolved** — otherwise a clean cherry-pick.

### Conflict: `tests/pytests/test_expire.py`

Two new test functions (`test_wide_schema_field_expiration` and `test_expire_past_timestamp_removes_doc`) were added by the original PR at the end of the file. The HEAD side of the conflict was empty — the functions didn't exist on 8.6-rse yet.

**Resolution**: Accepted the cherry-pick's additions verbatim.

---

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

**Release note:**

> Optimize handling of `EXPIRE` and `PERSIST` on indexed documents: the index now updates only the document's TTL metadata instead of fully reindexing the document, reducing CPU and memory churn for TTL-driven workloads. Applies to in-memory indexes
