### PR TITLE
MOD-15772: Support AlmaLinux install script selection

### DIFF
--- a/.install/README.md
+++ b/.install/README.md
@@ -5,7 +5,8 @@ On macOS (`uname -s` == `Darwin`), the script sources macos.sh directly.
 On Linux, the name is derived from /etc/os-release``:
 
   1. Read NAME and VERSION_ID (quotes stripped).
-  2. Rocky Linux: strip the minor version from VERSION_ID (e.g. "9.3" -> "9").
+  2. AlmaLinux: use the Rocky Linux install scripts.
+     Rocky Linux: strip the minor version from VERSION_ID (e.g. "9.3" -> "9").
      Alpine Linux: strip the minor and patch version (e.g. "3.22.1" -> "3").
   3. Lowercase NAME, append "_" and VERSION_ID.
   4. Replace all spaces and forward slashes with underscores.
@@ -15,6 +16,7 @@ Examples:
   NAME="Ubuntu"                   VERSION_ID="26.04"  ->  ubuntu_26.04.sh
   NAME="Debian GNU/Linux"         VERSION_ID="13"     ->  debian_gnu_linux_13.sh
   NAME="Rocky Linux"              VERSION_ID="10.0"   ->  rocky_linux_10.sh
+  NAME="AlmaLinux"                VERSION_ID="10.1"   ->  rocky_linux_10.sh
   NAME="Alpine Linux"             VERSION_ID="3.22.1" ->  alpine_linux_3.sh
   NAME="Amazon Linux"             VERSION_ID="2023"   ->  amazon_linux_2023.sh
   NAME="Microsoft Azure Linux"    VERSION_ID="3.0"    ->  microsoft_azure_linux_3.0.sh

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -12,6 +12,8 @@ else
     VERSION=${VERSION#"VERSION_ID="}
     OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
     OS_NAME=${OS_NAME#"NAME="}
+    # AlmaLinux is RHEL-compatible and uses the same install scripts as Rocky Linux.
+    [[ $OS_NAME == 'AlmaLinux' ]] && OS_NAME='Rocky Linux'
     [[ $OS_NAME == 'Rocky Linux' ]] && VERSION=${VERSION%.*} # remove minor version for Rocky Linux
     [[ $OS_NAME == 'Alpine Linux' ]] && VERSION=${VERSION%.*.*} # remove minor and patch version for Alpine Linux
     OS=${OS_NAME,,}_${VERSION}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `verify_build_deps.sh` can recognize AlmaLinux after #9712, but `.install/install_script.sh` still derives `almalinux_<version>.sh` from `/etc/os-release`, and no AlmaLinux-specific installer scripts exist.
2. Change: Map `NAME="AlmaLinux"` to `Rocky Linux` before deriving the installer script name, so AlmaLinux reuses the existing Rocky Linux install scripts for the matching major version.
3. Outcome: AlmaLinux 8/9/10 dependency installation follows the same path as Rocky Linux 8/9/10, completing the installer-side follow-up for #9712 / #9716.

#### Which additional issues this PR fixes
1. Completes the installer-side follow-up for #9712 / #9716.

#### Main objects this PR modified
1. `.install/install_script.sh`
2. `.install/README.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

## Testing

- `bash -n .install/install_script.sh`
- `git diff --check`
- Verified the selector normalization maps AlmaLinux `8.10`, `9.6`, and `10.1` to `rocky_linux_8`, `rocky_linux_9`, and `rocky_linux_10` respectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to installer OS-name normalization so AlmaLinux reuses existing Rocky Linux scripts; impact is limited to install-time dependency setup on that distro.
> 
> **Overview**
> Installer script selection now **treats `NAME=AlmaLinux` as `Rocky Linux`** when deriving the platform-specific `.sh` filename, so AlmaLinux versions map to the existing `rocky_linux_<major>.sh` scripts.
> 
> Documentation in `.install/README.md` is updated to describe this mapping and include an AlmaLinux example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b341f0a23d07e8626be8d6a4036b9770eff668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->