### PR TITLE
[MOD-15476] Remove SearchDisk_RegisterIndex; rename Unregister → CloseIndexOnMainThread

### DIFF
--- a/src/indexes.c
+++ b/src/indexes.c
@@ -210,8 +210,10 @@ void Indexes_Free(RedisModuleCtx *ctx, dict *d, bool deleteDiskData) {
   for (size_t i = 0; i < array_len(specs); ++i) {
     IndexSpec *spec = StrongRef_Get(specs[i]);
     if (spec && spec->diskSpec) {
-      // Unregister must always precede close (triggered by Indexes_RemoveSpecFromGlobals)
-      SearchDisk_UnregisterIndex(ctx, spec);
+      // Main-thread teardown must always precede close (which may run on a
+      // background thread when Indexes_RemoveSpecFromGlobals triggers the
+      // StrongRef destructor).
+      SearchDisk_CloseIndexOnMainThread(ctx, spec);
       if (deleteDiskData) {
         SearchDisk_MarkIndexForDeletion(spec->diskSpec);
       }
@@ -985,14 +987,14 @@ void Indexes_AbortSSTReplicationLoading(RedisModuleCtx *ctx) {
   for (size_t i = 0; i < array_len(specs); ++i) {
     IndexSpec *spec = StrongRef_Get(specs[i]);
     if (!spec) continue;
-    // Unregister here (not in the destructor) because the destructor may run
-    // on a background thread when the last StrongRef drops, and unregister
-    // needs the main-thread RedisModuleCtx. Must precede the close that
-    // IndexSpec_FreeUnlinkedData performs. SearchDisk_UnregisterIndex is
-    // idempotent, so it safely handles specs aborted before LOADING_ENDED
-    // registered them.
+    // Run the main-thread teardown here (not in the destructor) because the
+    // destructor may run on a background thread when the last StrongRef drops,
+    // and the teardown needs the main-thread RedisModuleCtx. Must precede the
+    // close that IndexSpec_FreeUnlinkedData performs.
+    // SearchDisk_CloseIndexOnMainThread is idempotent, so it safely handles
+    // specs aborted before LOADING_ENDED finalised them.
     if (spec->diskSpec) {
-      SearchDisk_UnregisterIndex(ctx, spec);
+      SearchDisk_CloseIndexOnMainThread(ctx, spec);
     }
     // pendingDiskRdbState and diskSpec are freed by IndexSpec_FreeUnlinkedData
     // once the last StrongRef is dropped below.

--- a/src/module.c
+++ b/src/module.c
@@ -719,7 +719,7 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   char *indexName = rm_strdup(IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog));
 
   if (sp->diskSpec) {
-    SearchDisk_UnregisterIndex(ctx, sp);
+    SearchDisk_CloseIndexOnMainThread(ctx, sp);
     SearchDisk_MarkIndexForDeletion(sp->diskSpec);
   }
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -654,8 +654,8 @@ static void DeleteDiskIndexesOnShutdown(RedisModuleCtx *ctx) {
     StrongRef spec_ref = dictGetRef(entry);
     IndexSpec *sp = StrongRef_Get(spec_ref);
     if (sp && sp->diskSpec) {
-      // Unregister must always precede close (see SearchDisk_CloseIndex docs).
-      SearchDisk_UnregisterIndex(ctx, sp);
+      // Main-thread teardown must always precede close (see SearchDisk_CloseIndex docs).
+      SearchDisk_CloseIndexOnMainThread(ctx, sp);
       SearchDisk_MarkIndexForDeletion(sp->diskSpec);
       SearchDisk_CloseIndex(sp->diskSpec);
       sp->diskSpec = NULL;

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -200,7 +200,13 @@ static SearchDiskCompactionCallbacks SearchDisk_CompactionCallbacks(void) {
 RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const HiddenString *indexName, const char *obfuscatedName, DocumentType type, bool deleteBeforeOpen, IndexSpec *c_index_spec) {
     RS_ASSERT(disk_db && c_index_spec);
     SearchDiskCompactionCallbacks callbacks = SearchDisk_CompactionCallbacks();
-    return disk->basic.openIndexSpec(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, deleteBeforeOpen, &callbacks, c_index_spec);
+    RedisSearchDiskIndexSpec *result = disk->basic.openIndexSpec(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, deleteBeforeOpen, &callbacks, c_index_spec);
+    if (result) {
+        // Open atomically registers with BigModule, so the spec needs a
+        // matching SearchDisk_CloseIndexOnMainThread before SearchDisk_CloseIndex.
+        c_index_spec->diskRegistered = true;
+    }
+    return result;
 }
 
 void SearchDisk_UpdateLogObfuscation() {
@@ -214,19 +220,12 @@ void SearchDisk_MarkIndexForDeletion(RedisSearchDiskIndexSpec *index) {
     disk->index.markToBeDeleted(index);
 }
 
-void SearchDisk_RegisterIndex(RedisModuleCtx *ctx, IndexSpec *spec) {
-    RS_ASSERT(disk_db && spec && spec->diskSpec && ctx);
-    RS_ASSERT(!spec->diskRegistered);
-    disk->basic.registerIndex(ctx, spec->diskSpec);
-    spec->diskRegistered = true;
-}
-
-void SearchDisk_UnregisterIndex(RedisModuleCtx *ctx, IndexSpec *spec) {
+void SearchDisk_CloseIndexOnMainThread(RedisModuleCtx *ctx, IndexSpec *spec) {
     RS_ASSERT(disk_db && spec && spec->diskSpec && ctx);
     if (!spec->diskRegistered) {
         return;
     }
-    disk->basic.unregisterIndex(ctx, spec->diskSpec);
+    disk->basic.closeIndexOnMainThread(ctx, spec->diskSpec);
     spec->diskRegistered = false;
 }
 
@@ -253,7 +252,13 @@ RedisSearchDiskIndexSpec* SearchDisk_OpenIndexWithRdbState(RedisModuleCtx *ctx,
                                                             IndexSpec *c_index_spec) {
   RS_ASSERT(disk && disk_db && indexName && rdbState && c_index_spec);
   SearchDiskCompactionCallbacks callbacks = SearchDisk_CompactionCallbacks();
-  return disk->basic.openIndexSpecWithRdbState(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, rdbState, &callbacks, c_index_spec);
+  RedisSearchDiskIndexSpec *result = disk->basic.openIndexSpecWithRdbState(ctx, disk_db, indexName, obfuscatedName, strlen(obfuscatedName), type, rdbState, &callbacks, c_index_spec);
+  if (result) {
+    // Open atomically registers with BigModule, so the spec needs a
+    // matching SearchDisk_CloseIndexOnMainThread before SearchDisk_CloseIndex.
+    c_index_spec->diskRegistered = true;
+  }
+  return result;
 }
 
 void SearchDisk_FreeRdbState(RedisSearchDiskRdbState *rdbState) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -88,34 +88,22 @@ RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(RedisModuleCtx *ctx, const Hidden
 void SearchDisk_MarkIndexForDeletion(RedisSearchDiskIndexSpec *index);
 
 /**
- * @brief Register the spec's disk index with Redis BigModule APIs
+ * @brief Main-thread half of closing the spec's disk index.
  *
- * Must be called from the main thread with a valid RedisModuleCtx.
- * Call this after SearchDisk_OpenIndex to register the database with Redis.
+ * Performs every teardown step that needs the Redis module API (today: unregister
+ * the database from BigModule). Must be called from the main thread with a valid
+ * RedisModuleCtx, and must precede SearchDisk_CloseIndex. The split exists because
+ * SearchDisk_CloseIndex may run on a background thread (StrongRef destructor) and
+ * cannot make Redis module API calls from there.
  *
- * Must not be called on an already-registered spec; doing so asserts in debug
- * builds. The spec's diskRegistered flag is updated by this function; callers
- * must not toggle it directly.
- *
- * @param ctx Redis module context (required, must be valid)
- * @param spec IndexSpec whose diskSpec should be registered (must have a non-NULL diskSpec)
- */
-void SearchDisk_RegisterIndex(RedisModuleCtx *ctx, IndexSpec *spec);
-
-/**
- * @brief Unregister the spec's disk index from Redis BigModule APIs
- *
- * Must be called from the main thread with a valid RedisModuleCtx.
- * Call this before SearchDisk_CloseIndex to unregister the database from Redis.
- *
- * Idempotent: a no-op when the spec is not currently registered (either never
- * registered, or already unregistered). The spec's diskRegistered flag is
- * updated by this function; callers must not toggle it directly.
+ * Idempotent: a no-op when the spec has no diskSpec or has already been
+ * closed-on-main-thread.
  *
  * @param ctx Redis module context (required, must be valid)
- * @param spec IndexSpec whose diskSpec should be unregistered (must have a non-NULL diskSpec)
+ * @param spec IndexSpec whose diskSpec should be torn down on the main thread
+ *             (must have a non-NULL diskSpec)
  */
-void SearchDisk_UnregisterIndex(RedisModuleCtx *ctx, IndexSpec *spec);
+void SearchDisk_CloseIndexOnMainThread(RedisModuleCtx *ctx, IndexSpec *spec);
 
 /**
  * @brief Close an index, **Important** must be called once and only once for every index

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -160,8 +160,8 @@ typedef struct BasicDiskAPI {
    *                     IndexSpec for its lifetime.
    * @return Pointer to the index spec, or NULL on error
    *
-   * @note This opens the database but does NOT register it with Redis. Call registerIndex after this
-   *       to register with BigModule APIs.
+   * @note This both opens the database and registers it with Redis BigModule APIs.
+   *       Registration is atomic with creation; there is no separate register step.
    */
   RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisModuleCtx *ctx, RedisSearchDisk *disk, const HiddenString *indexName, const char *obfuscatedName, size_t obfuscatedNameLen, DocumentType type, bool deleteBeforeOpen, const SearchDiskCompactionCallbacks *callbacks, void *private_data);
   /**
@@ -169,28 +169,24 @@ typedef struct BasicDiskAPI {
    * @param disk Pointer to the disk context (for cleanup of index metrics)
    * @param index Pointer to the index spec
    *
-   * @note This closes the database but does NOT unregister from Redis. Call unregisterIndex
-   *       before this to unregister from BigModule APIs.
+   * @note This closes the database but performs no Redis module API calls, so it is safe
+   *       to run on a background thread. The matching main-thread teardown
+   *       (BigUnregisterDb) is performed by closeIndexOnMainThread, which must be called
+   *       before this on the main thread.
    */
   void (*closeIndexSpec)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
   /**
-   * @brief Register an index's database with Redis BigModule APIs
+   * @brief Main-thread half of closing an index: performs every teardown step that needs
+   *        the Redis module API (today: BigUnregisterDb).
    * @param ctx Redis module context (required, must be valid)
    * @param index Pointer to the index spec
    *
-   * @note Must be called from the main thread with a valid RedisModuleCtx.
-   *       Call this after openIndexSpec to register the database with Redis.
+   * @note Must be called from the main thread with a valid RedisModuleCtx, and must
+   *       precede closeIndexSpec. The split exists because closeIndexSpec may run on
+   *       a background thread (the StrongRef destructor) and cannot make Redis module
+   *       API calls from there.
    */
-  void (*registerIndex)(RedisModuleCtx *ctx, RedisSearchDiskIndexSpec *index);
-  /**
-   * @brief Unregister an index's database from Redis BigModule APIs
-   * @param ctx Redis module context (required, must be valid)
-   * @param index Pointer to the index spec
-   *
-   * @note Must be called from the main thread with a valid RedisModuleCtx.
-   *       Call this before closeIndexSpec to unregister the database from Redis.
-   */
-  void (*unregisterIndex)(RedisModuleCtx *ctx, RedisSearchDiskIndexSpec *index);
+  void (*closeIndexOnMainThread)(RedisModuleCtx *ctx, RedisSearchDiskIndexSpec *index);
   /**
    * @brief Save the index spec's disk-related state to RDB.
    *

--- a/src/spec.c
+++ b/src/spec.c
@@ -1716,7 +1716,6 @@ static StrongRef IndexSpec_ParseFromArgCursor(RedisModuleCtx *ctx, const HiddenS
       QueryError_SetError(status, QUERY_ERROR_CODE_DISK_CREATION, "Could not open disk index");
       goto failure;
     }
-    SearchDisk_RegisterIndex(ctx, spec);
   }
 
   if (AC_IsInitialized(&acStopwords)) {
@@ -1757,7 +1756,7 @@ failure:  // Result-like contract: on failure the error is set in `status`, the
           // INVALID_STRONG_REF is returned. On success a valid spec is returned.
   spec->flags &= ~Index_Temporary;
   if (spec->diskSpec) {
-    SearchDisk_UnregisterIndex(ctx, spec);
+    SearchDisk_CloseIndexOnMainThread(ctx, spec);
   }
   IndexSpec_Unlink(spec_ref, false);
   return INVALID_STRONG_REF;
@@ -2937,7 +2936,6 @@ bool IndexSpec_SSTRdbOpenAndApply(RedisModuleCtx *ctx, IndexSpec *sp) {
   // Make sure TagDiskIndex is created for every TAG field. In regular FT.CREATE the TagIndex is ensured lazily
   // in the first document insertion
   IndexSpec_EnsureTagDiskIndexes(sp);
-  SearchDisk_RegisterIndex(ctx, sp);
 
   return true;
 }
@@ -3139,8 +3137,8 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
 
 cleanup:
   if (sp && sp->diskSpec) {
-    // Idempotent — no-op if registration never happened on this path.
-    SearchDisk_UnregisterIndex(ctx, sp);
+    // Idempotent — no-op if the open never registered on this path.
+    SearchDisk_CloseIndexOnMainThread(ctx, sp);
   }
   StrongRef_Release(spec_ref);
 cleanup_no_index:
@@ -3162,7 +3160,6 @@ int IndexSpec_RdbLoadOpenDisk(RedisModuleCtx *ctx, IndexSpec *sp, bool useSst, Q
     }
     IndexSpec_PopulateVectorDiskParams(sp);
     IndexSpec_EnsureTagDiskIndexes(sp);
-    SearchDisk_RegisterIndex(ctx, sp);
   }
   return REDISMODULE_OK;
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Registration with Redis BigModule is now atomic with open on the Rust side, so SearchDisk_RegisterIndex has nothing left to do — remove it. The matching unregister step still exists because SearchDisk_CloseIndex may run on a background thread (the StrongRef destructor) and cannot make Redis module API calls from there, so unregister must run separately on the main thread.

Rename SearchDisk_UnregisterIndex → SearchDisk_CloseIndexOnMainThread to describe its role in the lifecycle rather than its current implementation:
it is the main-thread half of close, paired with the background-safe SearchDisk_CloseIndex. The asymmetric open / close-on-main-thread / close shape reflects the actual threading model — there is no main-thread step after open and no main-thread step in the final tear-down, so a symmetric register/unregister pairing would only manufacture a no-op for visual
symmetry.

SearchDisk_OpenIndex and SearchDisk_OpenIndexWithRdbState now set spec->diskRegistered = true themselves on success, consolidating the invariant (diskSpec != NULL ⇒ diskRegistered == true until SearchDisk_CloseIndexOnMainThread) in one place. All call sites in spec.c, indexes.c, module.c, and notifications.c are updated.

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the disk index lifecycle/ABI: `openIndexSpec` now performs Redis BigModule registration implicitly, so incorrect call sites/threading assumptions could lead to double-registration or missing registration behavior at runtime.
> 
> **Overview**
> **Disk index opening now implicitly registers with Redis BigModule APIs.** The separate `SearchDisk_RegisterIndex` wrapper and the `BasicDiskAPI.registerIndex` function pointer were removed, and call sites in `spec.c` no longer perform an explicit registration step.
> 
> API docs were updated to note that `openIndexSpec` must be invoked from the main thread with a valid `RedisModuleCtx`, while index unregistration remains an explicit step via `unregisterIndex` before close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc36efbca887622f8ce9f1cf2c2e75287f37dce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->