### PR TITLE
[MOD-15775] Move IteratorsConfig to Rust

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -153,6 +153,21 @@ static int set_uint_numeric_config(const char *name, long long val,
   return REDISMODULE_OK;
 }
 
+// Like set_uint_numeric_config but accepts values above UINT32_MAX (clamping with a warning).
+// Used for fields that were previously long long and may have larger values persisted in RDB.
+static int set_uint_clamped_numeric_config(const char *name, long long val,
+                                           void *privdata, RedisModuleString **err) {
+  REDISMODULE_NOT_USED(err);
+  if (val > UINT32_MAX) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "%s value %lld exceeds maximum (%u), clamping",
+                    name, val, UINT32_MAX);
+    val = UINT32_MAX;
+  }
+  *(unsigned int *)privdata = (unsigned int) val;
+  return REDISMODULE_OK;
+}
+
 static long long get_uint_numeric_config(const char *name, void *privdata) {
   REDISMODULE_NOT_USED(name);
   return (long long)(*(unsigned int *)privdata);
@@ -378,13 +393,24 @@ CONFIG_BOOLEAN_GETTER(getNoMemPools, noMemPool, 0)
 
 // MINPREFIX
 CONFIG_SETTER(setMinPrefix) {
-  int acrc = AC_GetLongLong(ac, &config->iteratorsConfigParams.minTermPrefix, AC_F_GE1);
-  RETURN_STATUS(acrc);
+  long long val;
+  int acrc = AC_GetLongLong(ac, &val, AC_F_GE1);
+  if (acrc != AC_OK) {
+    RETURN_STATUS(acrc);
+  }
+  if (val > UINT32_MAX) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "MINPREFIX value %lld exceeds maximum (%u), clamping",
+                    val, UINT32_MAX);
+    val = UINT32_MAX;
+  }
+  config->iteratorsConfigParams.minTermPrefix = (uint32_t) val;
+  return REDISMODULE_OK;
 }
 
 CONFIG_GETTER(getMinPrefix) {
   sds ss = sdsempty();
-  return sdscatprintf(ss, "%lld", config->iteratorsConfigParams.minTermPrefix);
+  return sdscatprintf(ss, "%u", config->iteratorsConfigParams.minTermPrefix);
 }
 
 // MINSTEMLEN
@@ -479,13 +505,24 @@ CONFIG_GETTER(getMaxAggregateResults) {
 
 // MAXEXPANSIONS MAXPREFIXEXPANSIONS
 CONFIG_SETTER(setMaxExpansions) {
-  int acrc = AC_GetLongLong(ac, &config->iteratorsConfigParams.maxPrefixExpansions, AC_F_GE1);
-  RETURN_STATUS(acrc);
+  long long val;
+  int acrc = AC_GetLongLong(ac, &val, AC_F_GE1);
+  if (acrc != AC_OK) {
+    RETURN_STATUS(acrc);
+  }
+  if (val > UINT32_MAX) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "MAXPREFIXEXPANSIONS value %lld exceeds maximum (%u), clamping",
+                    val, UINT32_MAX);
+    val = UINT32_MAX;
+  }
+  config->iteratorsConfigParams.maxPrefixExpansions = (uint32_t) val;
+  return REDISMODULE_OK;
 }
 
 CONFIG_GETTER(getMaxExpansions) {
   sds ss = sdsempty();
-  return sdscatprintf(ss, "%llu", config->iteratorsConfigParams.maxPrefixExpansions);
+  return sdscatprintf(ss, "%u", config->iteratorsConfigParams.maxPrefixExpansions);
 }
 
 // TIMEOUT
@@ -907,13 +944,24 @@ CONFIG_GETTER(getForkGcRetryInterval) {
 
 // UNION_ITERATOR_HEAP
 CONFIG_SETTER(setMinUnionIteratorHeap) {
-  int acrc = AC_GetLongLong(ac, &config->iteratorsConfigParams.minUnionIterHeap, AC_F_GE1);
-  RETURN_STATUS(acrc);
+  long long val;
+  int acrc = AC_GetLongLong(ac, &val, AC_F_GE1);
+  if (acrc != AC_OK) {
+    RETURN_STATUS(acrc);
+  }
+  if (val > UINT32_MAX) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "UNION_ITERATOR_HEAP value %lld exceeds maximum (%u), clamping",
+                    val, UINT32_MAX);
+    val = UINT32_MAX;
+  }
+  config->iteratorsConfigParams.minUnionIterHeap = (uint32_t) val;
+  return REDISMODULE_OK;
 }
 
 CONFIG_GETTER(getMinUnionIteratorHeap) {
   sds ss = sdsempty();
-  return sdscatprintf(ss, "%lld", config->iteratorsConfigParams.minUnionIterHeap);
+  return sdscatprintf(ss, "%u", config->iteratorsConfigParams.minUnionIterHeap);
 }
 
 // CURSOR_MAX_IDLE
