### PR TITLE
fix null ptr dereference in redisearch api when nprefixes is above limit

### DIFF
--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -200,7 +200,17 @@ void RediSearch_IndexExisting(RefManager* rm, SchemaRuleArgs* args) {
   RWLOCK_ACQUIRE_WRITE();
   IndexSpec *sp = __RefManager_Get_Object(rm);
   if (!sp->rule) {
-    sp->rule = SchemaRule_Create(args, IndexSpec_GetStrongRefUnsafe(sp), NULL);
+    QueryError status = QueryError_Default();
+    sp->rule = SchemaRule_Create(args, IndexSpec_GetStrongRefUnsafe(sp), &status);
+    if (!sp->rule) {
+      RedisModule_Log(RSDummyContext, "warning",
+                      "RediSearch_IndexExisting: failed to create schema rule: %s",
+                      QueryError_GetUserError(&status));
+      QueryError_ClearError(&status);
+      RWLOCK_RELEASE();
+      return;
+    }
+    QueryError_ClearError(&status);
   }
   sp->rule->index_all = true;
   RWLOCK_RELEASE();

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -16,6 +16,7 @@
 #include "config.h"
 #include "numeric_range_tree.h"
 #include "numeric_range_tree_ffi.h"
+#include "rules.h"
 
 #include <set>
 #include <string>
@@ -1478,6 +1479,28 @@ TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
   EXPECT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained.
+
+  RediSearch_DropIndex(index);
+}
+
+// Calling RediSearch_IndexExisting with more prefixes than MAX_SCHEMA_PREFIXES
+// used to dereference a NULL QueryError inside SchemaRule_CreateInternal and
+// abort the process. The call must now return without crashing and leave
+// sp->rule unset so the spec stays in a safe state.
+TEST_F(LLApiTest, testIndexExistingTooManyPrefixes) {
+  RSIndex *index = RediSearch_CreateIndex("idx_existing_overlimit", NULL);
+  ASSERT_NE(index, nullptr);
+
+  char config_index_all[] = "ENABLE";
+  SchemaRuleArgs args = {};
+  args.type = "HASH";
+  args.index_all = config_index_all;
+  args.nprefixes = MAX_SCHEMA_PREFIXES + 1;  // check fires before iteration
+  args.prefixes = nullptr;
+
+  RediSearch_IndexExisting(index, &args);
+
+  ASSERT_EQ(get_spec(index)->rule, nullptr);
 
   RediSearch_DropIndex(index);
 }


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LLAPI index rule creation and error handling; while the change is small, it alters behavior on invalid inputs and adds a new early-return path that could affect callers relying on rule initialization.
> 
> **Overview**
> Prevents a process abort in `RediSearch_IndexExisting` when schema rule creation fails (e.g., `nprefixes > MAX_SCHEMA_PREFIXES`) by passing a real `QueryError`, logging the failure, clearing the error, and returning without setting `sp->rule`.
> 
> Adds a regression LLAPI C++ test that calls `RediSearch_IndexExisting` with too many prefixes and asserts the index spec remains in a safe state (`rule == nullptr`) instead of crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26705b9de6596c616c624ba35606467f4d143ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->