### PR TITLE
[MOD-15910] ForkGC: Replace thread-based pause protocol with direct lifecycle hooks

### DIFF
--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -39,6 +39,13 @@ typedef struct {
   uint64_t gcBlocksDenied;
 } ForkGCStats;
 
+// Optional hook for tests. beforeApply is called in the parent after fork(),
+// letting tests inject mutations invisible to the child before results are applied.
+typedef struct {
+  void (*beforeApply)(void *privdata);
+  void *privdata;
+} FGCHook;
+
 /* Internal definition of the garbage collector context (each index has one) */
 typedef struct ForkGC {
 
@@ -54,9 +61,6 @@ typedef struct ForkGC {
   int pipe_write_fd;
   struct pollfd pollfd_read[1]; // pollfd to poll the read pipe so that we don't block while read
 
-  volatile uint32_t pauseState;
-  volatile uint32_t execState;
-
   struct timespec retryInterval;
   RS_Atomic(size_t) deletedOrUpdatedDocsFromLastRun;
 
@@ -67,61 +71,9 @@ typedef struct ForkGC {
 
 ForkGC *FGC_Create(StrongRef spec_ref, GCCallbacks *callbacks);
 
-typedef enum {
-  // Normal "open" state. No pausing will happen
-  FGC_PAUSED_UNPAUSED = 0x00,
-  // Prevent invoking the child. The child is not invoked until this flag is
-  // cleared
-  FGC_PAUSED_CHILD = 0x01,
-  // Prevent the parent reading from the child. The results from the child are
-  // not read until this flag is cleared.
-  FGC_PAUSED_PARENT = 0x02
-} FGCPauseFlags;
-
-typedef enum {
-  // Idle, "normal" state
-  FGC_STATE_IDLE = 0,
-
-  // Set when the PAUSED_CHILD flag is set, indicates that we are
-  // awaiting this flag to be cleared.
-  FGC_STATE_WAIT_FORK,
-
-  // Set when the child has been launched, but before the first results have
-  // been applied.
-  FGC_STATE_SCANNING,
-
-  // Set when the PAUSED_PARENT flag is set. The results will not be
-  // scanned until the PAUSED_PARENT flag is unset
-  FGC_STATE_WAIT_APPLY,
-
-  // Set when results are being applied from the child to the parent
-  FGC_STATE_APPLYING
-} FGCState;
-
-/**
- * Indicate that the gc should wait immediately prior to
- * forking. This is in order to perform some commands which
- * may not be visible by the fork gc engine.
- *
- * This function will return before the fork is performed. You
- * must call FGC_ForkAndWaitBeforeApply or FGC_Apply to allow the GC to
- * resume functioning
- */
-//TODO: I'm not sure this one is necessary, we already wait before we call the callback. (in cbWrapper)
-void FGC_WaitBeforeFork(ForkGC *gc);
-
-/**
- * Indicate that the GC should continue from FGC_WaitBeforeFork, and
- * wait before the changes are applied. At this point, the child and parent process
- * no longer share the same memory, hence, the child will not be aware of any
- * changes made in the main process.
- */
-void FGC_ForkAndWaitBeforeApply(ForkGC *gc);
-
-/**
- * Apply the changes the parent received from the child.
- */
-void FGC_Apply(ForkGC *gc);
+// Run one full GC cycle. In production, called via the GCCallbacks with hooks=NULL.
+// Tests call this directly with hooks to inject mutations at specific lifecycle points.
+bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook);
 
 #ifdef __cplusplus
 }

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -111,8 +111,7 @@ static void reap_child_blocking(RedisModuleCtx *ctx, pid_t cpid, int timeout_sec
   }
 }
 
-static bool periodicCb(void *privdata, bool force) {
-  ForkGC *gc = privdata;
+bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook) {
   RedisModuleCtx *ctx = gc->ctx;
 
   // This check must be done first, because some values (like `deletedDocsFromLastRun`) that are used for
@@ -139,12 +138,6 @@ static bool periodicCb(void *privdata, bool force) {
   bool gcrv = true;
   pid_t cpid;
   TimeSample ts;
-
-  while (gc->pauseState == FGC_PAUSED_CHILD) {
-    gc->execState = FGC_STATE_WAIT_FORK;
-    // spin or sleep
-    usleep(500);
-  }
 
   TimeSampler_Start(&ts);
   int pipefd[2];
@@ -173,8 +166,6 @@ static bool periodicCb(void *privdata, bool force) {
     close(gc->pipe_write_fd);
     return true;
   }
-
-  gc->execState = FGC_STATE_SCANNING;
 
   cpid = RedisModule_Fork(NULL, NULL);  // duplicate the current process
 
@@ -215,13 +206,10 @@ static bool periodicCb(void *privdata, bool force) {
     // release the strong reference to the index for the main process (see comment above)
     IndexSpecRef_Release(early_check);
     close(gc->pipe_write_fd);
-    while (gc->pauseState == FGC_PAUSED_PARENT) {
-      gc->execState = FGC_STATE_WAIT_APPLY;
-      // spin
-      usleep(500);
-    }
 
-    gc->execState = FGC_STATE_APPLYING;
+    // Test hook: lets tests inject mutations after fork (invisible to child) before results are applied.
+    if (hook && hook->beforeApply) hook->beforeApply(hook->privdata);
+
     gc->cleanNumericEmptyNodes = RSGlobalConfig.gcConfigParams.gcSettings.forkGCCleanNumericEmptyNodes;
     if (FGC_parentHandleFromChild(gc) == FGC_SPEC_DELETED) {
       gcrv = false;
@@ -249,7 +237,6 @@ static bool periodicCb(void *privdata, bool force) {
   }
 
   IndexsGlobalStats_DecreaseLogicallyDeleted(num_docs_to_clean);
-  gc->execState = FGC_STATE_IDLE;
   TimeSampler_End(&ts);
   long long msRun = TimeSampler_DurationMS(&ts);
 
@@ -260,40 +247,8 @@ static bool periodicCb(void *privdata, bool force) {
   return gcrv;
 }
 
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-#define NO_TSAN_CHECK __attribute__((no_sanitize("thread")))
-#endif
-#endif
-#ifndef NO_TSAN_CHECK
-#define NO_TSAN_CHECK
-#endif
-
-void FGC_WaitBeforeFork(ForkGC *gc) NO_TSAN_CHECK {
-  RS_LOG_ASSERT(gc->pauseState == 0, "FGC pause state should be 0");
-  gc->pauseState = FGC_PAUSED_CHILD;
-
-  while (gc->execState != FGC_STATE_WAIT_FORK) {
-    usleep(500);
-  }
-}
-
-void FGC_ForkAndWaitBeforeApply(ForkGC *gc) NO_TSAN_CHECK {
-  // Ensure that we're waiting for the child to begin
-  RS_LOG_ASSERT(gc->pauseState == FGC_PAUSED_CHILD, "FGC pause state should be CHILD");
-  RS_LOG_ASSERT(gc->execState == FGC_STATE_WAIT_FORK, "FGC exec state should be WAIT_FORK");
-
-  gc->pauseState = FGC_PAUSED_PARENT;
-  while (gc->execState != FGC_STATE_WAIT_APPLY) {
-    usleep(500);
-  }
-}
-
-void FGC_Apply(ForkGC *gc) NO_TSAN_CHECK {
-  gc->pauseState = FGC_PAUSED_UNPAUSED;
-  while (gc->execState != FGC_STATE_IDLE) {
-    usleep(500);
-  }
+static bool periodicCb(void *privdata, bool force) {
+  return FGC_RunCycle(privdata, force, NULL);
 }
 
 static void onTerminateCb(void *privdata) {

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -56,65 +56,34 @@ static timespec getTimespecCb(void *) {
   return ts;
 }
 
-typedef struct {
-  void *fgc;
-  RefManager *ism;
-  volatile bool runGc;
-} args_t;
-
-void *cbWrapper(void *args) {
-  args_t *fgcArgs = (args_t *)args;
-  GCContext *gc = get_spec(fgcArgs->ism)->gc;
-  ForkGC *fgc = reinterpret_cast<ForkGC *>(gc->gcCtx);
-
-  while (true) {
-    // sync thread
-    while (fgcArgs->runGc && fgc->pauseState != FGC_PAUSED_CHILD) {
-      usleep(500);
-    }
-    if (!fgcArgs->runGc) {
-      break;
-    }
-
-    // run ForkGC
-    gc->callbacks.periodicCallback(fgc, false);
-  }
-  return NULL;
-}
-
 class FGCTest : public ::testing::Test {
  protected:
   RMCK::Context ctx;
   RefManager *ism;
   ForkGC *fgc;
-  args_t args;
-  pthread_t thread;
 
   void SetUp() override {
     Initialize_KeyspaceNotifications();
     ism = createSpec(ctx);
     RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold = 0;
     RSGlobalStats.totalStats.logically_deleted = 0;
-    runGcThread();
-  }
-
-  void runGcThread() {
     fgc = reinterpret_cast<ForkGC *>(get_spec(ism)->gc->gcCtx);
-    thread = {0};
-    args = {.fgc = fgc, .ism = ism, .runGc = true};
-
-    pthread_create(&thread, NULL, cbWrapper, &args);
   }
 
   void TearDown() override {
-    args.runGc = false;
-    // wait for the gc thread to finish current loop and exit the thread
-    pthread_join(thread, NULL);
     freeSpec(ism);
   }
 
   size_t addDocumentWrapper(const char *docid, const char *field, const char *value) {
     return ::addDocumentWrapper(ctx, ism, docid, field, value);
+  }
+
+  void runGC(std::function<void()> beforeApply = {}) {
+    FGCHook hook{
+      [](void *p) { if (auto &f = *static_cast<std::function<void()>*>(p)) f(); },
+      &beforeApply
+    };
+    FGC_RunCycle(fgc, true, beforeApply ? &hook : nullptr);
   }
 };
 
@@ -174,23 +143,20 @@ TEST_F(FGCTestNumeric, testNumeric) {
   ASSERT_EQ(total_mem, numeric_tree_mem);
   ASSERT_EQ(total_mem, spec_inv_index_mem_stats);
 
-  // Delete some docs
-  FGC_WaitBeforeFork(fgc);
   size_t deleted_docs = num_docs / 4;
   std::mt19937 gen(42);
   std::uniform_int_distribution<size_t> dis(0, num_docs - 1);
   std::unordered_set<size_t> generated_numbers;
+
   for (size_t i = 0; i < deleted_docs; ++i) {
     size_t random_id = dis(gen);
-    while (generated_numbers.find(random_id) != generated_numbers.end()) {
-        random_id = dis(gen);
-    }
+    while (generated_numbers.find(random_id) != generated_numbers.end())
+      random_id = dis(gen);
     generated_numbers.insert(random_id);
-    auto rv = RS::deleteDocument(ctx, ism, numToDocStr(random_id).c_str());
-    ASSERT_TRUE(rv) << "Failed to delete doc " << random_id << " at iteration " << i;
+    ASSERT_TRUE(RS::deleteDocument(ctx, ism, numToDocStr(random_id).c_str()))
+        << "Failed to delete doc " << random_id << " at iteration " << i;
   }
-  FGC_ForkAndWaitBeforeApply(fgc);
-  FGC_Apply(fgc);
+  runGC();
 
   size_t spec_inv_index_mem_stats_after_delete = (get_spec(ism))->stats.invertedSize;
   size_t numeric_tree_mem_after_delete = NumericRangeTree_GetInvertedIndexesSize(rt);
@@ -215,20 +181,12 @@ TEST_F(FGCTestTag, testRemoveEntryFromLastBlock) {
    * To properly test this; we must ensure that the gc is forked AFTER
    * the deletion, but BEFORE the addition.
    */
-  FGC_WaitBeforeFork(fgc);
-  auto rv = RS::deleteDocument(ctx, ism, "doc1");
-  ASSERT_TRUE(rv);
-
-  /**
-   * This function allows the GC to perform fork(2), but makes it wait
-   * before it begins receiving results.
-   */
-  FGC_ForkAndWaitBeforeApply(fgc);
-  rv = RS::deleteDocument(ctx, ism, "doc2");
-
-  size_t invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
-  /** This function allows the gc to receive the results */
-  FGC_Apply(fgc);
+  ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc1"));
+  size_t invertedSizeBeforeApply;
+  runGC([&]() {
+    RS::deleteDocument(ctx, ism, "doc2");
+    invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
+  });
 
   // gc stats
   ASSERT_EQ(0, fgc->stats.gcBlocksDenied);
@@ -256,20 +214,12 @@ TEST_F(FGCTestTag, testRemoveLastBlockWhileUpdate) {
    * To properly test this; we must ensure that the gc is forked AFTER
    * the deletion, but BEFORE the addition.
    */
-  FGC_WaitBeforeFork(fgc);
-  auto rv = RS::deleteDocument(ctx, ism, "doc1");
-  ASSERT_TRUE(rv);
-
-  /**
-   * This function allows the GC to perform fork(2), but makes it wait
-   * before it begins receiving results.
-   */
-  FGC_ForkAndWaitBeforeApply(fgc);
-  ASSERT_TRUE(RS::addDocument(ctx, ism, "doc2", "f1", "hello"));
-
-  size_t invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
-  /** This function allows the gc to receive the results */
-  FGC_Apply(fgc);
+  ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc1"));
+  size_t invertedSizeBeforeApply;
+  runGC([&]() {
+    ASSERT_TRUE(RS::addDocument(ctx, ism, "doc2", "f1", "hello"));
+    invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
+  });
 
   // gc stats
   ASSERT_EQ(1, fgc->stats.gcBlocksDenied);
@@ -300,25 +250,19 @@ TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
   // Delete one of the documents.
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc1"));
 
-  FGC_WaitBeforeFork(fgc);
-
-  // The fork will see one block of 2 docs with 1 deleted doc.
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // Now add documents until we have new blocks added.
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
   sctx.spec->monitorDocumentExpiration = false;
-  auto iv = getTagInvidx(&sctx,  "f1", "hello");
-  while (InvertedIndex_NumBlocks(iv) < 3) {
-    ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(curId++).c_str(), "f1", "hello"));
-  }
-  ASSERT_EQ(3, TotalIIBlocks() - startValue);
+  auto iv = getTagInvidx(&sctx, "f1", "hello");
+  const char *originalData;
+  size_t invertedSizeBeforeApply;
 
-  // Save the pointer to the original block data.
-  const char *originalData = IndexBlock_Data(InvertedIndex_BlockRef(iv, 0));
-  // The fork will return an array of one block with one entry, but we will ignore it.
-  size_t invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
-  FGC_Apply(fgc);
+  runGC([&]() {
+    while (InvertedIndex_NumBlocks(iv) < 3)
+      ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(curId++).c_str(), "f1", "hello"));
+    ASSERT_EQ(3, TotalIIBlocks() - startValue);
+    originalData = IndexBlock_Data(InvertedIndex_BlockRef(iv, 0));
+    invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
+  });
 
   const char *afterGcData = IndexBlock_Data(InvertedIndex_BlockRef(iv, 0));
   ASSERT_EQ(afterGcData, originalData);
@@ -359,40 +303,24 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
 
   ASSERT_EQ(2, TotalIIBlocks() - startValue);
 
-  FGC_WaitBeforeFork(fgc);
-  // Delete all.
+  size_t invertedSizeBeforeApply;
+  const char *originalData;
+
   for (unsigned i = 1; i < curId; i++) {
     size_t n = snprintf(buf, sizeof(buf), "doc%u", i);
     ASSERT_TRUE(RS::deleteDocument(ctx, ism, buf));
   }
-
   ASSERT_EQ(0, sctx.spec->stats.scoring.numDocuments);
-
-  /**
-   * This function allows the GC to perform fork(2), but makes it wait
-   * before it begins receiving results. From this point any changes made by the
-   * main process are not part of the forked process.
-   */
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  size_t invertedSizeBeforeApply = sctx.spec->stats.invertedSize;
-  // Add a new document so the last block's is different from the the one copied to the fork.
-  size_t n = snprintf(buf, sizeof(buf), "doc%u", curId);
-  lastBlockMemory += this->addDocumentWrapper(buf, "f1", "hello");
-
-  // Save the pointer to the original last block data.
-  const IndexBlock *lastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 1);
-  const char *originalData = IndexBlock_Data(lastBlock);
-
-  /** Apply the child changes. All the entries the child has seen are marked as deleted,
-   * but since the last block was modified by the main the process, we keep it, assuming it
-   * will be deleted in the next gc run (where the fork is not running during modifications,
-   * or the we opened a new block and this block is no longer the last)
-   */
-  FGC_Apply(fgc);
+  runGC([&]() {
+      invertedSizeBeforeApply = sctx.spec->stats.invertedSize;
+      size_t n = snprintf(buf, sizeof(buf), "doc%u", curId);
+      lastBlockMemory += this->addDocumentWrapper(buf, "f1", "hello");
+      const IndexBlock *lastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 1);
+      originalData = IndexBlock_Data(lastBlock);
+    });
 
   // gc stats - make sure we skipped the last block
-  lastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 1);
+  const IndexBlock *lastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 1);
   const char *afterGcData = IndexBlock_Data(lastBlock);
   ASSERT_EQ(afterGcData, originalData);
   ASSERT_EQ(1, fgc->stats.gcBlocksDenied);
@@ -444,34 +372,26 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
   snprintf(buf, sizeof(buf), "doc%u", curId++);
   RS::addDocument(ctx, ism, buf, "f1", "hello");
 
-  // Wait before we fork so the next updates will copied to the child memory.
-  FGC_WaitBeforeFork(fgc);
+  unsigned total_deletions;
+  size_t valid_docs;
+  size_t lastBlockEntries;
 
-  // Delete the second entry of the last block
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, buf));
-  // Delete first entry in the index
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc1"));
-  unsigned total_deletions = 2;
-
-  // Delete the second block (out of 3 blocks)
+  total_deletions = 2;
   for (unsigned i = middleBlockFirstId; i < lastBlockFirstId; ++i) {
     snprintf(buf, sizeof(buf), "doc%u", i);
     ASSERT_TRUE(RS::deleteDocument(ctx, ism, buf));
     ++total_deletions;
   }
