### PR TITLE
MOD-14813: commands.json: factor REDUCE + AS for cleaner FT.AGGREGATE/FT.HYBRID railroad diagrams

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2547,7 +2547,6 @@
                   {
                     "name": "generic_body",
                     "type": "block",
-                    "summary": null,
                     "arguments": [
                       {
                         "name": "function",

--- a/commands.json
+++ b/commands.json
@@ -1352,7 +1352,6 @@
                   {
                     "name": "generic_body",
                     "type": "block",
-                    "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
                     "arguments": [
                       {
                         "name": "function",

--- a/commands.json
+++ b/commands.json
@@ -1336,220 +1336,215 @@
           },
           {
             "name": "reduce",
-            "type": "oneof",
+            "type": "block",
             "optional": true,
             "multiple": true,
             "arguments": [
               {
-                "name": "generic_reduce",
-                "type": "block",
-                "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
-                "arguments": [
-                  {
-                    "name": "reduce",
-                    "token": "REDUCE",
-                    "type": "pure-token"
-                  },
-                  {
-                    "name": "function",
-                    "type": "oneof",
-                    "arguments": [
-                      {
-                        "name": "count",
-                        "type": "pure-token",
-                        "token": "COUNT"
-                      },
-                      {
-                        "name": "count_distinct",
-                        "type": "pure-token",
-                        "token": "COUNT_DISTINCT"
-                      },
-                      {
-                        "name": "count_distinctish",
-                        "type": "pure-token",
-                        "token": "COUNT_DISTINCTISH"
-                      },
-                      {
-                        "name": "sum",
-                        "type": "pure-token",
-                        "token": "SUM"
-                      },
-                      {
-                        "name": "min",
-                        "type": "pure-token",
-                        "token": "MIN"
-                      },
-                      {
-                        "name": "max",
-                        "type": "pure-token",
-                        "token": "MAX"
-                      },
-                      {
-                        "name": "avg",
-                        "type": "pure-token",
-                        "token": "AVG"
-                      },
-                      {
-                        "name": "stddev",
-                        "type": "pure-token",
-                        "token": "STDDEV"
-                      },
-                      {
-                        "name": "quantile",
-                        "type": "pure-token",
-                        "token": "QUANTILE"
-                      },
-                      {
-                        "name": "tolist",
-                        "type": "pure-token",
-                        "token": "TOLIST"
-                      },
-                      {
-                        "name": "first_value",
-                        "type": "pure-token",
-                        "token": "FIRST_VALUE"
-                      },
-                      {
-                        "name": "random_sample",
-                        "type": "pure-token",
-                        "token": "RANDOM_SAMPLE"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "nargs",
-                    "type": "integer"
-                  },
-                  {
-                    "name": "arg",
-                    "type": "string",
-                    "multiple": true
-                  },
-                  {
-                    "name": "name",
-                    "type": "string",
-                    "token": "AS",
-                    "optional": true
-                  }
-                ]
+                "name": "reduce_token",
+                "type": "pure-token",
+                "token": "REDUCE"
               },
               {
-                "name": "collect_reduce",
-                "type": "block",
-                "since": "8.8.0",
+                "name": "reducer_body",
+                "type": "oneof",
                 "arguments": [
                   {
-                    "name": "reduce",
-                    "token": "REDUCE",
-                    "type": "pure-token"
-                  },
-                  {
-                    "name": "collect_token",
-                    "type": "pure-token",
-                    "token": "COLLECT"
-                  },
-                  {
-                    "name": "nargs",
-                    "type": "integer"
-                  },
-                  {
-                    "name": "fields_clause",
-                    "type": "oneof",
+                    "name": "generic_body",
+                    "type": "block",
+                    "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
                     "arguments": [
                       {
-                        "name": "fields",
-                        "type": "block",
+                        "name": "function",
+                        "type": "oneof",
                         "arguments": [
                           {
-                            "name": "num_fields",
-                            "type": "integer",
-                            "token": "FIELDS"
+                            "name": "count",
+                            "type": "pure-token",
+                            "token": "COUNT"
                           },
                           {
-                            "name": "field",
-                            "type": "string",
-                            "multiple": true
+                            "name": "count_distinct",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCT"
+                          },
+                          {
+                            "name": "count_distinctish",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCTISH"
+                          },
+                          {
+                            "name": "sum",
+                            "type": "pure-token",
+                            "token": "SUM"
+                          },
+                          {
+                            "name": "min",
+                            "type": "pure-token",
+                            "token": "MIN"
+                          },
+                          {
+                            "name": "max",
+                            "type": "pure-token",
+                            "token": "MAX"
+                          },
+                          {
+                            "name": "avg",
+                            "type": "pure-token",
+                            "token": "AVG"
+                          },
+                          {
+                            "name": "stddev",
+                            "type": "pure-token",
+                            "token": "STDDEV"
+                          },
+                          {
+                            "name": "quantile",
+                            "type": "pure-token",
+                            "token": "QUANTILE"
+                          },
+                          {
+                            "name": "tolist",
+                            "type": "pure-token",
+                            "token": "TOLIST"
+                          },
+                          {
+                            "name": "first_value",
+                            "type": "pure-token",
+                            "token": "FIRST_VALUE"
+                          },
+                          {
+                            "name": "random_sample",
+                            "type": "pure-token",
+                            "token": "RANDOM_SAMPLE"
                           }
                         ]
-                      },
-                      {
-                        "name": "fieldsall",
-                        "type": "pure-token",
-                        "token": "FIELDS *"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "sortby",
-                    "type": "block",
-                    "optional": true,
-                    "arguments": [
-                      {
-                        "name": "sortby_token",
-                        "type": "pure-token",
-                        "token": "SORTBY"
                       },
                       {
                         "name": "nargs",
                         "type": "integer"
                       },
                       {
-                        "name": "key",
-                        "type": "block",
-                        "multiple": true,
+                        "name": "arg",
+                        "type": "string",
+                        "multiple": true
+                      }
+                    ]
+                  },
+                  {
+                    "name": "collect_body",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "fields_clause",
+                        "type": "oneof",
                         "arguments": [
                           {
-                            "name": "field",
-                            "type": "string"
-                          },
-                          {
-                            "name": "order",
-                            "type": "oneof",
-                            "optional": true,
+                            "name": "fields",
+                            "type": "block",
                             "arguments": [
                               {
-                                "name": "asc",
-                                "type": "pure-token",
-                                "token": "ASC"
+                                "name": "num_fields",
+                                "type": "integer",
+                                "token": "FIELDS"
                               },
                               {
-                                "name": "desc",
-                                "type": "pure-token",
-                                "token": "DESC"
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          },
+                          {
+                            "name": "fieldsall",
+                            "type": "pure-token",
+                            "token": "FIELDS *"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
                               }
                             ]
                           }
                         ]
-                      }
-                    ]
-                  },
-                  {
-                    "name": "limit",
-                    "type": "block",
-                    "optional": true,
-                    "arguments": [
-                      {
-                        "name": "limit_token",
-                        "type": "pure-token",
-                        "token": "LIMIT"
                       },
                       {
-                        "name": "offset",
-                        "type": "integer"
-                      },
-                      {
-                        "name": "count",
-                        "type": "integer"
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
                       }
                     ]
-                  },
-                  {
-                    "name": "name",
-                    "type": "string",
-                    "token": "AS",
-                    "optional": true
                   }
                 ]
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "token": "AS",
+                "optional": true
               }
             ]
           }
@@ -2536,219 +2531,215 @@
           },
           {
             "name": "reduce",
-            "type": "oneof",
+            "type": "block",
             "optional": true,
             "multiple": true,
             "arguments": [
               {
-                "name": "generic_reduce",
-                "type": "block",
-                "arguments": [
-                  {
-                    "name": "reduce",
-                    "type": "pure-token",
-                    "token": "REDUCE"
-                  },
-                  {
-                    "name": "function",
-                    "type": "oneof",
-                    "arguments": [
-                      {
-                        "name": "count",
-                        "type": "pure-token",
-                        "token": "COUNT"
-                      },
-                      {
-                        "name": "count_distinct",
-                        "type": "pure-token",
-                        "token": "COUNT_DISTINCT"
-                      },
-                      {
-                        "name": "count_distinctish",
-                        "type": "pure-token",
-                        "token": "COUNT_DISTINCTISH"
-                      },
-                      {
-                        "name": "sum",
-                        "type": "pure-token",
-                        "token": "SUM"
-                      },
-                      {
-                        "name": "min",
-                        "type": "pure-token",
-                        "token": "MIN"
-                      },
-                      {
-                        "name": "max",
-                        "type": "pure-token",
-                        "token": "MAX"
-                      },
-                      {
-                        "name": "avg",
-                        "type": "pure-token",
-                        "token": "AVG"
-                      },
-                      {
-                        "name": "stddev",
-                        "type": "pure-token",
-                        "token": "STDDEV"
-                      },
-                      {
-                        "name": "quantile",
-                        "type": "pure-token",
-                        "token": "QUANTILE"
-                      },
-                      {
-                        "name": "tolist",
-                        "type": "pure-token",
-                        "token": "TOLIST"
-                      },
-                      {
-                        "name": "first_value",
-                        "type": "pure-token",
-                        "token": "FIRST_VALUE"
-                      },
-                      {
-                        "name": "random_sample",
-                        "type": "pure-token",
-                        "token": "RANDOM_SAMPLE"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "nargs",
-                    "type": "integer"
-                  },
-                  {
-                    "name": "arg",
-                    "type": "string",
-                    "multiple": true
-                  },
-                  {
-                    "name": "name",
-                    "type": "string",
-                    "token": "AS",
-                    "optional": true
-                  }
-                ]
+                "name": "reduce_token",
+                "type": "pure-token",
+                "token": "REDUCE"
               },
               {
-                "name": "collect_reduce",
-                "type": "block",
-                "since": "8.8.0",
+                "name": "reducer_body",
+                "type": "oneof",
                 "arguments": [
                   {
-                    "name": "reduce",
-                    "type": "pure-token",
-                    "token": "REDUCE"
-                  },
-                  {
-                    "name": "collect_token",
-                    "type": "pure-token",
-                    "token": "COLLECT"
-                  },
-                  {
-                    "name": "nargs",
-                    "type": "integer"
-                  },
-                  {
-                    "name": "fields_clause",
-                    "type": "oneof",
+                    "name": "generic_body",
+                    "type": "block",
+                    "summary": null,
                     "arguments": [
                       {
-                        "name": "fields",
-                        "type": "block",
+                        "name": "function",
+                        "type": "oneof",
                         "arguments": [
                           {
-                            "name": "num_fields",
-                            "type": "integer",
-                            "token": "FIELDS"
+                            "name": "count",
+                            "type": "pure-token",
+                            "token": "COUNT"
                           },
                           {
-                            "name": "field",
-                            "type": "string",
-                            "multiple": true
+                            "name": "count_distinct",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCT"
+                          },
+                          {
+                            "name": "count_distinctish",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCTISH"
+                          },
+                          {
+                            "name": "sum",
+                            "type": "pure-token",
+                            "token": "SUM"
+                          },
+                          {
+                            "name": "min",
+                            "type": "pure-token",
+                            "token": "MIN"
+                          },
+                          {
+                            "name": "max",
+                            "type": "pure-token",
+                            "token": "MAX"
+                          },
+                          {
+                            "name": "avg",
+                            "type": "pure-token",
+                            "token": "AVG"
+                          },
+                          {
+                            "name": "stddev",
+                            "type": "pure-token",
+                            "token": "STDDEV"
+                          },
+                          {
+                            "name": "quantile",
+                            "type": "pure-token",
+                            "token": "QUANTILE"
+                          },
+                          {
+                            "name": "tolist",
+                            "type": "pure-token",
+                            "token": "TOLIST"
+                          },
+                          {
+                            "name": "first_value",
+                            "type": "pure-token",
+                            "token": "FIRST_VALUE"
+                          },
+                          {
+                            "name": "random_sample",
+                            "type": "pure-token",
+                            "token": "RANDOM_SAMPLE"
                           }
                         ]
-                      },
-                      {
-                        "name": "fieldsall",
-                        "type": "pure-token",
-                        "token": "FIELDS *"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "sortby",
-                    "type": "block",
-                    "optional": true,
-                    "arguments": [
-                      {
-                        "name": "sortby_token",
-                        "type": "pure-token",
-                        "token": "SORTBY"
                       },
                       {
                         "name": "nargs",
                         "type": "integer"
                       },
                       {
-                        "name": "key",
-                        "type": "block",
-                        "multiple": true,
+                        "name": "arg",
+                        "type": "string",
+                        "multiple": true
+                      }
+                    ]
+                  },
+                  {
+                    "name": "collect_body",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "fields_clause",
+                        "type": "oneof",
                         "arguments": [
                           {
-                            "name": "field",
-                            "type": "string"
-                          },
-                          {
-                            "name": "order",
-                            "type": "oneof",
-                            "optional": true,
+                            "name": "fields",
+                            "type": "block",
                             "arguments": [
                               {
-                                "name": "asc",
-                                "type": "pure-token",
-                                "token": "ASC"
+                                "name": "num_fields",
+                                "type": "integer",
+                                "token": "FIELDS"
                               },
                               {
-                                "name": "desc",
-                                "type": "pure-token",
-                                "token": "DESC"
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          },
+                          {
+                            "name": "fieldsall",
+                            "type": "pure-token",
+                            "token": "FIELDS *"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
                               }
                             ]
                           }
                         ]
-                      }
-                    ]
-                  },
-                  {
-                    "name": "limit",
-                    "type": "block",
-                    "optional": true,
-                    "arguments": [
-                      {
-                        "name": "limit_token",
-                        "type": "pure-token",
-                        "token": "LIMIT"
                       },
                       {
-                        "name": "offset",
-                        "type": "integer"
-                      },
-                      {
-                        "name": "count",
-                        "type": "integer"
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
                       }
                     ]
-                  },
-                  {
-                    "name": "name",
-                    "type": "string",
-                    "token": "AS",
-                    "optional": true
                   }
                 ]
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "token": "AS",
+                "optional": true
               }
             ]
           }

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1549,7 +1549,6 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
                 .subargs = (RedisModuleCommandArg[]){
                   {
                     .name = "generic_body",
-                    .summary = "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
                     .type = REDISMODULE_ARG_TYPE_BLOCK,
                     .subargs = (RedisModuleCommandArg[]){
                       {
@@ -2829,7 +2828,6 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                 .subargs = (RedisModuleCommandArg[]){
                   {
                     .name = "generic_body",
-                    .summary = "",
                     .type = REDISMODULE_ARG_TYPE_BLOCK,
                     .subargs = (RedisModuleCommandArg[]){
                       {

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -1535,160 +1535,110 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
           },
           {
             .name = "reduce",
-            .type = REDISMODULE_ARG_TYPE_ONEOF,
+            .type = REDISMODULE_ARG_TYPE_BLOCK,
             .flags = REDISMODULE_CMD_ARG_OPTIONAL | REDISMODULE_CMD_ARG_MULTIPLE,
             .subargs = (RedisModuleCommandArg[]){
               {
-                .name = "generic_reduce",
-                .summary = "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
-                .type = REDISMODULE_ARG_TYPE_BLOCK,
-                .subargs = (RedisModuleCommandArg[]){
-                  {
-                    .name = "reduce",
-                    .token = "REDUCE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "function",
-                    .type = REDISMODULE_ARG_TYPE_ONEOF,
-                    .subargs = (RedisModuleCommandArg[]){
-                      {
-                        .name = "count",
-                        .token = "COUNT",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "count_distinct",
-                        .token = "COUNT_DISTINCT",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "count_distinctish",
-                        .token = "COUNT_DISTINCTISH",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "sum",
-                        .token = "SUM",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "min",
-                        .token = "MIN",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "max",
-                        .token = "MAX",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "avg",
-                        .token = "AVG",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "stddev",
-                        .token = "STDDEV",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "quantile",
-                        .token = "QUANTILE",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "tolist",
-                        .token = "TOLIST",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "first_value",
-                        .token = "FIRST_VALUE",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "random_sample",
-                        .token = "RANDOM_SAMPLE",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {0}
-                    },
-                  },
-                  {
-                    .name = "nargs",
-                    .type = REDISMODULE_ARG_TYPE_INTEGER,
-                  },
-                  {
-                    .name = "arg",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-                  },
-                  {
-                    .name = "name",
-                    .token = "AS",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                  },
-                  {0}
-                },
+                .name = "reduce_token",
+                .token = "REDUCE",
+                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
               },
               {
-                .name = "collect_reduce",
-                .since = "8.8.0",
-                .type = REDISMODULE_ARG_TYPE_BLOCK,
+                .name = "reducer_body",
+                .type = REDISMODULE_ARG_TYPE_ONEOF,
                 .subargs = (RedisModuleCommandArg[]){
                   {
-                    .name = "reduce",
-                    .token = "REDUCE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "collect_token",
-                    .token = "COLLECT",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "nargs",
-                    .type = REDISMODULE_ARG_TYPE_INTEGER,
-                  },
-                  {
-                    .name = "fields_clause",
-                    .type = REDISMODULE_ARG_TYPE_ONEOF,
+                    .name = "generic_body",
+                    .summary = "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "fields",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .name = "function",
+                        .type = REDISMODULE_ARG_TYPE_ONEOF,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "num_fields",
-                            .token = "FIELDS",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                            .name = "count",
+                            .token = "COUNT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                           },
                           {
-                            .name = "field",
-                            .type = REDISMODULE_ARG_TYPE_STRING,
-                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .name = "count_distinct",
+                            .token = "COUNT_DISTINCT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "count_distinctish",
+                            .token = "COUNT_DISTINCTISH",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "sum",
+                            .token = "SUM",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "min",
+                            .token = "MIN",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "max",
+                            .token = "MAX",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "avg",
+                            .token = "AVG",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "stddev",
+                            .token = "STDDEV",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "quantile",
+                            .token = "QUANTILE",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "tolist",
+                            .token = "TOLIST",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "first_value",
+                            .token = "FIRST_VALUE",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "random_sample",
+                            .token = "RANDOM_SAMPLE",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                           },
                           {0}
                         },
                       },
                       {
-                        .name = "fieldsall",
-                        .token = "FIELDS *",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                        .name = "nargs",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {
+                        .name = "arg",
+                        .type = REDISMODULE_ARG_TYPE_STRING,
+                        .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                       },
                       {0}
                     },
                   },
                   {
-                    .name = "sortby",
+                    .name = "collect_body",
+                    .since = "8.8.0",
                     .type = REDISMODULE_ARG_TYPE_BLOCK,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "sortby_token",
-                        .token = "SORTBY",
+                        .name = "collect_token",
+                        .token = "COLLECT",
                         .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {
@@ -1696,28 +1646,74 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
                         .type = REDISMODULE_ARG_TYPE_INTEGER,
                       },
                       {
-                        .name = "key",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                        .name = "fields_clause",
+                        .type = REDISMODULE_ARG_TYPE_ONEOF,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "field",
-                            .type = REDISMODULE_ARG_TYPE_STRING,
-                          },
-                          {
-                            .name = "order",
-                            .type = REDISMODULE_ARG_TYPE_ONEOF,
-                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                            .name = "fields",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
                             .subargs = (RedisModuleCommandArg[]){
                               {
-                                .name = "asc",
-                                .token = "ASC",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                .name = "num_fields",
+                                .token = "FIELDS",
+                                .type = REDISMODULE_ARG_TYPE_INTEGER,
                               },
                               {
-                                .name = "desc",
-                                .token = "DESC",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                .name = "field",
+                                .type = REDISMODULE_ARG_TYPE_STRING,
+                                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                              },
+                              {0}
+                            },
+                          },
+                          {
+                            .name = "fieldsall",
+                            .token = "FIELDS *",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {0}
+                        },
+                      },
+                      {
+                        .name = "sortby",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "sortby_token",
+                            .token = "SORTBY",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "nargs",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "field",
+                                .type = REDISMODULE_ARG_TYPE_STRING,
+                              },
+                              {
+                                .name = "order",
+                                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                                .subargs = (RedisModuleCommandArg[]){
+                                  {
+                                    .name = "asc",
+                                    .token = "ASC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {
+                                    .name = "desc",
+                                    .token = "DESC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {0}
+                                },
                               },
                               {0}
                             },
@@ -1725,38 +1721,38 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
                           {0}
                         },
                       },
+                      {
+                        .name = "limit",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "limit_token",
+                            .token = "LIMIT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "offset",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "count",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {0}
+                        },
+                      },
                       {0}
                     },
-                  },
-                  {
-                    .name = "limit",
-                    .type = REDISMODULE_ARG_TYPE_BLOCK,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                    .subargs = (RedisModuleCommandArg[]){
-                      {
-                        .name = "limit_token",
-                        .token = "LIMIT",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "offset",
-                        .type = REDISMODULE_ARG_TYPE_INTEGER,
-                      },
-                      {
-                        .name = "count",
-                        .type = REDISMODULE_ARG_TYPE_INTEGER,
-                      },
-                      {0}
-                    },
-                  },
-                  {
-                    .name = "name",
-                    .token = "AS",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
                   {0}
                 },
+              },
+              {
+                .name = "name",
+                .token = "AS",
+                .type = REDISMODULE_ARG_TYPE_STRING,
+                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
               },
               {0}
             },
@@ -2819,159 +2815,110 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
           },
           {
             .name = "reduce",
-            .type = REDISMODULE_ARG_TYPE_ONEOF,
+            .type = REDISMODULE_ARG_TYPE_BLOCK,
             .flags = REDISMODULE_CMD_ARG_OPTIONAL | REDISMODULE_CMD_ARG_MULTIPLE,
             .subargs = (RedisModuleCommandArg[]){
               {
-                .name = "generic_reduce",
-                .type = REDISMODULE_ARG_TYPE_BLOCK,
-                .subargs = (RedisModuleCommandArg[]){
-                  {
-                    .name = "reduce",
-                    .token = "REDUCE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "function",
-                    .type = REDISMODULE_ARG_TYPE_ONEOF,
-                    .subargs = (RedisModuleCommandArg[]){
-                      {
-                        .name = "count",
-                        .token = "COUNT",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "count_distinct",
-                        .token = "COUNT_DISTINCT",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "count_distinctish",
-                        .token = "COUNT_DISTINCTISH",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "sum",
-                        .token = "SUM",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "min",
-                        .token = "MIN",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "max",
-                        .token = "MAX",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "avg",
-                        .token = "AVG",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "stddev",
-                        .token = "STDDEV",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "quantile",
-                        .token = "QUANTILE",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "tolist",
-                        .token = "TOLIST",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "first_value",
-                        .token = "FIRST_VALUE",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "random_sample",
-                        .token = "RANDOM_SAMPLE",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {0}
-                    },
-                  },
-                  {
-                    .name = "nargs",
-                    .type = REDISMODULE_ARG_TYPE_INTEGER,
-                  },
-                  {
-                    .name = "arg",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_MULTIPLE,
-                  },
-                  {
-                    .name = "name",
-                    .token = "AS",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                  },
-                  {0}
-                },
+                .name = "reduce_token",
+                .token = "REDUCE",
+                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
               },
               {
-                .name = "collect_reduce",
-                .since = "8.8.0",
-                .type = REDISMODULE_ARG_TYPE_BLOCK,
+                .name = "reducer_body",
+                .type = REDISMODULE_ARG_TYPE_ONEOF,
                 .subargs = (RedisModuleCommandArg[]){
                   {
-                    .name = "reduce",
-                    .token = "REDUCE",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "collect_token",
-                    .token = "COLLECT",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                  },
-                  {
-                    .name = "nargs",
-                    .type = REDISMODULE_ARG_TYPE_INTEGER,
-                  },
-                  {
-                    .name = "fields_clause",
-                    .type = REDISMODULE_ARG_TYPE_ONEOF,
+                    .name = "generic_body",
+                    .summary = "",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "fields",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .name = "function",
+                        .type = REDISMODULE_ARG_TYPE_ONEOF,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "num_fields",
-                            .token = "FIELDS",
-                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                            .name = "count",
+                            .token = "COUNT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                           },
                           {
-                            .name = "field",
-                            .type = REDISMODULE_ARG_TYPE_STRING,
-                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .name = "count_distinct",
+                            .token = "COUNT_DISTINCT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "count_distinctish",
+                            .token = "COUNT_DISTINCTISH",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "sum",
+                            .token = "SUM",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "min",
+                            .token = "MIN",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "max",
+                            .token = "MAX",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "avg",
+                            .token = "AVG",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "stddev",
+                            .token = "STDDEV",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "quantile",
+                            .token = "QUANTILE",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "tolist",
+                            .token = "TOLIST",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "first_value",
+                            .token = "FIRST_VALUE",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "random_sample",
+                            .token = "RANDOM_SAMPLE",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                           },
                           {0}
                         },
                       },
                       {
-                        .name = "fieldsall",
-                        .token = "FIELDS *",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                        .name = "nargs",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                      },
+                      {
+                        .name = "arg",
+                        .type = REDISMODULE_ARG_TYPE_STRING,
+                        .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                       },
                       {0}
                     },
                   },
                   {
-                    .name = "sortby",
+                    .name = "collect_body",
+                    .since = "8.8.0",
                     .type = REDISMODULE_ARG_TYPE_BLOCK,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                     .subargs = (RedisModuleCommandArg[]){
                       {
-                        .name = "sortby_token",
-                        .token = "SORTBY",
+                        .name = "collect_token",
+                        .token = "COLLECT",
                         .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                       },
                       {
@@ -2979,28 +2926,74 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                         .type = REDISMODULE_ARG_TYPE_INTEGER,
                       },
                       {
-                        .name = "key",
-                        .type = REDISMODULE_ARG_TYPE_BLOCK,
-                        .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                        .name = "fields_clause",
+                        .type = REDISMODULE_ARG_TYPE_ONEOF,
                         .subargs = (RedisModuleCommandArg[]){
                           {
-                            .name = "field",
-                            .type = REDISMODULE_ARG_TYPE_STRING,
-                          },
-                          {
-                            .name = "order",
-                            .type = REDISMODULE_ARG_TYPE_ONEOF,
-                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                            .name = "fields",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
                             .subargs = (RedisModuleCommandArg[]){
                               {
-                                .name = "asc",
-                                .token = "ASC",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                .name = "num_fields",
+                                .token = "FIELDS",
+                                .type = REDISMODULE_ARG_TYPE_INTEGER,
                               },
                               {
-                                .name = "desc",
-                                .token = "DESC",
-                                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                .name = "field",
+                                .type = REDISMODULE_ARG_TYPE_STRING,
+                                .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                              },
+                              {0}
+                            },
+                          },
+                          {
+                            .name = "fieldsall",
+                            .token = "FIELDS *",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {0}
+                        },
+                      },
+                      {
+                        .name = "sortby",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "sortby_token",
+                            .token = "SORTBY",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "nargs",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .subargs = (RedisModuleCommandArg[]){
+                              {
+                                .name = "field",
+                                .type = REDISMODULE_ARG_TYPE_STRING,
+                              },
+                              {
+                                .name = "order",
+                                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                                .subargs = (RedisModuleCommandArg[]){
+                                  {
+                                    .name = "asc",
+                                    .token = "ASC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {
+                                    .name = "desc",
+                                    .token = "DESC",
+                                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                  },
+                                  {0}
+                                },
                               },
                               {0}
                             },
@@ -3008,38 +3001,38 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                           {0}
                         },
                       },
+                      {
+                        .name = "limit",
+                        .type = REDISMODULE_ARG_TYPE_BLOCK,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                        .subargs = (RedisModuleCommandArg[]){
+                          {
+                            .name = "limit_token",
+                            .token = "LIMIT",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                          },
+                          {
+                            .name = "offset",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {
+                            .name = "count",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                          },
+                          {0}
+                        },
+                      },
                       {0}
                     },
-                  },
-                  {
-                    .name = "limit",
-                    .type = REDISMODULE_ARG_TYPE_BLOCK,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                    .subargs = (RedisModuleCommandArg[]){
-                      {
-                        .name = "limit_token",
-                        .token = "LIMIT",
-                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                      },
-                      {
-                        .name = "offset",
-                        .type = REDISMODULE_ARG_TYPE_INTEGER,
-                      },
-                      {
-                        .name = "count",
-                        .type = REDISMODULE_ARG_TYPE_INTEGER,
-                      },
-                      {0}
-                    },
-                  },
-                  {
-                    .name = "name",
-                    .token = "AS",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
                   {0}
                 },
+              },
+              {
+                .name = "name",
+                .token = "AS",
+                .type = REDISMODULE_ARG_TYPE_STRING,
+                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
               },
               {0}
             },


### PR DESCRIPTION
Restructured `groupby.reduce` in both `FT.AGGREGATE` and `FT.HYBRID` so the common parts are factored *outside* the inner `oneof`. The reducer is now a `block` containing: a single shared `REDUCE` pure-token, an inner `oneof` of `generic_body` (function-choice + `nargs` + `arg*`) and `collect_body` (`COLLECT nargs FIELDS … [SORTBY] [LIMIT]`), and a single shared optional `AS name` tail. `src/command_info/command_info.c` was regenerated by `srcutil/gen_command_info.py`.

**Outcome**: The rendered diagram now draws `REDUCE` once, `AS name` once (shared by both arms), and uses a compact `OneOrMore` loopback instead of a duplicated subtree. 

#### Before / after — FT.AGGREGATE `GROUPBY` section

**Before** (current `master`, 4 `REDUCE` boxes, duplicated `AS`):

<img width="1651" height="388" alt="image" src="https://github.com/user-attachments/assets/92145350-7fd5-4922-9b76-102e825dbde1" />

**After** (this PR, single shared `REDUCE` and `AS`):

<img width="784" height="205" alt="image" src="https://github.com/user-attachments/assets/073187af-6924-42ef-9a14-79bec6c49b61" />

#### Which additional issues this PR fixes

1. MOD-14813 (rendering follow-up), DOC-6571

#### Main objects this PR modified

1. `commands.json` — restructured `groupby.reduce` in `FT.AGGREGATE` and `FT.HYBRID`.
2. `src/command_info/command_info.c` — regenerated by `srcutil/gen_command_info.py -j commands.json -f src/command_info/command_info -i command_info`.

No behavior change. The C parser (`RDCRCollect_New` in `src/aggregate/reducers/collect.c`, `PLNGroupStep_AddReducer` in `src/aggregate/aggregate_request.c`) is position/token-based and never inspects the JSON nesting names. The Rust FFI (`reducers_ffi/src/collect/`) and tests are unchanged.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Metadata-only change — affects the rendered Redis docs railroad diagram and the auto-generated `command_info.c`; no user-visible behavior change.

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only restructuring of the command argument schema and regenerated `command_info.c`; low risk but could affect generated docs/command introspection if the new nesting is interpreted differently by tooling.
> 
> **Overview**
> Refactors `commands.json` for `FT.AGGREGATE` and `FT.HYBRID` so `GROUPBY`’s `reduce` becomes a single `block` with a shared `REDUCE` token, a `oneof` body (`generic_body` reducer function vs `COLLECT` reducer), and a shared optional `AS name` tail, reducing duplicated schema branches for cleaner railroad diagrams.
> 
> Regenerates `src/command_info/command_info.c` to match the updated JSON schema (no functional command behavior changes intended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ff15134b2065ba91e2fae4bb9fc835e7f78934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->