### PR TITLE
[8.8] [MOD-15490] Run SVS query sanity tests standalone-only

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -283,7 +283,12 @@ for workers in [0, 4]:
             metrics = VECSIM_DISTANCE_METRICS if EXTENDED_PYTESTS else ['IP']
             for metric in metrics:
                 test_name = f"test_queries_sanity_{compression_type}_{data_type}_{metric}" + name_suffix
-                globals()[test_name] = func_gen(test_name, compression_type, data_type, metric, workers)
+                test_func = func_gen(test_name, compression_type, data_type, metric, workers)
+                # The broad SVS compression/datatype/metric matrix is covered in standalone.
+                # In cluster mode, the same training work is multiplied across shards and can
+                # exceed the coverage job budget without adding meaningful distributed coverage.
+                test_func = skip(cluster=True)(test_func)
+                globals()[test_name] = test_func
 
 '''
 This test validates SVS-VAMANA tiered indexing across all datatype, metric, and compression combinations.


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9664 to `8.8`.

1. Current: The generated SVS query sanity matrix still runs in OSS cluster mode on this branch.
2. Change: Wrap generated `test_queries_sanity_*` tests with `skip(cluster=True)`.
3. Outcome: The broad SVS compression/datatype/metric matrix remains covered in standalone while cluster CI avoids the multiplied SVS training cost.

#### Which additional issues this PR fixes
1. MOD-15490
2. MOD-15569
3. MOD-15570
4. #9664

#### Main objects this PR modified
1. `tests/pytests/test_vecsim_svs.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only affects pytest execution by skipping a generated SVS query-sanity test matrix in cluster CI to avoid excessive training cost.
> 
> **Overview**
> Runs the generated `test_queries_sanity_*` SVS-VAMANA query sanity matrix **standalone-only** by wrapping each dynamically created test with `skip(cluster=True)`.
> 
> This reduces cluster CI runtime/cost by avoiding duplicated SVS training work across shards while keeping the same coverage in non-cluster runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871dc044a04c188a6d65cc36076e26212b0e77ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->