### PR TITLE
[MOD-14646] Add Malay language support

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -538,7 +538,7 @@ int StemmerExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
     } else {
       dd = ctx->privdata = rm_calloc(1, sizeof(*dd));
       dd->isCn = 0;
-      sb = dd->data.latin = sb_stemmer_new(RSLanguage_ToString(ctx->language), NULL);
+      sb = dd->data.latin = sb_stemmer_new(RSLanguage_ToSnowballStemmer(ctx->language), NULL);
     }
   }
 

--- a/src/language.c
+++ b/src/language.c
@@ -96,7 +96,7 @@ const char *RSLanguage_ToSnowballStemmer(RSLanguage language) {
   // Malay is not in libstemmer; Indonesian shares enough morphology to be a
   // reasonable backing algorithm.
   if (language == RS_LANG_MALAY) {
-    return "indonesian";
+    RSLanguage_ToString(RS_LANG_INDONESIAN);
   }
   return RSLanguage_ToString(language);
 }

--- a/src/language.c
+++ b/src/language.c
@@ -96,7 +96,7 @@ const char *RSLanguage_ToSnowballStemmer(RSLanguage language) {
   // Malay is not in libstemmer; Indonesian shares enough morphology to be a
   // reasonable backing algorithm.
   if (language == RS_LANG_MALAY) {
-    RSLanguage_ToString(RS_LANG_INDONESIAN);
+    return RSLanguage_ToString(RS_LANG_INDONESIAN);
   }
   return RSLanguage_ToString(language);
 }

