### PR TITLE
[8.2] [MOD-15490] Run SVS query sanity tests standalone-only

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -277,7 +277,12 @@ for workers in [0, 4]:
             metrics = VECSIM_DISTANCE_METRICS if EXTENDED_PYTESTS else ['IP']
             for metric in metrics:
                 test_name = f"test_queries_sanity_{compression_type}_{data_type}_{metric}" + name_suffix
-                globals()[test_name] = func_gen(test_name, compression_type, data_type, metric, workers)
+                test_func = func_gen(test_name, compression_type, data_type, metric, workers)
+                # The broad SVS compression/datatype/metric matrix is covered in standalone.
+                # In cluster mode, the same training work is multiplied across shards and can
+                # exceed the coverage job budget without adding meaningful distributed coverage.
+                test_func = skip(cluster=True)(test_func)
+                globals()[test_name] = test_func
 
 '''
 This test validates SVS-VAMANA tiered indexing across all datatype, metric, and compression combinations.


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9664 to `8.2`.

1. Current: The generated SVS query sanity matrix still runs in OSS cluster mode on this branch.
2. Change: Wrap generated `test_queries_sanity_*` tests with `skip(cluster=True)`.
3. Outcome: The broad SVS compression/datatype/metric matrix remains covered in standalone while cluster CI avoids the multiplied SVS training cost.

#### Which additional issues this PR fixes
1. MOD-15490
2. MOD-15569
3. MOD-15570
4. #9664

#### Main objects this PR modified
1. `tests/pytests/test_vecsim_svs.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that skips an expensive SVS query-sanity matrix when running in cluster mode, reducing CI load without affecting production code.
> 
> **Overview**
> **Reduces cluster CI cost for SVS tests.** The generated `test_queries_sanity_*` SVS query-sanity matrix is now wrapped with `skip(cluster=True)`, so it continues to run in standalone coverage but is skipped in cluster runs where SVS training work multiplies across shards and can exceed job budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f8cc885bb77adb491634ec033691a0e6e946e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->