### PR TITLE
[skills] report-flaky-test: default flaky_test label and gh log fallback

### DIFF
--- a/.skills/report-flaky-test/SKILL.md
+++ b/.skills/report-flaky-test/SKILL.md
@@ -22,6 +22,8 @@ Defaults:
 - Parent epic: `MOD-9672` (`[RQE] CI Stability - MAG`)
 - Issue type: `Bug`
 - Components: `RediSearch`, `RedisAI`
+- Labels: `flaky_test` (every existing flaky-test ticket in MOD carries this label; always set it
+  on new tickets and prefer it as a JQL filter, e.g. `labels = flaky_test`)
 
 ## Instructions
 
@@ -43,6 +45,20 @@ gh run view <run_id> --repo RediSearch/RediSearch --json url,headBranch,headSha,
 gh run view <run_id> --repo RediSearch/RediSearch --log-failed
 mkdir -p /tmp/redisearch-flaky-<run_id>
 gh run download <run_id> --repo RediSearch/RediSearch --dir /tmp/redisearch-flaky-<run_id>
+```
+
+Gotcha: `gh run view --log-failed` sometimes exits 0 with an empty body (seen on
+`merge_group` runs and on some macOS matrix jobs). If the output is empty, fall back to the
+raw job log via the REST API, then grep for the failure:
+
+```bash
+# Pick the failing job id first:
+gh run view <run_id> --repo RediSearch/RediSearch \
+  --json jobs --jq '.jobs[] | select(.conclusion=="failure") | {name, databaseId, url}'
+
+# Download the full job log (works when --log-failed returns empty):
+gh api /repos/RediSearch/RediSearch/actions/jobs/<job_id>/logs > /tmp/job-<job_id>.log
+grep -nE 'FAIL|Total Tests Failed|Traceback|❌' /tmp/job-<job_id>.log | head
 ```
 
 CI uploads failed test artifacts named `Test Logs ...` from `task-test.yml`. Look in the downloaded
@@ -113,6 +129,7 @@ Notes:
 If no existing issue is found, prepare a new Jira `Bug` under `MOD-9672`:
 - Summary: `Flaky test: <test_file>:<test_name> <short symptom/context>`
 - Components: `RediSearch`, `RedisAI`
+- Labels: `flaky_test`
 - Description:
 
 ~~~markdown


### PR DESCRIPTION

## Describe the changes in the pull request

Improves the `report-flaky-test` skill with three small additions discovered while reporting a recent macOS flake (`test_numbers:testOverrides`):

1. **Current:** The skill listed `Project`, `Parent epic`, `Issue type`, and `Components` as defaults but did not mention the `flaky_test` label, even though every existing flaky-test ticket in `MOD` already carries it. Agents had to infer this from JQL results.
   **Change:** Add `flaky_test` to the `Defaults` block (with a note to use it as a JQL filter) and to the new-issue payload template.
   **Outcome:** New tickets created via the skill consistently carry the label, and `labels = flaky_test` becomes a reliable JQL filter for future searches.

2. **Current:** The skill instructs agents to use `gh run view <run_id> --log-failed` to fetch failure logs.
   **Change:** Document the observed gotcha that `--log-failed` sometimes exits 0 with an empty body (seen on `merge_group` runs and some macOS matrix jobs) and add a fallback recipe using `gh api /repos/{owner}/{repo}/actions/jobs/{job_id}/logs` followed by a grep.
   **Outcome:** Agents stop silently losing minutes on empty `--log-failed` output and have a deterministic way to retrieve the failing-step log.

3. **Current:** The new-issue payload template did not list `Labels`, so drafts diverged from the documented defaults.
   **Change:** Add `Labels: flaky_test` to the payload template.
   **Outcome:** The template and the defaults match.

No code, build, test, or runtime behavior is affected — this is a skill documentation change only.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `.skills/report-flaky-test/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to the `report-flaky-test` skill, with no runtime or build impact.
> 
> **Overview**
> Updates the `report-flaky-test` skill docs to **standardize Jira ticket metadata** by explicitly defaulting and templating the `flaky_test` label.
> 
> Adds a **GitHub CLI log-retrieval fallback** for cases where `gh run view --log-failed` returns empty output, documenting a REST API-based download path and a quick grep recipe to locate failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfabe094153d974b5ed452be613b49feee0c5fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->