@@ -1750,9 +1798,9 @@ sds RSConfig_GetInfoString(const RSConfig *config) {
   sds ss = sdsempty();
 
   ss = sdscatprintf(ss, "gc: %s, ", config->gcConfigParams.enableGC ? "ON" : "OFF");
-  ss = sdscatprintf(ss, "prefix min length: %lld, ", config->iteratorsConfigParams.minTermPrefix);
+  ss = sdscatprintf(ss, "prefix min length: %u, ", config->iteratorsConfigParams.minTermPrefix);
   ss = sdscatprintf(ss, "min word length to stem: %u, ", config->iteratorsConfigParams.minStemLength);
-  ss = sdscatprintf(ss, "prefix max expansions: %lld, ", config->iteratorsConfigParams.maxPrefixExpansions);
+  ss = sdscatprintf(ss, "prefix max expansions: %u, ", config->iteratorsConfigParams.maxPrefixExpansions);
   ss = sdscatprintf(ss, "query timeout (ms): %lld, ", config->requestConfigParams.queryTimeoutMS);
   ss = sdscatprintf(ss, "timeout policy: %s, ", TimeoutPolicy_ToString(config->requestConfigParams.timeoutPolicy));
   ss = sdscatprintf(ss, "oom policy: %s, ", OomPolicy_ToString(config->requestConfigParams.oomPolicy));
@@ -2007,8 +2055,8 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig(
       ctx, "search-max-prefix-expansions", DEFAULT_MAX_PREFIX_EXPANSIONS,
-      REDISMODULE_CONFIG_UNPREFIXED, 1, LLONG_MAX,
-      get_long_numeric_config, set_long_numeric_config, NULL,
+      REDISMODULE_CONFIG_UNPREFIXED, 1,
+      LLONG_MAX, get_uint_numeric_config, set_uint_clamped_numeric_config, NULL,
       (void *)&(RSGlobalConfig.iteratorsConfigParams.maxPrefixExpansions)
     )
   )
@@ -2063,7 +2111,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     RedisModule_RegisterNumericConfig(
       ctx, "search-min-prefix", DEFAULT_MIN_TERM_PREFIX,
       REDISMODULE_CONFIG_UNPREFIXED, 1,
-      LLONG_MAX, get_long_numeric_config, set_long_numeric_config, NULL,
+      LLONG_MAX, get_uint_numeric_config, set_uint_clamped_numeric_config, NULL,
       (void *)&(RSGlobalConfig.iteratorsConfigParams.minTermPrefix)
     )
   )
@@ -2108,7 +2156,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     RedisModule_RegisterNumericConfig(
       ctx, "search-union-iterator-heap", DEFAULT_UNION_ITERATOR_HEAP,
       REDISMODULE_CONFIG_UNPREFIXED, 1,
-      LLONG_MAX, get_long_numeric_config, set_long_numeric_config, NULL,
+      LLONG_MAX, get_uint_numeric_config, set_uint_clamped_numeric_config, NULL,
       (void *)&(RSGlobalConfig.iteratorsConfigParams.minUnionIterHeap)
     )
   )

--- a/src/config.h
+++ b/src/config.h
@@ -12,6 +12,7 @@
 #include "hiredis/sds.h"
 #include "rmutil/args.h"
 #include "reply.h"
+#include "rqe_iterators.h"
 #include "util/config_macros.h"
 #include "ext/default.h"
 
@@ -106,17 +107,6 @@ typedef struct {
   // OOM policy
   RSOomPolicy oomPolicy;
 } RequestConfig;
