### PR TITLE
Add flaky test reporting skills

### DIFF
--- a/.skills/investigate-flaky-test/SKILL.md
+++ b/.skills/investigate-flaky-test/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: investigate-flaky-test
+description: Investigate a RediSearch flaky-test report from a Jira key, CI failure, test id, or local logs. Use this to collect evidence, identify a supported root cause, and propose a real fix; if the evidence is insufficient, say so and ask for the missing data instead of suggesting workaround-only fixes or skip_until.
+---
+
+# Investigate Flaky Test
+
+Investigate a flaky-test report and propose a proper fix only when the evidence supports it.
+
+## Arguments
+
+`$ARGUMENTS` may contain any of:
+- Jira issue key, usually `MOD-...`
+- GitHub Actions run URL, job URL, PR URL, or run id
+- Test id, usually `test_file:testName` or `test_file.py::test_name`
+- Local log file or failure excerpt
+
+## Instructions
+
+### 1. Gather Evidence
+
+Collect enough context to reason from facts:
+- Jira description and comments, if a Jira key is provided
+- GitHub Actions run/job logs and `Test Logs ...` artifacts, if a CI URL/run id is provided
+- Failure excerpt, stack trace, Redis server logs, Rust panic/backtrace, C backtrace, and INFO sections
+- Failed test source and nearby helpers
+- Relevant production code touched by the test path
+- Similar Jira issues or failures for the same test or same failure signature
+- Recent related changes, when they can explain a regression
+
+For GitHub Actions failures, prefer `gh`:
+
+```bash
+gh run view <run_id> --repo RediSearch/RediSearch --json url,headBranch,headSha,event,jobs
+gh run view <run_id> --repo RediSearch/RediSearch --log-failed
+mkdir -p /tmp/redisearch-flaky-<run_id>
+gh run download <run_id> --repo RediSearch/RediSearch --dir /tmp/redisearch-flaky-<run_id>
+```
+
+CI failed-test artifacts commonly contain `tests/**/logs/*.log*`, `bin/**/redisearch.so`, and
+`bin/**/redisearch.so.debug`.
+
+### 2. Classify The Failure
+
+Classify the failure before proposing a fix:
+- Assertion race or nondeterministic ordering
+- Timeout or performance budget issue
+- Redis/RLTest lifecycle issue, such as save/reload, expiration, cursor reap, or server shutdown
+- Coordinator/cluster-only behavior
+- Sanitizer, crash, panic, or memory safety issue
+- Environment or runner issue
+- Unknown or insufficient evidence
+
+Separate proven facts from inference. Use language like "the logs show" for facts and "likely" or
+"possible" for hypotheses.
+
+### 3. Find The Root Cause
+
+Trace from the failing assertion or exception to the code path that can produce it:
+- For Python flow tests, inspect the exact test, fixtures, helper decorators, `Env()` settings, cluster
+  skips, and waits.
+- For C/C++ unit tests, inspect the failing assertion, setup/teardown, thread usage, and decoded stack
+  traces.
+- For Rust tests or panics, inspect the panic message, backtrace, unsafe boundaries, and FFI wrappers.
+- For coordinator failures, compare standalone and coordinator paths and check shard placement.
+- For timeouts, distinguish slow-but-correct behavior from a hang, deadlock, polling bug, or excessive
+  test data size.
+
+Avoid stopping at "probably flaky" when the logs identify a specific race, missing wait, lifecycle
+conflict, or environment failure.
+
+### 4. Propose A Real Fix Or Say Evidence Is Insufficient
+
+Propose a fix only when the cause is supported well enough to justify a code or test change.
+
+A good fix proposal includes:
+- Root cause, with evidence
+- Exact target files/functions
+- Behavior change
+- Why this is preferable to a workaround
+- Verification commands
+- Remaining risk
+
+If the cause is unclear, say so plainly. Do not suggest workaround-only fixes, quarantine, or
+`skip_until` from this skill. Instead, list the missing data needed, such as:
+- Full `Test Logs ...` artifact
+- Failed job log with timestamps
+- Reproduction command and seed/config
+- Server log around the assertion or crash
+- A second occurrence to compare signatures
+
+### 5. Verification Plan
+
+Choose verification based on the proposed fix:
+- Python flow test:
+  ```bash
+  ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<test_file>:<test_name>"
+  ```
+- Coordinator-specific flow test:
+  ```bash
+  REDIS_STANDALONE=0 ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="<test_file>:<test_name>"
+  ```
+- C/C++ unit test:
+  ```bash
+  ./build.sh RUN_UNIT_TESTS ENABLE_ASSERT=1 TEST=<unit_test_name>
+  ```
+- Rust test:
+  ```bash
+  cd src/redisearch_rs && cargo nextest run -p <crate_name> <test_filter>
+  ```
+
+If the failure is timing-sensitive, recommend repeating the focused test enough times to gain
+confidence, and include any required environment variables from the CI failure.
+
+## Report Back
+
+End with:
+- Classification
+- Evidence-backed root cause, or "insufficient evidence"
+- Proposed real fix, if supported
+- Verification plan
+- Missing data, if blocked

