### PR TITLE
MOD-15772: verify_build_deps: recognize AlmaLinux as an RPM-family OS

### DIFF
--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -50,6 +50,7 @@ declare -A os_package_checkers=(
   ["ubuntu"]="check_package_dpkg"
   ["debian"]="check_package_dpkg"
   ["rocky"]="check_package_rpm"
+  ["almalinux"]="check_package_rpm"
   ["amzn2"]="check_package_yum"
   ["amzn2023"]="check_package_dnf"
   ["alpine"]="check_package_apk"
@@ -232,7 +233,7 @@ if [[ "$OS" == "ubuntu" || "$OS" == "debian" ]]; then
   for key in "${!ubuntu_dependencies[@]}"; do
     dependencies["$key"]="${ubuntu_dependencies[$key]}"
   done
-elif [[ "$OS" == "rocky" ]]; then
+elif [[ "$OS" == "rocky" || "$OS" == "almalinux" ]]; then
   for key in "${!rocky_dependencies[@]}"; do
     dependencies["$key"]="${rocky_dependencies[$key]}"
   done


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `verify_build_deps.sh` treats `ID=almalinux` as unsupported, so dependency verification aborts on AlmaLinux even when the RPM packages are installed.
2. Change: Cherry-picked RediSearch/RediSearch#9712 commit `929ab6b173a2b135e665686f07aa015ace2eeda7`, adding AlmaLinux to the RPM package checker map and routing it through the existing Rocky Linux dependency set.
3. Outcome: AlmaLinux can reuse the supported RPM dependency verification path without changing behavior for the existing supported distributions.

Credit: This change was originally contributed by @kalinstaykov in RediSearch/RediSearch#9712. This PR republishes that work from an in-repository branch because CI is currently broken for fork PRs.

#### Which additional issues this PR fixes
1. MOD-15772
2. #9712
3. #9714

#### Main objects this PR modified
1. `.install/verify_build_deps.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

Validation:
- `bash -n .install/verify_build_deps.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands OS detection/branching in `.install/verify_build_deps.sh` to treat AlmaLinux as an RPM-family distro and reuse existing Rocky Linux dependency checks.
> 
> **Overview**
> Build dependency verification now recognizes **AlmaLinux** as a supported OS by routing it through the existing RPM package checker.
> 
> For OS-specific package requirements, AlmaLinux is treated like Rocky Linux and reuses the `rocky_dependencies` set instead of aborting as unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3af216020c0e04255167b3096e7bed939eb4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->