-
-  // curId - 1 = total added documents
-  size_t valid_docs = curId - 1 - total_deletions;
+  valid_docs = curId - 1 - total_deletions;
   ASSERT_EQ(valid_docs, sctx.spec->stats.scoring.numDocuments);
-
-  size_t lastBlockEntries = IndexBlock_NumEntries(InvertedIndex_BlockRef(iv, 2));
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // Add a document -- this one is to keep
-  snprintf(buf, sizeof(buf), "doc%u", curId);
-  RS::addDocument(ctx, ism, buf, "f1", "hello");
-  ++valid_docs;
-  FGC_Apply(fgc);
+  lastBlockEntries = IndexBlock_NumEntries(InvertedIndex_BlockRef(iv, 2));
+  runGC([&]() {
+      snprintf(buf, sizeof(buf), "doc%u", curId);
+      RS::addDocument(ctx, ism, buf, "f1", "hello");
+      ++valid_docs;
+    });
 
   // Since we added entries to the last block after the fork, we ignore the fork updates in the last block
   ASSERT_EQ(1, fgc->stats.gcBlocksDenied);
@@ -512,17 +432,11 @@ TEST_F(FGCTestTag, testRepairLastBlock) {
   snprintf(buf, sizeof(buf), "doc%u", curId++);
   RS::addDocument(ctx, ism, buf, "f1", "hello");
 
-  FGC_WaitBeforeFork(fgc);
-
-  // Delete the doc we have just added.
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, buf));
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // Add a document to the last block. This change is not known to the child.
-  snprintf(buf, sizeof(buf), "doc%u", curId);
-  RS::addDocument(ctx, ism, buf, "f1", "hello");
-  FGC_Apply(fgc);
+  runGC([&]() {
+      snprintf(buf, sizeof(buf), "doc%u", curId);
+      RS::addDocument(ctx, ism, buf, "f1", "hello");
+    });
   // since the block size in the main process doesn't equal to its original size as seen by the child,
   // we ignore the fork collection - the last block changes should be discarded.
   ASSERT_EQ(1, fgc->stats.gcBlocksDenied);
