### PR TITLE
MOD-14811: Add test coverage for GROUPBY COLLECT reducer

### DIFF
--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1309,6 +1309,34 @@ def test_collect_sortby_limit_merges_global_topk_across_shards():
 
 
 # ---------------------------------------------------------------------------
+# Heap path (SORTBY without LIMIT) default-caps at 10 by design.
+# ---------------------------------------------------------------------------
+def test_collect_sortby_without_limit_caps_at_default_10():
+    """COLLECT + SORTBY without an explicit LIMIT runs the heap path with its
+    default capacity of 10, even when the group has more matching docs."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_hash(env)
+
+    # PRICED has 12 docs in the 'red' group; ASC top-10 by price drops the
+    # two highest-priced names (charlie=15, dave=15).
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+        'REDUCE', 'COLLECT', '7',
+            'FIELDS', '1', '@name',
+            'SORTBY', '2', '@price', 'ASC',
+        'AS', 'names')
+
+    entries = res['results'][0]['extra_attributes']['names']
+    env.assertEqual(len(entries), 10)
+    names = {e['name'] for e in entries}
+    # The two highest-priced docs must be the ones dropped.
+    env.assertNotContains('charlie', names)
+    env.assertNotContains('dave', names)
+
+
+# ---------------------------------------------------------------------------
 # Array path (no SORTBY, no LIMIT) capped by MAXAGGREGATERESULTS
 # ---------------------------------------------------------------------------
 @skip(no_json=True)

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1335,3 +1335,391 @@ def test_collect_array_path_capped_by_max_aggregate_results():
             env.assertContains(e['name'], known)
     finally:
         env.expect(config_cmd(), 'SET', 'MAXAGGREGATERESULTS', '-1').ok()
+
+
+# ---------------------------------------------------------------------------
+# Multiple COLLECT reducers in one GROUPBY: independent fields / LIMIT / SORTBY
+# ---------------------------------------------------------------------------
+def test_two_collect_reducers_different_fields():
+    """Two COLLECTs in the same GROUPBY emit independent arrays with their own
+    field sets."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'names',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@sweetness',
+                'SORTBY', '2', '@sweetness', 'ASC',
+            'AS', 'sweets')
+
+    expected_names = {
+        'green':  [{'name': 'kiwi'},   {'name': 'lime'}],
+        'red':    [{'name': 'apple'},  {'name': 'strawberry'}],
+        'yellow': [{'name': 'banana'}, {'name': 'lemon'}],
+    }
+    expected_sweets = {
+        'green':  [{'sweetness': '2'}, {'sweetness': '3'}],
+        'red':    [{'sweetness': '3'}, {'sweetness': '4'}],
+        'yellow': [{'sweetness': '2'}, {'sweetness': '4'}],
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        env.assertEqual(attrs['names'],  expected_names[attrs['color']])
+        env.assertEqual(attrs['sweets'], expected_sweets[attrs['color']])
+
+
+def test_two_collect_reducers_one_with_limit():
+    """LIMIT on one COLLECT must not bound the sibling COLLECT in the same group."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'all_names',
+            'REDUCE', 'COLLECT', '10',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+                'LIMIT', '0', '1',
+            'AS', 'one_name')
+
+    expected_all = {
+        'green':  [{'name': 'kiwi'},   {'name': 'lime'}],
+        'red':    [{'name': 'apple'},  {'name': 'strawberry'}],
+        'yellow': [{'name': 'banana'}, {'name': 'lemon'}],
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        env.assertEqual(attrs['all_names'], expected_all[attrs['color']])
+        # LIMIT 0,1 after SORTBY @name ASC picks the first of the full set.
+        env.assertEqual(attrs['one_name'], [expected_all[attrs['color']][0]])
+
+
+def test_two_collect_reducers_sortby_different_keys():
+    """Two COLLECTs with different SORTBY keys keep independent heap state."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '10',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+                'LIMIT', '0', '1',
+            'AS', 'first_by_name',
+            'REDUCE', 'COLLECT', '10',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'DESC',
+                'LIMIT', '0', '1',
+            'AS', 'top_sweet',
+        'SORTBY', '2', '@color', 'ASC')
+
+    # name ASC firsts: 'apple' < 'strawberry'; 'banana' < 'lemon'; 'kiwi' < 'lime'.
+    expected_first_by_name = {
+        'green':  [{'name': 'kiwi'}],
+        'red':    [{'name': 'apple'}],
+        'yellow': [{'name': 'banana'}],
+    }
+    # sweetness DESC: red -> apple(4); yellow -> banana(4); green tie -> kiwi(3).
+    expected_top_sweet = {
+        'green':  [{'name': 'kiwi'}],
+        'red':    [{'name': 'apple'}],
+        'yellow': [{'name': 'banana'}],
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        env.assertEqual(attrs['first_by_name'], expected_first_by_name[attrs['color']])
+        env.assertEqual(attrs['top_sweet'],     expected_top_sweet[attrs['color']])
+
+
+@skip(cluster=False)
+def test_two_collect_reducers_overlapping_fields_cluster():
+    """Two COLLECTs over @name with divergent SORTBY/LIMIT keep independent
+    state across shards."""
+    env = Env(shardsCount=3, protocol=3)
+    enable_unstable_features(env)
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA',
+               'name', 'TEXT', 'SORTABLE',
+               'color', 'TAG', 'SORTABLE').ok()
+
+    shard_tags = ['shard:0', 'shard:1', 'shard:3']
+    conn = getConnectionByEnv(env)
+    for i, f in enumerate(FRUITS):
+        conn.execute_command('HSET', f'doc:{i}{{{shard_tags[i % 3]}}}',
+                             'name', f['name'], 'color', f['color'])
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'all_asc',
+            'REDUCE', 'COLLECT', '10',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'DESC',
+                'LIMIT', '0', '1',
+            'AS', 'last_desc')
+
+    # Full ASC list — pins that both shards' rows are merged.
+    expected_all = {
+        'green':  [{'name': 'kiwi'},   {'name': 'lime'}],
+        'red':    [{'name': 'apple'},  {'name': 'strawberry'}],
+        'yellow': [{'name': 'banana'}, {'name': 'lemon'}],
+    }
+    # Top-1 DESC after global shard merge: must be the last name in the ASC list.
+    expected_last = {
+        'green':  [{'name': 'lime'}],
+        'red':    [{'name': 'strawberry'}],
+        'yellow': [{'name': 'lemon'}],
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        env.assertEqual(attrs['all_asc'],   expected_all[attrs['color']])
+        env.assertEqual(attrs['last_desc'], expected_last[attrs['color']])
+
+
+# ---------------------------------------------------------------------------
+# COLLECT across multiple GROUPBY stages
+# ---------------------------------------------------------------------------
+def test_collect_in_first_groupby_survives_second_groupby():
+    """A COLLECT array produced in stage 1 must round-trip as a payload through
+    a stage-2 GROUPBY."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COUNT', '0', 'AS', 'cnt',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'items',
+        'APPLY', 'to_str(@cnt)', 'AS', 'cnt_str',
+        'GROUPBY', '1', '@cnt_str',
+            'REDUCE', 'COLLECT', '8',
+                'FIELDS', '2', '@color', '@items',
+                'SORTBY', '2', '@color', 'ASC',
+            'AS', 'rolled')
+
+    # All three colors have cnt=2, so they roll up under a single cnt_str group.
+    env.assertEqual(len(res['results']), 1)
+    rolled = res['results'][0]['extra_attributes']['rolled']
+    env.assertEqual([e['color'] for e in rolled], ['green', 'red', 'yellow'])
+    for entry in rolled:
+        # The nested COLLECT array survived the regroup.
+        env.assertEqual(len(entry['items']), 2)
+
+
+def test_three_stage_groupby_with_collect_at_end():
+    """Three-stage pipeline: GROUPBY @color → APPLY derives @is_sweet →
+    GROUPBY @is_sweet with COLLECT."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'AVG', '1', '@sweetness', 'AS', 'avg_sweet',
+        'APPLY', '@avg_sweet >= 3', 'AS', 'is_sweet',
+        'GROUPBY', '1', '@is_sweet',
+            'REDUCE', 'COLLECT', '8',
+                'FIELDS', '2', '@color', '@avg_sweet',
+                'SORTBY', '2', '@color', 'ASC',
+            'AS', 'colors',
+        'SORTBY', '2', '@is_sweet', 'ASC')
+
+    # avg_sweet: green=2.5, red=3.5, yellow=3.0 → green is the only @is_sweet=0 group.
+    env.assertEqual(res['results'][0]['extra_attributes']['colors'],
+                    [{'color': 'green', 'avg_sweet': '2.5'}])
+    env.assertEqual(res['results'][1]['extra_attributes']['colors'], [
+        {'color': 'red',    'avg_sweet': '3.5'},
+        {'color': 'yellow', 'avg_sweet': '3'},
+    ])
+
+
+def test_chained_groupby_collect_of_collect_alias():
+    """A COLLECT alias from stage 1 can be re-collected in stage 2 as a nested
+    payload."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'names',
+        'GROUPBY', '0',
+            'REDUCE', 'COLLECT', '8',
+                'FIELDS', '2', '@color', '@names',
+                'SORTBY', '2', '@color', 'ASC',
+            'AS', 'all')
+
+    env.assertEqual(len(res['results']), 1)
+    env.assertEqual(res['results'][0]['extra_attributes']['all'], [
+        {'color': 'green',  'names': [{'name': 'kiwi'},   {'name': 'lime'}]},
+        {'color': 'red',    'names': [{'name': 'apple'},  {'name': 'strawberry'}]},
+        {'color': 'yellow', 'names': [{'name': 'banana'}, {'name': 'lemon'}]},
+    ])
+
+
+# ---------------------------------------------------------------------------
+# COLLECT combined with COUNT / AVG / MIN / MAX / TOLIST in one GROUPBY
+# ---------------------------------------------------------------------------
+def test_collect_with_count_and_avg():
+    """COLLECT alongside COUNT and AVG: per-group counts/averages must match
+    collected rows."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COUNT', '0', 'AS', 'cnt',
+            'REDUCE', 'AVG', '1', '@sweetness', 'AS', 'avg_sweet',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'names',
+        'SORTBY', '2', '@color', 'ASC')
+
+    expected = {
+        'green':  ('2', '2.5', [{'name': 'kiwi'},   {'name': 'lime'}]),
+        'red':    ('2', '3.5', [{'name': 'apple'},  {'name': 'strawberry'}]),
+        'yellow': ('2', '3',   [{'name': 'banana'}, {'name': 'lemon'}]),
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        exp_cnt, exp_avg, exp_names = expected[attrs['color']]
+        env.assertEqual(attrs['cnt'], exp_cnt)
+        env.assertEqual(attrs['avg_sweet'], exp_avg)
+        env.assertEqual(attrs['names'], exp_names)
+        env.assertEqual(int(attrs['cnt']), len(attrs['names']))
+
+
+def test_collect_with_tolist_same_field():
+    """TOLIST (flat list) and COLLECT (Array<Map>) over the same field have
+    different wire shapes."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'TOLIST', '1', '@name', 'AS', 'tolist_names',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'collect_names')
+
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        # COLLECT is server-sorted; TOLIST has no SORTBY, so sort Python-side.
+        collect_flat = [e['name'] for e in attrs['collect_names']]
+        env.assertEqual(sorted(attrs['tolist_names']), collect_flat)
+        # TOLIST returns plain strings; COLLECT returns maps.
+        for v in attrs['tolist_names']:
+            env.assertEqual(type(v), str)
+        for v in attrs['collect_names']:
+            env.assertEqual(type(v), dict)
+
+
+def test_collect_with_min_max_sortby():
+    """SORTBY+LIMIT inside COLLECT must agree with MIN/MAX over the same key."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'MIN', '1', '@price', 'AS', 'min_price',
+            'REDUCE', 'MAX', '1', '@price', 'AS', 'max_price',
+            'REDUCE', 'COLLECT', '11',
+                'FIELDS', '2', '@name', '@price',
+                'SORTBY', '2', '@price', 'DESC',
+                'LIMIT', '0', '3',
+            'AS', 'top3')
+
+    attrs = res['results'][0]['extra_attributes']
+    env.assertEqual(attrs['min_price'], '1')
+    env.assertEqual(attrs['max_price'], '15')
+    top3 = attrs['top3']
+    env.assertEqual(len(top3), 3)
+    # MAX must equal the first (DESC-sorted) collected price.
+    env.assertEqual(top3[0]['price'], attrs['max_price'])
+    # Collected prices are sorted DESC: 15, 15, 10 (charlie/dave tie, then alice).
+    env.assertEqual([e['price'] for e in top3], ['15', '15', '10'])
+
+
+def test_collect_with_quantile_and_stddev():
+    """QUANTILE and STDDEV coexist with COLLECT without state interference."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'QUANTILE', '2', '@price', '0.5', 'AS', 'q50',
+            'REDUCE', 'STDDEV', '1', '@price',          'AS', 'stddev_price',
+            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@price', 'AS', 'prices')
+
+    attrs = res['results'][0]['extra_attributes']
+    # All 12 prices are collected; reducers see the same 12 inputs.
+    env.assertEqual(len(attrs['prices']), 12)
+    # Sorted prices (0-indexed): [1, 2, 3, 4, 5, 6, 7, 8, 10, 10, 15, 15].
+    # QUANTILE picks rank = ceil(quantile * n) - 1 in the sorted input.
+    # For the median (quantile=0.5) over n=12 → index 5 → '6'.
+    env.assertEqual(attrs['q50'], '6')
+    # Sample STDDEV (n-1 denominator) over the 12 prices ≈ 4.6478.
+    env.assertAlmostEqual(float(attrs['stddev_price']), 4.6478, delta=1e-3)
+
+
+def test_collect_followed_by_apply_and_filter():
+    """COLLECT coexists with a post-GROUPBY APPLY and FILTER on sibling reducer
+    output."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COUNT', '0', 'AS', 'cnt',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@name', 'ASC',
+            'AS', 'names',
+        'APPLY', 'upper(@color)', 'AS', 'color_upper',
+        'FILTER', '@color == "red"')
+
+    env.assertEqual(len(res['results']), 1)
+    attrs = res['results'][0]['extra_attributes']
+    env.assertEqual(attrs['color'], 'red')
+    env.assertEqual(attrs['color_upper'], 'RED')
+    env.assertEqual(int(attrs['cnt']), 2)
+    env.assertEqual(attrs['names'], [{'name': 'apple'}, {'name': 'strawberry'}])

