### PR TITLE
MOD-15816: coord: dedupe identical remote COLLECT reducers in cluster aggregation

### DIFF
--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -82,21 +82,32 @@ struct ReducerDistCtx {
   bool addLocal(const char *name, QueryError *status, T... uargs) {
     return add(localGroup, name, NULL, status, uargs...);
   }
-  template <typename... T>
-  bool addRemote(const char *name, const char **alias, QueryError *status, T... uargs) {
-    ArgsCursorCXX args(uargs...);
-    ArgsCursor tmp = args;
-    // Check if the reducer already exists in the remote group. This may happen NOT AS SYNTAX ERROR if the client
-    // sends, for example, a query with COUNT and AVG, which we send to the shards as COUNT, COUNT and SUM. In this case,
-    // we don't want or need to add the same reducer twice.
+  // Dedup-aware remote add. If an identical (name, args) reducer already lives in the remote
+  // group, returns its alias via `*alias` and skips re-adding. Otherwise persists `cargs` and
+  // appends a new reducer.
+  //
+  // The same logical reducer may legitimately appear multiple times in a single distributed plan:
+  // e.g. an `AVG` rewrites to remote `COUNT` + `SUM`, so a client that asked for both `COUNT` and
+  // `AVG` produces two remote `COUNT`s. Likewise two `REDUCE COLLECT` calls over the same field in
+  // the same `GROUPBY` should run as a single remote COLLECT, with both local reducers reading its
+  // output. Deduping here avoids redundant shard work and avoids `SEARCH_FIELD_DUP` on synthetic
+  // remote aliases.
+  bool addRemote(const char *name, const char **alias, QueryError *status, ArgsCursor *cargs) {
+    ArgsCursor tmp = *cargs;
     auto existing = PLNGroupStep_FindReducer(remoteGroup, name, &tmp);
     if (existing) {
       if (alias) *alias = existing->alias;
       return true;
-    } else {
-      ArgsCursor *cargs = copyArgs(&args);
-      return add(remoteGroup, name, alias, status, cargs);
     }
+    return add(remoteGroup, name, alias, status, copyArgs(cargs));
+  }
+
+  template <typename... T>
+  bool addRemote(const char *name, const char **alias, QueryError *status, T... uargs) {
+    ArgsCursorCXX args(uargs...);
+    // Upcast disambiguates against this very template (`ArgsCursorCXX*` would re-match `T...`).
+    ArgsCursor *cargs = &args;
+    return addRemote(name, alias, status, cargs);
   }
 
   const char *srcarg(size_t n) const {
@@ -351,15 +362,17 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   const PLN_Reducer *src = rdctx->srcReducer;
   size_t argc = src->args.argc;
 
-  // Build temporary args, then persist their object arrays with copyArgs.
+  // Build temporary remote args; `addRemote` lazily persists them only on a miss.
   std::string remoteCountStr = std::to_string(argc);
   std::vector<void *> remoteObjs(collectObjsBufLen(argc, /*has_alias=*/false));
   ArgsCursor remoteArgs = buildCollectArgs(remoteObjs.data(), remoteCountStr.c_str(),
                                            &src->args, nullptr);
-  rdctx->copyArgs(&remoteArgs);
 
   const char *alias;
-  if (!rdctx->add(rdctx->remoteGroup, "COLLECT", &alias, status, &remoteArgs)) {
+  // Use addRemote (not add) so identical remote COLLECTs across sibling reducers are deduped;
+  // see MOD-15816. Each local reducer below will still produce its own user-aliased output by
+  // reading the shared remote alias via `inputAlias`.
+  if (!rdctx->addRemote("COLLECT", &alias, status, &remoteArgs)) {
     return REDISMODULE_ERR;
   }
 

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -105,7 +105,6 @@ struct ReducerDistCtx {
   template <typename... T>
   bool addRemote(const char *name, const char **alias, QueryError *status, T... uargs) {
     ArgsCursorCXX args(uargs...);
-    // Upcast disambiguates against this very template (`ArgsCursorCXX*` would re-match `T...`).
     ArgsCursor *cargs = &args;
     return addRemote(name, alias, status, cargs);
   }
@@ -369,9 +368,6 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
                                            &src->args, nullptr);
 
   const char *alias;
-  // Use addRemote (not add) so identical remote COLLECTs across sibling reducers are deduped;
-  // see MOD-15816. Each local reducer below will still produce its own user-aliased output by
-  // reading the shared remote alias via `inputAlias`.
   if (!rdctx->addRemote("COLLECT", &alias, status, &remoteArgs)) {
     return REDISMODULE_ERR;
   }

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1471,6 +1471,38 @@ def testErrorStatsResp3():
         res = conn.execute_command('info', 'errorstats')
         env.assertEqual(res, expected_errorstats)
 
+@skip(cluster=False)
+def test_groupby_duplicate_collect_dedup_cluster():
+    # MOD-15816: two REDUCE COLLECT calls over identical (name, args) inside one GROUPBY must be
+    # deduped on the remote side, so each shard runs a single COLLECT and the coordinator fans out
+    # the shared output into per-alias local reducers. Without dedup, distributeCollect appends
+    # two remote reducers with colliding synthetic aliases (`__generated_aliascollectfields,...`),
+    # which the coordinator's RLookup rejects with SEARCH_FIELD_DUP before any data is shipped.
+    env = Env(shardsCount=2, protocol=3)
+    enable_unstable_features(env)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
+               'color', 'TAG', 'SORTABLE', 'name', 'TEXT', 'SORTABLE').ok()
+    conn = getConnectionByEnv(env)
+    docs = [('red', 'apple'), ('red', 'cherry'), ('green', 'kiwi'), ('green', 'pear')]
+    for i, (color, name) in enumerate(docs):
+        conn.execute_command('HSET', f'doc{i}', 'color', color, 'name', name)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name', 'AS', 'names_a',
+            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name', 'AS', 'names_b')
+
+    groups = sorted(res['results'], key=lambda r: r['extra_attributes']['color'])
+    env.assertEqual([g['extra_attributes']['color'] for g in groups], ['green', 'red'])
+    for g in groups:
+        attrs = g['extra_attributes']
+        a = sorted(entry['name'] for entry in attrs['names_a'])
+        b = sorted(entry['name'] for entry in attrs['names_b'])
+        env.assertEqual(a, b)
+        env.assertEqual(a, sorted(n for c, n in docs if c == attrs['color']))
+
+
 def testAggregateBadLoadArgs(env):
     """Tests that we get a proper error message when passing bad arguments to LOAD"""
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'title', 'TEXT').ok()

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1471,38 +1471,6 @@ def testErrorStatsResp3():
         res = conn.execute_command('info', 'errorstats')
         env.assertEqual(res, expected_errorstats)
 
-@skip(cluster=False)
-def test_groupby_duplicate_collect_dedup_cluster():
-    # MOD-15816: two REDUCE COLLECT calls over identical (name, args) inside one GROUPBY must be
-    # deduped on the remote side, so each shard runs a single COLLECT and the coordinator fans out
-    # the shared output into per-alias local reducers. Without dedup, distributeCollect appends
-    # two remote reducers with colliding synthetic aliases (`__generated_aliascollectfields,...`),
-    # which the coordinator's RLookup rejects with SEARCH_FIELD_DUP before any data is shipped.
-    env = Env(shardsCount=2, protocol=3)
-    enable_unstable_features(env)
-    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
-               'color', 'TAG', 'SORTABLE', 'name', 'TEXT', 'SORTABLE').ok()
-    conn = getConnectionByEnv(env)
-    docs = [('red', 'apple'), ('red', 'cherry'), ('green', 'kiwi'), ('green', 'pear')]
-    for i, (color, name) in enumerate(docs):
-        conn.execute_command('HSET', f'doc{i}', 'color', color, 'name', name)
-
-    res = env.cmd(
-        'FT.AGGREGATE', 'idx', '*',
-        'GROUPBY', '1', '@color',
-            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name', 'AS', 'names_a',
-            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name', 'AS', 'names_b')
-
-    groups = sorted(res['results'], key=lambda r: r['extra_attributes']['color'])
-    env.assertEqual([g['extra_attributes']['color'] for g in groups], ['green', 'red'])
-    for g in groups:
-        attrs = g['extra_attributes']
-        a = sorted(entry['name'] for entry in attrs['names_a'])
-        b = sorted(entry['name'] for entry in attrs['names_b'])
-        env.assertEqual(a, b)
-        env.assertEqual(a, sorted(n for c, n in docs if c == attrs['color']))
-
-
 def testAggregateBadLoadArgs(env):
     """Tests that we get a proper error message when passing bad arguments to LOAD"""
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'title', 'TEXT').ok()

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1522,6 +1522,30 @@ def test_two_collect_reducers_overlapping_fields_cluster():
         env.assertEqual(attrs['last_desc'], expected_last[attrs['color']])
 
 
+def test_two_identical_collect_reducers():
+    # MOD-15816: two REDUCE COLLECT calls over identical (name, args) inside one GROUPBY
+    # should work.
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name', 'AS', 'names_a',
+            'REDUCE', 'COLLECT', '3', 'FIELDS', '1', '@name', 'AS', 'names_b')
+
+    expected = {
+        'green':  [{'name': 'kiwi'},   {'name': 'lime'}],
+        'red':    [{'name': 'apple'},  {'name': 'strawberry'}],
+        'yellow': [{'name': 'banana'}, {'name': 'lemon'}],
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        env.assertEqual(_sort_collected(attrs['names_a'], 'name'), expected[attrs['color']])
+        env.assertEqual(_sort_collected(attrs['names_b'], 'name'), expected[attrs['color']])
+
+
 # ---------------------------------------------------------------------------
 # COLLECT across multiple GROUPBY stages
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** In cluster mode, every `REDUCE COLLECT` in a `GROUPBY` is forwarded to each shard verbatim. `distributeCollect` calls `ReducerDistCtx::add` directly because the existing dedup-aware `addRemote` was a variadic template that couldn't accept a runtime-built `ArgsCursor*`. So when a client sends two `REDUCE COLLECT` calls over the same field, the coordinator emits two remote reducers with the same synthetic alias (`__generated_aliascollectfields,1,name`), which RLookup rejects with `SEARCH_FIELD_DUP` before any data is shipped:

   ```
   127.0.0.1:6379> FT.AGGREGATE idx * GROUPBY 1 @color \
     REDUCE COLLECT 3 FIELDS 1 @name AS a \
     REDUCE COLLECT 3 FIELDS 1 @name AS b
   (error) SEARCH_FIELD_DUP Property `__generated_aliascollectfields,1,name` specified more than once
   ```

   The same query with `REDUCE MIN` succeeds, because `distributeSingleArgSelf` goes through `addRemote` and dedups.

2. **Change:** Refactor `ReducerDistCtx::addRemote` into a non-templated overload taking an `ArgsCursor*` that owns the dedup logic (matches the two-overload pattern already used by `add`). The variadic template becomes a thin forwarder. Switch `distributeCollect` to the new overload and drop its now-redundant eager `copyArgs` (the overload persists args lazily, only on a miss).

3. **Outcome:** Identical `REDUCE COLLECT` calls in the same `GROUPBY` execute once per shard, with multiple local reducers reading from the shared remote alias via `inputAlias`. No more `SEARCH_FIELD_DUP`, and shards stop doing duplicate COLLECT work.

#### Which additional issues this PR fixes
1. MOD-15816
2. Related to MOD-15808 (same query symptom, orthogonal code path: this PR is the cluster-side dedup; MOD-15808 made un-aliased synthetic aliases unique in the local plan).

#### Main objects this PR modified
1. `src/coord/dist_plan.cpp` — `ReducerDistCtx::addRemote` overload pair + `distributeCollect`
2. `tests/pytests/test_groupby_collect.py` — `test_two_identical_collect_reducers`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Fixes a cluster-only error where identical `REDUCE COLLECT` calls in one `GROUPBY` returned `SEARCH_FIELD_DUP`, and removes duplicate per-shard work for the same case.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator-side distributed plan construction for `GROUPBY` reducers; incorrect deduping or arg persistence could change remote reducer aliases or reduce outputs in cluster aggregations. Scope is limited and covered by a new regression test for duplicate `COLLECT` reducers.
> 
> **Overview**
> Fixes a cluster-only `FT.AGGREGATE ... GROUPBY ... REDUCE COLLECT` failure when the same `COLLECT` reducer (same name + args) is specified twice: the coordinator now *dedupes identical remote reducers* instead of emitting duplicate synthetic aliases that can trigger `SEARCH_FIELD_DUP`.
> 
> Refactors `ReducerDistCtx::addRemote` to add a non-templated overload that accepts a runtime-built `ArgsCursor*`, performs the dedup lookup, and only persists args on a miss; `distributeCollect` is switched to use this path. Adds a regression test (`test_two_identical_collect_reducers`) to assert both local aliases can read from the single remote `COLLECT` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b3d19473b8a7a0111cc19caa2926d60c00af3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->