### PR TITLE
CI: Add release notes checkboxes to release bump PRs

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -142,9 +142,18 @@ jobs:
           if [[ "$GITHUB_ACTOR" != *"[bot]" ]]; then
             REVIEWERS="$REVIEWERS,$GITHUB_ACTOR"
           fi
+          PR_BODY_FILE="$(mktemp)"
+          cat > "$PR_BODY_FILE" <<EOF
+          This PR was automatically created by the release workflow of $RELEASE_TAG.
+
+          #### Release Notes
+
+          - [ ] This PR requires release notes
+          - [x] This PR does not require release notes
+          EOF
           gh pr create \
             --title    "Bump version from $CUR_VERSION to $NEXT_VERSION" \
-            --body     "This PR was automatically created by the release workflow of $RELEASE_TAG." \
+            --body-file "$PR_BODY_FILE" \
             --head     "$BRANCH" \
             --base     "$RELEASE_BRANCH" \
             --reviewer "$REVIEWERS" \


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The release workflow creates automatic post-release version bump PRs with a short body that omits the release notes checkboxes required by CI.
2. Change: Generate the automatic bump PR body through a temporary file and include the required release notes checkbox pair.
3. Outcome: Future release workflow-created version bump PRs can satisfy the release notes check without manual PR body edits.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `.github/workflows/event-release.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that affects the text/content of automatically created PRs. Main risk is formatting/escaping issues in the generated body file causing `gh pr create` to fail.
> 
> **Overview**
> The release workflow now generates the version-bump PR description via a temporary `--body-file` and includes the standard **Release Notes** checkbox pair, instead of using a single-line `--body`.
> 
> This ensures workflow-created bump PRs satisfy CI expectations without manual edits, while keeping reviewer selection behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad5dbb3fb03bef442eddbbd4e53a52057561f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->