### PR TITLE
MOD-15734: Optimize `COLLECT SORTBY` on shard

### DIFF
--- a/src/redisearch_rs/reducers/src/collect/heap.rs
+++ b/src/redisearch_rs/reducers/src/collect/heap.rs
@@ -11,16 +11,12 @@
 //! top-K path.
 //!
 //! Wraps an `Ord`-driven [`MinMaxHeap`][min_max_heap::MinMaxHeap] over
-//! [`HeapEntry<T>`], where the comparator only reads the [`EntryKey`] half. The
-//! split lets the heap defer payload projection until a candidate's survival is
-//! confirmed.
-//!
-//! ## Deferred projection
-//!
+//! [`HeapEntry<T>`], where the comparator only reads the [`EntryKey`] half,
+//! deferring payload projection until a candidate's survival is confirmed.
 //! [`EntryKey`] owns a *snapshot* of the sort-key values, severed from the
-//! reused upstream [`RLookupRow`][rlookup::RLookupRow] buffer. The payload
-//! `T` is materialised by the caller only after the candidate has beaten the
-//! current worst — see [`super::storage`].
+//! reused upstream [`RLookupRow`][rlookup::RLookupRow] buffer; the payload
+//! `T` is materialised only after the candidate beats the current worst —
+//! see [`super::storage`].
 //!
 
 use std::cmp::Ordering;
@@ -31,7 +27,7 @@ use value::comparison::cmp_fields;
 /// comparator is allowed to read.
 ///
 /// Bit `i` of `sort_asc_map` (LSB-first) selects ASC for the `i`-th key
