### PR TITLE
docs: clarify RUN_PYTEST TEST= selector syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ The codebase is primarily C, with an ongoing effort to port modules to Rust in `
 ./build.sh RUN_UNIT_TESTS TEST=unit_test_name # Specific C/C++ unit tests
 ./build.sh RUN_UNIT_TESTS SAN=address         # C/C++ unit tests with AddressSanitizer
 ./build.sh RUN_PYTEST                         # Python behavioral tests
-./build.sh RUN_PYTEST TEST=test_name          # Specific Python test
+./build.sh RUN_PYTEST TEST=<file>             # Whole Python test file
+./build.sh RUN_PYTEST TEST=<file>:<function>  # Specific Python test function
 cargo nextest run                             # Rust tests, from `src/redisearch_rs/`
 cargo +nightly miri test                      # Rust tests under `miri`, from `src/redisearch_rs/`
 ```


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `AGENTS.md` documented only `RUN_PYTEST TEST=<file>` for filtering Python tests, leaving the function-level selector undocumented.
2. **Change:** Added a second line showing `RUN_PYTEST TEST=<file>:<function>` for selecting a specific test function (RLTest's single-colon syntax).
3. **Outcome:** Contributors can run a single Python test without guessing the selector format.

#### Which additional issues this PR fixes
N/A

#### Main objects this PR modified
1. `AGENTS.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies test invocation syntax; no code paths or runtime behavior are affected.
> 
> **Overview**
> Clarifies Python test filtering in `AGENTS.md` by documenting `RUN_PYTEST TEST=<file>:<function>` for running a single test function (in addition to `TEST=<file>` for whole-file runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27147c31f96f0b31a9d0b3dd09fe90718ac65e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->