### PR TITLE
MOD-15792: Reduce duplicate automated code review comments

### DIFF
--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -25,7 +25,22 @@ If a path points to a directory, review all `.c` and `.h` files in that director
 
 **No argument:** default to reviewing uncommitted working-tree changes (`git diff`).
 
+**Optional flags:**
+- `--include-nits`: include minor style, formatting, naming, and preference comments
+  as non-blocking suggestions. Nits must still be actionable, non-duplicate, and grouped
+  by root cause when the same pattern appears in multiple places.
+
 ## Instructions
+
+### 0. Avoid duplicate PR comments
+
+When reviewing a GitHub PR:
+
+- First inspect existing PR comments, review threads, and prior bot comments when available.
+- Treat an issue as already reported if an existing comment identifies the same root cause, even if it points to a different line.
+- Do not post or include duplicate findings for issues that were already raised.
+- If a previous comment is still accurate, do not restate it. Only mention it again if the new diff changes the issue, invalidates the previous fix, or introduces materially new evidence.
+- If the same issue appears in multiple places, report it once on the clearest example and state that the same pattern may apply elsewhere.
 
 ### 1. Collect the code to review
 
@@ -129,6 +144,10 @@ Only applies when changes touch `src/rdb.c` or serialization logic:
 
 #### 2h. Style and conventions
 
+- By default, only report style and convention issues when they violate an explicit
+  project rule and would block maintainability. If `--include-nits` is requested,
+  minor style, formatting, naming, or preference issues may be reported as
+  non-blocking suggestions.
 - Code follows `.clang-format` conventions (2-space indent, 100-col limit, attached braces).
 - Public functions use `ModuleName_FunctionName` naming.
 - License header is present on new files.
@@ -146,12 +165,18 @@ Only applies when reviewing a PR (not files or commits directly):
 
 ### 3. Emit the report
 
-Present findings grouped by check (2a through 2i). For each group, list the
-violations or state "No issues found."
+Report only actionable, non-duplicate findings.
 
-At the end, provide a summary:
-- Total number of violations by severity (blocking vs. suggestion).
-- Whether the change is **ready to merge** or **needs revision**.
+For each finding include:
+- Severity: blocking or suggestion
+- File and line/range
+- Rule violated
+- Why it matters
+- Suggested fix
 
-Blocking violations: any issue in 2a, 2b, 2c, 2d, 2e, or 2f.
-Suggestions: issues in 2g (null safety), 2h (style), and 2i (PR description).
+Omit checklist sections with no findings. Do not include "No issues found" for every section.
+
+At the end, provide a short summary:
+- Total blocking findings
+- Total suggestions
+- Whether the change is **ready to merge** or **needs revision**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,20 @@ src/redisearch_rs/
     └── triemap_ffi/      # C-callable wrapper
 ```
 
+## Review guidelines
+
+When reviewing pull requests:
+
+- Invoke [/code-review](.skills/code-review/SKILL.md) for C code changes.
+- Invoke [/rust-review](.skills/rust-review/SKILL.md) for Rust code changes.
+- Before posting any review comment, inspect existing PR comments, review threads, and prior bot comments when available.
+- Do not post a duplicate comment if the same issue has already been raised, even if the code still contains the issue.
+- If an earlier comment is still relevant, avoid restating it. Only add a new comment when there is materially new information, a changed code location, or a distinct issue.
+- Prefer one comment per root cause. If the same pattern appears in several places, comment on the clearest instance and mention the pattern briefly.
+- Keep automated review comments high-signal: prioritize correctness, crashes, memory safety, undefined behavior, data loss, security, and clear test/CI failures.
+- Do not comment on minor style, formatting, naming, or preference issues by default unless they violate an explicit project rule and would block maintainability.
+- If the review explicitly requests nits, style comments, or `--include-nits`, minor findings may be reported as non-blocking suggestions, but must still avoid duplicates and should be grouped by root cause.
+
 ## Common Workflows
 
 When implementing changes that may become a PR, first check the current checkout. If it is dirty,


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Automated review guidance did not require checking existing PR comments before posting findings, so bot reviews could repeat issues already raised.
2. Change: Add repository-level review guidelines, duplicate-suppression rules for the C `code-review` skill, opt-in `--include-nits` behavior, and tighter report output guidance.
3. Outcome: Automated review comments should be more focused, avoid duplicate findings, and still allow minor nits when explicitly requested.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `AGENTS.md`
2. `.skills/code-review/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Testing

Documentation-only change. Verified with `git diff --check -- AGENTS.md .skills/code-review/SKILL.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that adjust automated review guidance; main risk is altering reviewer/bot behavior (potentially suppressing useful repeated reminders) rather than affecting runtime code.
> 
> **Overview**
> Updates C review skill guidance to **suppress duplicate PR findings** by requiring reviewers/bots to check existing threads first, report one comment per root cause, and avoid repeating still-valid issues.
> 
> Adds an opt-in `--include-nits` mode for minor style/preference feedback, and tightens report output requirements to emit only actionable findings (with severity, location, rule, rationale, fix) while omitting empty checklist sections.
> 
> Adds repo-level PR review guidelines in `AGENTS.md` mirroring the duplicate-avoidance and high-signal commenting expectations across C and Rust reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 679a4bc38b3a4404577a7551071074937447e326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->