### PR TITLE
[MOD-15810] Improve community contribution readiness

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,26 +1,31 @@
 name: Setup sccache
 description: |
-  Assume the sccache AWS role via OIDC, install the sccache binary, and export
-  sccache S3 env vars. Calling job MUST grant `id-token: write`.
+  Install the sccache binary and optionally configure S3 remote cache via AWS
+  OIDC. Jobs that enable remote cache MUST grant `id-token: write`.
 
 inputs:
+  remote-cache-enabled:
+    description: 'Whether to configure S3 remote cache'
+    required: false
+    default: 'true'
   aws-role:
     description: 'AWS IAM role ARN for sccache S3 access (pass vars.SCCACHE_AWS_ROLE_TO_ASSUME)'
-    required: true
+    required: false
   s3-bucket:
     description: 'S3 bucket name for sccache (pass vars.SCCACHE_S3_BUCKET)'
-    required: true
+    required: false
   s3-region:
     description: 'AWS region of the sccache S3 bucket (pass vars.SCCACHE_S3_REGION)'
-    required: true
+    required: false
   s3-key-prefix:
     description: 'S3 key prefix for sccache objects (pass vars.SCCACHE_S3_KEY_PREFIX)'
-    required: true
+    required: false
 
 runs:
   using: composite
   steps:
     - name: Configure AWS Credentials for sccache
+      if: ${{ inputs.remote-cache-enabled == 'true' && inputs.aws-role != '' && inputs.s3-bucket != '' && inputs.s3-region != '' && inputs.s3-key-prefix != '' }}
       uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role }}
@@ -41,14 +46,25 @@ runs:
       # as script-injection sinks.
       shell: bash --noprofile --norc -eo pipefail {0}
       env:
+        INPUT_REMOTE_CACHE_ENABLED: ${{ inputs.remote-cache-enabled }}
+        INPUT_AWS_ROLE: ${{ inputs.aws-role }}
         INPUT_S3_BUCKET: ${{ inputs.s3-bucket }}
         INPUT_S3_REGION: ${{ inputs.s3-region }}
         INPUT_S3_KEY_PREFIX: ${{ inputs.s3-key-prefix }}
       run: |
-        echo "SCCACHE_BUCKET=$INPUT_S3_BUCKET" >> "$GITHUB_ENV"
-        echo "SCCACHE_REGION=$INPUT_S3_REGION" >> "$GITHUB_ENV"
-        echo "SCCACHE_S3_KEY_PREFIX=$INPUT_S3_KEY_PREFIX" >> "$GITHUB_ENV"
-        echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
+        if [[ "$INPUT_REMOTE_CACHE_ENABLED" == "true" &&
+              -n "$INPUT_AWS_ROLE" &&
+              -n "$INPUT_S3_BUCKET" &&
+              -n "$INPUT_S3_REGION" &&
+              -n "$INPUT_S3_KEY_PREFIX" ]]; then
+          echo "SCCACHE_BUCKET=$INPUT_S3_BUCKET" >> "$GITHUB_ENV"
+          echo "SCCACHE_REGION=$INPUT_S3_REGION" >> "$GITHUB_ENV"
+          echo "SCCACHE_S3_KEY_PREFIX=$INPUT_S3_KEY_PREFIX" >> "$GITHUB_ENV"
+          echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
+          echo "Configured sccache S3 remote cache."
+        else
+          echo "Using local sccache only; S3 remote cache is disabled or not fully configured."
+        fi
         # Disable idle timeout so the sccache server stays alive for the
         # entire job, otherwise stats are lost if it shuts down between steps.
         echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -37,13 +37,6 @@ runs:
         # container and reports nothing. We show stats ourselves.
         disable_annotations: true
 
-    - name: Configure local sccache environment
-      shell: bash --noprofile --norc -eo pipefail {0}
-      run: |
-        # Disable idle timeout so the sccache server stays alive for the
-        # entire job, otherwise stats are lost if it shuts down between steps.
-        echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
-
     - name: Configure sccache S3 environment
       if: ${{ steps.aws-credentials.outcome == 'success' }}
       # Use --noprofile --norc to avoid Alpine's /etc/profile resetting PATH,
