### PR TITLE
CI: bump aws-actions/configure-aws-credentials to v6

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -25,7 +25,7 @@ runs:
     # Role-based auth
     - name: Configure AWS Credentials Using Role
       if: ${{ inputs.use_role == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.role_to_assume }}
         aws-region: ${{ inputs.aws_region }}
@@ -33,7 +33,7 @@ runs:
     # Key-based auth
     - name: Configure AWS Credentials Using Keys
       if: ${{ inputs.use_role != 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -180,13 +180,13 @@ jobs:
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Configure AWS Credentials Using Keys
         if: vars.USE_AWS_ROLE == 'false'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -32,7 +32,7 @@ jobs:
       ec2_instance_id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -184,7 +184,7 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -37,7 +37,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.CI_CTO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_CTO_AWS_SECRET_ACCESS_KEY }}
@@ -79,7 +79,7 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.CI_CTO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_CTO_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -106,7 +106,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -586,7 +586,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}


### PR DESCRIPTION
### Description
Bumps all remaining occurrences from `@v4` to `@v6`, matching the version
already used in `.github/actions/setup-sccache/action.yml`.

Test: https://github.com/RediSearch/RediSearch/actions/runs/25926670545

Files updated:
- `.github/workflows/event-release.yml`
- `.github/workflows/self-hosted.yml.TEMPLATE`
- `.github/workflows/task-test.yml`
- `.github/workflows/flow-micro-benchmarks-runner.yml`
- `.github/actions/configure-aws-credentials/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that bumps the AWS credentials GitHub Action version; main risk is workflow auth breaking if v6 behavior/inputs differ in these jobs.
> 
> **Overview**
> Updates all remaining CI workflows and the local composite action to use `aws-actions/configure-aws-credentials@v6` instead of `@v4`, covering role-based (OIDC) and access-key based AWS authentication paths.
> 
> This affects AWS credential setup in release artifact publishing and in EC2 self-hosted runner start/stop flows used by tests and micro-benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6bb7883d0ce711398fbe9f29273ee1202554763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->