@@ -554,19 +468,14 @@ TEST_F(FGCTestTag, testRepairMiddleRemoveLast) {
    * In this case, we want to keep `curId`, but we want to delete a 'middle' entry
    * while appending documents to it..
    **/
-  FGC_WaitBeforeFork(fgc);
-
   while (curId > 100) {
     snprintf(buf, sizeof(buf), "doc%u", --curId);
     ASSERT_TRUE(RS::deleteDocument(ctx, ism, buf));
   }
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  snprintf(buf, sizeof(buf), "doc%u", next_id);
-  ASSERT_TRUE(RS::addDocument(ctx, ism, buf, "f1", "hello"));
-
-  FGC_Apply(fgc);
+  runGC([&]() {
+      snprintf(buf, sizeof(buf), "doc%u", next_id);
+      ASSERT_TRUE(RS::addDocument(ctx, ism, buf, "f1", "hello"));
+    });
   ASSERT_EQ(2, InvertedIndex_NumBlocks(iv));
 }
 
@@ -594,35 +503,27 @@ TEST_F(FGCTestTag, testRemoveMiddleBlock) {
   unsigned lastMidId = curId - 1;
   ASSERT_EQ(3, TotalIIBlocks() - startValue);
 
-  FGC_WaitBeforeFork(fgc);
+  unsigned newLastBlockId = 0;
+  unsigned lastLastBlockId = 0;
+  const char *pp = nullptr;
 
-  // Delete the middle block
-  for (size_t ii = firstMidId; ii < firstLastBlockId; ++ii) {
+  for (size_t ii = firstMidId; ii < firstLastBlockId; ++ii)
     RS::deleteDocument(ctx, ism, numToDocStr(ii).c_str());
-  }
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // While the child is running, fill the last block and add another block.
-  unsigned newLastBlockId = curId + 1;
-  while (InvertedIndex_NumBlocks(iv) < 4) {
-    ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(++curId).c_str(), "f1", "hello"));
-  }
-  unsigned lastLastBlockId = curId - 1;
-
-  // Get the previous pointer, i.e. the one we expect to have the updated
-  // info. We do -2 and not -1 because we have one new document in the
-  // fourth block (as a sentinel)
-  const IndexBlock *secondLastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 2);
-  const char *pp = IndexBlock_Data(secondLastBlock);
-  FGC_Apply(fgc);
+  runGC([&]() {
+      newLastBlockId = curId + 1;
+      while (InvertedIndex_NumBlocks(iv) < 4)
+        ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(++curId).c_str(), "f1", "hello"));
+      lastLastBlockId = curId - 1;
+      const IndexBlock *secondLastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 2);
+      pp = IndexBlock_Data(secondLastBlock);
+    });
 
   // We add new documents to the last block after the fork, so we expect the GC to deny it.
   ASSERT_EQ(1, fgc->stats.gcBlocksDenied);
   ASSERT_EQ(3, InvertedIndex_NumBlocks(iv));
 
   // The pointer to the last gc-block, received from the fork
