### PR TITLE
[CI] update workflows to target the latest 8.8 release

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert to using the latest stable ref in redis
+    # TODO: Switch to the latest 8.8 release/pre-release line once it is ready.
     runs-on: ubuntu-slim
     outputs:
       tag: 3cd464263b03b425ffae2e23db24df3dc9346871
@@ -25,12 +25,7 @@ jobs:
     # with:
     #   repo: redis/redis
 
-  check-what-changed:
-    uses: ./.github/workflows/task-check-changes.yml
-
   lint:
-    needs: check-what-changed
-    if: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -43,10 +38,9 @@ jobs:
       advisories-base-ref: ${{ github.event.merge_group.base_sha }}
 
   test-matrix:
-    # Wait for lint so we do not spend MQ test capacity when CI is already going to fail.
-    # Use explicit status checks so test-only changes still run even when lint is skipped.
-    needs: [get-latest-redis-tag, check-what-changed, lint]
-    if: ${{ !cancelled() && !failure() && (needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true') }}
+    # MQ is the 8.8 release gate, so run the full supported matrix with full tests.
+    needs: [get-latest-redis-tag, lint]
+    if: ${{ !cancelled() && !failure() }}
     permissions:
       contents: read
       packages: write
@@ -55,18 +49,17 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos-26,alpine:3.23,intel'  # on feature branches this should be 'all'
+      platform: all
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,fail-fast,sanitize' }}
       separate-coordinator-job: true
-      rejson-branch: master
+      rejson-branch: '8.8'
 
   pr-validation:
     needs:
       - get-latest-redis-tag
-      - check-what-changed
       - lint
       - test-matrix
     runs-on: ubuntu-slim

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Revert when 8.4 is released
+    # TODO: Switch to the latest 8.8 release/pre-release line once it is ready.
     runs-on: ubuntu-slim
     outputs:
       tag: 3cd464263b03b425ffae2e23db24df3dc9346871
@@ -44,8 +44,9 @@ jobs:
     uses: ./.github/workflows/generate-basic-matrix.yml
     with:
       include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
-      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
-      include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
+      # Keep version-branch PRs lightweight: coverage/sanitize are label-forced and draft-skipped.
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
+      include-sanitize: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
       separate-coordinator-job: true
 
   test-matrix:
@@ -79,7 +80,7 @@ jobs:
       unit-tests: ${{ matrix.test-mode != 'coordinator' }}
       coverage: ${{ (matrix.job-type || 'test') == 'coverage' }}
       san: ${{ (matrix.job-type || 'test') == 'sanitize' && 'address' || '' }}
-      rejson-branch: master
+      rejson-branch: '8.8'
 
   pr-validation:
     needs:


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions gating for both merge-queue and PR workflows (including when lint/tests run and which test matrix executes), which can affect required checks and CI load but does not touch product code.
> 
> **Overview**
> Updates CI workflows to track the latest Redis `8.8` release by switching `get-latest-redis-tag` from a hardcoded commit to `task-get-latest-tag.yml` with `prefix: '8.8'`, and sets `rejson-branch` to `8.8`.
> 
> Tightens merge-queue (`event-merge-to-queue.yml`) to always run the full supported test matrix (`platform: all`) and removes the change-detection gate from lint/tests.
> 
> Keeps PR CI lighter by making coverage/sanitize jobs *label-forced only* (and draft-skipped) in `generate-basic-matrix.yml` inputs, instead of running them automatically on code/test changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d181c784488c6e9296512756e4494a469dbdfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->