### PR TITLE
CMakeLists: actually make format warnings fatal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,8 +212,8 @@ execute_process(
 set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${CMAKE_LD_FLAGS}")
 
 # Treat all format-string warnings as errors
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Wformat")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=format")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format")
 
 # Promote specific warnings to errors. These use add_compile_options() which
 # propagates to ALL subdirectories, including deps (libuv, VectorSimilarity, etc.).

--- a/deps/rmutil/cmdparse.c
+++ b/deps/rmutil/cmdparse.c
@@ -13,6 +13,7 @@
 #include <limits.h>
 #include <sys/errno.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdarg.h>
 
@@ -40,7 +41,7 @@ void CmdArg_Print(CmdArg *n, int depth) {
   pad(depth);
   switch (n->type) {
     case CmdArg_Integer:
-      printf("%zd", n->i);
+      printf("%" PRId64, n->i);
       break;
     case CmdArg_Double:
       printf("%f", n->d);

--- a/src/config.c
+++ b/src/config.c
@@ -982,7 +982,7 @@ CONFIG_SETTER(setNumericTreeMaxDepthRange) {
 
 CONFIG_GETTER(getNumericTreeMaxDepthRange) {
   sds ss = sdsempty();
-  return sdscatprintf(ss, "%ld", config->numericTreeMaxDepthRange);
+  return sdscatprintf(ss, "%zu", config->numericTreeMaxDepthRange);
 }
 
 // DEFAULT_DIALECT

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -13,6 +13,7 @@
 #include "cursor.h"
 #include "info/indexes_info.h"
 #include "util/units.h"
+#include <inttypes.h>
 #include "module_init_ffi.h"
 #include "info/info_redis/types/blocked_queries.h"
 #include "info/info_redis/threads/current_thread.h"
@@ -459,7 +460,7 @@ static void AddCursorsToInfo(RedisModuleInfoCtx *ctx, BlockedQueries* activeQuer
     BlockedCursorNode *at = DLLIST_ITEM(node, BlockedCursorNode, llnode);
     IndexSpec *spec = StrongRef_Get(at->spec);
     char buffer[21]; // 20 is the max length of a uint64_t
-    snprintf(buffer, sizeof(buffer), "%zu", at->cursorId);
+    snprintf(buffer, sizeof(buffer), "%" PRIu64, at->cursorId);
     RedisModule_InfoBeginDictField(ctx, buffer);
     RedisModule_InfoAddFieldCString(ctx, "index", spec ? IndexSpec_FormatName(spec, RSGlobalConfig.hideUserDataFromLog) : "n/a");
     RedisModule_InfoAddFieldULongLong(ctx, "started_at", at->start);

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -10,6 +10,7 @@
 #include "rmutil/rm_assert.h"
 #include "redismodule.h"
 #include "rmutil/rm_assert.h"
+#include <inttypes.h>
 
 BlockedQueries *BlockedQueries_Init() {
   BlockedQueries* blockedQueries = rm_calloc(1, sizeof(BlockedQueries));
@@ -39,7 +40,7 @@ static size_t PrintActiveCursors(BlockedQueries *blockedQueries) {
     ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
     const char *indexName = sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a";
     const char *query = at->query && !RSGlobalConfig.hideUserDataFromLog ? at->query : "n/a";
-    RedisModule_Log(NULL, "warning", "Active cursor %zu, on index %s, query: %s, started at %ld", at->cursorId, indexName, query, at->start);
+    RedisModule_Log(NULL, "warning", "Active cursor %" PRIu64 ", on index %s, query: %s, started at %ld", at->cursorId, indexName, query, at->start);
   }
   return count;
 }

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -214,7 +214,7 @@ IteratorStatus OPT_Read(QueryIterator *self) {
         }
       } else {
         RedisModule_Log(RSDummyContext, "verbose", "Not enough results collected, but success ratio is %f", getSuccessRatio(it));
-        RedisModule_Log(RSDummyContext, "debug", "Heap size: %d, heap count: %d, offset: %ld, childEstimate: %ld",
+        RedisModule_Log(RSDummyContext, "debug", "Heap size: %d, heap count: %d, offset: %zu, childEstimate: %zu",
                                         heap_size(it->heap), heap_count(it->heap), it->offset, it->childEstimate);
       }
     }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -880,7 +880,7 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     RedisModule_Log(RSDummyContext, "notice", "Loading event failed");
     break;
   default:
-    RS_LOG_ASSERT_FMT(0, "Unknown sub-event %d", subevent);
+    RS_LOG_ASSERT_FMT(0, "Unknown sub-event %llu", (unsigned long long)subevent);
     break;
   }
 }

--- a/src/obfuscation/obfuscation_api.c
+++ b/src/obfuscation/obfuscation_api.c
@@ -12,6 +12,7 @@
 
 #include "query_node.h"
 
+#include <inttypes.h>
 #include <string.h>
 
 void Obfuscate_Index(const Sha1 *hash, char* buffer) {
@@ -21,15 +22,15 @@ void Obfuscate_Index(const Sha1 *hash, char* buffer) {
 }
 
 void Obfuscate_Field(t_uniqueId fieldId, char* buffer) {
-  sprintf(buffer, "Field@%zu", fieldId);
+  sprintf(buffer, "Field@%" PRIu64, fieldId);
 }
 
 void Obfuscate_FieldPath(t_uniqueId fieldId, char* buffer) {
-  sprintf(buffer, "FieldPath@%zu", fieldId);
+  sprintf(buffer, "FieldPath@%" PRIu64, fieldId);
 }
 
 void Obfuscate_Document(t_uniqueId docId, char* buffer) {
-  sprintf(buffer, "Document@%zu", docId);
+  sprintf(buffer, "Document@%" PRIu64, docId);
 }
 
 void Obfuscate_KeyWithTime(struct timespec spec, char* buffer) {

--- a/src/query.c
+++ b/src/query.c
@@ -2083,7 +2083,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
             did = DocTable_GetId(&spec->docs, qs->fn.keys[i], sdslen(qs->fn.keys[i]));
           }
           if (did != 0) {
-            s = sdscatprintf(s, "%lu,", did);
+            s = sdscatprintf(s, "%" PRIu64 ",", did);
           }
         }
       }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2998,10 +2998,10 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     if (scanner->cancelled) {
 
       if (scanner->global) {
-        RedisModule_Log(ctx, "notice", "Scanning indexes in background: cancelled (scanned=%ld)",
+        RedisModule_Log(ctx, "notice", "Scanning indexes in background: cancelled (scanned=%zu)",
                         scanner->scannedKeys);
       } else {
-        RedisModule_Log(ctx, "notice", "Scanning index %s in background: cancelled (scanned=%ld)",
+        RedisModule_Log(ctx, "notice", "Scanning index %s in background: cancelled (scanned=%zu)",
                     scanner->spec_name_for_logs, scanner->scannedKeys);
         goto end;
       }
@@ -3014,10 +3014,10 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
   }
 
   if (scanner->global) {
-    RedisModule_Log(ctx, "notice", "Scanning indexes in background: done (scanned=%ld)",
+    RedisModule_Log(ctx, "notice", "Scanning indexes in background: done (scanned=%zu)",
                     scanner->scannedKeys);
   } else {
-    RedisModule_Log(ctx, "notice", "Scanning index %s in background: done (scanned=%ld)",
+    RedisModule_Log(ctx, "notice", "Scanning index %s in background: done (scanned=%zu)",
                     scanner->spec_name_for_logs, scanner->scannedKeys);
   }
 

--- a/src/synonym_map.c
+++ b/src/synonym_map.c
@@ -13,6 +13,7 @@
 #include "rmutil/rm_assert.h"
 #include "rdb.h"
 #include "util/likely.h"
+#include <inttypes.h>
 
 #define INITIAL_CAPACITY 2
 #define SYNONYM_PREFIX "~%s"
@@ -88,7 +89,7 @@ TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver) {
   if (unlikely(ids_len > MAX_SYNONYM_GROUP_IDS)) {
     RedisModule_LogIOError(
         rdb, "warning",
-        "RDB Load: Synonym group IDs (%llu) exceeds maximum allowed (%d)",
+        "RDB Load: Synonym group IDs (%" PRIu64 ") exceeds maximum allowed (%d)",
         ids_len, MAX_SYNONYM_GROUP_IDS);
     goto cleanup;
   }
@@ -97,7 +98,7 @@ TermData* TermData_RdbLoad(RedisModuleIO* rdb, int encver) {
     char* groupId = NULL;
     if (encver <= INDEX_MIN_WITH_SYNONYMS_INT_GROUP_ID) {
       uint64_t id = LoadUnsigned_IOError(rdb, goto cleanup);
-      rm_asprintf(&groupId, "%ld", id);
+      rm_asprintf(&groupId, "%" PRIu64, id);
     } else {
       groupId = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
     }

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -8,6 +8,7 @@
 */
 
 
+#include <inttypes.h>
 #include "gtest/gtest.h"
 #include "aggregate/aggregate.h"
 #include "redismock/redismock.h"
@@ -51,7 +52,7 @@ TEST_F(ExpireTest, testSkipTo) {
   // Add 1000 documents to the index and expire the fields
   for (t_docId doc = 1; doc <= maxDocId; ++doc) {
     char buf[1024];
-    snprintf(buf, sizeof(buf), "doc:%ld", doc);
+    snprintf(buf, sizeof(buf), "doc:%" PRIu64, doc);
     hset_args[0] = RedisModule_CreateString(ctx, buf, strlen(buf));
     RedisModuleCallReply *hset = RedisModule_Call(ctx, "HSET", "!v", hset_args, sizeof(hset_args) / sizeof(hset_args[0]));
     RedisModule_FreeCallReply(hset);


### PR DESCRIPTION
Comment claims they are errors but they were actually just warnings.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling `-Werror=format` can break builds on platforms/compilers where third-party or existing code triggers format warnings, and the PR touches several logging/printf callsites to address those warnings.
> 
> **Overview**
> Makes format-string warnings *actually fatal* by switching `CMakeLists.txt` from `-Wformat` to `-Werror=format` for both C and C++ builds.
> 
> Fixes the resulting format issues across the codebase by standardizing integer printing: adds `<inttypes.h>` where needed and replaces mismatched `%ld/%lu/%zd/%zu` usages with `PRIu64`/`PRId64` (and correct `size_t` specifiers) in logging, INFO output, obfuscation helpers, query dumping, synonym RDB load warnings, and a C++ expire test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 886a95110fc167541653f72d42e55febcaf1e07c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->