### PR TITLE
Fix FT.SYNUPDATE arity validation for SKIPINITIALSCAN without terms

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -791,7 +791,7 @@ int SynAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 /**
- * FT.SYNUPDATE <index> <group id> [SKIPINITIALSCAN] <term1> <term2> ...
+ * FT.SYNUPDATE <index> <group id> [SKIPINITIALSCAN] term1 [term2 ...]
  *
  * Update an already existing synonym group with the given terms.
  * It can be used only to add new terms to a synonym group.
@@ -799,6 +799,18 @@ int SynAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  */
 int SynUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc < 4) return RedisModule_WrongArity(ctx);
+
+  bool initialScan = true;
+  int offset = 3;
+  int loc = RMUtil_ArgIndex(SPEC_SKIPINITIALSCAN_STR, &argv[3], 1);
+  if (loc == 0) {  // if doesn't exist, `-1` is returned
+    initialScan = false;
+    offset = 4;
+  }
+
+  if (argc - offset < 1) {
+    return RedisModule_WrongArity(ctx);
+  }
 
   const char *id = RedisModule_StringPtrLen(argv[2], NULL);
 
@@ -814,14 +826,6 @@ int SynUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
   CurrentThread_SetIndexSpec(ref);
-
-  bool initialScan = true;
-  int offset = 3;
-  int loc = RMUtil_ArgIndex(SPEC_SKIPINITIALSCAN_STR, &argv[3], 1);
-  if (loc == 0) {  // if doesn't exist, `-1` is returned
-    initialScan = false;
-    offset = 4;
-  }
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   RedisSearchCtx_LockSpecWrite(&sctx);

--- a/tests/pytests/test_synonyms.py
+++ b/tests/pytests/test_synonyms.py
@@ -99,6 +99,9 @@ def testSynonymUpdateWorngArity(env):
     env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child')
     with env.assertResponseError(contained='wrong number of arguments'):
         env.cmd('ft.synupdate', 'idx', 'id1')
+    # SKIPINITIALSCAN alone (no terms) must be rejected:
+    with env.assertResponseError(contained='wrong number of arguments'):
+        env.cmd('ft.synupdate', 'idx', 'id1', 'SKIPINITIALSCAN')
 
 def testSynonymUpdateUnknownIndex(env):
     env.expect('ft.synupdate', 'idx', '0', 'child').error().contains('SEARCH_INDEX_NOT_FOUND Index not found')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.SYNUPDATE <index> <group id> SKIPINITIALSCAN` without any synonym terms was accepted and reached the synonym update path.
2. Change: Validate that at least one term is provided after the optional `SKIPINITIALSCAN` argument.
3. Outcome: The command now returns a wrong-arity error for `SKIPINITIALSCAN` without terms, matching the documented syntax and preventing an empty synonym update.


#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Bug Fix: Fixed `FT.SYNUPDATE` to correctly reject `SKIPINITIALSCAN` without any synonym terms, returning a wrong-arity error instead of silently accepting an empty update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small arity-validation change in `FT.SYNUPDATE` plus a targeted test update; behavior only changes for an invalid/edge-case invocation.
> 
> **Overview**
> Fixes `FT.SYNUPDATE` to **require at least one synonym term** after the optional `SKIPINITIALSCAN` flag, returning a wrong-arity error instead of proceeding with an empty update.
> 
> Updates the synonyms Python tests to assert that `FT.SYNUPDATE <idx> <id> SKIPINITIALSCAN` (with no terms) is rejected, and clarifies the command syntax comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f229c6e7b928fedc0621f7f12aafba5f09a2820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->