### PR TITLE
cmake: add CONFIGURE_DEPENDS to source globs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ add_subdirectory(ttl_table)
 
 #----------------------------------------------------------------------------------------------
 # Source files for the core library
-file(GLOB SOURCES
+file(GLOB SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/pipeline/*.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/aggregate/*.c"

--- a/src/coord/CMakeLists.txt
+++ b/src/coord/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(
 
 add_subdirectory(rmr)
 
-file(GLOB_RECURSE COORDINATOR_SRC *.c *.cpp)
+file(GLOB_RECURSE COORDINATOR_SRC CONFIGURE_DEPENDS *.c *.cpp)
 add_library(coordinator-core OBJECT ${COORDINATOR_SRC})
 
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `src/CMakeLists.txt` and `src/coord/CMakeLists.txt` collect sources with `file(GLOB ...)` without `CONFIGURE_DEPENDS`. CMake evaluates the glob only at configure time and caches the result, so adding, renaming, or deleting a `.c`/`.cpp` file is invisible to subsequent `make` runs. The workaround has been to invoke `./build.sh FORCE`, which deletes `CMakeCache.txt` + `CMakeFiles/` and reconfigures from scratch.

2. **Change:** Add `CONFIGURE_DEPENDS` to both glob calls. This asks CMake to re-evaluate the globs at build time via a small check target and to automatically reconfigure when the result set changes.

3. **Outcome:** `./build.sh DEBUG=1` (no `FORCE`) now picks up new and removed source files automatically. Locally verified by adding then deleting a probe file under `src/util/` and confirming the symbol appears in / disappears from `redisearch.so` without any manual reconfigure. Verified rebuilds took ~12 s each.

CMake's documentation notes that `CONFIGURE_DEPENDS` is "best effort" — it is reliable on the Makefile and Ninja generators used by this project. The build-time stat cost on the globbed directories is sub-100 ms and dwarfed by compile time.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/CMakeLists.txt` — `file(GLOB SOURCES ...)` → `file(GLOB SOURCES CONFIGURE_DEPENDS ...)`
2. `src/coord/CMakeLists.txt` — `file(GLOB_RECURSE COORDINATOR_SRC ...)` → `file(GLOB_RECURSE COORDINATOR_SRC CONFIGURE_DEPENDS ...)`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system-only change: adds `CONFIGURE_DEPENDS` to CMake source globs so new/removed `.c`/`.cpp` files trigger an automatic reconfigure; may slightly increase configure/build overhead on some generators.
> 
> **Overview**
> Improves developer build ergonomics by making CMake automatically notice added/removed/renamed source files.
> 
> Specifically, adds `CONFIGURE_DEPENDS` to the `file(GLOB ...)` in `src/CMakeLists.txt` and the `file(GLOB_RECURSE ...)` in `src/coord/CMakeLists.txt`, so builds reconfigure when the globbed source set changes (without requiring manual cache deletion/forced rebuilds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d9d743d678671acf106b4b75ba3a7ab5f41462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->