### PR TITLE
[2.8] [CI] Use GitHub App token for CI workflows

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -150,9 +150,20 @@ jobs:
             --reviewer "$TEAM_LEADERS,$ISSUES_SHIFT_ASSIGNEE,$GITHUB_ACTOR" \
             --draft
 
+      - name: Generate GitHub App token
+        id: generate-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_PR_APP_ID }}
+          private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Trigger CI
         env:
-          GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-app-token.outputs.token }}
         run: |
           gh pr ready "$BRANCH" -R "$GITHUB_REPOSITORY"
           gh pr merge "$BRANCH" -R "$GITHUB_REPOSITORY" --auto

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -42,12 +42,21 @@ jobs:
           aws-access-key-id: ${{ secrets.CI_CTO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_CTO_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.CI_CTO_AWS_REGION }}
+      - name: Generate GitHub App token
+        id: generate-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_PR_APP_ID }}
+          private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: write
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2
         with:
           mode: start
-          github-token: ${{ secrets.CI_GH_P_TOKEN }}
+          github-token: ${{ steps.generate-app-token.outputs.token }}
           ec2-image-id: ${{ env.AWS_IMAGE_ID }}
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           subnet-id: ${{ secrets.CI_CTO_AWS_EC2_SUBNET_ID }}
@@ -75,10 +84,19 @@ jobs:
           aws-access-key-id: ${{ secrets.CI_CTO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_CTO_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.CI_CTO_AWS_REGION }}
+      - name: Generate GitHub App token
+        id: generate-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_PR_APP_ID }}
+          private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: write
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop
-          github-token: ${{ secrets.CI_GH_P_TOKEN }}
+          github-token: ${{ steps.generate-app-token.outputs.token }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
Backport of #9520 to `2.8`.

# Description
Manual backport after the automatic backport could not cherry-pick cleanly.

Original commit: 1225b779fa1499079ffcc7f7d1a76e6ce9522fb6