### PR TITLE
ci: drop noble clang/libclang-dev to silence LLVMgold v18↔v21 warnings

### DIFF
--- a/.install/ubuntu_24.04.sh
+++ b/.install/ubuntu_24.04.sh
@@ -5,8 +5,13 @@ MODE=$1 # whether to install using sudo or not
 source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
 
 apt_get_cmd "$MODE" update -qq
+# Do NOT install distro `clang`/`libclang-dev` here: on Noble those resolve to
+# LLVM 18, which plants /usr/lib/bfd-plugins/LLVMgold.so v18. install_llvm.sh
+# below pulls clang-21 + libclang-21-dev from apt.llvm.org (Rust's LLVM major).
+# Two LLVMs side-by-side cause `ar` to emit "Unknown attribute kind (102)"
+# warnings while indexing LTO-bitcode archives (v18 plugin can't read v21 IR).
 apt_get_cmd "$MODE" install -yqq git wget build-essential lcov openssl libssl-dev \
-    unzip rsync clang curl libclang-dev gdb
+    unzip rsync curl gdb
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: On Ubuntu Noble (24.04) CI jobs, every build of `libredisearch_all.a` / `redisearch.so` floods the log with hundreds of lines:
   ```
   bfd plugin: LLVM gold plugin has failed to create LTO module:
   Unknown attribute kind (102) (Producer: 'LLVM21.1.8' Reader: 'LLVM 18.1.3')
   ```
   The final `.so` still links (lld-21 handles bitcode natively), so the warnings are non-fatal — but they're noise that hides real diagnostics.

2. **Change**: Stop installing the distro's `clang` / `libclang-dev` packages in `.install/ubuntu_24.04.sh`. On Noble those resolve to **LLVM 18** and plant `/usr/lib/bfd-plugins/LLVMgold.so` pointing at the v18 plugin. The subsequent `install_llvm.sh` already installs `clang-21` + `libclang-21-dev` from apt.llvm.org (matching `rustc`'s LLVM major), so the distro packages were redundant *and* harmful: `ar` indexes LTO-bitcode archives via that bfd plugin, which on Noble was v18 — unable to read v21 IR.

3. **Outcome**: Build runs silently on Noble. Verified in workflow run **[#25984000843](https://github.com/RediSearch/RediSearch/actions/runs/25984000843)** (and the prior validation run [#25981120988](https://github.com/RediSearch/RediSearch/actions/runs/25981120988)): zero `bfd plugin:` warnings on both Noble aarch64 and Noble x86_64; LTO still enabled (`LTO: 1`); all Linux tests pass.

Why only Noble was affected:
- **Jammy (22.04)**: `.install/ubuntu_22.04.sh` installs `gcc-12` only — never installs distro clang → no LLVMgold plugin planted.
- **Noble (24.04)**: distro `clang` = clang-18 → mismatch with rustc's LLVM 21 → warnings.
- **Resolute (26.04)**: distro `clang` = clang-21 → matches → no mismatch.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `.install/ubuntu_24.04.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal CI log-cleanup only — no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI provisioning change that only adjusts toolchain packages on Ubuntu 24.04; main risk is missing dependencies if any job implicitly relied on distro `clang`/`libclang-dev`.
> 
> **Overview**
> On Ubuntu 24.04 CI installs, this drops the distro `clang`/`libclang-dev` packages and adds a comment explaining that Noble’s LLVM 18 `LLVMgold.so` conflicts with the LLVM 21 toolchain used for LTO.
> 
> The job now relies on `install_llvm.sh` to provide `clang-21`/`libclang-21-dev`, reducing noisy `ar`/LTO “Unknown attribute kind (102)” warnings from mixed LLVM versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b227350e6d3febdf61449971695bb315bed3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->