### PR TITLE
trie: move and rename __sv_equals to sparse_vector::sv_equals

### DIFF
--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -112,25 +112,13 @@ void __dfaNode_free(dfaNode *d) {
   rm_free(d);
 }
 
-int __sv_equals(sparseVector *sv1, sparseVector *sv2) {
-  if (sv1->len != sv2->len) return 0;
-
-  for (int i = 0; i < sv1->len; i++) {
-    if (sv1->entries[i].idx != sv2->entries[i].idx || sv1->entries[i].val != sv2->entries[i].val) {
-      return 0;
-    }
-  }
-
-  return 1;
-}
-
 dfaNode *__dfn_getCache(Vector *cache, sparseVector *v) {
   size_t n = Vector_Size(cache);
   for (int i = 0; i < n; i++) {
     dfaNode *dfn;
     Vector_Get(cache, i, &dfn);
 
-    if (__sv_equals(v, dfn->v)) {
+    if (sv_equals(v, dfn->v)) {
       return dfn;
     }
   }

--- a/src/trie/sparse_vector.c
+++ b/src/trie/sparse_vector.c
@@ -57,3 +57,18 @@ void sparseVector_append(sparseVector **vp, int index, int value) {
 void sparseVector_free(sparseVector *v) {
   rm_free(v);
 }
+
+// sv_equals returns 1 iff sv1 and sv2 have identical (idx, val) entry
+// sequences. The cap field is ignored — it is allocation bookkeeping,
+// not part of the vector's value.
+int sv_equals(sparseVector *sv1, sparseVector *sv2) {
+  if (sv1->len != sv2->len) return 0;
+
+  for (int i = 0; i < sv1->len; i++) {
+    if (sv1->entries[i].idx != sv2->entries[i].idx || sv1->entries[i].val != sv2->entries[i].val) {
+      return 0;
+    }
+  }
+
+  return 1;
+}

--- a/src/trie/sparse_vector.h
+++ b/src/trie/sparse_vector.h
@@ -37,4 +37,6 @@ void sparseVector_append(sparseVector **v, int index, int value);
 sparseVector *newSparseVector(int *values, int len);
 
 void sparseVector_free(sparseVector *v);
+
+int sv_equals(sparseVector *sv1, sparseVector *sv2);
 #endif


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `__sv_equals` lives in `src/trie/levenshtein.c`, where it is called from a single location (`__dfn_getCache`). It is a fundamental value-type operation on `sparseVector` and also carries a reserved-prefix `__` identifier (C standard §7.1.3).
2. **Change:** Move the function to `sparse_vector.{c,h}` alongside the other `sv_*` helpers, and rename `__sv_equals` → `sv_equals`. A short comment is added explaining that the equality check intentionally ignores the `cap` field — capacity is allocation bookkeeping, not part of the vector's value.
3. **Outcome:** Equality is now exposed as a primitive operation on `sparseVector`, with the function colocated with the type it belongs to. No behavior change; identical entry-by-entry comparison logic.

#### Which additional issues this PR fixes
None. Independent of #9783; either may merge first.

#### Main objects this PR modified
1. `src/trie/sparse_vector.{c,h}` — added `sv_equals` declaration and definition.
2. `src/trie/levenshtein.c` — removed the `__sv_equals` definition; updated the lone call site.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)