### PR TITLE
[MOD-15393] trie: add opaque accessors for TrieNode fields used by suffix.c

### DIFF
--- a/src/suffix.c
+++ b/src/suffix.c
@@ -17,10 +17,7 @@
 #include <strings.h>
 
 static inline suffixData *Suffix_GetData(const TrieNode *node) {
-  char *data;
-  uint32_t len;
-  if (!TrieNode_GetPayload(node, &data, &len)) return NULL;
-  return (suffixData *)data;
+  return (suffixData *)TrieNode_GetPayloadData(node);
 }
 
 

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -16,8 +16,12 @@
 #include <string.h>
 #include <strings.h>
 
-#define Suffix_GetData(node) node ? node->payload ? \
-                             (suffixData *)node->payload->data : NULL : NULL
+static inline suffixData *Suffix_GetData(const TrieNode *node) {
+  char *data;
+  uint32_t len;
+  if (!TrieNode_GetPayload(node, &data, &len)) return NULL;
+  return (suffixData *)data;
+}
 
 
 /***********************************************************/
@@ -84,7 +88,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
     TrieNode *trienode = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
 
     data = Suffix_GetData(trienode);
-    if (!trienode || !trienode->payload) {
+    if (!data) {
       suffixData newdata = createSuffixNode(copyStr, 0);
       RSPayload payload = { .data = (char*)&newdata, .len = sizeof(newdata) };
       int rc = Trie_InsertRune(trie, runes + j, rlen - j, 1, ADD_REPLACE, &payload, 0);
@@ -161,19 +165,16 @@ static int processSuffixData(suffixData *data, SuffixCtx *sufCtx) {
 }
 
 static int recursiveAdd(TrieNode *node, SuffixCtx *sufCtx) {
-  if (node->payload) {
-    size_t rlen;
-    suffixData *data = Suffix_GetData(node);
+  suffixData *data = Suffix_GetData(node);
+  if (data) {
     if (processSuffixData(data, sufCtx) != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
   }
-  if (node->numChildren) {
-    TrieNode **children = __trieNode_children(node);
-    for (int i = 0; i < node->numChildren; ++i) {
-      if (recursiveAdd(children[i], sufCtx) != REDISMODULE_OK) {
-        return REDISMODULE_ERR;
-      }
+  t_len numChildren = TrieNode_NumChildren(node);
+  for (t_len i = 0; i < numChildren; ++i) {
+    if (recursiveAdd(TrieNode_ChildAt(node, i), sufCtx) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
     }
   }
   return REDISMODULE_OK;

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -135,7 +135,7 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
 
 static TrieNode *__trieNode_resizeChildren(TrieNode *n, int offset) {
   n = rm_realloc(n, __trieNode_Sizeof(n->numChildren + offset, n->len));
-  TrieNode **children = __trieNode_children(n);
+  TrieNode **children = TrieNode_Children(n);
 
   // stretch or shrink the child key cache array
   memmove(((rune *)children) + offset, (rune *)children, sizeof(TrieNode *) * n->numChildren);
@@ -153,10 +153,10 @@ static TrieNode *__trie_AddChildIdx(TrieNode *n, const rune *str, t_len offset, 
 
   if (n->numChildren > 1) {
     memmove(__trieNode_childKey(n, idx + 1), __trieNode_childKey(n, idx), (n->numChildren - idx - 1) * sizeof(rune));
-    memmove(__trieNode_children(n) + idx + 1, __trieNode_children(n) + idx, (n->numChildren - idx - 1) * sizeof(TrieNode *));
+    memmove(TrieNode_Children(n) + idx + 1, TrieNode_Children(n) + idx, (n->numChildren - idx - 1) * sizeof(TrieNode *));
   }
   *__trieNode_childKey(n, idx) = str[offset];
-  __trieNode_children(n)[idx] = child;
+  TrieNode_Children(n)[idx] = child;
   return n;
 }
 
@@ -171,8 +171,8 @@ static TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
   newChild->flags = n->flags;
   newChild->payload = n->payload;
   n->payload = NULL;
-  TrieNode **children = __trieNode_children(n);
-  TrieNode **newChildren = __trieNode_children(newChild);
+  TrieNode **children = TrieNode_Children(n);
+  TrieNode **newChildren = TrieNode_Children(newChild);
   memcpy(newChildren, children, sizeof(TrieNode *) * n->numChildren);
   memcpy(__trieNode_childKey(newChild, 0), __trieNode_childKey(n, 0), n->numChildren * sizeof(rune));
 
@@ -186,7 +186,7 @@ static TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
 
   updateScore(n, newChild->score);
   n = rm_realloc(n, __trieNode_Sizeof(n->numChildren, n->len));
-  __trieNode_children(n)[0] = newChild;
+  TrieNode_Children(n)[0] = newChild;
   *__trieNode_childKey(n, 0) = newChild->str[0];
 
   return n;
@@ -199,7 +199,7 @@ static TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback f
   if (__trieNode_isTerminal(n) || n->numChildren != 1) {
     return n;
   }
-  TrieNode *ch = *__trieNode_children(n);
+  TrieNode *ch = *TrieNode_Children(n);
 
   // Copy the current node's data and children to a new child node
   rune nstr[n->len + ch->len + 1];
@@ -213,8 +213,8 @@ static TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback f
   merged->payload = ch->payload;
   ch->payload = NULL;
   merged->flags = ch->flags;
-  TrieNode **children = __trieNode_children(ch);
-  TrieNode **newChildren = __trieNode_children(merged);
+  TrieNode **children = TrieNode_Children(ch);
+  TrieNode **newChildren = TrieNode_Children(merged);
   memcpy(newChildren, children, sizeof(TrieNode *) * merged->numChildren);
   memcpy(__trieNode_childKey(merged, 0), __trieNode_childKey(ch, 0),
          merged->numChildren * sizeof(rune));
@@ -255,7 +255,7 @@ static int __trieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *
       n->score = score;
       n->flags |= TRIENODE_TERMINAL;
       n->numDocs += numDocs;
-      TrieNode *newChild = __trieNode_children(n)[0];
+      TrieNode *newChild = TrieNode_Children(n)[0];
       n = rm_realloc(n, __trieNode_Sizeof(n->numChildren, n->len));
       if (n->payload != NULL) {
         triePayload_Free(n->payload, freecb);
@@ -265,7 +265,7 @@ static int __trieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *
         n->payload = triePayload_New(payload->data, (uint32_t)payload->len);
       }
 
-      __trieNode_children(n)[0] = newChild;
+      TrieNode_Children(n)[0] = newChild;
     } else {
       // a node after a split has a single child
       int idx = str[offset] > *__trieNode_childKey(n, 0) ? 1 : 0;
@@ -314,18 +314,18 @@ static int __trieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *
   int scoreIdx = REDISEARCH_UNINITIALIZED;
   for (; idx < n->numChildren; idx++) {
     const rune *childKey = __trieNode_childKey(n, idx);
-    TrieNode *child = __trieNode_children(n)[idx];
+    TrieNode *child = TrieNode_Children(n)[idx];
     if (str[offset] == *childKey) {
       // Payload is validated at the entry point (TrieNode_Add), so
       // TRIE_ERR_PAYLOAD_OVERFLOW cannot occur here.
       int rc = __trieNode_Add(&child, str + offset, len - offset, payload, score, op, freecb,
                             numDocs);
       *__trieNode_childKey(n, idx) = str[offset];
-      __trieNode_children(n)[idx] = child;
+      TrieNode_Children(n)[idx] = child;
       // In score mode, check if the order was kept and fix as necessary
       if (n->sortMode == Trie_Sort_Score && n->numChildren > 1) {
-        if ((idx > 0 && child->maxChildScore > __trieNode_children(n)[idx - 1]->maxChildScore) ||
-            (idx < n->numChildren - 2 && child->maxChildScore < __trieNode_children(n)[idx + 1]->maxChildScore)) {
+        if ((idx > 0 && child->maxChildScore > TrieNode_Children(n)[idx - 1]->maxChildScore) ||
+            (idx < n->numChildren - 2 && child->maxChildScore < TrieNode_Children(n)[idx + 1]->maxChildScore)) {
           __trieNode_sortChildren(n);
         }
       }
@@ -392,7 +392,7 @@ TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int 
       rune *childKeys = __trieNode_childKey(n, 0);
       for (; i < n->numChildren; i++) {
         if (str[offset] == childKeys[i]) {
-          nextChild = __trieNode_children(n)[i];
+          nextChild = TrieNode_Children(n)[i];
           break;
         }
         if (n->sortMode == Trie_Sort_Lex && str[offset] < childKeys[i]) {
@@ -419,7 +419,7 @@ TrieNode *TrieNode_Get(TrieNode *n, const rune *str, t_len len, bool exact, int 
 static int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
   int rc = 0;
   int i = 0;
-  TrieNode **nodes = __trieNode_children(n);
+  TrieNode **nodes = TrieNode_Children(n);
   n->maxChildScore = n->score;
   // free deleted terminal nodes
   while (i < n->numChildren) {
@@ -499,7 +499,7 @@ int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback fr
       for (; i < n->numChildren; i++) {
         rune ckey = *__trieNode_childKey(n, i);
         if (str[offset] == ckey) {
-          nextChild = __trieNode_children(n)[i];;
+          nextChild = TrieNode_Children(n)[i];;
           break;
         }
       }
@@ -522,7 +522,7 @@ end:
 
 void TrieNode_Free(TrieNode *n, TrieFreeCallback freecb) {
   for (t_len i = 0; i < n->numChildren; i++) {
-    TrieNode *child = __trieNode_children(n)[i];
+    TrieNode *child = TrieNode_Children(n)[i];
     TrieNode_Free(child, freecb);
   }
   if (n->payload != NULL) {
@@ -574,19 +574,19 @@ inline static int __trieNode_Cmp_Score(const void *p1, const void *p2) {
 
 /* Sort the children of a node */
 static void __trieNode_sortChildren(TrieNode *n) {
-  TrieNode **node = __trieNode_children(n);
+  TrieNode **node = TrieNode_Children(n);
   if (n->numChildren > 1) {
     switch (n->sortMode) {
     case Trie_Sort_Lex:
-      qsort(__trieNode_children(n), n->numChildren, sizeof(TrieNode *), __trieNode_Cmp_Lex);
+      qsort(TrieNode_Children(n), n->numChildren, sizeof(TrieNode *), __trieNode_Cmp_Lex);
       break;
     case Trie_Sort_Score:
-      qsort(__trieNode_children(n), n->numChildren, sizeof(TrieNode *), __trieNode_Cmp_Score);
+      qsort(TrieNode_Children(n), n->numChildren, sizeof(TrieNode *), __trieNode_Cmp_Score);
       break;
     }
     // Sort the local rune array by the rune in child
     for (int i = 0; i < n->numChildren; ++i) {
-      *__trieNode_childKey(n, i) = __trieNode_children(n)[i]->str[0];
+      *__trieNode_childKey(n, i) = TrieNode_Children(n)[i]->str[0];
     }
   }
 }
@@ -674,7 +674,7 @@ inline int __ti_step(TrieIterator *it, void *matchCtx) {
     default:
       // push the next child
       if (current->childOffset < current->n->numChildren) {
-        TrieNode *ch = __trieNode_children(current->n)[current->childOffset++];
+        TrieNode *ch = TrieNode_Children(current->n)[current->childOffset++];
         if (ch->maxChildScore >= it->minScore || ch->score >= it->minScore) {
           __ti_Push(it, ch, 0);
           it->nodesConsumed++;
@@ -772,7 +772,7 @@ TrieNode *TrieNode_RandomWalk(TrieNode *n, int minSteps, rune **str, t_len *len)
       continue;
     }
     /* Push a child on the stack */
-    TrieNode *child = __trieNode_children(n)[rnd];
+    TrieNode *child = TrieNode_Children(n)[rnd];
     stack[stackSz++] = child;
 
     steps++;
@@ -848,7 +848,7 @@ static int rangeIterateSubTree(TrieNode *n, RangeCtx *r) {
     }
   }
 
-  TrieNode **arr = __trieNode_children(n);
+  TrieNode **arr = TrieNode_Children(n);
 
   for (size_t ii = 0; ii < n->numChildren; ++ii) {
     if (rangeIterateSubTree(arr[ii], r) != REDISEARCH_OK) {
@@ -886,7 +886,7 @@ static void rangeIterate(TrieNode *n, const rune *min, int nmin, const rune *max
   int endIdx = -1;
   rsbHelper h = {0};
 
-  TrieNode **arr = __trieNode_children(n);
+  TrieNode **arr = TrieNode_Children(n);
   size_t arrlen = n->numChildren;
   if (!arrlen) {
     // no children, just return.
@@ -1079,7 +1079,7 @@ done:
 // check next char on node or children
 static void containsNext(TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r) {
   if (n->len == localOffset || n->len == 0 ) {
-    TrieNode **children = __trieNode_children(n);
+    TrieNode **children = TrieNode_Children(n);
     for (t_len i = 0; i < n->numChildren && r->stop == 0; ++i) {
       containsIterate(children[i], 0, globalOffset, r);
     }
@@ -1177,7 +1177,7 @@ static void wildcardIterate(TrieNode *n, RangeCtx *r) {
       if (!r->containsStars && array_len(r->buf) >= r->lenOrigStr) {
         break;
       }
-      TrieNode **children = __trieNode_children(n);
+      TrieNode **children = TrieNode_Children(n);
       for (t_len i = 0; i < n->numChildren && r->stop == 0; ++i) {
         wildcardIterate(children[i], r);
       }

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -111,13 +111,10 @@ static inline TrieNode *TrieNode_ChildAt(const TrieNode *n, t_len i) {
   return children[i];
 }
 
-/* If the node has a payload, write its data pointer and length to *data and
- * *len and return true. Otherwise (or if n is NULL) return false. */
-static inline bool TrieNode_GetPayload(const TrieNode *n, char **data, uint32_t *len) {
-  if (!n || !n->payload) return false;
-  *data = n->payload->data;
-  *len = n->payload->len;
-  return true;
+/* Return the node's payload data pointer, or NULL if the node has no payload
+ * (or n is NULL). */
+static inline char *TrieNode_GetPayloadData(const TrieNode *n) {
+  return (n && n->payload) ? n->payload->data : NULL;
 }
 
 typedef enum {

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -79,7 +79,7 @@ typedef struct {
   // the string of the current node
   rune str[];
   // ... here come the first letters of each child childRunes[]
-  // ... now come the children, to be accessed with __trieNode_children
+  // ... now come the children, to be accessed with TrieNode_Children
 } TrieNode;
 #pragma pack()
 
@@ -90,11 +90,6 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
                         t_len numChildren, float score, int terminal, TrieSortMode sortMode,
                         size_t numDocs);
 
-/* Get a pointer to the children array of a node. This is not an actual member
- * of the node for memory saving reasons */
-#define __trieNode_children(n) \
-  ((TrieNode **)((void *)n + sizeof(TrieNode) + ((n->len + 1) + (n->numChildren)) * sizeof(rune)))
-
 #define __trieNode_isTerminal(n) (n->flags & TRIENODE_TERMINAL)
 
 /* Opaque accessors over TrieNode struct internals. Prefer these over direct
@@ -103,12 +98,17 @@ static inline t_len TrieNode_NumChildren(const TrieNode *n) {
   return n->numChildren;
 }
 
+/* Get a pointer to the children array of a node. The children are not an
+ * actual member of the node for memory saving reasons. char* arithmetic is
+ * used so this stays valid when included in C++ TUs (void* arithmetic is a
+ * GCC C extension). */
+static inline TrieNode **TrieNode_Children(const TrieNode *n) {
+  return (TrieNode **)((char *)n + sizeof(TrieNode) +
+                       ((n->len + 1) + n->numChildren) * sizeof(rune));
+}
+
 static inline TrieNode *TrieNode_ChildAt(const TrieNode *n, t_len i) {
-  /* Mirror __trieNode_children but with char* arithmetic so this stays valid
-   * when included in C++ TUs (void* arithmetic is a GCC C extension). */
-  TrieNode **children = (TrieNode **)((char *)n + sizeof(TrieNode) +
-                                      ((n->len + 1) + n->numChildren) * sizeof(rune));
-  return children[i];
+  return TrieNode_Children(n)[i];
 }
 
 /* Return the node's payload data pointer, or NULL if the node has no payload

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -97,6 +97,29 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
 
 #define __trieNode_isTerminal(n) (n->flags & TRIENODE_TERMINAL)
 
+/* Opaque accessors over TrieNode struct internals. Prefer these over direct
+ * field/macro access so callers stay decoupled from layout changes. */
+static inline t_len TrieNode_NumChildren(const TrieNode *n) {
+  return n->numChildren;
+}
+
+static inline TrieNode *TrieNode_ChildAt(const TrieNode *n, t_len i) {
+  /* Mirror __trieNode_children but with char* arithmetic so this stays valid
+   * when included in C++ TUs (void* arithmetic is a GCC C extension). */
+  TrieNode **children = (TrieNode **)((char *)n + sizeof(TrieNode) +
+                                      ((n->len + 1) + n->numChildren) * sizeof(rune));
+  return children[i];
+}
+
+/* If the node has a payload, write its data pointer and length to *data and
+ * *len and return true. Otherwise (or if n is NULL) return false. */
+static inline bool TrieNode_GetPayload(const TrieNode *n, char **data, uint32_t *len) {
+  if (!n || !n->payload) return false;
+  *data = n->payload->data;
+  *len = n->payload->len;
+  return true;
+}
+
 typedef enum {
   ADD_REPLACE,
   ADD_INCR,


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `suffix.c` reaches directly into `TrieNode` struct internals (`node->payload`, `node->numChildren`) and uses the `__trieNode_children` macro to walk children. It is the only production caller outside `src/trie/` that depends on the TrieNode layout. This blocks treating TrieNode as an opaque type and constrains the upcoming Rust port of the trie module.
2. **Change:** Adds three `static inline` accessors to `src/trie/trie_node.h` — `TrieNode_NumChildren`, `TrieNode_ChildAt`, `TrieNode_GetPayload` — and rewrites the reach-ins in `src/suffix.c` to use them. `Suffix_GetData` macro becomes a `static inline` helper over `TrieNode_GetPayload`, and the matching `if (!trienode || !trienode->payload)` / `if (node->payload)` checks collapse to `if (!data)` / `if (data)`. `TrieNode_ChildAt` inlines the child-pointer arithmetic with a `char *` cast rather than reusing `__trieNode_children`, because the existing macro relies on `void *` arithmetic (a GCC C extension) and the accessor must compile inside C++ TUs that transitively include `trie_node.h`.
3. **Outcome:** No behavioural or codegen change (accessors are `static inline`). All production callers of TrieNode outside the trie module now go through a small function-shaped API surface. Preparatory step for narrowing the effective Trie / TrieNode API ahead of the Rust port.

#### Which additional issues this PR fixes
1. MOD-15393

#### Main objects this PR modified
1. `src/trie/trie_node.h` — adds `TrieNode_NumChildren`, `TrieNode_ChildAt`, `TrieNode_GetPayload`
2. `src/suffix.c` — replaces direct struct/macro reach-ins with the new accessors; `Suffix_GetData` macro becomes a `static inline` function

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactor but it touches core trie node traversal/mutation code and pointer arithmetic for the packed children array, so mistakes could cause subtle memory issues.
> 
> **Overview**
> **Decouples callers from `TrieNode` layout** by introducing inline accessors in `trie_node.h` (`TrieNode_NumChildren`, `TrieNode_Children`, `TrieNode_ChildAt`, `TrieNode_GetPayloadData`) and removing the `__trieNode_children` macro.
> 
> Updates `suffix.c` and `trie_node.c` to use these accessors instead of direct `TrieNode` field/macro access, including simplifying payload presence checks to `if (data)` / `if (!data)` and iterating children via `TrieNode_NumChildren` + `TrieNode_ChildAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a8618d9d30910c049b465ae4e1c9ebbee1afe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->