### PR TITLE
CI: clarify enable_lto config and drop intel x86 default

### DIFF
--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -141,7 +141,6 @@ jobs:
                       'setup_script': 'echo "HOME=/home/ubuntu" >> $GITHUB_ENV',
                       'name': 'Intel x86_64',
                       'env': '',
-                      'container': '',
                       'ec2_image_id': 'ami-09fabd03bb09b3704',
                       'ec2_instance_type': 'c7i.xlarge'
                   }

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -117,7 +117,8 @@ jobs:
               "macos-15": {
                   "x86_64": {
                       'env': 'macos-15-intel',
-                      'name': 'macOS 15 x86_64'
+                      'name': 'macOS 15 x86_64',
+                      'enable_lto': '0' # Currently not possible on macOS.
                   },
                   "aarch64": {
                       'env': 'macos-15',
@@ -128,7 +129,8 @@ jobs:
               "macos-26": {
                   "x86_64": {
                       'env': 'macos-26-large',
-                      'name': 'macOS 26 x86_64'
+                      'name': 'macOS 26 x86_64',
+                      'enable_lto': '0' # Currently not possible on macOS.
                   },
                   "aarch64": {
                       'env': 'macos-26',
@@ -142,19 +144,22 @@ jobs:
                       'name': 'Intel x86_64',
                       'env': '',
                       'ec2_image_id': 'ami-09fabd03bb09b3704',
-                      'ec2_instance_type': 'c7i.xlarge'
+                      'ec2_instance_type': 'c7i.xlarge',
+                      'enable_lto': '0' # Platform is not used to produce artifacts.
                   }
               },
               "ubuntu:latest": {
                   "x86_64": {
                       'container': 'ubuntu:latest',
                       'setup_script': 'apt update && apt install -y git',
-                      'name': 'Ubuntu Latest x86_64'
+                      'name': 'Ubuntu Latest x86_64',
+                      'enable_lto': '0' # Platform is not used to produce artifacts.
                   },
                   "aarch64": {
                       'container': 'ubuntu:latest',
                       'setup_script': 'apt update && apt install -y git',
-                      'name': 'Ubuntu Latest ARM64'
+                      'name': 'Ubuntu Latest ARM64',
+                      'enable_lto': '0' # Platform is not used to produce artifacts.
                   }
               },
               "ubuntu:resolute": {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `task-get-config.yml` set `enable_lto` only on some platforms, leaving readers to infer the default from per-platform overrides. The `intel` x86_64 entry also carried an empty `'container': ''` and no explicit LTO flag.
2. **Change**: Add explicit `enable_lto` entries (with inline rationale) on every platform/architecture combination where LTO is off, so the reason is documented next to the value. Remove the redundant default `'container': ''` from the `intel` entry.
3. **Outcome**: Anyone reading the workflow can see at a glance why LTO is off for a given platform (macOS toolchain limitation, glibc too old for clang 21, non-artifact platform, etc.) without cross-referencing the default block.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `.github/workflows/task-get-config.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow config-only change that clarifies and standardizes `enable_lto` outputs without altering application code. Potential impact is limited to build behavior if any job previously relied on implicit defaults for those platforms.
> 
> **Overview**
> Clarifies CI build configuration by explicitly setting `enable_lto: '0'` (with inline rationale) for additional platform/arch entries that have LTO disabled, rather than relying on implicit defaults.
> 
> Cleans up the `intel` runner config by removing the redundant empty `container` field while also making its LTO-disabled status explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 480429fbbba5afd90f570d35ef657048ee5ecd91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->