### PR TITLE
MOD-15781: FT.INFO: Make Total Block Count Value Be Per Schema

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1060,10 +1060,7 @@ DEBUG_COMMAND(GCCleanNumeric) {
   }
 
   rv = NumericRangeTree_TrimEmptyLeaves(rt);
-  if (rv.block_count_delta) {
-    __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                       (size_t)rv.block_count_delta, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(&sctx->spec->stats, rv.block_count_delta);
 
 end:
   SearchCtx_Free(sctx);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1060,6 +1060,10 @@ DEBUG_COMMAND(GCCleanNumeric) {
   }
 
   rv = NumericRangeTree_TrimEmptyLeaves(rt);
+  if (rv.block_count_delta) {
+    __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                       (size_t)rv.block_count_delta, __ATOMIC_RELAXED);
+  }
 
 end:
   SearchCtx_Free(sctx);

--- a/src/document.c
+++ b/src/document.c
@@ -600,12 +600,20 @@ FIELD_BULK_INDEXER(numericIndexer) {
     AddResult rv = NumericRangeTree_Add(rt, aCtx->doc->docId, fdata->numeric, false);
     ctx->spec->stats.invertedSize += rv.size_delta;
     ctx->spec->stats.numRecords += rv.num_records_delta;
+    if (rv.block_count_delta) {
+      __atomic_add_fetch(&ctx->spec->stats.totalInvertedIndexBlocks,
+                         (size_t)rv.block_count_delta, __ATOMIC_RELAXED);
+    }
   } else {
     for (uint32_t i = 0; i < array_len(fdata->arrNumeric); ++i) {
       double numval = fdata->arrNumeric[i];
       AddResult rv = NumericRangeTree_Add(rt, aCtx->doc->docId, numval, true);
       ctx->spec->stats.invertedSize += rv.size_delta;
       ctx->spec->stats.numRecords += rv.num_records_delta;
+      if (rv.block_count_delta) {
+        __atomic_add_fetch(&ctx->spec->stats.totalInvertedIndexBlocks,
+                           (size_t)rv.block_count_delta, __ATOMIC_RELAXED);
+      }
     }
   }
 

--- a/src/document.c
+++ b/src/document.c
@@ -600,20 +600,14 @@ FIELD_BULK_INDEXER(numericIndexer) {
     AddResult rv = NumericRangeTree_Add(rt, aCtx->doc->docId, fdata->numeric, false);
     ctx->spec->stats.invertedSize += rv.size_delta;
     ctx->spec->stats.numRecords += rv.num_records_delta;
-    if (rv.block_count_delta) {
-      __atomic_add_fetch(&ctx->spec->stats.totalInvertedIndexBlocks,
-                         (size_t)rv.block_count_delta, __ATOMIC_RELAXED);
-    }
+    IndexStats_BlockCountAdd(&ctx->spec->stats, rv.block_count_delta);
   } else {
     for (uint32_t i = 0; i < array_len(fdata->arrNumeric); ++i) {
       double numval = fdata->arrNumeric[i];
       AddResult rv = NumericRangeTree_Add(rt, aCtx->doc->docId, numval, true);
       ctx->spec->stats.invertedSize += rv.size_delta;
       ctx->spec->stats.numRecords += rv.num_records_delta;
-      if (rv.block_count_delta) {
-        __atomic_add_fetch(&ctx->spec->stats.totalInvertedIndexBlocks,
-                           (size_t)rv.block_count_delta, __ATOMIC_RELAXED);
-      }
+      IndexStats_BlockCountAdd(&ctx->spec->stats, rv.block_count_delta);
     }
   }
 

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -74,17 +74,23 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
 
   idx = sp->existingDocs;
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info, &sp->stats.totalInvertedIndexBlocks);
   delta = NULL;
 
   // We don't count the records that we removed, because we also don't count
   // their addition (they are duplications so we have no such desire).
 
   if (InvertedIndex_NumDocs(idx) == 0) {
-    // inverted index was cleaned entirely, let's free it
+    // inverted index was cleaned entirely, let's free it. Read the per-spec stats off the
+    // index before freeing it — `InvertedIndex_Free` doesn't know about the owning spec.
     info.bytes_freed += InvertedIndex_MemUsage(idx);
+    size_t inv_idx_blocks = InvertedIndex_NumBlocks(idx);
     InvertedIndex_Free(idx);
     sp->existingDocs = NULL;
+    if (inv_idx_blocks > 0) {
+      __atomic_sub_fetch(&sp->stats.totalInvertedIndexBlocks,
+                         inv_idx_blocks, __ATOMIC_RELAXED);
+    }
   }
   FGC_updateStats(gc, sctx, 0, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);
 

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -74,8 +74,12 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
 
   idx = sp->existingDocs;
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info, &sp->stats.totalInvertedIndexBlocks);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
+  if (info.block_count_delta) {
+    __atomic_add_fetch(&sp->stats.totalInvertedIndexBlocks,
+                       (size_t)info.block_count_delta, __ATOMIC_RELAXED);
+  }
 
   // We don't count the records that we removed, because we also don't count
   // their addition (they are duplications so we have no such desire).

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -85,7 +85,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
     // Sample memory and block count before freeing the index — `InvertedIndex_Free`
     // doesn't know about the owning spec.
     info.bytes_freed += InvertedIndex_MemUsage(idx);
-    IndexStats_BlockCountAdd(&sp->stats, -(ptrdiff_t)InvertedIndex_NumBlocks(idx));
+    IndexStats_BlockCountAdd(&sp->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
     InvertedIndex_Free(idx);
     sp->existingDocs = NULL;
   }

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -74,7 +74,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
 
   idx = sp->existingDocs;
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info);
+  InvertedIndex_ApplyGCDelta(idx, delta, &info);
   delta = NULL;
   IndexStats_BlockCountAdd(&sp->stats, info.block_count_delta);
 

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -76,25 +76,18 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
 
   InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
-  if (info.block_count_delta) {
-    __atomic_add_fetch(&sp->stats.totalInvertedIndexBlocks,
-                       (size_t)info.block_count_delta, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(&sp->stats, info.block_count_delta);
 
   // We don't count the records that we removed, because we also don't count
   // their addition (they are duplications so we have no such desire).
 
   if (InvertedIndex_NumDocs(idx) == 0) {
-    // inverted index was cleaned entirely, let's free it. Read the per-spec stats off the
-    // index before freeing it — `InvertedIndex_Free` doesn't know about the owning spec.
+    // Sample memory and block count before freeing the index — `InvertedIndex_Free`
+    // doesn't know about the owning spec.
     info.bytes_freed += InvertedIndex_MemUsage(idx);
-    size_t inv_idx_blocks = InvertedIndex_NumBlocks(idx);
+    IndexStats_BlockCountAdd(&sp->stats, -(ptrdiff_t)InvertedIndex_NumBlocks(idx));
     InvertedIndex_Free(idx);
     sp->existingDocs = NULL;
-    if (inv_idx_blocks > 0) {
-      __atomic_sub_fetch(&sp->stats.totalInvertedIndexBlocks,
-                         inv_idx_blocks, __ATOMIC_RELAXED);
-    }
   }
   FGC_updateStats(gc, sctx, 0, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);
 

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -99,7 +99,7 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     // Sample memory and block count before the destructor callback (InvIndFreeCb) frees
     // the index without spec context.
     info.bytes_freed += InvertedIndex_MemUsage(idx);
-    IndexStats_BlockCountAdd(&sctx->spec->stats, -(ptrdiff_t)InvertedIndex_NumBlocks(idx));
+    IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
     dictDelete(sctx->spec->missingFieldDict, fieldName);
   }
   FGC_updateStats(gc, sctx, info.entries_removed, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -91,7 +91,7 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info);
+  InvertedIndex_ApplyGCDelta(idx, delta, &info);
   delta = NULL;
   IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -93,21 +93,13 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
 
   InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
-  if (info.block_count_delta) {
-    __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                       (size_t)info.block_count_delta, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 
   if (InvertedIndex_NumDocs(idx) == 0) {
-    // inverted index was cleaned entirely lets free it
+    // Sample memory and block count before the destructor callback (InvIndFreeCb) frees
+    // the index without spec context.
     info.bytes_freed += InvertedIndex_MemUsage(idx);
-    // Decrement per-spec block counter for any remaining blocks before the destructor
-    // callback (`InvIndFreeCb`) frees the index without spec context.
-    size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
-    if (remaining_blocks > 0) {
-      __atomic_sub_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                         remaining_blocks, __ATOMIC_RELAXED);
-    }
+    IndexStats_BlockCountAdd(&sctx->spec->stats, -(ptrdiff_t)InvertedIndex_NumBlocks(idx));
     dictDelete(sctx->spec->missingFieldDict, fieldName);
   }
   FGC_updateStats(gc, sctx, info.entries_removed, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -91,12 +91,19 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info, &sctx->spec->stats.totalInvertedIndexBlocks);
   delta = NULL;
 
   if (InvertedIndex_NumDocs(idx) == 0) {
     // inverted index was cleaned entirely lets free it
     info.bytes_freed += InvertedIndex_MemUsage(idx);
+    // Decrement per-spec block counter for any remaining blocks before the destructor
+    // callback (`InvIndFreeCb`) frees the index without spec context.
+    size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
+    if (remaining_blocks > 0) {
+      __atomic_sub_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                         remaining_blocks, __ATOMIC_RELAXED);
+    }
     dictDelete(sctx->spec->missingFieldDict, fieldName);
   }
   FGC_updateStats(gc, sctx, info.entries_removed, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -91,8 +91,12 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info, &sctx->spec->stats.totalInvertedIndexBlocks);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
+  if (info.block_count_delta) {
+    __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                       (size_t)info.block_count_delta, __ATOMIC_RELAXED);
+  }
 
   if (InvertedIndex_NumDocs(idx) == 0) {
     // inverted index was cleaned entirely lets free it

--- a/src/fork_gc/numeric.c
+++ b/src/fork_gc/numeric.c
@@ -143,6 +143,11 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
                         r.gc_result.index_gc_info.bytes_freed,
                         r.gc_result.index_gc_info.bytes_allocated,
                         r.gc_result.index_gc_info.ignored_last_block);
+        if (r.gc_result.index_gc_info.block_count_delta) {
+          __atomic_add_fetch(&_sctx.spec->stats.totalInvertedIndexBlocks,
+                             (size_t)r.gc_result.index_gc_info.block_count_delta,
+                             __ATOMIC_RELAXED);
+        }
         break;
       case NodeNotFound:
         gc->stats.gcNumericNodesMissed++;
@@ -173,6 +178,10 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     CompactIfSparseResult r = NumericRangeTree_CompactIfSparse(rt);
     if (r.inverted_index_size_delta < 0) {
       FGC_updateStats(gc, &sctx2, 0, -r.inverted_index_size_delta, 0, 0);
+    }
+    if (r.block_count_delta) {
+      __atomic_add_fetch(&sctx2.spec->stats.totalInvertedIndexBlocks,
+                         (size_t)r.block_count_delta, __ATOMIC_RELAXED);
     }
     RedisSearchCtx_UnlockSpec(&sctx2);
     IndexSpecRef_Release(spec_ref);

--- a/src/fork_gc/numeric.c
+++ b/src/fork_gc/numeric.c
@@ -143,11 +143,8 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
                         r.gc_result.index_gc_info.bytes_freed,
                         r.gc_result.index_gc_info.bytes_allocated,
                         r.gc_result.index_gc_info.ignored_last_block);
-        if (r.gc_result.index_gc_info.block_count_delta) {
-          __atomic_add_fetch(&_sctx.spec->stats.totalInvertedIndexBlocks,
-                             (size_t)r.gc_result.index_gc_info.block_count_delta,
-                             __ATOMIC_RELAXED);
-        }
+        IndexStats_BlockCountAdd(&_sctx.spec->stats,
+                                 r.gc_result.index_gc_info.block_count_delta);
         break;
       case NodeNotFound:
         gc->stats.gcNumericNodesMissed++;
@@ -179,10 +176,7 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     if (r.inverted_index_size_delta < 0) {
       FGC_updateStats(gc, &sctx2, 0, -r.inverted_index_size_delta, 0, 0);
     }
-    if (r.block_count_delta) {
-      __atomic_add_fetch(&sctx2.spec->stats.totalInvertedIndexBlocks,
-                         (size_t)r.block_count_delta, __ATOMIC_RELAXED);
-    }
+    IndexStats_BlockCountAdd(&sctx2.spec->stats, r.block_count_delta);
     RedisSearchCtx_UnlockSpec(&sctx2);
     IndexSpecRef_Release(spec_ref);
   }

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -159,13 +159,20 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       goto loop_cleanup;
     }
 
