### PR TITLE
[MOD-15333] Fix flaky SVS small window test

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -60,15 +60,16 @@ def test_small_window_size():
     conn = getConnectionByEnv(env)
 
     dim = 2
-    # Non-compressed SVS trains after DEFAULT_BLOCK_SIZE vectors, while LVQ8 uses
-    # a larger training threshold.
+    # The threshold is per shard in cluster mode, so add a small margin for
+    # non-compressed SVS to train on every shard.
+    no_compression_training_th = int(DEFAULT_BLOCK_SIZE * 1.1 * env.shardsCount)
     compression_training_th = DEFAULT_BLOCK_SIZE * 10
     keep_count = 10
     field_name = 'v_SVS_VAMANA'
     for data_type in VECSIM_SVS_DATA_TYPES:
         query_vec = create_random_np_array_typed(dim, data_type)
         for compression in [[], ["COMPRESSION", "LVQ8"]]:
-            num_vectors = compression_training_th if compression else DEFAULT_BLOCK_SIZE
+            num_vectors = compression_training_th if compression else no_compression_training_th
             params = ['TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
                       "CONSTRUCTION_WINDOW_SIZE", 10, *compression]
             conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', field_name, 'VECTOR', 'SVS-VAMANA', len(params), *params)

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -60,45 +60,33 @@ def test_small_window_size():
     conn = getConnectionByEnv(env)
 
     dim = 2
-    # The vectors will be moved from the flat buffer to svs after 1024 * 10 vectors.
-    svs_transfer_th = 1024 * 10
+    # Non-compressed SVS trains after DEFAULT_BLOCK_SIZE vectors, while LVQ8 uses
+    # a larger training threshold.
+    compression_training_th = DEFAULT_BLOCK_SIZE * 10
     keep_count = 10
-    num_vectors = svs_transfer_th
     field_name = 'v_SVS_VAMANA'
     for data_type in VECSIM_SVS_DATA_TYPES:
         query_vec = create_random_np_array_typed(dim, data_type)
         for compression in [[], ["COMPRESSION", "LVQ8"]]:
-            params = ['TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2', "CONSTRUCTION_WINDOW_SIZE", 10, *compression]
+            num_vectors = compression_training_th if compression else DEFAULT_BLOCK_SIZE
+            params = ['TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+                      "CONSTRUCTION_WINDOW_SIZE", 10, *compression]
             conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', field_name, 'VECTOR', 'SVS-VAMANA', len(params), *params)
 
             # Add enough vector to trigger transfer to svs
-            vectors = []
             for i in range(num_vectors):
                 vector = create_random_np_array_typed(dim, data_type)
-                vectors.append(vector)
                 conn.execute_command('HSET', f'doc_{i}', field_name, vector.tobytes())
 
-            # Create unique filename for this iteration
-            compression_str = "no_compression" if not compression else "_".join(compression)
-            filename = f"vectors_{data_type}_{compression_str}.txt"
-            with open(filename, 'w') as f:
-                f.write(f"Data Type: {data_type}, Compression: {compression}, Dim: {dim}, Count: {num_vectors}\n")
-                f.write(str([vector.tolist() for vector in vectors]))
-            # try:
-            #     conn.execute_command('FT.SEARCH', 'idx', f'*=>[KNN {keep_count} @{field_name} $vec_param]', 'PARAMS', 2, 'vec_param', query_vec.tobytes(), 'RETURN', 1, f'__{field_name}_score')
-            # except Exception as e:
-            #     env.assertTrue(False, message=f"compression: {compression} data_type: {data_type}. Search failed with exception: {e}")
             # delete most
             for i in range(num_vectors - keep_count):
                 conn.execute_command('DEL', f'doc_{i}')
 
             # run topk for remaining
             # Before fixing MOD-10771, search crashed
-            try:
-                conn.execute_command('FT.SEARCH', 'idx', f'*=>[KNN {keep_count} @{field_name} $vec_param]', 'PARAMS', 2, 'vec_param', query_vec.tobytes(), 'RETURN', 1, f'__{field_name}_score')
-            except Exception as e:
-                env.assertTrue(False, message=f"compression: {compression} data_type: {data_type}. Search failed with exception: {e}")
-                return
+            env.expect('FT.SEARCH', 'idx', f'*=>[KNN {keep_count} @{field_name} $vec_param]',
+                       'PARAMS', 2, 'vec_param', query_vec.tobytes(), 'RETURN', 1,
+                       f'__{field_name}_score').noError()
             conn.execute_command('FLUSHALL')
 
 def test_rdb_load_trained_svs_vamana():

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -70,8 +70,7 @@ def test_small_window_size():
         query_vec = create_random_np_array_typed(dim, data_type)
         for compression in [[], ["COMPRESSION", "LVQ8"]]:
             num_vectors = compression_training_th if compression else no_compression_training_th
-            params = ['TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-                      "CONSTRUCTION_WINDOW_SIZE", 10, *compression]
+            params = ['TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2', "CONSTRUCTION_WINDOW_SIZE", 10, *compression]
             conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', field_name, 'VECTOR', 'SVS-VAMANA', len(params), *params)
 
             # Add enough vector to trigger transfer to svs


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `test_vecsim_svs.py::test_small_window_size` always inserts 10,240 vectors for both compressed and non-compressed SVS, writes leftover `vectors_*.txt` debug artifacts, and wraps the final search in a manual `try`/`except`.
2. Change: Use the smaller `DEFAULT_BLOCK_SIZE` training threshold for the non-compressed case, keep `DEFAULT_BLOCK_SIZE * 10` for LVQ8, remove the vector dump/debug leftovers, and assert the final search with `env.expect(...).noError()`.
3. Outcome: The test keeps the small `CONSTRUCTION_WINDOW_SIZE` crash coverage while avoiding the pathological no-compression workload that flakes on macOS x86_64 cluster jobs.

#### Which additional issues this PR fixes
1. MOD-15333

#### Main objects this PR modified
1. `tests/pytests/test_vecsim_svs.py::test_small_window_size`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

## Testing

- `./build.sh RUN_PYTEST TEST=test_vecsim_svs.py:test_small_window_size REDISEARCH_GENERATE_HEADERS=OFF`
- `./build.sh RUN_PYTEST TEST=test_vecsim_svs.py:test_small_window_size REDIS_STANDALONE=0 REDISEARCH_GENERATE_HEADERS=OFF`
- `git status --ignored --short tests/pytests | rg 'vectors_FLOAT' || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts a pytest workload and assertion style; no production code paths change, so risk is limited to potentially altering test coverage thresholds in cluster vs standalone runs.
> 
> **Overview**
> Makes `test_small_window_size` less flaky by **reducing the inserted vector count for non-compressed SVS** to a shard-aware `DEFAULT_BLOCK_SIZE`-based threshold while **keeping a higher threshold for LVQ8 compression**.
> 
> Removes leftover debug vector-dump file generation and simplifies the final KNN verification by switching from a manual `try/except` to `env.expect(...).noError()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6442e613b2635ed80dfa87029e28c991d7b95935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->