-
-// Configuration parameters related to the query execution.
-typedef struct {
-  // The maximal number of expansions we allow for a prefix. Default: 200
-  long long maxPrefixExpansions;
-  // The minimal number of characters we allow expansion for in a prefix search. Default: 2
-  long long minTermPrefix;
-  // The minimal word length to stem. Default 4
-  unsigned int minStemLength;
-  long long minUnionIterHeap;
-} IteratorsConfig;
 
 /* RSConfig is a global configuration struct for the module, it can be included from each file,
  * and is initialized with user config options during module startup */

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -12,7 +12,9 @@ use std::ptr::{self, NonNull};
 use ffi::{GeoFilter, RSGlobalConfig};
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use query_node_type::QueryNodeType;
-use rqe_iterators::{c2rust::CRQEIterator, interop::RQEIteratorWrapper, new_geo_range_iterator};
+use rqe_iterators::{
+    IteratorsConfig, c2rust::CRQEIterator, interop::RQEIteratorWrapper, new_geo_range_iterator,
+};
 
 use crate::inverted_index::numeric::NumericIterator;
 
@@ -37,7 +39,7 @@ use crate::inverted_index::numeric::NumericIterator;
 pub unsafe extern "C" fn NewGeoRangeIterator(
     ctx: *const ffi::RedisSearchCtx,
     gf: *mut GeoFilter,
-    config: *const ffi::IteratorsConfig,
+    config: *const IteratorsConfig,
 ) -> *mut ffi::QueryIterator {
     // SAFETY: 3. guarantees gf is non-null and writable.
     let geo = unsafe { &mut *gf };
@@ -53,7 +55,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
     // SAFETY: RSGlobalConfig is initialised by the time any index is created.
     let compress = unsafe { RSGlobalConfig.numericCompress };
     // SAFETY: 4. guarantees config is valid and non-null.
-    let min_union_iter_heap = unsafe { (*config).minUnionIterHeap } as usize;
+    let min_union_iter_heap = unsafe { (*config).min_union_iter_heap } as usize;
 
     // SAFETY: caller upholds requirements 1–3.
     let Ok(groups) = (unsafe { new_geo_range_iterator(sctx, geo, &field_ctx, compress) }) else {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -15,7 +15,7 @@ use inverted_index::NumericFilter;
 use query_node_type::QueryNodeType;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
-    NumericIteratorVariant, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
+    IteratorsConfig, NumericIteratorVariant, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
     open_numeric_or_geo_index,
 };
 
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn openNumericOrGeoIndex(
 /// 3. `flt` must be a valid non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
 ///    is a valid non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
 ///    returned iterator.
-/// 4. `config` must be a valid non-NULL pointer to an [`ffi::IteratorsConfig`].
+/// 4. `config` must be a valid non-NULL pointer to an [`IteratorsConfig`].
 /// 5. `filter_ctx` must be a valid non-NULL pointer to a [`FieldFilterContext`] with a field
 ///    index (not a field mask).
 #[unsafe(no_mangle)]
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
     ctx: *const ffi::RedisSearchCtx,
     flt: *const NumericFilter,
     _for_type: ffi::FieldType,
-    config: *const ffi::IteratorsConfig,
+    config: *const IteratorsConfig,
     filter_ctx: *const FieldFilterContext,
 ) -> *mut ffi::QueryIterator {
     debug_assert!(!ctx.is_null());
@@ -264,7 +264,7 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
     // SAFETY: RSGlobalConfig is initialised by the time any index is created.
     let compress = unsafe { RSGlobalConfig.numericCompress };
     // SAFETY: 4. guarantees config is valid and non-null.
-    let min_union_iter_heap = unsafe { (*config).minUnionIterHeap } as usize;
+    let min_union_iter_heap = unsafe { (*config).min_union_iter_heap } as usize;
 
     // SAFETY: 1. guarantees ctx is valid and non-null.
     let sctx = unsafe { NonNull::new_unchecked(ctx as *mut ffi::RedisSearchCtx) };

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -11,12 +11,12 @@
 
 use std::{ffi::c_char, ptr::NonNull};
 
-use ffi::{IteratorsConfig, QueryIterator, QueryNodeType};
+use ffi::{QueryIterator, QueryNodeType};
 
 use crate::profile::Profile_AddIters;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
-    RQEIterator, UnionVariant, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
+    IteratorsConfig, RQEIterator, UnionVariant, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
     union_opaque::UnionOpaque, union_reducer::new_union_iterator,
 };
 
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn NewUnionIterator(
     debug_assert!(num >= 0, "NewUnionIterator called with negative num: {num}");
     let num = num.max(0) as usize;
     // SAFETY: caller guarantees config is valid (4).
-    let min_union_iter_heap = unsafe { (*config).minUnionIterHeap } as usize;
+    let min_union_iter_heap = unsafe { (*config).min_union_iter_heap } as usize;
 
     // Build Vec<CRQEIterator> from the C array.
     let children: Vec<CRQEIterator> = (0..num)

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -339,6 +339,8 @@ const PERMITTED_GENERATED_HEADERS: &[&str] = &[
     "result_processor_ffi.h",
     // `enum IteratorType` is used by value in `src/iterators/iterator_api.h`.
     "rqe_iterator_type.h",
+    // `IteratorsConfig` is embedded by value in `RSGlobalConfig` (src/config.h).
+    "rqe_iterators.h",
     // `src/rlookup.h` has `static inline` accessors that dereference
     // `RLookupKey` / `RLookupIterator` fields, so the full struct bodies in
     // these three are required. (`rlookup_ffi.h` includes `search_result_rs.h`
@@ -375,7 +377,6 @@ const BLOCKLIST_FILES: &[&str] = &[
     ".*/query_term.h",
     ".*/query_term_ffi.h",
     ".*/rqe_iterator_type.h",
-    ".*/rqe_iterators.h",
 ];
 
 fn main() {

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -181,7 +181,7 @@ QueryIterator *NewOptionalIterator(QueryIterator *child, QueryEvalCtx *q, t_docI
  *      freed by `GeoFilter_Free`.
  * 4. `config` must be a valid non-NULL pointer to an `IteratorsConfig`.
  */
-QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, const IteratorsConfig *config);
+QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, const struct IteratorsConfig *config);
 
 /**
  * Creates a new iterator over a list of unsorted document IDs.
@@ -474,7 +474,7 @@ const QueryIterator *GetIntersectionIteratorChild(const QueryIterator *header, s
  * 3. Null entries in `its` are treated as empty iterators.
  * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
  */
-QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const IteratorsConfig *config);
+QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
 
 /**
  * Creates a new missing-field inverted index iterator.
@@ -718,11 +718,11 @@ QueryNodeType GetUnionIteratorQueryNodeType(const QueryIterator *it);
  * 3. `flt` must be a valid non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
  *    is a valid non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
  *    returned iterator.
- * 4. `config` must be a valid non-NULL pointer to an [`ffi::IteratorsConfig`].
+ * 4. `config` must be a valid non-NULL pointer to an [`IteratorsConfig`].
  * 5. `filter_ctx` must be a valid non-NULL pointer to a [`FieldFilterContext`] with a field
  *    index (not a field mask).
  */
-QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct NumericFilter *flt, FieldType _for_type, const IteratorsConfig *config, const struct FieldFilterContext *filter_ctx);
+QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct NumericFilter *flt, FieldType _for_type, const struct IteratorsConfig *config, const struct FieldFilterContext *filter_ctx);
 
 /**
  * Returns the query string pointer stored in the union iterator, or null.

--- a/src/redisearch_rs/headers/rqe_iterators.h
+++ b/src/redisearch_rs/headers/rqe_iterators.h
@@ -23,21 +23,21 @@ typedef struct IteratorsConfig {
   /**
    * The maximal number of expansions we allow for a prefix. Default: 200
    */