-    InvertedIndex_ApplyGcDelta(idx, delta, &info);
+    InvertedIndex_ApplyGcDelta(idx, delta, &info, &sctx->spec->stats.totalInvertedIndexBlocks);
     delta = NULL;
 
     // if tag value is empty, let's remove it.
     if (InvertedIndex_NumDocs(idx) == 0) {
       // get memory before deleting the inverted index
       info.bytes_freed += InvertedIndex_MemUsage(idx);
+      // Decrement per-spec block counter for any remaining blocks before the TrieMap destructor
+      // callback frees the index without spec context.
+      size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
+      if (remaining_blocks > 0) {
+        __atomic_sub_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                           remaining_blocks, __ATOMIC_RELAXED);
+      }
       TrieMap_Delete(tagIdx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 
       if (tagIdx->suffix) {

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -159,8 +159,12 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       goto loop_cleanup;
     }
 
-    InvertedIndex_ApplyGcDelta(idx, delta, &info, &sctx->spec->stats.totalInvertedIndexBlocks);
+    InvertedIndex_ApplyGcDelta(idx, delta, &info);
     delta = NULL;
+    if (info.block_count_delta) {
+      __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                         (size_t)info.block_count_delta, __ATOMIC_RELAXED);
+    }
 
     // if tag value is empty, let's remove it.
     if (InvertedIndex_NumDocs(idx) == 0) {

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -168,7 +168,7 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       // Sample memory and block count before the TrieMap destructor callback frees the
       // index without spec context.
       info.bytes_freed += InvertedIndex_MemUsage(idx);
-      IndexStats_BlockCountAdd(&sctx->spec->stats, -(ptrdiff_t)InvertedIndex_NumBlocks(idx));
+      IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
       TrieMap_Delete(tagIdx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 
       if (tagIdx->suffix) {

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -161,22 +161,14 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
 
     InvertedIndex_ApplyGcDelta(idx, delta, &info);
     delta = NULL;
-    if (info.block_count_delta) {
-      __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                         (size_t)info.block_count_delta, __ATOMIC_RELAXED);
-    }
+    IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 
     // if tag value is empty, let's remove it.
     if (InvertedIndex_NumDocs(idx) == 0) {
-      // get memory before deleting the inverted index
+      // Sample memory and block count before the TrieMap destructor callback frees the
+      // index without spec context.
       info.bytes_freed += InvertedIndex_MemUsage(idx);
-      // Decrement per-spec block counter for any remaining blocks before the TrieMap destructor
-      // callback frees the index without spec context.
-      size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
-      if (remaining_blocks > 0) {
-        __atomic_sub_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                           remaining_blocks, __ATOMIC_RELAXED);
-      }
+      IndexStats_BlockCountAdd(&sctx->spec->stats, -(ptrdiff_t)InvertedIndex_NumBlocks(idx));
       TrieMap_Delete(tagIdx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 
       if (tagIdx->suffix) {

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -159,7 +159,7 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       goto loop_cleanup;
     }
 
-    InvertedIndex_ApplyGcDelta(idx, delta, &info);
+    InvertedIndex_ApplyGCDelta(idx, delta, &info);
     delta = NULL;
     IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -96,7 +96,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info);
+  InvertedIndex_ApplyGCDelta(idx, delta, &info);
   delta = NULL;
   IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -96,7 +96,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info, &sctx->spec->stats.totalInvertedIndexBlocks);
   delta = NULL;
 
   if (InvertedIndex_NumDocs(idx) == 0) {
@@ -106,8 +106,15 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
       CharBuf termKey = {.buf = term, .len = len};
       // get memory before deleting the inverted index
       size_t inv_idx_size = InvertedIndex_MemUsage(idx);
+      // Decrement per-spec block counter for any remaining blocks before the destructor
+      // callback (`InvIndFreeCb`) frees the index without spec context.
+      size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
       if (dictDelete(sctx->spec->keysDict, &termKey) == DICT_OK) {
         info.bytes_freed += inv_idx_size;
+        if (remaining_blocks > 0) {
+          __atomic_sub_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                             remaining_blocks, __ATOMIC_RELAXED);
+        }
       }
     }
 

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -98,27 +98,20 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
 
   InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
-  if (info.block_count_delta) {
-    __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                       (size_t)info.block_count_delta, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 
   if (InvertedIndex_NumDocs(idx) == 0) {
 
     // inverted index was cleaned entirely lets free it
     if (sctx->spec->keysDict) {
       CharBuf termKey = {.buf = term, .len = len};
-      // get memory before deleting the inverted index
+      // Sample memory and block count before the destructor callback (InvIndFreeCb) frees
+      // the index without spec context.
       size_t inv_idx_size = InvertedIndex_MemUsage(idx);
-      // Decrement per-spec block counter for any remaining blocks before the destructor
-      // callback (`InvIndFreeCb`) frees the index without spec context.
       size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
       if (dictDelete(sctx->spec->keysDict, &termKey) == DICT_OK) {
         info.bytes_freed += inv_idx_size;
-        if (remaining_blocks > 0) {
-          __atomic_sub_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
-                             remaining_blocks, __ATOMIC_RELAXED);
-        }
+        IndexStats_BlockCountAdd(&sctx->spec->stats, -(ptrdiff_t)remaining_blocks);
       }
     }
 

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -96,8 +96,12 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGcDelta(idx, delta, &info, &sctx->spec->stats.totalInvertedIndexBlocks);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
+  if (info.block_count_delta) {
+    __atomic_add_fetch(&sctx->spec->stats.totalInvertedIndexBlocks,
+                       (size_t)info.block_count_delta, __ATOMIC_RELAXED);
+  }
 
   if (InvertedIndex_NumDocs(idx) == 0) {
 

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -111,7 +111,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
       size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
       if (dictDelete(sctx->spec->keysDict, &termKey) == DICT_OK) {
         info.bytes_freed += inv_idx_size;
-        IndexStats_BlockCountAdd(&sctx->spec->stats, -(ptrdiff_t)remaining_blocks);
+        IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)remaining_blocks);
       }
     }
 

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -282,14 +282,11 @@ int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo
   return 0;
 }
 
-/** Write a forward-index entry to the index.
- *
- * `spec_block_counter`, when non-NULL, is the address of the owning spec's
- * `stats.totalInvertedIndexBlocks` counter. The Rust write atomically bumps it by the number of
- * new blocks created by this write (typically 0 or 1). Pass NULL to skip per-spec accounting.
+/** Write a forward-index entry to the index. Returns an `AddRecordOutcome` carrying the memory
+ * growth and the number of new blocks the write created — callers maintaining per-spec
+ * `total_inverted_index_blocks` should add `.blocks_added` to their counter.
  */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent,
-                                            size_t *spec_block_counter) {
+AddRecordOutcome InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
   RSIndexResult rec = {.data.term_tag = RSResultData_Term,
                        .data.term.borrowed.tag = RSTermRecord_Borrowed,
                        .docId = ent->docId,
@@ -301,7 +298,7 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntr
     rec.data.term.borrowed.offsets.data = VVW_GetByteData(ent->vw);
     rec.data.term.borrowed.offsets.len = VVW_GetByteLength(ent->vw);
   }
-  return InvertedIndex_WriteEntryGeneric(idx, &rec, spec_block_counter);
+  return InvertedIndex_WriteEntryGeneric(idx, &rec);
 }
 
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash) {

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -282,8 +282,14 @@ int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo
   return 0;
 }
 
-/** Write a forward-index entry to the index */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
+/** Write a forward-index entry to the index.
+ *
+ * `spec_block_counter`, when non-NULL, is the address of the owning spec's
+ * `stats.totalInvertedIndexBlocks` counter. The Rust write atomically bumps it by the number of
+ * new blocks created by this write (typically 0 or 1). Pass NULL to skip per-spec accounting.
+ */
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent,
+                                            size_t *spec_block_counter) {
   RSIndexResult rec = {.data.term_tag = RSResultData_Term,
                        .data.term.borrowed.tag = RSTermRecord_Borrowed,
                        .docId = ent->docId,
@@ -295,7 +301,7 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntr
     rec.data.term.borrowed.offsets.data = VVW_GetByteData(ent->vw);
     rec.data.term.borrowed.offsets.len = VVW_GetByteLength(ent->vw);
   }
-  return InvertedIndex_WriteEntryGeneric(idx, &rec);
+  return InvertedIndex_WriteEntryGeneric(idx, &rec, spec_block_counter);
 }
 
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash) {

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -87,14 +87,11 @@ ForwardIndexEntry *ForwardIndexIterator_Next(ForwardIndexIterator *iter);
 // Find an existing entry within the index
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash);
 
-/* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index.
- *
- * `spec_block_counter`, when non-NULL, is the address of the owning spec's
- * `stats.totalInvertedIndexBlocks` counter. The Rust write atomically bumps it by the number of
- * new blocks created by this write (typically 0 or 1). Pass NULL to skip per-spec accounting.
+/* Write a ForwardIndexEntry into an indexWriter. Returns an `AddRecordOutcome` carrying the
+ * memory growth and the number of new blocks created — callers maintaining per-spec
+ * `total_inverted_index_blocks` should add `.blocks_added` to their counter.
  */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent,
-                                            size_t *spec_block_counter);
+AddRecordOutcome InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent);
 
 #ifdef __cplusplus
 }

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -87,9 +87,14 @@ ForwardIndexEntry *ForwardIndexIterator_Next(ForwardIndexIterator *iter);
 // Find an existing entry within the index
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash);
 
-/* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
+/* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index.
+ *
+ * `spec_block_counter`, when non-NULL, is the address of the owning spec's
+ * `stats.totalInvertedIndexBlocks` counter. The Rust write atomically bumps it by the number of
+ * new blocks created by this write (typically 0 or 1). Pass NULL to skip per-spec accounting.
  */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent);
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent,
+                                            size_t *spec_block_counter);
 
 #ifdef __cplusplus
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -32,7 +32,10 @@ extern RedisModuleCtx *RSDummyContext;
 #include <unistd.h>
 
 static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEntry *entry) {
-  size_t sz = InvertedIndex_WriteForwardIndexEntry(idx, entry);
+  // `&spec->stats.totalInvertedIndexBlocks` is the per-spec block counter that the Rust write
+  // atomically bumps if a new block was created. See `InvertedIndex_WriteEntryGeneric` docs.
+  size_t sz = InvertedIndex_WriteForwardIndexEntry(idx, entry,
+                                                   &spec->stats.totalInvertedIndexBlocks);
 
   // Update index statistics:
 
@@ -391,7 +394,8 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     t_docId docId = aCtx->doc->docId;
     RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                          .metrics = MetricsVec_New()};
