### PR TITLE
[MOD-15561] ForkGC: Existing docs scanner - child part

### DIFF
--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -23,10 +23,7 @@ void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
 
     II_GCWriter wr = { .ctx = gc, .write = pipe_write_cb };
 
-    InvertedIndex_GcDelta_Scan(
-        &wr, sctx, idx,
-        &cb, NULL
-    );
+    InvertedIndex_GcDelta_Scan(&wr, sctx, idx, &cb);
   }
 
   // we are done with existing docs inverted index

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -11,25 +11,6 @@
 #include "inverted_index_ffi.h"
 #include "numeric_range_tree_ffi.h"
 
-void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
-  IndexSpec *spec = sctx->spec;
-
-  InvertedIndex *idx = spec->existingDocs;
-  if (idx) {
-    struct iovec iov = {.iov_base = (void *)"", 0};
-
-    CTX_II_GC_Callback cbCtx = { .gc = gc, .hdrarg = &iov };
-    II_GCCallback cb = { .ctx = &cbCtx, .call = sendHeaderString };
-
-    II_GCWriter wr = { .ctx = gc, .write = pipe_write_cb };
-
-    InvertedIndex_GcDelta_Scan(&wr, sctx, idx, &cb);
-  }
-
-  // we are done with existing docs inverted index
-  FGC_sendTerminator(gc);
-}
-
 FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
   FGCError status = FGC_COLLECTED;
 

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -30,10 +30,7 @@ void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
 
       II_GCWriter wr = { .ctx = gc, .write = pipe_write_cb };
 
-      InvertedIndex_GcDelta_Scan(
-          &wr, sctx, idx,
-          &cb, NULL
-      );
+      InvertedIndex_GcDelta_Scan(&wr, sctx, idx, &cb);
     }
   }
   dictReleaseIterator(iter);

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -75,7 +75,6 @@ FGCError FGC_parentHandleTags(ForkGC *gc);
 void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
 
-void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
 
 #endif /* FORK_GC_PIPE_H_ */

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -67,10 +67,7 @@ void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx) {
 
         II_GCWriter wr = { .ctx = gc, .write = pipe_write_cb };
 
-        InvertedIndex_GcDelta_Scan(
-            &wr, sctx, value,
-            &cb, NULL
-        );
+        InvertedIndex_GcDelta_Scan(&wr, sctx, value, &cb);
       }
 
       // we are done with the current field

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -34,10 +34,7 @@ void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
 
       II_GCWriter wr = { .ctx = gc, .write = pipe_write_cb };
 
-      InvertedIndex_GcDelta_Scan(
-          &wr, sctx, idx,
-          &cb, NULL
-      );
+      InvertedIndex_GcDelta_Scan(&wr, sctx, idx, &cb);
     }
     rm_free(term);
   }

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1069,6 +1069,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "field_spec",
+ "inverted_index",
  "pretty_assertions",
  "redis_mock",
  "redisearch_rs",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -716,9 +716,13 @@ name = "fork_gc"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "index_spec",
+ "inverted_index",
  "libc",
  "nix",
  "redis-module",
+ "rmp-serde",
+ "serde",
  "tracing",
  "workspace_hack",
 ]
