### PR TITLE
redisearch_rs/.gitignore: ignore insta `*.snap.new` pending files

### DIFF
--- a/src/redisearch_rs/.gitignore
+++ b/src/redisearch_rs/.gitignore
@@ -13,5 +13,7 @@
 
 # Regressions in `proptest` tests
 **/proptest-regressions/**
+
 # `insta` pending snapshots
 **/*.pending-snap
+**/*.snap.new


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `src/redisearch_rs/.gitignore` only covered `*.pending-snap` (the older insta convention), leaving `*.snap.new` files untracked.
2. **Change**: Add `*.snap.new` next to `*.pending-snap` in the gitignore.
3. **Outcome**: `git status` stays clean after failing snapshot assertions with insta 1.46.3+; committing a `*.snap.new` by accident (which shadows the real `.snap` on the next run) is prevented.

#### Which additional issues this PR fixes
N/A

#### Main objects this PR modified
1. `src/redisearch_rs/.gitignore`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `.gitignore` patterns and does not affect runtime code or build output.
> 
> **Overview**
> Keeps the Rust `redisearch_rs` workspace clean after failing `insta` snapshot tests by extending `.gitignore` to ignore `**/*.snap.new` files (alongside `**/*.pending-snap`), preventing accidental commits of pending snapshot artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cf25aa40c0b9944fd5f935db1760914907ce5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->