### PR TITLE
[MOD-15882] Declarative test environments for Python tests

### DIFF
--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -557,7 +557,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = 2,
+    .arity = -2,
     .since = "8.10.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -557,7 +557,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = -2,
+    .arity = 2,
     .since = "8.10.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
@@ -3477,4 +3477,3 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
-

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -529,7 +529,7 @@ def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None
             if len(inspect.signature(f).parameters) > 0:
                 # Honor a declared @env_spec when constructing the env so the
                 # spec stays load-bearing even when @skip is stacked on top.
-                spec = getattr(f, '_rltest_env_spec', None) or {}
+                spec = getattr(f, '_rltest_env_spec', {})
                 env = Env(**spec)
                 return f(env)
             else:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -14,7 +14,7 @@ from redis.client import NEVER_DECODE
 from redis import exceptions as redis_exceptions
 import RLTest
 from typing import Any, Callable, List, Dict
-from RLTest import Env
+from RLTest import Env, env_spec
 from RLTest.env import Query
 import numpy as np
 from scipy import spatial
@@ -499,6 +499,10 @@ def skipTestUntil(date_str, reason=None):
 
 def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False):
     def decorate(f):
+        # functools.wraps propagates the wrapped function's __dict__ onto the
+        # wrapper. That's how @env_spec metadata survives the @skip wrap when
+        # the two decorators are stacked.
+        @wraps(f)
         def wrapper():
             if not ((cluster is not None) or macos or asan or msan or redis_less_than or redis_greater_equal or min_shards or no_json):
                 raise SkipTest()
@@ -523,7 +527,10 @@ def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None
             if no_json and not REJSON:
                 raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