-    aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
+    aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(
+        iiMissingDocs, &rec, &aCtx->spec->stats.totalInvertedIndexBlocks);
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);
@@ -412,7 +416,8 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   t_docId docId = aCtx->doc->docId;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
-  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
+  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(
+      sctx->spec->existingDocs, &rec, &aCtx->spec->stats.totalInvertedIndexBlocks);
 }
 
 /**

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -32,15 +32,17 @@ extern RedisModuleCtx *RSDummyContext;
 #include <unistd.h>
 
 static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEntry *entry) {
-  // `&spec->stats.totalInvertedIndexBlocks` is the per-spec block counter that the Rust write
-  // atomically bumps if a new block was created. See `InvertedIndex_WriteEntryGeneric` docs.
-  size_t sz = InvertedIndex_WriteForwardIndexEntry(idx, entry,
-                                                   &spec->stats.totalInvertedIndexBlocks);
+  AddRecordOutcome r = InvertedIndex_WriteForwardIndexEntry(idx, entry);
 
   // Update index statistics:
 
   // Number of additional bytes
-  spec->stats.invertedSize += sz;
+  spec->stats.invertedSize += r.mem_growth;
+  // Per-spec block count for FT.INFO `total_inverted_index_blocks`.
+  if (r.blocks_added) {
+    __atomic_add_fetch(&spec->stats.totalInvertedIndexBlocks,
+                       r.blocks_added, __ATOMIC_RELAXED);
+  }
   // Number of records
   spec->stats.numRecords++;
 
@@ -394,8 +396,12 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     t_docId docId = aCtx->doc->docId;
     RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                          .metrics = MetricsVec_New()};
-    aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(
-        iiMissingDocs, &rec, &aCtx->spec->stats.totalInvertedIndexBlocks);
+    AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
+    aCtx->spec->stats.invertedSize += r.mem_growth;
+    if (r.blocks_added) {
+      __atomic_add_fetch(&aCtx->spec->stats.totalInvertedIndexBlocks,
+                         r.blocks_added, __ATOMIC_RELAXED);
+    }
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);
@@ -416,8 +422,12 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   t_docId docId = aCtx->doc->docId;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
-  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(
-      sctx->spec->existingDocs, &rec, &aCtx->spec->stats.totalInvertedIndexBlocks);
+  AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
+  aCtx->spec->stats.invertedSize += r.mem_growth;
+  if (r.blocks_added) {
+    __atomic_add_fetch(&aCtx->spec->stats.totalInvertedIndexBlocks,
+                       r.blocks_added, __ATOMIC_RELAXED);
+  }
 }
 
 /**

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -38,11 +38,7 @@ static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEnt
 
   // Number of additional bytes
   spec->stats.invertedSize += r.mem_growth;
-  // Per-spec block count for FT.INFO `total_inverted_index_blocks`.
-  if (r.blocks_added) {
-    __atomic_add_fetch(&spec->stats.totalInvertedIndexBlocks,
-                       r.blocks_added, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(&spec->stats, r.blocks_added);
   // Number of records
   spec->stats.numRecords++;
 
@@ -398,10 +394,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
                          .metrics = MetricsVec_New()};
     AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
     aCtx->spec->stats.invertedSize += r.mem_growth;
-    if (r.blocks_added) {
-      __atomic_add_fetch(&aCtx->spec->stats.totalInvertedIndexBlocks,
-                         r.blocks_added, __ATOMIC_RELAXED);
-    }
+    IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);
@@ -424,10 +417,7 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
                        .metrics = MetricsVec_New()};
   AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
   aCtx->spec->stats.invertedSize += r.mem_growth;
-  if (r.blocks_added) {
-    __atomic_add_fetch(&aCtx->spec->stats.totalInvertedIndexBlocks,
-                       r.blocks_added, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
 }
 
 /**

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -266,7 +266,10 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   // Vector indexes (e.g. HNSW) remain in memory even when the rest of the
   // index is stored on disk, so their memory must always be reported.
   size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
-  size_t total_ii_blocks = isDisk ? 0 : TotalIIBlocks();
+  // FT.INFO reports per-spec block counts, not the process-global TotalIIBlocks (the latter
+  // is still exposed via Redis `INFO modules` for cluster-wide aggregation in spec.c).
+  size_t total_ii_blocks = isDisk ? 0
+      : __atomic_load_n(&sp->stats.totalInvertedIndexBlocks, __ATOMIC_RELAXED);
   size_t offset_vecs_size = isDisk ? 0 : sp->stats.offsetVecsSize;
   size_t sortables_size = isDisk ? 0 : sp->docs.sortablesSize;
   size_t dt_tm_size = isDisk ? 0 : TrieMap_MemUsage(sp->docs.dim.tm);

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -228,14 +228,20 @@ pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usi
 /// with the `StoreNumeric` flag. The function returns the number of bytes the memory usage of the
 /// index grew by.
 ///
+/// `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
+/// atomically incremented by the number of new blocks this write created (typically 0 or 1).
+/// Pass NULL when there's no owning spec (tests, transient indexes).
+///
 /// # Safety
-/// The following invariant must be upheld when calling this function:
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+/// - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
+///   the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii: *mut InvertedIndex,
     doc_id: t_docId,
     value: f64,
+    spec_block_counter: *mut usize,
 ) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
 
@@ -243,20 +249,32 @@ pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
 
     // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
     let ii = unsafe { &mut *ii };
-    ii_dispatch!(ii, add_record, &record).unwrap()
+    let blocks_before = ii_dispatch!(&*ii, number_of_blocks);
+    let mem_growth = ii_dispatch!(ii, add_record, &record).unwrap();
+    let blocks_after = ii_dispatch!(&*ii, number_of_blocks);
+    // SAFETY: the contract on `spec_block_counter` guarantees the pointer is valid for atomic
+    // access (or null).
+    unsafe { bump_spec_counter(spec_block_counter, blocks_after, blocks_before) };
+    mem_growth
 }
 
 /// Write a new entry to the inverted index. The function returns the number of bytes the memory
 /// usage of the index grew by.
 ///
+/// `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
+/// atomically incremented by the number of new blocks this write created (typically 0 or 1).
+/// Pass NULL when there's no owning spec (tests, transient indexes).
+///
 /// # Safety
-/// The following invariants must be upheld when calling this function:
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
 /// - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
+/// - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
+///   the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
     ii: *mut InvertedIndex,
     record: *const RSIndexResult,
+    spec_block_counter: *mut usize,
 ) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
     debug_assert!(!record.is_null(), "record must not be null");
@@ -267,7 +285,33 @@ pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
     // SAFETY: The caller must ensure that `record` is a valid pointer to an `RSIndexResult`
     let record = unsafe { &*record };
 
-    ii_dispatch!(ii, add_record, record).unwrap()
+    let blocks_before = ii_dispatch!(&*ii, number_of_blocks);
+    let mem_growth = ii_dispatch!(ii, add_record, record).unwrap();
+    let blocks_after = ii_dispatch!(&*ii, number_of_blocks);
+    // SAFETY: the contract on `spec_block_counter` guarantees the pointer is valid for atomic
+    // access (or null).
+    unsafe { bump_spec_counter(spec_block_counter, blocks_after, blocks_before) };
+    mem_growth
+}
+
+/// Apply `new_blocks - old_blocks` (signed) to `*counter` atomically. NULL pointer is a no-op.
+///
+/// # Safety
+/// `counter`, if non-null, must point to a `size_t` valid for atomic read/write for the
+/// duration of this call. Sized to match C's `size_t`/Rust's `usize` exactly.
+#[inline]
+unsafe fn bump_spec_counter(counter: *mut usize, new_blocks: usize, old_blocks: usize) {
+    if counter.is_null() {
+        return;
+    }
+    // SAFETY: caller-guaranteed.
+    let atomic = unsafe { std::sync::atomic::AtomicUsize::from_ptr(counter) };
+    use std::sync::atomic::Ordering::Relaxed;
+    if new_blocks > old_blocks {
+        atomic.fetch_add(new_blocks - old_blocks, Relaxed);
+    } else if old_blocks > new_blocks {
+        atomic.fetch_sub(old_blocks - new_blocks, Relaxed);
+    }
 }
 
 /// Return the number of blocks in the inverted index.
@@ -647,6 +691,7 @@ pub unsafe extern "C" fn InvertedIndex_ApplyGcDelta(
     ii: *mut InvertedIndex,
     deltas: *mut GcScanDelta,
     apply_info: *mut GcApplyInfo,
+    spec_block_counter: *mut usize,
 ) {
     debug_assert!(!ii.is_null(), "ii must not be null");
     debug_assert!(!deltas.is_null(), "deltas must not be null");
@@ -659,7 +704,12 @@ pub unsafe extern "C" fn InvertedIndex_ApplyGcDelta(
     let deltas = unsafe { Box::from_raw(deltas) };
     let deltas = *deltas;
 
+    let blocks_before = ii_dispatch!(&*ii, number_of_blocks);
     let info = ii_dispatch!(ii, apply_gc, deltas);
+    let blocks_after = ii_dispatch!(&*ii, number_of_blocks);
+
+    // SAFETY: contract on `spec_block_counter` guarantees validity.
+    unsafe { bump_spec_counter(spec_block_counter, blocks_after, blocks_before) };
 
     // SAFETY: The caller must ensure `apply_info` is a valid pointer to a `GcApplyInfo`
     unsafe { *apply_info = info };

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -225,10 +225,8 @@ pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usi
 }
 
 /// Write a new numeric entry to the inverted index. This is only valid for numeric indexes
-/// created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting both the
-/// memory growth and the number of new index blocks created. The 8-byte struct returns by
-/// value in a single register (x86_64 SysV ABI), so this is no more expensive than a plain
-/// `size_t` return.
+/// created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting the memory
+/// growth and the number of new index blocks created.
 ///
 /// # Safety
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
@@ -247,9 +245,8 @@ pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii_dispatch!(ii, add_record, &record).unwrap()
 }
 
-/// Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting both
-/// the memory growth and the number of new index blocks created. The 8-byte struct returns
-/// by value in a single register (x86_64 SysV ABI).
+/// Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting the
+/// memory growth and the number of new index blocks created.
 ///
 /// # Safety
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
@@ -591,7 +588,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
 }
 
 /// Read a GC delta from the provided reader. The returned pointer must be freed using
-/// [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGcDelta`].
+/// [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGCDelta`].
 ///
 /// # Safety
 ///
@@ -646,7 +643,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Free(deltas: *mut GcScanDelta) {
 ///   [`InvertedIndex_GcDelta_Read`].
 /// - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_ApplyGcDelta(
+pub unsafe extern "C" fn InvertedIndex_ApplyGCDelta(
     ii: *mut InvertedIndex,
     deltas: *mut GcScanDelta,
     apply_info: *mut GcApplyInfo,

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -24,9 +24,9 @@ use fork_gc::{InvertedIndexGCCallback, InvertedIndexGCReader, InvertedIndexGCWri
 use index_result::RSIndexResult;
 pub use inverted_index::opaque::InvertedIndex;
 use inverted_index::{
-    EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader, FilterMaskReader,
-    FilterNumericReader, GcApplyInfo, GcScanDelta, IndexBlock, IndexReader as _, NumericFilter,
-    ReadFilter,
+    AddRecordOutcome, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader,
+    FilterMaskReader, FilterNumericReader, GcApplyInfo, GcScanDelta, IndexBlock, IndexReader as _,
+    NumericFilter, ReadFilter,
     debug::{BlockSummary, Summary},
     doc_ids_only::DocIdsOnly,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
@@ -224,58 +224,41 @@ pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usi
     ii_dispatch!(ii, memory_usage)
 }
 
-/// Write a new numeric entry to the inverted index. This is only valid for numeric indexes created
-/// with the `StoreNumeric` flag. The function returns the number of bytes the memory usage of the
-/// index grew by.
-///
-/// `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
-/// atomically incremented by the number of new blocks this write created (typically 0 or 1).
-/// Pass NULL when there's no owning spec (tests, transient indexes).
+/// Write a new numeric entry to the inverted index. This is only valid for numeric indexes
+/// created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting both the
+/// memory growth and the number of new index blocks created. The 8-byte struct returns by
+/// value in a single register (x86_64 SysV ABI), so this is no more expensive than a plain
+/// `size_t` return.
 ///
 /// # Safety
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
-/// - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
-///   the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii: *mut InvertedIndex,
     doc_id: t_docId,
     value: f64,
-    spec_block_counter: *mut usize,
-) -> usize {
+) -> AddRecordOutcome {
     debug_assert!(!ii.is_null(), "ii must not be null");
 
     let record = RSIndexResult::build_numeric(value).doc_id(doc_id).build();
 
     // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
     let ii = unsafe { &mut *ii };
-    let blocks_before = ii_dispatch!(&*ii, number_of_blocks);
-    let mem_growth = ii_dispatch!(ii, add_record, &record).unwrap();
-    let blocks_after = ii_dispatch!(&*ii, number_of_blocks);
-    // SAFETY: the contract on `spec_block_counter` guarantees the pointer is valid for atomic
-    // access (or null).
-    unsafe { bump_spec_counter(spec_block_counter, blocks_after, blocks_before) };
-    mem_growth
+    ii_dispatch!(ii, add_record, &record).unwrap()
 }
 
-/// Write a new entry to the inverted index. The function returns the number of bytes the memory
-/// usage of the index grew by.
-///
-/// `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
-/// atomically incremented by the number of new blocks this write created (typically 0 or 1).
-/// Pass NULL when there's no owning spec (tests, transient indexes).
+/// Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting both
+/// the memory growth and the number of new index blocks created. The 8-byte struct returns
+/// by value in a single register (x86_64 SysV ABI).
 ///
 /// # Safety
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
 /// - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
-/// - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
-///   the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
     ii: *mut InvertedIndex,
     record: *const RSIndexResult,
-    spec_block_counter: *mut usize,
-) -> usize {
+) -> AddRecordOutcome {
     debug_assert!(!ii.is_null(), "ii must not be null");
     debug_assert!(!record.is_null(), "record must not be null");
 
@@ -285,33 +268,7 @@ pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
     // SAFETY: The caller must ensure that `record` is a valid pointer to an `RSIndexResult`
     let record = unsafe { &*record };
 
-    let blocks_before = ii_dispatch!(&*ii, number_of_blocks);
-    let mem_growth = ii_dispatch!(ii, add_record, record).unwrap();
-    let blocks_after = ii_dispatch!(&*ii, number_of_blocks);
-    // SAFETY: the contract on `spec_block_counter` guarantees the pointer is valid for atomic
-    // access (or null).
-    unsafe { bump_spec_counter(spec_block_counter, blocks_after, blocks_before) };
-    mem_growth
-}
-
-/// Apply `new_blocks - old_blocks` (signed) to `*counter` atomically. NULL pointer is a no-op.
-///
-/// # Safety
-/// `counter`, if non-null, must point to a `size_t` valid for atomic read/write for the
-/// duration of this call. Sized to match C's `size_t`/Rust's `usize` exactly.
-#[inline]
-unsafe fn bump_spec_counter(counter: *mut usize, new_blocks: usize, old_blocks: usize) {
-    if counter.is_null() {
-        return;
-    }
-    // SAFETY: caller-guaranteed.
-    let atomic = unsafe { std::sync::atomic::AtomicUsize::from_ptr(counter) };
-    use std::sync::atomic::Ordering::Relaxed;
-    if new_blocks > old_blocks {
-        atomic.fetch_add(new_blocks - old_blocks, Relaxed);
-    } else if old_blocks > new_blocks {
-        atomic.fetch_sub(old_blocks - new_blocks, Relaxed);
-    }
+    ii_dispatch!(ii, add_record, record).unwrap()
 }
 
 /// Return the number of blocks in the inverted index.
@@ -674,7 +631,9 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Free(deltas: *mut GcScanDelta) {
 }
 
 /// Apply a GC delta to the inverted index. The output parameter `apply_info` will be set to
-/// information about the applied delta.
+/// information about the applied delta — in particular, `apply_info.block_count_delta` carries
+/// the signed change in block count, which callers maintaining per-spec totals should add to
+/// their counter.
 ///
 /// This will take ownership of the `deltas` pointer and free it. Therefore, it should not be
 /// used or freed after calling this function.
@@ -691,7 +650,6 @@ pub unsafe extern "C" fn InvertedIndex_ApplyGcDelta(
     ii: *mut InvertedIndex,
     deltas: *mut GcScanDelta,
     apply_info: *mut GcApplyInfo,
-    spec_block_counter: *mut usize,
 ) {
     debug_assert!(!ii.is_null(), "ii must not be null");
     debug_assert!(!deltas.is_null(), "deltas must not be null");
@@ -704,12 +662,7 @@ pub unsafe extern "C" fn InvertedIndex_ApplyGcDelta(
     let deltas = unsafe { Box::from_raw(deltas) };
     let deltas = *deltas;
 
-    let blocks_before = ii_dispatch!(&*ii, number_of_blocks);
     let info = ii_dispatch!(ii, apply_gc, deltas);
-    let blocks_after = ii_dispatch!(&*ii, number_of_blocks);
-
-    // SAFETY: contract on `spec_block_counter` guarantees validity.
-    unsafe { bump_spec_counter(spec_block_counter, blocks_after, blocks_before) };
 
     // SAFETY: The caller must ensure `apply_info` is a valid pointer to a `GcApplyInfo`
     unsafe { *apply_info = info };

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -60,10 +60,18 @@ typedef struct RSDocumentMetadata_s RSDocumentMetadata;
 includes = ["redisearch_types.h", "config.h", "search_ctx.h", "spec.h"]
 trailer = """
 // Create a new inverted index object, with the given flag.
-// The out parameter memsize must be not NULL, the total of allocated memory
-// will be returned in it.
+// The out parameter `memsize` must not be NULL: the total allocated memory is returned in it.
+// The inverted index should be freed using `InvertedIndex_Free` when no longer needed.
 //
-// The inverted index should be freed using [`InvertedIndex_Free`] when no longer needed.
+// Per-spec `total_inverted_index_blocks` accounting is opt-in at *operation* time: pass the
+// address of `spec->stats.totalInvertedIndexBlocks` to `InvertedIndex_WriteEntryGeneric`,
+// `InvertedIndex_WriteNumericEntry`, and `InvertedIndex_ApplyGcDelta` — the Rust side reads
+// `blocks.len()` before and after each call and atomically bumps the pointed-to counter.
+// When freeing an inverted index, the C caller is responsible for reading
+// `InvertedIndex_NumBlocks(ii)` and atomically decrementing the per-spec counter before
+// calling `InvertedIndex_Free` (mirroring the existing `InvertedIndex_MemUsage` pattern).
+// Pass NULL when no spec is involved (tests / transient indexes); the process-global
+// `TotalIIBlocks()` is always maintained.
 inline static struct InvertedIndex *NewInvertedIndex(IndexFlags flags, size_t *memsize) {
   return NewInvertedIndex_Ex(flags, RSGlobalConfig.invertedIndexRawDocidEncoding, RSGlobalConfig.numericCompress, memsize);
 }

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -60,18 +60,10 @@ typedef struct RSDocumentMetadata_s RSDocumentMetadata;
 includes = ["redisearch_types.h", "config.h", "search_ctx.h", "spec.h"]
 trailer = """
 // Create a new inverted index object, with the given flag.
-// The out parameter `memsize` must not be NULL: the total allocated memory is returned in it.
-// The inverted index should be freed using `InvertedIndex_Free` when no longer needed.
+// The out parameter memsize must be not NULL, the total of allocated memory
+// will be returned in it.
 //
-// Per-spec `total_inverted_index_blocks` accounting is opt-in at *operation* time: pass the
-// address of `spec->stats.totalInvertedIndexBlocks` to `InvertedIndex_WriteEntryGeneric`,
-// `InvertedIndex_WriteNumericEntry`, and `InvertedIndex_ApplyGcDelta` — the Rust side reads
-// `blocks.len()` before and after each call and atomically bumps the pointed-to counter.
-// When freeing an inverted index, the C caller is responsible for reading
-// `InvertedIndex_NumBlocks(ii)` and atomically decrementing the per-spec counter before
-// calling `InvertedIndex_Free` (mirroring the existing `InvertedIndex_MemUsage` pattern).
-// Pass NULL when no spec is involved (tests / transient indexes); the process-global
-// `TotalIIBlocks()` is always maintained.
+// The inverted index should be freed using [`InvertedIndex_Free`] when no longer needed.
 inline static struct InvertedIndex *NewInvertedIndex(IndexFlags flags, size_t *memsize) {
   return NewInvertedIndex_Ex(flags, RSGlobalConfig.invertedIndexRawDocidEncoding, RSGlobalConfig.numericCompress, memsize);
 }

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -102,6 +102,24 @@ typedef struct IIBlockSummary {
 } IIBlockSummary;
 
 /**
+ * Outcome of [`InvertedIndex::add_record`]: the memory the index grew by and how many new
+ * blocks the write created. `u32` is plenty for both — `mem_growth` per call is bounded by the
+ * block size plus a doubling of its buffer capacity, and `blocks_added` is at most 2 (a new
+ * block when the previous one was full, plus another when the encoded delta overflowed). Kept
+ * `#[repr(C)]` so callers (including the FFI) can read it as a flat struct.
+ */
+typedef struct AddRecordOutcome {
+  /**
+   * Number of bytes the inverted index's memory usage grew by.
+   */
+  uint32_t mem_growth;
+  /**
+   * Number of new index blocks this write created.
+   */
+  uint32_t blocks_added;
+} AddRecordOutcome;
+
+/**
  * Filter to apply when reading from an index. Entries which don't match the filter will not be
  * returned by the reader.
  */
