### PR TITLE
Fix race in `thpool.verify_init`

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -295,6 +295,15 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
     n_new_threads = n_threads;
   }
 
+  /* Publish INITIALIZED before spawning new threads. A freshly spawned thread
+   * can pick up a job already in the queue and re-enter add_work →
+   * verify_init before this call returns; if state were still UNINITIALIZED
+   * at that point, the re-entrant call would take the Case 2 branch (threads
+   * alive, state UNINITIALIZED) and push admin jobs the calling worker
+   * cannot process — deadlocking on barrier_wait_and_destroy. Setting state
+   * first makes the re-entrant call short-circuit at the top of the function. */
+  thpool_p->state = THPOOL_INITIALIZED;
+
   /* Add new threads if needed */
   if (n_new_threads > 0) {
     volatile bool started[n_new_threads];
@@ -314,7 +323,6 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
       usleep(1);
     }
   }
-  thpool_p->state = THPOOL_INITIALIZED;
 
   LOG_IF_EXISTS("verbose", "Thread pool of size %zu initialized successfully",
                 thpool_p->n_threads)

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -228,6 +228,17 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
   if (thpool_p->state == THPOOL_INITIALIZED)
     return; // Already initialized and all threads are active.
 
+  /* Pool has been disabled (e.g. WORKERS 0) — n_threads was decremented to 0
+   * and state set to UNINITIALIZED by schedule_config_reduce_threads_job.
+   * There is nothing to revive or spawn; any still-alive workers are in
+   * TERMINATE_WHEN_EMPTY state and will drain the just-pushed job before
+   * exiting. Falling into the case-2 branch below with n_threads == 0
+   * pushes `curr_num_threads_alive` TERMINATE_ASAP admin jobs and waits on
+   * a barrier that includes the calling worker if add_work was re-entered
+   * from inside a worker job — deadlocking on barrier_wait_and_destroy. */
+  if (thpool_p->n_threads == 0)
+    return;
+
   /** Else, either:
    * case 1: There are no threads alive, just add n_threads threads.
    * case 2: There are threads alive in terminate_when_empty state.


### PR DESCRIPTION
I hit a niche/boutique race in how we handle thread pools during the lazy-init period, i.e. on first job.

The race is this:
1. The main thread receives FT.HYBRID and pushes it into the workers pool.
2. This calls `add_work` to push the task into the queue and then calls `verify_init` to lazy-init the threads.
  2.1. The state is UNINITIALIZED so it spawns the threads and waits until `n_started < n_new_threads`
3. Now before the poll completes and while the state is still UNInITIALIZED, assume one of the now-spawned threads picks up the added work from the queue.
4. Now assume the task itself schedules work items in the same thread pool.
5. This scheduling calls `add_work` and again calls `verify_init`. 
6. Because the state is still `UNINITIALIZED` (since 2.1 has not yet finished) but we now have alive threads this spawns a barrier and pushes admin "revive" jobs in the queue.
7. However, the worker thread is itself counted in the count of the barrier and is stuck on it so it cannot consume its admin job, so it deadlocks.

This is seen also from the stack traces (from [this CI failure](https://github.com/RediSearch/RediSearch/actions/runs/26224850093/job/77170335107?pr=9769)):

```
  workers-2571 (dispatcher thread)
    HREQ_Execute_Callback
      RPSafeDepleter_StartDepletionAll                <----- submits work to the worker's queue
        redisearch_thpool_add_work +0xa8                        deps/thpool/thpool.c:357
          redisearch_thpool_verify_init (+0x69959b)             deps/thpool/thpool.c:227
            barrier_wait_and_destroy                            deps/thpool/barrier.c:25 (polling usleep)

  workers-6002
    thread_do → admin_job_change_state (inlined)                deps/thpool/thpool.c:994
      barrier_wait → pthread_barrier_wait (blocked, count=2)
``` 

I did not want to remove the lazy-init of the pool as the implications might be difficult to predict. As an attempt to resolve this issue in a more simple way, this change moves setting the init state to before the spawning of threads. The idea is that reentry while still in UNINITIALIZED should avoid getting into that situation. My other idea is to introduce some kind of a synchronisation primitive here (i.e. a single call to set up the threads is allow and all other calls to verify_init must wait for that single call to complete).

Note: We are seeing this now because the base branch is making a change to run the hybrid pipeline on the shard entirely in the workers pool. See #9769 and #9478.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker-thread initialization ordering; incorrect ordering could cause subtle pool lifecycle bugs, but the fix is narrowly scoped to verify_init.
> 
> **Overview**
> Fixes a **deadlock during lazy thread-pool initialization** when a worker picks up work before `verify_init` finishes and that work schedules more pool jobs (e.g. hybrid search on the workers pool).
> 
> In `redisearch_thpool_verify_init`, **`THPOOL_INITIALIZED` is set before spawning threads** instead of after the start-up wait, so a re-entrant `verify_init` returns immediately instead of taking the “threads alive but still uninitialized” path that posts admin barrier jobs the calling worker cannot run.
> 
> Adds an **early return when `n_threads == 0`** (disabled pool / thread reduction) so the same barrier path is not entered with no threads to revive, which could also deadlock if `add_work` is re-entered from a worker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c74cde44003e124f3d6cc6436e6f720b8a6e5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->