-                env = Env()
+                # Honor a declared @env_spec when constructing the env so the
+                # spec stays load-bearing even when @skip is stacked on top.
+                spec = getattr(f, '_rltest_env_spec', None) or {}
+                env = Env(**spec)
                 return f(env)
             else:
                 return f()

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -497,34 +497,102 @@ def skipTestUntil(date_str, reason=None):
     """
     skip_until(date_str, reason)(lambda: None)()
 
+def _any_skip_condition_set(*, cluster, macos, asan, msan, redis_less_than,
+                            redis_greater_equal, min_shards, arch, gc_no_fork,
+                            no_json):
+    """True if the caller provided at least one skip condition.
+
+    With no conditions, @skip's legacy behaviour is to always skip — used as a
+    "temporarily disable this test" marker.
+    """
+    return ((cluster is not None) or macos or asan or msan or redis_less_than
+            or redis_greater_equal or min_shards or (arch is not None)
+            or gc_no_fork or no_json)
+
+
+def _skip_fires_statically(*, cluster, macos, asan, msan, min_shards, arch,
+                            no_json):
+    """Evaluate the subset of @skip predicates that don't need a live Redis.
+
+    Excludes redis_less_than/redis_greater_equal/gc_no_fork — those genuinely
+    need a running env, so they can't decide at module-load time.
+    """
+    if cluster is not None and cluster == CLUSTER:
+        return True
+    if macos and OS == 'macos':
+        return True
+    if arch == platform.machine():
+        return True
+    if asan and SANITIZER == 'address':
+        return True
+    if msan and SANITIZER == 'memory':
+        return True
+    if min_shards and Defaults.num_shards < min_shards:
+        return True
+    if no_json and not REJSON:
+        return True
+    return False
+
+
+def _skip_fires_at_runtime(*, redis_less_than, redis_greater_equal, gc_no_fork):
+    """Evaluate the @skip predicates that need a live Redis.
+
+    Spawns a transient Env for gc_no_fork; the version helpers maintain their
+    own connection.
+    """
+    if redis_less_than and server_version_is_less_than(redis_less_than):
+        return True
+    if redis_greater_equal and server_version_is_at_least(redis_greater_equal):
+        return True
+    if gc_no_fork and Env().cmd(config_cmd(), 'GET', 'GC_POLICY')[0][1] != 'fork':
+        return True
+    return False
+
+
 def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False):
-    def decorate(f):
-        # functools.wraps propagates the wrapped function's __dict__ onto the
-        # wrapper. That's how @env_spec metadata survives the @skip wrap when
-        # the two decorators are stacked.
-        @wraps(f)
+    static_kwargs = dict(cluster=cluster, macos=macos, asan=asan, msan=msan,
+                         min_shards=min_shards, arch=arch, no_json=no_json)
+    runtime_kwargs = dict(redis_less_than=redis_less_than,
+                          redis_greater_equal=redis_greater_equal,
+                          gc_no_fork=gc_no_fork)
+    any_condition = _any_skip_condition_set(
+        **static_kwargs, **runtime_kwargs,
+    )
+
+    def decorate(target):
+        if isinstance(target, type):
+            # Class decoration. We must decide whether to skip BEFORE RLTest
+            # provisions a class's @env_spec env — otherwise a cluster-only
+            # test class would spin up a 3-shard env on standalone runs just
+            # to be thrown away. Evaluate the static predicates now; if any
+            # fires, strip the @env_spec marker (so no env is built) and
+            # replace __init__ with one that raises SkipTest the moment
+            # RLTest tries to instantiate the class.
+            if redis_less_than or redis_greater_equal or gc_no_fork:
+                raise TypeError(
+                    "@skip on a class cannot use redis_less_than, "
+                    "redis_greater_equal, or gc_no_fork because those need a "
+                    "live Redis and would defeat the purpose of skipping "
+                    "before env provisioning. Use skipTest() inside a method "
+                    "instead, or apply @skip to individual functions."
+                )
+            # No conditions = legacy "always skip" marker.
+            fires = (not any_condition) or _skip_fires_statically(**static_kwargs)
+            if fires:
+                if hasattr(target, '_rltest_env_spec'):
+                    delattr(target, '_rltest_env_spec')
+                def _skipping_init(self, *args, **kwargs):
+                    raise SkipTest()
+                target.__init__ = _skipping_init
+            return target
+
+        f = target
         def wrapper():
-            if not ((cluster is not None) or macos or asan or msan or redis_less_than or redis_greater_equal or min_shards or no_json):
+            if not any_condition:
                 raise SkipTest()
-            if cluster == CLUSTER:
+            if _skip_fires_statically(**static_kwargs):
                 raise SkipTest()
-            if macos and OS == 'macos':
-                raise SkipTest()
-            if arch == platform.machine():
-                raise SkipTest()
-            if asan and SANITIZER == 'address':
-                raise SkipTest()
-            if msan and SANITIZER == 'memory':
-                raise SkipTest()
-            if redis_less_than and server_version_is_less_than(redis_less_than):
-                raise SkipTest()
-            if redis_greater_equal and server_version_is_at_least(redis_greater_equal):
-                raise SkipTest()
-            if min_shards and Defaults.num_shards < min_shards:
-                raise SkipTest()
-            if gc_no_fork and Env().cmd(config_cmd(), 'GET', 'GC_POLICY')[0][1] != 'fork':
-                raise SkipTest()
-            if no_json and not REJSON:
+            if _skip_fires_at_runtime(**runtime_kwargs):
                 raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 # Honor a declared @env_spec when constructing the env so the
@@ -534,6 +602,19 @@ def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None
                 return f(env)
             else:
                 return f()
+        # Propagate identifying metadata + the env_spec marker. Deliberately
+        # NOT functools.wraps: that would set wrapper.__wrapped__ = f, which
+        # exposes f's signature to inspect.signature(follow_wrapped=True) and
+        # could trick callers into passing an env arg to this zero-arg
+        # wrapper. We only need __name__/__qualname__ for debugging and
+        # _rltest_env_spec so RLTest's loader can read the declared spec off
+        # the wrapper.
+        wrapper.__name__ = f.__name__
+        wrapper.__qualname__ = f.__qualname__
+        wrapper.__doc__ = f.__doc__
+        spec = getattr(f, '_rltest_env_spec', None)
+        if spec is not None:
+            wrapper._rltest_env_spec = spec
         return wrapper
     return decorate
 

--- a/tests/pytests/pyproject.toml
+++ b/tests/pytests/pyproject.toml
@@ -7,11 +7,11 @@ dependencies = [
     "packaging<=24.2",
     "deepdiff==8.6.2",
     "redis>=5.2.1,<7.0.0", # Pin to avoid redis-py 7.x incompatibility (todo: update once fixed)
-    "RLTest==0.7.25",
+    "rltest==0.7.26",
     "numpy<=2.2.4",
     "scipy<=1.15.2",
     "faker<=37.1.0",
     "distro<=1.9.0",
     "orderly-set<=5.4.1", # Update pin once Python 3.8 is not used in CI
-    "ml_dtypes <= 0.5.3"
+    "ml_dtypes <= 0.5.3",
 ]

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -45,15 +45,11 @@ def _common_cluster_test_scenario(env):
 
     return n_docs
 
-# An empty @env_spec() opts the class into RLTest building an Env at
-# construction time (with defaults) and passing it to __init__. Methods then
-# access it via self.env. The skipTest still runs inside __init__ — for
-# skipped runs the env is built and immediately torn down, which is cheap.
+@skip(cluster=True)
 @env_spec()
 class testOomStandaloneBehavior:
 
     def __init__(self, env):
-        skipTest(cluster=True)
         self.env = env
         _common_test_scenario(self.env)
         # Init all shards
@@ -117,10 +113,10 @@ def test_oom_verbosity_cluster_hybrid_profile(env):
     env.assertContains('Profile', res)
 
 
+@skip(cluster=False)
 @env_spec(shardsCount=3)
 class testOomClusterBehavior:
     def __init__(self, env):
-        skipTest(cluster=False)
         self.env = env
         self.n_docs = _common_cluster_test_scenario(self.env)
         allShards_change_maxmemory_low(self.env)
@@ -265,11 +261,11 @@ def _common_hybrid_cluster_test_scenario(env):
 
     return n_docs
 
+@skip(cluster=True)
 @env_spec()
 class testOomHybridStandaloneBehavior:
 
     def __init__(self, env):
-        skipTest(cluster=True)
         self.env = env
         _common_hybrid_test_scenario(self.env)
         verify_shard_init(self.env.getConnection())
@@ -293,10 +289,10 @@ class testOomHybridStandaloneBehavior:
         res = self.env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
         self.env.assertEqual(res[1], 0)
 
+@skip(cluster=False)
 @env_spec(shardsCount=3)
 class testOomHybridClusterBehavior:
     def __init__(self, env):
-        skipTest(cluster=False)
         self.env = env
         self.n_docs = _common_hybrid_cluster_test_scenario(self.env)
         allShards_change_maxmemory_low(self.env)

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -45,11 +45,16 @@ def _common_cluster_test_scenario(env):
 
     return n_docs
 
+# An empty @env_spec() opts the class into RLTest building an Env at
+# construction time (with defaults) and passing it to __init__. Methods then
+# access it via self.env. The skipTest still runs inside __init__ — for
+# skipped runs the env is built and immediately torn down, which is cheap.
+@env_spec()
 class testOomStandaloneBehavior:
 
-    def __init__(self):
+    def __init__(self, env):
         skipTest(cluster=True)
-        self.env = Env()
+        self.env = env
         _common_test_scenario(self.env)
         # Init all shards
         verify_shard_init(self.env.getConnection())
@@ -75,8 +80,8 @@ class testOomStandaloneBehavior:
         self.env.assertEqual(res, [0])
 
 @skip(cluster=True)
-def test_oom_verbosity_standalone():
-    env = Env(protocol=3)
+@env_spec(protocol=3)
+def test_oom_verbosity_standalone(env):
     _common_test_scenario(env)
 
     # Check commands return SHARD_OOM_WARNING when returning empty results
@@ -98,9 +103,8 @@ def test_oom_verbosity_standalone():
     env.assertContains('Profile', res)
 
 @skip(cluster=False)
-def test_oom_verbosity_cluster_hybrid_profile():
-    env = Env(shardsCount=3, protocol=3)
-
+@env_spec(shardsCount=3, protocol=3)
+def test_oom_verbosity_cluster_hybrid_profile(env):
     allShards_change_oom_policy(env, 'return')
     _common_hybrid_cluster_test_scenario(env)
     allShards_change_maxmemory_low(env)
@@ -113,10 +117,11 @@ def test_oom_verbosity_cluster_hybrid_profile():
     env.assertContains('Profile', res)
 
 
+@env_spec(shardsCount=3)
 class testOomClusterBehavior:
-    def __init__(self):
+    def __init__(self, env):
         skipTest(cluster=False)
-        self.env = Env(shardsCount=3)
+        self.env = env
         self.n_docs = _common_cluster_test_scenario(self.env)
         allShards_change_maxmemory_low(self.env)
         # Init all shards
@@ -163,12 +168,11 @@ class testOomClusterBehavior:
         self.env.assertEqual(len(res), n_keys + 1)
 
 # Test OOM error returned from shards (only for fail), enforcing first reply from non-error shard
-# Test has specific environment requirements, so it's left out of the test class
+# Test has specific environment requirements, so it's left out of the test class.
+# Workers is necessary to make sure the query is not finished before we resume the shards.
 @skip(cluster=False, asan=True)
-def test_query_oom_cluster_shards_error_first_reply():
-    # Workers is necessary to make sure the query is not finished before we resume the shards
-    env  = Env(shardsCount=3, moduleArgs='WORKERS 1')
-
+@env_spec(shardsCount=3, moduleArgs='WORKERS 1')
+def test_query_oom_cluster_shards_error_first_reply(env):
     # Init all shards
     for i in range(env.shardsCount):
         verify_shard_init(env.getConnection(i))
@@ -261,11 +265,12 @@ def _common_hybrid_cluster_test_scenario(env):
 
     return n_docs
 
+@env_spec()
 class testOomHybridStandaloneBehavior:
 
-    def __init__(self):
+    def __init__(self, env):
         skipTest(cluster=True)
-        self.env = Env()
+        self.env = env
         _common_hybrid_test_scenario(self.env)
         verify_shard_init(self.env.getConnection())
 
@@ -288,10 +293,11 @@ class testOomHybridStandaloneBehavior:
         res = self.env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
         self.env.assertEqual(res[1], 0)
 
+@env_spec(shardsCount=3)
 class testOomHybridClusterBehavior:
-    def __init__(self):
+    def __init__(self, env):
         skipTest(cluster=False)
-        self.env = Env(shardsCount=3)
+        self.env = env
         self.n_docs = _common_hybrid_cluster_test_scenario(self.env)
         allShards_change_maxmemory_low(self.env)
         # Init all shards
@@ -339,9 +345,8 @@ class testOomHybridClusterBehavior:
         self.env.assertEqual(res[5][0], COORD_OOM_WARNING)
 
 @skip(cluster=False)
-def test_oom_verbosity_cluster_return():
-    env  = Env(shardsCount=3, protocol=3)
-
+@env_spec(shardsCount=3, protocol=3)
+def test_oom_verbosity_cluster_return(env):
     # Init all shards
     for i in range(env.shardsCount):
         verify_shard_init(env.getConnection(i))

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [{ name = "pip" }]
 
 [[package]]
 name = "rltest"
-version = "0.7.25"
+version = "0.7.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distro" },
@@ -474,9 +474,9 @@ dependencies = [
     { name = "pytest-cov" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/07/41e2a7acb84460edf504e1894b30d3dff38ef26bcc2e49225e2fae496a06/rltest-0.7.25.tar.gz", hash = "sha256:0836ab407a3ab5629be98e2d98bc0c3113a96e388a72e69cdb4137e439471625", size = 42629, upload-time = "2026-04-26T10:52:50.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/54/a428d74cd68859a8a29897d04f95e2472f121bac8a898a2fca3a840478ea/rltest-0.7.26.tar.gz", hash = "sha256:288073a3540bb8888029c00578942065c7b0d0b50c0050513bb0fb0ca4bfc032", size = 45274, upload-time = "2026-05-25T13:49:27.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/8b/1b78f12f887742a48ebe3c5cfed4e008c91d4db68e3695797b8e647e15d7/rltest-0.7.25-py3-none-any.whl", hash = "sha256:7a599bae73e858530369e7f68248ed0228134550c23ac724efc4adaa128079b2", size = 47886, upload-time = "2026-04-26T10:52:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/41/a509c4161aa12d7e0b329c77aa2e30b457313339993019c6577e51092c1f/rltest-0.7.26-py3-none-any.whl", hash = "sha256:10706d25a7a05adf05f4b698041c3f783a33246c421c28e06907a5d4dd385f17", size = 50729, upload-time = "2026-05-25T13:49:28.287Z" },
 ]
 
 [[package]]
@@ -508,7 +508,7 @@ requires-dist = [
     { name = "orderly-set", specifier = "<=5.4.1" },
     { name = "packaging", specifier = "<=24.2" },
     { name = "redis", specifier = ">=5.2.1,<7.0.0" },
-    { name = "rltest", specifier = "==0.7.25" },
+    { name = "rltest", specifier = "==0.7.26" },
     { name = "scipy", specifier = "<=1.15.2" },
 ]
 


### PR DESCRIPTION
## Describe the changes in the pull request

Showcase how the new decorator from https://github.com/RedisLabsModules/RLTest/pull/250 can be used in RediSearch Python tests.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and dependency bump only; no production search or Redis module behavior changes beyond a whitespace line in generated command_info.c.
> 
> **Overview**
> Adopts **RLTest 0.7.26** and wires RediSearch pytests to declarative **`@env_spec`** so Redis topology (shards, protocol, module args) is declared on tests instead of built inside `__init__` or `skipTest()`.
> 
> **`common.py`**: imports `env_spec`; refactors **`@skip`** into static vs runtime predicates, class-level skip that strips `_rltest_env_spec` before env provisioning (avoids spinning up cluster envs on standalone), and function wrappers that build `Env(**spec)` from the stacked `@env_spec`. Runtime-only skip flags on classes are rejected with `TypeError`.
> 
> **`test_query_oom.py`**: OOM tests/classes use `@env_spec(...)` + `@skip(...)` and take `env` from RLTest instead of manual `Env()` / `skipTest()`.
> 
> **Deps**: `pyproject.toml` / `uv.lock` bump `rltest` to **0.7.26** (package name normalized to lowercase).
> 
> **`command_info.c`**: trivial trailing whitespace removal only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0d8ac1fccd039a2f753860ec4317ca3765845d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->