### PR TITLE
docs: note worktree removal requires --force on submodule trees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,8 @@ on an unrelated branch, or already tied to another open PR, automatically create
 worktree from the target branch and do the work there. Use the existing checkout only when it is
 already the right clean branch for the task.
 
+To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules), then `git branch -D <name>`.
+
 ### C Code
 Invoke [/code-review](.skills/code-review/SKILL.md) to review C code changes or PRs.
 Invoke [/run-c-unit-tests](.skills/run-c-unit-tests/SKILL.md) to run C/C++ unit tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ on an unrelated branch, or already tied to another open PR, automatically create
 worktree from the target branch and do the work there. Use the existing checkout only when it is
 already the right clean branch for the task.
 
-To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules), then `git branch -D <name>`.
+To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules).
 
 ### C Code
 Invoke [/code-review](.skills/code-review/SKILL.md) to review C code changes or PRs.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Running `git worktree remove` on a worktree under `.claude/worktrees/` fails with `fatal: working trees containing submodules cannot be moved or removed`, because the recommended setup recursively initializes submodules inside the worktree. The error message gives no hint at the fix, and contributors hit it repeatedly.
2. **Change:** Add a one-line note under `## Common Workflows` in `AGENTS.md` documenting the working incantation: `git worktree remove --force <path>` followed by `git branch -D <name>` to clean up the dangling branch. `CLAUDE.md` is a symlink to `AGENTS.md` so the guidance reaches Claude Code agents too.
3. **Outcome:** Future runs (human or agent) know to reach for `--force` immediately instead of guessing or polluting the repo with stale worktrees.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `AGENTS.md` (one-sentence addition under `## Common Workflows`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change. Adds guidance to avoid a common `git worktree remove` failure when worktrees contain initialized submodules.
> 
> **Overview**
> Adds a note to `AGENTS.md` under **Common Workflows** documenting that worktrees containing initialized submodules should be removed with `git worktree remove --force <path>` (since plain `remove` can fail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49680d4f321a0417d9f8f268f6190567058ebccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->