@@ -155,6 +173,12 @@ typedef struct II_GCScanStats {
    * The number of entries that were removed from the index including duplicates
    */
   size_t entries_removed;
+  /**
+   * Net change in the index's block count for this apply. Positive when blocks were added
+   * (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
+   * Callers maintaining per-spec totals should add this signed value to their counter.
+   */
+  ptrdiff_t block_count_delta;
   /**
    * Whether or not we ignored the last block in the index, since it changed
    * compared to the time we performed the scan

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -178,7 +178,7 @@ typedef struct II_GCScanStats {
    * (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
    * Callers maintaining per-spec totals should add this signed value to their counter.
    */
-  ptrdiff_t block_count_delta;
+  int64_t block_count_delta;
   /**
    * Whether or not we ignored the last block in the index, since it changed
    * compared to the time we performed the scan

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -102,11 +102,7 @@ typedef struct IIBlockSummary {
 } IIBlockSummary;
 
 /**
- * Outcome of [`InvertedIndex::add_record`]: the memory the index grew by and how many new
- * blocks the write created. `u32` is plenty for both — `mem_growth` per call is bounded by the
- * block size plus a doubling of its buffer capacity, and `blocks_added` is at most 2 (a new
- * block when the previous one was full, plus another when the encoded delta overflowed). Kept
- * `#[repr(C)]` so callers (including the FFI) can read it as a flat struct.
+ * Outcome of [`InvertedIndex::add_record`]: how the index grew during the write.
  */
 typedef struct AddRecordOutcome {
   /**

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -138,22 +138,32 @@ size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
  * with the `StoreNumeric` flag. The function returns the number of bytes the memory usage of the
  * index grew by.
  *
+ * `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
+ * atomically incremented by the number of new blocks this write created (typically 0 or 1).
+ * Pass NULL when there's no owning spec (tests, transient indexes).
+ *
  * # Safety
- * The following invariant must be upheld when calling this function:
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
+ *   the duration of this call.
  */
-size_t InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
+size_t InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value, size_t *spec_block_counter);
 
 /**
  * Write a new entry to the inverted index. The function returns the number of bytes the memory
  * usage of the index grew by.
  *
+ * `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
+ * atomically incremented by the number of new blocks this write created (typically 0 or 1).
+ * Pass NULL when there's no owning spec (tests, transient indexes).
+ *
  * # Safety
- * The following invariants must be upheld when calling this function:
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
+ * - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
+ *   the duration of this call.
  */
-size_t InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record);
+size_t InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record, size_t *spec_block_counter);
 
 /**
  * Return the number of blocks in the inverted index.
@@ -329,7 +339,7 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
  *   [`InvertedIndex_GcDelta_Read`].
  * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
  */
-void InvertedIndex_ApplyGcDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
+void InvertedIndex_ApplyGcDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info, size_t *spec_block_counter);
 
 /**
  * Get the index of the last block in the GC delta.
@@ -524,10 +534,18 @@ bool IndexReader_Revalidate(struct IndexReader *ir);
 }  // extern "C"
 #endif  // __cplusplus
 // Create a new inverted index object, with the given flag.
-// The out parameter memsize must be not NULL, the total of allocated memory
-// will be returned in it.
+// The out parameter `memsize` must not be NULL: the total allocated memory is returned in it.
+// The inverted index should be freed using `InvertedIndex_Free` when no longer needed.
 //
-// The inverted index should be freed using [`InvertedIndex_Free`] when no longer needed.
+// Per-spec `total_inverted_index_blocks` accounting is opt-in at *operation* time: pass the
+// address of `spec->stats.totalInvertedIndexBlocks` to `InvertedIndex_WriteEntryGeneric`,
+// `InvertedIndex_WriteNumericEntry`, and `InvertedIndex_ApplyGcDelta` — the Rust side reads
+// `blocks.len()` before and after each call and atomically bumps the pointed-to counter.
+// When freeing an inverted index, the C caller is responsible for reading
+// `InvertedIndex_NumBlocks(ii)` and atomically decrementing the per-spec counter before
+// calling `InvertedIndex_Free` (mirroring the existing `InvertedIndex_MemUsage` pattern).
+// Pass NULL when no spec is involved (tests / transient indexes); the process-global
+// `TotalIIBlocks()` is always maintained.
 inline static struct InvertedIndex *NewInvertedIndex(IndexFlags flags, size_t *memsize) {
   return NewInvertedIndex_Ex(flags, RSGlobalConfig.invertedIndexRawDocidEncoding, RSGlobalConfig.numericCompress, memsize);
 }

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -135,10 +135,8 @@ size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
 
 /**
  * Write a new numeric entry to the inverted index. This is only valid for numeric indexes
- * created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting both the
- * memory growth and the number of new index blocks created. The 8-byte struct returns by
- * value in a single register (x86_64 SysV ABI), so this is no more expensive than a plain
- * `size_t` return.
+ * created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting the memory
+ * growth and the number of new index blocks created.
  *
  * # Safety
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
@@ -146,9 +144,8 @@ size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
 struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
 
 /**
- * Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting both
- * the memory growth and the number of new index blocks created. The 8-byte struct returns
- * by value in a single register (x86_64 SysV ABI).
+ * Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting the
+ * memory growth and the number of new index blocks created.
  *
  * # Safety
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
@@ -295,7 +292,7 @@ bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, st
 
 /**
  * Read a GC delta from the provided reader. The returned pointer must be freed using
- * [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGcDelta`].
+ * [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGCDelta`].
  *
  * # Safety
  *
@@ -332,7 +329,7 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
  *   [`InvertedIndex_GcDelta_Read`].
  * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
  */
-void InvertedIndex_ApplyGcDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
+void InvertedIndex_ApplyGCDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
 
 /**
  * Get the index of the last block in the GC delta.

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -527,18 +527,10 @@ bool IndexReader_Revalidate(struct IndexReader *ir);
 }  // extern "C"
 #endif  // __cplusplus
 // Create a new inverted index object, with the given flag.
-// The out parameter `memsize` must not be NULL: the total allocated memory is returned in it.
-// The inverted index should be freed using `InvertedIndex_Free` when no longer needed.
+// The out parameter memsize must be not NULL, the total of allocated memory
+// will be returned in it.
 //
-// Per-spec `total_inverted_index_blocks` accounting is opt-in at *operation* time: pass the
-// address of `spec->stats.totalInvertedIndexBlocks` to `InvertedIndex_WriteEntryGeneric`,
-// `InvertedIndex_WriteNumericEntry`, and `InvertedIndex_ApplyGcDelta` — the Rust side reads
-// `blocks.len()` before and after each call and atomically bumps the pointed-to counter.
-// When freeing an inverted index, the C caller is responsible for reading
-// `InvertedIndex_NumBlocks(ii)` and atomically decrementing the per-spec counter before
-// calling `InvertedIndex_Free` (mirroring the existing `InvertedIndex_MemUsage` pattern).
-// Pass NULL when no spec is involved (tests / transient indexes); the process-global
-// `TotalIIBlocks()` is always maintained.
+// The inverted index should be freed using [`InvertedIndex_Free`] when no longer needed.
 inline static struct InvertedIndex *NewInvertedIndex(IndexFlags flags, size_t *memsize) {
   return NewInvertedIndex_Ex(flags, RSGlobalConfig.invertedIndexRawDocidEncoding, RSGlobalConfig.numericCompress, memsize);
 }

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -134,36 +134,27 @@ void InvertedIndex_Free(struct InvertedIndex *ii);
 size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
 
 /**
- * Write a new numeric entry to the inverted index. This is only valid for numeric indexes created
- * with the `StoreNumeric` flag. The function returns the number of bytes the memory usage of the
- * index grew by.
- *
- * `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
- * atomically incremented by the number of new blocks this write created (typically 0 or 1).
- * Pass NULL when there's no owning spec (tests, transient indexes).
+ * Write a new numeric entry to the inverted index. This is only valid for numeric indexes
+ * created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting both the
+ * memory growth and the number of new index blocks created. The 8-byte struct returns by
+ * value in a single register (x86_64 SysV ABI), so this is no more expensive than a plain
+ * `size_t` return.
  *
  * # Safety
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- * - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
- *   the duration of this call.
  */
-size_t InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value, size_t *spec_block_counter);
+struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
 
 /**
- * Write a new entry to the inverted index. The function returns the number of bytes the memory
- * usage of the index grew by.
- *
- * `spec_block_counter`, when non-NULL, points to a per-spec `size_t` counter that is
- * atomically incremented by the number of new blocks this write created (typically 0 or 1).
- * Pass NULL when there's no owning spec (tests, transient indexes).
+ * Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting both
+ * the memory growth and the number of new index blocks created. The 8-byte struct returns
+ * by value in a single register (x86_64 SysV ABI).
  *
  * # Safety
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
- * - `spec_block_counter` is either NULL or points to a `size_t` valid for atomic access for
- *   the duration of this call.
  */
-size_t InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record, size_t *spec_block_counter);
+struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record);
 
 /**
  * Return the number of blocks in the inverted index.
@@ -326,7 +317,9 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
 
 /**
  * Apply a GC delta to the inverted index. The output parameter `apply_info` will be set to
- * information about the applied delta.
+ * information about the applied delta — in particular, `apply_info.block_count_delta` carries
+ * the signed change in block count, which callers maintaining per-spec totals should add to
+ * their counter.
  *
  * This will take ownership of the `deltas` pointer and free it. Therefore, it should not be
  * used or freed after calling this function.
@@ -339,7 +332,7 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
  *   [`InvertedIndex_GcDelta_Read`].
  * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
  */
-void InvertedIndex_ApplyGcDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info, size_t *spec_block_counter);
+void InvertedIndex_ApplyGcDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
 
 /**
  * Get the index of the last block in the GC delta.

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -137,8 +137,7 @@ typedef struct AddResult {
    * The net change in the number of inverted-index blocks across all leaves touched by
    * this add. Block growth (writes spilling into a new block, new leaves created by a
    * split) contributes positively; range removals during rebalancing (`remove_range`,
-   * rotations dropping an internal node's retained range) contribute negatively. C callers
-   * maintaining per-spec `total_inverted_index_blocks` should add this to their counter.
+   * rotations dropping an internal node's retained range) contribute negatively.
    */
   int32_t block_count_delta;
 } AddResult;
@@ -177,8 +176,7 @@ typedef struct CompactIfSparseResult {
   int64_t node_size_delta;
   /**
    * Net change in inverted-index block count across all dropped leaves. Always non-positive
-   * (trimming only removes blocks). Callers maintaining per-spec
-   * `total_inverted_index_blocks` should add this signed value to their counter.
+   * (trimming only removes blocks).
    */
   int32_t block_count_delta;
 } CompactIfSparseResult;
@@ -211,9 +209,8 @@ typedef struct TrimEmptyLeavesResult {
    */
   int32_t num_leaves_delta;
   /**
-   * The net change in the number of inverted-index blocks across all dropped leaves. Always
-   * non-positive (trimming only removes blocks). C callers maintaining per-spec
-   * `total_inverted_index_blocks` should add this to their counter.
+   * Net change in inverted-index block count across all dropped leaves. Always non-positive
+   * (trimming only removes blocks).
    */
   int32_t block_count_delta;
 } TrimEmptyLeavesResult;

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -135,9 +135,10 @@ typedef struct AddResult {
   int32_t num_leaves_delta;
   /**
    * The net change in the number of inverted-index blocks across all leaves touched by
-   * this add. Splits and growth into a new block contribute positively; nothing here
-   * can shrink. C callers maintaining per-spec `total_inverted_index_blocks` should add
-   * this to their counter.
+   * this add. Block growth (writes spilling into a new block, new leaves created by a
+   * split) contributes positively; range removals during rebalancing (`remove_range`,
+   * rotations dropping an internal node's retained range) contribute negatively. C callers
+   * maintaining per-spec `total_inverted_index_blocks` should add this to their counter.
    */
   int32_t block_count_delta;
 } AddResult;

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -133,6 +133,13 @@ typedef struct AddResult {
    * Splitting a leaf adds one new leaf. Trimming decreases this.
    */
   int32_t num_leaves_delta;
+  /**
+   * The net change in the number of inverted-index blocks across all leaves touched by
+   * this add. Splits and growth into a new block contribute positively; nothing here
+   * can shrink. C callers maintaining per-spec `total_inverted_index_blocks` should add
+   * this to their counter.
+   */
+  int32_t block_count_delta;
 } AddResult;
 
 /**
@@ -167,6 +174,12 @@ typedef struct CompactIfSparseResult {
    * Positive values indicate growth, negative values indicate shrinkage.
    */
   int64_t node_size_delta;
