### PR TITLE
[MOD-15393] trie: drop dead nu_readstr pass in strToLowerRunes

### DIFF
--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -72,15 +72,6 @@ rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len) {
     return NULL;
   }
 
-  uint32_t u_stack_buffer[SSO_MAX_LENGTH];
-  uint32_t *u_buffer = u_stack_buffer;
-  if (rlen > SSO_MAX_LENGTH - 1) {
-    u_buffer = rm_malloc((rlen + 1) * sizeof(*u_buffer));
-  }
-
-  u_buffer[rlen] = 0;
-  nu_readstr(str, u_buffer, nu_utf8_read);
-
   rune *ret = rm_calloc(rlen + 1, sizeof(rune));
   const char *encoded_char = str;
   uint32_t codepoint;
@@ -107,9 +98,6 @@ rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len) {
   }
   *unicode_len = rlen;
 
-  if (u_buffer != u_stack_buffer) {
-    rm_free(u_buffer);
-  }
   return ret;
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `strToLowerRunes` in `src/trie/rune_util.c` makes two parallel decode passes over its input. The first calls libnu's unbounded `nu_readstr` into a stack buffer `u_buffer`; the second is a manual `while (encoded_char < str + utf8_len)` loop that fills the returned `ret` array. Only the result of the second pass is ever read — `u_buffer` is written and then discarded. The unbounded first pass walks until it hits a NUL terminator regardless of `utf8_len`, so if a caller passes a length-bounded buffer that isn't NUL-terminated, the decoder overruns into adjacent stack memory and trips `__stack_chk_fail`. All in-tree callers happen to pass NUL-terminated input (`RedisModule_StringPtrLen` results, string literals), so the trap has stayed latent.
2. **Change**: Delete the dead `u_buffer` allocation, the `nu_readstr` call that fills it, and the matching `rm_free`. The function's observable output (`ret`, `*unicode_len`) is produced exclusively by the bounded manual loop, which is unchanged.
3. **Outcome**: 12 lines removed, zero added. Every current caller sees identical behavior. Future callers that respect the documented `(str, utf8_len)` contract but pass a non-NUL-terminated buffer no longer abort.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/trie/rune_util.c` — `strToLowerRunes`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes dead code and an unnecessary allocation/free without changing the bounded lowercasing loop output; primarily reduces potential buffer overread/crash risk for non-NUL-terminated inputs.
> 
> **Overview**
> `strToLowerRunes` no longer allocates a temporary `u_buffer` or calls unbounded `nu_readstr` before lowercasing.
> 
> The function now relies solely on the existing length-bounded UTF-8 decode/lowercase loop, eliminating an extra decode pass and removing a latent overread/abort risk when `utf8_len` buffers aren’t NUL-terminated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733b0fff13ada549ca041c4189df46e51918e8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->