-  secondLastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 2);
+  const IndexBlock *secondLastBlock = InvertedIndex_BlockRef(iv, InvertedIndex_NumBlocks(iv) - 2);
   const char *gcpp = IndexBlock_Data(secondLastBlock);
   ASSERT_EQ(pp, gcpp);
 
@@ -648,15 +549,9 @@ TEST_F(FGCTestTag, testDeleteDuringGCCleanup) {
   RS::deleteDocument(ctx, ism, numToDocStr(1).c_str());
   ASSERT_EQ(RSGlobalStats.totalStats.logically_deleted, 1);
 
-  FGC_WaitBeforeFork(fgc);
-
-  // Delete the second document while fGC is waiting before the fork. If we were storing the number
-  // of document to delete at this point, we wouldn't have accounted for this deletion later on
-  // after the GC is done.
   RS::deleteDocument(ctx, ism, numToDocStr(2).c_str());
   ASSERT_EQ(fgc->deletedOrUpdatedDocsFromLastRun, 2);
-
-  FGC_Apply(fgc);
+  runGC();
 
   ASSERT_EQ(RSGlobalStats.totalStats.logically_deleted, 0);
 }
@@ -671,22 +566,14 @@ TEST_F(FGCTestTag, testPipeErrorDuringGC) {
   ASSERT_TRUE(RS::addDocument(ctx, ism, "doc2", "f1", "hello"));
   ASSERT_TRUE(RS::addDocument(ctx, ism, "doc3", "f1", "hello"));
 
-  FGC_WaitBeforeFork(fgc);
-
-  // Delete documents to trigger GC work
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc1"));
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc2"));
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // Close the read end of the pipe from the parent's perspective
-  // This will cause poll() to immediately return an error (POLLNVAL),
-  // simulating a pipe failure scenario without waiting 3 minutes
-  close(fgc->pipe_read_fd);
-  fgc->pipe_read_fd = -1;  // Invalidate the fd to prevent accidental use or double-close
-
-  // This should handle the error gracefully without crashes or double-frees
-  FGC_Apply(fgc);
+  runGC([&]() {
+    // Close the read end of the pipe to trigger a poll() error (POLLNVAL),
+    // simulating a pipe failure without waiting 3 minutes.
+    close(fgc->pipe_read_fd);
+    fgc->pipe_read_fd = -1;
+  });
 
   // The GC should have failed, so no bytes should be collected
   // (or at least the operation should complete without crashing)
@@ -730,20 +617,12 @@ TEST_F(FGCTestTag, testPipeErrorDuringApply) {
     ASSERT_TRUE(RS::addDocument(ctx, ism, doc2.c_str(), "f1", "hello"));
     ASSERT_TRUE(RS::addDocument(ctx, ism, doc3.c_str(), "f1", "hello"));
 
-    FGC_WaitBeforeFork(fgc);
-
-    // Delete documents to trigger GC work
     ASSERT_TRUE(RS::deleteDocument(ctx, ism, doc1.c_str()));
     ASSERT_TRUE(RS::deleteDocument(ctx, ism, doc2.c_str()));
-
-    FGC_ForkAndWaitBeforeApply(fgc);
-
-    // Signal the closer thread to close the pipe after a variable delay
-    delay_usec = iteration * 2;
-    should_close = true;
-
-    // Apply should handle the pipe closure gracefully without crashing
-    FGC_Apply(fgc);
+    runGC([&]() {
+      delay_usec = iteration * 2;
+      should_close = true;
+    });
 
     // Wait for the closer to finish this iteration
     while (should_close) {
@@ -785,27 +664,16 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
   ASSERT_TRUE(rootRange);
   EXPECT_EQ(cur_cardinality, NumericRange_GetCardinality(rootRange));
-  FGC_WaitBeforeFork(fgc);
-
-  // Delete some docs from the blocks
-  for (size_t i = expected_total_blocks; i < cur_id; i += 10) {
-    auto rv = RS::deleteDocument(ctx, ism, numToDocStr(i).c_str());
-    ASSERT_TRUE(rv) << "Failed to delete doc " << i;
-  }
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // Add a half block worth of documents to the index with a different value. The fork is not aware of these changes.
-  ASSERT_LT(++cur_cardinality, first_split_card);
-  expected_total_blocks++;
-  for (size_t i = 0; i < docs_per_block / 2; i++) {
-    this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(1.4142).c_str());
-  }
-
-  FGC_Apply(fgc);
+  for (size_t i = expected_total_blocks; i < cur_id; i += 10)
+    ASSERT_TRUE(RS::deleteDocument(ctx, ism, numToDocStr(i).c_str())) << "Failed to delete doc " << i;
+  runGC([&]() {
+    ASSERT_LT(++cur_cardinality, first_split_card);
+    expected_total_blocks++;
+    for (size_t i = 0; i < docs_per_block / 2; i++)
+      this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(1.4142).c_str());
+  });
 
   EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
-  // Refresh root/range references as tree may have changed
   root = NumericRangeTree_GetRoot(rt);
   rootRange = NumericRangeNode_GetRange(root);
   ASSERT_TRUE(rootRange);
@@ -817,55 +685,34 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
    * Scenario 2: Not taking the child last block, and need to address the parent's changes (ignored + last block).
    */
 
-  FGC_WaitBeforeFork(fgc);
-
-  // Delete some docs from the blocks
-  for (size_t i = expected_total_blocks; i < cur_id; i += 10) {
-    auto rv = RS::deleteDocument(ctx, ism, numToDocStr(i).c_str());
-    ASSERT_TRUE(rv) << "Failed to delete doc " << i;
-  }
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-
-  // Add a half block worth of documents to the index with a different value. The fork is not aware of these changes.
-  ASSERT_LT(++cur_cardinality, first_split_card);
-  for (size_t i = 0; i < docs_per_block / 2; i++) {
-    this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(2.718).c_str());
-  }
-  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks) << "Number of blocks should not change";
-  // Add another half block worth of documents to the index with a different value.
-  ASSERT_LT(++cur_cardinality, first_split_card);
-  expected_total_blocks++;
-  for (size_t i = 0; i < docs_per_block / 2; i++) {
-    this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(1.618).c_str());
-  }
-  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
-
-  FGC_Apply(fgc);
+  for (size_t i = expected_total_blocks; i < cur_id; i += 10)
+    ASSERT_TRUE(RS::deleteDocument(ctx, ism, numToDocStr(i).c_str())) << "Failed to delete doc " << i;
+  runGC([&]() {
+    ASSERT_LT(++cur_cardinality, first_split_card);
+    for (size_t i = 0; i < docs_per_block / 2; i++)
+      this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(2.718).c_str());
+    EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks) << "Number of blocks should not change";
+    ASSERT_LT(++cur_cardinality, first_split_card);
+    expected_total_blocks++;
+    for (size_t i = 0; i < docs_per_block / 2; i++)
+      this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(1.618).c_str());
+    EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
+  });
 
   EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
