### PR TITLE
[MOD-15490] Run SVS query sanity tests standalone-only

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -8,7 +8,6 @@ from vecsim_utils import *
 from common import (
     getConnectionByEnv,
     skip,
-    skip_until,
     assertInfoField,
     index_info,
     to_dict,
@@ -274,13 +273,6 @@ def test_memory_info():
 
 
 func_gen = lambda tn, comp, dt, dist, wr: lambda: queries_sanity(tn, comp, dt, dist, wr)
-# (compression_type, data_type, metric, workers) tuples that are flaky on the
-# coverage (Coordinator-only) job and are temporarily skipped via skip_until.
-# Only applied when running under coverage; see MOD-15569 / MOD-15570.
-QUERIES_SANITY_SKIP_UNTIL = {
-    ('LVQ8', 'FLOAT16', 'IP', 0): ('2026-06-12', 'Flaky test under coverage, see MOD-15570'),
-    ('LVQ8', 'FLOAT16', 'IP', 4): ('2026-06-12', 'Flaky test under coverage, see MOD-15569'),
-} if CODE_COVERAGE else {}
 for workers in [0, 4]:
     name_suffix = "_async" if workers else ""
     # Create SVS VAMANA index with all compression flavors
@@ -292,10 +284,10 @@ for workers in [0, 4]:
             for metric in metrics:
                 test_name = f"test_queries_sanity_{compression_type}_{data_type}_{metric}" + name_suffix
                 test_func = func_gen(test_name, compression_type, data_type, metric, workers)
-                skip_spec = QUERIES_SANITY_SKIP_UNTIL.get((compression_type, data_type, metric, workers))
-                if skip_spec is not None:
-                    skip_date, skip_reason = skip_spec
-                    test_func = skip_until(skip_date, reason=skip_reason)(test_func)
+                # The broad SVS compression/datatype/metric matrix is covered in standalone.
+                # In cluster mode, the same training work is multiplied across shards and can
+                # exceed the coverage job budget without adding meaningful distributed coverage.
+                test_func = skip(cluster=True)(test_func)
                 globals()[test_name] = test_func
 
 '''


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The dynamically generated `test_vecsim_svs:test_queries_sanity_*` SVS matrix runs in coordinator mode and coverage mode. Expensive `FLOAT16` + LVQ SVS-VAMANA training cases have been timing out in the coverage Coordinator-only job, especially when training is multiplied across OSS cluster shards.
2. Change: Make the broad generated SVS query sanity matrix standalone-only by wrapping generated tests with `skip(cluster=True)`. Remove the temporary coverage-only `skip_until` allowlist for the LVQ8/FLOAT16/IP variants.
3. Outcome: Coordinator CI avoids the resource-heavy generated matrix, while standalone still covers the compression/datatype/metric combinations. The temporary skips for MOD-15569 and MOD-15570 are replaced by a stable test-scope boundary.

#### Which additional issues this PR fixes
1. MOD-15490
2. MOD-15569
3. MOD-15570

#### Main objects this PR modified
1. `tests/pytests/test_vecsim_svs.py` - removes the temporary `skip_until` table and marks generated `queries_sanity` tests as standalone-only.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to pytest/CI behavior by skipping an expensive dynamically-generated SVS test matrix in cluster mode, reducing coordinator/coverage runtime without affecting production code.
> 
> **Overview**
> Limits the dynamically generated `test_queries_sanity_*` SVS-VAMANA matrix to *standalone-only* by wrapping each generated test with `skip(cluster=True)`, avoiding expensive training multiplied across shards in coordinator/coverage runs.
> 
> Removes the prior coverage-only `skip_until` allowlist for specific LVQ8/FLOAT16/IP variants since the entire matrix is now excluded from cluster mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95379c50a378535291445087e2a7ad919939bd1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->