-/// (set) or DESC (clear), matching `SORTASCMAP_GETASC` / `cmp_fields`.
+/// (set) or DESC (clear), matching `SORTASCMAP_GETASC` / [`cmp_fields`].
 pub struct EntryKey {
     sort_vals: Box<[Option<SharedValue>]>,
     sort_asc_map: u64,
@@ -54,14 +50,32 @@ impl EntryKey {
     ///
     /// `candidate` yields one value per sort key, in the same order as
     /// `self`'s. Missing-worst handling is delegated to [`cmp_fields`].
+    /// `Ordering::Equal` means the candidate ties the worst entry; callers
+    /// treat ties as losses and drop the candidate.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// Asserts that `candidate` yields exactly as many items as
+    /// `self.sort_vals` contains. A mismatch causes [`std::iter::zip`] to
+    /// silently truncate, producing a wrong ordering.
     ///
     /// [`Storage::insert_entry`]: super::storage::Storage::insert_entry
     pub fn cmp_candidate<'a, I>(&self, candidate: I) -> Ordering
     where
         I: IntoIterator<Item = Option<&'a SharedValue>>,
     {
-        let pairs = candidate
-            .into_iter()
+        let iter = candidate.into_iter();
+        #[cfg(debug_assertions)]
+        let iter = {
+            let v: Vec<_> = iter.collect();
+            debug_assert_eq!(
+                v.len(),
+                self.sort_vals.len(),
+                "cmp_candidate: candidate key count must match sort_vals"
+            );
+            v.into_iter()
+        };
+        let pairs = iter
             .map(|v| v.map(|s| &**s))
             .zip(self.sort_vals.iter().map(|v| v.as_deref()));
         cmp_fields(pairs, self.sort_asc_map, None)
@@ -94,19 +108,19 @@ impl Ord for EntryKey {
             .iter()
             .zip(other.sort_vals.iter())
             .map(|(a, b)| (a.as_deref(), b.as_deref()));
-        // Direct delegation: `cmp_fields` already returns
-        // `Ordering::Greater` for the "better" side, matching the
-        // "best = max" convention in `SearchResult_CmpByFields` and the
-        // C `RPSorter`'s `mmh_pop_max` consumer.
+        // cmp_fields returns Greater for the "better" side — matching the
+        // "best = max" convention used by the C RPSorter.
         cmp_fields(pairs, self.sort_asc_map, None)
     }
 }
 
 /// Heap slot: the comparator key alongside the projected payload.
 ///
-/// `T` is the per-row payload the consumer (`Storage::Heap`) yields at
-/// finalize. Comparing only reads `key`, so the choice of `T` does not
+/// `T` is the per-row payload the consumer ([`Storage::Heap`]) yields when
+/// draining. Comparing only reads `key`, so the choice of `T` does not
 /// affect ranking.
+///
+/// [`Storage::Heap`]: super::storage::Storage::Heap
 pub struct HeapEntry<T> {
     key: EntryKey,
     projected: T,
@@ -125,7 +139,6 @@ impl<T> HeapEntry<T> {
         &self.projected
     }
 
-    /// Return the projected payload.
     pub fn into_projected(self) -> T {
         self.projected
     }

--- a/src/redisearch_rs/reducers/src/collect/heap.rs
+++ b/src/redisearch_rs/reducers/src/collect/heap.rs
@@ -44,6 +44,28 @@ impl EntryKey {
             sort_asc_map,
         }
     }
+
+    /// Borrow-only counterpart to [`Ord::cmp`] against `self`.
+    ///
+    /// Returns [`Ordering::Greater`] when `candidate` beats `self`, without
+    /// allocating the owned snapshot or per-key [`SharedValue`] clones that
+    /// [`EntryKey::new`] would incur. Lets [`Storage::insert_entry`] reject
+    /// doomed heap-at-cap candidates with a single borrowed pass.
+    ///
+    /// `candidate` yields one value per sort key, in the same order as
+    /// `self`'s. Missing-worst handling is delegated to [`cmp_fields`].
+    ///
+    /// [`Storage::insert_entry`]: super::storage::Storage::insert_entry
+    pub fn cmp_candidate<'a, I>(&self, candidate: I) -> Ordering
+    where
+        I: IntoIterator<Item = Option<&'a SharedValue>>,
+    {
+        let pairs = candidate
+            .into_iter()
+            .map(|v| v.map(|s| &**s))
+            .zip(self.sort_vals.iter().map(|v| v.as_deref()));
+        cmp_fields(pairs, self.sort_asc_map, None)
+    }
 }
 
 impl PartialEq for EntryKey {

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -109,17 +109,6 @@ impl Fields {
     }
 }
 
-/// Snapshot sort-key values for heap comparison, preserving absent keys as
-/// `None` so [`cmp_fields`][value::comparison::cmp_fields] can apply its
-/// missing-worst policy.
-fn snapshot_sort_keys(sort_key_names: &[CString], item: &Value) -> Box<[Option<SharedValue>]> {
-    debug_assert!(matches!(item, Value::Map(_) | Value::Array(_)));
-    sort_key_names
-        .iter()
-        .map(|name| get_field(item, name.to_bytes()).cloned())
-        .collect()
-}
-
 /// Materialize `(k, v)` as a typed [`RLookupRow`] entry.
 ///
 /// Terminates the wire-side `BString → CString` check; a non-string or
@@ -229,8 +218,9 @@ impl LocalCollectCtx {
         }
     }
 
-    /// Deserialize the shard payload carried by `row` into [`RLookupRow`]s,
-    /// honouring `LIMIT` via [`Storage::insert_entry`].
+    /// Deserialize each item from the shard payload carried by `row` and
+    /// forward it to [`Storage::insert_entry`] with a borrow-only
+    /// sort-key view.
     pub fn add(&mut self, r: &LocalCollectReducer, row: &RLookupRow) {
         let Some(Value::Array(items)) = row.get(r.input_key).map(|p| &**p) else {
             tracing_assert::debug_assert_warn!(
@@ -248,10 +238,14 @@ impl LocalCollectCtx {
                 );
                 continue;
             }
-            self.storage.insert_entry(
-                || snapshot_sort_keys(r.fields.sort_key_names(), item),
-                || r.fields.prepare_row(item, &mut self.lookup),
-            );
+            let sort_view = || {
+                r.fields
+                    .sort_key_names()
+                    .iter()
+                    .map(|name| get_field(item, name.to_bytes()))
+            };
+            let project = || r.fields.prepare_row(item, &mut self.lookup);
+            self.storage.insert_entry(sort_view, project);
         }
     }
 

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -226,20 +226,10 @@ impl RemoteCollectCtx {
         }
     }
 
