### PR TITLE
Fix rustdoc warnings when generating headers

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn NewIntersectionIterator(
 ///
 /// # Safety
 ///
-/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator`].
+/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn GetIntersectionIteratorNumChildren(header: *const QueryIterator) -> usize {
     debug_assert!(!header.is_null());
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn GetIntersectionIteratorNumChildren(header: *const Query
 ///
 /// # Safety
 ///
-/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator`].
+/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
 /// 2. `idx` must be less than [`GetIntersectionIteratorNumChildren`]`(header)`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn GetIntersectionIteratorChild(
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn GetIntersectionIteratorChild(
 ///
 /// # Safety
 ///
-/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator`].
+/// 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
 /// 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AddIntersectionIteratorChild(

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -26,7 +26,7 @@ type NotOptimizedFfi<'index> = NotOptimized<'index, NewWildcardIterator<'index>,
 /// Enum holding both NOT iterator variants with concrete [`CRQEIterator`] child.
 ///
 /// The `NotOptimized` variant is intentionally large because it inlines a
-/// [`WildcardIterator`] to avoid heap allocation. Both variants are
+/// `WildcardIterator` to avoid heap allocation. Both variants are
 /// long-lived (query lifetime), and the size difference is acceptable.
 #[expect(
     clippy::large_enum_variant,
@@ -256,8 +256,8 @@ pub unsafe extern "C" fn NewNotIterator(
 /// # Safety
 ///
 /// 1. `it` must be a valid non-null pointer to a non-reduced NOT iterator
-///    created via [`NewNotIterator`]. Must not be called on a reduced
-///    (wildcard/empty) iterator returned by [`NewNotIterator`].
+///    created via [`NewNotIterator()`]. Must not be called on a reduced
+///    (wildcard/empty) iterator returned by [`NewNotIterator()`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn GetNotIteratorChild(it: *const QueryIterator) -> *const QueryIterator {
     debug_assert!(!it.is_null());

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
@@ -30,7 +30,7 @@ use rqe_iterators::optional_reducer::{
 ///
 /// 1. `child`, when non-null, must be a valid owning pointer to a C query iterator that is not aliased.
 /// 2. `q` must be a valid non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
-///    [`new_optional_iterator`](rqe_iterators::optional_reducer::new_optional_iterator).
+///    [`new_optional_iterator`].
 pub unsafe extern "C" fn NewOptionalIterator(
     child: *mut QueryIterator,
     q: *mut QueryEvalCtx,

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -152,7 +152,7 @@ bool IsWildcardIterator(const QueryIterator *it);
  *
  * 1. `child`, when non-null, must be a valid owning pointer to a C query iterator that is not aliased.
  * 2. `q` must be a valid non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
- *    [`new_optional_iterator`](rqe_iterators::optional_reducer::new_optional_iterator).
+ *    [`new_optional_iterator`].
  */
 QueryIterator *NewOptionalIterator(QueryIterator *child, QueryEvalCtx *q, t_docId max_doc_id, double weight);
 
@@ -371,7 +371,7 @@ QueryIterator *IntoProfiled(QueryIterator *iter);
  *
  * # Safety
  *
- * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator`].
+ * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
  */
 size_t GetIntersectionIteratorNumChildren(const QueryIterator *header);
 
@@ -447,7 +447,7 @@ RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
  *
  * # Safety
  *
- * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator`].
+ * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
  * 2. `idx` must be less than [`GetIntersectionIteratorNumChildren`]`(header)`.
  */
 const QueryIterator *GetIntersectionIteratorChild(const QueryIterator *header, size_t idx);
@@ -624,7 +624,7 @@ enum MetricType GetMetricType(const QueryIterator *header);
  *
  * # Safety
  *
- * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator`].
+ * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
  * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
  */
 void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
@@ -734,8 +734,8 @@ const char *GetUnionIteratorQueryString(const QueryIterator *it);
  * # Safety
  *
  * 1. `it` must be a valid non-null pointer to a non-reduced NOT iterator
- *    created via [`NewNotIterator`]. Must not be called on a reduced
- *    (wildcard/empty) iterator returned by [`NewNotIterator`].
+ *    created via [`NewNotIterator()`]. Must not be called on a reduced
+ *    (wildcard/empty) iterator returned by [`NewNotIterator()`].
  */
 const QueryIterator *GetNotIteratorChild(const QueryIterator *it);
 


### PR DESCRIPTION
Disambiguate links to NewIntersectionIterator and NewNotIterator (both function and enum), remove redundant explicit link target in optional.rs, and escape non-existent WildcardIterator link in not.rs.

Fix warnings during the headers generation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc/comment-only changes to Rust FFI iterator wrappers and the generated C header; no runtime behavior or API signatures change.
> 
> **Overview**
> Fixes rustdoc/header generation warnings in `iterators_ffi` by **disambiguating intra-doc links** (e.g., `NewIntersectionIterator()` and `NewNotIterator()`), removing an over-specified `new_optional_iterator` link target, and escaping a non-existent `WildcardIterator` link.
> 
> Updates the corresponding documentation comments in the generated `iterators_ffi.h` to match, with **no functional code changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b750979d6cb15b212cfcc8b0997370b5b613d328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->