@@ -730,6 +734,7 @@ dependencies = [
  "cheadergen",
  "ffi",
  "fork_gc",
+ "index_spec",
  "tracing",
  "tracing_log_error",
  "workspace_hack",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -716,6 +716,7 @@ name = "fork_gc"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "index_result",
  "index_spec",
  "inverted_index",
  "libc",

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 cheadergen.workspace = true
 ffi = { workspace = true }
 fork_gc = { workspace = true }
+index_spec.workspace = true
 tracing.workspace = true
 tracing_log_error.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -31,11 +31,15 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
 
+    // SAFETY: caller guarantees (2); sctx is a valid non-null pointer.
+    let spec_ptr = unsafe { (*sctx).spec };
     // SAFETY: caller guarantees (2); sctx.spec is a valid non-null IndexSpec.
-    // We don't actually hold a read lock, but when the Fork GC code runs it holds the Redis GIL
+    let spec = unsafe { &*spec_ptr };
+
+    // SAFETY: We don't actually hold a read lock, but when the Fork GC code runs it holds the Redis GIL
     // (so no other thread would be touching any shared Redis state), then forks and the child has
     // only one thread with exclusive access to the index spec.
-    let guard = unsafe { IndexSpecReadGuard::from_locked(&*(*sctx).spec) };
+    let guard = unsafe { IndexSpecReadGuard::from_locked(spec) };
 
-    collect_existing_docs(&mut fgc.writer(), &*guard).unwrap_or_exit();
+    collect_existing_docs(&mut fgc.writer(), &guard).unwrap_or_exit();
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use fork_gc::{ForkGC, existing_docs::collect_existing_docs, io_result_ext::IoResultExt};
+use index_spec::IndexSpecReadGuard;
+
+/// Collect GC delta data for the spec's `existingDocs` inverted index and
+/// send it to the parent process over the pipe.
+///
+/// If the spec has no existing-docs index, or the scan produces no delta,
+/// only the terminator is sent.  Otherwise an empty header followed by the
+/// serialised GC delta is sent before the terminator.
+///
+/// # Safety
+///
+/// 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
+///    writable file descriptor.
+/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
+///    a non-null `IndexSpec`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn FGC_childCollectExistingDocs(
+    gc: *mut ffi::ForkGC,
+    sctx: *mut ffi::RedisSearchCtx,
+) {
+    // SAFETY: caller guarantees (1).
+    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+
+    // SAFETY: caller guarantees (2); sctx.spec is a valid non-null IndexSpec.
+    // We don't actually hold a read lock, but when the Fork GC code runs it holds the Redis GIL
+    // (so no other thread would be touching any shared Redis state), then forks and the child has
+    // only one thread with exclusive access to the index spec.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&*(*sctx).spec) };
+
+    collect_existing_docs(fgc, &*guard).unwrap_or_exit();
+}

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -37,5 +37,5 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
     // only one thread with exclusive access to the index spec.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&*(*sctx).spec) };
 
-    collect_existing_docs(fgc, &*guard).unwrap_or_exit();
+    collect_existing_docs(&mut fgc.writer(), &*guard).unwrap_or_exit();
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -25,6 +25,7 @@ use fork_gc::{ForkGC, Frame, io_result_ext::IoResultExt};
 use tracing::Level;
 use tracing_log_error::log_error;
 
+mod existing_docs;
 mod util;
 
 /// Status code returned by Fork GC parent-side pipe-receive operations.

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -12,7 +12,7 @@
 
 pub mod fork_gc;
 
