### PR TITLE
MOD-15772: verify_build_deps: recognize AlmaLinux as an RPM-family OS

### DIFF
--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -50,6 +50,7 @@ declare -A os_package_checkers=(
   ["ubuntu"]="check_package_dpkg"
   ["debian"]="check_package_dpkg"
   ["rocky"]="check_package_rpm"
+  ["almalinux"]="check_package_rpm"
   ["amzn2"]="check_package_yum"
   ["amzn2023"]="check_package_dnf"
   ["alpine"]="check_package_apk"
@@ -232,7 +233,7 @@ if [[ "$OS" == "ubuntu" || "$OS" == "debian" ]]; then
   for key in "${!ubuntu_dependencies[@]}"; do
     dependencies["$key"]="${ubuntu_dependencies[$key]}"
   done
-elif [[ "$OS" == "rocky" ]]; then
+elif [[ "$OS" == "rocky" || "$OS" == "almalinux" ]]; then
   for key in "${!rocky_dependencies[@]}"; do
     dependencies["$key"]="${rocky_dependencies[$key]}"
   done


### PR DESCRIPTION
## Summary
- `/etc/os-release` reports `ID=almalinux` on AlmaLinux, which `verify_build_deps.sh` does not currently map to a package checker. The script bails out early with `Error: Unsupported operating system: almalinux. Abort dependency check.` even when all required packages are installed, which blocks any `BUILD_WITH_MODULES=yes` build of Redis on AlmaLinux 8 / 9 / 10.
- AlmaLinux uses RPM packages with the same names as the already-supported Rocky Linux path (`openssl-devel`, …), so this PR adds `almalinux` to the `os_package_checkers` map pointing at `check_package_rpm`, and extends the `rocky` branch of the OS-specific dependency merge to also match `almalinux`.
- No behavioral change for `rocky`, `ubuntu`, `debian`, `alpine`, `amzn*`, `mariner`, or `azurelinux`.

## Before
```text
Error: Unsupported operating system: almalinux.
Abort dependency check.
```

## After
```text
===== Build Dependencies Checker =====

openssl-devel       ✓
cmake               ✓
make                ✓
cargo               ✓
python3             ✓
gcc                 ✓
g++                 ✓

All required dependencies are met.
```

## Test plan
- [x] `bash .install/verify_build_deps.sh` on `almalinux:10.1` Docker image with `gcc`, `g++`, `make`, `cmake`, `python3`, `cargo`, and `openssl-devel` installed — exits 0, all 7 deps reported satisfied.
- [x] No-op for other OSes: the conditional is a strict `||` addition, the map entry is additive — Rocky Linux, Ubuntu/Debian, Alpine, Amazon Linux, Mariner/Azure Linux paths are byte-for-byte unchanged.

## Out of scope (follow-ups)
- The `install_script.sh` sibling assumes a per-distro `<os>_<version>.sh` install file. AlmaLinux 8 / 9 / 10 would also need their own install scripts (or the Rocky Linux ones aliased). That can ship separately; users who install dependencies manually (or via the parent Redis build) are unblocked by this PR alone.
- On AlmaLinux 10 the bundled system `clang` is LLVM 20 while the Rust toolchain installed via `INSTALL_RUST_TOOLCHAIN=yes` ships LLVM 21, which trips `build.sh`'s cross-language LTO requirement. That's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds AlmaLinux to the OS detection map and reuses the existing Rocky/RPM dependency path without changing dependency logic for other distros.
> 
> **Overview**
> `verify_build_deps.sh` now recognizes `ID=almalinux` as a supported OS by mapping it to the RPM package checker.
> 
> AlmaLinux is routed through the existing Rocky Linux dependency set (e.g., `openssl-devel`) so dependency verification no longer bails out as “unsupported OS” on AlmaLinux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929ab6b173a2b135e665686f07aa015ace2eeda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
