### PR TITLE
trie: document DFAFilter matchCtx running-min dist semantics

### DIFF
--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -237,6 +237,15 @@ void DFAFilter_Free(DFAFilter *fc) {
   Vector_Free(fc->distStack);
 }
 
+// Emit the running minimum edit distance into the caller-supplied matchCtx
+// (an `int *`). On each rune step we track minDist = MIN over all accept-state
+// costs reached along the current DFA path, kept in parallel with the DFA
+// state stack via distStack. dn->distance is the cost stored at the last
+// entry of the DFA state's sparse vector — when dn->match is true this is
+// min Levenshtein(query, input consumed so far) (see SparseAutomaton_IsMatch).
+// In prefix mode, once the prefix accepts, minDist is preserved across the
+// NULL stack entries pushed for the remainder of the term, so *matchCtx ends
+// up holding the cost recorded at the accept boundary.
 FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx, runeTransform rTransform) {
   DFAFilter *fc = ctx;
   dfaNode *dn;

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -79,7 +79,9 @@ typedef struct {
     Vector *cache;
     // A stack of the states leading up to the current state
     Vector *stack;
-    // A stack of the minimal distance for each state, used for prefix matching
+    // A stack tracking, per DFA state on `stack`, the running minimum of
+    // accept-state distances along the path leading to it. Used to report the
+    // cost of the best prefix match seen so far via matchCtx in FilterFunc.
     Vector *distStack;
     // whether the filter works in prefix mode or not
     int prefixMode;
@@ -92,7 +94,23 @@ typedef struct {
  * onwards to all suffixes. */
 DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, int prefixMode);
 
-/* A callback function for the DFA Filter, passed to the Trie iterator */
+/* A callback function for the DFA Filter, passed to the Trie iterator.
+ *
+ * `matchCtx` is an `int *`. On every accept state reached along the DFA path,
+ * the filter writes `MIN(state->distance, running_min_so_far)` into *matchCtx,
+ * where running_min_so_far is tracked on a parallel `distStack` that mirrors
+ * the DFA state stack and pops in sync with it on backtrack. At yield time
+ * *matchCtx therefore holds the minimum accept cost reached on the DFA path
+ * leading to the yielded term — i.e. the edit distance of the best query
+ * match against any consumed prefix of the term. In prefix mode, once the
+ * prefix has been accepted, distStack carries this value forward across the
+ * remaining runes so *matchCtx reflects the cost at the accept boundary.
+ *
+ * NOTE: This is NOT Levenshtein(query, yielded_term) in the general case;
+ * it is the minimum cost reached among all accept states encountered along
+ * the consumed-input prefix of the term. For prefix-mode FUZZY ranking this
+ * is the desired metric (FT.SUGGET FUZZY scoring depends on it via
+ * `score *= exp(-2 * dist)`). */
 // FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx);
 FilterCode FoldingFilterFunc(rune b, void *ctx, int *matched, void *matchCtx);
 FilterCode LoweringFilterFunc(rune b, void *ctx, int *matched, void *matchCtx);

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -16,6 +16,22 @@
 #include "trie_node.h"
 
 /*
+ * This file contains two layers:
+ *
+ * 1. Sparse Levenshtein automaton (`SparseAutomaton`, `dfaNode`, `dfa_build`,
+ *    `SparseAutomaton_IsMatch`). A DFA over query Q and threshold k that
+ *    accepts string S iff Levenshtein(Q, S) <= k.
+ *
+ * 2. Trie-walk filter built on top of the automaton (`DFAFilter`, `FilterFunc`,
+ *    `StackPop`). The automaton is used as a building block to compute prefix
+ *    edit distance (PED) — the metric reported through `matchCtx`:
+ *        PED(Q, T) = min over k in [0..|T|] of Levenshtein(Q, T[0..k])
+ *    See `FilterFunc` docs for details and worked examples. PED is the
+ *    standard scoring metric for approximate autocomplete and the basis of
+ *    FT.SUGGET FUZZY ranking.
+ */
+
+/*
 * SparseAutomaton is a C implementation of a levenshtein automaton using
 * sparse vectors, as described and implemented here:
 * http://julesjacobs.github.io/2015/06/17/disqus-levenshtein-simple-and-fast.html

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -110,7 +110,13 @@ DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, int prefixMode);
  * it is the minimum cost reached among all accept states encountered along
  * the consumed-input prefix of the term. For prefix-mode FUZZY ranking this
  * is the desired metric (FT.SUGGET FUZZY scoring depends on it via
- * `score *= exp(-2 * dist)`). */
+ * `score *= exp(-2 * dist)`).
+ *
+ * Examples (maxDist=2):
+ *   non-prefix: query "ab", term "abc" → *matchCtx=0 (exact accept at "ab"),
+ *               Levenshtein("ab","abc")=1.
+ *   prefix:     query "abc", term "abzzz" → *matchCtx=1 (cost at "ab" accept,
+ *               carried across NULL frames), Levenshtein("abc","abzzz")=4. */
 // FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx);
 FilterCode FoldingFilterFunc(rune b, void *ctx, int *matched, void *matchCtx);
 FilterCode LoweringFilterFunc(rune b, void *ctx, int *matched, void *matchCtx);

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -29,6 +29,14 @@
  *    See `FilterFunc` docs for details and worked examples. PED is the
  *    standard scoring metric for approximate autocomplete and the basis of
  *    FT.SUGGET FUZZY ranking.
+ *
+ *    Admission criteria differ by mode (DFAFilter.prefixMode):
+ *      - non-prefix: term T is admitted iff Lev(Q, T) <= maxDist.
+ *      - prefix:     term T is admitted iff PED(Q, T) <= maxDist (some prefix
+ *                    of T is within maxDist of Q; the tail is unconstrained).
+ *    *matchCtx reports PED in both modes; only in prefix mode does PED also
+ *    gate admission. This is why the prefix example in FilterFunc can yield
+ *    a term whose Lev(query, term) exceeds maxDist.
  */
 
 /*

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -112,27 +112,28 @@ DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, int prefixMode);
 
 /* A callback function for the DFA Filter, passed to the Trie iterator.
  *
- * `matchCtx` is an `int *`. On every accept state reached along the DFA path,
- * the filter writes `MIN(state->distance, running_min_so_far)` into *matchCtx,
- * where running_min_so_far is tracked on a parallel `distStack` that mirrors
- * the DFA state stack and pops in sync with it on backtrack. At yield time
- * *matchCtx therefore holds the minimum accept cost reached on the DFA path
- * leading to the yielded term — i.e. the edit distance of the best query
- * match against any consumed prefix of the term. In prefix mode, once the
- * prefix has been accepted, distStack carries this value forward across the
- * remaining runes so *matchCtx reflects the cost at the accept boundary.
+ * Computes prefix edit distance (see file header) for the yielded term and
+ * writes it through `matchCtx` (typed `int *`). Mechanics:
  *
- * NOTE: This is NOT Levenshtein(query, yielded_term) in the general case;
- * it is the minimum cost reached among all accept states encountered along
- * the consumed-input prefix of the term. For prefix-mode FUZZY ranking this
- * is the desired metric (FT.SUGGET FUZZY scoring depends on it via
- * `score *= exp(-2 * dist)`).
+ *   - The DFAFilter keeps a `distStack` parallel to its DFA state stack,
+ *     each entry holding the running minimum of accept-state costs along
+ *     the current DFA path. Both stacks pop in sync on backtrack
+ *     (`StackPop`).
+ *   - On each rune step that reaches an accept state, *matchCtx is set to
+ *     `MIN(state->distance, running_min_so_far)`.
+ *   - In prefix mode, once a prefix has accepted, the filter pushes NULL
+ *     state-stack frames for the remaining runes; distStack carries the
+ *     running minimum forward unchanged, so *matchCtx at yield time
+ *     reflects the cost at the accept boundary.
  *
  * Examples (maxDist=2):
  *   non-prefix: query "ab", term "abc" → *matchCtx=0 (exact accept at "ab"),
  *               Levenshtein("ab","abc")=1.
  *   prefix:     query "abc", term "abzzz" → *matchCtx=1 (cost at "ab" accept,
- *               carried across NULL frames), Levenshtein("abc","abzzz")=4. */
+ *               carried across NULL frames), Levenshtein("abc","abzzz")=4.
+ *
+ * FT.SUGGET FUZZY ranks results by `score *= exp(-2 * dist)` using this
+ * metric. */
 // FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx);
 FilterCode FoldingFilterFunc(rune b, void *ctx, int *matched, void *matchCtx);
 FilterCode LoweringFilterFunc(rune b, void *ctx, int *matched, void *matchCtx);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `FilterFunc` (in `src/trie/levenshtein.c`) writes the per-match edit distance into `matchCtx`, but neither the function nor the surrounding `DFAFilter` struct documents the actual semantics.