-    /// Project the source row's field values into a stored [`RLookupRow`]
-    /// and snapshot the sort-key values for the heap comparator.
-    ///
-    /// The array path ignores the snapshot closure entirely. The heap path
-    /// uses the snapshot to drive comparisons, dropping doomed candidates
-    /// without paying the row-projection cost.
+    /// Project the source row and forward it to [`Storage::insert_entry`]
+    /// with a borrow-only sort-key view.
     pub fn add(&mut self, r: &RemoteCollectReducer<'_>, row: &RLookupRow<'_>) {
-        let sort_vals = || -> Box<[Option<SharedValue>]> {
-            r.fields
-                .sort_keys()
-                .iter()
-                .map(|key| row.get(key).cloned())
-                .collect()
-        };
+        let sort_view = || r.fields.sort_keys().iter().map(|key| row.get(key));
         let project = || {
             let mut dst = RLookupRow::new();
             for key in r.fields.get_keys_add() {
@@ -249,7 +239,7 @@ impl RemoteCollectCtx {
             }
             dst
         };
-        self.storage.insert_entry(sort_vals, project);
+        self.storage.insert_entry(sort_view, project);
     }
 
     /// Serialize the buffered rows into an array of maps. Keys absent from a

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -76,19 +76,25 @@ impl Storage {
         }
     }
 
-    /// Insert an entry under the cap. Two-phase to preserve the
-    /// deferred-projection invariant:
+    /// Insert an entry, honouring the `offset + count` cap.
     ///
-    /// - `sort_vals` is invoked only on the heap path (the array path
-    ///   ignores it).
-    /// - `project` is invoked only when the entry will actually be
-    ///   retained (i.e. on the heap path, only when the candidate beats
-    ///   the current worst).
+    /// Both closures defer their cost: the array path ignores `sort_view`,
+    /// and `project` runs only when the entry will be retained. On the
+    /// heap-at-cap branch, `sort_view` is consulted via
+    /// [`EntryKey::cmp_candidate`] for a borrow-only compare against the
+    /// worst survivor; the owned snapshot is built only when the
+    /// candidate wins.
     ///
-    /// Returns `true` if the entry was buffered, `false` if it was dropped.
-    pub fn insert_entry<S, P>(&mut self, sort_vals: S, project: P) -> bool
+    /// `sort_view` is [`Fn`] (not [`FnOnce`]) because it may be invoked
+    /// twice on a winner — compare, then materialize. Callers must shape
+    /// it as an idempotent projection over a stable borrowed source.
+    ///
+    /// Returns `true` if the entry was buffered, `false` if it was
+    /// dropped.
+    pub fn insert_entry<'r, F, I, P>(&mut self, sort_view: F, project: P) -> bool
     where