--- a/.skills/investigate-flaky-test/SKILL.md
+++ b/.skills/investigate-flaky-test/SKILL.md
@@ -71,7 +71,9 @@ conflict, or environment failure.
 
 ### 4. Propose A Real Fix Or Say Evidence Is Insufficient
 
-Propose a fix only when the cause is supported well enough to justify a code or test change.
+Propose a root-cause fix only when the cause is supported well enough to justify a code or test
+change. If the logs, source path, and failure signature do not support a specific cause, do not
+claim one.
 
 A good fix proposal includes:
 - Root cause, with evidence
@@ -88,6 +90,13 @@ If the cause is unclear, say so plainly. Do not suggest workaround-only fixes, q
 - Reproduction command and seed/config
 - Server log around the assertion or crash
 - A second occurrence to compare signatures
+
+When the current evidence is not enough but the next failure could be made more informative,
+recommend a diagnostic PR instead of a workaround. A valid recommendation is to add focused debug
+logs, counters, state dumps, or richer test assertion messages, merge or run that instrumentation in
+CI for a few days, and use the next flaky occurrence to identify the root cause. Do not present this
+as "add logs and rerun once to find the root cause right away"; a focused local rerun can help, but
+the main goal is better evidence when the intermittent failure happens again.
 
 ### 5. Verification Plan
 

--- a/.skills/report-flaky-test/SKILL.md
+++ b/.skills/report-flaky-test/SKILL.md
@@ -21,6 +21,7 @@ Defaults:
 - Project: `MOD`
 - Parent epic: `MOD-9672` (`[RQE] CI Stability - MAG`)
 - Issue type: `Bug`
+- Components: `RediSearch`, `RedisAI`
 
 ## Instructions
 
@@ -94,7 +95,7 @@ Notes:
 
 If no existing issue is found, prepare a new Jira `Bug` under `MOD-9672`:
 - Summary: `Flaky test: <test_file>:<test_name> <short symptom/context>`
-- Components: `RediSearch` when accepted by Jira metadata
+- Components: `RediSearch`, `RedisAI`
 - Description:
 
 ~~~markdown

--- a/.skills/report-flaky-test/SKILL.md
+++ b/.skills/report-flaky-test/SKILL.md
@@ -34,6 +34,7 @@ From the provided input, gather the best available facts:
 - GitHub Actions run, attempt, job URL, PR, branch, and HEAD SHA
 - Platform, architecture, Redis ref, standalone/coordinator mode, and special config
 - Relevant failure excerpt, stack trace, Redis log excerpt, Rust panic/backtrace, or C backtrace
+- Likely test owner, with confidence and evidence
 
 For GitHub Actions failures, prefer `gh`:
 
@@ -52,7 +53,22 @@ artifact tree for:
 
 If artifact download is unavailable, use the CI job log and include links to the run/job.
 