@@ -61,3 +54,6 @@ runs:
         echo "SCCACHE_REGION=$INPUT_S3_REGION" >> "$GITHUB_ENV"
         echo "SCCACHE_S3_KEY_PREFIX=$INPUT_S3_KEY_PREFIX" >> "$GITHUB_ENV"
         echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
+        # Disable idle timeout so the sccache server stays alive for the
+        # entire job, otherwise stats are lost if it shuts down between steps.
+        echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -37,7 +37,15 @@ runs:
         # container and reports nothing. We show stats ourselves.
         disable_annotations: true
 
-    - name: Configure sccache environment
+    - name: Configure local sccache environment
+      shell: bash --noprofile --norc -eo pipefail {0}
+      run: |
+        # Disable idle timeout so the sccache server stays alive for the
+        # entire job, otherwise stats are lost if it shuts down between steps.
+        echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
+
+    - name: Configure sccache S3 environment
+      if: ${{ steps.aws-credentials.outcome == 'success' }}
       # Use --noprofile --norc to avoid Alpine's /etc/profile resetting PATH,
       # which would hide the sccache binary installed by the previous step.
       # Input values are passed via env (not interpolated into the script)
@@ -45,25 +53,11 @@ runs:
       # as script-injection sinks.
       shell: bash --noprofile --norc -eo pipefail {0}
       env:
-        INPUT_REMOTE_CACHE_CONFIGURED: ${{ steps.aws-credentials.outcome == 'success' }}
-        INPUT_AWS_ROLE: ${{ inputs.aws-role }}
         INPUT_S3_BUCKET: ${{ inputs.s3-bucket }}
         INPUT_S3_REGION: ${{ inputs.s3-region }}
         INPUT_S3_KEY_PREFIX: ${{ inputs.s3-key-prefix }}
       run: |
-        if [[ "$INPUT_REMOTE_CACHE_CONFIGURED" == "true" &&
-              -n "$INPUT_AWS_ROLE" &&
-              -n "$INPUT_S3_BUCKET" &&
-              -n "$INPUT_S3_REGION" &&
-              -n "$INPUT_S3_KEY_PREFIX" ]]; then
-          echo "SCCACHE_BUCKET=$INPUT_S3_BUCKET" >> "$GITHUB_ENV"
-          echo "SCCACHE_REGION=$INPUT_S3_REGION" >> "$GITHUB_ENV"
-          echo "SCCACHE_S3_KEY_PREFIX=$INPUT_S3_KEY_PREFIX" >> "$GITHUB_ENV"
-          echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
-          echo "Configured sccache S3 remote cache."
-        else
-          echo "Using local sccache only; S3 remote cache is disabled or not fully configured."
-        fi
-        # Disable idle timeout so the sccache server stays alive for the
-        # entire job, otherwise stats are lost if it shuts down between steps.
-        echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
+        echo "SCCACHE_BUCKET=$INPUT_S3_BUCKET" >> "$GITHUB_ENV"
+        echo "SCCACHE_REGION=$INPUT_S3_REGION" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_KEY_PREFIX=$INPUT_S3_KEY_PREFIX" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,13 +1,10 @@
 name: Setup sccache
 description: |
   Install the sccache binary and optionally configure S3 remote cache via AWS
-  OIDC. Jobs that enable remote cache MUST grant `id-token: write`.
+  OIDC. Remote cache setup is best-effort; jobs that can use it MUST grant
+  `id-token: write`.
 
 inputs:
-  remote-cache-enabled:
-    description: 'Whether to configure S3 remote cache'
-    required: false
-    default: 'true'
   aws-role:
     description: 'AWS IAM role ARN for sccache S3 access (pass vars.SCCACHE_AWS_ROLE_TO_ASSUME)'
     required: false
@@ -25,7 +22,9 @@ runs:
   using: composite
   steps:
     - name: Configure AWS Credentials for sccache
-      if: ${{ inputs.remote-cache-enabled == 'true' && inputs.aws-role != '' && inputs.s3-bucket != '' && inputs.s3-region != '' && inputs.s3-key-prefix != '' }}
+      id: aws-credentials
+      if: ${{ inputs.aws-role != '' && inputs.s3-bucket != '' && inputs.s3-region != '' && inputs.s3-key-prefix != '' }}
+      continue-on-error: true
       uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role }}