-use std::ffi::{c_char, c_void};
+use std::ffi::c_char;
 
 use ffi::{
     DocTable_Exists, IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreFieldFlags,
@@ -497,17 +497,6 @@ pub unsafe extern "C" fn InvertedIndex_GcMarkerInc(ii: *mut InvertedIndex) {
     ii_dispatch!(ii, gc_marker_inc);
 }
 
-/// Setting to pass to the GC scan function
-#[repr(C)]
-pub struct IndexRepairParams {
-    /// Callback to call for each entry that is still valid
-    pub repair_callback:
-        Option<extern "C" fn(res: *const RSIndexResult, ib: *const IndexBlock, *mut c_void)>,
-
-    /// Argument to pass to the repair callback
-    pub repair_arg: *mut c_void,
-}
-
 /// Scan the inverted index for garbage and write the GC delta to the provided writer. The function
 /// returns true if the scan was successful and false otherwise.
 ///
@@ -518,7 +507,6 @@ pub struct IndexRepairParams {
 /// - `sctx` must be a valid, non NULL, pointer to a `RedisSearchCtx` instance.
 /// - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
 /// - `cb` must be a valid, non NULL, pointer to an `InvertedIndexGCCallback` instance.
-/// - `params` must be a valid, NULLable, pointer to an `IndexRepairParams` instance.
 /// - The `spec` field of the `RedisSearchCtx` must be a valid, non NULL, pointer to an
 ///   `IndexSpec` instance.
 #[unsafe(no_mangle)]
@@ -527,7 +515,6 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
     sctx: *mut RedisSearchCtx,
     idx: *mut InvertedIndex,
     cb: *mut InvertedIndexGCCallback,
-    params: *mut IndexRepairParams,
 ) -> bool {
     debug_assert!(!sctx.is_null(), "sctx must not be null");
     debug_assert!(!idx.is_null(), "idx must not be null");
@@ -547,21 +534,10 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
     // SAFETY: We know `doc_table` is a valid `DocTable` because it just got it off the spec
     let doc_exists = |id| unsafe { DocTable_Exists(&doc_table, id) };
 
-    let repair = if params.is_null() {
-        None
-    } else {
-        // SAFETY: The caller must ensure `params` is a valid pointer to a `IndexRepairParams` and
-        // we just checked it is not NULL
-        let params = unsafe { &*params };
-        params
-            .repair_callback
-            .map(|cb| move |res: &RSIndexResult, ib: &IndexBlock| cb(res, ib, params.repair_arg))
-    };
-
     // SAFETY: The caller must ensure `idx` is a valid pointer to an `InvertedIndex`
     let ii = unsafe { &*idx };
 
-    let Ok(deltas) = ii_dispatch!(ii, scan_gc, doc_exists, repair) else {
+    let Ok(deltas) = ii_dispatch!(ii, scan_gc, doc_exists, None::<fn(&_, &_)>) else {
         return false;
     };
 

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -36,34 +36,12 @@ use inverted_index::{
     freqs_offsets::FreqsOffsets,
     freqs_only::FreqsOnly,
     full::{Full, FullWide},
+    ii_dispatch,
     numeric::{Numeric, NumericFloatCompression},
     offsets_only::OffsetsOnly,
     raw_doc_ids_only::RawDocIdsOnly,
 };
 use serde::{Deserialize, Serialize};
-
-// Macro to make calling the methods on the inner index easier
-macro_rules! ii_dispatch {
-    ($self:expr, $method:ident $(, $args:expr)*) => {
-        match $self {
-            InvertedIndex::Full(ii) => ii.$method($($args),*),
-            InvertedIndex::FullWide(ii) => ii.$method($($args),*),
-            InvertedIndex::FreqsFields(ii) => ii.$method($($args),*),
-            InvertedIndex::FreqsFieldsWide(ii) => ii.$method($($args),*),
-            InvertedIndex::FreqsOnly(ii) => ii.$method($($args),*),
-            InvertedIndex::FieldsOnly(ii) => ii.$method($($args),*),
-            InvertedIndex::FieldsOnlyWide(ii) => ii.$method($($args),*),
-            InvertedIndex::FieldsOffsets(ii) => ii.$method($($args),*),
-            InvertedIndex::FieldsOffsetsWide(ii) => ii.$method($($args),*),
-            InvertedIndex::OffsetsOnly(ii) => ii.$method($($args),*),
-            InvertedIndex::FreqsOffsets(ii) => ii.$method($($args),*),
-            InvertedIndex::DocIdsOnly(ii) => ii.$method($($args),*),
-            InvertedIndex::RawDocIdsOnly(ii) => ii.$method($($args),*),
-            InvertedIndex::Numeric(ii) => ii.$method($($args),*),
-            InvertedIndex::NumericFloatCompression(ii) => ii.$method($($args),*),
-        }
-    };
-}
 
 /// The mask of flags that determine the index storage type. This includes all flags that affect
 /// the storage format of the index.
@@ -537,7 +515,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
     // SAFETY: The caller must ensure `idx` is a valid pointer to an `InvertedIndex`
     let ii = unsafe { &*idx };
 
-    let Ok(deltas) = ii_dispatch!(ii, scan_gc, doc_exists, None::<fn(&_, &_)>) else {
+    let Ok(deltas) = ii.scan_gc(doc_exists) else {
         return false;
     };
 

--- a/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 ffi.workspace = true
 field_spec.workspace = true
+inverted_index.workspace = true
 schema_rule.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -9,9 +9,10 @@
 
 //! Safe wrapper around [`ffi::IndexSpec`].
 
-use std::{ffi::c_char, slice};
+use std::{ffi::c_char, ptr::NonNull, slice};
 
 use field_spec::FieldSpec;
+use inverted_index::opaque::InvertedIndex;
 use schema_rule::SchemaRule;
 
 /// A safe wrapper around an `ffi::IndexSpec`.
@@ -148,7 +149,7 @@ impl<'lock> IndexSpecWriteGuard<'lock> {
     }
 
     /// Sets the existing documents inverted index pointer.
-    pub const fn set_existing_docs(&mut self, existing_docs: *mut ffi::InvertedIndex) {
+    pub const fn set_existing_docs_ptr(&mut self, existing_docs: *mut ffi::InvertedIndex) {
         self.0.existingDocs = existing_docs;
     }
 
@@ -218,6 +219,23 @@ impl<'lock> IndexSpecReadGuard<'lock> {
         std::mem::ManuallyDrop::new(Self(index_spec))
     }
 
+    /// Check whether the document with the given id exists in this spec's document table.
+    pub fn doc_exists(&self, id: ffi::t_docId) -> bool {
+        // SAFETY: docs is a valid DocTable for a properly initialised IndexSpec.
+        unsafe { ffi::DocTable_Exists(&self.0.docs, id) }
+    }
+
+    /// Return the inverted index tracking all existing (live) document IDs, if present.
+    ///
+    /// This index is only populated when the spec's schema rule has
+    /// [`index_all`](ffi::SchemaRule::index_all) set.
+    pub fn existing_docs(&self) -> Option<&InvertedIndex> {
+        NonNull::new(self.0.existingDocs).map(|existing_docs| {
+            // SAFETY: existingDocs is a valid, non-null pointer to an opaque InvertedIndex.
+            unsafe { existing_docs.cast::<InvertedIndex>().as_ref() }
+        })
+    }
+
     /// Returns whether the keys dictionary is available.
     ///
     /// The keys dictionary maps TEXT terms to their inverted indexes.
@@ -238,7 +256,7 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     /// Returns a pointer to the existing documents inverted index.
     ///
     /// May be null if all documents have been garbage collected.
-    pub const fn existing_docs(&self) -> *mut ffi::InvertedIndex {
+    pub const fn existing_docs_ptr(&self) -> *mut ffi::InvertedIndex {
         self.0.existingDocs
     }
 

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -53,7 +53,7 @@ typedef uint64_t t_fieldMask;
 [header.field]
 
 [header.fork_gc_ffi]
-includes = ["fork_gc.h"]
+includes = ["fork_gc.h", "search_ctx.h"]
 
 [header.inverted_index]
 # `index_result_rs.h` carries the types historically defined in this header

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -23,4 +23,3 @@ workspace_hack.workspace = true
 [dev-dependencies]
 ffi = { workspace = true }
 index_result = { workspace = true }
-inverted_index = { workspace = true }

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -10,9 +10,13 @@ workspace = true
 
 [dependencies]
 ffi = { workspace = true }
+inverted_index = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true }
 redis-module = { workspace = true }
+rmp-serde.workspace = true
+index_spec.workspace = true
+serde.workspace = true
 tracing.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -22,3 +22,5 @@ workspace_hack.workspace = true
 
 [dev-dependencies]
 ffi = { workspace = true }
+index_result = { workspace = true }
+inverted_index = { workspace = true }

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -34,11 +34,11 @@ pub fn collect_existing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard)
     if let Some(ii) = spec.existing_docs()
         && let Ok(Some(deltas)) = ii.scan_gc(doc_exists)
     {
-        Frame::Empty.write(writer)?;
+        Frame::Empty.encode(writer)?;
         deltas
             .serialize(&mut rmp_serde::Serializer::new(&mut *writer))
             .map_err(io::Error::other)?;
     }
 
-    Frame::Terminator.write(writer)
+    Frame::Terminator.encode(writer)
 }

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Child-side GC collection for the `existingDocs` inverted index.
+
+use std::io;
+
+use index_spec::IndexSpecReadGuard;
+use serde::Serialize as _;
+
+use crate::{ForkGC, Frame};
+
+/// Collect the GC delta for the spec's `existingDocs` inverted index and write
+/// it to the parent process.
+///
+/// If the spec has no existing-docs index, or the scan produces no delta, only
+/// the terminator is written. Otherwise an empty header followed by the
+/// serialised [`GcScanDelta`] is written before the terminator.
+///
+/// Scan errors are silently ignored (same block is retried on the next GC
+/// cycle). Write errors are surfaced to the caller so they can terminate the
+/// child process.
+///
+/// [`GcScanDelta`]: inverted_index::GcScanDelta
+pub fn collect_existing_docs(fgc: &mut ForkGC, spec: &IndexSpecReadGuard) -> io::Result<()> {
+    let doc_exists = |id| spec.doc_exists(id);
+    let mut writer = fgc.writer();
+
+    if let Some(ii) = spec.existing_docs()
+        && let Ok(Some(deltas)) = ii.scan_gc(doc_exists)
+    {
+        Frame::Empty.write(&mut writer)?;
+        deltas
+            .serialize(&mut rmp_serde::Serializer::new(&mut writer))
+            .map_err(io::Error::other)?;
+    }
+
+    Frame::Terminator.write(&mut writer)
+}

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -9,15 +9,15 @@
 
 //! Child-side GC collection for the `existingDocs` inverted index.
 
-use std::io;
+use std::io::{self, Write};
 
 use index_spec::IndexSpecReadGuard;
 use serde::Serialize as _;
 
-use crate::{ForkGC, Frame};
+use crate::Frame;
 
 /// Collect the GC delta for the spec's `existingDocs` inverted index and write
-/// it to the parent process.
+/// it to `writer`.
 ///
 /// If the spec has no existing-docs index, or the scan produces no delta, only
 /// the terminator is written. Otherwise an empty header followed by the
@@ -28,18 +28,17 @@ use crate::{ForkGC, Frame};
 /// child process.
 ///
 /// [`GcScanDelta`]: inverted_index::GcScanDelta
-pub fn collect_existing_docs(fgc: &mut ForkGC, spec: &IndexSpecReadGuard) -> io::Result<()> {
+pub fn collect_existing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) -> io::Result<()> {
     let doc_exists = |id| spec.doc_exists(id);
-    let mut writer = fgc.writer();
 
     if let Some(ii) = spec.existing_docs()
         && let Ok(Some(deltas)) = ii.scan_gc(doc_exists)
     {
-        Frame::Empty.write(&mut writer)?;
+        Frame::Empty.write(writer)?;
         deltas
-            .serialize(&mut rmp_serde::Serializer::new(&mut writer))
+            .serialize(&mut rmp_serde::Serializer::new(&mut *writer))
             .map_err(io::Error::other)?;
     }
 
-    Frame::Terminator.write(&mut writer)
+    Frame::Terminator.write(writer)
 }

--- a/src/redisearch_rs/fork_gc/src/lib.rs
+++ b/src/redisearch_rs/fork_gc/src/lib.rs
@@ -15,6 +15,7 @@
 //! in the `fork_gc_ffi` crate, which is a thin trampoline on top of this
 //! one.
 
+pub mod existing_docs;
 pub mod fork_gc;
 pub mod frame;
 pub mod io_result_ext;

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -45,7 +45,7 @@ fn no_existing_docs_writes_only_terminator() {
 
     let mut cursor = Cursor::new(&buf);
     assert!(matches!(
-        Frame::read(&mut cursor).unwrap(),
+        Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
 }
@@ -67,7 +67,7 @@ fn empty_existing_docs_writes_only_terminator() {
 
     let mut cursor = Cursor::new(&buf);
     assert!(matches!(
-        Frame::read(&mut cursor).unwrap(),
+        Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
 
@@ -95,11 +95,11 @@ fn existing_docs_with_deleted_entries_writes_delta() {
     collect_existing_docs(&mut buf, &*guard).unwrap();
 
     let mut cursor = Cursor::new(&buf);
-    assert!(matches!(Frame::read(&mut cursor).unwrap(), Frame::Empty));
+    assert!(matches!(Frame::decode(&mut cursor).unwrap(), Frame::Empty));
     let delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
     assert_eq!(delta.last_block_idx(), 0);
     assert!(matches!(
-        Frame::read(&mut cursor).unwrap(),
+        Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
 

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{io::Cursor, mem};
+
+use ffi::IndexFlags_Index_DocIdsOnly;
+use fork_gc::{Frame, existing_docs::collect_existing_docs};
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
+use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
+
+// `collect_existing_docs` calls `spec.doc_exists()`, which calls `DocTable_Exists`
+// from the C library. That symbol is unavailable in pure-Rust test binaries, so we
+// provide a stub here. A zeroed `DocTable` has `maxDocId == 0`, so the real
+// implementation would return `false` for any doc ID anyway — the stub is consistent.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn DocTable_Exists(_: *const ffi::DocTable, _: ffi::t_docId) -> bool {
+    false
+}
+
+fn make_spec(existing_docs: *mut ffi::InvertedIndex) -> ffi::IndexSpec {
+    // SAFETY: zeroed IndexSpec is valid for read-only access; existingDocs is
+    // either null or a caller-managed pointer that outlives this struct.
+    let mut spec: ffi::IndexSpec = unsafe { mem::zeroed() };
+    spec.existingDocs = existing_docs;
+    spec
+}
+
+/// When the spec has no `existingDocs` index, only a Terminator is written.
+#[test]
+fn no_existing_docs_writes_only_terminator() {
+    let spec = make_spec(std::ptr::null_mut());
+    // SAFETY: spec is valid and lives for the duration of the test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_existing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    assert!(matches!(
+        Frame::read(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+}
+
+/// When `existingDocs` is present but empty, `scan_gc` returns no delta and
+/// only a Terminator is written.
+#[test]
+fn empty_existing_docs_writes_only_terminator() {
+    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(
+        InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+    ));
+    let ii_ptr = Box::into_raw(ii);
+    let spec = make_spec(ii_ptr.cast());
+    // SAFETY: spec and ii_ptr are valid and live for the duration of the test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_existing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    assert!(matches!(
+        Frame::read(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+
+    // SAFETY: ii_ptr was created via Box::into_raw above.
+    unsafe { drop(Box::from_raw(ii_ptr)) };
+}
+
+/// When `existingDocs` has entries and all docs are absent from the DocTable
+/// (stub returns false), `scan_gc` produces a delta. The output is an Empty
+/// frame, the serialised [`GcScanDelta`], then a Terminator.
+#[test]
+fn existing_docs_with_deleted_entries_writes_delta() {
+    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(1).build())
+        .unwrap();
+    ii.add_record(&RSIndexResult::build_virt().doc_id(2).build())
+        .unwrap();
+    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
+    let ii_ptr = Box::into_raw(ii);
+    let spec = make_spec(ii_ptr.cast());
+    // SAFETY: spec and ii_ptr are valid and live for the duration of the test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_existing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    assert!(matches!(Frame::read(&mut cursor).unwrap(), Frame::Empty));
+    let delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+    assert_eq!(delta.last_block_idx(), 0);
+    assert!(matches!(
+        Frame::read(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+
+    // SAFETY: ii_ptr was created via Box::into_raw above.
+    unsafe { drop(Box::from_raw(ii_ptr)) };
+}

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "fork_gc.h"
+#include "search_ctx.h"
 
 /**
  * Status code returned by Fork GC parent-side pipe-receive operations.
@@ -38,6 +39,23 @@ typedef enum FGCError {
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/**
+ * Collect GC delta data for the spec's `existingDocs` inverted index and
+ * send it to the parent process over the pipe.
+ *
+ * If the spec has no existing-docs index, or the scan produces no delta,
+ * only the terminator is sent.  Otherwise an empty header followed by the
+ * serialised GC delta is sent before the terminator.
+ *
+ * # Safety
+ *
+ * 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
+ *    writable file descriptor.
+ * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
+ *    a non-null `IndexSpec`.
+ */
+void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 
 /**
  * Write exactly `len` bytes from `buff` to the FGC pipe.

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -19,11 +19,6 @@
 typedef struct RSIndexResult RSIndexResult;
 
 /**
- * Setting to pass to the GC scan function
- */
-typedef struct IndexRepairParams IndexRepairParams;
-
-/**
  * An opaque inverted index reader structure. The actual implementation is determined at runtime
  * based on the index type and filter provided when creating the reader. This allows us to have a
  * single interface for all index reader types while still being able to optimize the storage
@@ -279,11 +274,10 @@ void InvertedIndex_GcMarkerInc(struct InvertedIndex *ii);
  * - `sctx` must be a valid, non NULL, pointer to a `RedisSearchCtx` instance.
  * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
  * - `cb` must be a valid, non NULL, pointer to an `InvertedIndexGCCallback` instance.
- * - `params` must be a valid, NULLable, pointer to an `IndexRepairParams` instance.
  * - The `spec` field of the `RedisSearchCtx` must be a valid, non NULL, pointer to an
  *   `IndexSpec` instance.
  */
-bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, struct InvertedIndex *idx, struct II_GCCallback *cb, struct IndexRepairParams *params);
+bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, struct InvertedIndex *idx, struct II_GCCallback *cb);
 
 /**
  * Read a GC delta from the provided reader. The returned pointer must be freed using

--- a/src/redisearch_rs/inverted_index/src/index/opaque.rs
+++ b/src/redisearch_rs/inverted_index/src/index/opaque.rs
@@ -11,6 +11,9 @@
 
 use std::fmt::Debug;
 
+use ffi::t_docId;
+
+use crate::ii_dispatch;
 use crate::{
     EntriesTrackingIndex, FieldMaskTrackingIndex, InvertedIndex as InvertedIndexInner,
     doc_ids_only::DocIdsOnly,
@@ -132,6 +135,18 @@ pub enum InvertedIndex {
     NumericFloatCompression(EntriesTrackingIndex<NumericFloatCompression>),
 }
 
+impl InvertedIndex {
+    /// Scan the index for blocks that can be garbage collected.
+    ///
+    /// This is a dispatch wrapper around the typed [`InvertedIndex::scan_gc`].
+    pub fn scan_gc(
+        &self,
+        doc_exist: impl Fn(t_docId) -> bool,
+    ) -> std::io::Result<Option<crate::GcScanDelta>> {
+        ii_dispatch!(self, scan_gc, doc_exist, None::<fn(&_, &_)>)
+    }
+}
+
 impl Debug for InvertedIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -154,4 +169,35 @@ impl Debug for InvertedIndex {
             }
         }
     }
+}
+
+/// Dispatch a method call to the inner index of an [`InvertedIndex`] variant.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let usage: usize = ii_dispatch!(ii, memory_usage);
+/// let result = ii_dispatch!(ii, add_record, &record);
+/// ```
+#[macro_export]
+macro_rules! ii_dispatch {
+    ($self:expr, $method:ident $(, $args:expr)*) => {
+        match $self {
+            $crate::opaque::InvertedIndex::Full(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FullWide(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FreqsFields(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FreqsFieldsWide(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FreqsOnly(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FieldsOnly(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FieldsOnlyWide(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FieldsOffsets(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FieldsOffsetsWide(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::OffsetsOnly(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::FreqsOffsets(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::DocIdsOnly(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::RawDocIdsOnly(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::Numeric(ii) => ii.$method($($args),*),
+            $crate::opaque::InvertedIndex::NumericFloatCompression(ii) => ii.$method($($args),*),
+        }
+    };
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -74,16 +74,11 @@ where
     ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
     ///    variant matches `E`.
     fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
-        let existing_docs = spec
-            .existing_docs()
-            .cast::<inverted_index::opaque::InvertedIndex>();
-        if existing_docs.is_null() {
-            // the garbage collector may set existing_docs to NULL after garbage collecting all documents
+        // the garbage collector may set existing_docs to NULL after garbage collecting all documents
+        let Some(existing_docs) = spec.existing_docs() else {
             return true;
-        }
+        };
 
-        // SAFETY: spec.existing_docs() returns a valid pointer when non-null, and we just checked it's not null.
-        let existing_docs = unsafe { &*existing_docs };
         // SAFETY: The encoding variant matches E (structural invariant).
         let ii = E::from_opaque(existing_docs);
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -152,11 +152,11 @@ mod not_miri {
         let new_ii = Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
             inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
-        let old_existing_docs = test.test.context.spec_read().existing_docs();
+        let old_existing_docs = test.test.context.spec_read().existing_docs_ptr();
         test.test
             .context
             .spec_write()
-            .set_existing_docs(new_ii.cast());
+            .set_existing_docs_ptr(new_ii.cast());
 
         // Revalidate should return Aborted because existingDocs no longer
         // points to the same index the reader was created from.
@@ -170,7 +170,7 @@ mod not_miri {
         test.test
             .context
             .spec_write()
-            .set_existing_docs(old_existing_docs);
+            .set_existing_docs_ptr(old_existing_docs);
         unsafe {
             drop(Box::from_raw(new_ii));
         }
@@ -201,11 +201,11 @@ mod not_miri {
 
         // Simulate the garbage collector setting existingDocs to NULL after
         // collecting all documents.
-        let old_existing_docs = test.test.context.spec_read().existing_docs();
+        let old_existing_docs = test.test.context.spec_read().existing_docs_ptr();
         test.test
             .context
             .spec_write()
-            .set_existing_docs(std::ptr::null_mut());
+            .set_existing_docs_ptr(std::ptr::null_mut());
 
         let status = it
             .revalidate(&*test.test.context.spec_read())
@@ -216,7 +216,7 @@ mod not_miri {
         test.test
             .context
             .spec_write()
-            .set_existing_docs(old_existing_docs);
+            .set_existing_docs_ptr(old_existing_docs);
     }
 
     /// Test that `reader()` returns a reference to the underlying reader.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -668,16 +668,18 @@ mod revalidate {
             InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
         )));
         // We temporarily swap `existingDocs` to trigger a wildcard abort.
-        let old_existing_docs = context.spec_read().existing_docs();
+        let old_existing_docs = context.spec_read().existing_docs_ptr();
 
-        context.spec_write().set_existing_docs(new_ii.cast());
+        context.spec_write().set_existing_docs_ptr(new_ii.cast());
 
         let status = it.revalidate(&*context.spec_read()).unwrap();
         assert_eq!(status, RQEValidateStatus::Aborted);
 
         // Restoring the original `existingDocs` pointer and dropping
         // `new_ii` which was created via `Box::into_raw` above.
-        context.spec_write().set_existing_docs(old_existing_docs);
+        context
+            .spec_write()
+            .set_existing_docs_ptr(old_existing_docs);
         // SAFETY: Dropping Box from raw pointer.
         unsafe {
             drop(Box::from_raw(new_ii));


### PR DESCRIPTION
## Describe the changes in the pull request

**Current:**
 - `FGC_childCollectExistingDocs` — the fork GC child-side scan for the existingDocs inverted index — is implemented in C (`src/fork_gc/existing_docs.c`). The `InvertedIndex_GcDelta_Scan` FFI function accepted a nullable `IndexRepairParams*` that was always passed as `NULL`. The `ii_dispatch!` macro lived in the `inverted_index_ffi` crate, and `IndexSpecReadGuard` only exposed raw pointer accessors for `existingDocs`.

**Change:**
 - Drop the unused params argument from `InvertedIndex_GcDelta_Scan` and update all C call sites.
 - Move the `ii_dispatch!` macro into the inverted_index crate (opaque module) and add a `scan_gc` method on the opaque `InvertedIndex` enum that dispatches internally, removing the need for callers to use the macro directly.
 - Add safe `doc_exists(id)` and `existing_docs() -> Option<&InvertedIndex>` methods to `IndexSpecReadGuard`; rename the raw-pointer variants to `existing_docs_ptr` / `set_existing_docs_ptr`.
 - Delete the C `FGC_childCollectExistingDocs` and reimplement it in Rust (`fork_gc::existing_docs`, exposed via `fork_gc_ffi`), using the new safe `IndexSpecReadGuard` API.

**Outcome:**
 - The existingDocs GC collection path is now fully in Rust with no unsafe raw-pointer gymnastics at the call site. The `ii_dispatch!` macro is now a proper library export, and the `IndexSpecReadGuard` API differentiates between safe references and raw pointers.

## Main objects this PR modified

  1. `src/fork_gc/existing_docs.c` — deleted FGC_childCollectExistingDocs
  2. `src/redisearch_rs/fork_gc/src/existing_docs.rs` — new Rust implementation
  3. `src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs` — new FFI entry point
  4. `src/redisearch_rs/c_wrappers/index_spec/src/lib.rs` — doc_exists, existing_docs, renamed ptr variants
  5. `src/redisearch_rs/inverted_index/src/index/opaque.rs` — ii_dispatch! macro moved here, scan_gc method added

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-GC child I/O and inverted-index GC scanning on a live index snapshot; behavior should match the removed C path but mistakes could affect wildcard/GC consistency.
> 
> **Overview**
> **Moves the fork-GC child scan for `existingDocs` from C into Rust**, keeping the same pipe protocol (empty frame + serialized delta + terminator). The C implementation in `existing_docs.c` is removed; `FGC_childCollectExistingDocs` is now exported from `fork_gc_ffi` and delegates to `fork_gc::existing_docs::collect_existing_docs`, which uses `IndexSpecReadGuard` and opaque `InvertedIndex::scan_gc` instead of `InvertedIndex_GcDelta_Scan` with callbacks.
> 
> **Inverted-index GC FFI is simplified:** `IndexRepairParams` and the nullable fifth argument to `InvertedIndex_GcDelta_Scan` are dropped (call sites in terms/tags/missing_docs always passed `NULL`). The `ii_dispatch!` macro moves into the `inverted_index` crate with a new `scan_gc` wrapper on the opaque enum.
> 
> **`IndexSpecReadGuard` gains safe accessors** (`doc_exists`, `existing_docs() -> Option<&InvertedIndex>`); raw-pointer helpers are renamed to `existing_docs_ptr` / `set_existing_docs_ptr`, with wildcard revalidate tests updated accordingly. Unit tests cover terminator-only vs delta output for `collect_existing_docs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb52e009fd4ef6c20bf95b297f3d4ec33b52b1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->