+  /**
+   * Net change in inverted-index block count across all dropped leaves. Always non-positive
+   * (trimming only removes blocks). Callers maintaining per-spec
+   * `total_inverted_index_blocks` should add this signed value to their counter.
+   */
+  int32_t block_count_delta;
 } CompactIfSparseResult;
 
 /**
@@ -196,4 +209,10 @@ typedef struct TrimEmptyLeavesResult {
    * The net change in the number of leaf nodes.
    */
   int32_t num_leaves_delta;
+  /**
+   * The net change in the number of inverted-index blocks across all dropped leaves. Always
+   * non-positive (trimming only removes blocks). C callers maintaining per-spec
+   * `total_inverted_index_blocks` should add this to their counter.
+   */
+  int32_t block_count_delta;
 } TrimEmptyLeavesResult;

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -88,7 +88,7 @@ pub struct GcApplyInfo {
     /// Net change in the index's block count for this apply. Positive when blocks were added
     /// (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
     /// Callers maintaining per-spec totals should add this signed value to their counter.
-    pub block_count_delta: isize,
+    pub block_count_delta: i64,
 
     /// Whether or not we ignored the last block in the index, since it changed
     /// compared to the time we performed the scan
@@ -289,7 +289,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             }
         }
 
-        info.block_count_delta = self.blocks.len() as isize - blocks_before as isize;
+        info.block_count_delta = self.blocks.len() as i64 - blocks_before as i64;
         self.gc_marker_inc();
 
         info

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -85,6 +85,11 @@ pub struct GcApplyInfo {
     /// The number of entries that were removed from the index including duplicates
     pub entries_removed: usize,
 
+    /// Net change in the index's block count for this apply. Positive when blocks were added
+    /// (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
+    /// Callers maintaining per-spec totals should add this signed value to their counter.
+    pub block_count_delta: isize,
+
     /// Whether or not we ignored the last block in the index, since it changed
     /// compared to the time we performed the scan
     pub ignored_last_block: bool,
@@ -198,8 +203,11 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             bytes_freed: 0,
             bytes_allocated: 0,
             entries_removed: 0,
+            block_count_delta: 0,
             ignored_last_block: false,
         };
+
+        let blocks_before = self.blocks.len();
 
         // Check if the last block has changed since the scan was performed
         let last_block_changed = self
@@ -281,6 +289,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             }
         }
 
+        info.block_count_delta = self.blocks.len() as isize - blocks_before as isize;
         self.gc_marker_inc();
 
         info

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -310,8 +310,15 @@ impl<E: Encoder> InvertedIndex<E> {
             self.flags |= IndexFlags_Index_HasMultiValue;
         }
 
+        let total_mem_growth = buf_growth + mem_growth;
+        // A single add_record can grow memory by at most one block-buffer doubling plus the
+        // overhead of inserting one new block into the `blocks` ThinVec — comfortably below 4 GiB.
+        debug_assert!(
+            total_mem_growth <= u32::MAX as usize,
+            "AddRecordOutcome::mem_growth overflowed u32 ({total_mem_growth} bytes in one add)"
+        );
         Ok(AddRecordOutcome {
-            mem_growth: (buf_growth + mem_growth) as u32,
+            mem_growth: total_mem_growth as u32,
             blocks_added: (self.blocks.len() - blocks_before) as u32,
         })
     }

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -55,11 +55,7 @@ pub struct InvertedIndex<E> {
     pub(crate) _encoder: PhantomData<E>,
 }
 
-/// Outcome of [`InvertedIndex::add_record`]: the memory the index grew by and how many new
-/// blocks the write created. `u32` is plenty for both — `mem_growth` per call is bounded by the
-/// block size plus a doubling of its buffer capacity, and `blocks_added` is at most 2 (a new
-/// block when the previous one was full, plus another when the encoded delta overflowed). Kept
-/// `#[repr(C)]` so callers (including the FFI) can read it as a flat struct.
+/// Outcome of [`InvertedIndex::add_record`]: how the index grew during the write.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct AddRecordOutcome {

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -55,6 +55,20 @@ pub struct InvertedIndex<E> {
     pub(crate) _encoder: PhantomData<E>,
 }
 
+/// Outcome of [`InvertedIndex::add_record`]: the memory the index grew by and how many new
+/// blocks the write created. `u32` is plenty for both — `mem_growth` per call is bounded by the
+/// block size plus a doubling of its buffer capacity, and `blocks_added` is at most 2 (a new
+/// block when the previous one was full, plus another when the encoded delta overflowed). Kept
+/// `#[repr(C)]` so callers (including the FFI) can read it as a flat struct.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[repr(C)]
+pub struct AddRecordOutcome {
+    /// Number of bytes the inverted index's memory usage grew by.
+    pub mem_growth: u32,
+    /// Number of new index blocks this write created.
+    pub blocks_added: u32,
+}
+
 /// Each `IndexBlock` contains a set of entries for a specific range of document IDs. The entries
 /// are ordered by document ID, so the first entry in the block has the lowest document ID, and the
 /// last entry has the highest document ID. The block also contains a buffer that is used to
@@ -219,9 +233,15 @@ impl<E: Encoder> InvertedIndex<E> {
         blocks_heap + blocks_buffers + stack
     }
 
-    /// Add a new record to the index and return by how much memory grew. It is expected that
-    /// the document ID of the record is greater than or equal the last document ID in the index.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
+    /// Add a new record to the index. Returns an [`AddRecordOutcome`] reporting how many bytes
+    /// the index's memory usage grew by and how many new index blocks the write created (0 in
+    /// the common case, up to 2 when a new block was needed for the encoded delta and/or the
+    /// previous block was full). Callers that maintain a per-spec block counter should add
+    /// `outcome.blocks_added` to it.
+    ///
+    /// It is expected that the document ID of the record is greater than or equal to the last
+    /// document ID in the index.
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
         let doc_id = record.doc_id;
 
         let same_doc = match (
@@ -233,10 +253,12 @@ impl<E: Encoder> InvertedIndex<E> {
                 // Even though we might allow duplicate document IDs, this encoder does not allow
                 // it since it will contain redundant information. Therefore, we are skipping this
                 // record.
-                return Ok(0);
+                return Ok(AddRecordOutcome::default());
             }
             (_, false) => false,
         };
+
+        let blocks_before = self.blocks.len();
 
         // We take ownership of the block since we are going to keep using self. So we can't have a
         // mutable reference to the block we are working with at the same time.
@@ -288,7 +310,10 @@ impl<E: Encoder> InvertedIndex<E> {
             self.flags |= IndexFlags_Index_HasMultiValue;
         }
 
-        Ok(buf_growth + mem_growth)
+        Ok(AddRecordOutcome {
+            mem_growth: (buf_growth + mem_growth) as u32,
+            blocks_added: (self.blocks.len() - blocks_before) as u32,
+        })
     }
 
     /// Returns the last document ID in the index, if any.

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -8,7 +8,7 @@
 */
 
 use crate::{
-    DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
+    AddRecordOutcome, DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
@@ -36,16 +36,16 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
         }
     }
 
-    /// Add a new record to the index and return by how much memory grew. It is expected that
-    /// the document ID of the record is greater than or equal the last document ID in the index.
+    /// Add a new record to the index. See [`InvertedIndex::add_record`] for the meaning of the
+    /// returned `(memory_growth, blocks_added)` pair.
     ///
     /// The total number of entries in the index is incremented by one.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
-        let mem_growth = self.index.add_record(record)?;
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
+        let result = self.index.add_record(record)?;
 
         self.number_of_entries += 1;
 
-        Ok(mem_growth)
+        Ok(result)
     }
 
     /// The memory size of the index in bytes.

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -8,7 +8,8 @@
 */
 
 use crate::{
-    DecodedBy, Encoder, FilterMaskReader, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
+    AddRecordOutcome, DecodedBy, Encoder, FilterMaskReader, GcApplyInfo, GcScanDelta, IndexBlock,
+    InvertedIndex,
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
@@ -41,14 +42,14 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
         }
     }
 
-    /// Add a new record to the index and return by how much memory grew. It is expected that
-    /// the document ID of the record is greater than or equal the last document ID in the index.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
-        let mem_growth = self.index.add_record(record)?;
+    /// Add a new record to the index. See [`InvertedIndex::add_record`] for the meaning of the
+    /// returned `(memory_growth, blocks_added)` pair.
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
+        let result = self.index.add_record(record)?;
 
         self.field_mask |= record.field_mask;
 
-        Ok(mem_growth)
+        Ok(result)
     }
 
     /// The memory size of the index in bytes.

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -505,7 +505,9 @@ fn ii_apply_gc() {
             // The third and fifth block was split making 168 new bytes
             bytes_allocated: 168,
             entries_removed: 5,
-            ignored_last_block: false
+            // Removed 3, added back (split blocks) — see `apply_gc` for the exact net delta
+            block_count_delta: 0,
+            ignored_last_block: false,
         }
     );
 }
@@ -600,8 +602,10 @@ fn ii_apply_gc_last_block_updated() {
             // Nothing new was made in the end
             bytes_allocated: 0,
             entries_removed: 2,
+            // Removed one block
+            block_count_delta: -1,
             // Ignored the last block
-            ignored_last_block: true
+            ignored_last_block: true,
         }
     );
 }
@@ -653,6 +657,7 @@ fn ii_apply_gc_last_block_updated_no_delta() {
             bytes_freed: 56,
             bytes_allocated: 0,
             entries_removed: 2,
+            block_count_delta: -1,
             // The key assertion: ignored_last_block must be true even without
             // a delta for the last block.
             ignored_last_block: true,
@@ -783,7 +788,8 @@ fn ii_apply_gc_entries_tracking_index() {
             bytes_freed: 65,
             bytes_allocated: 56,
             entries_removed: 2,
-            ignored_last_block: false
+            block_count_delta: 0,
+            ignored_last_block: false,
         }
     );
 }

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -78,7 +78,7 @@ fn adding_same_record_twice() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     let record = RSIndexResult::build_virt().doc_id(10).build();
 
-    ii.add_record(&record).unwrap().mem_growth as usize;
+    ii.add_record(&record).unwrap();
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [0, 0, 0, 0]);
     assert_eq!(ii.blocks[0].num_entries, 1);
@@ -124,12 +124,12 @@ fn adding_same_record_twice() {
 
     let mut ii = InvertedIndex::<AllowDupsDummy>::new(IndexFlags_Index_DocIdsOnly);
 
-    ii.add_record(&record).unwrap().mem_growth as usize;
+    ii.add_record(&record).unwrap();
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [255]);
     assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    ii.add_record(&record).unwrap();
 
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -33,7 +33,7 @@ fn memory_usage() {
     assert_eq!(ii.memory_usage(), empty_size);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(ii.memory_usage(), empty_size + mem_growth);
 }
@@ -43,7 +43,7 @@ fn adding_records() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     let record = RSIndexResult::build_virt().doc_id(10).build();
 
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         mem_growth,
@@ -59,7 +59,7 @@ fn adding_records() {
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
 
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         mem_growth, 5,
@@ -78,13 +78,13 @@ fn adding_same_record_twice() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     let record = RSIndexResult::build_virt().doc_id(10).build();
 
-    ii.add_record(&record).unwrap();
+    ii.add_record(&record).unwrap().mem_growth as usize;
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [0, 0, 0, 0]);
     assert_eq!(ii.blocks[0].num_entries, 1);
     assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         mem_growth, 0,
