### PR TITLE
[MOD-15808] FT.AGGREGATE: avoid synthetic alias clash for identical reducers in GROUPBY

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -812,33 +812,22 @@ static char *getReducerAlias(PLN_GroupStep *g, const char *func, const ArgsCurso
   // Two identical un-aliased reducers in the same GROUPBY
   // (e.g. `REDUCE COUNT 0 REDUCE COUNT 0`) would otherwise produce the same
   // synthetic alias and collide on the RLookup write key, failing the query
-  // with `SEARCH_FIELD_DUP`. Only when a clash is detected against an
-  // already-added reducer (or against a user-provided alias on a prior
-  // reducer) do we suffix with `_2`, `_3`, ... — this keeps the alias of the
-  // common single-reducer case unchanged, avoiding a behavior break for
-  // clients that depend on the historical synthetic alias format.
+  // with `SEARCH_FIELD_DUP`. On a duplicate, append `_<idx>` where `idx` is
+  // this reducer's position in the group — that's unique among auto-generated
+  // aliases in the same group, so a single check + bump is enough. The common
+  // single-reducer case keeps its historical alias unchanged.
   //
-  // NOTE: This is a wasteful O(n^2) way to enforce uniqueness, kept only to
-  // avoid a breaking change to the generated alias format.
-  // TODO: switch to an unconditional unique suffix (e.g. reducer index) once
-  // we are willing to change the generated alias contract.
-  size_t n = array_len(g->reducers);
-  size_t base_len = sdslen(out);
-  size_t suffix = 1;
-  bool clash;
-  do {
-    clash = false;
-    // The current reducer was just appended to g->reducers by the caller and
-    // its alias is not set yet; compare only against the prior entries.
-    for (size_t i = 0; i + 1 < n; ++i) {
-      if (g->reducers[i].alias && strcmp(g->reducers[i].alias, out) == 0) {
-        clash = true;
-        sdsrange(out, 0, base_len - 1);             // drop any prior suffix
-        out = sdscatprintf(out, "_%zu", ++suffix);  // _2, _3, ...
-        break;
-      }
+  // NOTE: This conditional suffixing exists only to avoid breaking the
+  // historical generated-alias format for clients that depend on it.
+  // TODO: drop the conditional and always append `_<idx>` once we are
+  // willing to change the generated alias contract.
+  size_t idx = array_len(g->reducers) - 1;
+  for (size_t i = 0; i < idx; ++i) {
+    if (g->reducers[i].alias && strcmp(g->reducers[i].alias, out) == 0) {
+      out = sdscatprintf(out, "_%zu", idx);
+      break;
     }
-  } while (clash);
+  }
 
   // duplicate everything. yeah this is lame but this function is not in a tight loop
   char *dup = rm_strndup(out, sdslen(out));

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -792,8 +792,6 @@ static char *getReducerAlias(PLN_GroupStep *g, const char *func, const ArgsCurso
 
   sds out = sdsnew("__generated_alias");
   out = sdscat(out, func);
-  // only put parentheses if we actually have args
-  char buf[255];
   ArgsCursor tmp = *args;
   while (!AC_IsAtEnd(&tmp)) {
     size_t l;
@@ -809,8 +807,38 @@ static char *getReducerAlias(PLN_GroupStep *g, const char *func, const ArgsCurso
     }
   }
 
-  // only put parentheses if we actually have args
   sdstolower(out);
+
+  // Two identical un-aliased reducers in the same GROUPBY
+  // (e.g. `REDUCE COUNT 0 REDUCE COUNT 0`) would otherwise produce the same
+  // synthetic alias and collide on the RLookup write key, failing the query
+  // with `SEARCH_FIELD_DUP`. Only when a clash is detected against an
+  // already-added reducer (or against a user-provided alias on a prior
+  // reducer) do we suffix with `_2`, `_3`, ... — this keeps the alias of the
+  // common single-reducer case unchanged, avoiding a behavior break for
+  // clients that depend on the historical synthetic alias format.
+  //
+  // NOTE: This is a wasteful O(n^2) way to enforce uniqueness, kept only to
+  // avoid a breaking change to the generated alias format.
+  // TODO: switch to an unconditional unique suffix (e.g. reducer index) once
+  // we are willing to change the generated alias contract.
+  size_t n = array_len(g->reducers);
+  size_t base_len = sdslen(out);
+  size_t suffix = 1;
+  bool clash;
+  do {
+    clash = false;
+    // The current reducer was just appended to g->reducers by the caller and
+    // its alias is not set yet; compare only against the prior entries.
+    for (size_t i = 0; i + 1 < n; ++i) {
+      if (g->reducers[i].alias && strcmp(g->reducers[i].alias, out) == 0) {
+        clash = true;
+        sdsrange(out, 0, base_len - 1);             // drop any prior suffix
+        out = sdscatprintf(out, "_%zu", ++suffix);  // _2, _3, ...
+        break;
+      }
+    }
+  } while (clash);
 
   // duplicate everything. yeah this is lame but this function is not in a tight loop
   char *dup = rm_strndup(out, sdslen(out));

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -803,6 +803,19 @@ def testAggregateGroupByOnEmptyField(env):
     for var in expected:
         env.assertContains(var, res)
 
+def test_groupby_same_reducer(env):
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx:fruits', 'SCHEMA', 'color', 'TAG').ok()
+    conn.execute_command('HSET', 'doc1', 'color', 'red')
+    conn.execute_command('HSET', 'doc2', 'color', 'red')
+    conn.execute_command('HSET', 'doc3', 'color', 'green')
+
+    res = env.cmd('FT.AGGREGATE', 'idx:fruits', '*',
+                  'GROUPBY', '1', '@color',
+                  'REDUCE', 'COUNT', '0',
+                  'REDUCE', 'COUNT', '0')
+    env.assertEqual(res[0], 2, message=res)
+
 def test_groupby_array(env: Env):
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE').ok()
   with env.getClusterConnectionIfNeeded() as con:


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** in `getReducerAlias` two identical un-aliased reducers in the same `GROUPBY` (e.g. `REDUCE COUNT 0 REDUCE COUNT 0`) generate the same synthetic alias (`__generated_aliascount`), and the second registration of the alias as an RLookup write key fails with `SEARCH_FIELD_DUP Property '__generated_aliascount' specified more than once`. Reproduces on both standalone and cluster.
2. **Change:** scan the prior reducers of the group and, only on a clash, append `_<idx>` where `idx` is this reducer's position in the group. The index is by construction unique among auto-generated aliases in the same group, so a single bump always resolves it. The common single-reducer case keeps its historical alias, so this is non-breaking for clients that depend on the existing synthetic-alias format.
3. **Outcome:** the failing query succeeds; `test_groupby_same_reducer` is added as a regression test (fails before the fix, passes after, runs on standalone + cluster).

A `TODO` in the code points to dropping the conditional and always appending `_<idx>` once we are willing to change the generated-alias contract.

#### Which additional issues this PR fixes
1. MOD-15808

#### Main objects this PR modified
1. `src/aggregate/aggregate_request.c` (`getReducerAlias`)
2. `tests/pytests/test_aggregate.py` (new `test_groupby_same_reducer`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes