### PR TITLE
replace temp ACCESS_TRIMMED with upstream type

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1897,8 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "redis-module"
-version = "2.0.7"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=ce7e83074376494c20e2fbdb5059384db6c1ca26#ce7e83074376494c20e2fbdb5059384db6c1ca26"
+version = "2.0.8"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b#f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
 dependencies = [
  "backtrace",
  "bindgen",
@@ -1920,16 +1920,16 @@ dependencies = [
 
 [[package]]
 name = "redis-module-common"
-version = "0.1.0"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=ce7e83074376494c20e2fbdb5059384db6c1ca26#ce7e83074376494c20e2fbdb5059384db6c1ca26"
+version = "0.1.1"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b#f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "redis-module-macros-internals"
-version = "2.0.7"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=ce7e83074376494c20e2fbdb5059384db6c1ca26#ce7e83074376494c20e2fbdb5059384db6c1ca26"
+version = "2.0.8"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b#f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -210,7 +210,7 @@ xxhash-rust = "0.8"
 
 [workspace.dependencies.redis-module]
 git = "https://github.com/RedisLabsModules/redismodule-rs.git"
-rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26"
+rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
 default-features = false
 
 [profile.release]

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -23,16 +23,11 @@ use sorting_vector::RSSortingVector;
 const UNDERSCORE_KEY: &CStr = c"__key";
 
 /// Equivalent to `DOCUMENT_OPEN_KEY_QUERY_FLAGS` from `document.h`.
-///
-/// FIXME: `ACCESS_TRIMMED` (bit 22) is hardcoded because the `redis-module` crate
-/// does not expose it yet. This MUST be fixed by upstreaming the flag to
-/// `redismodule-rs` (`KeyFlags::ACCESS_TRIMMED`) and then replacing the raw bit
-/// here.
 const DOCUMENT_OPEN_KEY_QUERY_FLAGS: KeyFlags = KeyFlags::from_bits_retain(
     KeyFlags::NOEFFECTS.bits()
         | KeyFlags::NOEXPIRE.bits()
         | KeyFlags::ACCESS_EXPIRED.bits()
-        | (1 << 22), // ACCESS_TRIMMED
+        | KeyFlags::ACCESS_TRIMMED.bits(),
 );
 
 #[derive(Debug, thiserror::Error)]

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -76,7 +76,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -84,7 +84,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -92,7 +92,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -100,7 +100,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.x86_64-apple-darwin.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -108,7 +108,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.x86_64-apple-darwin.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -116,7 +116,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.aarch64-apple-darwin.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -124,7 +124,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -132,7 +132,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -140,7 +140,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -148,7 +148,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -156,7 +156,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -164,6 +164,6 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "ce7e83074376494c20e2fbdb5059384db6c1ca26", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
small followup now that the redismodule-rs PR is merged

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces a hardcoded key-flag bit with the upstream `KeyFlags::ACCESS_TRIMMED` constant and bumps the `redis-module` git revision, which should be behavior-preserving aside from any upstream dependency changes.
> 
> **Overview**
> Updates the `redis-module` dependency to a newer upstream git revision (and corresponding `Cargo.lock` entries).
> 
> Replaces the previously hardcoded `ACCESS_TRIMMED` bit in `DOCUMENT_OPEN_KEY_QUERY_FLAGS` with the now-upstreamed `KeyFlags::ACCESS_TRIMMED`, removing the local workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a90eac261e71f2ebf470e7e2dd52b16e688100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->