### PR TITLE
[CI] Make merge queue detector API calls resilient

### DIFF
--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -124,20 +124,17 @@ jobs:
                   if attempt < attempts:
                       time.sleep(2 * attempt)
 
-              return None
+              raise RuntimeError(f"{description} failed after {attempts} attempts")
 
 
           def load_gh_api_json(args, description, attempts=3):
               output = run_gh_api(args, description, attempts)
-              if output is None:
-                  return None
-
               try:
                   return json.loads(output)
               except json.JSONDecodeError as error:
                   print(f"{description} returned invalid JSON: {error}")
                   print(output)
-                  return None
+                  raise
 
 
           def query_pull_request(owner, repo, number):
@@ -155,9 +152,6 @@ jobs:
                   ],
                   f"Query PR #{number} merge queue timeline",
               )
-              if data is None:
-                  return None
-
               return data["data"]["repository"]["pullRequest"]
 
 
@@ -171,8 +165,6 @@ jobs:
                       ],
                       "Query merge queue workflow runs",
                   )
-                  if data is None:
-                      return None, None
 
                   candidates = []
                   for run in data["workflow_runs"]:
@@ -223,9 +215,6 @@ jobs:
           print(f"Checking whether PR #{pr_number} was resubmitted without new commits")
 
           pull_request = query_pull_request(owner, repo_name, pr_number)
-          if pull_request is None:
-              finish_without_alert("Could not query pull request data from GitHub")
-
           events = pull_request["timelineItems"]["nodes"]
           latest_add = latest(events, "AddedToMergeQueueEvent")
           latest_removal = latest(events, "RemovedFromMergeQueueEvent")

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -106,11 +106,43 @@ jobs:
               )
 
 
+          def run_gh_api(args, description, attempts=3):
+              command = ["gh", "api", *args]
+              for attempt in range(1, attempts + 1):
+                  result = subprocess.run(command, capture_output=True, text=True)
+                  if result.returncode == 0:
+                      return result.stdout
+
+                  print(f"{description} failed on attempt {attempt}/{attempts}")
+                  if result.stderr.strip():
+                      print("gh stderr:")
+                      print(result.stderr.strip())
+                  if result.stdout.strip():
+                      print("gh stdout:")
+                      print(result.stdout.strip())
+
+                  if attempt < attempts:
+                      time.sleep(2 * attempt)
+
+              return None
+
+
+          def load_gh_api_json(args, description, attempts=3):
+              output = run_gh_api(args, description, attempts)
+              if output is None:
+                  return None
+
+              try:
+                  return json.loads(output)
+              except json.JSONDecodeError as error:
+                  print(f"{description} returned invalid JSON: {error}")
+                  print(output)
+                  return None
+
+
           def query_pull_request(owner, repo, number):
-              result = subprocess.run(
+              data = load_gh_api_json(
                   [
-                      "gh",
-                      "api",
                       "graphql",
                       "-f",
                       f"owner={owner}",
@@ -121,30 +153,29 @@ jobs:
                       "-f",
                       f"query={QUERY}",
                   ],
-                  check=True,
-                  capture_output=True,
-                  text=True,
+                  f"Query PR #{number} merge queue timeline",
               )
-              return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
+              if data is None:
+                  return None
+
+              return data["data"]["repository"]["pullRequest"]
 
 
           def query_merge_queue_workflow_runs(repo, pr_number, queue_branch):
               pr_ref_pattern = re.compile(rf"(^|/)pr-{pr_number}-")
               candidates = []
               for attempt in range(5):
-                  result = subprocess.run(
+                  data = load_gh_api_json(
                       [
-                          "gh",
-                          "api",
                           f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
                       ],
-                      check=True,
-                      capture_output=True,
-                      text=True,
+                      "Query merge queue workflow runs",
                   )
+                  if data is None:
+                      return None, None
 
                   candidates = []
-                  for run in json.loads(result.stdout)["workflow_runs"]:
+                  for run in data["workflow_runs"]:
                       if run.get("path") != ".github/workflows/event-merge-to-queue.yml":
                           continue
 
@@ -192,6 +223,9 @@ jobs:
           print(f"Checking whether PR #{pr_number} was resubmitted without new commits")
 
           pull_request = query_pull_request(owner, repo_name, pr_number)
+          if pull_request is None:
+              finish_without_alert("Could not query pull request data from GitHub")
+
           events = pull_request["timelineItems"]["nodes"]
           latest_add = latest(events, "AddedToMergeQueueEvent")
           latest_removal = latest(events, "RemovedFromMergeQueueEvent")


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The merge queue resubmission detector fails the workflow when a transient `gh api` call exits non-zero, and the log hides the underlying stderr.
2. Change: Add a small retry wrapper for GitHub API calls, print stderr/stdout on failures, and fail closed with `resubmit=false` if PR data cannot be queried.
3. Outcome: GitHub API flakiness no longer blocks merge queue validation, and future failures include enough log context to diagnose.

#### Which additional issues this PR fixes
1. #9553 follow-up

#### Main objects this PR modified
1. `.github/workflows/event-merge-queue-resubmit.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to a GitHub Actions workflow script; main impact is potentially altering CI behavior when the GitHub API is flaky via retries and clearer failures.
> 
> **Overview**
> Makes the merge-queue resubmission detector workflow more resilient by wrapping `gh api` calls in a small retry helper that backs off, logs `stdout`/`stderr` on failures, and centralizes JSON parsing.
> 
> Updates the PR GraphQL query and the merge-queue workflow-runs lookup to use this wrapper instead of single-shot `subprocess.run(..., check=True)`, improving diagnosability and reducing CI flakes from transient API errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c3cc917b0da7bce96232b513d9ac80900157de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->