### PR TITLE
Allow downstream builders of RediSearch to turn off header generation.

### DIFF
--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -96,7 +96,7 @@ binstall --no-host-prebuilt cargo-nextest@0.9.130
 # See https://docs.rs/cargo-hakari/latest/cargo_hakari/about/
 binstall cargo-hakari@0.9.37
 # A CLI to generate C headers from Rust code
-binstall cheadergen_cli@0.2.0
+binstall cheadergen_cli@0.2.1
 # Make sure `miri` is fully operational before running tests with it.
 # See https://github.com/rust-lang/miri/blob/master/README.md#running-miri-on-ci
 # for more details.

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,9 @@ BUILD_INTEL_SVS_OPT=${BUILD_INTEL_SVS_OPT:-0} # Use SVS pre-compiled library
 # Clang needs to have the same version as the LLVM version used by Rust.
 # Check using `clang --version` and `rustc --version --verbose`.
 LTO=0
+# If set to `1`, C headers for Rust modules are (re)generated from the Rust source.
+# If set to `0`, (re)generation is skipped and the committed C headers are used.
+REDISEARCH_GENERATE_HEADERS=${REDISEARCH_GENERATE_HEADERS:-1}
 # Inline LSE atomics on Linux AArch64 (Armv8.1-a+). Set to 0 on pre-Armv8.1-a
 # cores (Cortex-A72, AWS Graviton1, Raspberry Pi 4) to avoid SIGILL on load.
 INLINE_LSE_ATOMICS=${INLINE_LSE_ATOMICS:-1}
@@ -115,6 +118,9 @@ parse_arguments() {
         ;;
       TEST=*)
         TEST_FILTER="${arg#*=}"
+        ;;
+      REDISEARCH_GENERATE_HEADERS=*)
+        REDISEARCH_GENERATE_HEADERS="${arg#*=}"
         ;;
       RUST_PROFILE=*)
         RUST_PROFILE="${arg#*=}"
@@ -534,6 +540,12 @@ prepare_cmake_arguments() {
 
   if [[ "$BUILD_TESTS" == "1" ]]; then
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DBUILD_SEARCH_UNIT_TESTS=ON"
+  fi
+
+  if [[ "$REDISEARCH_GENERATE_HEADERS" == "1" ]]; then
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DREDISEARCH_GENERATE_HEADERS=ON"
+  else
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DREDISEARCH_GENERATE_HEADERS=OFF"
   fi
 
   if [[ -n "$SAN" ]]; then


### PR DESCRIPTION
## Describe the changes in the pull request

Also upgrades `cheadergen` to `0.2.1` to fix a caching issue.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-script change that only affects CMake configuration and tool versioning, but could impact downstream builds if the new flag is mis-set or the CMake option is unsupported in some environments.
> 
> **Overview**
> Adds a `REDISEARCH_GENERATE_HEADERS` toggle (env var and `build.sh` arg) to let downstream builders **skip Rust→C header regeneration** and rely on committed headers, wiring it through to CMake as `-DREDISEARCH_GENERATE_HEADERS=ON|OFF`.
> 
> Upgrades the pinned `cheadergen_cli` tool from `0.2.0` to `0.2.1` to address a caching issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f499c9eb8beca8be9f7ae650e3229da44e615f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->