### PR TITLE
[MOD-15300] Unflake mixed coordinator burst test

### DIFF
--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -50,11 +50,13 @@ def _coordinator_reached_rq_limit(env, coord_initial_jobs_done, coord_initial_pe
     stats = getCoordThpoolStats(env)
     jobs_done_delta = stats['totalJobsDone'] - coord_initial_jobs_done
     pending_jobs_delta = stats['totalPendingJobs'] - coord_initial_pending_jobs
-    done = jobs_done_delta >= RQ_CAPACITY or pending_jobs_delta >= RQ_CAPACITY
+    jobs_seen_delta = jobs_done_delta + pending_jobs_delta
+    done = jobs_seen_delta >= RQ_CAPACITY
     return done, {
         'coord_stats': stats,
         'jobs_done_delta': jobs_done_delta,
         'pending_jobs_delta': pending_jobs_delta,
+        'jobs_seen_delta': jobs_seen_delta,
         'completed': completed[0],
     }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Current: `test_search_and_aggregate_burst` waits for either coordinator `totalJobsDone` or `totalPendingJobs` to individually reach the RQ capacity threshold. On faster or scheduler-dependent platforms, the same burst pressure can be split between jobs that already completed and jobs that are still pending, causing a false timeout.

Change: Count the coordinator jobs that were either completed or are still pending when deciding whether the burst reached the saturation threshold, and include the combined value in timeout diagnostics.

Outcome: The test no longer times out when the coordinator has already seen enough jobs but the work is split across done and pending counters.

#### Which additional issues this PR fixes
1. MOD-15300

#### Main objects this PR modified
1. `tests/pytests/test_burst_drains_without_deadlock.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

## Test Plan

- `CMAKE_ARGS=-DREDISEARCH_GENERATE_HEADERS=OFF REDIS_STANDALONE=0 ./build.sh FORCE RUN_PYTEST TEST=test_burst_drains_without_deadlock.py:test_search_and_aggregate_burst`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adjusts a timeout/saturation condition and adds extra diagnostics; no production logic is modified.
> 
> **Overview**
> Makes the mixed `FT.SEARCH`/`FT.AGGREGATE` burst test less flaky by treating coordinator saturation as **total jobs seen** (`totalJobsDone` + `totalPendingJobs`) rather than requiring either counter to hit `RQ_CAPACITY` individually.
> 
> Adds `jobs_seen_delta` to the condition return payload to improve timeout/debug output when the saturation wait fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2864a9a43bbd3e1b7356fa725e988aeeba4af064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->