--- a/tests/pytests/test_groupby_collect_limits.py
+++ b/tests/pytests/test_groupby_collect_limits.py
@@ -1,0 +1,192 @@
+from common import *
+
+
+# Limits exercised here, mirrored from C constants so a future bump fails loudly:
+#   COLLECT FIELDS count : SPEC_MAX_FIELDS + 1  (src/aggregate/reducers/collect.c)
+#   COLLECT SORTBY keys  : SORTASCMAP_MAXFIELDS (src/result_processor.h)
+SPEC_MAX_FIELDS = 1024
+COLLECT_MAX_FIELD_ARGS = SPEC_MAX_FIELDS + 1
+COLLECT_MAX_SORT_KEYS = 8
+
+# TEXT fields share the t_fieldMask bitmap (sizeof(t_fieldMask) * 8 = 128) so
+# only the first 128 fields can be TEXT; the rest must use TAG or NUMERIC.
+SPEC_MAX_TEXT_FIELDS = 128
+
+
+def _field_type(i):
+    """Distribute field types across the schema while staying within the TEXT
+    bitmap cap."""
+    if i < SPEC_MAX_TEXT_FIELDS:
+        return 'TEXT'
+    # Alternate TAG and NUMERIC for the remainder.
+    return 'TAG' if (i % 2 == 0) else 'NUMERIC'
+
+
+def _field_value(i):
+    """Numeric fields require parseable numeric values or indexing fails."""
+    return str(i) if _field_type(i) == 'NUMERIC' else f'v{i}'
+
+
+def _create_wide_index(env, n_fields):
+    """Create idx with `n_fields` fields named f0..f{n-1}"""
+    schema = []
+    for i in range(n_fields):
+        schema.extend([f'f{i}', _field_type(i)])
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', *schema).ok()
+
+
+def _create_sortby_index(env):
+    """Index with 9 sortable fields so we can build SORTBY lists at and over
+    COLLECT_MAX_SORT_KEYS (8)."""
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
+               's0', 'TAG', 'SORTABLE',
+               's1', 'NUMERIC', 'SORTABLE',
+               's2', 'NUMERIC', 'SORTABLE',
+               's3', 'NUMERIC', 'SORTABLE',
+               's4', 'NUMERIC', 'SORTABLE',
+               's5', 'NUMERIC', 'SORTABLE',
+               's6', 'NUMERIC', 'SORTABLE',
+               's7', 'NUMERIC', 'SORTABLE',
+               's8', 'NUMERIC', 'SORTABLE').ok()
+    getConnectionByEnv(env).execute_command(
+        'HSET', 'doc:1',
+        's0', 'g', 's1', '1', 's2', '2', 's3', '3', 's4', '4',
+        's5', '5', 's6', '6', 's7', '7', 's8', '8')
+
+
+# ---------------------------------------------------------------------------
+# COLLECT FIELDS count limit
+# ---------------------------------------------------------------------------
+def test_collect_fields_at_spec_max_fields():
+    """COLLECT FIELDS listing all SPEC_MAX_FIELDS (1024) schema fields runs
+    end-to-end."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _create_wide_index(env, SPEC_MAX_FIELDS)
+
+    # Create a single doc with all fields set.
+    args = ['HSET', 'doc:1']
+    for i in range(SPEC_MAX_FIELDS):
+        args.extend([f'f{i}', _field_value(i)])
+    getConnectionByEnv(env).execute_command(*args)
+
+    names = [f'@f{i}' for i in range(SPEC_MAX_FIELDS)]
+    reduce_argc = 2 + SPEC_MAX_FIELDS  # FIELDS <count> <name...>
+    # LOAD '*' pulls every hash field into the RLookup; without it only the
+    # SORTABLE @f0 would survive into the COLLECT input.
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'LOAD', '*',
+        'GROUPBY', '1', '@f0',
+            'REDUCE', 'COLLECT', str(reduce_argc),
+                'FIELDS', str(SPEC_MAX_FIELDS), *names,
+            'AS', 'rows')
+
+    env.assertEqual(len(res['results']), 1)
+    collected = res['results'][0]['extra_attributes']['rows']
+    env.assertEqual(len(collected), 1)
+    env.assertEqual(len(collected[0]), SPEC_MAX_FIELDS)
+    env.assertEqual(collected[0]['f0'], _field_value(0))
+    last = SPEC_MAX_FIELDS - 1
+    env.assertEqual(collected[0][f'f{last}'], _field_value(last))
+
+
+def test_collect_fields_sparse_docs():
+    """One doc per schema field, each setting only that single field."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _create_wide_index(env, SPEC_MAX_FIELDS)
+
+    # Create SPEC_MAX_FIELDS docs, each with a single field set.
+    conn = getConnectionByEnv(env)
+    for i in range(SPEC_MAX_FIELDS):
+        conn.execute_command('HSET', f'doc:{i}', f'f{i}', _field_value(i))
+
+    names = [f'@f{i}' for i in range(SPEC_MAX_FIELDS)]
+    reduce_argc = 2 + SPEC_MAX_FIELDS
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'LOAD', '*',
+        'GROUPBY', '0',
+            'REDUCE', 'COLLECT', str(reduce_argc),
+                'FIELDS', str(SPEC_MAX_FIELDS), *names,
+            'AS', 'rows')
+
+    env.assertEqual(len(res['results']), 1)
+    collected = res['results'][0]['extra_attributes']['rows']
+    print(collected)
+    env.assertEqual(len(collected), SPEC_MAX_FIELDS)
+    expected = sorted(
+        ({f'f{i}': _field_value(i)} for i in range(SPEC_MAX_FIELDS)),
+        key=lambda d: next(iter(d)))
+    got = sorted(collected, key=lambda d: next(iter(d)))
+    print(got)
+    env.assertEqual(got, expected)
+
+
+def test_collect_fields_count_over_max_errors():
+    """COLLECT FIELDS count > COLLECT_MAX_FIELD_ARGS is rejected at parse time,
+    so we don't need to actually provide the oversized name list."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _create_wide_index(env, 2)
+    over = COLLECT_MAX_FIELD_ARGS + 1
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@f0',
+            'REDUCE', 'COLLECT', '3',
+                'FIELDS', str(over), '@f0',
+            'AS', 'rows'
+    ).error().contains(
+        f'FIELDS count must be in [1, {COLLECT_MAX_FIELD_ARGS}]')
+
+
+# ---------------------------------------------------------------------------
+# COLLECT SORTBY key-count limit
+# ---------------------------------------------------------------------------
+def test_collect_sortby_at_max_keys():
+    """COLLECT SORTBY with exactly COLLECT_MAX_SORT_KEYS keys succeeds."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _create_sortby_index(env)
+
+    sort_tokens = []
+    for i in range(COLLECT_MAX_SORT_KEYS):
+        sort_tokens.extend([f'@s{i + 1}', 'ASC'])
+
+    reduce_argc = 5 + len(sort_tokens)  # FIELDS 1 @x SORTBY <n> <tokens>
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@s0',
+            'REDUCE', 'COLLECT', str(reduce_argc),
+                'FIELDS', '1', '@s1',
+                'SORTBY', str(len(sort_tokens)), *sort_tokens,
+            'AS', 'rows')
+
+    env.assertEqual(len(res['results']), 1)
+    env.assertEqual(res['results'][0]['extra_attributes']['rows'],
+                    [{'s1': '1'}])
+
+
+def test_collect_sortby_over_max_keys_errors():
+    """COLLECT SORTBY with > COLLECT_MAX_SORT_KEYS keys is rejected on the
+    standalone (local) parse path."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _create_sortby_index(env)
+
+    n = COLLECT_MAX_SORT_KEYS + 1
+    sort_tokens = []
+    for i in range(n):
+        sort_tokens.extend([f'@s{i}', 'ASC'])
+
+    reduce_argc = 5 + len(sort_tokens)  # FIELDS 1 @x SORTBY <n> <tokens>
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@s0',
+            'REDUCE', 'COLLECT', str(reduce_argc),
+                'FIELDS', '1', '@s1',
+                'SORTBY', str(len(sort_tokens)), *sort_tokens,
+            'AS', 'rows'
+    ).error().contains(
+        f'SORTBY exceeds maximum of {COLLECT_MAX_SORT_KEYS} fields')

--- a/tests/pytests/test_groupby_collect_limits.py
+++ b/tests/pytests/test_groupby_collect_limits.py
@@ -176,7 +176,7 @@ def test_collect_sortby_over_max_keys_errors():
     n = COLLECT_MAX_SORT_KEYS + 1
     sort_tokens = []
     for i in range(n):
-        sort_tokens.extend([f'@s{i}', 'ASC'])
+        sort_tokens.extend([f'@s{i}'])
 
     reduce_argc = 5 + len(sort_tokens)  # FIELDS 1 @x SORTBY <n> <tokens>
     env.expect(

--- a/tests/pytests/test_groupby_collect_limits.py
+++ b/tests/pytests/test_groupby_collect_limits.py
@@ -114,13 +114,11 @@ def test_collect_fields_sparse_docs():
 
     env.assertEqual(len(res['results']), 1)
     collected = res['results'][0]['extra_attributes']['rows']
-    print(collected)
     env.assertEqual(len(collected), SPEC_MAX_FIELDS)
     expected = sorted(
         ({f'f{i}': _field_value(i)} for i in range(SPEC_MAX_FIELDS)),
         key=lambda d: next(iter(d)))
     got = sorted(collected, key=lambda d: next(iter(d)))
-    print(got)
     env.assertEqual(got, expected)
 
 

--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -187,3 +187,71 @@ def test_hybrid_groupby_with_filter():
     sum_of_counts = sum(results.values())
     expected_sum = 8  # 2+2+2+2 (fitness with count=1 is filtered out)
     env.assertEqual(sum_of_counts, expected_sum)
+
+
+def test_hybrid_groupby_multiple_collect_reducers():
+    """FT.HYBRID with two COLLECT reducers in one GROUPBY, each producing a
+    'top hits' collection per group ordered by a different yielded score
+    (vector_score vs search_score)."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    setup_hybrid_groupby_index(env)
+
+    # All 9 docs contain "red", while VSIM RADIUS 2**2 covers doc:1..doc:6.
+    # FT.HYBRID returns the union of both subqueries, so doc:7..doc:9 are
+    # present too, but they do not carry vector_score.
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+    radius = 2**2
+
+    res = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', '@description:(red)',
+            'YIELD_SCORE_AS', 'search_score',
+        'VSIM', '@embedding', '$BLOB',
+            'RANGE', '2', 'RADIUS', str(radius),
+            'YIELD_SCORE_AS', 'vector_score',
+        'GROUPBY', '1', '@category',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '2', '@__key', '@vector_score',
+                'SORTBY', '1', '@vector_score',
+                'AS', 'top_vector_results',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '2', '@__key', '@search_score',
+                'SORTBY', '1', '@search_score',
+                'AS', 'top_search_results',
+        'SORTBY', '2', '@category', 'ASC',
+        'PARAMS', '2', 'BLOB', query_vector)
+
+    expected_by_category = {
+        'automotive': {'doc:1', 'doc:2'},
+        'clothing':   {'doc:3', 'doc:4'},
+        'footwear':   {'doc:5', 'doc:6'},
+        'food':       {'doc:7', 'doc:8'},
+        'fitness':    {'doc:9'},
+    }
+    vector_scored_categories = {'automotive', 'clothing', 'footwear'}
+
+    results = res['results']
+    env.assertEqual(len(results), len(expected_by_category))
+
+    for r in results:
+        attrs = r.get('extra_attributes', r)
+        cat = attrs['category']
+        env.assertTrue(cat in expected_by_category,
+                       message=f"Unexpected category: {cat}")
+        expected_keys = expected_by_category[cat]
+
+        # Both reducers should see the same set of docs per group; only the
+        # ordering induced by SORTBY differs.
+        vec_entries = attrs['top_vector_results']
+        srch_entries = attrs['top_search_results']
+        env.assertEqual({e['__key'] for e in vec_entries}, expected_keys)
+        env.assertEqual({e['__key'] for e in srch_entries}, expected_keys)
+
+        # Every doc has search_score. Only doc:1..doc:6 also have vector_score,
+        # so vector sort order can only be asserted for those categories.
+        srch_scores = [float(e['search_score']) for e in srch_entries]
+        env.assertEqual(srch_scores, sorted(srch_scores))
+        if cat in vector_scored_categories:
+            vec_scores = [float(e['vector_score']) for e in vec_entries]
+            env.assertEqual(vec_scores, sorted(vec_scores))


