### PR TITLE
[MOD-15932] trie: consolidate terminality flag; allow score=0 in FT.SUGADD

### DIFF
--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -196,8 +196,7 @@ void SpellCheck_SendReplyOnTerm(RedisModule_Reply *reply, char *term, size_t len
       for (int i = 0; i < n; ++i) {
         RedisModule_Reply_Map(reply);
           RedisModule_Reply_StringBuffer(reply, suggestions[i]->suggestion, suggestions[i]->len);
-          RedisModule_Reply_Double(reply, suggestions[i]->score == -1 ? 0 :
-                                        suggestions[i]->score / totalDocNumber);
+          RedisModule_Reply_Double(reply, suggestions[i]->score / totalDocNumber);
         RedisModule_Reply_MapEnd(reply);
       }
 
@@ -215,8 +214,7 @@ void SpellCheck_SendReplyOnTerm(RedisModule_Reply *reply, char *term, size_t len
         int n = array_len(suggestions);
         for (int i = 0; i < n; ++i) {
           RedisModule_Reply_Array(reply);
-            RedisModule_Reply_Double(reply, suggestions[i]->score == -1 ? 0 :
-                                            suggestions[i]->score / totalDocNumber);
+            RedisModule_Reply_Double(reply, suggestions[i]->score / totalDocNumber);
             RedisModule_Reply_StringBuffer(reply, suggestions[i]->suggestion, suggestions[i]->len);
           RedisModule_Reply_ArrayEnd(reply);
         }

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -54,11 +54,6 @@ RS_Suggestions *RS_SuggestionsCreate() {
 void RS_SuggestionsAdd(RS_Suggestions *s, char *term, size_t len, double score, int incr) {
   double currScore;
   bool isExists = SpellCheck_IsTermExistsInTrie(s->suggestionsTrie, term, len, &currScore);
-  if (score == 0) {
-    /** we can not add zero score so we set it to -1 instead :\ **/
-    score = -1;
-  }
-
   if (!incr) {
     if (!isExists) {
       // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur.
@@ -67,11 +62,11 @@ void RS_SuggestionsAdd(RS_Suggestions *s, char *term, size_t len, double score, 
     return;
   }
 
-  if (isExists && score == -1) {
+  if (isExists && score == 0) {
     return;
   }
 
-  if (!isExists || currScore == -1) {
+  if (!isExists || currScore == 0) {
     incr = 0;
   }
 

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -90,6 +90,10 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     RedisModule_ReplyWithError(ctx, "ERR invalid score");
     goto end;
   }
+  if (score == 0) {
+    RedisModule_ReplyWithError(ctx, "ERR score must not be 0");
+    goto end;
+  }
 
   /* Create an empty value object if the key is currently empty. */
   if (type == REDISMODULE_KEYTYPE_EMPTY) {

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -90,11 +90,6 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     RedisModule_ReplyWithError(ctx, "ERR invalid score");
     goto end;
   }
-  if (score == 0) {
-    RedisModule_ReplyWithError(ctx, "ERR score must not be 0");
-    goto end;
-  }
-
   /* Create an empty value object if the key is currently empty. */
   if (type == REDISMODULE_KEYTYPE_EMPTY) {
     tree = NewTrie(NULL, Trie_Sort_Score);

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -1114,7 +1114,7 @@ void TrieNode_IterateRange(TrieNode *n, const rune *min, int nmin, bool includeM
       // min = max, we should just search for min and check for its existence
       if (includeMin || includeMax) {
         TrieNode *node = TrieNode_Get(n, (rune *)min, nmin, true, NULL);
-        if (node && node->score != 0) {
+        if (node && TrieNode_IsTerminal(node)) {
           callback(min, nmin, ctx, NULL, node->numDocs);
         }
       }
@@ -1145,7 +1145,7 @@ void TrieNode_IterateContains(TrieNode *n, const rune *str, int nstr, bool prefi
   // exact match - should not be used. change to assert
   if (!prefix && !suffix) {
     TrieNode *node = TrieNode_Get(n, (rune *)str, nstr, true, NULL);
-    if (node && node->score != 0) {
+    if (node && TrieNode_IsTerminal(node)) {
       callback(str, nstr, ctx, NULL, node->numDocs);
     }
     return;

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -340,7 +340,7 @@ static TrieAddChildResult __trieNode_addChild_score(
 
 static int __trieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, float score,
                    TrieAddOp op, TrieFreeCallback freecb, size_t numDocs) {
-  if (score == 0 || len == 0) {
+  if (len == 0) {
     return TRIE_OK_UPDATED;
   }
   TrieNode *n = *np;
@@ -431,7 +431,7 @@ static int __trieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *
 
 int TrieNode_Add(TrieNode **np, const rune *str, t_len len, RSPayload *payload, float score,
                  TrieAddOp op, TrieFreeCallback freecb, size_t numDocs) {
-  if (score == 0 || len == 0) {
+  if (len == 0) {
     return TRIE_OK_UPDATED;
   }
 

--- a/src/trie/trie_node_internal.h
+++ b/src/trie/trie_node_internal.h
@@ -36,11 +36,9 @@ struct TriePayload {
 
 #pragma pack(1)
 /* TrieNode represents a single node in a trie. The actual size of it is bigger,
- * as the children are
- * allocated after str[].
- * Non terminal nodes always have a score of 0, meaning you can't insert nodes
- * with score 0 to the
- * trie.
+ * as the children are allocated after str[].
+ * Terminal nodes (real string ends) are identified by the TRIENODE_TERMINAL flag;
+ * tombstoned terminals carry TRIENODE_DELETED.
  */
 struct TrieNode {
   // the string length of this node. can be 0

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -85,6 +85,21 @@ def testSpellCheckWithIncludeDict(env):
     compare_lists(env, res, [['TERM', 'name', [['0.66666666666666663', 'name2'], ['0.33333333333333331', 'name1'],
                                                ['0', 'name3'], ['0', 'name4'], ['0', 'name5']]]])
 
+def testSpellCheckZeroScoreFromIncludeDict(env):
+    # Candidate term comes from an FT.DICTADD include dict but has no inverted
+    # index in the spec (not present in any indexed doc) → SpellCheck_GetScore
+    # returns 0 → RS_SuggestionsAdd stores it as a score=0 terminal. Verifies
+    # the suggestion still appears in the reply at score 0.
+    env.cmd('ft.dictadd', 'dict', 'xyzzy')
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT')
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('hset', 'doc1', 'name', 'unrelated')
+    waitForIndex(env, 'idx')
+
+    # Misspelling within edit distance 1 of "xyzzy".
+    res = env.cmd('ft.spellcheck', 'idx', 'xyzzx', 'TERMS', 'INCLUDE', 'dict')
+    env.assertEqual(res, [['TERM', 'xyzzx', [['0', 'xyzzy']]]])
+
 def testSpellCheckWithDuplications(env):
     env.cmd('ft.dictadd', 'dict', 'name1', 'name4', 'name5')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -259,7 +259,7 @@ def testWrongType(env):
         env.assertContains(errMsg, str(e))
 
 def testSuggestZeroScoreAdd(env):
-    # FT.SUGADD key string 0 — direct insert with score 0 (previously rejected).
+    # FT.SUGADD key string 0 — direct insert with score 0.
     # SUGGET queries use a strict prefix to avoid the (float)INT_MAX exact-match
     # boost applied to whole-term matches in Trie_Search.
     skipOnCrdtEnv(env)
@@ -273,7 +273,7 @@ def testSuggestZeroScoreAdd(env):
     env.assertEqual(0.0, float(res[1]))
 
 def testSuggestZeroScoreIncrOnMissing(env):
-    # FT.SUGADD key string 0 INCR on a previously absent term — terminal at 0.
+    # FT.SUGADD key string 0 INCR on an absent term — terminal at 0.
     skipOnCrdtEnv(env)
     conn = env.getClusterConnectionIfNeeded()
 

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -257,3 +257,56 @@ def testWrongType(env):
         env.assertTrue(False)
     except Exception as e:
         env.assertContains(errMsg, str(e))
+
+def testSuggestZeroScoreAdd(env):
+    # FT.SUGADD key string 0 — direct insert with score 0 (previously rejected).
+    # SUGGET queries use a strict prefix to avoid the (float)INT_MAX exact-match
+    # boost applied to whole-term matches in Trie_Search.
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    env.assertEqual(1, conn.execute_command('ft.sugadd', 'ac', 'foo', 0))
+    env.assertEqual(1, conn.execute_command('ft.suglen', 'ac'))
+    env.assertEqual(['foo'], conn.execute_command('ft.sugget', 'ac', 'fo'))
+    res = conn.execute_command('ft.sugget', 'ac', 'fo', 'WITHSCORES')
+    env.assertEqual('foo', res[0])
+    env.assertEqual(0.0, float(res[1]))
+
+def testSuggestZeroScoreIncrOnMissing(env):
+    # FT.SUGADD key string 0 INCR on a previously absent term — terminal at 0.
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    env.assertEqual(1, conn.execute_command('ft.sugadd', 'ac', 'foo', 0, 'INCR'))
+    env.assertEqual(1, conn.execute_command('ft.suglen', 'ac'))
+    res = conn.execute_command('ft.sugget', 'ac', 'fo', 'WITHSCORES')
+    env.assertEqual('foo', res[0])
+    env.assertEqual(0.0, float(res[1]))
+
+def testSuggestIncrToZero(env):
+    # FT.SUGADD key string N, then FT.SUGADD key string -N INCR — net score 0
+    # on a pre-existing node; entry must remain terminal and visible to SUGGET.
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    env.assertEqual(1, conn.execute_command('ft.sugadd', 'ac', 'foo', 2))
+    env.assertEqual(1, conn.execute_command('ft.sugadd', 'ac', 'foo', -2, 'INCR'))
+    env.assertEqual(1, conn.execute_command('ft.suglen', 'ac'))
+    res = conn.execute_command('ft.sugget', 'ac', 'fo', 'WITHSCORES')
+    env.assertEqual('foo', res[0])
+    env.assertEqual(0.0, float(res[1]))
+
+    # Still deletable after collapsing to score 0.
+    env.assertEqual(1, conn.execute_command('ft.sugdel', 'ac', 'foo'))
+    env.assertEqual(0, conn.execute_command('ft.suglen', 'ac'))
+
+def testSuggestZeroScoreSortsLast(env):
+    # Score-0 entries must rank below positively-scored peers in SUGGET.
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    conn.execute_command('ft.sugadd', 'ac', 'foo zero', 0)
+    conn.execute_command('ft.sugadd', 'ac', 'foo one', 1)
+    conn.execute_command('ft.sugadd', 'ac', 'foo two', 2)
+    res = conn.execute_command('ft.sugget', 'ac', 'foo')
+    env.assertEqual(['foo two', 'foo one', 'foo zero'], res)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `trie_node.c` uses two parallel terminality protocols: the `TRIENODE_TERMINAL` flag (checked by `TrieNode_IsTerminal`) and a score sentinel (`node->score != 0`). Two reader sites in `TrieNode_IterateRange` and `TrieNode_IterateContains` use the score sentinel instead of the flag. Additionally, `TrieNode_Add` rejects score==0 inserts — a guard that existed to prevent zero-score nodes from appearing non-terminal under the old sentinel — and `spell_check.c` works around this with a `0 → -1` conversion hack. `SuggestAddCommand` (FT.SUGADD) also rejects score==0 inputs for the same reason.

2. **Change:**
   - Replace the two `node->score != 0` sentinel reads with `TrieNode_IsTerminal(node)`
   - Update the `TrieNode` header comment to describe the flag-based protocol
   - Drop the `score == 0` half of the guard in `TrieNode_Add` / `__trieNode_Add` (the `len == 0` half is retained)
   - Remove the `0 → -1` workaround in `spell_check.c`, replacing `-1` sentinel comparisons with `0`
   - Allow `score == 0` in `SuggestAddCommand` (FT.SUGADD); zero-scored suggestions now insert as real terminals and rank last in `FT.SUGGET` results

3. **Outcome:** Single terminality protocol throughout `trie_node.c`. Internal invariants unchanged. One user-facing change: `FT.SUGADD … 0` no longer errors and instead adds a terminal entry with score 0. All 821 unit tests pass.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified
1. `src/trie/trie_node.c`
2. `src/trie/trie_node.h`
3. `src/spell_check.c`
4. `src/suggest.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core trie insert/iterate semantics and changes FT.SUGADD/spell-check behavior for score 0, but scope is localized with added regression tests.
> 
> **Overview**
> Trie nodes now treat **terminality** via `TRIENODE_TERMINAL` / `TrieNode_IsTerminal` everywhere, instead of inferring “real entries” from `score != 0`. **`TrieNode_Add`** no longer rejects `score == 0`, so zero-weight terminals can live in the trie like any other suggestion.
> 
> **Spell check** drops the old `0 → -1` score hack: suggestions store and reply with literal **0** scores (no special-case mapping to 0 in the reply).
> 
> **`FT.SUGADD`** accepts **score 0** (add, `INCR`, and net-zero after increment); those entries stay visible in **`FT.SUGGET`**, report **0.0** with `WITHSCORES`, and sort **below** positive scores. Include-dict spell-check candidates with no index hits still surface at score **0**.
> 
> New Python tests cover spell-check include-dict zero scores and suggest zero-score behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68c568d160b4c72552f9c19a676044cd00e8f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->