--- a/src/language.c
+++ b/src/language.c
@@ -36,6 +36,7 @@ langPair_t __langPairs[] = {
   { "irish",      RS_LANG_IRISH },
   { "italian",    RS_LANG_ITALIAN },
   { "lithuanian", RS_LANG_LITHUANIAN },
+  { "malay",      RS_LANG_MALAY },
   { "nepali",     RS_LANG_NEPALI },
   { "norwegian",  RS_LANG_NORWEGIAN },
   { "portuguese", RS_LANG_PORTUGUESE },
@@ -72,6 +73,7 @@ const char *RSLanguage_ToString(RSLanguage language) {
     case  RS_LANG_IRISH:       ret = "irish";      break;
     case  RS_LANG_ITALIAN:     ret = "italian";    break;
     case  RS_LANG_LITHUANIAN:  ret = "lithuanian"; break;
+    case  RS_LANG_MALAY:       ret = "malay";      break;
     case  RS_LANG_NEPALI:      ret = "nepali";     break;
     case  RS_LANG_NORWEGIAN:   ret = "norwegian";  break;
     case  RS_LANG_PORTUGUESE:  ret = "portuguese"; break;
@@ -88,6 +90,15 @@ const char *RSLanguage_ToString(RSLanguage language) {
     default: break;
   }
   return (const char *)ret;
+}
+
+const char *RSLanguage_ToSnowballStemmer(RSLanguage language) {
+  // Malay is not in libstemmer; Indonesian shares enough morphology to be a
+  // reasonable backing algorithm.
+  if (language == RS_LANG_MALAY) {
+    return "indonesian";
+  }
+  return RSLanguage_ToString(language);
 }
 
 RSLanguage RSLanguage_Find(const char *language, size_t len) {

--- a/src/language.h
+++ b/src/language.h
@@ -44,6 +44,7 @@ typedef enum {
   RS_LANG_SERBIAN,
   RS_LANG_YIDDISH,
   RS_LANG_TAGALOG,
+  RS_LANG_MALAY,
   RS_LANG_UNSUPPORTED,
   RS_LANG_UNSET, // The user did not set the language for FT.SEARCH, use the index language
 } RSLanguage;
@@ -53,6 +54,11 @@ typedef enum {
 /* check if a language is supported by our stemmers */
 RSLanguage RSLanguage_Find(const char *language, size_t len);
 const char *RSLanguage_ToString(RSLanguage language);
+
+/* Snowball stemmer name for a language. Usually identical to RSLanguage_ToString,
+ * but maps languages without a dedicated snowball algorithm onto a linguistically
+ * close one (e.g. Malay -> Indonesian). */
+const char *RSLanguage_ToSnowballStemmer(RSLanguage language);
 
 #ifdef __cplusplus
 }

--- a/src/stemmer.c
+++ b/src/stemmer.c
@@ -65,7 +65,7 @@ static int sbstemmer_Reset(Stemmer *stemmer, StemmerType type, RSLanguage langua
 }
 
 Stemmer *__newSnowballStemmer(RSLanguage language) {
-  struct sb_stemmer *sb = sb_stemmer_new(RSLanguage_ToString(language), NULL);
+  struct sb_stemmer *sb = sb_stemmer_new(RSLanguage_ToSnowballStemmer(language), NULL);
   // No stemmer available for this language
   if (!sb) {
     return NULL;

--- a/tests/pytests/test_language.py
+++ b/tests/pytests/test_language.py
@@ -560,10 +560,43 @@ def testTagalogLanguage(env):
     res = env.cmd('FT.SEARCH', 'idx_tl', 'kain', 'SORTBY', 'word', 'ASC')
     env.assertEqual(res[0], 2)
 
+
+def testMalayLanguage(env):
+    conn = getConnectionByEnv(env)
+
+    # Malay is stemmed via the Indonesian Snowball algorithm; both pairs below
+    # share a stem (niaga / selamat) under that algorithm.
+    conn.execute_command('HSET', '{ml}:1', 'word', 'perniagaan')
+    conn.execute_command('HSET', '{ml}:2', 'word', 'berniaga')
+
+    env.cmd('FT.CREATE', 'idx_ml', 'ON', 'HASH', 'PREFIX', '1', '{ml}:',
+            'LANGUAGE', 'malay', 'SCHEMA', 'word', 'TEXT')
+    waitForIndex(env, 'idx_ml')
+
+    res = env.cmd('FT.SEARCH', 'idx_ml', 'perniagaan', 'SORTBY', 'word', 'ASC')
+    env.assertEqual(res[0], 2)
+
+    res = env.cmd('FT.SEARCH', 'idx_ml', 'berniaga', 'SORTBY', 'word', 'ASC')
+    env.assertEqual(res[0], 2)
+
+    conn.execute_command('HSET', '{ml2}:1', 'word', 'keselamatan')
+    conn.execute_command('HSET', '{ml2}:2', 'word', 'selamat')
+
+    env.cmd('FT.CREATE', 'idx_ml2', 'ON', 'HASH', 'PREFIX', '1', '{ml2}:',
+            'LANGUAGE', 'malay', 'SCHEMA', 'word', 'TEXT')
+    waitForIndex(env, 'idx_ml2')
+
+    res = env.cmd('FT.SEARCH', 'idx_ml2', 'keselamatan', 'SORTBY', 'word', 'ASC')
+    env.assertEqual(res[0], 2)
+
+    res = env.cmd('FT.SEARCH', 'idx_ml2', 'selamat', 'SORTBY', 'word', 'ASC')
+    env.assertEqual(res[0], 2)
+
+
 def testLanguageInfo(env):
     languages = ['arabic', 'armenian', 'basque', 'catalan', 'danish', 'dutch',
                  'finnish', 'french', 'german', 'greek', 'hindi', 'hungarian',
-                 'indonesian', 'irish', 'italian', 'lithuanian',
+                 'indonesian', 'irish', 'italian', 'lithuanian', 'malay',
                  'nepali', 'norwegian', 'portuguese', 'romanian', 'russian',
                  'serbian', 'spanish', 'swedish', 'tagalog', 'tamil',
                  'turkish', 'yiddish', 'chinese']


### PR DESCRIPTION
Per the internal validation, the indonesian stemmer seems good enough for Malay.

This change adds Malay as a supported language.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new supported language and changes Snowball stemmer selection logic for all languages via a new mapping function; risk is mainly around unintended stemming behavior or language-selection regressions.
> 
> **Overview**
> Adds **Malay** as a supported `LANGUAGE` option, including enum/string mapping updates and exposure via `FT.INFO`.
> 
> Introduces `RSLanguage_ToSnowballStemmer()` and switches Snowball stemmer creation in `stemmer.c` and the default query expander to use it, mapping `malay` to the Indonesian Snowball algorithm.
> 
> Extends Python tests with a dedicated Malay stemming test and updates the language-info coverage to include `malay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45af78037a032b8ad48cabac872257e28181acf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->