### PR TITLE
query_eval: add str_to_lower_runes

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,deps/*,*.csv,./srcutil/*,srcutil/*,./bin/*,bin/*,./sbin/*,sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py,tests/ctests/test_trie.c
+skip = .git,./deps/*,deps/*,*.csv,./srcutil/*,srcutil/*,./bin/*,bin/*,./sbin/*,sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py,tests/ctests/test_trie.c,src/redisearch_rs/query_eval/tests/integration/string_utils/*
 
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1705,6 +1705,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "query_eval"
+version = "0.0.1"
+dependencies = [
+ "build_utils",
+ "ffi",
+ "proptest",
+ "query_eval",
+ "redis_mock",
+ "redisearch_rs",
+ "workspace_hack",
+]
+
+[[package]]
 name = "query_flags"
 version = "0.0.1"
 dependencies = [

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
  "query_eval",
  "redis_mock",
  "redisearch_rs",
+ "thiserror",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "wildcard",
     "workspace_hack",
     "idf",
+    "query_eval",
 ]
 
 resolver = "3"
@@ -119,6 +120,7 @@ numeric_range_tree = { path = "./numeric_range_tree" }
 redis_reply = { path = "./redis_reply" }
 qint = { path = "./qint" }
 query_error = { path = "./query_error" }
+query_eval = { path = "./query_eval" }
 query_flags = { path = "./query_flags" }
 query_term = { path = "./query_term" }
 redis_json_api = { path = "./redis_json_api" }

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -254,6 +254,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/trie/rune_util.h",
+        fns: &["strToLowerRunes"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/trie/trie.h",
         fns: &["Trie_DecrementNumDocs"],
         types: &[],

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -14,6 +14,7 @@ unittest = []
 build_utils.workspace = true
 
 [dependencies]
+thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "query_eval"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[features]
+# feature enabled when building tests so they can link the C code in build.rs
+# see https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+unittest = []
+
+[build-dependencies]
+build_utils.workspace = true
+
+[dependencies]
+workspace_hack.workspace = true
+
+[dev-dependencies]
+ffi.workspace = true
+proptest = { workspace = true, features = ["std"] }
+query_eval = { path = ".", features = ["unittest"] }
+redis_mock.workspace = true
+redisearch_rs = { workspace = true, features = ["mock_allocator"] }
+
+[lints]
+workspace = true

--- a/src/redisearch_rs/query_eval/build.rs
+++ b/src/redisearch_rs/query_eval/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Query evaluation: traverses a parsed query AST and builds an executable
+//! iterator tree.
+
+pub mod string_utils;

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -11,3 +11,14 @@
 //!
 //! These are pure-Rust replacements for C helpers that were previously
 //! implemented using `libnu` for Unicode operations.
+
+/// Convert a UTF-8 string to a lowercase array of runes ([`u16`]) for trie
+/// lookups.
+///
+/// Each Unicode codepoint is lowercased and then truncated to [`u16`].
+pub fn str_to_lower_runes(s: &str) -> Vec<u16> {
+    s.chars()
+        .flat_map(char::to_lowercase)
+        .map(|c| c as u16)
+        .collect()
+}

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -12,13 +12,33 @@
 //! These are pure-Rust replacements for C helpers that were previously
 //! implemented using `libnu` for Unicode operations.
 
+/// Maximum number of runes (lowercased codepoints) allowed in a single
+/// conversion, matching the C `MAX_RUNESTR_LEN` constant.
+pub const MAX_RUNE_STR_LEN: usize = 1024;
+
+/// Error returned when the lowercased rune sequence exceeds
+/// [`MAX_RUNE_STR_LEN`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("lowercased rune length {len} exceeds maximum {MAX_RUNE_STR_LEN}")]
+pub struct RuneStrTooLong {
+    pub len: usize,
+}
+
 /// Convert a UTF-8 string to a lowercase array of runes ([`u16`]) for trie
 /// lookups.
 ///
 /// Each Unicode codepoint is lowercased and then truncated to [`u16`].
-pub fn str_to_lower_runes(s: &str) -> Vec<u16> {
-    s.chars()
+///
+/// Returns [`Err(`[`RuneStrTooLong`]`)`] if the resulting rune count exceeds
+/// [`MAX_RUNE_STR_LEN`].
+pub fn str_to_lower_runes(s: &str) -> Result<Vec<u16>, RuneStrTooLong> {
+    let runes: Vec<u16> = s
+        .chars()
         .flat_map(char::to_lowercase)
         .map(|c| c as u16)
-        .collect()
+        .collect();
+    if runes.len() > MAX_RUNE_STR_LEN {
+        return Err(RuneStrTooLong { len: runes.len() });
+    }
+    Ok(runes)
 }

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! String utility functions for query evaluation.
+//!
+//! These are pure-Rust replacements for C helpers that were previously
+//! implemented using `libnu` for Unicode operations.

--- a/src/redisearch_rs/query_eval/tests/integration/main.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/main.rs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#![cfg_attr(miri, allow(dead_code, unused_imports))]
+
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;
+
+mod string_utils;

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/mod.rs
@@ -6,3 +6,5 @@
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
 */
