### PR TITLE
MOD-15097 skip in cluster for testConfigAPILoadTimeNumericParams

### DIFF
--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -759,7 +759,7 @@ def testModuleLoadexNumericParams():
         os.unlink(rdbFilePath)
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
-@skip(redis_less_than='7.9.227', asan=True)
+@skip(cluster=True, redis_less_than='7.9.227', asan=True)
 def testConfigAPILoadTimeNumericParams():
     env = Env(noDefaultModuleArgs=True, module='', moduleArgs='')
     redisearch_module_path = os.getenv('MODULE')


### PR DESCRIPTION

## Describe the changes in the pull request

skip testConfigAPILoadTimeNumericParams in cluster since the test can hang on MAC

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test execution conditions by skipping `testConfigAPILoadTimeNumericParams` when running in cluster, reducing flaky/hanging CI without affecting runtime code.
> 
> **Overview**
> **Skips a flaky config test in cluster runs.**
> 
> Updates `testConfigAPILoadTimeNumericParams` in `tests/pytests/test_config.py` to be skipped when `cluster=True` (in addition to existing Redis version and ASAN constraints), avoiding potential hangs in cluster CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5de4df834b016cb1759f5ea9bbba3c2ea0a2559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->