### PR TITLE
enable legacy RDB load for Disk

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -852,10 +852,11 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     RedisModule_Log(RSDummyContext, "notice", "Loading RDB event ended");
     break;
   case REDISMODULE_SUBEVENT_LOADING_ENDED:
-    if (!SearchDisk_IsEnabled()) {
-      // This only handles legacy indices that are not available in disk
-      Indexes_EndRDBLoadingEvent(ctx);
-    } else if (useSst) {
+    if (!useSst) {
+      Indexes_EndRDBLoadingEvent(ctx, useSst);
+    }
+    if (useSst) {
+      RS_ASSERT(SearchDisk_IsEnabled());
       RedisModule_Log(RSDummyContext, "notice", "Loading event ended (SST + RDB ready). Finish loading");
       Indexes_FinishSSTReplication(ctx);
     }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -853,7 +853,9 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     break;
   case REDISMODULE_SUBEVENT_LOADING_ENDED:
     if (!useSst) {
-      Indexes_EndRDBLoadingEvent(ctx, useSst);
+      // SST replication only carries v25+ payloads, so legacy upgrade only
+      // runs on the non-SST path.
+      Indexes_FinishLegacyRDBLoad(ctx);
     }
     if (useSst) {
       RS_ASSERT(SearchDisk_IsEnabled());

--- a/src/spec.c
+++ b/src/spec.c
@@ -1780,6 +1780,57 @@ static void IndexSpec_EnsureTagDiskIndexes(IndexSpec *sp) {
   }
 }
 
+// Open the disk handle for an RDB-loaded spec, populate vector/tag disk state,
+// and register with disk. On failure sp->diskSpec is left NULL and the caller
+// must handle teardown. Used by the non-SST RDB load path and by the legacy
+// upgrade — not by FT.CREATE, which opens the disk handle earlier (before
+// field parsing).
+static bool IndexSpec_OpenDiskFromRdb(RedisModuleCtx *ctx, IndexSpec *sp) {
+  sp->diskSpec = SearchDisk_OpenIndex(ctx, sp->specName, sp->obfuscatedName,
+                                      sp->rule->type, false);
+  if (!sp->diskSpec) return false;
+  IndexSpec_PopulateVectorDiskParams(sp);
+  IndexSpec_EnsureTagDiskIndexes(sp);
+  SearchDisk_RegisterIndex(ctx, sp);
+  return true;
+}
+
+// Forward declaration: defined later in the RDB save/load section.
+static void IndexScoringStats_RdbLoad(RedisModuleIO *rdb, ScoringIndexStats *stats, int encver);
+
+// Consume the SST-flow disk payload from the RDB and stash it on the spec.
+//
+// The SST save flow writes the scoring stats, the terms trie, and a
+// disk-RDB blob (max_doc_id, deleted_ids) right after the schema. We always
+// consume the bytes — even for duplicates — so the RDB stream stays aligned.
+// The disk blob is stashed in sp->pendingDiskRdbState and consumed later by
+// Indexes_FinishSSTReplication at LOADING_SST_ENDED, or freed by the spec
+// destructor on the duplicate / cleanup / abort paths.
+//
+// Returns false if the disk-RDB blob could not be parsed; the terms-trie
+// failure path is fatal (RS_LOG_ASSERT) since a missing trie means an
+// already-corrupt stream.
+static bool IndexSpec_LoadStateFromRdb(RedisModuleCtx *ctx, IndexSpec *sp,
+                                          RedisModuleIO *rdb, int encver) {
+  RS_ASSERT(encver >= INDEX_DISK_VERSION);
+  RS_ASSERT(disk_db);
+
+  IndexScoringStats_RdbLoad(rdb, &sp->stats.scoring, encver);
+  if (sp->terms) {
+    TrieType_Free(sp->terms);
+  }
+  sp->terms = TrieType_GenericLoad(rdb, false, true);
+  RS_LOG_ASSERT(sp->terms, "SST replication: Failed to load terms trie");
+
+  sp->pendingDiskRdbState = SearchDisk_LoadRdbToTempObject(rdb);
+  if (!sp->pendingDiskRdbState) {
+    RedisModule_Log(ctx, "error",
+                    "SST replication: Failed to load disk index data for spec from RDB");
+    return false;
+  }
+  return true;
+}
+
 void handleBadArguments(IndexSpec *spec, const char *badarg, QueryError *status, ACArgSpec *non_flex_argopts) {
   if (isSpecOnDiskForValidation(spec)) {
     bool isKnownArg = false;
@@ -3301,7 +3352,11 @@ void IndexSpec_DropLegacyIndexFromKeySpace(IndexSpec *sp) {
   HiddenString_LegacyDropFromKeySpace(ctx.redisCtx, INDEX_SPEC_KEY_FMT, sp->specName);
 }
 
-void Indexes_UpgradeLegacyIndexes() {
+void Indexes_UpgradeLegacyIndexes(RedisModuleCtx *ctx, bool useSst) {
+  // SST replication only carries v25+ payloads, so reaching here means there
+  // can't be any legacy specs staged for an SST flow.
+  RS_ASSERT(!useSst || dictSize(legacySpecDict) == 0);
+
   dictIterator *iter = dictGetIterator(legacySpecDict);
   dictEntry *entry = NULL;
   while ((entry = dictNext(iter))) {
@@ -3311,12 +3366,30 @@ void Indexes_UpgradeLegacyIndexes() {
 
     // recreate the doctable
     DocTable_Free(&sp->docs);
-    sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
+    if (!isSpecOnDisk(sp)) {
+      sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
+    }
 
     // clear index stats
     memset(&sp->stats, 0, sizeof(sp->stats));
     // Init the index error
     sp->stats.indexError = IndexError_Init();
+
+    // On disk, open the empty disk index so the subsequent keyspace reindex
+    // routes documents through the disk pipeline. Legacy RDB carries no disk
+    // state, so this mirrors the non-SST disk-open path in IndexSpec_RdbLoad.
+    if (isSpecOnDisk(sp)) {
+      RS_ASSERT(!sp->isDuplicate);
+      bool opened = IndexSpec_OpenDiskFromRdb(ctx, sp);
+      RS_LOG_ASSERT(opened,
+                    "Legacy upgrade: failed to open disk index for spec");
+      if (opened) {
+        IndexSpec_StartGC(spec_ref, sp, GCPolicy_Disk);
+      } else {
+        RedisModule_Log(ctx, "error",
+          "Legacy upgrade: failed to open disk index for spec");
+      }
+    }
 
     // put the new index in the global spec dictionaries (by name and by specId)
     dictAdd(specDict_g, (void*)sp->specName, spec_ref.rm);
@@ -3513,37 +3586,18 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
   }
 
   if (isSpecOnDisk(sp) && useSst) {
-    // Load the disk-related index data if we are on disk and the save flow used
-    // sst-files. We load it into a temporary in-memory object first, then use it
-    // to open the index with the RDB state applied.
-    // We must always consume the RDB data to avoid corrupting the stream,
-    // even for duplicates. We just won't use it in the duplicate case.
-    RS_ASSERT(encver >= INDEX_DISK_VERSION);
-    RS_ASSERT(disk_db);
-    IndexScoringStats_RdbLoad(rdb, &sp->stats.scoring, encver);
-    if (sp->terms) {
-      TrieType_Free(sp->terms);
-    }
-    sp->terms = TrieType_GenericLoad(rdb, false, true);
-    RS_LOG_ASSERT(sp->terms, "Failed to load terms trie");
-
-    // Load disk metadata (max_doc_id, deleted_ids) into the spec. Stashed
-    // here directly; consumed at LOADING_SST_ENDED (SST flow) or freed by
-    // the spec destructor (duplicate / cleanup / abort).
-    sp->pendingDiskRdbState = SearchDisk_LoadRdbToTempObject(rdb);
-    if (!sp->pendingDiskRdbState) {
+    if (!IndexSpec_LoadStateFromRdb(ctx, sp, rdb, encver)) {
       goto cleanup;
     }
   } else if (isSpecOnDisk(sp) && !sp->isDuplicate) {
     // If the regular RDB method is used, just open an Index without any populated data.
     RS_ASSERT(!useSst);
-    sp->diskSpec = SearchDisk_OpenIndex(ctx, sp->specName, sp->obfuscatedName, sp->rule->type, false);
-    if (!sp->diskSpec) {
+    bool opened = IndexSpec_OpenDiskFromRdb(ctx, sp);
+    RS_LOG_ASSERT(opened, "RDB load: Failed to open disk index for spec");
+    if (!opened) {
+      RedisModule_Log(ctx, "error", "RDB load: Failed to open disk index for spec");
       goto cleanup;
     }
-    IndexSpec_PopulateVectorDiskParams(sp);
-    IndexSpec_EnsureTagDiskIndexes(sp);
-    SearchDisk_RegisterIndex(ctx, sp);
   }
 
   return sp;
@@ -3618,7 +3672,9 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver < LEGACY_INDEX_MIN_VERSION || encver > LEGACY_INDEX_MAX_VERSION) {
     return NULL;
   }
-  RS_LOG_ASSERT(!SearchDisk_IsEnabled(), "Legacy indexes are not supported on disk");
+  // SST replication only happens between v25+ peers, so legacy + SST is impossible.
+  RS_LOG_ASSERT(!IS_SST_RDB_IN_PROCESS(RedisModule_GetContextFromIO(rdb)),
+                "Legacy indexes cannot arrive via SST replication");
   char *legacyName = RedisModule_LoadStringBuffer(rdb, NULL);
 
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
@@ -3744,7 +3800,12 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
     return NULL;
   }
 
-  IndexSpec_StartGC(spec_ref, sp, GCPolicy_Fork);
+  // Fork GC is for memory-mode specs only. On disk-enabled instances the
+  // disk GC is started later from Indexes_UpgradeLegacyIndexes, once diskSpec
+  // is opened.
+  if (!SearchDisk_IsEnabled()) {
+    IndexSpec_StartGC(spec_ref, sp, GCPolicy_Fork);
+  }
   Cursors_initSpec(sp);
 
   dictAdd(legacySpecDict, (void*)sp->specName, spec_ref.rm);
@@ -4673,19 +4734,17 @@ static inline void DebugIndexesScanner_pauseCheck(DebugIndexesScanner* dScanner,
 
 void Indexes_StartRDBLoadingEvent(RedisModuleCtx* ctx) {
   Indexes_Free(ctx, specDict_g, false);
-  if (!SearchDisk_IsEnabled()) {
-    if (legacySpecDict) {
-      dictEmpty(legacySpecDict, NULL);
-    } else {
-      legacySpecDict = dictCreate(&dictTypeHeapHiddenStrings, NULL);
-    }
+  if (legacySpecDict) {
+    dictEmpty(legacySpecDict, NULL);
+  } else {
+    legacySpecDict = dictCreate(&dictTypeHeapHiddenStrings, NULL);
   }
   g_isLoading = true;
 }
 
-void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx) {
+void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx, bool useSst) {
   int hasLegacyIndexes = dictSize(legacySpecDict);
-  Indexes_UpgradeLegacyIndexes();
+  Indexes_UpgradeLegacyIndexes(ctx, useSst);
 
   // we do not need the legacy dict specs anymore
   dictRelease(legacySpecDict);

--- a/src/spec.c
+++ b/src/spec.c
@@ -3352,11 +3352,7 @@ void IndexSpec_DropLegacyIndexFromKeySpace(IndexSpec *sp) {
   HiddenString_LegacyDropFromKeySpace(ctx.redisCtx, INDEX_SPEC_KEY_FMT, sp->specName);
 }
 
-void Indexes_UpgradeLegacyIndexes(RedisModuleCtx *ctx, bool useSst) {
-  // SST replication only carries v25+ payloads, so reaching here means there
-  // can't be any legacy specs staged for an SST flow.
-  RS_ASSERT(!useSst || dictSize(legacySpecDict) == 0);
-
+void Indexes_UpgradeLegacyIndexes(RedisModuleCtx *ctx) {
   dictIterator *iter = dictGetIterator(legacySpecDict);
   dictEntry *entry = NULL;
   while ((entry = dictNext(iter))) {
@@ -3364,11 +3360,12 @@ void Indexes_UpgradeLegacyIndexes(RedisModuleCtx *ctx, bool useSst) {
     IndexSpec *sp = StrongRef_Get(spec_ref);
     IndexSpec_DropLegacyIndexFromKeySpace(sp);
 
-    // recreate the doctable
+    // Recreate the doctable. Always allocate a fresh empty one — even for disk
+    // specs — so IndexSpec_FreeUnlinkedData's later DocTable_Free sees a valid
+    // struct. Leaving sp->docs zeroed-out-after-free would cause a UAF on the
+    // dangling buckets and a double-free of the DocIdMap TrieMap.
     DocTable_Free(&sp->docs);
-    if (!isSpecOnDisk(sp)) {
-      sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
-    }
+    sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
 
     // clear index stats
     memset(&sp->stats, 0, sizeof(sp->stats));
@@ -4742,9 +4739,9 @@ void Indexes_StartRDBLoadingEvent(RedisModuleCtx* ctx) {
   g_isLoading = true;
 }
 
-void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx, bool useSst) {
+void Indexes_FinishLegacyRDBLoad(RedisModuleCtx *ctx) {
   int hasLegacyIndexes = dictSize(legacySpecDict);
-  Indexes_UpgradeLegacyIndexes(ctx, useSst);
+  Indexes_UpgradeLegacyIndexes(ctx);
 
   // we do not need the legacy dict specs anymore
   dictRelease(legacySpecDict);
@@ -4752,7 +4749,8 @@ void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx, bool useSst) {
 
   LegacySchemaRulesArgs_Free(ctx);
 
-  if (hasLegacyIndexes) {
+  if (hasLegacyIndexes && !SearchDisk_IsEnabled()) {
+    // TODO: SearchDisk does not yet support Scan And reindex
     Indexes_ScanAndReindex();
   }
 }

--- a/src/spec.h
+++ b/src/spec.h
@@ -793,7 +793,7 @@ void IndexSpecRef_Release(StrongRef ref);
 void Indexes_StartRDBLoadingEvent(RedisModuleCtx *ctx);
 
 // This function is called in case the server ends RDB loading.
-void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx);
+void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx, bool useSst);
 
 // This function is to be called when loading finishes (failed or not)
 void Indexes_EndLoading();

--- a/src/spec.h
+++ b/src/spec.h
@@ -792,8 +792,9 @@ void IndexSpecRef_Release(StrongRef ref);
 // This function is called in case the server starts RDB loading.
 void Indexes_StartRDBLoadingEvent(RedisModuleCtx *ctx);
 
-// This function is called in case the server ends RDB loading.
-void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx, bool useSst);
+// Called at the end of legacy (pre-v25) RDB loading to upgrade staged legacy
+// specs into the current spec format and trigger a keyspace reindex.
+void Indexes_FinishLegacyRDBLoad(RedisModuleCtx *ctx);
 
 // This function is to be called when loading finishes (failed or not)
 void Indexes_EndLoading();


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Legacy RDB load (encver < 25) hard-asserted `!SearchDisk_IsEnabled()`, so a disk-enabled instance could not load an older RDB. `legacySpecDict` was only allocated in memory mode, and the LOADING_ENDED handler routed legacy upgrade exclusively through the memory path (`!SearchDisk_IsEnabled()`) — there was no provision for the "disk-enabled but non-SST RDB" case.

2. **Change**:
   - Allow legacy RDB load on disk-enabled instances. The blanket `RS_LOG_ASSERT(!SearchDisk_IsEnabled(), …)` in `IndexSpec_LegacyRdbLoad` is replaced with `RS_LOG_ASSERT(!IS_SST_RDB_IN_PROCESS(...))` — the only truly impossible combination is *legacy + SST replication*, since SST only happens between v25+ peers.
   - `legacySpecDict` is now created in `Indexes_StartRDBLoadingEvent` unconditionally — disk-enabled servers also need it to stage legacy specs during load.
   - In `IndexSpec_LegacyRdbLoad`, the eager `IndexSpec_StartGC(GCPolicy_Fork)` is gated on `!SearchDisk_IsEnabled()`. On disk, GC is deferred and started later with `GCPolicy_Disk` once the disk handle exists.
   - `Indexes_UpgradeLegacyIndexes` now takes `RedisModuleCtx *ctx`. For each upgraded spec on a disk-enabled instance it opens the empty disk index, populates vector/tag disk state, registers it, and starts disk GC. A disk-open failure here is unrecoverable mid-RDB-load, so we `RS_LOG_ASSERT` rather than try to partially recover.
   - The doctable is now **always** reallocated after `DocTable_Free`, including on disk. The previous `if (!isSpecOnDisk(sp))` guard left `sp->docs` with dangling buckets and a non-zero `cap` — the subsequent `DocTable_Free` in `IndexSpec_FreeUnlinkedData` would have caused a use-after-free over the freed bucket array and a double-free of the `DocIdMap` TrieMap. Fixed.
   - `notifications.c` LOADING_ENDED branching switches from `!SearchDisk_IsEnabled()` to `!useSst`. The legacy-upgrade hook is now called on every non-SST path (memory **and** disk); only the SST path goes through `Indexes_FinishSSTReplication`.
   - The legacy-upgrade hook was renamed `Indexes_EndRDBLoadingEvent` → `Indexes_FinishLegacyRDBLoad` and lost its unused `useSst` parameter — every line of its body is legacy-specific (`Indexes_UpgradeLegacyIndexes`, `legacySpecDict` teardown, `LegacySchemaRulesArgs_Free`, legacy-only reindex), so the old name was misleading.
   - Two helpers extracted to dedupe the disk-RDB handshake:
     - `IndexSpec_OpenDiskFromRdb(ctx, sp)` — opens disk handle, populates vector/tag disk state, registers. Used by the non-SST RDB path and the legacy upgrade.
     - `IndexSpec_LoadStateFromRdb(ctx, sp, rdb, encver)` — consumes the SST-flow payload (scoring stats, terms trie, disk-RDB blob into `pendingDiskRdbState`) at RDB-load time, leaving the disk-open work to `Indexes_FinishSSTReplication` at LOADING_SST_ENDED.
   - `Indexes_ScanAndReindex` is now gated on `!SearchDisk_IsEnabled()` with a `TODO` — SearchDisk does not yet support the scan-and-reindex pipeline, so legacy-upgrade on disk leaves the empty disk index unpopulated for now. Memory-mode behavior is unchanged.

3. **Outcome**: A disk-enabled instance can now load a pre-v25 RDB without tripping the legacy assertion. Legacy specs are upgraded into `specDict_g` and their empty disk indexes are opened and registered. Memory-mode legacy upgrade still triggers `Indexes_ScanAndReindex` to repopulate from the keyspace; the disk-mode reindex is a follow-up. SST and memory paths are unchanged in behavior; the SST + legacy combination is now explicitly asserted impossible.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. `src/spec.c` — `IndexSpec_LegacyRdbLoad`, `Indexes_UpgradeLegacyIndexes`, `Indexes_StartRDBLoadingEvent`, `Indexes_FinishLegacyRDBLoad` (renamed), new `IndexSpec_OpenDiskFromRdb` and `IndexSpec_LoadStateFromRdb` helpers, DocTable double-free fix in legacy upgrade
2. `src/spec.h` — `Indexes_EndRDBLoadingEvent` renamed to `Indexes_FinishLegacyRDBLoad`, no `useSst` parameter
3. `src/notifications.c` — `RDB_LoadingEvent` LOADING_ENDED branch keyed on `useSst` instead of `SearchDisk_IsEnabled()`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Release note: disk-enabled (Flex) Redis instances can now upgrade from a pre-v25 RDB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB loading/upgrade paths and disk-index initialization, which can affect startup/replication behavior and has failure-mode implications if disk handles or staged state are mishandled.
> 
> **Overview**
> Allows disk-enabled servers to **load pre-v25 (legacy) RDB specs** by staging them in `legacySpecDict`, upgrading them at `LOADING_ENDED`, and (for disk specs) opening/registering an empty disk index. Memory-mode legacy upgrade still triggers a keyspace reindex to repopulate from the keyspace; the disk-mode reindex is deferred to a follow-up.
> 
> Refactors RDB-load disk handling by extracting `IndexSpec_OpenDiskFromRdb` (shared non-SST disk-open/registration logic) and `IndexSpec_LoadStateFromRdb` (consume/stash SST-flow payload), and updates the loading-event routing to run legacy-upgrade on the *non-SST* path while keeping SST completion handled by `Indexes_FinishSSTReplication`. Also fixes a DocTable double-free in the legacy-upgrade disk path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20dba3fd2b0c5da05ab3ea29ba688cee1795020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