@@ -124,12 +124,12 @@ fn adding_same_record_twice() {
 
     let mut ii = InvertedIndex::<AllowDupsDummy>::new(IndexFlags_Index_DocIdsOnly);
 
-    ii.add_record(&record).unwrap();
+    ii.add_record(&record).unwrap().mem_growth as usize;
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [255]);
     assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(
@@ -178,7 +178,8 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
 
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(10).build())
-        .unwrap();
+        .unwrap()
+        .mem_growth as usize;
     assert_eq!(
         mem_growth,
         8 + IndexBlock::STACK_SIZE + 1,
@@ -187,14 +188,16 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
     assert_eq!(ii.blocks.len(), 1);
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(11).build())
-        .unwrap();
+        .unwrap()
+        .mem_growth as usize;
     assert_eq!(mem_growth, 1, "buffer needs to grow for the new byte");
     assert_eq!(ii.blocks.len(), 1);
 
     // 3 entry should create a new block
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(12).build())
-        .unwrap();
+        .unwrap()
+        .mem_growth as usize;
     assert_eq!(
         mem_growth,
         IndexBlock::STACK_SIZE + 1,
@@ -207,14 +210,16 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
     );
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(13).build())
-        .unwrap();
+        .unwrap()
+        .mem_growth as usize;
     assert_eq!(mem_growth, 1, "buffer needs to grow for the new byte");
     assert_eq!(ii.blocks.len(), 2);
 
     // But duplicate entry does not go in new block even if the current block is full
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(13).build())
-        .unwrap();
+        .unwrap()
+        .mem_growth as usize;
     assert_eq!(mem_growth, 1, "buffer needs to grow again");
     assert_eq!(
         ii.blocks.len(),
@@ -232,7 +237,7 @@ fn adding_big_delta_makes_new_block() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     let record = RSIndexResult::build_virt().doc_id(10).build();
 
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         mem_growth,
@@ -250,7 +255,7 @@ fn adding_big_delta_makes_new_block() {
     let doc_id = (u32::MAX as u64) + 11;
     let record = RSIndexResult::build_virt().doc_id(doc_id).build();
 
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         mem_growth,
@@ -381,13 +386,13 @@ fn adding_tracks_entries() {
     assert_eq!(ii.number_of_entries(), 0);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(ii.memory_usage(), empty_size + mem_growth);
     assert_eq!(ii.number_of_entries(), 1);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(ii.number_of_entries(), 2);
 }
@@ -403,7 +408,7 @@ fn adding_track_field_mask() {
         .doc_id(10)
         .field_mask(0b101)
         .build();
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         mem_growth,
@@ -416,7 +421,7 @@ fn adding_track_field_mask() {
         .doc_id(11)
         .field_mask(0b101)
         .build();
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(mem_growth, 5);
     assert_eq!(ii.field_mask(), 0b101);
@@ -425,7 +430,7 @@ fn adding_track_field_mask() {
         .doc_id(12)
         .field_mask(0b011)
         .build();
-    let mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(mem_growth, 5);
     assert_eq!(ii.field_mask(), 0b111);
@@ -459,10 +464,10 @@ fn summary() {
     );
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         ii.summary(),
@@ -496,10 +501,10 @@ fn summary_store_numeric() {
     );
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     assert_eq!(
         ii.summary(),
@@ -543,13 +548,13 @@ fn blocks_summary() {
     assert_eq!(ii.blocks_summary().len(), 0);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let record = RSIndexResult::build_virt().doc_id(12).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let summaries = ii.blocks_summary();
     assert_eq!(
@@ -597,13 +602,13 @@ fn blocks_summary_store_numeric() {
     assert_eq!(ii.blocks_summary().len(), 0);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let record = RSIndexResult::build_virt().doc_id(12).build();
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
 
     let summaries = ii.blocks_summary();
     assert_eq!(

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -43,13 +43,14 @@ impl NumericIndex {
         }
     }
 
-    /// Add a record to the index, returning bytes written.
+    /// Add a record to the index. Returns `(memory_growth, blocks_added)` — see
+    /// [`InvertedIndex::add_record`][inverted_index::InvertedIndex::add_record].
     ///
     /// # Panics
     ///
     /// Panics if the underlying write fails. This should never happen with
     /// in-memory inverted indexes, so a panic indicates a bug.
-    pub fn add_record(&mut self, record: &RSIndexResult<'_>) -> usize {
+    pub fn add_record(&mut self, record: &RSIndexResult<'_>) -> inverted_index::AddRecordOutcome {
         let result = match self {
             NumericIndex::Uncompressed(idx) => idx.add_record(record),
             NumericIndex::Compressed(idx) => idx.add_record(record),

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -116,7 +116,11 @@ impl NumericRange {
     ///   node, cardinality is already tracked at the leaf level.
     /// - **Splitting**: When redistributing entries during a split, the caller
     ///   explicitly updates cardinality for each destination range.
-    pub fn add_without_cardinality(&mut self, doc_id: t_docId, value: f64) -> inverted_index::AddRecordOutcome {
+    pub fn add_without_cardinality(
+        &mut self,
+        doc_id: t_docId,
+        value: f64,
+    ) -> inverted_index::AddRecordOutcome {
         // Update bounds
         if value < self.min_val {
             self.min_val = value;

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -95,8 +95,10 @@ impl NumericRange {
     /// Add a (docId, value) entry to this range.
     ///
     /// Updates min/max bounds and cardinality estimation.
-    /// Returns the number of bytes the inverted index grew by.
-    pub fn add(&mut self, doc_id: t_docId, value: f64) -> usize {
+    /// Returns `(memory_growth, blocks_added)` — the number of bytes the inverted index grew by
+    /// and the number of new index blocks the write created (0 in the common case, 1 when a new
+    /// block had to be allocated).
+    pub fn add(&mut self, doc_id: t_docId, value: f64) -> inverted_index::AddRecordOutcome {
         self.hll.add(&value.into());
         self.add_without_cardinality(doc_id, value)
     }
@@ -105,6 +107,7 @@ impl NumericRange {
     ///
     /// This function DOES NOT update the cardinality of the range.
     /// Use [`add`][Self::add] to add an entry _and_ update cardinality of the range.
+    /// Returns `(memory_growth, blocks_added)` — see [`Self::add`].
     ///
     /// # Use Cases
     ///
@@ -112,7 +115,7 @@ impl NumericRange {
     ///   node, cardinality is already tracked at the leaf level.
     /// - **Splitting**: When redistributing entries during a split, the caller
     ///   explicitly updates cardinality for each destination range.
-    pub fn add_without_cardinality(&mut self, doc_id: t_docId, value: f64) -> usize {
+    pub fn add_without_cardinality(&mut self, doc_id: t_docId, value: f64) -> inverted_index::AddRecordOutcome {
         // Update bounds
         if value < self.min_val {
             self.min_val = value;

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -94,10 +94,11 @@ impl NumericRange {
 
     /// Add a (docId, value) entry to this range.
     ///
-    /// Updates min/max bounds and cardinality estimation.
-    /// Returns `(memory_growth, blocks_added)` — the number of bytes the inverted index grew by
-    /// and the number of new index blocks the write created (0 in the common case, 1 when a new
-    /// block had to be allocated).
+    /// Updates min/max bounds and cardinality estimation. Returns an [`AddRecordOutcome`]
+    /// reporting how many bytes the inverted index grew by and how many new index blocks the
+    /// write created.
+    ///
+    /// [`AddRecordOutcome`]: inverted_index::AddRecordOutcome
     pub fn add(&mut self, doc_id: t_docId, value: f64) -> inverted_index::AddRecordOutcome {
         self.hll.add(&value.into());
         self.add_without_cardinality(doc_id, value)

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -63,8 +63,7 @@ pub struct CompactIfSparseResult {
     /// Positive values indicate growth, negative values indicate shrinkage.
     pub node_size_delta: i64,
     /// Net change in inverted-index block count across all dropped leaves. Always non-positive
-    /// (trimming only removes blocks). Callers maintaining per-spec
-    /// `total_inverted_index_blocks` should add this signed value to their counter.
+    /// (trimming only removes blocks).
     pub block_count_delta: i32,
 }
 

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -330,6 +330,7 @@ impl NumericRangeTree {
                 let br = Self::balance_node(nodes, node_idx);
                 rv.size_delta += br.size_delta;
                 rv.num_ranges_delta += br.num_ranges_delta;
+                rv.block_count_delta += br.block_count_delta;
                 if let NumericRangeNode::Internal(internal) = &mut nodes[node_idx] {
                     internal.max_depth = br.new_depth;
                 }
@@ -354,6 +355,7 @@ impl NumericRangeTree {
         if let Some(r) = nodes[node_idx].take_range() {
             rv.size_delta -= r.memory_usage() as i64;
             rv.num_ranges_delta -= 1;
+            rv.block_count_delta -= r.entries().num_blocks() as i32;
         }
 
         if right_empty {

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -62,6 +62,10 @@ pub struct CompactIfSparseResult {
     /// The change in the tree's node memory usage, in bytes.
     /// Positive values indicate growth, negative values indicate shrinkage.
     pub node_size_delta: i64,
+    /// Net change in inverted-index block count across all dropped leaves. Always non-positive
+    /// (trimming only removes blocks). Callers maintaining per-spec
+    /// `total_inverted_index_blocks` should add this signed value to their counter.
+    pub block_count_delta: i32,
 }
 
 impl NumericRangeNode {
@@ -214,6 +218,7 @@ impl NumericRangeTree {
         CompactIfSparseResult {
             inverted_index_size_delta: rv.size_delta,
             node_size_delta: -(slab_freed as i64),
+            block_count_delta: rv.block_count_delta,
         }
     }
 
@@ -382,11 +387,13 @@ impl NumericRangeTree {
                 rv.num_leaves_delta -= 1;
                 rv.size_delta -= leaf.range.memory_usage() as i64;
                 rv.num_ranges_delta -= 1;
+                rv.block_count_delta -= leaf.range.entries().num_blocks() as i32;
             }
             NumericRangeNode::Internal(internal) => {
                 if let Some(range) = internal.range.as_ref() {
                     rv.size_delta -= range.memory_usage() as i64;
                     rv.num_ranges_delta -= 1;
+                    rv.block_count_delta -= range.entries().num_blocks() as i32;
                 }
             }
         }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -204,6 +204,7 @@ impl NumericRangeTree {
                     rv.size_delta += br.size_delta;
                     rv.num_records_delta += br.num_records_delta;
                     rv.num_ranges_delta += br.num_ranges_delta;
+                    rv.block_count_delta += br.block_count_delta;
                     if let NumericRangeNode::Internal(internal) = &mut nodes[node_idx] {
                         internal.max_depth = br.new_depth;
                     }
@@ -381,6 +382,7 @@ impl NumericRangeTree {
             rv.size_delta -= range.memory_usage() as i64;
             rv.num_records_delta -= range.num_entries() as i32;
             rv.num_ranges_delta -= 1;
+            rv.block_count_delta -= range.entries().num_blocks() as i32;
         }
     }
 
@@ -438,6 +440,7 @@ impl NumericRangeTree {
                 result.size_delta -= range.memory_usage() as i64;
                 result.num_records_delta -= range.num_entries() as i32;
                 result.num_ranges_delta -= 1;
+                result.block_count_delta -= range.entries().num_blocks() as i32;
             }
         }
 
@@ -460,4 +463,6 @@ pub(super) struct BalanceResult {
     pub num_records_delta: i32,
     /// Change in range count from dropped ranges.
     pub num_ranges_delta: i32,
+    /// Change in inverted-index block count from dropped ranges (always ≤ 0).
+    pub block_count_delta: i32,
 }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -192,8 +192,9 @@ impl NumericRangeTree {
                 if let NumericRangeNode::Internal(internal) = &mut nodes[node_idx]
                     && let Some(range) = internal.range.as_mut()
                 {
-                    let size = range.add_without_cardinality(doc_id, value);
-                    rv.size_delta += size as i64;
+                    let outcome = range.add_without_cardinality(doc_id, value);
+                    rv.size_delta += outcome.mem_growth as i64;
+                    rv.block_count_delta += outcome.blocks_added as i32;
                     rv.num_records_delta += 1;
                 }
 
@@ -227,13 +228,14 @@ impl NumericRangeTree {
                     *empty_leaves -= 1;
                 }
 
-                let size = leaf.range.add(doc_id, value);
+                let outcome = leaf.range.add(doc_id, value);
                 let mut rv = AddResult {
-                    size_delta: size as i64,
+                    size_delta: outcome.mem_growth as i64,
                     num_records_delta: 1,
                     changed: false,
                     num_ranges_delta: 0,
                     num_leaves_delta: 0,
+                    block_count_delta: outcome.blocks_added as i32,
                 };
 
                 let card = leaf.range.cardinality();
@@ -329,8 +331,9 @@ impl NumericRangeTree {
             };
 
             if let Some(target_range) = nodes[target_idx].range_mut() {
-                let size = target_range.add(result.doc_id, entry_value);
-                rv.size_delta += size as i64;
+                let outcome = target_range.add(result.doc_id, entry_value);
+                rv.size_delta += outcome.mem_growth as i64;
+                rv.block_count_delta += outcome.blocks_added as i32;
             }
             rv.num_records_delta += 1;
         }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -61,6 +61,11 @@ pub struct AddResult {
     /// The net change in the number of leaf nodes.
     /// Splitting a leaf adds one new leaf. Trimming decreases this.
     pub num_leaves_delta: i32,
+    /// The net change in the number of inverted-index blocks across all leaves touched by
+    /// this add. Splits and growth into a new block contribute positively; nothing here
+    /// can shrink. C callers maintaining per-spec `total_inverted_index_blocks` should add
+    /// this to their counter.
+    pub block_count_delta: i32,
 }
 
 /// Result of trimming empty leaves from the tree.
@@ -82,6 +87,10 @@ pub struct TrimEmptyLeavesResult {
     pub num_ranges_delta: i32,
     /// The net change in the number of leaf nodes.
     pub num_leaves_delta: i32,
+    /// The net change in the number of inverted-index blocks across all dropped leaves. Always
+    /// non-positive (trimming only removes blocks). C callers maintaining per-spec
+    /// `total_inverted_index_blocks` should add this to their counter.
+    pub block_count_delta: i32,
 }
 
 /// Aggregate statistics for a [`NumericRangeTree`].

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -62,9 +62,10 @@ pub struct AddResult {
     /// Splitting a leaf adds one new leaf. Trimming decreases this.
     pub num_leaves_delta: i32,
     /// The net change in the number of inverted-index blocks across all leaves touched by
-    /// this add. Splits and growth into a new block contribute positively; nothing here
-    /// can shrink. C callers maintaining per-spec `total_inverted_index_blocks` should add
-    /// this to their counter.
+    /// this add. Block growth (writes spilling into a new block, new leaves created by a
+    /// split) contributes positively; range removals during rebalancing (`remove_range`,
+    /// rotations dropping an internal node's retained range) contribute negatively. C callers
+    /// maintaining per-spec `total_inverted_index_blocks` should add this to their counter.
     pub block_count_delta: i32,
 }
 

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -64,8 +64,7 @@ pub struct AddResult {
     /// The net change in the number of inverted-index blocks across all leaves touched by
     /// this add. Block growth (writes spilling into a new block, new leaves created by a
     /// split) contributes positively; range removals during rebalancing (`remove_range`,
-    /// rotations dropping an internal node's retained range) contribute negatively. C callers
-    /// maintaining per-spec `total_inverted_index_blocks` should add this to their counter.
+    /// rotations dropping an internal node's retained range) contribute negatively.
     pub block_count_delta: i32,
 }
 
@@ -88,9 +87,8 @@ pub struct TrimEmptyLeavesResult {
     pub num_ranges_delta: i32,
     /// The net change in the number of leaf nodes.
     pub num_leaves_delta: i32,
-    /// The net change in the number of inverted-index blocks across all dropped leaves. Always
-    /// non-positive (trimming only removes blocks). C callers maintaining per-spec
-    /// `total_inverted_index_blocks` should add this to their counter.
+    /// Net change in inverted-index block count across all dropped leaves. Always non-positive
+    /// (trimming only removes blocks).
     pub block_count_delta: i32,
 }
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -244,12 +244,7 @@ impl InvertedIndex {
     #[inline(always)]
     pub fn write_numeric_entry(&self, doc_id: u64, value: f64) {
         unsafe {
-            inverted_index_ffi::InvertedIndex_WriteNumericEntry(
-                self.ii.cast(),
-                doc_id,
-                value,
-                std::ptr::null_mut(),
-            );
+            inverted_index_ffi::InvertedIndex_WriteNumericEntry(self.ii.cast(), doc_id, value);
         }
     }
 
@@ -274,7 +269,6 @@ impl InvertedIndex {
             inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
                 self.ii.cast(),
                 &record as *const _ as *mut _,
-                std::ptr::null_mut(),
             );
         }
     }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -244,7 +244,12 @@ impl InvertedIndex {
     #[inline(always)]
     pub fn write_numeric_entry(&self, doc_id: u64, value: f64) {
         unsafe {
-            inverted_index_ffi::InvertedIndex_WriteNumericEntry(self.ii.cast(), doc_id, value);
+            inverted_index_ffi::InvertedIndex_WriteNumericEntry(
+                self.ii.cast(),
+                doc_id,
+                value,
+                std::ptr::null_mut(),
+            );
         }
     }
 
@@ -269,6 +274,7 @@ impl InvertedIndex {
             inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
                 self.ii.cast(),
                 &record as *const _ as *mut _,
+                std::ptr::null_mut(),
             );
         }
     }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -353,6 +353,7 @@ impl TestContext {
                 inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
                     ii_ptr,
                     &record as *const _ as *mut _,
+                    std::ptr::null_mut(),
                 );
             }
         }
@@ -417,6 +418,7 @@ impl TestContext {
                 inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
                     ii_ptr,
                     &record as *const _ as *mut _,
+                    std::ptr::null_mut(),
                 );
             }
         }
@@ -507,6 +509,7 @@ impl TestContext {
                 inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
                     ii_opaque,
                     &record as *const _ as *mut _,
+                    std::ptr::null_mut(),
                 );
             }
         }
@@ -552,7 +555,7 @@ impl TestContext {
 
         // Write the entry to the inverted index
         unsafe {
-            ffi::InvertedIndex_WriteForwardIndexEntry(idx, &mut entry);
+            ffi::InvertedIndex_WriteForwardIndexEntry(idx, &mut entry, std::ptr::null_mut());
         }
 
         varint_ffi::VVW_Free(Some(vw_nonnull));

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -350,11 +350,7 @@ impl TestContext {
             let record = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
             unsafe {
-                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
-                    ii_ptr,
-                    &record as *const _ as *mut _,
-                    std::ptr::null_mut(),
-                );
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(ii_ptr, &record as *const _ as *mut _);
             }
         }
 
@@ -415,11 +411,7 @@ impl TestContext {
             let record = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
             unsafe {
-                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
-                    ii_ptr,
-                    &record as *const _ as *mut _,
-                    std::ptr::null_mut(),
-                );
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(ii_ptr, &record as *const _ as *mut _);
             }
         }
 
@@ -506,11 +498,7 @@ impl TestContext {
             // SAFETY: ii_opaque is a valid pointer created via TagIndex_OpenIndex
             // which delegates to NewInvertedIndex_Ex (Rust FFI).
             unsafe {
-                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
-                    ii_opaque,
-                    &record as *const _ as *mut _,
-                    std::ptr::null_mut(),
-                );
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(ii_opaque, &record as *const _ as *mut _);
             }
         }
 
@@ -555,7 +543,7 @@ impl TestContext {
 
         // Write the entry to the inverted index
         unsafe {
-            ffi::InvertedIndex_WriteForwardIndexEntry(idx, &mut entry, std::ptr::null_mut());
+            ffi::InvertedIndex_WriteForwardIndexEntry(idx, &mut entry);
         }
 
         varint_ffi::VVW_Free(Some(vw_nonnull));

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -350,7 +350,10 @@ impl TestContext {
             let record = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
             unsafe {
-                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(ii_ptr, &record as *const _ as *mut _);
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
+                    ii_ptr,
+                    &record as *const _ as *mut _,
+                );
             }
         }
 
@@ -411,7 +414,10 @@ impl TestContext {
             let record = RSIndexResult::build_virt().doc_id(doc_id).build();
             // SAFETY: ii is a valid pointer created via NewInvertedIndex_Ex
             unsafe {
-                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(ii_ptr, &record as *const _ as *mut _);
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
+                    ii_ptr,
+                    &record as *const _ as *mut _,
+                );
             }
         }
 
@@ -498,7 +504,10 @@ impl TestContext {
             // SAFETY: ii_opaque is a valid pointer created via TagIndex_OpenIndex
             // which delegates to NewInvertedIndex_Ex (Rust FFI).
             unsafe {
-                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(ii_opaque, &record as *const _ as *mut _);
+                inverted_index_ffi::InvertedIndex_WriteEntryGeneric(
+                    ii_opaque,
+                    &record as *const _ as *mut _,
+                );
             }
         }
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -165,6 +165,15 @@ typedef struct {
   size_t offsetVecsSize;
   size_t offsetVecRecords;
   size_t termsSize;
+  // Number of inverted-index blocks currently owned by this spec; reported by FT.INFO as
+  // `total_inverted_index_blocks`. Pass `&stats.totalInvertedIndexBlocks` as the
+  // `spec_block_counter` argument to `InvertedIndex_WriteEntryGeneric`,
+  // `InvertedIndex_WriteNumericEntry`, and `InvertedIndex_ApplyGcDelta` — the Rust side
+  // atomically updates it. When freeing an inverted index, read
+  // `InvertedIndex_NumBlocks(idx)` before the free and atomically decrement this counter
+  // (mirroring how `InvertedIndex_MemUsage` is queried before `InvertedIndex_Free`). C reads
+  // should also be atomic (e.g. `__atomic_load_n`).
+  size_t totalInvertedIndexBlocks;
   rs_wall_clock_ns_t totalIndexTime;
   IndexError indexError;
   uint32_t activeQueries;

--- a/src/spec.h
+++ b/src/spec.h
@@ -178,7 +178,7 @@ typedef struct {
 // Atomically apply `delta` to `stats->totalInvertedIndexBlocks`. Accepts signed deltas:
 // negative values wrap via size_t two's-complement, producing the correct unsigned
 // subtraction. Zero is a no-op (skips the atomic in the common no-new-blocks path).
-static inline void IndexStats_BlockCountAdd(IndexStats *stats, ptrdiff_t delta) {
+static inline void IndexStats_BlockCountAdd(IndexStats *stats, int64_t delta) {
   if (delta) {
     __atomic_add_fetch(&stats->totalInvertedIndexBlocks,
                        (size_t)delta, __ATOMIC_RELAXED);

--- a/src/spec.h
+++ b/src/spec.h
@@ -166,19 +166,24 @@ typedef struct {
   size_t offsetVecRecords;
   size_t termsSize;
   // Number of inverted-index blocks currently owned by this spec; reported by FT.INFO as
-  // `total_inverted_index_blocks`. Maintained at operation time: writes return
-  // `AddRecordOutcome.blocks_added`, GC and numeric-tree mutations return signed
-  // `block_count_delta` fields in their result structs — callers `__atomic_add_fetch` the
-  // delta into this counter. When freeing an inverted index mid-life, read
-  // `InvertedIndex_NumBlocks(idx)` before the free and `__atomic_sub_fetch` (mirroring how
-  // `InvertedIndex_MemUsage` is queried before `InvertedIndex_Free`). Reads should also be
-  // atomic (e.g. `__atomic_load_n`).
+  // `total_inverted_index_blocks`. Update via `IndexStats_BlockCountAdd` (handles +/- deltas)
+  // or the explicit `__atomic_sub_fetch` for mid-life destruction. Reads should be atomic.
   size_t totalInvertedIndexBlocks;
   rs_wall_clock_ns_t totalIndexTime;
   IndexError indexError;
   uint32_t activeQueries;
   uint32_t activeWrites;
 } IndexStats;
+
+// Atomically apply `delta` to `stats->totalInvertedIndexBlocks`. Accepts signed deltas:
+// negative values wrap via size_t two's-complement, producing the correct unsigned
+// subtraction. Zero is a no-op (skips the atomic in the common no-new-blocks path).
+static inline void IndexStats_BlockCountAdd(IndexStats *stats, ptrdiff_t delta) {
+  if (delta) {
+    __atomic_add_fetch(&stats->totalInvertedIndexBlocks,
+                       (size_t)delta, __ATOMIC_RELAXED);
+  }
+}
 
 typedef enum {
   Index_StoreTermOffsets = 0x01,

--- a/src/spec.h
+++ b/src/spec.h
@@ -166,13 +166,13 @@ typedef struct {
   size_t offsetVecRecords;
   size_t termsSize;
   // Number of inverted-index blocks currently owned by this spec; reported by FT.INFO as
-  // `total_inverted_index_blocks`. Pass `&stats.totalInvertedIndexBlocks` as the
-  // `spec_block_counter` argument to `InvertedIndex_WriteEntryGeneric`,
-  // `InvertedIndex_WriteNumericEntry`, and `InvertedIndex_ApplyGcDelta` — the Rust side
-  // atomically updates it. When freeing an inverted index, read
-  // `InvertedIndex_NumBlocks(idx)` before the free and atomically decrement this counter
-  // (mirroring how `InvertedIndex_MemUsage` is queried before `InvertedIndex_Free`). C reads
-  // should also be atomic (e.g. `__atomic_load_n`).
+  // `total_inverted_index_blocks`. Maintained at operation time: writes return
+  // `AddRecordOutcome.blocks_added`, GC and numeric-tree mutations return signed
+  // `block_count_delta` fields in their result structs — callers `__atomic_add_fetch` the
+  // delta into this counter. When freeing an inverted index mid-life, read
+  // `InvertedIndex_NumBlocks(idx)` before the free and `__atomic_sub_fetch` (mirroring how
+  // `InvertedIndex_MemUsage` is queried before `InvertedIndex_Free`). Reads should also be
+  // atomic (e.g. `__atomic_load_n`).
   size_t totalInvertedIndexBlocks;
   rs_wall_clock_ns_t totalIndexTime;
   IndexError indexError;

--- a/src/spec.h
+++ b/src/spec.h
@@ -166,8 +166,8 @@ typedef struct {
   size_t offsetVecRecords;
   size_t termsSize;
   // Number of inverted-index blocks currently owned by this spec; reported by FT.INFO as
-  // `total_inverted_index_blocks`. Update via `IndexStats_BlockCountAdd` (handles +/- deltas)
-  // or the explicit `__atomic_sub_fetch` for mid-life destruction. Reads should be atomic.
+  // `total_inverted_index_blocks`. Writes must go through `IndexStats_BlockCountAdd` (signed
+  // delta, atomic). Reads must use `__atomic_load_n`.
   size_t totalInvertedIndexBlocks;
   rs_wall_clock_ns_t totalIndexTime;
   IndexError indexError;
@@ -177,7 +177,7 @@ typedef struct {
 
 // Atomically apply `delta` to `stats->totalInvertedIndexBlocks`. Accepts signed deltas:
 // negative values wrap via size_t two's-complement, producing the correct unsigned
-// subtraction. Zero is a no-op (skips the atomic in the common no-new-blocks path).
+// subtraction.
 static inline void IndexStats_BlockCountAdd(IndexStats *stats, int64_t delta) {
   if (delta) {
     __atomic_add_fetch(&stats->totalInvertedIndexBlocks,

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -207,12 +207,14 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // Encode a single docId into a specific tag value
 // Returns the number of bytes occupied by the encoded entry plus the size of
 // the inverted index (if a new inverted index was created)
-static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
+static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId,
+                                  IndexStats *stats) {
   size_t sz;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
-  return InvertedIndex_WriteEntryGeneric(iv, &rec) + sz;
+  size_t bytes = InvertedIndex_WriteEntryGeneric(iv, &rec, &stats->totalInvertedIndexBlocks);
+  return bytes + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */
@@ -241,7 +243,7 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, const char **values, siz
     for (size_t ii = 0; ii < n; ++ii) {
       const char *tok = values[ii];
       if (tok) {
-        stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId);
+        stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, stats);
 
         if (idx->suffix && (*tok != '\0')) { // add to suffix TrieMap
           addSuffixTrieMap(idx->suffix, tok, strlen(tok));

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -213,8 +213,12 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
-  size_t bytes = InvertedIndex_WriteEntryGeneric(iv, &rec, &stats->totalInvertedIndexBlocks);
-  return bytes + sz;
+  AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iv, &rec);
+  if (r.blocks_added) {
+    __atomic_add_fetch(&stats->totalInvertedIndexBlocks,
+                       r.blocks_added, __ATOMIC_RELAXED);
+  }
+  return r.mem_growth + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -214,10 +214,7 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
                        .metrics = MetricsVec_New()};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
   AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iv, &rec);
-  if (r.blocks_added) {
-    __atomic_add_fetch(&stats->totalInvertedIndexBlocks,
-                       r.blocks_added, __ATOMIC_RELAXED);
-  }
+  IndexStats_BlockCountAdd(stats, r.blocks_added);
   return r.mem_growth + sz;
 }
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -392,7 +392,7 @@ TEST_F(IndexTest, testNumericInverted) {
     }
 
     // Check if the write matches the simulation
-    sz = InvertedIndex_WriteNumericEntry(idx, i + 1, (double)(i + 1));
+    sz = InvertedIndex_WriteNumericEntry(idx, i + 1, (double)(i + 1)).mem_growth;
     ASSERT_EQ(sz, expected_sz) << " at i=" << i;
   }
   ASSERT_EQ(75, InvertedIndex_LastId(idx));
@@ -429,7 +429,7 @@ TEST_F(IndexTest, testNumericVaried) {
   static const size_t numCount = sizeof(nums) / sizeof(double);
 
   for (size_t i = 0; i < numCount; i++) {
-    size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
+    size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]).mem_growth;
     // printf("[%lu]: Stored %lf\n", i, nums[i]);
   }
 
@@ -490,10 +490,10 @@ void testNumericEncodingHelper(bool isMulti) {
 
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
-    size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
+    size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value).mem_growth;
 
     if (isMulti) {
-      size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
+      size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value).mem_growth;
     }
   }
 
@@ -1177,7 +1177,7 @@ TEST_F(IndexTest, testIndexFlags) {
   // storing fieldmask on idx             16
   ASSERT_EQ(40, index_memsize);
   ASSERT_TRUE(InvertedIndex_Flags(w) == flags);
-  size_t sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
+  size_t sz = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
   ASSERT_EQ(73, sz);
   InvertedIndex_Free(w);
 
@@ -1185,7 +1185,7 @@ TEST_F(IndexTest, testIndexFlags) {
   w = NewInvertedIndex(IndexFlags(flags), &index_memsize);
   ASSERT_EQ(40, index_memsize);
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
-  size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, &h);
+  size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
   ASSERT_EQ(sz2, 60);
   InvertedIndex_Free(w);
 
@@ -1194,7 +1194,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_EQ(40, index_memsize);
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
   h.fieldMask = 0xffffffffffff;
-  ASSERT_EQ(77, InvertedIndex_WriteForwardIndexEntry(w, &h));
+  ASSERT_EQ(77, InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth);
   InvertedIndex_Free(w);
 
   flags &= Index_StoreFreqs;
@@ -1206,7 +1206,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_EQ(24, index_memsize);
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreFieldFlags));
-  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
   ASSERT_EQ(59, sz);
   InvertedIndex_Free(w);
 
@@ -1216,7 +1216,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_StoreFieldFlags));
   h.fieldMask = 0xffffffffffff;
-  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
   ASSERT_EQ(67, sz);
   InvertedIndex_Free(w);
 

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -155,6 +155,45 @@ def test_info_text_tag_overhead(env):
   env.assertEqual(float(res['tag_overhead_sz_mb']), 24. / 1024 / 1024)
   env.assertEqual(float(res['text_overhead_sz_mb']), 0)
 
+@skip(cluster=True)
+def test_total_inverted_index_blocks_per_spec(env):
+  """Regression test for MOD-15781: `FT.INFO total_inverted_index_blocks` must reflect only the
+  queried spec's blocks, not the process-global block count summed across all in-memory
+  indexes."""
+
+  conn = getConnectionByEnv(env)
+
+  # Two indexes with deliberately different sizes so a global-counter bug would surface as
+  # both reports having the same (summed) value.
+  env.expect('FT.CREATE', 'small_idx', 'SCHEMA', 'tag1', 'TAG').ok()
+  env.expect('FT.CREATE', 'large_idx', 'SCHEMA', 'tag1', 'TAG').ok()
+
+  # Each unique tag value gets its own inverted index (with at least one block), so a unique
+  # tag per doc maximises block count per doc.
+  for i in range(50):
+    conn.execute_command('HSET', f'small:{i}', 'tag1', f'sm{i}')
+  for i in range(500):
+    conn.execute_command('HSET', f'large:{i}', 'tag1', f'lg{i}')
+
+  small_blocks = int(index_info(env, 'small_idx')['total_inverted_index_blocks'])
+  large_blocks = int(index_info(env, 'large_idx')['total_inverted_index_blocks'])
+
+  # Each unique tag yields one DocIdsOnly inverted index with a single block. With a
+  # process-global counter (the pre-fix bug) both reports would equal the sum and `small_blocks`
+  # would equal `large_blocks`; with a per-spec counter `large_blocks` is ~10x `small_blocks`.
+  env.assertGreaterEqual(small_blocks, 50, message=f'small={small_blocks}, large={large_blocks}')
+  env.assertGreaterEqual(large_blocks, 500, message=f'small={small_blocks}, large={large_blocks}')
+  env.assertGreater(large_blocks, small_blocks * 5,
+                    message=f'per-spec counter regressed to a global sum: '
+                            f'small={small_blocks}, large={large_blocks}')
+
+  # Dropping `large_idx` must not change `small_idx`'s block count.
+  env.expect('FT.DROPINDEX', 'large_idx', 'DD').ok()
+  small_blocks_after_drop = int(index_info(env, 'small_idx')['total_inverted_index_blocks'])
+  env.assertEqual(small_blocks_after_drop, small_blocks,
+                  message=f'dropping a sibling spec must not change this spec\'s block count: '
+                          f'before={small_blocks} after={small_blocks_after_drop}')
+
 def test_vecsim_info_stats_memory():
   env = Env(protocol=3)
   vec_size = 6

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -164,9 +164,10 @@ def test_total_inverted_index_blocks_per_spec(env):
   conn = getConnectionByEnv(env)
 
   # Two indexes with deliberately different sizes so a global-counter bug would surface as
-  # both reports having the same (summed) value.
-  env.expect('FT.CREATE', 'small_idx', 'SCHEMA', 'tag1', 'TAG').ok()
-  env.expect('FT.CREATE', 'large_idx', 'SCHEMA', 'tag1', 'TAG').ok()
+  # both reports having the same (summed) value. PREFIX keeps each spec isolated so each
+  # doc gets indexed into exactly one of them.
+  env.expect('FT.CREATE', 'small_idx', 'PREFIX', 1, 'small:', 'SCHEMA', 'tag1', 'TAG').ok()
+  env.expect('FT.CREATE', 'large_idx', 'PREFIX', 1, 'large:', 'SCHEMA', 'tag1', 'TAG').ok()
 
   # Each unique tag value gets its own inverted index (with at least one block), so a unique
   # tag per doc maximises block count per doc.

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -567,8 +567,10 @@ def testInfoStatsAndSearchAsSingle(env):
         json_val = {k:v for (k,v) in zip([f'val{i + 1}' for i in range(val_count)], val_list)}
         conn.execute_command('JSON.SET', f'doc:single:{{{doc}}}', '$', json.dumps(json_val))
 
-    # Compare INFO stats
-    interesting_attr = ['num_docs', 'max_doc_id', 'num_records', 'total_inverted_index_blocks']
+    # Compare INFO stats. `total_inverted_index_blocks` is per-spec (MOD-15781) and
+    # legitimately differs here: idx:single has 5 numeric trees (one per attribute),
+    # idx:multi has a single tree — same total records, different number of blocks.
+    interesting_attr = ['num_docs', 'max_doc_id', 'num_records']
     info_single = keep_dict_keys(index_info(env, 'idx:single'), interesting_attr)
     info_multi = keep_dict_keys(index_info(env, 'idx:multi'), interesting_attr)
     env.assertEqual(info_single, info_multi)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `FT.INFO total_inverted_index_blocks` is backed by a process-global atomic
   (`TOTAL_BLOCKS` in `inverted_index/src/index/core.rs`). Every in-memory index in the same
   Redis process returns the same value — the sum of inverted-index blocks across **all**
   in-memory specs. The field is reported per-spec but the value is not.

2. **Change**: Add `IndexStats.totalInvertedIndexBlocks` to `IndexSpec` and have the C side
   maintain it explicitly at the moments when block counts change. Rust reports the deltas;
   C does the atomic update.

   - The block-mutating FFIs — `InvertedIndex_WriteEntryGeneric`, `InvertedIndex_WriteNumericEntry`,
     and `InvertedIndex_WriteForwardIndexEntry` — now return a small `#[repr(C)]` struct
     `AddRecordOutcome { u32 mem_growth; u32 blocks_added; }` (8 bytes, returns by value in a
     single register on x86_64 SysV). No counter pointer, no out-param.
   - `InvertedIndex_ApplyGcDelta` writes `info.block_count_delta` (signed) into its existing
     `II_GCScanStats` out-struct.
   - `NumericRangeTree_Add` / `NumericRangeTree_ApplyGcEntry` / `NumericRangeTree_CompactIfSparse`
     / `NumericRangeTree_TrimEmptyLeaves` all carry a `block_count_delta` field in their result
     structs (signed). Tree-internal block drops (`remove_range`, `balance_node` rotations, and
     `_trim_empty_leaves`'s internal-node range removal) all contribute to that delta so the
     counter survives restructuring as well as the leaf-level GC paths. C reads the delta and
     `__atomic_add_fetch`es into the spec counter (signed deltas are cast to `size_t`; unsigned
     wraparound delivers the correct subtraction).
   - For mid-life destruction (fork-GC dropping an empty term / tag value / missing-docs index,
     or freeing `spec->existingDocs`), the caller reads `InvertedIndex_NumBlocks(idx)` before
     the free and atomic-subs (mirroring the existing `InvertedIndex_MemUsage`-before-`_Free`
     convention).

   `InvertedIndex` itself is unchanged (no new field, no struct-size growth). The process-global
   `TOTAL_BLOCKS` counter is kept as-is and still exposed via the process-wide Redis
   `INFO modules` stat at `spec.c:3198`. `FT.INFO` (`info_command.c:269`) now reads the per-spec
   counter via `__atomic_load_n`.

3. **Outcome**: Each spec's `FT.INFO total_inverted_index_blocks` reflects only that spec's
   blocks across text/tag/numeric/missing-docs/existing-docs paths and is correctly maintained
   under fork GC. Multi-tenant deployments and cross-spec comparisons now see correct values.
   The process-wide aggregate remains available via `INFO modules` for cluster-side rollups.

#### Which additional issues this PR fixes
1. MOD-15781

#### Main objects this PR modified

1. **C — `IndexStats`**: new `size_t totalInvertedIndexBlocks` on `IndexSpec.stats`.
2. **Rust — `AddRecordOutcome`**: new `#[repr(C)]` struct returned by value from the write FFIs.
   `add_record` / wrappers (`FieldMaskTrackingIndex`, `EntriesTrackingIndex`, `NumericIndex`,
   `NumericRange`) all return it.
3. **Rust — `block_count_delta` fields** on `GcApplyInfo`, `AddResult`, `BalanceResult`,
   `TrimEmptyLeavesResult`, and `CompactIfSparseResult`. Populated by `apply_gc`,
   `node_add` / `split_node` / `remove_range` / `balance_node`,
   `_trim_empty_leaves` / `free_subtree` / `remove_empty_children`, and `compact_if_sparse`.
4. **C production paths**: `indexer.c` (text + missing-docs + existing-docs writes),
   `tag_index.c` (tag writes), `forward_index.c` (forward-index writes),
   `document.c` (numeric writes), the four `fork_gc/*.c` paths (apply-gc and mid-life
   destruction), and `debug_commands.c` (numeric trim debug command) all read the relevant
   delta and atomic-update `sp->stats.totalInvertedIndexBlocks`.
5. **`info_command.c`**: per-spec atomic read replaces `TotalIIBlocks()`.

#### Mid-life destruction coverage

The following paths destroy an inverted index while the owning spec is still alive; all of them
update the per-spec counter:

| Path | Mechanism |
|------|-----------|
| Fork GC empty-term dict delete | Read `NumBlocks` + atomic-sub before `dictDelete(keysDict)` |
| Fork GC empty-tag triemap delete | Read `NumBlocks` + atomic-sub before `TrieMap_Delete(values)` |
| Fork GC empty-missing-docs dict delete | Read `NumBlocks` + atomic-sub before `dictDelete(missingFieldDict)` |
| Fork GC empty `existingDocs` free | Read `NumBlocks` + atomic-sub before `InvertedIndex_Free` |
| Fork GC numeric leaf GC (replace / delete) | `apply_info.block_count_delta` from `NumericRangeTree_ApplyGcEntry` |
| Fork GC numeric empty-leaf trim | `CompactIfSparseResult.block_count_delta` |
| Numeric insert restructuring | `AddResult.block_count_delta` (covers `split_node`, `remove_range`, `balance_node`) |
| Debug `NumericRangeTree_TrimEmptyLeaves` | `TrimEmptyLeavesResult.block_count_delta` |

Counter is intentionally not maintained when the owning spec is being torn down (`IndexSpec_Free`,
`FieldSpec_Free` → `NumericRangeTree_Free`, dict bulk-release via `InvIndFreeCb`): the spec is
gone before any reader can observe the value.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

FFI signatures changed (`InvertedIndex_WriteEntryGeneric`, `InvertedIndex_WriteNumericEntry`,
`InvertedIndex_WriteForwardIndexEntry` now return `AddRecordOutcome`; `InvertedIndex_ApplyGcDelta`
populates an extra field on the existing `II_GCScanStats` out-struct; `AddResult` /
`TrimEmptyLeavesResult` / `CompactIfSparseResult` gained a `block_count_delta` field). All
in-tree callers updated. No public Redis command shape changed — the `FT.INFO` field name and key
are unchanged, only the value semantics are now correct.

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

> **Bug fix**: `FT.INFO total_inverted_index_blocks` previously reported the same value for
> every in-memory index in a Redis process (the global sum across all specs). It now reports
> only the queried spec's blocks. The process-wide aggregate is unchanged and remains
> available via `INFO modules`'s `search_total_inverted_index_blocks` field.

## Test plan
- [x] Rust unit + integration tests (`cargo nextest run --workspace`) — 1956 tests, no regressions.
- [x] `tests/pytests/test_info.py::test_total_inverted_index_blocks_per_spec` — two
      PREFIX-isolated indexes of clearly different sizes (50 vs 500 unique tags); asserts each
      `FT.INFO` value reflects only its own spec (would fail under the pre-fix global-counter
      bug), and that dropping a sibling spec doesn't change the surviving spec's count.
- [x] `tests/pytests/test_info.py::test_total_inverted_index_blocks_field_types` — mixed-schema
      index (TEXT + TAG + NUMERIC + INDEXMISSING + INDEXALL) with 250 docs covering all field
      types; asserts substantial block-count growth across text/tag/numeric/missing/existing-docs
      paths and that GC reduces the per-spec counter.
- [x] C++ unit tests (`tests/cpptests/test_cpp_forkgc.cpp`) covering `TotalIIBlocks()` deltas
      — 13 tests pass; process-global counter is unchanged.
- [x] Existing pytests that exercise `total_inverted_index_blocks`:
      - `test_json_multi_numeric.py` — 19/19 pass after fixing a leaked tree-restructuring
        path that dropped blocks without updating the per-spec counter (caught by
        `testInfoAndGC`), and after updating `testInfoStatsAndSearchAsSingle` which
        previously compared the counter across two specs with different schemas (legitimately
        differs under per-spec semantics).
      - `test_resp3.py` — 33/33 pass.
      - `test_crash.py` — 2/2 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches indexing, fork GC, and numeric tree paths across C/Rust FFI; incorrect deltas would skew FT.INFO stats but not change query results.
> 
> **Overview**
> **`FT.INFO total_inverted_index_blocks`** now reports only the queried index’s blocks instead of a process-wide sum shared by every in-memory spec (MOD-15781).
> 
> The fix adds **`IndexStats.totalInvertedIndexBlocks`** on each **`IndexSpec`**, updated via **`IndexStats_BlockCountAdd`** at every block-changing path: indexing (text, tags, numerics, missing/existing-docs), forward-index writes, fork-GC apply deltas, numeric tree insert/GC/trim/compaction, and explicit decrements when an inverted index is removed mid-life (empty term/tag/missing-docs/existing-docs). Rust exposes **`AddRecordOutcome`** (`mem_growth`, `blocks_added`) from write FFIs and signed **`block_count_delta`** on GC/numeric result structs; **`InvertedIndex_ApplyGcDelta`** is renamed **`InvertedIndex_ApplyGCDelta`**. **`info_command.c`** atomically loads the per-spec counter; the global **`TotalIIBlocks()`** aggregate remains for **`INFO modules`**.
> 
> Tests add **`test_total_inverted_index_blocks_per_spec`** and adjust comparisons where per-spec block counts legitimately differ across schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9cf4b4279fbb130f7c198660fda330d03019bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->