### PR DESCRIPTION
## Description

1. **Current:** `FT.AGGREGATE ... GROUPBY ... REDUCE COLLECT` had limited
   Python coverage — only basic single-COLLECT cases were tested.
   Multiple-COLLECT-in-one-GROUPBY scenarios, interaction with other
   reducers and pipeline stages, the FT.HYBRID path, and the
   parser-level FIELDS / SORTBY caps were not exercised.
   
   
2. **Change:** Add Python tests across three new/extended test files:

   **`tests/pytests/test_groupby_collect.py`** — 
   multiple `COLLECT`  reducers in `GROUPBY` and interactions with other operators.

   **`tests/pytests/test_hybrid_groupby.py`** — 
   FT.HYBRID with multiple  `COLLECT` reducers in `GROUPBY`:

   **`tests/pytests/test_groupby_collect_limits.py`** (new file) —  
   parser-level caps and dense / sparse field population.

3. **Outcome:** Regressions in COLLECT behaviour — across multiple
   reducers in one GROUPBY, interaction with other reducers / chained
   GROUPBYs / APPLY / FILTER, FT.HYBRID dispatch, and the FIELDS /
   SORTBY parse caps — are caught by the Python suite.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
Add tests for multiple COLLECT reducers
 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are test-only, but they may increase CI runtime due to large-schema (1024-field) cases and additional cluster/hybrid scenarios.
> 
> **Overview**
> Expands `COLLECT` reducer test coverage to catch regressions in **multi-`COLLECT` per `GROUPBY`** behavior (independent `FIELDS`/`SORTBY`/`LIMIT` state), `SORTBY`-without-`LIMIT` default heap cap behavior, and interactions across chained `GROUPBY` stages plus `APPLY`/`FILTER`.
> 
> Adds a new `test_groupby_collect_limits.py` suite that exercises parser/runtime caps for `COLLECT` (`FIELDS` up to 1024, over-limit errors, and `SORTBY` key-count max), and extends `FT.HYBRID` tests to validate multiple `COLLECT` reducers over different yielded scores in a single `GROUPBY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2932d66b225dfe5f989e5c95547fe0f2da15f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->