### PR TITLE
feat(suggest): allow score=0 in FT.SUGADD

### DIFF
--- a/src/suggest.c
+++ b/src/suggest.c
@@ -90,11 +90,6 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     RedisModule_ReplyWithError(ctx, "ERR invalid score");
     goto end;
   }
-  if (score == 0) {
-    RedisModule_ReplyWithError(ctx, "ERR score must not be 0");
-    goto end;
-  }
-
   /* Create an empty value object if the key is currently empty. */
   if (type == REDISMODULE_KEYTYPE_EMPTY) {
     tree = NewTrie(NULL, Trie_Sort_Score);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** FT.SUGADD rejects score=0 with `ERR score must not be 0` (added in #9774 to preserve the previous silent no-op behaviour during the trie terminality refactor).

2. **Change:** Remove the score==0 rejection from `SuggestAddCommand`. Single line deletion.

3. **Outcome:** `FT.SUGADD key term 0` inserts a real terminal with score 0.0. It appears in `FT.SUGGET` results ranked last (below all positive-score entries). Previously it was silently ignored with no error; the intermediate error added in #9774 is now also gone.

#### Which additional issues this PR fixes
Stacked on #9774.

#### Main objects this PR modified
1. `src/suggest.c`

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `FT.SUGADD` command semantics by accepting `score=0`, which may affect client expectations and result ordering/visibility for zero-scored suggestions. Code change is small and localized to input validation in `RSSuggestAddCommand`.
> 
> **Overview**
> **`FT.SUGADD` now permits `score=0`** by removing the explicit validation that rejected zero scores.
> 
> As a result, zero-scored suggestions will be inserted into the trie like any other entry (instead of returning an error), affecting API behavior for clients that previously relied on rejection/no-op handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd14b08f8ecc1e511dec1dd4430553f759977a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->