### PR TITLE
fix hfe benchmark

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin>=0.12.29
+redisbench_admin @ git+https://github.com/redis-performance/redisbench-admin.git@ce2911b9bd048a0e933fee16e4fb7497cbafda69
 numpy>=2.0.0
 pandas
 requests

--- a/tests/benchmarks/search-hfe-write-read-concurrent.yml
+++ b/tests/benchmarks/search-hfe-write-read-concurrent.yml
@@ -17,7 +17,7 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s"
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s-hfe"
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64

--- a/tests/benchmarks/search-hfe-write-read-concurrent.yml
+++ b/tests/benchmarks/search-hfe-write-read-concurrent.yml
@@ -17,7 +17,7 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s-hfe"
+  - dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s"
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64


### PR DESCRIPTION
## Describe the changes in the pull request

redisbench-admin groups by dataset-name.

The alternative to add read-only would pollute the environment with the other expire.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the benchmark test dependencies by pinning `redisbench_admin` to a specific upstream commit; runtime code paths are unaffected. Risk is limited to potential benchmark behavior changes due to the new dependency version.
> 
> **Overview**
> Updates benchmark dependency resolution by switching `tests/benchmarks/requirements.txt` from a version constraint to a git-pinned `redisbench_admin` commit (`ce2911b...`). This ensures benchmarks run against a known `redisbench-admin` revision, likely aligning dataset grouping/behavior with the expected HFE benchmark setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682eb56c63b81a663fdd0d5562b7dec3079eb695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->