### PR TITLE
trie: reset numDocs in TrieNode_Delete alongside score

### DIFF
--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -486,6 +486,7 @@ int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback fr
           n->flags |= TRIENODE_DELETED;
           n->flags &= ~TRIENODE_TERMINAL;
           n->score = 0;
+          n->numDocs = 0;
           rc = 1;
         }
         goto end;

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -479,6 +479,44 @@ int testNumDocs() {
   return 0;
 }
 
+// Regression: TrieNode_Delete is a soft delete (tombstone). It must zero numDocs
+// alongside score so that re-inserting the same term doesn't accumulate the
+// pre-delete count via __trieNode_Add's `n->numDocs += numDocs`.
+int testDeleteThenReinsertResetsNumDocs() {
+  Trie *t = NewTrie(NULL, Trie_Sort_Score);
+  ASSERT(t != NULL);
+
+  size_t helloLen;
+  rune *helloRunes = strToRunes("hello", &helloLen);
+
+  // Insert "hello" with numDocs = 7.
+  int rc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 0, NULL, 7);
+  ASSERT_EQUAL(1, rc);
+  TrieNode *node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
+  ASSERT(node != NULL);
+  ASSERT_EQUAL(7, node->numDocs);
+
+  // Soft-delete the term.
+  int delRc = Trie_Delete(t, "hello", 5);
+  ASSERT_EQUAL(1, delRc);
+  // Trie_GetNode filters deleted nodes.
+  node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
+  ASSERT(node == NULL);
+
+  // Re-insert "hello" with numDocs = 3.
+  // Pre-fix this would accumulate to 10 (7 stale + 3 new); post-fix it should be 3.
+  rc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 0, NULL, 3);
+  // Re-inserting a deleted node returns TRIE_OK_NEW (rc == 1), not UPDATED.
+  ASSERT_EQUAL(1, rc);
+  node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
+  ASSERT(node != NULL);
+  ASSERT_EQUAL(3, node->numDocs);
+
+  free(helloRunes);
+  TrieType_Free(t);
+  return 0;
+}
+
 int testDecrementNumDocs() {
   Trie *t = NewTrie(NULL, Trie_Sort_Score);
   ASSERT(t != NULL);
@@ -1101,6 +1139,7 @@ TEST_MAIN({
   TESTFUNC(testPayload);
   TESTFUNC(testUnicode);
   TESTFUNC(testNumDocs);
+  TESTFUNC(testDeleteThenReinsertResetsNumDocs);
   TESTFUNC(testDecrementNumDocs);
   TESTFUNC(testDecrementNumDocsComplex);
   TESTFUNC(testDecrementNumDocsNonTerminal);

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -479,37 +479,42 @@ int testNumDocs() {
   return 0;
 }
 
-// Regression: TrieNode_Delete is a soft delete (tombstone). It must zero numDocs
-// alongside score so that re-inserting the same term doesn't accumulate the
-// pre-delete count via __trieNode_Add's `n->numDocs += numDocs`.
-int testDeleteThenReinsertResetsNumDocs() {
+// Regression: TrieNode_Delete is a soft delete (tombstone). It must zero both
+// numDocs and score so that re-inserting the same term doesn't accumulate the
+// pre-delete values via __trieNode_Add's `n->numDocs += numDocs` (always
+// accumulates) and `n->score += score` (accumulates in ADD_INCR mode). Use
+// ADD_INCR (incr=1) so the score half is also exercised — ADD_REPLACE would
+// mask a missing score reset.
+int testDeleteThenReinsertResetsState() {
   Trie *t = NewTrie(NULL, Trie_Sort_Score);
   ASSERT(t != NULL);
 
   size_t helloLen;
   rune *helloRunes = strToRunes("hello", &helloLen);
 
-  // Insert "hello" with numDocs = 7.
-  int rc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 0, NULL, 7);
+  // Insert "hello" with score = 2.5 and numDocs = 7 in ADD_INCR mode.
+  int rc = Trie_InsertStringBuffer(t, "hello", 5, 2.5, 1, NULL, 7);
   ASSERT_EQUAL(1, rc);
   TrieNode *node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node != NULL);
+  ASSERT(node->score == 2.5f);
   ASSERT_EQUAL(7, node->numDocs);
 
-  // Soft-delete the term.
+  // Soft-delete the term; tombstone must zero both fields.
   int delRc = Trie_Delete(t, "hello", 5);
   ASSERT_EQUAL(1, delRc);
   // Trie_GetNode filters deleted nodes.
   node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node == NULL);
 
-  // Re-insert "hello" with numDocs = 3.
-  // Pre-fix this would accumulate to 10 (7 stale + 3 new); post-fix it should be 3.
-  rc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 0, NULL, 3);
+  // Re-insert with score = 1.0 and numDocs = 3 in ADD_INCR mode.
+  // Without the reset, score would accumulate to 3.5 and numDocs to 10.
+  rc = Trie_InsertStringBuffer(t, "hello", 5, 1.0, 1, NULL, 3);
   // Re-inserting a deleted node returns TRIE_OK_NEW (rc == 1), not UPDATED.
   ASSERT_EQUAL(1, rc);
   node = Trie_GetNode(t, helloRunes, helloLen, true, NULL);
   ASSERT(node != NULL);
+  ASSERT(node->score == 1.0f);
   ASSERT_EQUAL(3, node->numDocs);
 
   free(helloRunes);
@@ -1139,7 +1144,7 @@ TEST_MAIN({
   TESTFUNC(testPayload);
   TESTFUNC(testUnicode);
   TESTFUNC(testNumDocs);
-  TESTFUNC(testDeleteThenReinsertResetsNumDocs);
+  TESTFUNC(testDeleteThenReinsertResetsState);
   TESTFUNC(testDecrementNumDocs);
   TESTFUNC(testDecrementNumDocsComplex);
   TESTFUNC(testDecrementNumDocsNonTerminal);


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current:** `TrieNode_Delete` is a soft delete (tombstone). It marks the node `TRIENODE_DELETED`, clears `TRIENODE_TERMINAL`, and zeros `n->score` — but leaves `n->numDocs` untouched. On re-insert, `__trieNode_Add`'s `offset == len` branch (trie_node.c:282) runs `n->numDocs += numDocs`, accumulating the stale pre-delete count onto the new value.
2. **Change:** Zero `n->numDocs` alongside `n->score` in `TrieNode_Delete` so a re-insert at the same key starts from whatever the caller passed, not preserved + new. Add `testDeleteThenReinsertResetsNumDocs` covering insert(7) → `Trie_Delete` → insert(3), asserting `numDocs == 3` (was 10 pre-fix).
3. **Outcome:** Removes a latent footgun without altering observable behavior. The accumulation never fired in production: the only caller passing non-zero `numDocs` on insert is `Trie_DecrementNumDocs`, which already drives `numDocs` to 0 before triggering delete; all other callers (`dictionary.c`, `suggest.c`, `spell_check.c`, `fork_gc/terms.c`) insert with `numDocs = 0`. Every reader of `numDocs` is also gated upstream — `query.c` uses `Trie_GetNode` (returns NULL for deleted nodes), and the trie's range/wildcard/iterator paths check `__trieNode_isTerminal` or `score != 0` before reading `numDocs`.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `src/trie/trie_node.c` — `TrieNode_Delete`
2. `tests/ctests/test_trie.c` — new regression test

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line state reset in `TrieNode_Delete` plus a targeted regression test; behavior change is limited to re-inserting previously soft-deleted terms with non-zero `numDocs`/incremental scoring.
> 
> **Overview**
> Soft deletes in `TrieNode_Delete` now also zero `n->numDocs` (in addition to clearing terminal/deleted flags and resetting `score`), preventing stale document counts from being added back when the same term is re-inserted.
> 
> Adds a regression test (`testDeleteThenReinsertResetsState`) that inserts a term with non-zero `score`/`numDocs`, deletes it, then re-inserts in `ADD_INCR` mode and asserts the post-reinsert `score`/`numDocs` match the new values rather than accumulating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d29a843104e457a8369de0f041d715db9bec82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->