-### 2. Find Existing Jira Ticket
+### 2. Identify The Likely Test Owner
+
+Try to identify a likely owner to mention in the Jira ticket or PR:
+- First check `CODEOWNERS` if the repo has one.
+- If no ownership file exists, inspect test history with:
+  ```bash
+  git log --follow --format='%h %an <%ae> %ad %s' -- <test_file>
+  git blame -L <start>,<end> -- <test_file>
+  ```
+- Prefer the person who most recently changed the failing test or the helper/assertion involved in
+  the failure, not merely the oldest author of the file.
+- If several candidates are plausible, list them as candidates instead of pretending certainty.
+- Mention an owner only when you can map them to a GitHub or Jira identity confidently. Otherwise
+  include the owner evidence in plain text and say that the owner should be confirmed manually.
+
+### 3. Find Existing Jira Ticket
 
 Search Jira before creating anything. Match by normalized test id first:
 
@@ -67,7 +83,7 @@ Treat same test with a different platform, config, or failure signature as the s
 Mention the difference in the comment. Do not create a duplicate unless the existing issue is clearly
 about an unrelated failure mode and the user confirms.
 
-### 3. Prepare The Jira Update
+### 4. Prepare The Jira Update
 
 If an existing issue is found, prepare a comment:
 
@@ -81,6 +97,7 @@ If an existing issue is found, prepare a comment:
 * Mode/config: `<standalone-or-coordinator>`, `<config>`, Redis `<redis-ref>`
 * Failure category: `<category>`
 * Failure reason: `<short reason>`