+
+mod str_to_lower_runes;

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/str_to_lower_runes.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/str_to_lower_runes.rs
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use query_eval::string_utils::str_to_lower_runes;
+
+#[test]
+fn ascii() {
+    let runes = str_to_lower_runes("ABC");
+    assert_eq!(runes, vec![b'a' as u16, b'b' as u16, b'c' as u16]);
+}
+
+#[test]
+fn unicode_multibyte() {
+    // 'É' (U+00C9) → 'é' (U+00E9)
+    let runes = str_to_lower_runes("É");
+    assert_eq!(runes, vec![0x00E9]);
+}
+
+#[test]
+fn empty() {
+    let runes = str_to_lower_runes("");
+    assert!(runes.is_empty());
+}
+
+#[test]
+fn multi_codepoint_mapping() {
+    // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE → U+0069 + U+0307
+    let runes = str_to_lower_runes("\u{0130}");
+    assert_eq!(runes, vec![0x0069, 0x0307]);
+}
+
+// strToLowerRunes calls nu_readstr which reads until a null byte (ignoring
+// the utf8_len parameter). Rust &str is not null-terminated, so we must
+// pass a CString copy. Compare Rust output against C for BMP-only strings
+// where libnu and Rust's Unicode tables agree on lowercasing.
+#[cfg(not(miri))]
+mod ffi_comparison {
+    use proptest::prelude::*;
+    use query_eval::string_utils::str_to_lower_runes;
+    use std::ffi::{CString, c_void};
+
+    /// Call C `strToLowerRunes` via FFI and return the resulting rune slice.
+    fn c_str_to_lower_runes(s: &str) -> Option<Vec<u16>> {
+        let cstr = CString::new(s).expect("input must not contain null bytes");
+        let mut unicode_len: usize = 0;
+        // SAFETY: `cstr` is a valid null-terminated buffer. `strToLowerRunes`
+        // internally calls `nu_readstr` which reads until null, and separately
+        // uses `utf8_len` for the lowercasing loop.
+        let ptr = unsafe { ffi::strToLowerRunes(cstr.as_ptr(), s.len(), &mut unicode_len) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `ptr` is a valid `rm_calloc`'d array of `unicode_len` runes.
+        let runes = unsafe { std::slice::from_raw_parts(ptr, unicode_len) }.to_vec();
+        // SAFETY: `ptr` was allocated by `rm_calloc` (backed by RedisModule_Alloc).
+        unsafe {
+            (ffi::RedisModule_Free.expect("Redis allocator not available"))(ptr.cast::<c_void>());
+        }
+        Some(runes)
+    }
+
+    fn assert_runes_match_c(s: &str) {
+        let c_result =
+            c_str_to_lower_runes(s).expect("FFI strToLowerRunes returned NULL unexpectedly");
+        let rust_result = str_to_lower_runes(s);
+        assert_eq!(
+            rust_result, c_result,
+            "mismatch for input {:?}: rust={:?}, c={:?}",
+            s, rust_result, c_result,
+        );
+    }
+
+    #[test]
+    fn ffi_ascii() {
+        assert_runes_match_c("ABC");
+    }
+
+    #[test]
+    fn ffi_empty() {
+        assert_runes_match_c("");
+    }
+
+    #[test]
+    fn ffi_unicode() {
+        assert_runes_match_c("Héllo Wörld");
+    }
+
+    /// Generate BMP strings (U+0001..U+D7FF).
+    fn bmp_string() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            (0x0001u32..=0xD7FFu32).prop_filter_map("valid BMP char", |cp| char::from_u32(cp)),
+            0..100,
+        )
+        .prop_map(|chars| chars.into_iter().collect::<String>())
+    }
+
+    proptest! {
+        #[test]
+        fn ffi_matches_rust(s in bmp_string()) {
+            assert_runes_match_c(&s);
+        }
+    }
+}
+
+#[cfg(not(miri))]
+mod proptest_checks {
+    use proptest::prelude::*;
+    use query_eval::string_utils::str_to_lower_runes;
+
+    /// Generate strings of BMP-only codepoints (U+0000..U+FFFF), since
+    /// rune is u16 and non-BMP codepoints are truncated.
+    fn bmp_string() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            prop_oneof![
+                5 => 0x41u32..=0x7Au32,
+                3 => 0xC0u32..=0x4FFu32,
+                1 => 0x4E00u32..=0x9FFFu32,
+                1 => 0x0020u32..=0xD7FFu32,
+            ]
+            .prop_filter_map("valid BMP char", |cp| char::from_u32(cp)),
+            0..200,
+        )
+        .prop_map(|chars| chars.into_iter().collect::<String>())
+    }
+
+    proptest! {
+        #[test]
+        fn agrees_with_std_lowercase(s in bmp_string()) {
+            let runes = str_to_lower_runes(&s);
+            let from_runes: String = runes
+                .iter()
+                .filter_map(|&r| char::from_u32(r as u32))
+                .collect();
+            let expected: String = s
+                .chars()
+                .flat_map(char::to_lowercase)
+                .filter(|&c| (c as u32) <= 0xFFFF)
+                .collect();
+            assert_eq!(from_runes, expected, "mismatch for input {:?}", s);
+        }
+    }
+}