-  long long maxPrefixExpansions;
+  uint32_t maxPrefixExpansions;
   /**
    * The minimal number of characters we allow expansion for in a prefix
    * search. Default: 2
    */
-  long long minTermPrefix;
+  uint32_t minTermPrefix;
   /**
    * The minimal word length to stem. Default: 4
    */
-  unsigned int minStemLength;
+  uint32_t minStemLength;
   /**
    * Minimum number of children for a union iterator to use a heap-based
    * implementation instead of a flat (linear scan) one. Default: 20
    */
-  long long minUnionIterHeap;
+  uint32_t minUnionIterHeap;
 } IteratorsConfig;
 
 /**

--- a/src/redisearch_rs/headers/rqe_iterators.h
+++ b/src/redisearch_rs/headers/rqe_iterators.h
@@ -17,6 +17,30 @@ typedef enum MetricType {
 } MetricType;
 
 /**
+ * Configuration parameters related to the query execution.
+ */
+typedef struct IteratorsConfig {
+  /**
+   * The maximal number of expansions we allow for a prefix. Default: 200
+   */
+  long long maxPrefixExpansions;
+  /**
+   * The minimal number of characters we allow expansion for in a prefix
+   * search. Default: 2
+   */
+  long long minTermPrefix;
+  /**
+   * The minimal word length to stem. Default: 4
+   */
+  unsigned int minStemLength;
+  /**
+   * Minimum number of children for a union iterator to use a heap-based
+   * implementation instead of a flat (linear scan) one. Default: 20
+   */
+  long long minUnionIterHeap;
+} IteratorsConfig;
+
+/**
  * Profile counters collected during query execution.
  *
  * This struct is `#[repr(C)]` so that C code can access its fields directly.

--- a/src/redisearch_rs/rqe_iterators/src/config.rs
+++ b/src/redisearch_rs/rqe_iterators/src/config.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Configuration parameters related to query execution.
+
+use std::ffi::{c_longlong, c_uint};
+
+/// Configuration parameters related to the query execution.
+#[cheadergen::config(export, rename_all = "camelCase")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct IteratorsConfig {
+    /// The maximal number of expansions we allow for a prefix. Default: 200
+    pub max_prefix_expansions: c_longlong,
+    /// The minimal number of characters we allow expansion for in a prefix
+    /// search. Default: 2
+    pub min_term_prefix: c_longlong,
+    /// The minimal word length to stem. Default: 4
+    pub min_stem_length: c_uint,
+    /// Minimum number of children for a union iterator to use a heap-based
+    /// implementation instead of a flat (linear scan) one. Default: 20
+    pub min_union_iter_heap: c_longlong,
+}
+
+impl Default for IteratorsConfig {
+    fn default() -> Self {
+        Self {
+            max_prefix_expansions: 200,
+            min_term_prefix: 2,
+            min_stem_length: 4,
+            min_union_iter_heap: 20,
+        }
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/config.rs
+++ b/src/redisearch_rs/rqe_iterators/src/config.rs
@@ -9,23 +9,21 @@
 
 //! Configuration parameters related to query execution.
 
-use std::ffi::{c_longlong, c_uint};
-
 /// Configuration parameters related to the query execution.
 #[cheadergen::config(export, rename_all = "camelCase")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct IteratorsConfig {
     /// The maximal number of expansions we allow for a prefix. Default: 200
-    pub max_prefix_expansions: c_longlong,
+    pub max_prefix_expansions: u32,
     /// The minimal number of characters we allow expansion for in a prefix
     /// search. Default: 2
-    pub min_term_prefix: c_longlong,
+    pub min_term_prefix: u32,
     /// The minimal word length to stem. Default: 4
-    pub min_stem_length: c_uint,
+    pub min_stem_length: u32,
     /// Minimum number of children for a union iterator to use a heap-based
     /// implementation instead of a flat (linear scan) one. Default: 20
-    pub min_union_iter_heap: c_longlong,
+    pub min_union_iter_heap: u32,
 }
 
 impl Default for IteratorsConfig {

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -18,6 +18,7 @@ use index_result::RSIndexResult;
 use query_term::RSQueryTerm;
 
 pub mod c2rust;
+pub mod config;
 pub mod empty;
 pub mod expiration_checker;
 pub mod id_list;
@@ -42,6 +43,7 @@ mod union_trimmed;
 pub mod utils;
 pub mod wildcard;
 
+pub use config::IteratorsConfig;
 pub use empty::Empty;
 pub use expiration_checker::{ExpirationChecker, FieldExpirationChecker, NoOpChecker};
 pub use id_list::IdList;

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -564,16 +564,16 @@ numericConfigs = [
     ('search-index-cursor-limit', 'INDEX_CURSOR_LIMIT', 128, 0, LLONG_MAX, False, False),
     ('search-max-aggregate-results', 'MAXAGGREGATERESULTS', DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS, 0, MAX_AGGREGATE_REQUEST_RESULTS, False, False),
     ('search-max-doctablesize', 'MAXDOCTABLESIZE', 1_000_000, 1, 100_000_000, True, False),
-    ('search-max-prefix-expansions', 'MAXPREFIXEXPANSIONS', 200, 1, LLONG_MAX, False, False),
+    ('search-max-prefix-expansions', 'MAXPREFIXEXPANSIONS', 200, 1, UINT32_MAX, False, False),
     ('search-max-search-results', 'MAXSEARCHRESULTS', DEFAULT_MAX_SEARCH_REQUEST_RESULTS, 0, MAX_SEARCH_REQUEST_RESULTS, False, False),
     ('search-min-operation-workers', 'MIN_OPERATION_WORKERS', 4, 0, 16, False, False),
     ('search-min-phonetic-term-len', 'MIN_PHONETIC_TERM_LEN', 3, 1, LLONG_MAX, False, False),
-    ('search-min-prefix', 'MINPREFIX', 2, 1, LLONG_MAX, False, False),
+    ('search-min-prefix', 'MINPREFIX', 2, 1, UINT32_MAX, False, False),
     ('search-min-stem-len', 'MINSTEMLEN', 4, 2, UINT32_MAX, False, False),
     ('search-multi-text-slop', 'MULTI_TEXT_SLOP', 100, 1, UINT32_MAX, True, False),
     ('search-tiered-hnsw-buffer-limit', 'TIERED_HNSW_BUFFER_LIMIT', 1024, 0, LLONG_MAX, True, False),
     ('search-timeout', 'TIMEOUT', 500, 1, LLONG_MAX, False, False),
-    ('search-union-iterator-heap', 'UNION_ITERATOR_HEAP', 20, 1, LLONG_MAX, False, False),
+    ('search-union-iterator-heap', 'UNION_ITERATOR_HEAP', 20, 1, UINT32_MAX, False, False),
     ('search-vss-max-resize', 'VSS_MAX_RESIZE', 0, 0, UINT32_MAX, False, False),
     ('search-workers', 'WORKERS', min(MAX_WORKER_THREADS, os.cpu_count()), 0, 16, False, False),
     ('search-workers-priority-bias-threshold', 'WORKERS_PRIORITY_BIAS_THRESHOLD', 1, 0, LLONG_MAX, True, False),
@@ -590,6 +590,14 @@ numericConfigs = [
     ('search-conn-per-shard', 'CONN_PER_SHARD', 0, 0, UINT32_MAX, False, True),
     ('search-connect-timeout', 'CONNECT_TIMEOUT', 10_000, 0, INT_MAX, False, True),
 ]
+
+# Configs whose backing type narrowed from long long to uint32_t. Values above
+# UINT32_MAX are accepted but clamped (for backwards compatibility with persisted settings).
+CLAMPED_CONFIGS = {
+    'search-max-prefix-expansions': UINT32_MAX,
+    'search-min-prefix': UINT32_MAX,
+    'search-union-iterator-heap': UINT32_MAX,
+}
 
 @skip(redis_less_than='7.9.227')
 def testConfigAPIRunTimeNumericParams():
@@ -632,8 +640,14 @@ def testConfigAPIRunTimeNumericParams():
             .contains('CONFIG SET failed')
         env.expect('CONFIG', 'SET', configName, str(min - 1)).error()\
             .contains('CONFIG SET failed')
-        env.expect('CONFIG', 'SET', configName, str(max + 1)).error()\
-            .contains('CONFIG SET failed')
+        if configName in CLAMPED_CONFIGS:
+            # Values above UINT32_MAX are accepted and clamped (backwards compat)
+            env.expect('CONFIG', 'SET', configName, str(max + 1)).equal('OK')
+            env.expect('CONFIG', 'GET', configName)\
+                .equal([configName, str(max)])
+        else:
+            env.expect('CONFIG', 'SET', configName, str(max + 1)).error()\
+                .contains('CONFIG SET failed')
 
         # test valid range limits
         env.expect('CONFIG', 'SET', configName, str(min)).equal('OK')
@@ -769,6 +783,9 @@ def testConfigAPILoadTimeNumericParams():
 
     for configName, argName, default, minValue, maxValue, immutable, clusterConfig in numericConfigs:
         if clusterConfig:
+            continue
+        if configName in CLAMPED_CONFIGS:
+            # Values above UINT32_MAX are accepted and clamped (backwards compat)
             continue
 
         # Test that the limits are enforced using MODULE LOADEX


### PR DESCRIPTION
## Describe the changes in the pull request

- move `IteratorsConfig` to `rqe_iterators` crate.
- set all `IteratorsConfig` fields to `u32`, no need for big values.

This will help using `QueryEvalCtx::config` from Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-language FFI and module configuration plumbing; mistakes could cause ABI mismatches or unexpected runtime config values (now clamped to `UINT32_MAX` with warnings) when loading persisted settings.
> 
> **Overview**
> Moves `IteratorsConfig`’s source of truth to the Rust `rqe_iterators` crate (new `config.rs` + re-export) and updates the C/Rust FFI boundary to consume that generated `rqe_iterators.h` definition (including bindgen allowlisting and header prototypes).
> 
> Narrows `IteratorsConfig`-backed numeric configs (`MINPREFIX`, `MAXPREFIXEXPANSIONS`, `UNION_ITERATOR_HEAP`) to `uint32_t` semantics: getters now print `%u`, setters accept `> UINT32_MAX` but **log a warning and clamp** (to preserve backward compatibility with large values persisted in RDB). Tests are updated to reflect the new max range and clamping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd907acf2a96828d8924a6e2181789cd0242426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->