### PR TITLE
[CI] Make merge queue Slack mappings explicit

### DIFF
--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -276,31 +276,19 @@ jobs:
           missing_slack_mappings = []
 
           def slack_fields_for(login, label):
-              display_login = login or "unknown"
-              if login:
-                  slack_id = slack_mapping.get(login.lower())
-                  if slack_id and re.fullmatch(r"U[A-Z0-9]+", slack_id):
-                      return display_login, slack_id
-                  if slack_id:
-                      missing_slack_mappings.append(f"{label}: {display_login} has invalid Slack ID")
-                      print(
-                          "::warning::Invalid Slack mapping for "
-                          f"{label} GitHub login '{display_login}'; using fallback Slack user"
-                      )
-                      return (
-                          f"{display_login} (invalid Slack mapping)",
-                          SLACK_MAPPING_FALLBACK_USER_ID,
-                      )
+              slack_id = slack_mapping.get(login.lower())
+              if slack_id:
+                  return login, slack_id
 
-              missing_slack_mappings.append(f"{label}: {display_login}")
+              missing_slack_mappings.append(f"{label}: {login}")
               print(
                   "::warning::Missing Slack mapping for "
-                  f"{label} GitHub login '{display_login}'; using fallback Slack user"
+                  f"{label} GitHub login '{login}'; using fallback Slack user"
               )