@@ -46,13 +45,13 @@ runs:
       # as script-injection sinks.
       shell: bash --noprofile --norc -eo pipefail {0}
       env:
-        INPUT_REMOTE_CACHE_ENABLED: ${{ inputs.remote-cache-enabled }}
+        INPUT_REMOTE_CACHE_CONFIGURED: ${{ steps.aws-credentials.outcome == 'success' }}
         INPUT_AWS_ROLE: ${{ inputs.aws-role }}
         INPUT_S3_BUCKET: ${{ inputs.s3-bucket }}
         INPUT_S3_REGION: ${{ inputs.s3-region }}
         INPUT_S3_KEY_PREFIX: ${{ inputs.s3-key-prefix }}
       run: |
-        if [[ "$INPUT_REMOTE_CACHE_ENABLED" == "true" &&
+        if [[ "$INPUT_REMOTE_CACHE_CONFIGURED" == "true" &&
               -n "$INPUT_AWS_ROLE" &&
               -n "$INPUT_S3_BUCKET" &&
               -n "$INPUT_S3_REGION" &&

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
+          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -56,7 +57,8 @@ jobs:
       - name: Build RediSearch
         run: make build LTO=1
       - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
-          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -57,7 +56,6 @@ jobs:
       - name: Build RediSearch
         run: make build LTO=1
       - name: Show sccache stats
-        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -55,8 +55,6 @@ jobs:
           s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Build RediSearch
         run: make build LTO=1
-      - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -30,6 +30,7 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       # build.sh maps `uname -m == x86_64` -> `x64` and `uname -m == aarch64` -> `aarch64`;
       # BUILD_DIR mirrors that so the upload step finds the .so.
       BUILD_DIR: ${{ format('bin/linux-{0}-release/search-community', inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
@@ -47,6 +48,7 @@ jobs:
         working-directory: .install
         run: ./install_boost.sh
       - name: Setup sccache
+        if: ${{ env.IS_FORK_PR != 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -55,6 +55,8 @@ jobs:
           s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Build RediSearch
         run: make build LTO=1
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
+          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -113,7 +114,8 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           make micro-benchmarks
       - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Collect results
         env:
           INPUT_ARCHITECTURE: ${{ inputs.architecture }}

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -112,8 +112,6 @@ jobs:
           export HOME=/home/ubuntu
           export PATH="$HOME/.cargo/bin:$PATH"
           make micro-benchmarks
-      - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Collect results
         env:
           INPUT_ARCHITECTURE: ${{ inputs.architecture }}

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -65,6 +65,8 @@ jobs:
     permissions:
       contents: read  # actions/checkout
       id-token: write # OIDC role assumption for sccache S3
+    env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get -y --no-install-recommends install git
@@ -84,6 +86,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Setup sccache
+        if: ${{ env.IS_FORK_PR != 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -112,6 +112,8 @@ jobs:
           export HOME=/home/ubuntu
           export PATH="$HOME/.cargo/bin:$PATH"
           make micro-benchmarks
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Collect results
         env:
           INPUT_ARCHITECTURE: ${{ inputs.architecture }}

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
-          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -114,7 +113,6 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           make micro-benchmarks
       - name: Show sccache stats
-        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Collect results
         env:

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -61,9 +61,6 @@ jobs:
         run: cargo bench --workspace -- --save-baseline master
         working-directory: src/redisearch_rs
 
-      - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats || true
-
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -61,6 +61,9 @@ jobs:
         run: cargo bench --workspace -- --save-baseline master
         working-directory: src/redisearch_rs
 
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
+
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
+          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -62,7 +63,8 @@ jobs:
         working-directory: src/redisearch_rs
 
       - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
 
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
-          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -63,7 +62,6 @@ jobs:
         working-directory: src/redisearch_rs
 
       - name: Show sccache stats
-        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
 
       - name: Upload rust baseline benchmarks for master

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -11,6 +11,7 @@ jobs:
       id-token: write # OIDC role assumption for sccache S3
       actions: read   # dawidd6/action-download-artifact (cross-workflow)
     env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       RUST_BACKTRACE: full
     steps:
       - name: Checkout
@@ -21,6 +22,7 @@ jobs:
         working-directory: .install
         run: ./install_script.sh sudo
       - name: Setup sccache
+        if: ${{ env.IS_FORK_PR != 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -172,9 +172,6 @@ jobs:
             COORD: oss
         run: ${{ env.BUILD_CMD }} && make pack
 
-      - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats || true
-
       - name: Validate glibc version
         if: runner.os == 'Linux' && inputs.platform != 'ubuntu:focal'
         uses: ./.github/actions/validate-glibc-version

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -172,6 +172,9 @@ jobs:
             COORD: oss
         run: ${{ env.BUILD_CMD }} && make pack
 
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
+
       - name: Validate glibc version
         if: runner.os == 'Linux' && inputs.platform != 'ubuntu:focal'
         uses: ./.github/actions/validate-glibc-version

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
+          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -173,7 +174,8 @@ jobs:
         run: ${{ env.BUILD_CMD }} && make pack
 
       - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
 
       - name: Validate glibc version
         if: runner.os == 'Linux' && inputs.platform != 'ubuntu:focal'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -77,6 +77,7 @@ jobs:
       || null }}
 
     env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       VERBOSE: 1 # For logging
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
       LTO: ${{ needs.get-config.outputs.enable_lto }}
@@ -133,6 +134,7 @@ jobs:
           submodules: recursive
           ref: ${{ env.REF }}
       - name: Setup sccache
+        if: ${{ env.IS_FORK_PR != 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -135,7 +135,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
-          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -174,7 +173,6 @@ jobs:
         run: ${{ env.BUILD_CMD }} && make pack
 
       - name: Show sccache stats
-        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
 
       - name: Validate glibc version

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
+          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -158,7 +159,8 @@ jobs:
             exit 1
           fi
       - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Fail if any step failed
         if: |
           steps.lint.outcome == 'failure' ||

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -157,8 +157,6 @@ jobs:
             echo "    cargo hakari generate && cargo hakari manage-deps"
             exit 1
           fi
-      - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Fail if any step failed
         if: |
           steps.lint.outcome == 'failure' ||

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -72,7 +72,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
-          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -159,7 +158,6 @@ jobs:
             exit 1
           fi
       - name: Show sccache stats
-        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Fail if any step failed
         if: |

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -157,6 +157,8 @@ jobs:
             echo "    cargo hakari generate && cargo hakari manage-deps"
             exit 1
           fi
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Fail if any step failed
         if: |
           steps.lint.outcome == 'failure' ||

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -40,6 +40,9 @@ jobs:
         && fromJSON(format('{{"image":"{0}","options":"--user root"}}', needs.build-image.outputs.image))
       || null }}
 
+    env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,6 +73,7 @@ jobs:
             echo "mode=sudo" >> "$GITHUB_OUTPUT"
           fi
       - name: Setup sccache
+        if: ${{ env.IS_FORK_PR != 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -172,6 +172,7 @@ jobs:
       actions: write  # Swatinem/rust-cache read/write of GH cache
 
     env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       # LTO is disabled on coverage and sanitizer tasks
       LTO: ${{ needs.get-config.outputs.enable_lto == '1' && inputs.san == '' && !inputs.coverage && 1 || 0 }}
 
@@ -547,43 +548,43 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (combined)
         if: inputs.coverage && inputs.standalone && inputs.coordinator
-        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
           flags: flow
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.standalone && !inputs.coordinator
-        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
           flags: flow
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && !inputs.standalone && inputs.coordinator
-        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true
           flags: flow
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage && inputs.unit-tests
-        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true
           flags: unit
-          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Stop EC2 runner for self-hosted platforms (always runs if `start-runner` succeeds, to ensure cleanup)

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -282,7 +282,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
-          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -449,7 +448,6 @@ jobs:
         run: make rust-tests
 
       - name: Show sccache stats
-        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
 
       - name: Check test logs folder size

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -281,6 +281,7 @@ jobs:
           echo "Runner Architecture: $RUNNER_ARCH"
           echo "========================"
       - name: Setup sccache
+        if: ${{ env.IS_FORK_PR != 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -448,9 +448,6 @@ jobs:
           ENABLE_ASSERT: 1
         run: make rust-tests
 
-      - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats || true
-
       - name: Check test logs folder size
         if: always()
         run: |

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -282,6 +282,7 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
+          remote-cache-enabled: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           aws-role: ${{ vars.SCCACHE_AWS_ROLE_TO_ASSUME }}
           s3-bucket: ${{ vars.SCCACHE_S3_BUCKET }}
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
@@ -448,7 +449,8 @@ jobs:
         run: make rust-tests
 
       - name: Show sccache stats
-        run: ${SCCACHE_PATH:-sccache} --show-stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
 
       - name: Check test logs folder size
         if: always()
@@ -547,39 +549,43 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (combined)
         if: inputs.coverage && inputs.standalone && inputs.coordinator
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
           flags: flow
-          fail_ci_if_error: true # Fail on upload errors
+          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.standalone && !inputs.coordinator
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
           flags: flow
-          fail_ci_if_error: true # Fail on upload errors
+          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && !inputs.standalone && inputs.coordinator
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true
           flags: flow
-          fail_ci_if_error: true # Fail on upload errors
+          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage && inputs.unit-tests
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true
           flags: unit
-          fail_ci_if_error: true # Fail on upload errors
+          fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Stop EC2 runner for self-hosted platforms (always runs if `start-runner` succeeds, to ensure cleanup)

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -448,6 +448,9 @@ jobs:
           ENABLE_ASSERT: 1
         run: make rust-tests
 
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
+
       - name: Check test logs folder size
         if: always()
         run: |

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -548,7 +548,6 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (combined)
         if: inputs.coverage && inputs.standalone && inputs.coordinator
-        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
@@ -558,7 +557,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.standalone && !inputs.coordinator
-        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_standalone.info
@@ -568,7 +566,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && !inputs.standalone && inputs.coordinator
-        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/flow_coordinator.info
@@ -578,7 +575,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage && inputs.unit-tests
-        continue-on-error: ${{ env.IS_FORK_PR == 'true' }}
         uses: codecov/codecov-action@v6 # NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 RediSearch is a Redis module providing full-text search, secondary indexing, and vector similarity search.
 The codebase is primarily C, with an ongoing effort to port modules to Rust in `src/redisearch_rs/`.
 
+For human contributor instructions, see `CONTRIBUTING.md`. This file is optimized for coding agents and internal automation workflows.
+
 ## Build Commands
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,128 @@
+# Contributing to RediSearch
+
+Thank you for your interest in contributing to RediSearch. This guide explains how to set up the project, follow the repository conventions, submit a pull request, and work through review.
+
+By contributing code to this Redis project in any form, you agree to the Redis Software Grant and Contributor License Agreement in the [Legal](#legal) section below. Contributions are subject to the Redis tri-license under RSALv2, SSPLv1, or AGPLv3 as described in `LICENSE.txt`.
+
+## Before You Start
+
+- Use GitHub issues for bugs and detailed feature requests.
+- Ask general usage questions on the [Redis Discord](https://discord.com/invite/redis) or [Stack Overflow](https://stackoverflow.com/questions/tagged/redis).
+- Report security bugs and vulnerabilities through `SECURITY.md`.
+- For major features or semantic changes, open an issue and discuss the design before investing heavily in code.
+- Documentation-only changes for redis.io documentation usually belong in the [redis-doc](https://github.com/redis/redis-doc) repository.
+
+## Set Up Locally
+
+1. Fork the repository on GitHub.
+2. Clone your fork with submodules:
+
+   ```bash
+   git clone --recursive git@github.com:<your-user>/RediSearch.git
+   cd RediSearch
+   ```
+
+   If you cloned without submodules, initialize them later:
+
+   ```bash
+   git submodule update --init --recursive
+   ```
+
+3. Install platform dependencies. Use the scripts in `.install/`; see `.install/README.md` for platform-specific details. For example:
+
+   ```bash
+   cd .install
+   ./install_script.sh sudo
+   cd ..
+   ```
+
+4. Build RediSearch:
+
+   ```bash
+   ./build.sh
+   ./build.sh DEBUG=1
+   ```
+
+   `DEBUG=1` is recommended while developing. Use `./build.sh FORCE` to rebuild from a clean build state.
+
+5. Rust code lives in `src/redisearch_rs/`. Run Rust workspace commands from that directory unless a command says otherwise.
+
+## Coding Standards
+
+### C and C++
+
+- `.clang-format` at the repository root is the formatting source of truth.
+- Use 2-space indentation, no tabs, and no trailing whitespace.
+- Use `rm_malloc`, `rm_free`, `rm_calloc`, and `rm_realloc` in module code. Do not use raw `malloc` or `free`.
+- Return `REDISMODULE_OK` or `REDISMODULE_ERR` for status-code APIs.
+- Use a `goto cleanup` pattern when a function needs shared cleanup on error paths.
+- Add the required Redis license header to new source files.
+
+### Rust
+
+- Rust code uses edition 2024.
+- Document every `unsafe` block with a `// SAFETY:` comment.
+- Prefer `#[expect(...)]` over `#[allow(...)]` for lint suppressions.
+- Use `tracing` macros such as `debug!`, `info!`, `warn!`, and `error!` for logging.
+- If Rust/C FFI headers or generated files change, commit the generated outputs with the source change.
+
+## Branch and Pull Request Workflow
+
+1. Create a topic branch in your fork:
+
+   ```bash
+   git checkout -b fix-short-description
+   ```
+
+2. Keep pull requests focused on one bug fix, feature, or cleanup.
+3. Push your branch to your fork and open a pull request against `RediSearch/RediSearch:master`.
+4. Fill out the pull request template. Include:
+   - the current behavior or problem,
+   - the change you made,
+   - the expected outcome,
+   - the main files or subsystems changed.
+5. Exactly one release-notes checkbox must be checked. CI enforces this.
+6. After review begins, address comments with follow-up commits. Do not force-push or rewrite history unless a maintainer asks you to.
+
+## Testing Requirements
+
+Run the tests that match the area you changed. Useful commands include:
+
+```bash
+./build.sh RUN_UNIT_TESTS
+./build.sh RUN_UNIT_TESTS TEST=unit_test_name
+./build.sh RUN_UNIT_TESTS SAN=address
+./build.sh RUN_PYTEST
+./build.sh RUN_PYTEST TEST=<file>
+./build.sh RUN_PYTEST TEST=<file>:<function>
+```
+
+For Rust tests:
+
+```bash
+cd src/redisearch_rs
+cargo nextest run
+cargo nextest run -p <crate_name>
+```
+
+Coverage runs in CI when selected by the pull request matrix. Contributors usually do not need to upload coverage locally.
+
+## CI for Fork Pull Requests
+
+Fork pull requests run on the regular `pull_request` event. They do not use Redis-owned sccache credentials or cache storage. Codecov upload is non-blocking for fork pull requests, but build, test, sanitizer, and coverage job failures still matter and may need to be fixed before merge.
+
+## Review Process
+
+Maintainers review pull requests for correctness, tests, documentation, compatibility, and release-note needs. CI must pass before merge. Reviews and merges may take time because maintainers prioritize work across bugs, releases, and community contributions.
+
+If a maintainer asks for changes, push follow-up commits to the same branch. GitHub will update the pull request automatically.
+
+## Legal
+
 By contributing code to the Redis project in any form you agree to the Redis Software Grant and Contributor License Agreement attached below. Only contributions made under the Redis Software Grant and Contributor License Agreement may be accepted by Redis, and any contribution is subject to the terms of the Redis tri-license under RSALv2/SSPLv1/AGPLv3 as described in the LICENSE.txt file included in the Redis source distribution.
 
 REDIS SOFTWARE GRANT AND CONTRIBUTOR LICENSE AGREEMENT
+
 To specify the intellectual property license granted in any Contribution, Redis Ltd., ("Redis") requires a Software Grant and Contributor License Agreement ("Agreement"). This Agreement is for your protection as a contributor as well as the protection of Redis and its users; it does not change your rights to use your own Contribution for any other purpose permitted by this Agreement.
 
 By making any Contribution, You accept and agree to the following terms and conditions for the Contribution. Except for the license granted in this Agreement to Redis and the recipients of the software distributed by Redis, You reserve all right, title, and interest in and to Your Contribution.
@@ -23,37 +145,4 @@ Disclaimer. You are not expected to provide support for Your Contribution, excep
 
 Enforceability. Nothing in this Agreement will be construed as creating any joint venture, employment relationship, or partnership between You and Redis. If any provision of this Agreement is held to be unenforceable, the remaining provisions of this Agreement will not be affected. This represents the entire agreement between You and Redis relating to the Contribution.
 
-IMPORTANT: HOW TO USE REDIS GITHUB ISSUES
-GitHub issues SHOULD ONLY BE USED to report bugs and for DETAILED feature requests. Everything else should be asked on Discord:
-
-https://discord.com/invite/redis
-PLEASE DO NOT POST GENERAL QUESTIONS that are not about bugs or suspected bugs in the GitHub issues system. We'll be delighted to help you and provide all the support on Discord.
-
-There is also an active community of Redis users at Stack Overflow:
-
-https://stackoverflow.com/questions/tagged/redis
-Issues and pull requests for documentation belong on the redis-doc repo:
-
-https://github.com/redis/redis-doc
-If you are reporting a security bug or vulnerability, see SECURITY.md.
-
-How to provide a patch for a new feature
-If it is a major feature or a semantical change, please don't start coding straight away: if your feature is not a conceptual fit you'll lose a lot of time writing the code without any reason. Start by posting in the mailing list and creating an issue at Github with the description of, exactly, what you want to accomplish and why. Use cases are important for features to be accepted. Here you can see if there is consensus about your idea.
-
-If in step 1 you get an acknowledgment from the project leaders, use the following procedure to submit a patch:
-
-a. Fork Redis on GitHub ( https://docs.github.com/en/github/getting-started-with-github/fork-a-repo ) 
-
-b. Create a topic branch (git checkout -b my_branch) 
-
-c. Push to your branch (git push origin my_branch)
-
-d. Initiate a pull request on GitHub ( https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request ) 
-
-e. Done :)
-
-Keep in mind that we are very overloaded, so issues and PRs sometimes wait for a very long time. However this is not a lack of interest, as the project gets more and more users, we find ourselves in a constant need to prioritize certain issues/PRs over others. If you think your issue/PR is very important, try to popularize it, have other users commenting and sharing their point of view, and so forth. This helps.
-
-For minor fixes - open a pull request on GitHub.
-
-Additional information on the RSALv2/SSPLv1/AGPLv3 tri-license is also found in the LICENSE.txt file.
+Additional information on the RSALv2, SSPLv1, and AGPLv3 tri-license is in `LICENSE.txt`.


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Community fork PRs could not reliably run validation because CI depended on Redis-owned cache credentials/storage, and `CONTRIBUTING.md` did not give external contributors a practical setup, testing, PR, and review guide.
2. Change: Keep validation on `pull_request`, skip Redis-owned sccache setup for fork PRs, keep Codecov upload non-blocking for fork PRs, and expand the contributor documentation while preserving the Redis Software Grant / Contributor License Agreement.
3. Outcome: Community contributors can open fork PRs with tests, sanitizer, and coverage validation, and can follow repository-level contribution instructions.

#### Which additional issues this PR fixes
1. MOD-15810

#### Main objects this PR modified
1. `.github/actions/setup-sccache/action.yml`
2. `.github/workflows/task-test.yml`
3. `CONTRIBUTING.md`
4. `AGENTS.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Validation:
- Parsed the modified YAML files with PyYAML.
- Ran `git diff --check`.
- Inspected `CONTRIBUTING.md` for MOD-15810 coverage: local setup, coding standards, branch/PR workflow, testing including coverage, and review process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate CI-behavior changes across multiple workflows (credential assumption, caching, and coverage upload gating) could impact build performance or reporting if conditions are mis-evaluated, but do not affect runtime product code.
> 
> **Overview**
> Improves fork PR reliability by making `setup-sccache` *optional* and best-effort: AWS role/S3 inputs are no longer required, AWS credential setup is conditional and `continue-on-error`, and S3 env vars are only exported when OIDC succeeds.
> 
> Updates multiple GitHub workflows to detect fork PRs (`IS_FORK_PR`) and **skip Redis-owned sccache configuration** in that case; `sccache --show-stats` is now non-fatal (`|| true`) to avoid failing jobs when sccache isn’t available.
> 
> Makes Codecov uploads non-blocking for fork PRs (`fail_ci_if_error` gated by `IS_FORK_PR`) and expands `CONTRIBUTING.md`/`AGENTS.md` to provide clearer external contributor setup, standards, and CI expectations while preserving the legal agreement text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52fb7c20b2f057972de8d7194a38498f9f6b61a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->