### PR TITLE
[MOD-15813] Don't borrow the filter in numeric/geo iterators

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -749,55 +749,29 @@ pub unsafe extern "C" fn IndexBlock_Data(ib: *const IndexBlock) -> *const c_char
 /// based on the index type and filter provided when creating the reader. This allows us to have a
 /// single interface for all index reader types while still being able to optimize the storage
 /// and performance for each index reader type.
-pub enum IndexReader<'index_and_filter> {
-    Full(FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, Full>>),
-    FullWide(FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FullWide>>),
-    FreqsFields(FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FreqsFields>>),
-    FreqsFieldsWide(
-        FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FreqsFieldsWide>>,
-    ),
-    FreqsOnly(inverted_index::IndexReaderCore<'index_and_filter, FreqsOnly>),
-    FieldsOnly(FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FieldsOnly>>),
-    FieldsOnlyWide(
-        FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FieldsOnlyWide>>,
-    ),
-    FieldsOffsets(
-        FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FieldsOffsets>>,
-    ),
-    FieldsOffsetsWide(
-        FilterMaskReader<inverted_index::IndexReaderCore<'index_and_filter, FieldsOffsetsWide>>,
-    ),
-    OffsetsOnly(inverted_index::IndexReaderCore<'index_and_filter, OffsetsOnly>),
-    FreqsOffsets(inverted_index::IndexReaderCore<'index_and_filter, FreqsOffsets>),
-    DocIdsOnly(inverted_index::IndexReaderCore<'index_and_filter, DocIdsOnly>),
-    RawDocIdsOnly(inverted_index::IndexReaderCore<'index_and_filter, RawDocIdsOnly>),
-    Numeric(inverted_index::IndexReaderCore<'index_and_filter, Numeric>),
-    NumericFiltered(
-        FilterNumericReader<
-            'index_and_filter,
-            inverted_index::IndexReaderCore<'index_and_filter, Numeric>,
-        >,
-    ),
-    NumericGeoFiltered(
-        FilterGeoReader<
-            'index_and_filter,
-            inverted_index::IndexReaderCore<'index_and_filter, Numeric>,
-        >,
-    ),
-    NumericFloatCompression(
-        inverted_index::IndexReaderCore<'index_and_filter, NumericFloatCompression>,
-    ),
+pub enum IndexReader<'index> {
+    Full(FilterMaskReader<inverted_index::IndexReaderCore<'index, Full>>),
+    FullWide(FilterMaskReader<inverted_index::IndexReaderCore<'index, FullWide>>),
+    FreqsFields(FilterMaskReader<inverted_index::IndexReaderCore<'index, FreqsFields>>),
+    FreqsFieldsWide(FilterMaskReader<inverted_index::IndexReaderCore<'index, FreqsFieldsWide>>),
+    FreqsOnly(inverted_index::IndexReaderCore<'index, FreqsOnly>),
+    FieldsOnly(FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOnly>>),
+    FieldsOnlyWide(FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOnlyWide>>),
+    FieldsOffsets(FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOffsets>>),
+    FieldsOffsetsWide(FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOffsetsWide>>),
+    OffsetsOnly(inverted_index::IndexReaderCore<'index, OffsetsOnly>),
+    FreqsOffsets(inverted_index::IndexReaderCore<'index, FreqsOffsets>),
+    DocIdsOnly(inverted_index::IndexReaderCore<'index, DocIdsOnly>),
+    RawDocIdsOnly(inverted_index::IndexReaderCore<'index, RawDocIdsOnly>),
+    Numeric(inverted_index::IndexReaderCore<'index, Numeric>),
+    NumericFiltered(FilterNumericReader<inverted_index::IndexReaderCore<'index, Numeric>>),
+    NumericGeoFiltered(FilterGeoReader<inverted_index::IndexReaderCore<'index, Numeric>>),
+    NumericFloatCompression(inverted_index::IndexReaderCore<'index, NumericFloatCompression>),
     NumericFilteredFloatCompression(
-        FilterNumericReader<
-            'index_and_filter,
-            inverted_index::IndexReaderCore<'index_and_filter, NumericFloatCompression>,
-        >,
+        FilterNumericReader<inverted_index::IndexReaderCore<'index, NumericFloatCompression>>,
     ),
     NumericGeoFilteredFloatCompression(
-        FilterGeoReader<
-            'index_and_filter,
-            inverted_index::IndexReaderCore<'index_and_filter, NumericFloatCompression>,
-        >,
+        FilterGeoReader<inverted_index::IndexReaderCore<'index, NumericFloatCompression>>,
     ),
 }
 
@@ -828,7 +802,7 @@ macro_rules! ir_dispatch {
     };
 }
 
-impl<'index_and_filter> IndexReader<'index_and_filter> {
+impl<'index> IndexReader<'index> {
     /// Get the flags associated with this index reader.
     pub fn flags(&self) -> IndexFlags {
         ir_dispatch!(self, flags)
@@ -836,7 +810,7 @@ impl<'index_and_filter> IndexReader<'index_and_filter> {
 
     /// Swap the inverted index of the reader with the given inverted index. This is only used
     /// by some C tests to trigger revalidation on the reader.
-    pub const fn swap_index(&mut self, ii: &'index_and_filter InvertedIndex) {
+    pub const fn swap_index(&mut self, ii: &'index InvertedIndex) {
         match (self, ii) {
             (IndexReader::Full(ir), InvertedIndex::Full(ii)) => ir.swap_index(&mut ii.inner()),
             (IndexReader::FullWide(ir), InvertedIndex::FullWide(ii)) => {
@@ -958,10 +932,10 @@ pub unsafe extern "C" fn NewIndexReader(
         (InvertedIndex::RawDocIdsOnly(ii), _) => IndexReader::RawDocIdsOnly(ii.reader()),
         (InvertedIndex::Numeric(ii), ReadFilter::None) => IndexReader::Numeric(ii.reader()),
         (InvertedIndex::Numeric(ii), ReadFilter::Numeric(filter)) if filter.is_numeric_filter() => {
-            IndexReader::NumericFiltered(FilterNumericReader::new(filter, ii.reader()))
+            IndexReader::NumericFiltered(FilterNumericReader::new(*filter, ii.reader()))
         }
         (InvertedIndex::Numeric(ii), ReadFilter::Numeric(filter)) => {
-            IndexReader::NumericGeoFiltered(FilterGeoReader::new(filter, ii.reader()))
+            IndexReader::NumericGeoFiltered(FilterGeoReader::new(*filter, ii.reader()))
         }
         (InvertedIndex::NumericFloatCompression(ii), ReadFilter::None) => {
             IndexReader::NumericFloatCompression(ii.reader())
@@ -970,13 +944,13 @@ pub unsafe extern "C" fn NewIndexReader(
             if filter.is_numeric_filter() =>
         {
             IndexReader::NumericFilteredFloatCompression(FilterNumericReader::new(
-                filter,
+                *filter,
                 ii.reader(),
             ))
         }
         (InvertedIndex::NumericFloatCompression(ii), ReadFilter::Numeric(filter)) => {
             IndexReader::NumericGeoFilteredFloatCompression(FilterGeoReader::new(
-                filter,
+                *filter,
                 ii.reader(),
             ))
         }
@@ -1114,9 +1088,9 @@ pub unsafe extern "C" fn IndexReader_IsIndex(
 /// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
 /// - `res` must be a valid pointer to an `RSIndexResult` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexReader_Next<'index_and_filter>(
-    ir: *mut IndexReader<'index_and_filter>,
-    res: *mut RSIndexResult<'index_and_filter>,
+pub unsafe extern "C" fn IndexReader_Next<'index>(
+    ir: *mut IndexReader<'index>,
+    res: *mut RSIndexResult<'index>,
 ) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
     debug_assert!(!res.is_null(), "res must not be null");
@@ -1160,10 +1134,10 @@ pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: t_docI
 /// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
 /// - `res` must be a valid pointer to an `RSIndexResult` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexReader_Seek<'index_and_filter>(
-    ir: *mut IndexReader<'index_and_filter>,
+pub unsafe extern "C" fn IndexReader_Seek<'index>(
+    ir: *mut IndexReader<'index>,
     doc_id: t_docId,
-    res: *mut RSIndexResult<'index_and_filter>,
+    res: *mut RSIndexResult<'index>,
 ) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
     debug_assert!(!res.is_null(), "res must not be null");

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/range.rs
@@ -135,11 +135,11 @@ pub unsafe extern "C" fn NumericRange_NewIndexReader<'a>(
 
                 if filter.is_numeric_filter() {
                     IndexReader::NumericFilteredFloatCompression(FilterNumericReader::new(
-                        filter, reader,
+                        *filter, reader,
                     ))
                 } else {
                     IndexReader::NumericGeoFilteredFloatCompression(FilterGeoReader::new(
-                        filter, reader,
+                        *filter, reader,
                     ))
                 }
             }
@@ -154,9 +154,9 @@ pub unsafe extern "C" fn NumericRange_NewIndexReader<'a>(
                 let filter = unsafe { &*filter };
 
                 if filter.is_numeric_filter() {
-                    IndexReader::NumericFiltered(FilterNumericReader::new(filter, reader))
+                    IndexReader::NumericFiltered(FilterNumericReader::new(*filter, reader))
                 } else {
-                    IndexReader::NumericGeoFiltered(FilterGeoReader::new(filter, reader))
+                    IndexReader::NumericGeoFiltered(FilterGeoReader::new(*filter, reader))
                 }
             }
         }

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -27,34 +27,44 @@ unsafe extern "C" {
 /// specified geo filter to be returned.
 ///
 /// This should only be wrapped around readers that return numeric records.
-pub struct FilterGeoReader<'filter, IR> {
+pub struct FilterGeoReader<IR> {
     /// Numeric filter with a geo filter set to which a record needs to match to be valid.
-    /// This is only needed because the reader needs to be able to return the original numeric
-    /// filter.
-    filter: &'filter NumericFilter,
+    /// `filter.geo_filter` is rebound at construction to point at our owned
+    /// [`geo_filter`](Self::geo_filter), so consumers of [`filter`](Self::filter)
+    /// never observe the caller's (potentially short-lived) `GeoFilter`.
+    filter: NumericFilter,
 
-    /// Geo filter which a record needs to match to be valid
-    geo_filter: &'filter GeoFilter,
+    /// Owned heap-allocated copy of the geo filter. Boxed so its address is
+    /// stable across moves of `Self`, which lets `filter.geo_filter` safely
+    /// alias it for the reader's lifetime.
+    geo_filter: Box<GeoFilter>,
 
     /// The inner reader that will be used to read the records from the index.
     inner: IR,
 }
 
-impl<'filter, 'index, IR: NumericReader<'index>> FilterGeoReader<'filter, IR> {
+impl<'index, IR: NumericReader<'index>> FilterGeoReader<IR> {
     /// Create a new filter geo reader with the given numeric filter and inner iterator
     ///
     /// # Safety
     /// The caller should ensure the `geo_filter` pointer in the numeric filter is set and a valid
-    /// pointer to a `GeoFilter` struct for the lifetime of this reader.
-    pub fn new(filter: &'filter NumericFilter, inner: IR) -> Self {
+    /// pointer to a `GeoFilter` struct at the time of construction; the
+    /// reader copies the geo filter onto the heap, so the original need only
+    /// outlive this call.
+    pub fn new(mut filter: NumericFilter, inner: IR) -> Self {
         debug_assert!(
             !filter.geo_filter.is_null(),
             "FilterGeoReader needs the geo filter to be set on the numeric filter"
         );
 
         // SAFETY: we just asserted the filter is set and the caller is to ensure it is a valid
-        // `GeoFilter` instance
-        let geo_filter = unsafe { &*(filter.geo_filter as *const GeoFilter) };
+        // `GeoFilter` instance. We copy the geo filter onto the heap so we own it for the
+        // reader's lifetime.
+        let geo_filter = Box::new(unsafe { *(filter.geo_filter as *const GeoFilter) });
+
+        // Rebind `filter.geo_filter` to our owned heap copy. The box's address is stable across
+        // moves of `Self`, so this pointer stays valid for as long as the reader is alive.
+        filter.geo_filter = std::ptr::from_ref::<GeoFilter>(&geo_filter).cast();
 
         Self {
             filter,
@@ -64,14 +74,14 @@ impl<'filter, 'index, IR: NumericReader<'index>> FilterGeoReader<'filter, IR> {
     }
 }
 
-impl<'filter, 'index, E> FilterGeoReader<'filter, IndexReaderCore<'index, E>> {
+impl<'index, E> FilterGeoReader<IndexReaderCore<'index, E>> {
     /// Get the numeric filter used by this reader.
     pub const fn filter(&self) -> &NumericFilter {
-        self.filter
+        &self.filter
     }
 }
 
-impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<'index, IR> {
+impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<IR> {
     /// Get the next record from the inner reader that matches the geo filter.
     ///
     /// # Safety
@@ -90,7 +100,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<
             let value = unsafe { result.as_numeric_unchecked_mut() };
 
             // SAFETY: we know the filter is not a null pointer since we hold a reference to it
-            let in_radius = unsafe { isWithinRadius(self.geo_filter, *value, value) };
+            let in_radius = unsafe { isWithinRadius(&*self.geo_filter, *value, value) };
 
             if in_radius {
                 return Ok(true);
@@ -119,7 +129,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<
         let value = unsafe { result.as_numeric_unchecked_mut() };
 
         // SAFETY: we know the filter is not a null pointer since we hold a reference to it
-        let in_radius = unsafe { isWithinRadius(self.geo_filter, *value, value) };
+        let in_radius = unsafe { isWithinRadius(&*self.geo_filter, *value, value) };
 
         if in_radius {
             Ok(true)
@@ -157,9 +167,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<
     }
 }
 
-impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
-    FilterGeoReader<'filter, IndexReaderCore<'index, E>>
-{
+impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> FilterGeoReader<IndexReaderCore<'index, E>> {
     /// Check if the underlying index has been modified since the last time this reader read from it.
     /// If it has, then the reader should be reset before reading from it again.
     pub fn needs_revalidation(&self) -> bool {
@@ -184,4 +192,4 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
 }
 
 /// A [`FilterGeoReader`] wrapping a [`NumericReader`] is also a [`NumericReader`].
-impl<'index, IR: NumericReader<'index>> NumericReader<'index> for FilterGeoReader<'index, IR> {}
+impl<'index, IR: NumericReader<'index>> NumericReader<'index> for FilterGeoReader<IR> {}

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -15,7 +15,7 @@ use ffi::{FieldSpec, IndexFlags, t_docId};
 use index_result::RSIndexResult;
 
 /// Filter details to apply to numeric values
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 #[cheadergen::config(export, rename_all = "camelCase")]
 pub struct NumericFilter {
@@ -84,29 +84,29 @@ impl NumericFilter {
 /// specified filter to be returned.
 ///
 /// This should only be wrapped around readers that return numeric records.
-pub struct FilterNumericReader<'filter, IR> {
+pub struct FilterNumericReader<IR> {
     /// The numeric filter that is used to filter the records.
-    filter: &'filter NumericFilter,
+    filter: NumericFilter,
 
     /// The inner reader that will be used to read the records from the index.
     inner: IR,
 }
 
-impl<'filter, 'index, IR: NumericReader<'index>> FilterNumericReader<'filter, IR> {
+impl<'index, IR: NumericReader<'index>> FilterNumericReader<IR> {
     /// Create a new filter numeric reader with the given filter and inner iterator.
-    pub const fn new(filter: &'filter NumericFilter, inner: IR) -> Self {
+    pub const fn new(filter: NumericFilter, inner: IR) -> Self {
         Self { filter, inner }
     }
 }
 
-impl<'filter, 'index, E> FilterNumericReader<'filter, IndexReaderCore<'index, E>> {
+impl<'index, E> FilterNumericReader<IndexReaderCore<'index, E>> {
     /// Get the numeric filter used by this reader.
     pub const fn filter(&self) -> &NumericFilter {
-        self.filter
+        &self.filter
     }
 }
 
-impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterNumericReader<'index, IR> {
+impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterNumericReader<IR> {
     /// Get the next record from the inner reader that matches the numeric filter.
     ///
     /// # Safety
@@ -186,8 +186,8 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterNumericRea
     }
 }
 
-impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
-    FilterNumericReader<'filter, IndexReaderCore<'index, E>>
+impl<'index, E: DecodedBy<Decoder = D>, D: Decoder>
+    FilterNumericReader<IndexReaderCore<'index, E>>
 {
     /// Check if the underlying index has been modified since the last time this reader read from it.
     /// If it has, then the reader should be reset before reading from it again.
@@ -213,4 +213,4 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
 }
 
 /// A [`FilterNumericReader`] wrapping a [`NumericReader`] is also a [`NumericReader`].
-impl<'index, IR: NumericReader<'index>> NumericReader<'index> for FilterNumericReader<'index, IR> {}
+impl<'index, IR: NumericReader<'index>> NumericReader<'index> for FilterNumericReader<IR> {}

--- a/src/redisearch_rs/inverted_index/src/tests/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/geo.rs
@@ -58,7 +58,7 @@ fn reading_filter_based_on_geo_filter() {
         offset: 0,
     };
 
-    let mut reader = FilterGeoReader::new(&filter, iter.into_iter());
+    let mut reader = FilterGeoReader::new(filter, iter.into_iter());
     let mut result = RSIndexResult::build_numeric(0.0).build();
 
     let found = reader.next_record(&mut result).unwrap();

--- a/src/redisearch_rs/inverted_index/src/tests/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/numeric.rs
@@ -35,7 +35,7 @@ fn reading_filter_based_on_numeric_filter() {
         offset: 0,
     };
 
-    let mut reader = FilterNumericReader::new(&filter, iter.into_iter());
+    let mut reader = FilterNumericReader::new(filter, iter.into_iter());
     let mut result = RSIndexResult::build_numeric(0.0).build();
 
     let found = reader.next_record(&mut result).unwrap();

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -263,20 +263,10 @@ pub enum NumericIteratorVariant<'index> {
     Unfiltered(Numeric<'index, NumericIndexReader<'index>, FieldExpirationChecker>),
     /// Numeric filter: skips entries outside the filter's value range.
     Filtered(
-        Numeric<
-            'index,
-            FilterNumericReader<'index, NumericIndexReader<'index>>,
-            FieldExpirationChecker,
-        >,
+        Numeric<'index, FilterNumericReader<NumericIndexReader<'index>>, FieldExpirationChecker>,
     ),
     /// Geo filter: skips entries that do not pass the geo predicate.
-    Geo(
-        Numeric<
-            'index,
-            FilterGeoReader<'index, NumericIndexReader<'index>>,
-            FieldExpirationChecker,
-        >,
-    ),
+    Geo(Numeric<'index, FilterGeoReader<NumericIndexReader<'index>>, FieldExpirationChecker>),
 }
 
 impl<'index> NumericIteratorVariant<'index> {
@@ -387,7 +377,7 @@ impl<'index> NumericIteratorVariant<'index> {
                 // SAFETY: `range_tree` lifetime is enforced by `'index`.
                 let iter = unsafe {
                     Numeric::new(
-                        FilterNumericReader::new(f, reader),
+                        FilterNumericReader::new(*f, reader),
                         expiration_checker,
                         range_tree,
                         Some(range_min),
@@ -400,7 +390,7 @@ impl<'index> NumericIteratorVariant<'index> {
                 // SAFETY: `range_tree` lifetime is enforced by `'index`.
                 let iter = unsafe {
                     Numeric::new(
-                        FilterGeoReader::new(f, reader),
+                        FilterGeoReader::new(*f, reader),
                         expiration_checker,
                         range_tree,
                         Some(range_min),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -168,7 +168,7 @@ fn numeric_read() {
     let test = NumericBaseTest::new(100);
     let filter = NumericFilter::default();
     let reader = test.test.ii.reader();
-    let reader = FilterNumericReader::new(&filter, reader);
+    let reader = FilterNumericReader::new(filter, reader);
     let mut it = NumericBuilder::new(reader)
         .range_tree(test.test.mock_ctx.numeric_range_tree())
         .build();
@@ -192,7 +192,7 @@ fn numeric_filter() {
         max: 75.0,
         ..Default::default()
     };
-    let reader = FilterNumericReader::new(&filter, test.test.ii.reader());
+    let reader = FilterNumericReader::new(filter, test.test.ii.reader());
     let mut it = NumericBuilder::new(reader)
         .range_tree(test.test.mock_ctx.numeric_range_tree())
         .build();
@@ -277,7 +277,7 @@ fn get_correct_value() {
         max: 3.0,
         ..Default::default()
     };
-    let reader = FilterNumericReader::new(&filter, ii.reader());
+    let reader = FilterNumericReader::new(filter, ii.reader());
 
     let context = MockContext::new(0, 0);
     let mut it = NumericBuilder::new(reader)
@@ -315,7 +315,7 @@ fn eof_after_filtering() {
         max: 2.0,
         ..Default::default()
     };
-    let reader = FilterNumericReader::new(&filter, ii.reader());
+    let reader = FilterNumericReader::new(filter, ii.reader());
     let context = MockContext::new(0, 0);
     let mut it = NumericBuilder::new(reader)
         .range_tree(context.numeric_range_tree())


### PR DESCRIPTION
## Describe the changes in the pull request

In preparation for our suspend/resume work, change geo/numeric iterators: own the filter rather than borrowing it.
This will make their suspended counterpart, which will be introduced later, lifetime-free (and thus satisfy the `'static` constraint we want to use).

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches numeric/geo filtering and FFI reader construction; incorrect filter copying or pointer rebinding could cause subtle query correctness or memory-safety issues in the geo path.
> 
> **Overview**
> Numeric/geo inverted-index filtering readers now **own their `NumericFilter`** instead of borrowing it, removing filter lifetimes from `FilterNumericReader`/`FilterGeoReader` and updating iterator variants accordingly.
> 
> Geo filtering additionally **copies the `GeoFilter` to owned heap storage** and rewires `filter.geo_filter` to that stable address, while FFI entrypoints (`NewIndexReader`, numeric range tree reader creation) and tests are updated to pass filters by value (`*filter`) rather than by reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb920950370bcd386aa7e9a4392adf0dbe50fbe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->