-              return f"{display_login} (missing Slack mapping)", SLACK_MAPPING_FALLBACK_USER_ID
+              return f"{login} (missing Slack mapping)", SLACK_MAPPING_FALLBACK_USER_ID
 
 
-          author_login = (pull_request.get("author") or {}).get("login") or ""
+          author_login = pull_request["author"]["login"]
           author_display, author_mention = slack_fields_for(author_login, "author")
           enqueuer_display, enqueuer_mention = slack_fields_for(enqueuer_login, "enqueuer")
 

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -84,6 +84,7 @@ jobs:
             }
           }
           """
+          SLACK_MAPPING_FALLBACK_USER_ID = "U01UN6JM38B"
 
 
           def append_output(name, value):
@@ -269,13 +270,39 @@ jobs:
               raw_mapping = json.loads(os.environ.get("GH_HANDLE_TO_SLACK_JSON") or "{}")
               slack_mapping = {str(k).lower(): str(v) for k, v in raw_mapping.items()}
           except (json.JSONDecodeError, AttributeError):
+              print("::warning::Could not parse GH_HANDLE_TO_SLACK_JSON; using Slack fallback user")
               slack_mapping = {}
 
-          def slack_id_for(login):
-              return slack_mapping.get(login.lower(), login) if login else ""
+          missing_slack_mappings = []
+
+          def slack_fields_for(login, label):
+              display_login = login or "unknown"
+              if login:
+                  slack_id = slack_mapping.get(login.lower())
+                  if slack_id and re.fullmatch(r"U[A-Z0-9]+", slack_id):
+                      return display_login, slack_id
+                  if slack_id:
+                      missing_slack_mappings.append(f"{label}: {display_login} has invalid Slack ID")
+                      print(
+                          "::warning::Invalid Slack mapping for "
+                          f"{label} GitHub login '{display_login}'; using fallback Slack user"
+                      )
+                      return (
+                          f"{display_login} (invalid Slack mapping)",
+                          SLACK_MAPPING_FALLBACK_USER_ID,
+                      )
+
+              missing_slack_mappings.append(f"{label}: {display_login}")
+              print(
+                  "::warning::Missing Slack mapping for "
+                  f"{label} GitHub login '{display_login}'; using fallback Slack user"
+              )
+              return f"{display_login} (missing Slack mapping)", SLACK_MAPPING_FALLBACK_USER_ID
 
 
           author_login = (pull_request.get("author") or {}).get("login") or ""
+          author_display, author_mention = slack_fields_for(author_login, "author")
+          enqueuer_display, enqueuer_mention = slack_fields_for(enqueuer_login, "enqueuer")
 
           print("PR was resubmitted after removal without new commits")
           print(f"Removal reason: {reason}")
@@ -285,12 +312,13 @@ jobs:
           append_output("resubmit", "true")
           append_output("pr_title", pull_request["title"])
           append_output("pr_url", pull_request["url"])
-          append_output("pr_author", author_login)
-          append_output("author_mention", slack_id_for(author_login))
+          append_output("pr_author", author_display)
+          append_output("author_mention", author_mention)
           append_output("reason", reason)
           append_output("removed_by", actor.get("login"))
-          append_output("enqueued_by", enqueuer_login)
-          append_output("enqueued_by_mention", slack_id_for(enqueuer_login))
+          append_output("enqueued_by", enqueuer_display)
+          append_output("enqueued_by_mention", enqueuer_mention)
+          append_output("missing_slack_mappings", ", ".join(missing_slack_mappings) or "None")
           append_output("removed_at", format_timestamp(latest_removal["createdAt"]))
           append_output("resubmitted_at", format_timestamp(latest_add["createdAt"]))
           append_output("head_commit", current_head)
@@ -319,6 +347,7 @@ jobs:
               "Removed_By": ${{ toJson(steps.check.outputs.removed_by) }},
               "Enqueued_By": ${{ toJson(steps.check.outputs.enqueued_by) }},
               "Enqueued_By_Mention": ${{ toJson(steps.check.outputs.enqueued_by_mention) }},
+              "Missing_Slack_Mappings": ${{ toJson(steps.check.outputs.missing_slack_mappings) }},
               "Head_Commit": ${{ toJson(steps.check.outputs.head_commit_url) }},
               "Head_Commit_SHA": ${{ toJson(steps.check.outputs.head_commit) }},
               "Head_Committed_At": ${{ toJson(steps.check.outputs.head_committed_at) }},

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -244,7 +244,7 @@ jobs:
           reason = latest_removal.get("reason") or "No reason provided"
           actor = latest_removal.get("actor") or {}
           enqueuer = latest_add.get("enqueuer") or latest_removal.get("enqueuer") or {}
-          enqueuer_login = enqueuer.get("login") or ""
+          enqueuer_login = enqueuer.get("login") or "unknown-enqueuer"
           detector_workflow_url = f"{os.environ['SERVER_URL']}/{repo}/actions/runs/{os.environ['CURRENT_RUN_ID']}"
           current_merge_queue_run, previous_merge_queue_run = query_merge_queue_workflow_runs(
               repo, pr_number, queue_branch
@@ -288,7 +288,7 @@ jobs:
               return f"{login} (missing Slack mapping)", SLACK_MAPPING_FALLBACK_USER_ID
 
 
-          author_login = pull_request["author"]["login"]
+          author_login = (pull_request.get("author") or {}).get("login") or "deleted-github-user"
           author_display, author_mention = slack_fields_for(author_login, "author")
           enqueuer_display, enqueuer_mention = slack_fields_for(enqueuer_login, "enqueuer")
 

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -318,7 +318,7 @@ jobs:
           append_output("removed_by", actor.get("login"))
           append_output("enqueued_by", enqueuer_display)
           append_output("enqueued_by_mention", enqueuer_mention)
-          append_output("missing_slack_mappings", ", ".join(missing_slack_mappings) or "None")
+          append_output("missing_slack_mappings", ", ".join(missing_slack_mappings))
           append_output("removed_at", format_timestamp(latest_removal["createdAt"]))
           append_output("resubmitted_at", format_timestamp(latest_add["createdAt"]))
           append_output("head_commit", current_head)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The merge queue resubmission detector sends GitHub logins into Slack Workflow Builder `user ID` fields when a login is missing from `GH_HANDLE_TO_SLACK_JSON`, causing Slack webhook failures.
2. Change: The detector now validates mapped Slack user IDs, falls back to `U01UN6JM38B` for missing or invalid mappings, logs GitHub Actions warnings, decorates the visible Slack text fields, and includes `Missing_Slack_Mappings` in the payload.
3. Outcome: Resubmission alerts keep sending while missing Slack mappings are still visible enough to fix.

#### Which additional issues does this PR fix
1. #9671 follow-up

#### Main objects this PR modified
1. `.github/workflows/event-merge-queue-resubmit.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

#### Validation

- Parsed `.github/workflows/event-merge-queue-resubmit.yml` as YAML
- Compiled the embedded Python
- Checked Slack mapping helper behavior for mapped, unmapped, empty, and invalid values
- Ran `git diff --check`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions logic that builds and sends merge-queue resubmission Slack alerts; mistakes could suppress or mis-route notifications. Scope is limited to this single workflow and adds safer fallbacks/warnings.
> 
> **Overview**
> Makes the merge-queue resubmission detector *explicitly validate* GitHub→Slack user mappings and **fall back to a fixed Slack user ID** when mappings are missing/unparseable, instead of passing GitHub logins into Slack user-id fields.
> 
> The workflow now decorates the displayed author/enqueuer names when a mapping is missing, emits GitHub Actions warnings, and includes a `Missing_Slack_Mappings` field in the Slack webhook payload for visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23efcb243a8bd6a99e59ba09af4908ca74ce7d93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->