### PR TITLE
[MOD-15393] trie: make TrieNode, TriePayload, TrieIterator opaque to external callers

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -568,7 +568,7 @@ QueryIterator *Query_EvalTokenNode(QueryEvalCtx *q, QueryNode *qn) {
     rune *runes = runeBufFill(qn->tn.str, qn->tn.len, &buf, &rlen);
     TrieNode *trienode = Trie_GetNode(q->sctx->spec->terms, runes, rlen, true, NULL);
     runeBufFree(&buf);
-    size_t numDocsInTerm = trienode ? trienode->numDocs : 0;
+    size_t numDocsInTerm = trienode ? TrieNode_NumDocs(trienode) : 0;
     double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
     double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
     bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, &qn->opts);
@@ -650,7 +650,7 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
     rune *runes = runeBufFill("", 1, &buf, &rlen);
     TrieNode *emptyNode = Trie_GetNode(terms, runes, rlen, true, NULL);
     runeBufFree(&buf);
-    size_t numDocsInEmpty = emptyNode ? emptyNode->numDocs : 0;
+    size_t numDocsInEmpty = emptyNode ? TrieNode_NumDocs(emptyNode) : 0;
     addTerm("", 0, numDocsInEmpty, q, opts, &its, &itsSz, &itsCap);
   }
 
@@ -871,7 +871,7 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
     rune *runes = runeBufFill(tok.str, tok.len, &buf, &rlen);
     TrieNode *trienode = Trie_GetNode(q->sctx->spec->terms, runes, rlen, true, NULL);
     runeBufFree(&buf);
-    size_t numDocsInTerm = trienode ? trienode->numDocs : 0;
+    size_t numDocsInTerm = trienode ? TrieNode_NumDocs(trienode) : 0;
     double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
     double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
     bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, ctx->opts);

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -332,7 +332,7 @@ int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, siz
     return REDISMODULE_OK;
   }
 
