### PR TITLE
string.c: remove redundant MAX macro, add explicit sys/param.h include

### DIFF
--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -19,11 +19,11 @@
 #include "query_term_ffi.h"
 
 #include <ctype.h>
+#include <sys/param.h>
 
 #define STRING_BLOCK_SIZE 512
 #define FMT_OUT_STR_MIN_PREALLOC 8
 #define FMT_OUT_STR_MAX_PREALLOC (1024 * 1024)
-#define MAX(i, j) (((i) > (j)) ? (i) : (j))
 
 static int func_matchedTerms(ExprEval *ctx, RSValue **argv, size_t argc, RSValue *result) {
   int maxTerms = 100;


### PR DESCRIPTION
Fix "‘MAX’ redefined" warning when building with clang.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time macro/include cleanup only; no runtime or API changes.
> 
> **Overview**
> Removes a **local `MAX` macro** in `string.c` that duplicated logic already available via `util/minmax.h` and could trigger a **clang “`MAX` redefined”** warning when system headers also define `MAX`.
> 
> Adds an explicit **`#include <sys/param.h>`** so platform `MAX`/`MIN` are available in a controlled order relative to `minmax.h`’s guarded definitions. **No behavior change** to string aggregate functions such as `substr`—only how the macro is sourced at compile time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d7c92db69354f760df43e17233ca85212f56fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->