-        S: FnOnce() -> Box<[Option<SharedValue>]>,
+        F: Fn() -> I,
+        I: IntoIterator<Item = Option<&'r SharedValue>>,
         P: FnOnce() -> RLookupRow<'static>,
     {
         match self {
@@ -114,18 +120,20 @@ impl Storage {
                     return false;
                 }
                 if heap.len() < max_size {
-                    let key = EntryKey::new(sort_vals(), *sort_asc_map);
+                    // Below cap: no worst to beat — materialize directly.
+                    let owned: Box<[Option<SharedValue>]> =
+                        sort_view().into_iter().map(|v| v.cloned()).collect();
+                    let key = EntryKey::new(owned, *sort_asc_map);
                     heap.push(HeapEntry::new(key, project()));
                     true
                 } else {
-                    let cand_key = EntryKey::new(sort_vals(), *sort_asc_map);
-                    // `peek_min` returns the worst surviving candidate
-                    // under the "best = max" convention (see `heap`).
-                    // The unwrap is sound: `cap > 0` implies the heap is
-                    // non-empty once we've reached the cap.
+                    // At cap: borrow-compare first; materialize only on win.
                     let worst = heap.peek_min().expect("heap at cap is non-empty");
-                    if cand_key > *worst.key() {
-                        heap.push_pop_min(HeapEntry::new(cand_key, project()));
+                    if worst.key().cmp_candidate(sort_view()) == std::cmp::Ordering::Greater {
+                        let owned: Box<[Option<SharedValue>]> =
+                            sort_view().into_iter().map(|v| v.cloned()).collect();
+                        let key = EntryKey::new(owned, *sort_asc_map);
+                        heap.push_pop_min(HeapEntry::new(key, project()));
                         true
                     } else {
                         false

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -17,6 +17,8 @@
 //!   primitive defined in [`super::heap`] and draining best→worst.
 //!   Suitable when a ranked top-K is needed.
 
+use std::cmp::Ordering;
+
 use itertools::Either;
 use min_max_heap::MinMaxHeap;
 use rlookup::RLookupRow;
@@ -78,19 +80,13 @@ impl Storage {
 
     /// Insert an entry, honouring the `offset + count` cap.
     ///
-    /// Both closures defer their cost: the array path ignores `sort_view`,
-    /// and `project` runs only when the entry will be retained. On the
-    /// heap-at-cap branch, `sort_view` is consulted via
-    /// [`EntryKey::cmp_candidate`] for a borrow-only compare against the
-    /// worst survivor; the owned snapshot is built only when the
-    /// candidate wins.
+    /// `project` is called only when the entry will be retained.
+    /// `sort_view` is [`Fn`] (not [`FnOnce`]) because it may be called twice
+    /// on a winner — once to borrow-compare via [`EntryKey::cmp_candidate`],
+    /// once to materialise the owned snapshot. Callers must ensure it is an
+    /// idempotent projection over a stable borrowed source.
     ///
-    /// `sort_view` is [`Fn`] (not [`FnOnce`]) because it may be invoked
-    /// twice on a winner — compare, then materialize. Callers must shape
-    /// it as an idempotent projection over a stable borrowed source.
-    ///
-    /// Returns `true` if the entry was buffered, `false` if it was
-    /// dropped.
+    /// Returns `true` if the entry was buffered, `false` if it was dropped.
     pub fn insert_entry<'r, F, I, P>(&mut self, sort_view: F, project: P) -> bool
     where
         F: Fn() -> I,
@@ -129,7 +125,7 @@ impl Storage {
                 } else {
                     // At cap: borrow-compare first; materialize only on win.
                     let worst = heap.peek_min().expect("heap at cap is non-empty");
-                    if worst.key().cmp_candidate(sort_view()) == std::cmp::Ordering::Greater {
+                    if worst.key().cmp_candidate(sort_view()) == Ordering::Greater {
                         let owned: Box<[Option<SharedValue>]> =
                             sort_view().into_iter().map(|v| v.cloned()).collect();
                         let key = EntryKey::new(owned, *sort_asc_map);

--- a/src/redisearch_rs/reducers/tests/heap.rs
+++ b/src/redisearch_rs/reducers/tests/heap.rs
@@ -183,62 +183,39 @@ fn cand(owned: &[Option<SharedValue>]) -> Vec<Option<&SharedValue>> {
     owned.iter().map(|v| v.as_ref()).collect()
 }
 
+// The cases below pin properties unique to `cmp_candidate`. ASC/DESC,
+// missing-worst, and multi-key semantics are owned by `cmp_fields` and
+// covered by the `ord_*` tests above; we do not re-test those here.
+
 #[test]
 fn cmp_candidate_under_asc_returns_greater_when_candidate_is_smaller() {
-    // ASC + cand < worst → cand "wins" → Greater under best=max.
+    // Orientation contract: cand wins → Greater under "best = max".
     let worst = key(&[5.0], asc(0));
     let cand_vals = vals(&[1.0]);
     assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Greater);
 }
 
 #[test]
-fn cmp_candidate_under_asc_returns_less_when_candidate_is_larger() {
-    // ASC + cand > worst → worst still wins → Less.
-    let worst = key(&[1.0], asc(0));
-    let cand_vals = vals(&[5.0]);
-    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
-}
-
-#[test]
-fn cmp_candidate_returns_equal_for_identical_values() {
-    let worst = key(&[3.0], asc(0));
-    let cand_vals = vals(&[3.0]);
-    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Equal);
-}
-
-#[test]
 fn cmp_candidate_under_desc_returns_greater_when_candidate_is_larger() {
-    // DESC + cand > worst → cand wins → Greater.
+    // Orientation must be invariant under direction flip.
     let worst = key(&[1.0], 0);
     let cand_vals = vals(&[5.0]);
     assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Greater);
 }
 
 #[test]
-fn cmp_candidate_under_desc_returns_less_when_candidate_is_smaller() {
-    let worst = key(&[5.0], 0);
-    let cand_vals = vals(&[1.0]);
-    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
-}
-
-#[test]
-fn cmp_candidate_missing_candidate_value_ranks_as_worst_under_asc() {
-    // Missing-worst is direction-agnostic: candidate has None → cand is worst.
+fn cmp_candidate_missing_candidate_value_ranks_as_worst() {
+    // Pins that `None` items survive the borrowed-view shim so the
+    // missing-worst branch in `cmp_fields` is reached. Direction-agnostic.
     let worst = key(&[3.0], asc(0));
     let cand_vals = vals(&[f64::NAN]);
     assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
 }
 
 #[test]
-fn cmp_candidate_missing_candidate_value_ranks_as_worst_under_desc() {
-    let worst = key(&[3.0], 0);
-    let cand_vals = vals(&[f64::NAN]);
-    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
-}
-
-#[test]
 fn cmp_candidate_breaks_tie_using_secondary_key_under_mixed_directions() {
-    // key0 ASC (bit 0 set), key1 DESC (bit 1 clear). Tie on key0, cand wins on key1.
+    // Pins iterator-zip alignment across keys: key0 ASC (bit 0 set), key1
+    // DESC (bit 1 clear). Tie on key0, cand wins on key1.
     let worst = key(&[5.0, 1.0], asc(0));
     let cand_vals = vals(&[5.0, 9.0]);
     assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Greater);

--- a/src/redisearch_rs/reducers/tests/heap.rs
+++ b/src/redisearch_rs/reducers/tests/heap.rs
@@ -162,3 +162,84 @@ fn min_max_heap_top_k_under_asc() {
     let drained: Vec<u64> = heap.drain_desc().map(HeapEntry::into_projected).collect();
     assert_eq!(drained, vec![1, 2, 3]);
 }
+
+/// Build owned `Option<SharedValue>`s from `f64`s. `f64::NAN` projects to
+/// `None` so tests can exercise the missing-worst policy.
+fn vals(nums: &[f64]) -> Vec<Option<SharedValue>> {
+    nums.iter()
+        .map(|v| {
+            if v.is_nan() {
+                None
+            } else {
+                Some(SharedValue::new_num(*v))
+            }
+        })
+        .collect()
+}
+
+/// Borrowed view fixture: project owned values into the
+/// `Option<&SharedValue>` shape consumed by [`EntryKey::cmp_candidate`].
+fn cand(owned: &[Option<SharedValue>]) -> Vec<Option<&SharedValue>> {
+    owned.iter().map(|v| v.as_ref()).collect()
+}
+
+#[test]
+fn cmp_candidate_under_asc_returns_greater_when_candidate_is_smaller() {
+    // ASC + cand < worst → cand "wins" → Greater under best=max.
+    let worst = key(&[5.0], asc(0));
+    let cand_vals = vals(&[1.0]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Greater);
+}
+
+#[test]
+fn cmp_candidate_under_asc_returns_less_when_candidate_is_larger() {
+    // ASC + cand > worst → worst still wins → Less.
+    let worst = key(&[1.0], asc(0));
+    let cand_vals = vals(&[5.0]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
+}
+
+#[test]
+fn cmp_candidate_returns_equal_for_identical_values() {
+    let worst = key(&[3.0], asc(0));
+    let cand_vals = vals(&[3.0]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Equal);
+}
+
+#[test]
+fn cmp_candidate_under_desc_returns_greater_when_candidate_is_larger() {
+    // DESC + cand > worst → cand wins → Greater.
+    let worst = key(&[1.0], 0);
+    let cand_vals = vals(&[5.0]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Greater);
+}
+
+#[test]
+fn cmp_candidate_under_desc_returns_less_when_candidate_is_smaller() {
+    let worst = key(&[5.0], 0);
+    let cand_vals = vals(&[1.0]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
+}
+
+#[test]
+fn cmp_candidate_missing_candidate_value_ranks_as_worst_under_asc() {
+    // Missing-worst is direction-agnostic: candidate has None → cand is worst.
+    let worst = key(&[3.0], asc(0));
+    let cand_vals = vals(&[f64::NAN]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
+}
+
+#[test]
+fn cmp_candidate_missing_candidate_value_ranks_as_worst_under_desc() {
+    let worst = key(&[3.0], 0);
+    let cand_vals = vals(&[f64::NAN]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Less);
+}
+
+#[test]
+fn cmp_candidate_breaks_tie_using_secondary_key_under_mixed_directions() {
+    // key0 ASC (bit 0 set), key1 DESC (bit 1 clear). Tie on key0, cand wins on key1.
+    let worst = key(&[5.0, 1.0], asc(0));
+    let cand_vals = vals(&[5.0, 9.0]);
+    assert_eq!(worst.cmp_candidate(cand(&cand_vals)), Ordering::Greater);
+}

--- a/src/redisearch_rs/reducers/tests/storage.rs
+++ b/src/redisearch_rs/reducers/tests/storage.rs
@@ -26,10 +26,6 @@ fn make_key() -> RLookupKey<'static> {
     RLookupKey::new(c"v", RLookupKeyFlags::empty())
 }
 
-fn sort_vals(v: f64) -> Box<[Option<SharedValue>]> {
-    vec![Some(SharedValue::new_num(v))].into_boxed_slice()
-}
-
 fn row(key: &RLookupKey<'_>, v: f64) -> RLookupRow<'static> {
     let mut r = RLookupRow::new();
     r.write_key(key, SharedValue::new_num(v));
@@ -60,7 +56,8 @@ fn insert_entry_array_caps_at_cap_in_insertion_order() {
     let key = make_key();
     let mut s = Storage::new(false, Some((0, 3)), 0);
     for i in 0..5 {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        let sv = SharedValue::new_num(i as f64);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(true).collect();
     assert_eq!(drained.len(), 3);
@@ -73,7 +70,8 @@ fn insert_entry_array_drops_excess_without_calling_project() {
     let mut counter = 0;
     let mut s = Storage::new(false, Some((0, 2)), 0);
     for v in [1.0_f64, 2.0, 3.0, 4.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        let sv = SharedValue::new_num(v);
+        s.insert_entry(|| [Some(&sv)], counting_project(&mut counter, &key, v));
     }
     assert_eq!(
         counter, 2,
@@ -86,7 +84,8 @@ fn insert_entry_heap_keeps_top_k_under_asc() {
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), || row(&key, i));
+        let sv = SharedValue::new_num(i);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i));
     }
     let drained: Vec<_> = s.drain(true).collect();
     // ASC: smallest is best; heap drains best→worst.
@@ -98,7 +97,8 @@ fn insert_entry_heap_keeps_top_k_under_desc() {
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_DESC);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), || row(&key, i));
+        let sv = SharedValue::new_num(i);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i));
     }
     let drained: Vec<_> = s.drain(true).collect();
     // DESC: largest is best; heap drains best→worst.
@@ -112,12 +112,14 @@ fn insert_entry_heap_skips_project_for_doomed_candidates() {
     let mut s = Storage::new(true, Some((0, 2)), SORT_ASC);
     // Fill with the two best candidates first.
     for v in [0.0_f64, 1.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        let sv = SharedValue::new_num(v);
+        s.insert_entry(|| [Some(&sv)], counting_project(&mut counter, &key, v));
     }
     // Each subsequent candidate is worse than the worst survivor (1.0)
     // under ASC, so `project` must not run.
     for v in [2.0_f64, 3.0, 4.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        let sv = SharedValue::new_num(v);
+        s.insert_entry(|| [Some(&sv)], counting_project(&mut counter, &key, v));
     }
     assert_eq!(
         counter, 2,
@@ -133,7 +135,8 @@ fn insert_entry_heap_invokes_project_on_eviction() {
     // Each insert is strictly better than the current worst, so every
     // candidate must be projected.
     for v in [5.0_f64, 3.0, 1.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        let sv = SharedValue::new_num(v);
+        s.insert_entry(|| [Some(&sv)], counting_project(&mut counter, &key, v));
     }
     assert_eq!(counter, 3);
 }
@@ -143,7 +146,8 @@ fn drain_array_applies_skip_take() {
     let key = make_key();
     let mut s = Storage::new(false, Some((1, 2)), 0);
     for i in 0..5 {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        let sv = SharedValue::new_num(i as f64);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(true).collect();
     assert_eq!(drained_nums(&key, &drained), vec![1.0, 2.0]);
@@ -154,7 +158,8 @@ fn drain_without_limit_ignores_stored_limit() {
     let key = make_key();
     let mut s = Storage::new(false, Some((1, 2)), 0);
     for i in 0..3 {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        let sv = SharedValue::new_num(i as f64);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(false).collect();
     assert_eq!(drained_nums(&key, &drained), vec![0.0, 1.0, 2.0]);
@@ -165,7 +170,8 @@ fn drain_heap_applies_skip_take_after_best_first_order() {
     let key = make_key();
     let mut s = Storage::new(true, Some((1, 2)), SORT_ASC);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), || row(&key, i));
+        let sv = SharedValue::new_num(i);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i));
     }
     // Top-3 under ASC = [0, 1, 2] best→worst; offset 1, count 2 → [1, 2].
     let drained: Vec<_> = s.drain(true).collect();
@@ -177,8 +183,75 @@ fn insert_entry_heap_uses_default_limit_when_no_explicit_limit() {
     let key = make_key();
     let mut s = Storage::new(true, None, SORT_ASC);
     for i in 0..(DEFAULT_LIMIT as usize + 5) {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        let sv = SharedValue::new_num(i as f64);
+        s.insert_entry(|| [Some(&sv)], || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(true).collect();
     assert_eq!(drained.len(), DEFAULT_LIMIT as usize);
+}
+
+#[test]
+fn insert_entry_heap_does_not_materialize_sort_view_for_doomed_candidates() {
+    use std::cell::Cell;
+    let key = make_key();
+    let mut s = Storage::new(true, Some((0, 2)), SORT_ASC);
+
+    // Fill heap with the two best candidates first.
+    for v in [0.0_f64, 1.0] {
+        let sv = SharedValue::new_num(v);
+        s.insert_entry(|| [Some(&sv)], || row(&key, v));
+    }
+
+    // Each subsequent candidate is worse than the worst survivor (1.0)
+    // under ASC. `Storage` must call `sort_view` exactly once (for the
+    // borrow-compare) — a second call would mean it wastefully
+    // materialized the owned snapshot for a doomed candidate.
+    for v in [2.0_f64, 3.0, 4.0] {
+        let sv = SharedValue::new_num(v);
+        let calls = Cell::new(0);
+        s.insert_entry(
+            || {
+                calls.set(calls.get() + 1);
+                [Some(&sv)]
+            },
+            || row(&key, v),
+        );
+        assert_eq!(
+            calls.get(),
+            1,
+            "sort_view must be invoked exactly once for a doomed candidate \
+             (compare-only); a second call indicates wasted materialization",
+        );
+    }
+}
+
+#[test]
+fn insert_entry_heap_materializes_sort_view_for_winners() {
+    use std::cell::Cell;
+    let key = make_key();
+    let mut s = Storage::new(true, Some((0, 2)), SORT_ASC);
+
+    // Fill with two retainable candidates.
+    for v in [5.0_f64, 3.0] {
+        let sv = SharedValue::new_num(v);
+        s.insert_entry(|| [Some(&sv)], || row(&key, v));
+    }
+
+    // Winner under ASC: 1.0 beats the heap's worst (5.0). `Storage` must
+    // call `sort_view` twice — once for the borrow-compare, once to
+    // materialize the owned snapshot now that survival is confirmed.
+    let sv = SharedValue::new_num(1.0);
+    let calls = Cell::new(0);
+    s.insert_entry(
+        || {
+            calls.set(calls.get() + 1);
+            [Some(&sv)]
+        },
+        || row(&key, 1.0),
+    );
+    assert_eq!(
+        calls.get(),
+        2,
+        "sort_view must be invoked twice for a winner: compare, then materialize",
+    );
 }


### PR DESCRIPTION
## Describe the changes in the pull request

**Current.** `Storage::insert_entry`, the buffering hot path behind `FT.AGGREGATE … COLLECT … SORTBY … LIMIT offset count`, took an `FnOnce() -> Box<[Option<SharedValue>]>` to snapshot the candidate's sort-key values. Once the heap reached the `offset + count` cap, *every* incoming row paid for that snapshot — an allocation plus one `Arc::clone` per sort key — even when the row was going to be discarded immediately because it lost the compare against the heap's current worst entry. On a shard returning many more rows than the final `LIMIT`, the doomed-candidate cost dominates.

**Change.** Split the snapshot into two phases:

1. A new borrow-only comparator, `EntryKey::cmp_candidate` (added in `src/redisearch_rs/reducers/src/collect/heap.rs`), compares a borrowed `Iterator<Item = Option<&SharedValue>>` against an existing `EntryKey` and returns `Ordering::Greater` iff the candidate would beat the entry. It reuses the same `cmp_fields` delegate as `Ord::cmp`, so the ASC/DESC orientation and missing-worst policy stay in one place.
2. `Storage::insert_entry` now takes a borrowed sort-key *view* — `F: Fn() -> impl IntoIterator<Item = Option<&'r SharedValue>>` — instead of an owned `Box`. On the heap-at-cap branch it uses `cmp_candidate` for a borrow-only compare against the current worst; the owned `Box<[Option<SharedValue>]>` is materialized only when the candidate has been confirmed to survive. Below cap (no worst to beat), the view is materialized directly, preserving the existing "first `cap` rows always buffered" semantics. The array path (unsorted `COLLECT`) is untouched.

Both call sites are switched to lazy borrowed views:

- `RemoteCollectCtx::add` (shard-side, `collect/remote.rs`) maps `row.get(key)` over `r.fields.sort_keys()`.
- `LocalCollectCtx::add` (coordinator-merge, `collect/local.rs`) maps `get_field(item, name)` over `r.fields.sort_key_names()`. The `snapshot_sort_keys` helper is now dead and removed.

**Outcome.** Doomed `COLLECT … SORTBY` candidates pay zero `Box` allocations and zero `Arc::clone` calls on the sort-key path — just one borrowed comparison against the heap's worst. Winners pay one extra borrowed compare in addition to the snapshot they were already paying for, which is a negligible cost relative to the saved allocations on doomed rows. The improvement scales with the ratio of input rows to the effective `offset + count` cap.

No FFI changes, no wire-format changes, no change to result ordering or to the missing-worst policy delegated to `cmp_fields`.

#### Which additional issues this PR fixes
1. MOD-15734

#### Main objects this PR modified
1. `EntryKey` — new inherent method `cmp_candidate` in `src/redisearch_rs/reducers/src/collect/heap.rs`.
2. `Storage::insert_entry` in `src/redisearch_rs/reducers/src/collect/storage.rs` — signature now takes a `Fn() -> IntoIterator<Item = Option<&SharedValue>>` borrow-view closure instead of `FnOnce() -> Box<[Option<SharedValue>]>`.
3. `RemoteCollectCtx::add` in `src/redisearch_rs/reducers/src/collect/remote.rs` and `LocalCollectCtx::add` in `src/redisearch_rs/reducers/src/collect/local.rs` — updated to pass borrowed sort-key iterators; `snapshot_sort_keys` removed.
4. `src/redisearch_rs/reducers/tests/{heap,storage}.rs` — new `cmp_candidate` tests (ASC/DESC orientation, missing-value propagation, multi-key zip alignment) and new behavioral canaries that count `sort_view` invocations (exactly 1 for doomed candidates, exactly 2 for winners).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: faster `FT.AGGREGATE … COLLECT … SORTBY … LIMIT` on shards that scan many more rows than the final limit, by skipping per-row sort-key allocations and `Arc` clones for candidates that lose the top-K compare.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the ranked `COLLECT SORTBY` top-K path and changes how sort keys are compared/materialized, so any subtle comparator/iterator-lifetime bug could affect result ordering or LIMIT behavior.
>
> **Overview**
> Optimizes shard-side and coordinator `COLLECT ... SORTBY` buffering by avoiding eager cloning of sort-key values for heap comparisons.
>
> `Storage::insert_entry` now accepts a borrow-only `sort_view` and uses new `EntryKey::cmp_candidate` to compare heap-at-cap candidates against the current worst without allocating; it only materializes the owned sort-key snapshot when the candidate actually survives. Local/remote COLLECT reducers are updated to pass borrowed sort-key iterators, and tests are expanded to pin the new compare semantics and ensure doomed candidates don't trigger materialization while winners do.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b101ba12ad0ba6df8701dbda7d7a6e70febbae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
