### PR TITLE
docs: clarify worktree creation requires -b to avoid branch conflict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,14 @@ src/redisearch_rs/
 
 When implementing changes that may become a PR, first check the current checkout. If it is dirty,
 on an unrelated branch, or already tied to another open PR, automatically create a dedicated
-worktree from the target branch and do the work there. Use the existing checkout only when it is
-already the right clean branch for the task.
+worktree and do the work there. Use the existing checkout only when it is already the right clean
+branch for the task.
+
+Always use `-b` when creating a worktree — git forbids two worktrees on the same branch, so checking out `master` directly will fail when master is already the main checkout:
+
+```bash
+git worktree add -b memark-<feature> .claude/worktrees/memark-<feature> origin/master
+```
 
 To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules).
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: CLAUDE.md/AGENTS.md worktree instructions don't mention that passing an existing branch name fails when that branch is already checked out in the main worktree.
2. Change: Add a note + example showing that `git worktree add -b <new-branch>` must be used instead of `git worktree add <path> master`.
3. Outcome: Agents no longer hit the `fatal: 'master' is already used by worktree` error.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified
1. `AGENTS.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code paths, build, or runtime behavior are affected.
> 
> **Overview**
> Clarifies the `AGENTS.md` *Common Workflows* instructions for creating dedicated git worktrees by explicitly requiring `git worktree add -b <new-branch>` and adding an example command.
> 
> This avoids the common failure case where attempting to use `master` directly errors because that branch is already checked out in the primary worktree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af12e49f1b9398b8b2aaec08115d6f71c37165c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->