### PR TITLE
[MOD-15782] move MetricRequest to rlookup crate

### DIFF
--- a/src/query.h
+++ b/src/query.h
@@ -28,19 +28,6 @@ typedef struct QueryError QueryError;
 extern "C" {
 #endif
 
-// Smart pointer handle for RLookupKey that can be invalidated when iterator is freed
-typedef struct RLookupKeyHandle {
-  RLookupKey **key_ptr;  // Pointer to the actual RLookupKey* field in the iterator
-  bool is_valid;         // Whether the iterator is still alive
-} RLookupKeyHandle;
-
-// Holds a yieldable field name, and the address to write the RLookupKey pointer later.
-typedef struct MetricRequest{
-  const char *metric_name;
-  RLookupKeyHandle *key_handle; // Handle that can be invalidated when iterator is freed
-  bool isInternal; // Indicates if this metric should be excluded from the response
-} MetricRequest;
-
 // Flags indicating which syntax features are enabled for this query
 typedef enum {
   // All syntax features are enabled

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -26,6 +26,12 @@ typedef struct timespec timespec;
 typedef struct NumericFilter NumericFilter;
 
 /**
+ * Smart pointer handle for [`RLookupKey`] that can be
+ * invalidated when the iterator that owns the key is freed.
+ */
+typedef struct RLookupKeyHandle RLookupKeyHandle;
+
+/**
  * A single term being evaluated at query time.
  *
  * Each term carries scoring metadata ([`idf`](RSQueryTerm::idf),

--- a/src/redisearch_rs/headers/rlookup.h
+++ b/src/redisearch_rs/headers/rlookup.h
@@ -164,6 +164,49 @@ typedef uint8_t Size_40[40];
 #endif /* SIZE_40_DEFINED */
 
 /**
+ * Smart pointer handle for [`RLookupKey`] that can be
+ * invalidated when the iterator that owns the key is freed.
+ */
+typedef struct RLookupKeyHandle {
+  /**
+   * Pointer to the [`RLookupKey`] pointer field inside
+   * the owning iterator.
+   */
+  RLookupKey * *key_ptr;
+  /**
+   * Whether the owning iterator is still alive. Set to `true` on
+   * creation and cleared to `false` when the iterator is freed.
+   */
+  bool is_valid;
+} RLookupKeyHandle;
+
+/**
+ * A deferred binding between a metric name produced during query parsing
+ * and the [`RLookupKey`] that will be resolved during
+ * pipeline construction.
+ */
+typedef struct MetricRequest {
+  /**
+   * The name of the metric field to register in the
+   * [`RLookup`] table (e.g. `"__vec_score"`).
+   */
+  const char *metric_name;
+  /**
+   * Optional handle back to the iterator's
+   * [`RLookupKey`] slot. `NULL` when the iterator
+   * that requested this metric was not created (e.g. an early
+   * empty-result short-circuit).
+   */
+  struct RLookupKeyHandle *key_handle;
+  /**
+   * When `true`, the metric is excluded from the query response
+   * (the corresponding [`RLookupKey`] is created
+   * with the `HIDDEN` flag).
+   */
+  bool isInternal;
+} MetricRequest;
+
+/**
  * An opaque lookup row which can be passed by value to C.
  *
  * The size and alignment of this struct must match the Rust `RLookupRow`

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod bindings;
 mod lookup;
+mod metric_request;
 mod row;
 
 // Link both Rust-provided and C-provided symbols
@@ -23,5 +24,6 @@ pub use lookup::{
     Cursor, CursorMut, Iter, IterMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags,
     RLookupOption, RLookupOptions, opaque::OpaqueRLookup,
 };
+pub use metric_request::{MetricRequest, RLookupKeyHandle};
 pub use row::RLookupRow;
 pub use row::opaque::OpaqueRLookupRow;

--- a/src/redisearch_rs/rlookup/src/metric_request.rs
+++ b/src/redisearch_rs/rlookup/src/metric_request.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::ffi::c_char;
+
+#[cfg(doc)]
+use crate::RLookup;
+use crate::RLookupKey;
+
+/// Smart pointer handle for [`RLookupKey`] that can be
+/// invalidated when the iterator that owns the key is freed.
+#[cheadergen::config(export)]
+#[repr(C)]
+#[derive(Debug)]
+pub struct RLookupKeyHandle<'a> {
+    /// Pointer to the [`RLookupKey`] pointer field inside
+    /// the owning iterator.
+    pub key_ptr: *mut *mut RLookupKey<'a>,
+    /// Whether the owning iterator is still alive. Set to `true` on
+    /// creation and cleared to `false` when the iterator is freed.
+    pub is_valid: bool,
+}
+
+/// A deferred binding between a metric name produced during query parsing
+/// and the [`RLookupKey`] that will be resolved during
+/// pipeline construction.
+#[cheadergen::config(export)]
+#[repr(C)]
+#[derive(Debug)]
+pub struct MetricRequest<'a> {
+    /// The name of the metric field to register in the
+    /// [`RLookup`] table (e.g. `"__vec_score"`).
+    pub metric_name: *const c_char,
+    /// Optional handle back to the iterator's
+    /// [`RLookupKey`] slot. `NULL` when the iterator
+    /// that requested this metric was not created (e.g. an early
+    /// empty-result short-circuit).
+    pub key_handle: *mut RLookupKeyHandle<'a>,
+    /// When `true`, the metric is excluded from the query response
+    /// (the corresponding [`RLookupKey`] is created
+    /// with the `HIDDEN` flag).
+    #[cheadergen(rename = "isInternal")]
+    pub is_internal: bool,
+}


### PR DESCRIPTION
This will help using `QueryEvalCtx::metricRequestsP` from Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes C/Rust FFI type declarations and header ownership, which can cause ABI mismatches or missing forward declarations at compile time if any include order assumptions exist.
> 
> **Overview**
> Moves the `MetricRequest` and `RLookupKeyHandle` C ABI types out of `query.h` and into the Rust `rlookup` crate, exporting them via a new `metric_request.rs` module and the generated `rlookup.h` header.
> 
> Updates the iterator FFI header (`iterators_ffi.h`) to forward-declare `RLookupKeyHandle` from the new location, consolidating metric-request plumbing under `rlookup` for easier Rust access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc26d67585e325325479041a95112fc4963521a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->