### PR TITLE
ci: skip Rust C-header regeneration in micro-benchmark runner

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -93,6 +93,8 @@ runs:
         SAN: ${{ inputs.san }}
         COVERAGE: ${{ inputs.coverage }}
         BUILD_TLS: ${{ inputs.build_tls }}
+        # Use committed Rust C headers; Redis's build context lacks rustc (see redis/redis#15220).
+        REDISEARCH_GENERATE_HEADERS: "0"
       run: |
         EXTRA=()
         if [[ "$BUILD_TLS" == "true" ]]; then

--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -93,8 +93,6 @@ runs:
         SAN: ${{ inputs.san }}
         COVERAGE: ${{ inputs.coverage }}
         BUILD_TLS: ${{ inputs.build_tls }}
-        # Use committed Rust C headers; Redis's build context lacks rustc (see redis/redis#15220).
-        REDISEARCH_GENERATE_HEADERS: "0"
       run: |
         EXTRA=()
         if [[ "$BUILD_TLS" == "true" ]]; then

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -104,6 +104,9 @@ jobs:
         env:
           ARCH: ${{ inputs.architecture }}
           LTO: 1
+          # Use committed Rust C headers; cheadergen is not installed on the
+          # benchmark EC2 runner (see redis/redis#15220 for the same pattern).
+          REDISEARCH_GENERATE_HEADERS: "0"
         timeout-minutes: 300
         run: |
           export HOME=/home/ubuntu


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current**: The nightly `test-all-platforms` job (e.g. [Nightly Flow #915](https://github.com/RediSearch/RediSearch/actions/runs/26059683374/attempts/1)) fails in the "Build Redis (cached)" step with `Command failed: rustc -vV`. When Redis `unstable`'s `make install` builds the bundled RediSearch submodule, it invokes our `build.sh`, which defaults to `REDISEARCH_GENERATE_HEADERS=1` and runs cbindgen — which probes `rustc -vV`. The Redis build context does not reliably have Rust on `PATH`.
2. **Change**: Set `REDISEARCH_GENERATE_HEADERS=0` in the env block of the `Build Redis (cache miss)` step in `.github/actions/build-redis/action.yml`, so the bundled RediSearch build uses the committed Rust C headers instead of regenerating them. Mirrors the default added in [redis/redis#15220](https://github.com/redis/redis/pull/15220).
3. **Outcome**: The Redis build no longer requires `rustc` in its environment. The standalone RediSearch build later in the test flow (`make build TESTS=1`) is unchanged and continues to regenerate headers from Rust source, so any drift against the committed headers is still caught.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `.github/actions/build-redis/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: it just tweaks environment for the micro-benchmark workflow to avoid needing header-generation tooling, with minimal chance of affecting benchmark behavior beyond build inputs.
> 
> **Overview**
> The micro-benchmark GitHub Actions workflow now sets `REDISEARCH_GENERATE_HEADERS=0` for the `make micro-benchmarks` step, forcing use of the committed Rust C headers instead of regenerating them.
> 
> This avoids requiring `cheadergen`/Rust toolchain availability on the benchmark EC2 runner and should reduce CI flakiness for that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a844a9491a6c34e74923968c413e1b11854489c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->