### PR TITLE
[MOD-15393] trie: make strToSingleCodepointFoldedRunes respect input length

### DIFF
--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -117,9 +117,9 @@ rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len) {
  * __fold is called.
  * If the folded rune occupies more than 1 codepoint, only the first
  * is used, the rest are ignored. */
-rune *strToSingleCodepointFoldedRunes(const char *str, size_t *len) {
+rune *strToSingleCodepointFoldedRunes(const char *str, size_t utf8_len, size_t *len) {
 
-  ssize_t rlen = nu_strlen(str, nu_utf8_read);
+  ssize_t rlen = nu_strnlen(str, utf8_len, nu_utf8_read);
   if (rlen > MAX_RUNESTR_LEN) {
     if (len) *len = 0;
     return NULL;
@@ -127,7 +127,7 @@ rune *strToSingleCodepointFoldedRunes(const char *str, size_t *len) {
 
   uint32_t decoded[rlen + 1];
   decoded[rlen] = 0;
-  nu_readstr(str, decoded, nu_utf8_read);
+  nu_readnstr(str, utf8_len, decoded, nu_utf8_read);
 
   rune *ret = rm_calloc(rlen + 1, sizeof(rune));
   for (int i = 0; i < rlen; i++) {

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -57,10 +57,15 @@ char *runesToStr(const rune *in, size_t len, size_t *utflen);
  */
 rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len);
 
-/* Convert a string to runes, fold them and return the folded runes.
- * If a folded runes contains more than one codepoint, only the first
- * codepoint is taken, the rest are ignored. */
-rune *strToSingleCodepointFoldedRunes(const char *str, size_t *len);
+/* Convert a UTF-8 byte buffer to runes, fold them and return the folded
+ * runes. If a folded rune contains more than one codepoint, only the
+ * first codepoint is taken, the rest are ignored.
+ * Parameters:
+ * - str: The input UTF-8 encoded buffer (need not be NUL-terminated).
+ * - utf8_len: The length of the input buffer in bytes.
+ * - len: A pointer to a size_t where the rune-count is written.
+ *   May be NULL. */
+rune *strToSingleCodepointFoldedRunes(const char *str, size_t utf8_len, size_t *len);
 
 /* Convert a utf-8 string to constant width runes */
 rune *strToRunes(const char *str, size_t *len);

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -232,7 +232,7 @@ Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDi
     return NULL;
   }
   size_t rlen;
-  rune *runes = strToSingleCodepointFoldedRunes(s, &rlen);
+  rune *runes = strToSingleCodepointFoldedRunes(s, len, &rlen);
   // make sure query length does not overflow
   if (!runes || rlen >= TRIE_MAX_PREFIX) {
     rm_free(runes);

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -105,7 +105,7 @@ int testRuneUtil() {
   free(backUnicodeStr);
 
   size_t foldedLen;
-  rune *foldedRunes = strToSingleCodepointFoldedRunes("yY", &foldedLen);
+  rune *foldedRunes = strToSingleCodepointFoldedRunes("yY", strlen("yY"), &foldedLen);
   ASSERT_EQUAL(foldedLen, 2);
   ASSERT_EQUAL(foldedRunes[0], 121);
   ASSERT_EQUAL(foldedRunes[1], 121);
@@ -113,7 +113,8 @@ int testRuneUtil() {
 
   // TESTING ∏ and Å because ∏ doesn't have a lowercase form, but Å does
   size_t foldedUnicodeLen;
-  rune *foldedUnicodeRunes = strToSingleCodepointFoldedRunes("Ø∏πåÅ", &foldedUnicodeLen);
+  rune *foldedUnicodeRunes =
+      strToSingleCodepointFoldedRunes("Ø∏πåÅ", strlen("Ø∏πåÅ"), &foldedUnicodeLen);
   ASSERT_EQUAL(runeFold(foldedUnicodeRunes[1]), foldedUnicodeRunes[1]);
   ASSERT_EQUAL(foldedUnicodeLen, 5);
   ASSERT_EQUAL(foldedUnicodeRunes[0], 248);
@@ -280,7 +281,7 @@ int testDFAFilter() {
   clock_gettime(CLOCK_REALTIME, &start_time);
 
   for (i = 0; terms[i] != NULL; i++) {
-    runes = strToSingleCodepointFoldedRunes(terms[i], &rlen);
+    runes = strToSingleCodepointFoldedRunes(terms[i], strlen(terms[i]), &rlen);
     DFAFilter *fc = NewDFAFilter(runes, rlen, 2, 0);
 
     TrieIterator *it = TrieNode_Iterate(root, FoldingFilterFunc, StackPop, fc);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `Trie_Search(s, len, ...)` (`src/trie/trie.c`) accepts a length-bounded UTF-8 buffer and validates `len`, then calls `strToSingleCodepointFoldedRunes(s, &rlen)` — which does not take a length and uses libnu's unbounded `nu_strlen` and `nu_readstr` to decode `s`. Both walk until they hit a NUL terminator, ignoring the caller's intended bound. The sole in-tree caller, `RSSuggestGetCommand`, sources `s` from `RedisModule_StringPtrLen`, which is always NUL-terminated, so the mismatch hasn't bitten production. Any caller that passes a sub-buffer would walk past `s + len` and either read uninitialised memory or corrupt the stack-allocated VLA used as the decode target.
2. **Change**: Give `strToSingleCodepointFoldedRunes` an explicit `size_t utf8_len` parameter (matching the existing `strToLowerRunes` shape), swap the unbounded libnu calls for their bounded counterparts (`nu_strnlen` and `nu_readnstr`), and have `Trie_Search` plumb its already-validated `len` through. Three direct callers in `tests/ctests/test_trie.c` are updated to pass `strlen(literal)` so they keep covering the same range.
3. **Outcome**: The function now enforces its length contract internally, so length-bounded callers no longer rely on incidental NUL termination of the input. Behavior is unchanged for the existing production caller, where `len == strlen(s)`.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/trie/rune_util.h` — `strToSingleCodepointFoldedRunes` signature
2. `src/trie/rune_util.c` — `strToSingleCodepointFoldedRunes` body
3. `src/trie/trie.c` — `Trie_Search` plumbs `len` through
4. `tests/ctests/test_trie.c` — direct callers pass `strlen(literal)`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the signature/ABI of `strToSingleCodepointFoldedRunes` and alters query decoding in `Trie_Search`, which could affect any out-of-tree callers and edge-case UTF-8 handling, though the behavioral intent is a safety fix.
> 
> **Overview**
> Makes `strToSingleCodepointFoldedRunes` length-aware by adding an explicit `utf8_len` parameter and switching to bounded libnu routines (`nu_strnlen`/`nu_readnstr`) so it no longer scans past the caller-provided buffer.
> 
> Plumbs the validated `len` from `Trie_Search` into this helper, and updates trie C tests to pass `strlen(...)` so existing coverage continues to exercise the same inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11176a1112ef0d0343271a321620976ea77a19f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->