### PR TITLE
[MOD-15739] Fix flakiness in test_expire. Align timings with other stable tests in same file

### DIFF
--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -725,17 +725,12 @@ def testKeyPersistWithNonMatchingIndexes(env):
     # the non-matching indexes keep their pre-TTL view.
     conn = _setup_non_matching_indexes(env)
 
-    # The TTL must be long enough that lazy expiration cannot fire between the
-    # client sending PEXPIRE and the server starting PERSIST. With a 1 ms TTL,
-    # PERSIST races against the deadline on slow CI runners; the server then
-    # lazy-expires the key inside expireIfNeeded() and fires `expired` (not
-    # `persist`), which removes doc:1 from idx_match entirely and masks the
-    # behavior this test is supposed to verify.
-    conn.execute_command('PEXPIRE', 'doc:1', '1000')
-    conn.execute_command('PERSIST', 'doc:1')
+    # Use the same 100 ms / 200 ms timing as test_MOD_14800_persist_clears_expiration_metadata.
+    env.expect('PEXPIRE', 'doc:1', '100').equal(1)
+    env.expect('PERSIST', 'doc:1').equal(1)
     # Sleep past the original PEXPIRE deadline: if PERSIST had failed to clear
     # dmd->expirationTimeNs, DocTable_IsDocExpired would now filter doc:1 out.
-    time.sleep(1.5)
+    time.sleep(0.2)
 
     # idx_match: PERSIST cleared the DocTable TTL, so DocTable_IsDocExpired
     # returns false and doc:1 is still visible.

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -725,11 +725,17 @@ def testKeyPersistWithNonMatchingIndexes(env):
     # the non-matching indexes keep their pre-TTL view.
     conn = _setup_non_matching_indexes(env)
 
-    conn.execute_command('PEXPIRE', 'doc:1', '1')
-    # PERSIST runs synchronously on the main thread before the sleep, so it
-    # clears the DocTable expiration recorded by the PEXPIRE notification.
+    # The TTL must be long enough that lazy expiration cannot fire between the
+    # client sending PEXPIRE and the server starting PERSIST. With a 1 ms TTL,
+    # PERSIST races against the deadline on slow CI runners; the server then
+    # lazy-expires the key inside expireIfNeeded() and fires `expired` (not
+    # `persist`), which removes doc:1 from idx_match entirely and masks the
+    # behavior this test is supposed to verify.
+    conn.execute_command('PEXPIRE', 'doc:1', '1000')
     conn.execute_command('PERSIST', 'doc:1')
-    time.sleep(0.015)
+    # Sleep past the original PEXPIRE deadline: if PERSIST had failed to clear
+    # dmd->expirationTimeNs, DocTable_IsDocExpired would now filter doc:1 out.
+    time.sleep(1.5)
 
     # idx_match: PERSIST cleared the DocTable TTL, so DocTable_IsDocExpired
     # returns false and doc:1 is still visible.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `tests/pytests/test_expire.py::testKeyPersistWithNonMatchingIndexes` issues `PEXPIRE doc:1 1` immediately followed by `PERSIST doc:1`. On slow CI runners (e.g. `macos-26-large`) more than 1 ms can elapse between the two client commands, so by the time the server starts processing `PERSIST` the key is already past its deadline. Redis lazy-expires it inside `expireIfNeeded()` and fires an `expired` keyspace event instead of `persist`. RediSearch routes `expired` to `Indexes_DeleteMatchingWithSchemaRules` in `src/notifications.c`, which deletes `doc:1` outright from `idx_match`. The subsequent `FT.SEARCH` then returns `[1, 'doc:2']` instead of the expected `[2, 'doc:1', 'doc:2']`.

   `DEBUG SET-ACTIVE-EXPIRE 0` (already set in `_setup_non_matching_indexes`) only disables the periodic active-expiration cycle; it does **not** disable lazy expiration on key access, so it cannot prevent this race.

2. **Change:** Align the timing in `testKeyPersistWithNonMatchingIndexes` with the existing-and-stable `test_MOD_14800_persist_clears_expiration_metadata` in the same file:
   - `PEXPIRE` TTL `1` ms → `100` ms, wrapped in `env.expect(...).equal(1)`.
   - `PERSIST` also wrapped in `env.expect(...).equal(1)` so that if the race ever resurfaces the test fails with a clear "PERSIST returned 0" message instead of a misleading search-result mismatch.
   - `time.sleep(0.015)` → `time.sleep(0.2)`, so the original PEXPIRE deadline still elapses before the assertion runs (otherwise the test would pass trivially even if PERSIST had failed to clear `dmd->expirationTimeNs`).

3. **Outcome:** The test reliably exercises the `persist` keyspace event path through `Indexes_UpdateMatchingDocExpiration` and still catches any regression in which PERSIST fails to clear `dmd->expirationTimeNs`.

#### Which additional issues this PR fixes
1. MOD-15739

#### Main objects this PR modified
1. `tests/pytests/test_expire.py` — `testKeyPersistWithNonMatchingIndexes`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes