### PR TITLE
[MOD-15300] Simplify mixed coordinator burst test

### DIFF
--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -28,9 +28,40 @@ def _build_mixed_burst_commands():
     return [search] * RQ_CAPACITY + [aggregate] * COORDINATOR_POOL_SIZE
 
 
-def _run_burst_command(env, conn, command, start_barrier, exceptions, completed, lock):
+def _new_burst_state():
+    return {
+        'ready': 0,
+        'started': 0,
+        'completed': 0,
+        'ready_by_type': {'FT.SEARCH': 0, 'FT.AGGREGATE': 0},
+        'started_by_type': {'FT.SEARCH': 0, 'FT.AGGREGATE': 0},
+        'completed_by_type': {'FT.SEARCH': 0, 'FT.AGGREGATE': 0},
+    }
+
+
+def _snapshot_burst_state(burst_state, lock):
+    with lock:
+        return {
+            'ready': burst_state['ready'],
+            'started': burst_state['started'],
+            'completed': burst_state['completed'],
+            'ready_by_type': burst_state['ready_by_type'].copy(),
+            'started_by_type': burst_state['started_by_type'].copy(),
+            'completed_by_type': burst_state['completed_by_type'].copy(),
+        }
+
+
+def _increment_burst_state(burst_state, lock, field, command):
+    with lock:
+        burst_state[field] += 1
+        burst_state[f'{field}_by_type'][command[0]] += 1
+
+
+def _run_burst_command(env, conn, command, start_barrier, exceptions, burst_state, lock):
     try:
+        _increment_burst_state(burst_state, lock, 'ready', command)
         start_barrier.wait(timeout=20)
+        _increment_burst_state(burst_state, lock, 'started', command)
         res = conn.execute_command(*command)
         if command[0] == 'FT.SEARCH':
             env.assertEqual(res, expected_search_res)
@@ -40,11 +71,16 @@ def _run_burst_command(env, conn, command, start_barrier, exceptions, completed,
         with lock:
             exceptions.append(f'{command}: {exc}')
     finally:
-        with lock:
-            completed[0] += 1
+        _increment_burst_state(burst_state, lock, 'completed', command)
 
 
-def _coordinator_reached_rq_limit(env, coord_initial_jobs_done, coord_initial_pending_jobs, completed):
+def _burst_threads_ready(commands, burst_state, lock):
+    state = _snapshot_burst_state(burst_state, lock)
+    return state['ready'] == len(commands), {'burst_state': state, 'total': len(commands)}
+
+
+def _coordinator_reached_rq_limit(env, coord_initial_jobs_done, coord_initial_pending_jobs,
+                                  burst_state, lock):
     stats = getCoordThpoolStats(env)
     jobs_done_delta = stats['totalJobsDone'] - coord_initial_jobs_done
     pending_jobs_delta = stats['totalPendingJobs'] - coord_initial_pending_jobs
@@ -55,7 +91,7 @@ def _coordinator_reached_rq_limit(env, coord_initial_jobs_done, coord_initial_pe
         'jobs_done_delta': jobs_done_delta,
         'pending_jobs_delta': pending_jobs_delta,
         'jobs_seen_delta': jobs_seen_delta,
-        'completed': completed[0],
+        'burst_state': _snapshot_burst_state(burst_state, lock),
     }
 
 
@@ -65,18 +101,20 @@ def _shards_started_draining(env, shard_initial_jobs_done):
     return done, {'current_jobs_done': current, 'initial_jobs_done': shard_initial_jobs_done}
 
 
-def _burst_completed(commands, completed, exceptions):
-    return completed[0] == len(commands), {
-        'completed': completed[0],
+def _burst_completed(commands, burst_state, lock, exceptions):
+    state = _snapshot_burst_state(burst_state, lock)
+    return state['completed'] == len(commands), {
+        'burst_state': state,
         'total': len(commands),
         'exceptions': exceptions,
     }
 
 
 def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pending_jobs,
-                       shard_initial_jobs_done, completed):
+                       shard_initial_jobs_done, burst_state, lock):
     coord_current_stats = getCoordThpoolStats(env)
     shard_current_jobs_done = [stats['totalJobsDone'] for stats in getWorkersThpoolStatsFromAllShards(env)]
+    burst_state_snapshot = _snapshot_burst_state(burst_state, lock)
     env.debugPrint('-' * 80, force=True)
     env.debugPrint(
         f'[{label}] '
@@ -85,7 +123,7 @@ def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pendin
         f'shard_initial_jobs_done={shard_initial_jobs_done} '
         f'coord_current_stats={coord_current_stats} '
         f'shard_current_jobs_done={shard_current_jobs_done} '
-        f'completed={completed[0]}',
+        f'burst_state={burst_state_snapshot}',
         force=True,
     )
 
@@ -124,7 +162,7 @@ def test_search_and_aggregate_burst():
     commands = _build_mixed_burst_commands()
     connections = [getConnectionByEnv(env) for _ in commands]
     exceptions = []
-    completed = [0]
+    burst_state = _new_burst_state()
     lock = threading.Lock()
     threads = []
     start_barrier = threading.Barrier(len(commands) + 1)
@@ -140,7 +178,8 @@ def test_search_and_aggregate_burst():
         coord_initial_jobs_done,
         coord_initial_pending_jobs,
         shard_initial_jobs_done,
-        completed,
+        burst_state,
+        lock,
     )
 
     verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'PAUSE')
@@ -149,12 +188,18 @@ def test_search_and_aggregate_burst():
         for i, (conn, command) in enumerate(zip(connections, commands)):
             thread = threading.Thread(
                 target=_run_burst_command,
-                args=(env, conn, command, start_barrier, exceptions, completed, lock),
+                args=(env, conn, command, start_barrier, exceptions, burst_state, lock),
                 name=f'search-and-aggregate-burst-query-{i}',
                 daemon=True,
             )
             thread.start()
             threads.append(thread)
+
+        wait_for_condition(
+            lambda: _burst_threads_ready(commands, burst_state, lock),
+            'Timeout waiting for burst threads to reach the launch barrier',
+            timeout=20,
+        )
 
         start_barrier.wait(timeout=20)
 
@@ -163,7 +208,8 @@ def test_search_and_aggregate_burst():
                 env,
                 coord_initial_jobs_done,
                 coord_initial_pending_jobs,
-                completed,
+                burst_state,
+                lock,
             ),
             'Timeout waiting for coordinator to reach the RQ saturation threshold',
             timeout=20,
@@ -185,11 +231,12 @@ def test_search_and_aggregate_burst():
             coord_initial_jobs_done,
             coord_initial_pending_jobs,
             shard_initial_jobs_done,
-            completed,
+            burst_state,
+            lock,
         )
 
         wait_for_condition(
-            lambda: _burst_completed(commands, completed, exceptions),
+            lambda: _burst_completed(commands, burst_state, lock, exceptions),
             'Timeout waiting for mixed FT.SEARCH/FT.AGGREGATE burst to drain',
             timeout=15,
         )
@@ -200,7 +247,8 @@ def test_search_and_aggregate_burst():
             coord_initial_jobs_done,
             coord_initial_pending_jobs,
             shard_initial_jobs_done,
-            completed,
+            burst_state,
+            lock,
         )
     # Best-effort cleanup: if the happy-path RESUME was skipped by a failure,
     # try to leave shard workers runnable before joining the background threads.

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -28,9 +28,9 @@ def _build_mixed_burst_commands():
     return [search] * RQ_CAPACITY + [aggregate] * COORDINATOR_POOL_SIZE
 
 
-def _run_burst_command(env, command, exceptions, completed, lock):
+def _run_burst_command(env, conn, command, start_barrier, exceptions, completed, lock):
     try:
-        conn = getConnectionByEnv(env)
+        start_barrier.wait(timeout=20)
         res = conn.execute_command(*command)
         if command[0] == 'FT.SEARCH':
             env.assertEqual(res, expected_search_res)
@@ -122,10 +122,12 @@ def test_search_and_aggregate_burst():
     waitForIndex(env, 'idx')
 
     commands = _build_mixed_burst_commands()
+    connections = [getConnectionByEnv(env) for _ in commands]
     exceptions = []
     completed = [0]
     lock = threading.Lock()
     threads = []
+    start_barrier = threading.Barrier(len(commands) + 1)
 
     coord_initial_stats = getCoordThpoolStats(env)
     coord_initial_jobs_done = coord_initial_stats['totalJobsDone']
@@ -144,15 +146,17 @@ def test_search_and_aggregate_burst():
     verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'PAUSE')
 
     try:
-        for i, command in enumerate(commands):
+        for i, (conn, command) in enumerate(zip(connections, commands)):
             thread = threading.Thread(
                 target=_run_burst_command,
-                args=(env, command, exceptions, completed, lock),
+                args=(env, conn, command, start_barrier, exceptions, completed, lock),
                 name=f'search-and-aggregate-burst-query-{i}',
                 daemon=True,
             )
             thread.start()
             threads.append(thread)
+
+        start_barrier.wait(timeout=20)
 
         wait_for_condition(
             lambda: _coordinator_reached_rq_limit(

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -3,6 +3,7 @@ import threading
 
 
 RQ_CAPACITY = 50  # CONN_PER_SHARD=1 and SEARCH_IO_THREADS=1 => 1 * PENDING_FACTOR(50)
+COORDINATOR_POOL_SIZE = 20
 SHARD_COUNT = 3
 WORKER_COUNT = 3
 DOC_COUNT = 240
@@ -24,10 +25,7 @@ expected_aggregate_res = [
                         ]
 
 def _build_mixed_burst_commands():
-    # Intentionally build a 3:1 FT.SEARCH-to-FT.AGGREGATE prefix so the burst
-    # stays mixed while still driving the coordinator into the saturation region,
-    # then continue draining the aggregate-heavy tail.
-    return ([search] * 3 + [aggregate]) * 30 + [aggregate] * 120
+    return [search] * RQ_CAPACITY + [aggregate] * COORDINATOR_POOL_SIZE
 
 
 def _run_burst_command(env, command, exceptions, completed, lock):


### PR DESCRIPTION
## Describe the changes in the pull request

Current: `test_search_and_aggregate_burst` could time out before reaching the intended coordinator state because client connection setup and Python thread startup happened inside the paused-worker window. In the observed CI failure, the observer only saw one coordinator job, so merely reducing the burst size is not enough.

Change: Pre-create the client connections, start every burst thread, and hold them on a barrier before releasing the burst. The burst itself is kept minimal for the scenario: 50 `FT.SEARCH` commands to reach the RQ threshold and 20 `FT.AGGREGATE` commands to occupy the coordinator pool.

The test also records harness-side counters for threads that reached the launch barrier, commands that started after the barrier, and commands that completed, split by `FT.SEARCH` and `FT.AGGREGATE`. These counters are included in timeout/debug state so a future failure can distinguish Python/thread setup issues from Redis/coordinator scheduling issues.

Outcome: The test now observes the intended deadlock-sensitive state: search reducer work can be queued while aggregate jobs occupy the coordinator pool, without depending on connection creation or thread startup racing successfully under load.

#### Which additional issues this PR fixes
1. MOD-15300

#### Main objects this PR modified
1. `tests/pytests/test_burst_drains_without_deadlock.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Test plan:
- `CMAKE_ARGS=-DREDISEARCH_GENERATE_HEADERS=OFF REDIS_STANDALONE=0 ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST=test_burst_drains_without_deadlock.py:test_search_and_aggregate_burst`