-  suffixData *data = (suffixData *)pl->data;
+  suffixData *data = (suffixData *)TriePayload_Data(pl);
   arrayof(char *) array = data->array;
   for (int i = 0; i < array_len(array); ++i) {
     if (Wildcard_MatchChar(sufCtx->cstr, sufCtx->cstrlen, array[i], strlen(array[i]))

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -14,6 +14,7 @@
 #include "util/misc.h"
 #include "rune_util.h"
 #include "trie.h"
+#include "trie_node_internal.h"
 #include "rmalloc.h"
 #include "rdb.h"
 

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include <sys/param.h>
-#include "trie_node.h"
+#include "trie_node_internal.h"
 #include "util/bsearch.h"
 #include "sparse_vector.h"
 #include "redisearch.h"
@@ -113,6 +113,38 @@ static void triePayload_Free(TriePayload *payload, TrieFreeCallback freecb) {
     freecb(payload->data);
   }
   rm_free(payload);
+}
+
+/* Opaque accessors. Definitions for the declarations in trie_node.h. With LTO
+ * these are inlined back at external call sites; without LTO they stay as
+ * regular function calls. */
+t_len TrieNode_NumChildren(const TrieNode *n) {
+  return n->numChildren;
+}
+
+bool TrieNode_IsTerminal(const TrieNode *n) {
+  return (n->flags & TRIENODE_TERMINAL) != 0;
+}
+
+size_t TrieNode_NumDocs(const TrieNode *n) {
+  return n->numDocs;
+}
+
+TrieNode **TrieNode_Children(const TrieNode *n) {
+  return (TrieNode **)((char *)n + sizeof(TrieNode) +
+                       ((n->len + 1) + n->numChildren) * sizeof(rune));
+}
+
+TrieNode *TrieNode_ChildAt(const TrieNode *n, t_len i) {
+  return TrieNode_Children(n)[i];
+}
+
+char *TrieNode_GetPayloadData(const TrieNode *n) {
+  return (n && n->payload) ? n->payload->data : NULL;
+}
+
+char *TriePayload_Data(TriePayload *p) {
+  return p ? p->data : NULL;
 }
 
 TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *payload, size_t plen,

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -23,8 +23,6 @@ typedef uint16_t t_len;
 
 #define TRIE_INITIAL_STRING_LEN 256
 #define TRIE_MAX_PREFIX 100
-#define TRIENODE_TERMINAL 0x1
-#define TRIENODE_DELETED 0x2
 
 /* TrieNode_Add return codes */
 #define TRIE_OK_NEW                1   /* Successfully added a new entry */
@@ -39,85 +37,30 @@ typedef enum {
 typedef void (*TrieFreeCallback)(void *node);
 struct timespec;
 
-#pragma pack(1)
-typedef struct {
-  uint32_t len;  // 4G payload is more than enough!!!!
-  char data[];   // this means the data will not take an extra pointer.
-} TriePayload;
-#pragma pack()
+/* Opaque types. Layouts live in trie_node_internal.h and are not visible to
+ * callers outside src/trie/. Use the accessors below. */
+typedef struct TriePayload TriePayload;
+typedef struct TrieNode TrieNode;
+typedef struct TrieIterator TrieIterator;
 
-#pragma pack(1)
-/* TrieNode represents a single node in a trie. The actual size of it is bigger,
- * as the children are
- * allocated after str[].
- * Non terminal nodes always have a score of 0, meaning you can't insert nodes
- * with score 0 to the
- * trie.
- */
-typedef struct {
-  // the string length of this node. can be 0
-  t_len len;
-  // the number of child nodes
-  t_len numChildren;
-
-  uint8_t flags : 2;
-  TrieSortMode sortMode : 1;
-
-  // the node's score. Non termn
-  float score;
-
-  // the maximal score of any descendant of this node, used to optimize
-  // traversal
-  float maxChildScore;
-
-  // the number of documents containing this key
-  size_t numDocs;
-
-  // the payload of terminal node. could be NULL if it's not terminal
-  TriePayload *payload;
-
-  // the string of the current node
-  rune str[];
-  // ... here come the first letters of each child childRunes[]
-  // ... now come the children, to be accessed with TrieNode_Children
-} TrieNode;
-#pragma pack()
-
-/* Create a new trie node. str is a string to be copied into the node, starting
- * from offset up until
- * len. numChildren is the initial number of allocated child nodes */
-TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *payload, size_t plen,
-                        t_len numChildren, float score, int terminal, TrieSortMode sortMode,
-                        size_t numDocs);
-
-/* Opaque accessors over TrieNode struct internals. Prefer these over direct
- * field/macro access so callers stay decoupled from layout changes. */
-static inline t_len TrieNode_NumChildren(const TrieNode *n) {
-  return n->numChildren;
-}
-
-static inline bool TrieNode_IsTerminal(const TrieNode *n) {
-  return (n->flags & TRIENODE_TERMINAL) != 0;
-}
-
-/* Get a pointer to the children array of a node. The children are not an
- * actual member of the node for memory saving reasons. char* arithmetic is
- * used so this stays valid when included in C++ TUs (void* arithmetic is a
- * GCC C extension). */
-static inline TrieNode **TrieNode_Children(const TrieNode *n) {
-  return (TrieNode **)((char *)n + sizeof(TrieNode) +
-                       ((n->len + 1) + n->numChildren) * sizeof(rune));
-}
-
-static inline TrieNode *TrieNode_ChildAt(const TrieNode *n, t_len i) {
-  return TrieNode_Children(n)[i];
-}
-
+/* Opaque accessors over TrieNode struct internals. These are the only
+ * supported way to read TrieNode fields from outside src/trie/. */
+t_len TrieNode_NumChildren(const TrieNode *n);
+bool TrieNode_IsTerminal(const TrieNode *n);
+/* Number of documents associated with this terminal entry (0 for non-terminal
+ * or deleted nodes). */
+size_t TrieNode_NumDocs(const TrieNode *n);
+/* Pointer to the children array (count is TrieNode_NumChildren). */
+TrieNode **TrieNode_Children(const TrieNode *n);
+TrieNode *TrieNode_ChildAt(const TrieNode *n, t_len i);
 /* Return the node's payload data pointer, or NULL if the node has no payload
  * (or n is NULL). */
-static inline char *TrieNode_GetPayloadData(const TrieNode *n) {
-  return (n && n->payload) ? n->payload->data : NULL;
-}
+char *TrieNode_GetPayloadData(const TrieNode *n);
+
+/* Return the raw data bytes of a TriePayload, or NULL if p is NULL. Used by
+ * range/contains callbacks that receive a TriePayload* in their payload
+ * argument. */
+char *TriePayload_Data(TriePayload *p);
 
 typedef enum {
   ADD_REPLACE,
@@ -151,15 +94,6 @@ int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback fr
 /* Free the trie's root and all its children recursively */
 void TrieNode_Free(TrieNode *n, TrieFreeCallback freecb);
 
-/* trie iterator stack node. for internal use only */
-typedef struct {
-  int state;
-  TrieNode *n;
-  t_len stringOffset;
-  t_len childOffset;
-  int isSkipped;
-} stackNode;
-
 typedef enum { F_CONTINUE = 0, F_STOP = 1 } FilterCode;
 
 // A callback for an automaton that receives the current state, evaluates the
@@ -169,48 +103,6 @@ typedef enum { F_CONTINUE = 0, F_STOP = 1 } FilterCode;
 typedef FilterCode (*StepFilter)(rune b, void *ctx, int *match, void *matchCtx);
 
 typedef void (*StackPopCallback)(void *ctx, int num);
-
-#define ITERSTATE_SELF 0
-#define ITERSTATE_CHILDREN 1
-#define ITERSTATE_MATCH 2
-
-/* Opaque trie iterator type */
-// typedef struct TrieIterator TrieIterator;
-typedef struct TrieIterator {
-  rune buf[TRIE_INITIAL_STRING_LEN + 1];
-  t_len bufOffset;
-
-  stackNode stack[TRIE_INITIAL_STRING_LEN + 1];
-  t_len stackOffset;
-  StepFilter filter;
-  float minScore;
-  int nodesConsumed;
-  int nodesSkipped;
-  StackPopCallback popCallback;
-  void *ctx;
-} TrieIterator;
-
-/* push a new trie iterator stack node  */
-void __ti_Push(TrieIterator *it, TrieNode *node, int skipped);
-
-/* the current top of the iterator stack */
-#define __ti_current(it) &it->stack[it->stackOffset - 1]
-
-/* pop a node from the iterator's stcak */
-void __ti_Pop(TrieIterator *it);
-
-/* Step itearator return codes below: */
-
-/* Stop the iteration */
-#define __STEP_STOP 0
-/* Continue to next node  */
-#define __STEP_CONT 1
-/* We found a match, return the state to the user but continue afterwards */
-#define __STEP_MATCH 3
-
-/* Single step iteration, feeding the given filter/automaton with the next
- * character */
-int __ti_step(TrieIterator *it, void *matchCtx);
 
 /* Iterate the tree with a step filter, which tells the iterator whether to
  * continue down the trie

--- a/src/trie/trie_node_internal.h
+++ b/src/trie/trie_node_internal.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+/* Internal header for the trie node module.
+ *
+ * Exposes the full layout of TrieNode, TriePayload, TrieIterator, plus the
+ * internal __newTrieNode / __ti_* helpers and the in-band flag bits. Intended
+ * for inclusion by trie.c, trie_node.c, and whitebox unit tests under
+ * tests/ctests/. Other translation units must include "trie_node.h" instead and
+ * go through the public accessors. */
+
+#ifndef __TRIE_NODE_INTERNAL_H__
+#define __TRIE_NODE_INTERNAL_H__
+
+#include "trie_node.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TRIENODE_TERMINAL 0x1
+#define TRIENODE_DELETED 0x2
+
+#pragma pack(1)
+struct TriePayload {
+  uint32_t len;  // 4G payload is more than enough!!!!
+  char data[];   // this means the data will not take an extra pointer.
+};
+#pragma pack()
+
+#pragma pack(1)
+/* TrieNode represents a single node in a trie. The actual size of it is bigger,
+ * as the children are
+ * allocated after str[].
+ * Non terminal nodes always have a score of 0, meaning you can't insert nodes
+ * with score 0 to the
+ * trie.
+ */
+struct TrieNode {
+  // the string length of this node. can be 0
+  t_len len;
+  // the number of child nodes
+  t_len numChildren;
+
+  uint8_t flags : 2;
+  TrieSortMode sortMode : 1;
+
+  // the node's score. Non termn
+  float score;
+
+  // the maximal score of any descendant of this node, used to optimize
+  // traversal
+  float maxChildScore;
+
+  // the number of documents containing this key
+  size_t numDocs;
+
+  // the payload of terminal node. could be NULL if it's not terminal
+  TriePayload *payload;
+
+  // the string of the current node
+  rune str[];
+  // ... here come the first letters of each child childRunes[]
+  // ... now come the children, to be accessed with TrieNode_Children
+};
+#pragma pack()
+
+/* Create a new trie node. str is a string to be copied into the node, starting
+ * from offset up until
+ * len. numChildren is the initial number of allocated child nodes */
+TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *payload, size_t plen,
+                        t_len numChildren, float score, int terminal, TrieSortMode sortMode,
+                        size_t numDocs);
+
+/* trie iterator stack node. for internal use only */
+typedef struct {
+  int state;
+  TrieNode *n;
+  t_len stringOffset;
+  t_len childOffset;
+  int isSkipped;
+} stackNode;
+
+#define ITERSTATE_SELF 0
+#define ITERSTATE_CHILDREN 1
+#define ITERSTATE_MATCH 2
+
+struct TrieIterator {
+  rune buf[TRIE_INITIAL_STRING_LEN + 1];
+  t_len bufOffset;
+
+  stackNode stack[TRIE_INITIAL_STRING_LEN + 1];
+  t_len stackOffset;
+  StepFilter filter;
+  float minScore;
+  int nodesConsumed;
+  int nodesSkipped;
+  StackPopCallback popCallback;
+  void *ctx;
+};
+
+/* push a new trie iterator stack node  */
+void __ti_Push(TrieIterator *it, TrieNode *node, int skipped);
+
+/* the current top of the iterator stack */
+#define __ti_current(it) &it->stack[it->stackOffset - 1]
+
+/* pop a node from the iterator's stcak */
+void __ti_Pop(TrieIterator *it);
+
+/* Step itearator return codes below: */
+
+/* Stop the iteration */
+#define __STEP_STOP 0
+/* Continue to next node  */
+#define __STEP_CONT 1
+/* We found a match, return the state to the user but continue afterwards */
+#define __STEP_MATCH 3
+
+/* Single step iteration, feeding the given filter/automaton with the next
+ * character */
+int __ti_step(TrieIterator *it, void *matchCtx);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -40,7 +40,7 @@ static void *triePayload(Trie *t, const char *s, size_t len, bool exact) {
   rune *runes = runeBufFill(s, len, &buf, &len);
   TrieNode *node = Trie_GetNode(t, runes, len, exact, NULL);
   runeBufFree(&buf);
-  return (node && node->payload) ? node->payload->data : nullptr;
+  return TrieNode_GetPayloadData(node);
 }
 
 static int rangeFunc(const rune *u16, size_t nrune, void *ctx, void *payload, size_t numDocsInTerm) {
@@ -837,7 +837,7 @@ static size_t trieGetNumDocs(Trie *t, const char *s) {
   if (node == NULL) {
     return 0;
   }
-  return node->numDocs;
+  return TrieNode_NumDocs(node);
 }
 
 // Regression: TrieType_GenericLoad must preserve sort mode across reload,

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -8,6 +8,7 @@
 */
 
 #include "trie/trie_node.h"
+#include "trie/trie_node_internal.h"
 #include "trie/trie.h"
 #include "trie/levenshtein.h"
 #include "trie/rune_util.h"


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on top of #9708.

1. **Current:** `src/trie/trie_node.h` exposes the full layout of `TrieNode`, `TriePayload`, and the trie iterator (stack frames, flag bits, internal allocator `__newTrieNode`). Any TU including the header can poke at struct fields directly; the compiler does not enforce the boundary.
2. **Change:** Splits `trie_node.h` into a slim public surface (forward declarations, public typedefs, accessor + function declarations) and a new private `trie_node_internal.h` containing the struct bodies, flag bits, `__newTrieNode`, and iterator push/pop/step internals. Adds two accessors uncovered by the migration: `TrieNode_NumDocs` (for `query.c`) and `TriePayload_Data` (for `suffix.c`). Whitebox tests (`tests/ctests/test_trie.c`) include the internal header directly to keep asserting struct fields.
3. **Outcome:** Public header shrinks 274 → 155 lines. No call site outside `src/trie/` (and the whitebox test) reads `TrieNode` or `TriePayload` fields directly — the boundary is now compiler-enforced. With LTO the accessor calls inline back; without LTO there is a function-call cost (acceptable for the affected paths, which are not hot loops).

#### Which additional issues this PR fixes
1. MOD-15393

#### Main objects this PR modified
1. `src/trie/trie_node.h` — slim public surface
2. `src/trie/trie_node_internal.h` — new private header with struct bodies and internals
3. `src/trie/trie_node.c` — accessor implementations
4. `src/query.c`, `src/suffix.c` — migrate to accessors
5. `tests/cpptests/test_cpp_trie.cpp`, `tests/ctests/test_trie.c` — migrate / whitebox include

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Encapsulation-only refactor with no API or serialization changes; query/suffix paths switch to accessors with equivalent behavior.
> 
> **Overview**
> This PR **hides trie node memory layout** from most of the codebase by splitting `trie_node.h` into a slim public API and a new **`trie_node_internal.h`** that holds `TrieNode`, `TriePayload`, and iterator struct bodies plus internal helpers.
> 
> **`TrieNode`**, **`TriePayload`**, and **`TrieIterator`** are now opaque forward declarations in the public header. Field reads that used to be inlines (or direct `->numDocs` / `->payload->data`) are replaced by **`TrieNode_NumDocs`**, **`TrieNode_GetPayloadData`**, **`TriePayload_Data`**, and related accessors implemented in `trie_node.c` (inlinable under LTO). **`query.c`** (disk IDF), **`suffix.c`** (wildcard callback), and C++ trie tests use these accessors; **`tests/ctests/test_trie.c`** includes the internal header for whitebox checks.
> 
> Only code under **`src/trie/`** (and the C whitebox test) may depend on struct layout; other TUs are steered through accessors, so future layout changes are compiler-enforced at the boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e2658bd688265297460dde2873a808440b43099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->