--- a/src/redisearch_rs/query_eval/tests/integration/string_utils/str_to_lower_runes.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/string_utils/str_to_lower_runes.rs
@@ -7,32 +7,45 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use query_eval::string_utils::str_to_lower_runes;
+use query_eval::string_utils::{MAX_RUNE_STR_LEN, str_to_lower_runes};
 
 #[test]
 fn ascii() {
-    let runes = str_to_lower_runes("ABC");
+    let runes = str_to_lower_runes("ABC").unwrap();
     assert_eq!(runes, vec![b'a' as u16, b'b' as u16, b'c' as u16]);
 }
 
 #[test]
 fn unicode_multibyte() {
     // 'É' (U+00C9) → 'é' (U+00E9)
-    let runes = str_to_lower_runes("É");
+    let runes = str_to_lower_runes("É").unwrap();
     assert_eq!(runes, vec![0x00E9]);
 }
 
 #[test]
 fn empty() {
-    let runes = str_to_lower_runes("");
+    let runes = str_to_lower_runes("").unwrap();
     assert!(runes.is_empty());
 }
 
 #[test]
 fn multi_codepoint_mapping() {
     // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE → U+0069 + U+0307
-    let runes = str_to_lower_runes("\u{0130}");
+    let runes = str_to_lower_runes("\u{0130}").unwrap();
     assert_eq!(runes, vec![0x0069, 0x0307]);
+}
+
+#[test]
+fn exactly_at_limit() {
+    let s: String = std::iter::repeat_n('a', MAX_RUNE_STR_LEN).collect();
+    assert_eq!(str_to_lower_runes(&s).unwrap().len(), MAX_RUNE_STR_LEN);
+}
+
+#[test]
+fn exceeds_limit() {
+    let s: String = std::iter::repeat_n('a', MAX_RUNE_STR_LEN + 1).collect();
+    let err = str_to_lower_runes(&s).unwrap_err();
+    assert_eq!(err.len, MAX_RUNE_STR_LEN + 1);
 }
 
 // strToLowerRunes calls nu_readstr which reads until a null byte (ignoring
@@ -68,7 +81,7 @@ mod ffi_comparison {
     fn assert_runes_match_c(s: &str) {
         let c_result =
             c_str_to_lower_runes(s).expect("FFI strToLowerRunes returned NULL unexpectedly");
-        let rust_result = str_to_lower_runes(s);
+        let rust_result = str_to_lower_runes(s).unwrap();
         assert_eq!(
             rust_result, c_result,
             "mismatch for input {:?}: rust={:?}, c={:?}",
@@ -132,7 +145,7 @@ mod proptest_checks {
     proptest! {
         #[test]
         fn agrees_with_std_lowercase(s in bmp_string()) {
-            let runes = str_to_lower_runes(&s);
+            let runes = str_to_lower_runes(&s).unwrap();
             let from_runes: String = runes
                 .iter()
                 .filter_map(|&r| char::from_u32(r as u32))


### PR DESCRIPTION
## Describe the changes in the pull request

Rust port of `strToLowerRunes` from `src/trie/rune_util.c`.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Rust crate and Unicode lowercasing/truncation logic intended to replace a C helper; subtle behavior differences vs the C/libnu implementation could affect trie/query matching once wired in.
> 
> **Overview**
> Introduces a new `query_eval` workspace crate and implements `string_utils::str_to_lower_runes`, a pure-Rust port of the C `strToLowerRunes`, including length guarding via `MAX_RUNE_STR_LEN` and a typed error.
> 
> Adds integration/property tests (including optional FFI comparison against the C implementation) and updates the workspace/FFI build configuration (`Cargo.toml`, `Cargo.lock`, `ffi/build.rs`) plus codespell ignores to accommodate the new module/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1114a2b8b8dbfea56704392fca8fd9838b9514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->