### PR TITLE
Trie - Rename C source and header files

### DIFF
--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -9,7 +9,7 @@
 #ifndef SRC_DICTIONARY_H_
 #define SRC_DICTIONARY_H_
 
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 
 Trie* SpellCheck_OpenDict(RedisModuleCtx* ctx, const char* dictName, int mode);
 

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -164,7 +164,7 @@ fn main() {
         src.join("numeric_filter.h"),
         src.join("tag_index.h"),
         src.join("trie").join("trie_node.h"),
-        src.join("trie").join("trie_type.h"),
+        src.join("trie").join("trie.h"),
         src.join("ttl_table").join("ttl_table.h"),
         src.join("util").join("arr").join("arr.h"),
         src.join("util").join("dict").join("dict.h"),

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -163,7 +163,7 @@ fn main() {
         src.join("stopwords.h"),
         src.join("numeric_filter.h"),
         src.join("tag_index.h"),
-        src.join("trie").join("trie.h"),
+        src.join("trie").join("trie_node.h"),
         src.join("trie").join("trie_type.h"),
         src.join("ttl_table").join("ttl_table.h"),
         src.join("util").join("arr").join("arr.h"),

--- a/src/spec.c
+++ b/src/spec.c
@@ -22,7 +22,7 @@
 #include "rmutil/vector.h"
 #include "rmutil/util.h"
 #include "rmutil/rm_assert.h"
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include "rmalloc.h"
 #include "config.h"
 #include "cursor.h"

--- a/src/spec.h
+++ b/src/spec.h
@@ -15,7 +15,7 @@
 #include "redismodule.h"
 #include "config.h"
 #include "doc_table.h"
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include "sortable.h"
 #include "stopwords.h"
 #include "gc.h"

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include "util/arr.h"
 
 typedef struct TrieMap TrieMap;

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -10,7 +10,7 @@
 #include "module.h"
 #include "rmutil/util.h"
 #include "rmutil/args.h"
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include "query_error_ffi.h"
 #include "util/likely.h"
 

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -13,7 +13,7 @@
 
 #include "sparse_vector.h"
 #include "rmutil/vector.h"
-#include "trie.h"
+#include "trie_node.h"
 
 /*
 * SparseAutomaton is a C implementation of a levenshtein automaton using

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -13,7 +13,7 @@
 #include "util/heap.h"
 #include "util/misc.h"
 #include "rune_util.h"
-#include "trie_type.h"
+#include "trie.h"
 #include "rmalloc.h"
 #include "rdb.h"
 

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -6,8 +6,8 @@
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
 */
-#ifndef __TRIE_TYPE_H__
-#define __TRIE_TYPE_H__
+#ifndef __TRIE_H__
+#define __TRIE_H__
 
 #include "redismodule.h"
 

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include <sys/param.h>
-#include "trie.h"
+#include "trie_node.h"
 #include "util/bsearch.h"
 #include "sparse_vector.h"
 #include "redisearch.h"

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -6,8 +6,8 @@
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
 */
-#ifndef __TRIE_H__
-#define __TRIE_H__
+#ifndef __TRIE_NODE_H__
+#define __TRIE_NODE_H__
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -12,7 +12,7 @@
 #include "redismodule.h"
 
 #include "rmutil/rm_assert.h"
-#include "trie.h"
+#include "trie_node.h"
 #include "levenshtein.h"
 
 #ifdef __cplusplus

--- a/tests/cpptests/test_cpp_cluster.cpp
+++ b/tests/cpptests/test_cpp_cluster.cpp
@@ -11,7 +11,7 @@
 #include "common.h"
 #include "redismock/redismock.h"
 
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 extern "C" {
 #include "dictionary.h"
 }

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -12,7 +12,7 @@
 #include "common.h"
 #include "redismock/redismock.h"
 #include "synonym_map.h"
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include <cstdint>  // For SIZE_MAX, UINT32_MAX
 
 extern "C" {

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -10,7 +10,7 @@
 
 #include "gtest/gtest.h"
 #include "trie/trie_node.h"
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include "redismock/redismock.h"
 
 #include <set>

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -9,7 +9,7 @@
 
 
 #include "gtest/gtest.h"
-#include "trie/trie.h"
+#include "trie/trie_node.h"
 #include "trie/trie_type.h"
 #include "redismock/redismock.h"
 

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -8,7 +8,7 @@
 */
 
 #include "trie/trie_node.h"
-#include "trie/trie_type.h"
+#include "trie/trie.h"
 #include "trie/levenshtein.h"
 #include "trie/rune_util.h"
 #include "libnu/libnu.h"

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-#include "trie/trie.h"
+#include "trie/trie_node.h"
 #include "trie/trie_type.h"
 #include "trie/levenshtein.h"
 #include "trie/rune_util.h"


### PR DESCRIPTION
👇🏽 
**NB: Look at the two commits separately, and everything becomes super easy!**
☝🏽 

## Describe the changes in the pull request

1. **Current**: `src/trie/trie.{h,c}` contained the trie node data structure, while `src/trie/trie_type.{h,c}` contained the higher-level `Trie` wrapper. The naming was confusing — the lower-level node module owned the `trie.h` name, while the actual user-facing trie type lived in `trie_type.h`.
2. **Change**: Pure file renames in two commits:
   - `trie.{h,c}` → `trie_node.{h,c}` (node-level operations)
   - `trie_type.{h,c}` → `trie.{h,c}` (user-facing `Trie` type)
   All `#include` sites and build references updated accordingly. No code changes beyond renames.
3. **Outcome**: Header names now match what each module actually exposes. Aligns with the ongoing Rust port naming in `src/redisearch_rs/` and reduces friction for readers searching for `trie.h`.

#### Which additional issues this PR fixes
1. None

#### Main objects this PR modified
1. `src/trie/trie.{h,c}` (was `trie_type.{h,c}`)
2. `src/trie/trie_node.{h,c}` (was `trie.{h,c}`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal refactor only — no user-visible behavior change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a file/module rename and code move within the trie implementation; risk is low but touches many include/build references, so build breakage is the main concern.
> 
> **Overview**
> **Renames and splits the trie implementation to align file names with responsibilities.** The former node-level `trie.{h,c}` is moved to `trie_node.{h,c}`, while the former `trie_type.{h,c}` becomes the new `trie.{h,c}` exposing the public `Trie` API.
> 
> All call sites and build/FFI inputs are updated to include `trie/trie.h` instead of `trie/trie_type.h`, and low-level users (e.g. tests/levenshtein/FFI) now include `trie/trie_node.h`. The Rust bindgen header allowlist is adjusted to add `trie_node.h` and drop `trie_type.h`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a290abeb0108545af74045d7751b27f88e80e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->