-  // Refresh root/range references as tree may have changed
   root = NumericRangeTree_GetRoot(rt);
   rootRange = NumericRangeNode_GetRange(root);
   ASSERT_TRUE(rootRange);
-  // The child is aware of 1 value in the first block and one in the second,
-  // while the parent is aware of a third value in the second block and a fourth in the third.
   EXPECT_EQ(cur_cardinality, NumericRange_GetCardinality(rootRange));
 
   /*
    * Scenario 3: Taking the child last block, without any parent changes.
    */
 
-  FGC_WaitBeforeFork(fgc);
-
-  // Delete the entire second block of documents.
-  for (size_t i = docs_per_block + 1; i <= 2 * docs_per_block; i++) {
+  for (size_t i = docs_per_block + 1; i <= 2 * docs_per_block; i++)
     RS::deleteDocument(ctx, ism, numToDocStr(i).c_str());
-  }
   EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
-
-  FGC_ForkAndWaitBeforeApply(fgc);
-  FGC_Apply(fgc);
+  runGC();
 
   expected_total_blocks--;
   EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The ForkGC test suite controlled the GC lifecycle using a
   background GC thread and a shared-state handshake built on `volatile`
   spin-waits. `volatile` provides no memory-ordering guarantees under the
   C11/C++11 memory model — making the handshake formally undefined behaviour.
   ThreadSanitizer correctly flagged these as data races, so three functions
   carried `NO_TSAN_CHECK` annotations to silence it rather than fix the root
   cause. The handshake was exposed as three public functions in production code
   — `FGC_WaitBeforeFork`, `FGC_ForkAndWaitBeforeApply`, and `FGC_Apply` —
   along with matching pause-state fields on the `ForkGC` struct, all of which
   existed solely for tests.