+* Likely owner: `<@owner or candidate names with evidence>`
 
 ```text
 <short relevant excerpt>
@@ -132,6 +149,9 @@ HEAD: `<sha>`
 **Special test configuration:**
 `<standalone-or-coordinator>`, `<config>`
 
+**Likely owner:**
+`<@owner or candidate names with evidence>`
+
 **Artifacts/logs:**
 <artifact link or local downloaded path>
 
@@ -142,7 +162,7 @@ HEAD: `<sha>`
 Always show the exact new issue payload or comment body and ask the user before creating/commenting
 in Jira. Do not mutate Jira without confirmation.
 
-### 4. Attach Or Link Logs
+### 5. Attach Or Link Logs
 
 If a Jira attachment tool is available, attach the relevant downloaded log archive or smallest useful
 log files. If no attachment capability is available, state that directly and include:
@@ -150,7 +170,7 @@ log files. If no attachment capability is available, state that directly and inc
 - Artifact names
 - Local downloaded artifact path under `/tmp/redisearch-flaky-<run_id>/`
 
-### 5. Quick Triage Recommendation
+### 6. Quick Triage Recommendation
 
 Do a short read-only scan of the failing test and nearby helpers before finalizing the report.
 
@@ -181,5 +201,6 @@ implementation.
 End with:
 - Existing Jira issue selected, or new Jira payload prepared
 - Whether Jira was updated or is waiting for confirmation
+- Likely owner and confidence, or why no confident owner was identified
 - Artifact/log status
 - Immediate triage recommendation, if any

--- a/.skills/report-flaky-test/SKILL.md
+++ b/.skills/report-flaky-test/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: report-flaky-test
+description: Report a flaky RediSearch test from a CI failure, Jira issue, test id, or local log. Use this to collect GitHub Actions logs/artifacts, find or create the right MOD Jira ticket, update existing flaky-test issues, and suggest immediate triage such as a trivial test-only fix or a temporary skip_until.
+---
+
+# Report Flaky Test
+
+Report a flaky test to Jira, or add a new failure occurrence to an existing flaky-test ticket.
+
+## Arguments
+
+`$ARGUMENTS` may contain any of:
+- GitHub Actions run URL, job URL, PR URL, or run id
+- Jira issue key
+- Test id, usually `test_file:testName` or `test_file.py::test_name`
+- Local log file or failure excerpt
+
+Defaults:
+- Jira cloud: `redislabs.atlassian.net`
+- Jira cloud id: `06f73ca7-8f2c-4392-b40a-08288e9d0ba3`
+- Project: `MOD`
+- Parent epic: `MOD-9672` (`[RQE] CI Stability - MAG`)
+- Issue type: `Bug`
+
+## Instructions
+
+### 1. Collect Failure Evidence
+
+From the provided input, gather the best available facts:
+- Test id and normalized test id (`test_file:testName`)
+- Failure reason and category: assertion failure, timeout, crash, sanitizer, Redis/RLTest lifecycle,
+  coordinator/cluster-only, or environment/runner issue
+- GitHub Actions run, attempt, job URL, PR, branch, and HEAD SHA
+- Platform, architecture, Redis ref, standalone/coordinator mode, and special config
+- Relevant failure excerpt, stack trace, Redis log excerpt, Rust panic/backtrace, or C backtrace
+
+For GitHub Actions failures, prefer `gh`:
+
+```bash
+gh run view <run_id> --repo RediSearch/RediSearch --json url,headBranch,headSha,event,jobs
+gh run view <run_id> --repo RediSearch/RediSearch --log-failed
+mkdir -p /tmp/redisearch-flaky-<run_id>
+gh run download <run_id> --repo RediSearch/RediSearch --dir /tmp/redisearch-flaky-<run_id>
+```
+
+CI uploads failed test artifacts named `Test Logs ...` from `task-test.yml`. Look in the downloaded
+artifact tree for:
+- `tests/**/logs/*.log*`
+- `bin/**/redisearch.so`
+- `bin/**/redisearch.so.debug`
+
+If artifact download is unavailable, use the CI job log and include links to the run/job.
+
+### 2. Find Existing Jira Ticket
+
+Search Jira before creating anything. Match by normalized test id first:
+
+```jql
+project = MOD AND issuetype = Bug AND
+(summary ~ "<test_file>" OR text ~ "<test_file>") AND
+(summary ~ "<test_name>" OR text ~ "<test_name>")
+ORDER BY updated DESC
+```
+
+Treat same test with a different platform, config, or failure signature as the same candidate first.
+Mention the difference in the comment. Do not create a duplicate unless the existing issue is clearly
+about an unrelated failure mode and the user confirms.
+
+### 3. Prepare The Jira Update
+
+If an existing issue is found, prepare a comment:
+
+~~~markdown
+### New flaky occurrence
+
+* Test: `<test_file>:<test_name>`
+* CI: <job-or-run-url>
+* Branch / HEAD: `<branch>` / `<sha>`
+* Platform: `<platform>`, `<arch>`
+* Mode/config: `<standalone-or-coordinator>`, `<config>`, Redis `<redis-ref>`
+* Failure category: `<category>`
+* Failure reason: `<short reason>`
+
+```text
+<short relevant excerpt>
+```
+
+Artifacts/logs:
+* <artifact link or local downloaded path>
+
+Notes:
+* <anything new compared with the existing ticket, or "Same signature as existing report.">
+~~~
+
+If no existing issue is found, prepare a new Jira `Bug` under `MOD-9672`:
+- Summary: `Flaky test: <test_file>:<test_name> <short symptom/context>`
+- Components: `RediSearch` when accepted by Jira metadata
+- Description:
+
+~~~markdown
+### Test Failure Report
+
+**Name of the test:**
+`<test_file>:<test_name>`
+
+**Failure reason:**
+<short reason>
+
+**Category:**
+<category>
+
+**Failure log:**
+
+```text
+<short relevant excerpt>
+```
+
+**Link to failed CI:**
+<job-or-run-url>
+
+**Branch & HEAD:**
+Branch: `<branch>`
+HEAD: `<sha>`
+
+**Platform (OS & arch):**
+`<platform>`, `<arch>`
+
+**Redis version/ref:**
+`<redis-ref>`
+
+**Special test configuration:**
+`<standalone-or-coordinator>`, `<config>`
+
+**Artifacts/logs:**
+<artifact link or local downloaded path>
+
+**Initial triage:**
+<quick read-only assessment, including immediate fix or skip recommendation when applicable>
+~~~
+
+Always show the exact new issue payload or comment body and ask the user before creating/commenting
+in Jira. Do not mutate Jira without confirmation.
+
+### 4. Attach Or Link Logs
+
+If a Jira attachment tool is available, attach the relevant downloaded log archive or smallest useful
+log files. If no attachment capability is available, state that directly and include:
+- GitHub Actions run/job URL
+- Artifact names
+- Local downloaded artifact path under `/tmp/redisearch-flaky-<run_id>/`
+
+### 5. Quick Triage Recommendation
+
+Do a short read-only scan of the failing test and nearby helpers before finalizing the report.
+
+Suggest an immediate test-only fix only when it is obvious and scoped, for example:
+- Add a missing wait for indexing, async work, GC, expiration, cursor reap, or cluster state
+- Make ordering deterministic before asserting
+- Restore or isolate global config changes
+- Use hash tags for cluster keys that must land on one shard
+- Adjust a clear timeout budget mismatch
+
+Suggest a temporary `skip_until("<date>", "<MOD-key/reason>")` from this reporting skill when:
+- The failure is repeatedly disrupting CI or merge queue
+- No trivial safe test-only fix is visible
+- The skip can be scoped to the smallest affected generated test, test function, mode, platform, or
+  configuration
+
+Any `skip_until` recommendation must include:
+- Jira key, or say it should be filled after the new ticket is created
+- Expiry date, normally about one month out unless the user gives another policy
+- Affected mode/platform/config
+- Exact smallest test scope to skip
+
+Do not implement the fix from this skill unless the user explicitly asks to switch from reporting to
+implementation.
+
+## Report Back
+
+End with:
+- Existing Jira issue selected, or new Jira payload prepared
+- Whether Jira was updated or is waiting for confirmation
+- Artifact/log status
+- Immediate triage recommendation, if any

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,11 @@ src/redisearch_rs/
 
 ## Common Workflows
 
+When implementing changes that may become a PR, first check the current checkout. If it is dirty,
+on an unrelated branch, or already tied to another open PR, automatically create a dedicated
+worktree from the target branch and do the work there. Use the existing checkout only when it is
+already the right clean branch for the task.
+
 ### C Code
 Invoke [/code-review](.skills/code-review/SKILL.md) to review C code changes or PRs.
 Invoke [/run-c-unit-tests](.skills/run-c-unit-tests/SKILL.md) to run C/C++ unit tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ Invoke [/write-rust-tests](.skills/write-rust-tests/SKILL.md) to add tests to Ru
 Invoke [/rust-review](.skills/rust-review/SKILL.md) to review Rust code changes.
 
 ### General
+Invoke [/report-flaky-test](.skills/report-flaky-test/SKILL.md) to report a flaky CI test to Jira or update an existing flaky-test ticket.
+Invoke [/investigate-flaky-test](.skills/investigate-flaky-test/SKILL.md) to investigate a flaky-test report and propose an evidence-backed fix.
 Invoke [/verify](.skills/verify/SKILL.md) to verify the correctness of your work before wrapping up.
 Invoke [/build](.skills/build/SKILL.md) to compile and verify the build.
 Invoke [/lint](.skills/lint/SKILL.md) to check code quality and formatting.


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: RediSearch has local Codex skills for build, verification, reviews, and tests, but no dedicated workflow for reporting or investigating flaky CI tests.
2. Change: Add complementary `report-flaky-test` and `investigate-flaky-test` skills, and reference them from `AGENTS.md`.
3. Outcome: Codex can consistently collect flaky-test evidence, dedupe/update Jira reports, recommend reporter-owned triage such as `skip_until`, and keep root-cause investigation focused on evidence-backed fixes.

#### Which additional issues this PR fixes
1. N/A
2. #...

#### Main objects this PR modified
1. `.skills/report-flaky-test/SKILL.md`
2. `.skills/investigate-flaky-test/SKILL.md`
3. `AGENTS.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adding new `.skills` guides and linking them from `AGENTS.md`, with no production code or CI behavior changes.
> 
> **Overview**
> Adds new `.skills/report-flaky-test` and `.skills/investigate-flaky-test` guides to standardize how flaky CI tests are *reported* (evidence collection, Jira de-dupe/update, optional `skip_until` triage) versus *investigated* (evidence-backed root cause and real fix, or explicitly requesting missing data).
> 
> Updates `AGENTS.md` to recommend using a dedicated worktree for PR-bound changes and to reference the two new flaky-test skills in the general workflow section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a459d612fb7731740dfd541c89e86f76c601694b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->