👉🏽 *A reader (like me) is likely to assume* the value is `Levenshtein(query, yielded_term)`, but it is not — it is the running minimum of accept-state costs along the DFA path, maintained via the parallel `distStack`. This trips up readers and porters (and led to a recent abortive "cleanup" attempt that broke `FT.SUGGET FUZZY` ranking).

4. **Change:** Add doc comments explaining the actual semantics:
   - On the `FilterFunc` definition: describe the running-min computation and the role of `distStack`.
   - On the `DFAFilter.distStack` field: clarify what it tracks.
   - On the `Foldering/LoweringFilterFunc` callbacks: paragraph-length doc explaining what `matchCtx` holds at yield time, with explicit note that this is NOT classical Levenshtein and why that is the desired metric for `FT.SUGGET FUZZY` ranking (`score *= exp(-2 * dist)`).

5. **Outcome:** Future readers — and the next person tempted to remove `distStack` as redundant state — have an in-tree explanation of why the running-min is load-bearing for prefix-mode FUZZY ranking. No behavior change.

#### Which additional issues this PR fixes
- N/A

#### Main objects this PR modified
1. `src/trie/levenshtein.c` — added `FilterFunc` doc comment.
3. `src/trie/levenshtein.h` — expanded `DFAFilter.distStack` comment, replaced one-line `FilterFunc`/`FoldingFilterFunc`/`LoweringFilterFunc` doc with a paragraph explaining `matchCtx` semantics.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes clarifying how `matchCtx`/`distStack` report prefix edit distance; no behavioral or data-flow modifications.
> 
> **Overview**
> **Documents the exact meaning of `matchCtx` returned by the Levenshtein trie `DFAFilter`.**
> 
> Adds detailed comments in `levenshtein.c`/`levenshtein.h` explaining that `matchCtx` is a running minimum of accept-state distances (prefix edit distance) tracked via the parallel `distStack`, including how prefix mode carries the minimum across NULL stack frames and why this metric is used for `FT.SUGGET` fuzzy ranking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44739437566fc43462ec388aae0d71bb20f305d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->