### PR TITLE
Use relaxed memory ordering for the request timedOut signal flag

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -30,10 +30,14 @@
 #ifdef __cplusplus
 #include <atomic>
 #define RS_Atomic(T) std::atomic<T>
+#define RS_AtomicLoadRelaxed(p)     ((p)->load(std::memory_order_relaxed))
+#define RS_AtomicStoreRelaxed(p, v) ((p)->store((v), std::memory_order_relaxed))
 extern "C" {
 #else
 #define RS_Atomic(T) _Atomic(T)
 #include <stdatomic.h>
+#define RS_AtomicLoadRelaxed(p)     atomic_load_explicit((p), memory_order_relaxed)
+#define RS_AtomicStoreRelaxed(p, v) atomic_store_explicit((p), (v), memory_order_relaxed)
 #endif
 
 #define DEFAULT_LIMIT 10
@@ -547,18 +551,10 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
 static inline bool AREQ_TimedOut(AREQ *req) {
-#ifdef __cplusplus
-  return req->syncCtx.timedOut.load(std::memory_order_relaxed);
-#else
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
-#endif
+  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
 }
 static inline void AREQ_SetTimedOut(AREQ *req) {
-#ifdef __cplusplus
-  req->syncCtx.timedOut.store(true, std::memory_order_relaxed);
-#else
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
-#endif
+  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
 }
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -546,8 +546,20 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 // Allows calling parseProfileArgs from reply_empty.c
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
-bool AREQ_TimedOut(AREQ *req);
-void AREQ_SetTimedOut(AREQ *req);
+static inline bool AREQ_TimedOut(AREQ *req) {
+#ifdef __cplusplus
+  return req->syncCtx.timedOut.load(std::memory_order_relaxed);
+#else
+  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
+#endif
+}
+static inline void AREQ_SetTimedOut(AREQ *req) {
+#ifdef __cplusplus
+  req->syncCtx.timedOut.store(true, std::memory_order_relaxed);
+#else
+  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
+#endif
+}
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`
 // to SyncPoint_WaitUntil to release the wait when the request is timed out.
@@ -557,7 +569,9 @@ bool areq_timed_out(void *arg);
 /* True when this AREQ uses the BG-thread / timeout-callback claim handshake
  * around AggregateResults (TryClaim/Signal/Wait). Currently set only on the
  * coordinator AREQ under RETURN-STRICT; all other paths skip the protocol. */
-bool AREQ_RequiresThreadsSyncResults(const AREQ *req);
+static inline bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
+  return req->syncCtx.requiresAggregateResultsSync;
+}
 
 /* TryClaim: atomic CAS on `aggregatingResults`; winner runs AggregateResults.
  * Signal: called by winner at completion. Wait: called by loser, blocks until Signal.

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1104,14 +1104,6 @@ AREQ *AREQ_New(void) {
   return req;
 }
 
-bool AREQ_TimedOut(AREQ *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
-}
-
-void AREQ_SetTimedOut(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
-}
-
 bool SearchTime_IsTimedOut(void *arg) {
   const SearchTime *time = arg;
   if (!time || !time->timedOutFlag) return false;
@@ -1119,13 +1111,10 @@ bool SearchTime_IsTimedOut(void *arg) {
                               memory_order_relaxed);
 }
 
-bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
-  return req->syncCtx.requiresAggregateResultsSync;
-}
-
 bool AREQ_TryClaimAggregateResults(AREQ *req) {
   bool expected = false;
-  return atomic_compare_exchange_strong(&req->syncCtx.aggregatingResults, &expected, true);
+  return atomic_compare_exchange_strong_explicit(&req->syncCtx.aggregatingResults, &expected, true,
+                                                 memory_order_relaxed, memory_order_relaxed);
 }
 
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {
@@ -1144,7 +1133,7 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
 }
 
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.aggregatingResults, false, memory_order_release);
+  atomic_store_explicit(&req->syncCtx.aggregatingResults, false, memory_order_relaxed);
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1105,11 +1105,11 @@ AREQ *AREQ_New(void) {
 }
 
 bool AREQ_TimedOut(AREQ *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_acquire);
+  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
 }
 
 void AREQ_SetTimedOut(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_release);
+  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
 }
 
 bool SearchTime_IsTimedOut(void *arg) {
@@ -1148,7 +1148,7 @@ void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);
-  atomic_store_explicit(&req->syncCtx.timedOut, false, memory_order_release);
+  atomic_store_explicit(&req->syncCtx.timedOut, false, memory_order_relaxed);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {
     ((RPNet *)root)->drainOnly = false;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1133,11 +1133,11 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
 }
 
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.aggregatingResults, false, memory_order_relaxed);
+  RS_AtomicStoreRelaxed(&req->syncCtx.aggregatingResults, false);
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);
-  atomic_store_explicit(&req->syncCtx.timedOut, false, memory_order_relaxed);
+  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, false);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {
     ((RPNet *)root)->drainOnly = false;

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -115,11 +115,11 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
 }
 
 bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return atomic_load_explicit(&ctx->timedOut, memory_order_acquire);
+  return atomic_load_explicit(&ctx->timedOut, memory_order_relaxed);
 }
 
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
-  atomic_store_explicit(&ctx->timedOut, true, memory_order_release);
+  atomic_store_explicit(&ctx->timedOut, true, memory_order_relaxed);
   // Also propagate to the underlying request if set
   if (ctx->type == COMMAND_HYBRID) {
     if (ctx->hreq) HybridRequest_SetTimedOut(ctx->hreq);

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -114,10 +114,6 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
   }
 }
 
-bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return atomic_load_explicit(&ctx->timedOut, memory_order_relaxed);
-}
-
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
   atomic_store_explicit(&ctx->timedOut, true, memory_order_relaxed);
   // Also propagate to the underlying request if set

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -115,7 +115,7 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
 }
 
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
-  atomic_store_explicit(&ctx->timedOut, true, memory_order_relaxed);
+  RS_AtomicStoreRelaxed(&ctx->timedOut, true);
   // Also propagate to the underlying request if set
   if (ctx->type == COMMAND_HYBRID) {
     if (ctx->hreq) HybridRequest_SetTimedOut(ctx->hreq);

--- a/src/coord/coord_request_ctx.h
+++ b/src/coord/coord_request_ctx.h
@@ -94,7 +94,7 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx);
  * Check if the coordinator request has timed out.
  */
 static inline bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return atomic_load_explicit(&ctx->timedOut, memory_order_relaxed);
+  return RS_AtomicLoadRelaxed(&ctx->timedOut);
 }
 
 /**

--- a/src/coord/coord_request_ctx.h
+++ b/src/coord/coord_request_ctx.h
@@ -93,7 +93,9 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx);
 /**
  * Check if the coordinator request has timed out.
  */
-bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx);
+static inline bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
+  return atomic_load_explicit(&ctx->timedOut, memory_order_relaxed);
+}
 
 /**
  * Set the timeout flag on the coordinator request context.

--- a/src/coord/rmr/chan.c
+++ b/src/coord/rmr/chan.c
@@ -168,7 +168,7 @@ void *MRChannel_PopWithTimeout(MRChannel *chan, const struct timespec *abstimeMo
   pthread_mutex_lock(&chan->lock);
   while (!chan->size) {
     // Sticky abort flipped by another thread (e.g. timeout callback + MRChannel_WakeAbort).
-    if (abortFlag && atomic_load_explicit(abortFlag, memory_order_acquire)) goto aborted;
+    if (abortFlag && atomic_load_explicit(abortFlag, memory_order_relaxed)) goto aborted;
     // One-shot unblock via MRChannel_Unblock; reset for the next pop.
     if (!chan->wait) { chan->wait = true; goto aborted; }
     // Park until pushed/broadcast/deadline. Re-checks all conditions on wake.

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -255,11 +255,11 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
 }
 
 bool HybridRequest_TimedOut(HybridRequest *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_acquire);
+  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
 }
 
 void HybridRequest_SetTimedOut(HybridRequest *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_release);
+  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
 }
 
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -254,14 +254,6 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     return hybridReq;
 }
 
-bool HybridRequest_TimedOut(HybridRequest *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
-}
-
-void HybridRequest_SetTimedOut(HybridRequest *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
-}
-
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -80,8 +80,20 @@ typedef struct HybridRequest {
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
-bool HybridRequest_TimedOut(HybridRequest *req);
-void HybridRequest_SetTimedOut(HybridRequest *req);
+static inline bool HybridRequest_TimedOut(HybridRequest *req) {
+#ifdef __cplusplus
+  return req->syncCtx.timedOut.load(std::memory_order_relaxed);
+#else
+  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
+#endif
+}
+static inline void HybridRequest_SetTimedOut(HybridRequest *req) {
+#ifdef __cplusplus
+  req->syncCtx.timedOut.store(true, std::memory_order_relaxed);
+#else
+  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
+#endif
+}
 
 // Cursor mutex wrappers for synchronizing cursor creation with timeout callback
 static inline void HybridRequest_LockCursors(HybridRequest *req) {

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -81,18 +81,10 @@ typedef struct HybridRequest {
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
 static inline bool HybridRequest_TimedOut(HybridRequest *req) {
-#ifdef __cplusplus
-  return req->syncCtx.timedOut.load(std::memory_order_relaxed);
-#else
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_relaxed);
-#endif
+  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
 }
 static inline void HybridRequest_SetTimedOut(HybridRequest *req) {
-#ifdef __cplusplus
-  req->syncCtx.timedOut.store(true, std::memory_order_relaxed);
-#else
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_relaxed);
-#endif
+  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
 }
 
 // Cursor mutex wrappers for synchronizing cursor creation with timeout callback


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current**: The `timedOut` flag inside `RequestSyncCtx` (on `AREQ`, `HybridRequest`) and the mirrored `timedOut` on `CoordRequestCtx` are stored with `memory_order_release` and loaded with `memory_order_acquire`. The same applies to the externally-supplied `abortFlag` load inside `MRChannel_PopWithTimeout`, which only ever receives `&areq->syncCtx.timedOut`.
2. **Change**: Downgrade every load and store of these flags to `memory_order_relaxed`.
3. **Outcome**: Identical behavior on x86_64 (same `mov` instruction either way); on arm64/POWER we drop the per-poll `dmb ish` / `lwsync` barriers that the polling sites pay on every shard reply in `getNextReply` and on every iteration of the barrier wait in `rpnetNext_Start`.

### Reasoning

`acquire`/`release` is only meaningful when it publishes *other* non-atomic state through the flag. Auditing every reader that follows a successful `*_TimedOut()` observation shows nothing rides on that edge:

- `AREQ_Execute_Callback`, `rpnetNext_Start`, `startPipeline` post-CAS, the `getNextReply` barrier wait — all bail out without touching any state that was written by the timeout-callback writer.
- `rpnetNext` follow-up cursor read does inspect `nc->drainOnly` and `areq->useReplyCallback`, but `drainOnly` is either written on the main thread *after* `AREQ_WaitForAggregateResultsComplete` (the condvar already carries happens-before), or under `setRequestLock` in `AREQ_ResetForCursorReadReturnStrict` (the mutex carries happens-before). Neither path relies on `timedOut` to publish it.
- `MRChannel_PopWithTimeout` reads the abort flag under its own `chan->lock`, which provides the synchronizing edge with the writers via `MRChannel_WakeAbort`.

The real synchronizing operations in the timeout protocol are the `aggregatingResults` CAS (default `seq_cst`), the `aggregateResultsLock` / `aggregateResultsCond` condvar pair, and `MRChannel`'s internal mutex. The `timedOut` flag is purely advisory — a level-triggered signal whose loss-of-promptness is bounded by those primitives. Relaxed atomics still give the C-standard guarantees we actually need from it:

- Race-freedom (so the polling reads aren't UB).
- The compiler may not elide loads inside polling loops (which `volatile` *also* gives, but `volatile` would leave us on UB ground under C11 and would diverge from the rest of the codebase's `RS_Atomic` pattern).

The atomicity itself is retained — only the ordering is relaxed.

#### Out of scope (intentional)

`MRIteratorCtx::timedOut` (set by per-shard reply callbacks in `MRIteratorCallback_SetTimedOut`) is a separate flag with a different lifecycle and is **not** touched by this PR. Its load in `MRIteratorCallback_GetTimedOut` still uses acquire.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `AREQ_TimedOut` / `AREQ_SetTimedOut` / `AREQ_ResetForCursorReadReturnStrict` in `src/aggregate/aggregate_request.c`
2. `CoordRequestCtx_TimedOut` / `CoordRequestCtx_SetTimedOut` in `src/coord/coord_request_ctx.c`
3. `HybridRequest_TimedOut` / `HybridRequest_SetTimedOut` in `src/hybrid/hybrid_request.c`
4. `MRChannel_PopWithTimeout`'s `abortFlag` load in `src/coord/rmr/chan.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only micro-optimization of synchronization primitives. No user-visible behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-thread timeout signaling by downgrading several atomic operations to `memory_order_relaxed`, which can cause subtle timing/visibility issues on weakly ordered architectures if any code implicitly relied on acquire/release semantics.
> 
> **Overview**
> Reduces synchronization overhead in request timeout signaling by switching `timedOut` loads/stores on `AREQ`, `HybridRequest`, and `CoordRequestCtx` from acquire/release to **relaxed** atomics, and centralizing these accesses via new `RS_AtomicLoadRelaxed`/`RS_AtomicStoreRelaxed` helpers.
> 
> Also updates related coordination points to match the relaxed model, including using explicit relaxed ordering on the `aggregatingResults` CAS and relaxing the `abortFlag` load in `MRChannel_PopWithTimeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aefd28a6f7f162ed6d97c4c9af163ec9ad36554a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->