### PR TITLE
[MOD-14980] Improve TTL Table (BitMask + FieldExpirations)

### DIFF
--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -118,9 +118,16 @@ impl FieldExpirations {
     /// `fe.index` must be **strictly greater** than the `index` of every
     /// entry already present in `self`.
     pub unsafe fn push_unchecked(&mut self, fe: FieldExpiration) {
-        // Elided in release mode
-        if let Some(last) = self.last() {
-            debug_assert!(last.index < fe.index);
+        #[cfg(debug_assertions)]
+        {
+            if let Some(last) = self.last() {
+                assert!(
+                    last.index < fe.index,
+                    "pushed index {} must be strictly greater than the last index {}",
+                    fe.index,
+                    last.index
+                );
+            }
         }
         self.inner.push(fe);
     }
@@ -198,12 +205,30 @@ impl TimeToLiveTable {
 
     /// Inserts a document's per-field expirations.
     ///
-    /// Ownership of `sorted_by_id` transfers to the table.
+    /// # Panics
+    ///
+    /// Panics if `field_expirations` is empty or if `doc_id` is already present
+    /// in the table.
+    pub fn add(&mut self, doc_id: t_docId, field_expirations: FieldExpirations) {
+        assert!(
+            !field_expirations.is_empty(),
+            "TTL table add requires at least one field expiration"
+        );
+        assert!(
+            self.find_entry(doc_id).is_none(),
+            "duplicate docId in TTL table"
+        );
+        // SAFETY: both preconditions of `add_unchecked` were just verified —
+        // `field_expirations` is non-empty and `doc_id` is absent from the table.
+        unsafe { self.add_unchecked(doc_id, field_expirations) };
+    }
+
+    /// Inserts a document's per-field expirations.
     ///
     /// # Safety
     ///
     /// The caller must guarantee:
-    /// - `sorted_by_id` is non-empty.
+    /// - `field_expirations` is non-empty.
     /// - `doc_id` is not already present in the table.
     ///
     /// These invariants are load-bearing for the lookup hot paths
@@ -212,11 +237,7 @@ impl TimeToLiveTable {
     /// [`verify_doc_and_wide_field_mask`](Self::verify_doc_and_wide_field_mask)),
     /// which assume them when scanning the per-bucket chain and the
     /// per-entry field-expiration list.
-    ///
-    /// In debug builds these preconditions are checked via `debug_assert!`
-    /// and will panic on violation; in release builds the checks are
-    /// elided.
-    pub unsafe fn add(&mut self, doc_id: t_docId, field_expirations: FieldExpirations) {
+    pub unsafe fn add_unchecked(&mut self, doc_id: t_docId, field_expirations: FieldExpirations) {
         debug_assert!(
             !field_expirations.is_empty(),
             "TTL table add requires at least one field expiration"
@@ -267,7 +288,8 @@ impl TimeToLiveTable {
     /// if no entry exists.
     ///
     /// The slice aliases storage owned by the table and is invalidated by any
-    /// subsequent [`add`](Self::add) / [`remove`](Self::remove) on this table.
+    /// subsequent [`add`](Self::add) / [`add_unchecked`](Self::add_unchecked) /
+    /// [`remove`](Self::remove) on this table.
     pub fn field_expirations(&self, doc_id: t_docId) -> Option<&FieldExpirations> {
         self.find_entry(doc_id).map(|e| &e.field_expirations)
     }
@@ -723,10 +745,6 @@ const fn did_expire(field: &timespec, now: &timespec) -> bool {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::undocumented_unsafe_blocks,
-    reason = "every `t.add` site below passes a non-empty, fresh-doc-id pair by inspection"
-)]
 mod tests {
     use super::test_utils::*;
     use super::*;
@@ -738,8 +756,7 @@ mod tests {
         // return true.
         const MAX: usize = 8;
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        // SAFETY: `DOC_ID_1` is fresh; the single-entry list is non-empty.
-        unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+        t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
 
         let unknown_collider: u64 = DOC_ID_1 + MAX as u64;
         // Be sure it is a collider
@@ -772,11 +789,9 @@ mod tests {
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_1));
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_2));
 
-        // SAFETY (each call below): the `doc_id` is unique across this test
-        // and each single-element list is non-empty.
-        unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
-        unsafe { t.add(DOC_ID_1_COLLIDER_1, fes([fe(FIELD_INDEX_1, PAST)])) };
-        unsafe { t.add(DOC_ID_1_COLLIDER_2, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+        t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
+        t.add(DOC_ID_1_COLLIDER_1, fes([fe(FIELD_INDEX_1, PAST)]));
+        t.add(DOC_ID_1_COLLIDER_2, fes([fe(FIELD_INDEX_1, FUTURE)]));
         t.remove(DOC_ID_1);
         // Doc 9: PAST ⇒ Default false.
         assert!(!t.verify_doc_and_field(
@@ -810,8 +825,7 @@ mod tests {
         const DOC_ID_1_COLLIDER: u64 = DOC_ID_1 + MAX as u64;
 
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        // SAFETY: `DOC_ID_1` is fresh; the single-element list is non-empty.
-        unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+        t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
 
         // Slot collider
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER));
@@ -830,11 +844,9 @@ mod tests {
     fn max_size_one_collapses_every_doc_to_slot_zero() {
         const MAX: usize = 1;
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        // SAFETY (each call below): doc_ids 0, 1, 2 are distinct; each
-        // single-element list is non-empty.
-        unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
-        unsafe { t.add(1, fes([fe(FIELD_INDEX_1, PAST)])) };
-        unsafe { t.add(2, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+        t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)]));
+        t.add(1, fes([fe(FIELD_INDEX_1, PAST)]));
+        t.add(2, fes([fe(FIELD_INDEX_1, FUTURE)]));
         assert_eq!(t.n_allocated_buckets(), 1);
         assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
         assert!(
@@ -876,12 +888,9 @@ mod tests {
         for x in 1u64..8 {
             assert_eq!(t.slot(x), t.slot(x + CAP));
             assert_eq!(t.slot(x), t.slot(x + 2 * CAP));
-            // SAFETY (each call below): `x`, `x + CAP`, `x + 2 * CAP` are
-            // distinct and never repeat across loop iterations; each
-            // single-element list is non-empty.
-            unsafe { t.add(x, fes([fe(0, PAST)])) };
-            unsafe { t.add(x + CAP, fes([fe(0, FUTURE)])) };
-            unsafe { t.add(x + 2 * CAP, fes([fe(0, PAST)])) };
+            t.add(x, fes([fe(0, PAST)]));
+            t.add(x + CAP, fes([fe(0, FUTURE)]));
+            t.add(x + 2 * CAP, fes([fe(0, PAST)]));
         }
         for x in 1u64..8 {
             assert!(!t.verify_doc_and_field(x, 0, FieldExpirationPredicate::Default, &NOW));

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -29,7 +29,7 @@
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
-use std::{iter::Chain, num::NonZeroUsize};
+use std::{iter::Chain, num::NonZeroUsize, ops::Deref};
 
 pub use ffi::FieldExpiration;
 use ffi::{FieldMask, t_expirationTimePoint as timespec};
@@ -37,6 +37,107 @@ pub use field::FieldExpirationPredicate;
 use thin_vec::ThinVec;
 
 use ffi::t_docId;
+
+/// An ascending-by-`index`, duplicate-free list of [`FieldExpiration`] entries.
+#[repr(transparent)]
+#[derive(Debug, Clone)]
+pub struct FieldExpirations {
+    inner: ThinVec<FieldExpiration>,
+}
+
+impl FieldExpirations {
+    /// Creates an empty `FieldExpirations`.
+    ///
+    /// No heap allocation is performed until the first insertion.
+    pub const fn new() -> Self {
+        Self {
+            inner: ThinVec::new(),
+        }
+    }
+
+    /// Creates an empty `FieldExpirations` with backing storage pre-sized for
+    /// at least `cap` entries.
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: ThinVec::with_capacity(cap),
+        }
+    }
+
+    /// Inserts `fe` into its sorted-by-`index` position.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(&fe)` — a reference to the newly inserted entry inside the list.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(fe)` if an entry with `fe.index` already exists; the list
+    /// is left unchanged and `fe` is handed back to the caller untouched.
+    pub fn add(
+        &mut self,
+        fe: FieldExpiration,
+    ) -> std::result::Result<&FieldExpiration, FieldExpiration> {
+        let result = self.inner.binary_search_by_key(&fe.index, |a| a.index);
+
+        match result {
+            Ok(_) => Err(fe),
+            Err(index) => {
+                self.inner.insert(index, fe);
+                Ok(&self.inner[index])
+            }
+        }
+    }
+
+    /// Appends `fe` to the end of the list without searching for the
+    /// insertion point.
+    ///
+    /// Use when the caller already knows that `fe.index` is strictly greater
+    /// than every index currently in `self`.
+    ///
+    /// # Safety
+    ///
+    /// `fe.index` must be **strictly greater** than the `index` of every
+    /// entry already present in `self`.
+    pub unsafe fn push_unchecked(&mut self, fe: FieldExpiration) {
+        // Elided in release mode
+        if let Some(last) = self.last() {
+            debug_assert!(last.index < fe.index);
+        }
+        self.inner.push(fe);
+    }
+
+    /// Wraps a pre-built [`ThinVec<FieldExpiration>`] without re-validating
+    /// its contents.
+    ///
+    /// # Safety
+    ///
+    /// `v` must be sorted ascending by `index` with no duplicate indices.
+    /// The same invariants are checked via `debug_assert!` and elided in
+    /// release.
+    #[cfg(feature = "test-utils")]
+    pub unsafe fn from_thin_vec_unchecked(v: ThinVec<FieldExpiration>) -> Self {
+        debug_assert!(
+            v.is_sorted_by(|a, b| a.index < b.index),
+            "FieldExpirations must be sorted ascending by index with no duplicates"
+        );
+        Self { inner: v }
+    }
+}
+
+impl Default for FieldExpirations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Read-only access to the underlying `ThinVec`.
+impl Deref for FieldExpirations {
+    type Target = ThinVec<FieldExpiration>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
 
 /// Initial bucket-array length the first time we grow from zero.
 ///
@@ -57,7 +158,7 @@ pub struct TimeToLiveEntry {
     /// The document id
     pub doc_id: t_docId,
     /// Owned, sorted by field index, never empty.
-    pub field_expirations: ThinVec<FieldExpiration>,
+    pub field_expirations: FieldExpirations,
 }
 
 /// Direct-modulo bucket array with contiguous-vec collision chains.
@@ -101,7 +202,6 @@ impl TimeToLiveTable {
     ///
     /// The caller must guarantee:
     /// - `sorted_by_id` is non-empty.
-    /// - `sorted_by_id` is sorted in ascending order by `index`.
     /// - `doc_id` is not already present in the table.
     ///
     /// These invariants are load-bearing for the lookup hot paths
@@ -114,14 +214,10 @@ impl TimeToLiveTable {
     /// In debug builds these preconditions are checked via `debug_assert!`
     /// and will panic on violation; in release builds the checks are
     /// elided.
-    pub unsafe fn add(&mut self, doc_id: t_docId, sorted_by_id: ThinVec<FieldExpiration>) {
+    pub unsafe fn add(&mut self, doc_id: t_docId, field_expirations: FieldExpirations) {
         debug_assert!(
-            !sorted_by_id.is_empty(),
+            !field_expirations.is_empty(),
             "TTL table add requires at least one field expiration"
-        );
-        debug_assert!(
-            sorted_by_id.is_sorted_by_key(|f| f.index),
-            "sorted_by_id is not sorted by index"
         );
 
         let slot = self.slot(doc_id);
@@ -134,7 +230,7 @@ impl TimeToLiveTable {
 
         self.buckets[slot].push(TimeToLiveEntry {
             doc_id,
-            field_expirations: sorted_by_id,
+            field_expirations,
         });
         self.count += 1;
     }
@@ -170,9 +266,8 @@ impl TimeToLiveTable {
     ///
     /// The slice aliases storage owned by the table and is invalidated by any
     /// subsequent [`add`](Self::add) / [`remove`](Self::remove) on this table.
-    pub fn field_expirations(&self, doc_id: t_docId) -> Option<&[FieldExpiration]> {
-        self.find_entry(doc_id)
-            .map(|e| e.field_expirations.as_slice())
+    pub fn field_expirations(&self, doc_id: t_docId) -> Option<&FieldExpirations> {
+        self.find_entry(doc_id).map(|e| &e.field_expirations)
     }
 
     /// Checks the expiration state of a single field of a document under
@@ -639,11 +734,13 @@ const fn did_expire(field: &timespec, now: &timespec) -> bool {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "every `t.add` site below passes a non-empty, fresh-doc-id pair by inspection"
+)]
 mod tests {
     use super::test_utils::*;
     use super::*;
-
-    use thin_vec::thin_vec;
 
     #[test]
     fn verify_field_returns_true_for_doc_colliding_with_a_known_doc() {
@@ -652,9 +749,8 @@ mod tests {
         // return true.
         const MAX: usize = 8;
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        // SAFETY: `DOC_ID_1` is fresh; `[fe(FIELD_INDEX_1, PAST)]` is non-empty
-        // and trivially sorted (single element).
-        unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+        // SAFETY: `DOC_ID_1` is fresh; the single-entry list is non-empty.
+        unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
 
         let unknown_collider: u64 = DOC_ID_1 + MAX as u64;
         // Be sure it is a collider
@@ -688,10 +784,10 @@ mod tests {
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER_2));
 
         // SAFETY (each call below): the `doc_id` is unique across this test
-        // and each single-element vec is non-empty and trivially sorted.
-        unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
-        unsafe { t.add(DOC_ID_1_COLLIDER_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
-        unsafe { t.add(DOC_ID_1_COLLIDER_2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+        // and each single-element list is non-empty.
+        unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+        unsafe { t.add(DOC_ID_1_COLLIDER_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+        unsafe { t.add(DOC_ID_1_COLLIDER_2, fes([fe(FIELD_INDEX_1, FUTURE)])) };
         t.remove(DOC_ID_1);
         // Doc 9: PAST ⇒ Default false.
         assert!(!t.verify_doc_and_field(
@@ -725,9 +821,8 @@ mod tests {
         const DOC_ID_1_COLLIDER: u64 = DOC_ID_1 + MAX as u64;
 
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-        // SAFETY: `DOC_ID_1` is fresh; the single-element vec is non-empty
-        // and trivially sorted.
-        unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+        // SAFETY: `DOC_ID_1` is fresh; the single-element list is non-empty.
+        unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
 
         // Slot collider
         assert_eq!(t.slot(DOC_ID_1), t.slot(DOC_ID_1_COLLIDER));
@@ -747,10 +842,10 @@ mod tests {
         const MAX: usize = 1;
         let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
         // SAFETY (each call below): doc_ids 0, 1, 2 are distinct; each
-        // single-element vec is non-empty and trivially sorted.
-        unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
-        unsafe { t.add(1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
-        unsafe { t.add(2, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+        // single-element list is non-empty.
+        unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+        unsafe { t.add(1, fes([fe(FIELD_INDEX_1, PAST)])) };
+        unsafe { t.add(2, fes([fe(FIELD_INDEX_1, FUTURE)])) };
         assert_eq!(t.n_allocated_buckets(), 1);
         assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
         assert!(
@@ -794,10 +889,10 @@ mod tests {
             assert_eq!(t.slot(x), t.slot(x + 2 * CAP));
             // SAFETY (each call below): `x`, `x + CAP`, `x + 2 * CAP` are
             // distinct and never repeat across loop iterations; each
-            // single-element vec is non-empty and trivially sorted.
-            unsafe { t.add(x, thin_vec![fe(0, PAST)]) };
-            unsafe { t.add(x + CAP, thin_vec![fe(0, FUTURE)]) };
-            unsafe { t.add(x + 2 * CAP, thin_vec![fe(0, PAST)]) };
+            // single-element list is non-empty.
+            unsafe { t.add(x, fes([fe(0, PAST)])) };
+            unsafe { t.add(x + CAP, fes([fe(0, FUTURE)])) };
+            unsafe { t.add(x + 2 * CAP, fes([fe(0, PAST)])) };
         }
         for x in 1u64..8 {
             assert!(!t.verify_doc_and_field(x, 0, FieldExpirationPredicate::Default, &NOW));
@@ -841,7 +936,7 @@ mod tests {
         const HIGH_BIT: u16 = 40;
         let entry = TimeToLiveEntry {
             doc_id: DOC_ID_1,
-            field_expirations: thin_vec![fe(HIGH_BIT, PAST)],
+            field_expirations: fes([fe(HIGH_BIT, PAST)]),
         };
         let map = identity_ft_id();
         let mask = mask_bit_u64(&[HIGH_BIT]);
@@ -867,7 +962,7 @@ mod tests {
         // Bit 2 → PAST, bit 35 → FUTURE. Default must return `true`.
         let entry = TimeToLiveEntry {
             doc_id: DOC_ID_1,
-            field_expirations: thin_vec![fe(2, PAST), fe(35, FUTURE)],
+            field_expirations: fes([fe(2, PAST), fe(35, FUTURE)]),
         };
         let map = identity_ft_id();
         let mask = mask_bit_u64(&[2, 35]);

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -73,10 +73,7 @@ impl FieldExpirations {
     ///
     /// Returns `Err(fe)` if an entry with `fe.index` already exists; the list
     /// is left unchanged and `fe` is handed back to the caller untouched.
-    pub fn add(
-        &mut self,
-        fe: FieldExpiration,
-    ) -> std::result::Result<&FieldExpiration, FieldExpiration> {
+    pub fn add(&mut self, fe: FieldExpiration) -> Result<&FieldExpiration, FieldExpiration> {
         let result = self.inner.binary_search_by_key(&fe.index, |a| a.index);
 
         match result {
@@ -85,6 +82,28 @@ impl FieldExpirations {
                 self.inner.insert(index, fe);
                 Ok(&self.inner[index])
             }
+        }
+    }
+
+    /// Appends `fe` to the end of the list without searching for the
+    /// insertion point.
+    ///
+    /// # Panics
+    ///
+    /// `fe.index` must be **strictly greater** than the `index` of every
+    /// entry already present in `self`.
+    pub fn push(&mut self, fe: FieldExpiration) {
+        if let Some(last) = self.last() {
+            assert!(
+                last.index < fe.index,
+                "pushed index {} must be strictly greater than the last index {}",
+                fe.index,
+                last.index
+            );
+        }
+        // Safety: checked above
+        unsafe {
+            self.push_unchecked(fe);
         }
     }
 
@@ -104,23 +123,6 @@ impl FieldExpirations {
             debug_assert!(last.index < fe.index);
         }
         self.inner.push(fe);
-    }
-
-    /// Wraps a pre-built [`ThinVec<FieldExpiration>`] without re-validating
-    /// its contents.
-    ///
-    /// # Safety
-    ///
-    /// `v` must be sorted ascending by `index` with no duplicate indices.
-    /// The same invariants are checked via `debug_assert!` and elided in
-    /// release.
-    #[cfg(feature = "test-utils")]
-    pub unsafe fn from_thin_vec_unchecked(v: ThinVec<FieldExpiration>) -> Self {
-        debug_assert!(
-            v.is_sorted_by(|a, b| a.index < b.index),
-            "FieldExpirations must be sorted ascending by index with no duplicates"
-        );
-        Self { inner: v }
     }
 }
 
@@ -382,26 +384,13 @@ impl TimeToLiveTable {
         expiration_point: &timespec,
         ft_id_to_field_index: &[u16],
     ) -> bool {
-        #[cfg(target_pointer_width = "64")]
-        {
-            verify_mask::<u128>(
-                self.find_entry(doc_id),
-                field_mask,
-                predicate,
-                expiration_point,
-                ft_id_to_field_index,
-            )
-        }
-        #[cfg(target_pointer_width = "32")]
-        {
-            verify_mask::<u64>(
-                self.find_entry(doc_id),
-                field_mask,
-                predicate,
-                expiration_point,
-                ft_id_to_field_index,
-            )
-        }
+        verify_mask::<FieldMask>(
+            self.find_entry(doc_id),
+            field_mask,
+            predicate,
+            expiration_point,
+            ft_id_to_field_index,
+        )
     }
 
     /// Direct-modulo slot formula
@@ -974,5 +963,26 @@ mod tests {
             &NOW,
             &map,
         ));
+    }
+
+    #[test]
+    fn push_appends_entries_with_strictly_increasing_index() {
+        let mut list = FieldExpirations::new();
+        list.push(fe(1, PAST));
+        list.push(fe(2, NOW));
+        list.push(fe(3, FUTURE));
+
+        let indices: Vec<u16> = list.iter().map(|fe| fe.index).collect();
+        assert_eq!(indices, [1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be strictly greater than the last index")]
+    fn push_panics_when_index_not_greater_than_last() {
+        let mut list = FieldExpirations::new();
+        list.push(fe(5, PAST));
+        // Deliberately violates the precondition (3 < 5) to exercise the panic
+        // branch; the call is expected to abort the test via panic.
+        list.push(fe(3, FUTURE));
     }
 }

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -31,8 +31,9 @@ pub mod test_utils;
 
 use std::{iter::Chain, num::NonZeroUsize};
 
+pub use ffi::FieldExpiration;
+use ffi::{FieldMask, t_expirationTimePoint as timespec};
 pub use field::FieldExpirationPredicate;
-use libc::timespec;
 use thin_vec::ThinVec;
 
 use ffi::t_docId;
@@ -49,15 +50,6 @@ const TTL_BUCKET_INITIAL_CAP: usize = 64;
 /// Very large tables don't take a single
 /// multi-MiB realloc hit and so the two allocators scale in lockstep.
 const TTL_BUCKET_MAX_GROW_STEP: usize = 1 << 20;
-
-/// The expiration time recorded for a single field of a document.
-#[derive(Debug, Clone, Copy)]
-pub struct FieldExpiration {
-    /// The field index this expiration applies to.
-    pub index: u16,
-    /// The point in time at which the field expires.
-    pub point: timespec,
-}
 
 /// A document's record in a [`TimeToLiveTable`] bucket's collision chain.
 #[derive(Debug)]
@@ -274,8 +266,14 @@ impl TimeToLiveTable {
         )
     }
 
-    /// Checks the expiration state of a set of fields described by a
-    /// 128-bit `field_mask` (the wide-schema variant).
+    /// Checks the expiration state of a set of fields described by a wide
+    /// [`FieldMask`] (the wide-schema variant).
+    ///
+    /// `FieldMask` is a compile-time alias chosen by the C build: it can be
+    /// either a 64-bit or a 128-bit unsigned integer. This function
+    /// dispatches to the matching bit-walk at compile time, based on the
+    /// target pointer width.
+    ///
     /// See also [`TimeToLiveTable::verify_doc_and_field_mask`].
     ///
     /// # Panics
@@ -284,18 +282,31 @@ impl TimeToLiveTable {
     pub fn verify_doc_and_wide_field_mask(
         &self,
         doc_id: t_docId,
-        field_mask: u128,
+        field_mask: FieldMask,
         predicate: FieldExpirationPredicate,
         expiration_point: &timespec,
         ft_id_to_field_index: &[u16],
     ) -> bool {
-        verify_mask::<u128>(
-            self.find_entry(doc_id),
-            field_mask,
-            predicate,
-            expiration_point,
-            ft_id_to_field_index,
-        )
+        #[cfg(target_pointer_width = "64")]
+        {
+            verify_mask::<u128>(
+                self.find_entry(doc_id),
+                field_mask,
+                predicate,
+                expiration_point,
+                ft_id_to_field_index,
+            )
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            verify_mask::<u64>(
+                self.find_entry(doc_id),
+                field_mask,
+                predicate,
+                expiration_point,
+                ft_id_to_field_index,
+            )
+        }
     }
 
     /// Direct-modulo slot formula
@@ -370,6 +381,22 @@ impl BitMask for u32 {
 
     fn count_ones(self) -> usize {
         u32::count_ones(self) as usize
+    }
+
+    fn higher_bit_position(self) -> usize {
+        (Self::BITS - self.leading_zeros()) as usize
+    }
+}
+
+impl BitMask for u64 {
+    type Iter = BitU64Iter;
+
+    fn iter(self) -> Self::Iter {
+        BitU64Iter::new(self)
+    }
+
+    fn count_ones(self) -> usize {
+        u64::count_ones(self) as usize
     }
 
     fn higher_bit_position(self) -> usize {
@@ -804,5 +831,53 @@ mod tests {
                 &NOW,
             ));
         }
+    }
+
+    #[test]
+    fn verify_mask_u64_walks_bits_above_31() {
+        // High-bit field (bit 40) is the only one tracked, and it is
+        // expired. Under Default this must report `false` (no valid
+        // field); under Missing it must report `true`.
+        const HIGH_BIT: u16 = 40;
+        let entry = TimeToLiveEntry {
+            doc_id: DOC_ID_1,
+            field_expirations: thin_vec![fe(HIGH_BIT, PAST)],
+        };
+        let map = identity_ft_id();
+        let mask = mask_bit_u64(&[HIGH_BIT]);
+
+        assert!(!verify_mask::<u64>(
+            Some(&entry),
+            mask,
+            FieldExpirationPredicate::Default,
+            &NOW,
+            &map,
+        ));
+        assert!(verify_mask::<u64>(
+            Some(&entry),
+            mask,
+            FieldExpirationPredicate::Missing,
+            &NOW,
+            &map,
+        ));
+    }
+
+    #[test]
+    fn verify_mask_u64_default_returns_true_when_any_selected_field_is_valid() {
+        // Bit 2 → PAST, bit 35 → FUTURE. Default must return `true`.
+        let entry = TimeToLiveEntry {
+            doc_id: DOC_ID_1,
+            field_expirations: thin_vec![fe(2, PAST), fe(35, FUTURE)],
+        };
+        let map = identity_ft_id();
+        let mask = mask_bit_u64(&[2, 35]);
+
+        assert!(verify_mask::<u64>(
+            Some(&entry),
+            mask,
+            FieldExpirationPredicate::Default,
+            &NOW,
+            &map,
+        ));
     }
 }

--- a/src/redisearch_rs/ttl_table/src/test_utils.rs
+++ b/src/redisearch_rs/ttl_table/src/test_utils.rs
@@ -9,11 +9,8 @@
 
 use std::num::NonZeroUsize;
 
-use ffi::t_docId;
-use libc::timespec;
+use ffi::{FieldExpiration, t_docId, t_expirationTimePoint as timespec};
 use thin_vec::ThinVec;
-
-use crate::FieldExpiration;
 
 pub const fn ts(sec: i64, nsec: i64) -> timespec {
     // `libc::time_t` is deprecated on musl (musl 1.2 changed it to 64-bit,
@@ -62,4 +59,8 @@ pub fn mask_bit(indexes: &[u16]) -> u32 {
 
 pub fn mask_bit_u128(indexes: &[u16]) -> u128 {
     indexes.iter().map(|index| 1 << index).sum()
+}
+
+pub fn mask_bit_u64(indexes: &[u16]) -> u64 {
+    indexes.iter().map(|index| 1u64 << index).sum()
 }

--- a/src/redisearch_rs/ttl_table/src/test_utils.rs
+++ b/src/redisearch_rs/ttl_table/src/test_utils.rs
@@ -11,7 +11,6 @@ use std::num::NonZeroUsize;
 
 use crate::FieldExpirations;
 use ffi::{FieldExpiration, t_docId, t_expirationTimePoint as timespec};
-use thin_vec::ThinVec;
 
 pub const fn ts(sec: i64, nsec: i64) -> timespec {
     // `libc::time_t` is deprecated on musl (musl 1.2 changed it to 64-bit,
@@ -51,13 +50,15 @@ pub const fn fe(index: u16, point: timespec) -> FieldExpiration {
 
 /// Builds a [`FieldExpirations`] from a `[FieldExpiration; N]` literal.
 ///
-/// All call sites in the test suite already pass sorted, duplicate-free
-/// inputs by inspection; the helper centralizes the corresponding
-/// `unsafe` block.
+/// Entries are appended via [`FieldExpirations::push`], so a misordered or
+/// duplicate-index literal panics loudly instead of silently violating the
+/// container's invariant.
 pub fn fes<const N: usize>(arr: [FieldExpiration; N]) -> FieldExpirations {
-    let v: ThinVec<FieldExpiration> = arr.into_iter().collect();
-    // SAFETY: tests construct sorted, duplicate-free input by inspection.
-    unsafe { FieldExpirations::from_thin_vec_unchecked(v) }
+    let mut fields = FieldExpirations::new();
+    for fe in arr {
+        fields.push(fe);
+    }
+    fields
 }
 
 /// Identity mapping from bit position → field index (bit `i` ↔ field `i`).

--- a/src/redisearch_rs/ttl_table/src/test_utils.rs
+++ b/src/redisearch_rs/ttl_table/src/test_utils.rs
@@ -9,6 +9,7 @@
 
 use std::num::NonZeroUsize;
 
+use crate::FieldExpirations;
 use ffi::{FieldExpiration, t_docId, t_expirationTimePoint as timespec};
 use thin_vec::ThinVec;
 
@@ -40,12 +41,23 @@ pub const NEVER: timespec = ts(0, 0);
 
 pub const TEST_MAX_SIZE: NonZeroUsize = NonZeroUsize::new(1024).unwrap();
 
-pub const fn empty_fields() -> ThinVec<FieldExpiration> {
-    ThinVec::new()
+pub const fn empty_fields() -> FieldExpirations {
+    FieldExpirations::new()
 }
 
 pub const fn fe(index: u16, point: timespec) -> FieldExpiration {
     FieldExpiration { index, point }
+}
+
+/// Builds a [`FieldExpirations`] from a `[FieldExpiration; N]` literal.
+///
+/// All call sites in the test suite already pass sorted, duplicate-free
+/// inputs by inspection; the helper centralizes the corresponding
+/// `unsafe` block.
+pub fn fes<const N: usize>(arr: [FieldExpiration; N]) -> FieldExpirations {
+    let v: ThinVec<FieldExpiration> = arr.into_iter().collect();
+    // SAFETY: tests construct sorted, duplicate-free input by inspection.
+    unsafe { FieldExpirations::from_thin_vec_unchecked(v) }
 }
 
 /// Identity mapping from bit position → field index (bit `i` ↔ field `i`).

--- a/src/redisearch_rs/ttl_table/tests/main.rs
+++ b/src/redisearch_rs/ttl_table/tests/main.rs
@@ -7,14 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-// Every test in this file constructs a fresh table and inserts one or more
-// documents whose IDs are obviously distinct, paired with one or more
-// `FieldExpiration`s whose `index`es are obviously sorted ascending and
-// whose vec is non-empty. The safety preconditions of `TimeToLiveTable::add`
-// are therefore met at every call site by inspection — adding per-call
-// `// SAFETY:` comments to ~60 callsites would be more noise than signal.
-#![expect(clippy::undocumented_unsafe_blocks)]
-
 use std::num::NonZeroUsize;
 
 use ttl_table::{test_utils::*, *};
@@ -29,15 +21,13 @@ fn new_table_doesnt_allocate() {
 #[test]
 fn add_then_remove_leaves_table_empty() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([FieldExpiration {
-                index: FIELD_INDEX_1,
-                point: FUTURE,
-            }]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([FieldExpiration {
+            index: FIELD_INDEX_1,
+            point: FUTURE,
+        }]),
+    );
     assert!(!t.is_empty());
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
@@ -62,7 +52,7 @@ fn field_expirations_on_empty_table_is_none() {
 fn field_expirations_returns_inserted_slice() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     let inserted = fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]);
-    unsafe { t.add(DOC_ID_1, inserted.clone()) };
+    t.add(DOC_ID_1, inserted.clone());
 
     let got = t.field_expirations(DOC_ID_1).expect("entry must exist");
     assert_eq!(got.len(), 2);
@@ -80,7 +70,7 @@ fn field_expirations_returns_inserted_slice() {
 #[test]
 fn field_expirations_after_remove_is_none() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert!(t.field_expirations(DOC_ID_1).is_some());
     t.remove(DOC_ID_1);
     assert!(t.field_expirations(DOC_ID_1).is_none());
@@ -90,14 +80,14 @@ fn field_expirations_after_remove_is_none() {
 #[should_panic(expected = "at least one field expiration")]
 fn add_with_empty_fields_panics() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(1, empty_fields()) };
+    t.add(1, empty_fields());
 }
 
 #[test]
 fn field_with_zero_expiration_never_expires() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     // Field never expires
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, NEVER)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, NEVER)]));
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -116,7 +106,7 @@ fn field_with_zero_expiration_never_expires() {
 fn field_with_past_expiration_has_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     // Expired field
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -134,7 +124,7 @@ fn field_with_past_expiration_has_expired() {
 #[test]
 fn field_with_equal_expiration_has_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, NOW)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, NOW)]));
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -152,7 +142,7 @@ fn field_with_equal_expiration_has_expired() {
 #[test]
 fn nanoseconds_break_seconds_tie() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -170,7 +160,7 @@ fn nanoseconds_break_seconds_tie() {
 #[test]
 fn field_with_future_expiration_has_not_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)]));
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -205,7 +195,7 @@ fn verify_field_returns_true_for_unknown_doc() {
 #[test]
 fn verify_field_absent_default_returns_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_2,
@@ -243,12 +233,10 @@ fn verify_mask_returns_true_for_unknown_doc() {
 #[test]
 fn verify_mask_default_short_circuits_when_more_bits_than_field_expirations() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
+    );
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -263,12 +251,10 @@ fn verify_mask_default_short_circuits_when_more_bits_than_field_expirations() {
 #[test]
 fn verify_mask_default_returns_false_when_all_matched_fields_expired_and_no_extras() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
+    );
     // Mask covers exactly the two expired fields ⇒ no field is valid.
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
@@ -283,12 +269,10 @@ fn verify_mask_default_returns_false_when_all_matched_fields_expired_and_no_extr
 #[test]
 fn verify_mask_missing_returns_true_when_any_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]),
+    );
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -302,12 +286,10 @@ fn verify_mask_missing_returns_true_when_any_matched_field_expired() {
 #[test]
 fn verify_mask_missing_returns_false_when_no_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
+    );
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -321,12 +303,10 @@ fn verify_mask_missing_returns_false_when_no_matched_field_expired() {
 #[test]
 fn verify_mask_default_returns_true_when_at_least_one_matched_field_valid() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)]),
+    );
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -347,12 +327,10 @@ fn verify_mask_skips_bits_whose_field_index_is_not_tracked() {
     // The doc only tracks FIELD_INDEX_1 and FIELD_INDEX_2; bit
     // UNTRACKED_FIELD_ID translates to FIELD_INDEX_3, which the entry
     // does not record — so the scan should treat it as "field absent".
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
+    );
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
         mask_bit(&[FIELD_ID as u16]),
@@ -375,16 +353,14 @@ fn verify_mask_with_sparse_monotonic_translation_table() {
     // 5 are valid.
     let map: Vec<u16> = vec![FIELD_INDEX_1, FIELD_INDEX_2, FIELD_INDEX_3, 0, 0];
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([
-                fe(FIELD_INDEX_1, FUTURE),
-                fe(FIELD_INDEX_2, PAST),
-                fe(FIELD_INDEX_3, FUTURE),
-            ]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([
+            fe(FIELD_INDEX_1, FUTURE),
+            fe(FIELD_INDEX_2, PAST),
+            fe(FIELD_INDEX_3, FUTURE),
+        ]),
+    );
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
         mask_bit(&[0, 1, 2]),
@@ -415,7 +391,7 @@ fn verify_wide_mask_high_bits_use_correct_field_index() {
     let mut map: Vec<u16> = vec![0; 128];
     map[MAPPING_BIT] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     let mask: u128 = 1u128 << MAPPING_BIT;
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -450,7 +426,7 @@ fn verify_wide_mask_returns_true_for_unknown_doc() {
 fn bucket_array_grows_lazily_from_zero() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     assert_eq!(t.n_allocated_buckets(), 0);
-    unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)]));
     // First grow seeds at TTL_BUCKET_INITIAL_CAP = 64.
     assert_eq!(t.n_allocated_buckets(), 64);
 }
@@ -461,7 +437,7 @@ fn bucket_array_grows_to_cover_requested_slot() {
     // doc_id 200 is past the initial-cap of 64, so growth must round up to
     // at least 201. Geometric step from 0 → 64 → 64+1+32 = 97; still not
     // enough for slot 200, so newcap is bumped to slot+1 = 201.
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert!(t.n_allocated_buckets() >= (DOC_ID_1 as usize + 1));
 }
 
@@ -469,7 +445,7 @@ fn bucket_array_grows_to_cover_requested_slot() {
 fn bucket_array_never_exceeds_max_size() {
     const MAX: usize = 16;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-    unsafe { t.add(0, fes([fe(0, FUTURE)])) };
+    t.add(0, fes([fe(0, FUTURE)]));
     // Initial cap of 64 gets clamped down to MAX.
     assert_eq!(t.n_allocated_buckets(), MAX);
 }
@@ -479,8 +455,8 @@ fn slot_collisions_are_handled_via_bucket_chains() {
     const MAX: usize = 8;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
     // doc_id 1 and doc_id 9 both land in slot 1.
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
-    unsafe { t.add(DOC_ID_2, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
+    t.add(DOC_ID_2, fes([fe(FIELD_INDEX_1, PAST)]));
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
@@ -507,7 +483,7 @@ fn slot_collisions_are_handled_via_bucket_chains() {
 #[test]
 fn no_shrink_on_delete() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(0, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(0, FUTURE)]));
     let cap_after_add = t.n_allocated_buckets();
     t.remove(DOC_ID_1);
     assert_eq!(t.n_allocated_buckets(), cap_after_add);
@@ -516,17 +492,15 @@ fn no_shrink_on_delete() {
 #[test]
 fn verify_wide_mask_with_bits_in_both_halves() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([
-                fe(FIELD_INDEX_1, PAST),
-                fe(FIELD_INDEX_2, PAST),
-                fe(FIELD_INDEX_3, FUTURE),
-                fe(FIELD_INDEX_4, PAST),
-            ]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([
+            fe(FIELD_INDEX_1, PAST),
+            fe(FIELD_INDEX_2, PAST),
+            fe(FIELD_INDEX_3, FUTURE),
+            fe(FIELD_INDEX_4, PAST),
+        ]),
+    );
     // NB: 64 and 65 fall in the second half
     let mut map = vec![0u16; 128];
     map[0] = FIELD_INDEX_1;
@@ -558,7 +532,7 @@ fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
     // ("one of the fields need to be valid"/"expired"), an empty query
     // cannot satisfy either ⇒ both predicates return false.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -579,7 +553,7 @@ fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
 #[test]
 fn verify_wide_mask_with_empty_mask_returns_false_for_both_predicates() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -603,7 +577,7 @@ fn verify_mask_panics_when_translation_table_is_too_short() {
     let count = 5;
 
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     let map: Vec<u16> = vec![0u16; count];
     let _ = t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -620,7 +594,7 @@ fn verify_wide_mask_panics_when_translation_table_is_too_short() {
     let count = 70;
 
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     let map: Vec<u16> = vec![0u16; count];
     let _ = t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -638,17 +612,17 @@ fn add_duplicate_doc_id_panics_in_debug() {
     // Per docs: in debug builds, `add` panics if `doc_id` is already
     // present in the table.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_2, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_2, FUTURE)]));
 }
 
 #[test]
 fn add_then_remove_then_add_keeps_count_consistent() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_2, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_2, FUTURE)]));
     assert!(!t.is_empty());
 
     assert!(t.verify_doc_and_field(
@@ -684,7 +658,7 @@ fn add_then_remove_then_add_keeps_count_consistent() {
 #[test]
 fn remove_same_doc_twice_is_idempotent() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     t.remove(DOC_ID_1);
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
@@ -693,9 +667,7 @@ fn remove_same_doc_twice_is_idempotent() {
 #[test]
 fn verify_field_walks_multi_field_entry() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(DOC_ID_1, fes([fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)]));
-    }
+    t.add(DOC_ID_1, fes([fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)]));
     // Field 1: FUTURE.
     assert!(t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Default, &NOW));
     assert!(!t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Missing, &NOW));
@@ -721,18 +693,16 @@ fn verify_mask_interleaved_skip_and_match_pattern() {
     // Entry: 5 fields at indices 1, 3, 5, 7, 9.
     // Identity translation lets us mix tracked and untracked bits.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([
-                fe(1, PAST),
-                fe(3, FUTURE),
-                fe(5, PAST),
-                fe(7, FUTURE),
-                fe(9, PAST),
-            ]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([
+            fe(1, PAST),
+            fe(3, FUTURE),
+            fe(5, PAST),
+            fe(7, FUTURE),
+            fe(9, PAST),
+        ]),
+    );
     let map = identity_ft_id();
 
     // Mask {1, 2, 3, 5, 7}: 5 bits, entry has 5 fields ⇒ no Default
@@ -783,7 +753,7 @@ fn field_with_zero_seconds_but_nonzero_nanos_is_not_the_never_sentinel() {
     // tv_sec == 0 but tv_nsec > 0 is a legitimate time (1ns past
     // epoch), which is in the past relative to NOW ⇒ expired.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, ts(0, 1))])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, ts(0, 1))]));
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -806,7 +776,7 @@ fn verify_wide_mask_at_bit_64_uses_correct_field_index() {
     let mut map = vec![0u16; 128];
     map[64] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     let mask = mask_bit_u128(&[64]);
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -829,7 +799,7 @@ fn verify_wide_mask_at_bit_127_uses_correct_field_index() {
     let mut map = vec![0u16; 128];
     map[127] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
     let mask = mask_bit_u128(&[127]);
     assert!(t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -850,12 +820,10 @@ fn verify_wide_mask_at_bit_127_uses_correct_field_index() {
 #[test]
 fn verify_wide_mask_default_short_circuits_when_more_bits_than_field_expirations() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
+    );
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     assert!(t.verify_doc_and_wide_field_mask(
@@ -870,12 +838,10 @@ fn verify_wide_mask_default_short_circuits_when_more_bits_than_field_expirations
 #[test]
 fn verify_wide_mask_default_returns_false_when_all_matched_fields_expired_and_no_extras() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
+    );
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
     assert!(!t.verify_doc_and_wide_field_mask(
@@ -890,12 +856,10 @@ fn verify_wide_mask_default_returns_false_when_all_matched_fields_expired_and_no
 #[test]
 fn verify_wide_mask_missing_returns_true_when_any_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]),
+    );
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
     assert!(t.verify_doc_and_wide_field_mask(
@@ -910,12 +874,10 @@ fn verify_wide_mask_missing_returns_true_when_any_matched_field_expired() {
 #[test]
 fn verify_wide_mask_missing_returns_false_when_no_matched_field_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
+    );
     let map = identity_ft_id();
     let mask = mask_bit_u128(&[FIELD_INDEX_1, FIELD_INDEX_2]);
     assert!(!t.verify_doc_and_wide_field_mask(
@@ -933,12 +895,10 @@ fn verify_wide_mask_skips_bits_whose_field_index_is_not_tracked() {
     let mut map: Vec<u16> = (0u16..128).collect();
     map[FIELD_ID] = FIELD_INDEX_3;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
+    );
     let mask = mask_bit_u128(&[FIELD_ID as u16]);
     // Untracked field ⇒ Default true, Missing false.
     assert!(t.verify_doc_and_wide_field_mask(
@@ -964,11 +924,11 @@ fn bucket_array_grows_geometrically_across_multiple_steps() {
     //   step 2: 64 → 64+1+32 = 97 (slot 64 forces a grow)
     //   step 3: 97 → 97+1+48 = 146 (slot 97 forces a grow)
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert_eq!(t.n_allocated_buckets(), 64);
-    unsafe { t.add(64, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(64, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert_eq!(t.n_allocated_buckets(), 97);
-    unsafe { t.add(97, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(97, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert_eq!(t.n_allocated_buckets(), 146);
 }
 
@@ -978,7 +938,7 @@ fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
     // First add into slot 500: initial cap of 64 is too small, so the
     // final cap must be `slot + 1 = 501`.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(500, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(500, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert_eq!(t.n_allocated_buckets(), 501);
 }
 
@@ -986,7 +946,7 @@ fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
 fn add_at_max_size_minus_one_works() {
     const MAX: usize = 16;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-    unsafe { t.add((MAX - 1) as u64, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add((MAX - 1) as u64, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(
         (MAX - 1) as u64,
@@ -999,11 +959,11 @@ fn add_at_max_size_minus_one_works() {
 #[test]
 fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
-    unsafe { t.add(2, fes([fe(FIELD_INDEX_1, PAST)])) };
-    unsafe { t.add(3, fes([fe(FIELD_INDEX_1, FUTURE)])) };
-    unsafe { t.add(4, fes([fe(FIELD_INDEX_1, PAST)])) };
-    unsafe { t.add(5, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(1, fes([fe(FIELD_INDEX_1, FUTURE)]));
+    t.add(2, fes([fe(FIELD_INDEX_1, PAST)]));
+    t.add(3, fes([fe(FIELD_INDEX_1, FUTURE)]));
+    t.add(4, fes([fe(FIELD_INDEX_1, PAST)]));
+    t.add(5, fes([fe(FIELD_INDEX_1, FUTURE)]));
     // FUTURE ⇒ Default true; PAST ⇒ Default false.
     assert!(t.verify_doc_and_field(1, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
     assert!(!t.verify_doc_and_field(2, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
@@ -1024,12 +984,10 @@ fn verify_mask_with_two_bits_translating_to_same_field_index() {
     map[0] = FIELD_INDEX_1;
     map[1] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
-        );
-    }
+    t.add(
+        DOC_ID_1,
+        fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
+    );
     let mask = mask_bit(&[0, 1]);
 
     assert!(t.verify_doc_and_field_mask(
@@ -1052,7 +1010,7 @@ fn verify_mask_with_two_bits_translating_to_same_field_index() {
 #[test]
 fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -1066,7 +1024,7 @@ fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
 #[test]
 fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
+    t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)]));
     let map = identity_ft_id();
     assert!(t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -1080,7 +1038,7 @@ fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
 #[test]
 fn doc_id_zero_is_a_valid_doc_id() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)]));
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
     t.remove(0);
@@ -1100,7 +1058,7 @@ fn high_density_chain_alternating_states_with_swap_last_removes() {
 
     for d in 1..=N {
         let point = if d & 1 == 1 { PAST } else { FUTURE };
-        unsafe { t.add(d, fes([fe(0, point)])) };
+        t.add(d, fes([fe(0, point)]));
     }
     for d in 1..=N {
         let valid = t.verify_doc_and_field(d, 0, FieldExpirationPredicate::Default, &NOW);
@@ -1143,7 +1101,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
 
     let small_ids: [u64; 4] = [1, 5, 42, 100];
     for d in small_ids {
-        unsafe { t.add(d, fes([fe(0, PAST)])) };
+        t.add(d, fes([fe(0, PAST)]));
     }
     let cap_after_small = t.n_allocated_buckets();
     assert!(
@@ -1157,7 +1115,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
 
     // Reads for docIds whose slot is still unallocated report "no TTL".
     assert!(t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
-    unsafe { t.add(999_999, fes([fe(0, PAST)])) };
+    t.add(999_999, fes([fe(0, PAST)]));
     assert!(t.n_allocated_buckets() >= 1_000_000);
     assert!(!t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
 
@@ -1171,7 +1129,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
     // Wrap-around docId routes via modulo into an already-allocated slot,
     // so cap must NOT change.
     let cap_before_wrap = t.n_allocated_buckets();
-    unsafe { t.add(MAX as u64 + 5, fes([fe(0, PAST)])) };
+    t.add(MAX as u64 + 5, fes([fe(0, PAST)]));
     assert_eq!(t.n_allocated_buckets(), cap_before_wrap);
     assert!(!t.verify_doc_and_field(MAX as u64 + 5, 0, FieldExpirationPredicate::Default, &NOW,));
     // The original docId=5 entry must remain distinct from the wrap.

--- a/src/redisearch_rs/ttl_table/tests/main.rs
+++ b/src/redisearch_rs/ttl_table/tests/main.rs
@@ -13,14 +13,10 @@
 // whose vec is non-empty. The safety preconditions of `TimeToLiveTable::add`
 // are therefore met at every call site by inspection — adding per-call
 // `// SAFETY:` comments to ~60 callsites would be more noise than signal.
-#![expect(
-    clippy::undocumented_unsafe_blocks,
-    clippy::multiple_unsafe_ops_per_block
-)]
+#![expect(clippy::undocumented_unsafe_blocks)]
 
 use std::num::NonZeroUsize;
 
-use thin_vec::thin_vec;
 use ttl_table::{test_utils::*, *};
 
 #[test]
@@ -36,10 +32,10 @@ fn add_then_remove_leaves_table_empty() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![FieldExpiration {
+            fes([FieldExpiration {
                 index: FIELD_INDEX_1,
                 point: FUTURE,
-            }],
+            }]),
         );
     }
     assert!(!t.is_empty());
@@ -65,7 +61,7 @@ fn field_expirations_on_empty_table_is_none() {
 #[test]
 fn field_expirations_returns_inserted_slice() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    let inserted = thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)];
+    let inserted = fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]);
     unsafe { t.add(DOC_ID_1, inserted.clone()) };
 
     let got = t.field_expirations(DOC_ID_1).expect("entry must exist");
@@ -84,7 +80,7 @@ fn field_expirations_returns_inserted_slice() {
 #[test]
 fn field_expirations_after_remove_is_none() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert!(t.field_expirations(DOC_ID_1).is_some());
     t.remove(DOC_ID_1);
     assert!(t.field_expirations(DOC_ID_1).is_none());
@@ -101,7 +97,7 @@ fn add_with_empty_fields_panics() {
 fn field_with_zero_expiration_never_expires() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     // Field never expires
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NEVER)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, NEVER)])) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -120,7 +116,7 @@ fn field_with_zero_expiration_never_expires() {
 fn field_with_past_expiration_has_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     // Expired field
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -138,7 +134,7 @@ fn field_with_past_expiration_has_expired() {
 #[test]
 fn field_with_equal_expiration_has_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, NOW)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, NOW)])) };
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -156,7 +152,7 @@ fn field_with_equal_expiration_has_expired() {
 #[test]
 fn nanoseconds_break_seconds_tie() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -174,7 +170,7 @@ fn nanoseconds_break_seconds_tie() {
 #[test]
 fn field_with_future_expiration_has_not_expired() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FAR_IN_THE_FUTURE)])) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -209,7 +205,7 @@ fn verify_field_returns_true_for_unknown_doc() {
 #[test]
 fn verify_field_absent_default_returns_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_2,
@@ -250,7 +246,7 @@ fn verify_mask_default_short_circuits_when_more_bits_than_field_expirations() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     let map = identity_ft_id();
@@ -270,7 +266,7 @@ fn verify_mask_default_returns_false_when_all_matched_fields_expired_and_no_extr
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     // Mask covers exactly the two expired fields ⇒ no field is valid.
@@ -290,7 +286,7 @@ fn verify_mask_missing_returns_true_when_any_matched_field_expired() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     let map = identity_ft_id();
@@ -309,7 +305,7 @@ fn verify_mask_missing_returns_false_when_no_matched_field_expired() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
         );
     }
     let map = identity_ft_id();
@@ -328,7 +324,7 @@ fn verify_mask_default_returns_true_when_at_least_one_matched_field_valid() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, FUTURE)]),
         );
     }
     let map = identity_ft_id();
@@ -354,7 +350,7 @@ fn verify_mask_skips_bits_whose_field_index_is_not_tracked() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     assert!(t.verify_doc_and_field_mask(
@@ -382,11 +378,11 @@ fn verify_mask_with_sparse_monotonic_translation_table() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![
+            fes([
                 fe(FIELD_INDEX_1, FUTURE),
                 fe(FIELD_INDEX_2, PAST),
-                fe(FIELD_INDEX_3, FUTURE)
-            ],
+                fe(FIELD_INDEX_3, FUTURE),
+            ]),
         );
     }
     assert!(t.verify_doc_and_field_mask(
@@ -419,7 +415,7 @@ fn verify_wide_mask_high_bits_use_correct_field_index() {
     let mut map: Vec<u16> = vec![0; 128];
     map[MAPPING_BIT] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     let mask: u128 = 1u128 << MAPPING_BIT;
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -454,7 +450,7 @@ fn verify_wide_mask_returns_true_for_unknown_doc() {
 fn bucket_array_grows_lazily_from_zero() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     assert_eq!(t.n_allocated_buckets(), 0);
-    unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     // First grow seeds at TTL_BUCKET_INITIAL_CAP = 64.
     assert_eq!(t.n_allocated_buckets(), 64);
 }
@@ -465,7 +461,7 @@ fn bucket_array_grows_to_cover_requested_slot() {
     // doc_id 200 is past the initial-cap of 64, so growth must round up to
     // at least 201. Geometric step from 0 → 64 → 64+1+32 = 97; still not
     // enough for slot 200, so newcap is bumped to slot+1 = 201.
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert!(t.n_allocated_buckets() >= (DOC_ID_1 as usize + 1));
 }
 
@@ -473,7 +469,7 @@ fn bucket_array_grows_to_cover_requested_slot() {
 fn bucket_array_never_exceeds_max_size() {
     const MAX: usize = 16;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-    unsafe { t.add(0, thin_vec![fe(0, FUTURE)]) };
+    unsafe { t.add(0, fes([fe(0, FUTURE)])) };
     // Initial cap of 64 gets clamped down to MAX.
     assert_eq!(t.n_allocated_buckets(), MAX);
 }
@@ -483,8 +479,8 @@ fn slot_collisions_are_handled_via_bucket_chains() {
     const MAX: usize = 8;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
     // doc_id 1 and doc_id 9 both land in slot 1.
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
-    unsafe { t.add(DOC_ID_2, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    unsafe { t.add(DOC_ID_2, fes([fe(FIELD_INDEX_1, PAST)])) };
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(
         DOC_ID_1,
@@ -511,7 +507,7 @@ fn slot_collisions_are_handled_via_bucket_chains() {
 #[test]
 fn no_shrink_on_delete() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(0, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(0, FUTURE)])) };
     let cap_after_add = t.n_allocated_buckets();
     t.remove(DOC_ID_1);
     assert_eq!(t.n_allocated_buckets(), cap_after_add);
@@ -523,12 +519,12 @@ fn verify_wide_mask_with_bits_in_both_halves() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![
+            fes([
                 fe(FIELD_INDEX_1, PAST),
                 fe(FIELD_INDEX_2, PAST),
                 fe(FIELD_INDEX_3, FUTURE),
                 fe(FIELD_INDEX_4, PAST),
-            ],
+            ]),
         );
     }
     // NB: 64 and 65 fall in the second half
@@ -562,7 +558,7 @@ fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
     // ("one of the fields need to be valid"/"expired"), an empty query
     // cannot satisfy either ⇒ both predicates return false.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -583,7 +579,7 @@ fn verify_mask_with_empty_mask_returns_false_for_both_predicates() {
 #[test]
 fn verify_wide_mask_with_empty_mask_returns_false_for_both_predicates() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     let map = identity_ft_id();
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -607,7 +603,7 @@ fn verify_mask_panics_when_translation_table_is_too_short() {
     let count = 5;
 
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     let map: Vec<u16> = vec![0u16; count];
     let _ = t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -624,7 +620,7 @@ fn verify_wide_mask_panics_when_translation_table_is_too_short() {
     let count = 70;
 
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     let map: Vec<u16> = vec![0u16; count];
     let _ = t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -642,17 +638,17 @@ fn add_duplicate_doc_id_panics_in_debug() {
     // Per docs: in debug builds, `add` panics if `doc_id` is already
     // present in the table.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_2, FUTURE)])) };
 }
 
 #[test]
 fn add_then_remove_then_add_keeps_count_consistent() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_2, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_2, FUTURE)])) };
     assert!(!t.is_empty());
 
     assert!(t.verify_doc_and_field(
@@ -688,7 +684,7 @@ fn add_then_remove_then_add_keeps_count_consistent() {
 #[test]
 fn remove_same_doc_twice_is_idempotent() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     t.remove(DOC_ID_1);
     t.remove(DOC_ID_1);
     assert!(t.is_empty());
@@ -698,10 +694,7 @@ fn remove_same_doc_twice_is_idempotent() {
 fn verify_field_walks_multi_field_entry() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
     unsafe {
-        t.add(
-            DOC_ID_1,
-            thin_vec![fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)],
-        );
+        t.add(DOC_ID_1, fes([fe(1, FUTURE), fe(3, PAST), fe(5, FUTURE)]));
     }
     // Field 1: FUTURE.
     assert!(t.verify_doc_and_field(DOC_ID_1, 1, FieldExpirationPredicate::Default, &NOW));
@@ -731,13 +724,13 @@ fn verify_mask_interleaved_skip_and_match_pattern() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![
+            fes([
                 fe(1, PAST),
                 fe(3, FUTURE),
                 fe(5, PAST),
                 fe(7, FUTURE),
                 fe(9, PAST),
-            ],
+            ]),
         );
     }
     let map = identity_ft_id();
@@ -790,7 +783,7 @@ fn field_with_zero_seconds_but_nonzero_nanos_is_not_the_never_sentinel() {
     // tv_sec == 0 but tv_nsec > 0 is a legitimate time (1ns past
     // epoch), which is in the past relative to NOW ⇒ expired.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, ts(0, 1))]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, ts(0, 1))])) };
     assert!(!t.verify_doc_and_field(
         DOC_ID_1,
         FIELD_INDEX_1,
@@ -813,7 +806,7 @@ fn verify_wide_mask_at_bit_64_uses_correct_field_index() {
     let mut map = vec![0u16; 128];
     map[64] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     let mask = mask_bit_u128(&[64]);
     assert!(!t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -836,7 +829,7 @@ fn verify_wide_mask_at_bit_127_uses_correct_field_index() {
     let mut map = vec![0u16; 128];
     map[127] = FIELD_INDEX_1;
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     let mask = mask_bit_u128(&[127]);
     assert!(t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -860,7 +853,7 @@ fn verify_wide_mask_default_short_circuits_when_more_bits_than_field_expirations
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     let map = identity_ft_id();
@@ -880,7 +873,7 @@ fn verify_wide_mask_default_returns_false_when_all_matched_fields_expired_and_no
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     let map = identity_ft_id();
@@ -900,7 +893,7 @@ fn verify_wide_mask_missing_returns_true_when_any_matched_field_expired() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     let map = identity_ft_id();
@@ -920,7 +913,7 @@ fn verify_wide_mask_missing_returns_false_when_no_matched_field_expired() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
         );
     }
     let map = identity_ft_id();
@@ -943,7 +936,7 @@ fn verify_wide_mask_skips_bits_whose_field_index_is_not_tracked() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)],
+            fes([fe(FIELD_INDEX_1, PAST), fe(FIELD_INDEX_2, PAST)]),
         );
     }
     let mask = mask_bit_u128(&[FIELD_ID as u16]);
@@ -971,11 +964,11 @@ fn bucket_array_grows_geometrically_across_multiple_steps() {
     //   step 2: 64 → 64+1+32 = 97 (slot 64 forces a grow)
     //   step 3: 97 → 97+1+48 = 146 (slot 97 forces a grow)
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert_eq!(t.n_allocated_buckets(), 64);
-    unsafe { t.add(64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(64, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert_eq!(t.n_allocated_buckets(), 97);
-    unsafe { t.add(97, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(97, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert_eq!(t.n_allocated_buckets(), 146);
 }
 
@@ -985,7 +978,7 @@ fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
     // First add into slot 500: initial cap of 64 is too small, so the
     // final cap must be `slot + 1 = 501`.
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(500, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(500, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert_eq!(t.n_allocated_buckets(), 501);
 }
 
@@ -993,7 +986,7 @@ fn bucket_array_rounds_up_to_slot_plus_one_when_geometric_step_too_small() {
 fn add_at_max_size_minus_one_works() {
     const MAX: usize = 16;
     let mut t = TimeToLiveTable::new(NonZeroUsize::new(MAX).unwrap());
-    unsafe { t.add((MAX - 1) as u64, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add((MAX - 1) as u64, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(
         (MAX - 1) as u64,
@@ -1006,11 +999,11 @@ fn add_at_max_size_minus_one_works() {
 #[test]
 fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(1, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
-    unsafe { t.add(2, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
-    unsafe { t.add(3, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
-    unsafe { t.add(4, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
-    unsafe { t.add(5, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(1, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    unsafe { t.add(2, fes([fe(FIELD_INDEX_1, PAST)])) };
+    unsafe { t.add(3, fes([fe(FIELD_INDEX_1, FUTURE)])) };
+    unsafe { t.add(4, fes([fe(FIELD_INDEX_1, PAST)])) };
+    unsafe { t.add(5, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     // FUTURE ⇒ Default true; PAST ⇒ Default false.
     assert!(t.verify_doc_and_field(1, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
     assert!(!t.verify_doc_and_field(2, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW));
@@ -1027,16 +1020,17 @@ fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
 
 #[test]
 #[cfg(debug_assertions)]
-#[should_panic(expected = "sorted_by_id is not sorted by index")]
-fn add_unsorted_fields_panics_in_debug() {
-    let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe {
-        t.add(
-            DOC_ID_1,
-            // Not sorted
-            thin_vec![fe(FIELD_INDEX_2, FUTURE), fe(FIELD_INDEX_1, FUTURE)],
-        );
-    }
+#[should_panic(expected = "FieldExpirations must be sorted ascending by index")]
+fn from_thin_vec_unchecked_unsorted_panics_in_debug() {
+    use thin_vec::thin_vec;
+    // SAFETY: intentionally violates the unchecked-constructor contract to
+    // exercise the debug-assert.
+    let _ = unsafe {
+        FieldExpirations::from_thin_vec_unchecked(thin_vec![
+            fe(FIELD_INDEX_2, FUTURE),
+            fe(FIELD_INDEX_1, FUTURE),
+        ])
+    };
 }
 
 #[test]
@@ -1048,7 +1042,7 @@ fn verify_mask_with_two_bits_translating_to_same_field_index() {
     unsafe {
         t.add(
             DOC_ID_1,
-            thin_vec![fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)],
+            fes([fe(FIELD_INDEX_1, FUTURE), fe(FIELD_INDEX_2, FUTURE)]),
         );
     }
     let mask = mask_bit(&[0, 1]);
@@ -1073,7 +1067,7 @@ fn verify_mask_with_two_bits_translating_to_same_field_index() {
 #[test]
 fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     let map = identity_ft_id();
     assert!(t.verify_doc_and_field_mask(
         DOC_ID_1,
@@ -1087,7 +1081,7 @@ fn verify_mask_with_all_bits_set_default_short_circuits_to_true() {
 #[test]
 fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(DOC_ID_1, thin_vec![fe(FIELD_INDEX_1, PAST)]) };
+    unsafe { t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, PAST)])) };
     let map = identity_ft_id();
     assert!(t.verify_doc_and_wide_field_mask(
         DOC_ID_1,
@@ -1101,7 +1095,7 @@ fn verify_wide_mask_with_all_bits_set_default_short_circuits_to_true() {
 #[test]
 fn doc_id_zero_is_a_valid_doc_id() {
     let mut t = TimeToLiveTable::new(TEST_MAX_SIZE);
-    unsafe { t.add(0, thin_vec![fe(FIELD_INDEX_1, FUTURE)]) };
+    unsafe { t.add(0, fes([fe(FIELD_INDEX_1, FUTURE)])) };
     assert!(!t.is_empty());
     assert!(t.verify_doc_and_field(0, FIELD_INDEX_1, FieldExpirationPredicate::Default, &NOW,));
     t.remove(0);
@@ -1121,7 +1115,7 @@ fn high_density_chain_alternating_states_with_swap_last_removes() {
 
     for d in 1..=N {
         let point = if d & 1 == 1 { PAST } else { FUTURE };
-        unsafe { t.add(d, thin_vec![fe(0, point)]) };
+        unsafe { t.add(d, fes([fe(0, point)])) };
     }
     for d in 1..=N {
         let valid = t.verify_doc_and_field(d, 0, FieldExpirationPredicate::Default, &NOW);
@@ -1164,7 +1158,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
 
     let small_ids: [u64; 4] = [1, 5, 42, 100];
     for d in small_ids {
-        unsafe { t.add(d, thin_vec![fe(0, PAST)]) };
+        unsafe { t.add(d, fes([fe(0, PAST)])) };
     }
     let cap_after_small = t.n_allocated_buckets();
     assert!(
@@ -1178,7 +1172,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
 
     // Reads for docIds whose slot is still unallocated report "no TTL".
     assert!(t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
-    unsafe { t.add(999_999, thin_vec![fe(0, PAST)]) };
+    unsafe { t.add(999_999, fes([fe(0, PAST)])) };
     assert!(t.n_allocated_buckets() >= 1_000_000);
     assert!(!t.verify_doc_and_field(999_999, 0, FieldExpirationPredicate::Default, &NOW));
 
@@ -1192,7 +1186,7 @@ fn production_scale_max_size_keeps_cap_proportional_to_use() {
     // Wrap-around docId routes via modulo into an already-allocated slot,
     // so cap must NOT change.
     let cap_before_wrap = t.n_allocated_buckets();
-    unsafe { t.add(MAX as u64 + 5, thin_vec![fe(0, PAST)]) };
+    unsafe { t.add(MAX as u64 + 5, fes([fe(0, PAST)])) };
     assert_eq!(t.n_allocated_buckets(), cap_before_wrap);
     assert!(!t.verify_doc_and_field(MAX as u64 + 5, 0, FieldExpirationPredicate::Default, &NOW,));
     // The original docId=5 entry must remain distinct from the wrap.

--- a/src/redisearch_rs/ttl_table/tests/main.rs
+++ b/src/redisearch_rs/ttl_table/tests/main.rs
@@ -1019,21 +1019,6 @@ fn multiple_docs_on_distinct_slots_are_independently_retrievable() {
 }
 
 #[test]
-#[cfg(debug_assertions)]
-#[should_panic(expected = "FieldExpirations must be sorted ascending by index")]
-fn from_thin_vec_unchecked_unsorted_panics_in_debug() {
-    use thin_vec::thin_vec;
-    // SAFETY: intentionally violates the unchecked-constructor contract to
-    // exercise the debug-assert.
-    let _ = unsafe {
-        FieldExpirations::from_thin_vec_unchecked(thin_vec![
-            fe(FIELD_INDEX_2, FUTURE),
-            fe(FIELD_INDEX_1, FUTURE),
-        ])
-    };
-}
-
-#[test]
 fn verify_mask_with_two_bits_translating_to_same_field_index() {
     let mut map = vec![0u16; 32];
     map[0] = FIELD_INDEX_1;


### PR DESCRIPTION
## Describe the changes in the pull request

Improve TTL Table:
- add u64 support for BitMask
- add FieldExpirations wrapper

See: https://github.com/RediSearch/RediSearch/pull/9420

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to public API changes in `TimeToLiveTable` (`add` signature/behavior, `field_expirations` return type, and wide-mask type) that could break downstream callers and alter panic conditions. Core TTL verification paths are also touched via new mask dispatch, so regressions would affect expiration filtering behavior.
> 
> **Overview**
> **Improves TTL table ergonomics and wide-schema support.** Adds a new `FieldExpirations` wrapper (sorted, duplicate-free) and switches `TimeToLiveEntry`/`TimeToLiveTable::add` to accept it, making `add` safe (asserts non-empty and non-duplicate `doc_id`) and exposing an `unsafe add_unchecked` for callers that already uphold invariants.
> 
> **Extends bitmask verification to `u64` and makes wide-mask type configurable.** Implements `BitMask` for `u64`, updates `verify_doc_and_wide_field_mask` to take the FFI-provided `FieldMask` alias and dispatch accordingly, and adjusts tests/utilities to construct `FieldExpirations` and cover high-bit `u64` walks and `FieldExpirations::push` invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e744b59555b5a004fba2e03196a54becd95fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->