2. **Change:** Replaced the entire mechanism with a minimal `FGCHook` struct
   (one callback + privdata) and a new public entry point `FGC_RunCycle(gc,
   force, hook)`.
   Tests call `FGC_RunCycle` directly with a single `beforeApply`
   callback — the only lifecycle point where tests genuinely need to inject
   behaviour. Mutations made after the fork are invisible to the child, which
   is the invariant being tested. Everything previously done via
   `FGC_WaitBeforeFork` can simply be placed before the `FGC_RunCycle` call,
   since the call is synchronous and any state set up beforehand is already
   visible to the child. That hook therefore wasn't needed at all; it existed
   only because the thread-based design required explicit synchronisation at
   every phase. The production path registers a thin `periodicCb` wrapper that
   calls `FGC_RunCycle(gc, force, NULL)`.

3. **Outcome:** `FGC_WaitBeforeFork`, `FGC_ForkAndWaitBeforeApply`, and
   `FGC_Apply` are gone. All test-only synchronisation infrastructure is removed
   from production code. The `ForkGC` struct loses its pause-state fields.
   `NO_TSAN_CHECK` annotations are gone. Each test reads as a linear sequence
   of setup → `runGC(beforeApply)` → assertions, with no background thread, no
   shared-state protocol, and no helper library.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/fork_gc.h` — removed `FGC_WaitBeforeFork`, `FGC_ForkAndWaitBeforeApply`,
   `FGC_Apply`, and pause-state fields; added `FGCHook` and `FGC_RunCycle`
2. `src/fork_gc/fork_gc.c` — `periodicCb` becomes a one-line wrapper around
   `FGC_RunCycle`; the `beforeApply` hook replaces the spin-wait pause block
3. `tests/cpptests/test_cpp_forkgc.cpp` — no background thread, no
   synchronisation helpers; each test calls `runGC(beforeApply)` directly

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-GC parent/apply timing in production (hook is NULL there) and removes test-only synchronization; behavior should match prior cycles but this is sensitive index/GC infrastructure.
> 
> **Overview**
> ForkGC tests no longer drive production through a **background GC thread** and a **volatile pause/exec spin-wait handshake** (`FGC_WaitBeforeFork`, `FGC_ForkAndWaitBeforeApply`, `FGC_Apply`). Those APIs, **`ForkGC` pause state fields**, and **`NO_TSAN_CHECK`** are removed from production code.
> 
> GC cycles are centralized in **`FGC_RunCycle`**, with an optional **`FGCHook.beforeApply`** callback invoked in the **parent after `fork()`** and before applying child results—so tests can mutate the index in ways the child cannot see. Production still runs GC via a thin **`periodicCb`** that calls **`FGC_RunCycle(..., NULL)`**.
> 
> ForkGC C++ tests now call **`runGC(beforeApply)`** synchronously instead of coordinating phases across threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2ab90a46a01e20207d6f4892e070580777dac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->