### PR TITLE
[MOD-15522] Cache atom count in WildcardPattern

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,deps/*,*.csv,./srcutil/*,srcutil/*,./bin/*,bin/*,./sbin/*,sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py,tests/ctests/test_trie.c,src/redisearch_rs/query_eval/tests/integration/string_utils/*
+skip = .git,./deps/*,deps/*,*.csv,./srcutil/*,srcutil/*,./bin/*,bin/*,./sbin/*,sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/rqe_wildcard/tests/integration/*,src/redisearch_rs/rqe_wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py,tests/ctests/test_trie.c,src/redisearch_rs/query_eval/tests/integration/string_utils/*
 
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt

--- a/src/redisearch_rs/rqe_wildcard/src/fmt.rs
+++ b/src/redisearch_rs/rqe_wildcard/src/fmt.rs
@@ -46,6 +46,7 @@ impl std::fmt::Debug for WildcardPattern<'_> {
         f.debug_struct("WildcardPattern")
             .field("tokens", &self.tokens)
             .field("expected_length", &self.expected_length)
+            .field("atom_count", &self.atom_count())
             .finish()
     }
 }

--- a/src/redisearch_rs/rqe_wildcard/src/lib.rs
+++ b/src/redisearch_rs/rqe_wildcard/src/lib.rs
@@ -68,6 +68,11 @@ pub struct WildcardPattern<'pattern> {
     /// This can be used as an optimization to short-circuit the matching process
     /// early on if the input is longer than the expected length.
     expected_length: Option<usize>,
+    /// Number of "atoms" in the pattern, where one atom is the smallest matchable
+    /// unit produced by [`Self::parse`]: either a single byte from a `Literal`
+    /// token or a `?` / `*` token. Maintained on the fly by `parse` so callers
+    /// (e.g. NFA-size dispatchers) don't have to re-walk `tokens`.
+    atom_count: usize,
 }
 
 impl<'pattern> WildcardPattern<'pattern> {
@@ -121,6 +126,11 @@ impl<'pattern> WildcardPattern<'pattern> {
         let mut tokens: Vec<Token<'pattern>> = Vec::new();
 
         let mut expected_length = Some(pattern.len());
+        // Maintained alongside `tokens`: every branch below that contributes
+        // one matchable unit (`?`, `*`, or a single literal byte — whether
+        // it starts a fresh `Literal` or extends an existing one) bumps this
+        // by one. `\` and `**` simplifications add nothing.
+        let mut atom_count: usize = 0;
         let mut pattern_iter = pattern.iter().copied().enumerate().peekable();
 
         let mut escape_next = false;
@@ -139,7 +149,10 @@ impl<'pattern> WildcardPattern<'pattern> {
                     // e.g. `*??` becomes `??*`, `*?*?*` becomes `??*`.
                     loop {
                         match pattern_iter.peek().map(|(_, c)| c) {
-                            Some(b'?') => tokens.push(Token::One),
+                            Some(b'?') => {
+                                tokens.push(Token::One);
+                                atom_count += 1;
+                            }
                             Some(b'*') => {}
                             _ => break,
                         }
@@ -147,33 +160,63 @@ impl<'pattern> WildcardPattern<'pattern> {
                     }
 
                     tokens.push(Token::Any);
+                    atom_count += 1;
                     expected_length = None;
                 }
                 (b'*', _, false) => {
                     tokens.push(Token::Any);
+                    atom_count += 1;
                     expected_length = None;
                 }
-                (b'?', _, false) => tokens.push(Token::One),
+                (b'?', _, false) => {
+                    tokens.push(Token::One);
+                    atom_count += 1;
+                }
                 (_, _, true) => {
                     // Handle escaped characters by starting a new `Literal` token
                     tokens.push(Token::Literal(&pattern[i..i + 1]));
+                    atom_count += 1;
                 }
-                _ => match tokens.last_mut() {
-                    // Literal encountered. Either start a new `Literal` token or extend the last one.
-                    Some(Token::Literal(chunk)) => {
-                        let chunk_len = chunk.len();
-                        let chunk_start = i - chunk_len;
-                        *chunk = &pattern[chunk_start..chunk_start + chunk_len + 1];
+                _ => {
+                    match tokens.last_mut() {
+                        // Literal encountered. Either start a new `Literal` token or extend the last one.
+                        Some(Token::Literal(chunk)) => {
+                            let chunk_len = chunk.len();
+                            let chunk_start = i - chunk_len;
+                            *chunk = &pattern[chunk_start..chunk_start + chunk_len + 1];
+                        }
+                        _ => tokens.push(Token::Literal(&pattern[i..i + 1])),
                     }
-                    _ => tokens.push(Token::Literal(&pattern[i..i + 1])),
-                },
+                    atom_count += 1;
+                }
             }
             escape_next = false;
+        }
+
+        // With debug assertions on, recompute the count from the final
+        // `tokens` and check it against the inline-maintained value.
+        // Guards against future edits to the match arms above that
+        // forget to bump `atom_count` alongside a push. Stripped in
+        // release.
+        #[cfg(debug_assertions)]
+        {
+            let recomputed: usize = tokens
+                .iter()
+                .map(|t| match t {
+                    Token::Literal(bytes) => bytes.len(),
+                    Token::One | Token::Any => 1,
+                })
+                .sum();
+            debug_assert_eq!(
+                atom_count, recomputed,
+                "WildcardPattern::atom_count is out of sync with `tokens`",
+            );
         }
 
         Self {
             tokens,
             expected_length,
+            atom_count,
         }
     }
 
@@ -297,6 +340,17 @@ impl<'pattern> WildcardPattern<'pattern> {
     /// it contains at least one wildcard).
     pub const fn expected_length(&self) -> Option<usize> {
         self.expected_length
+    }
+
+    /// The number of "atoms" in the pattern: every `?`, every `*`, and one
+    /// per byte inside any `Literal` token. Cached during [`Self::parse`],
+    /// so this is O(1).
+    ///
+    /// Useful for downstream consumers that need to size data structures
+    /// proportionally to the pattern (e.g. picking the right bitset width
+    /// for a wildcard NFA).
+    pub const fn atom_count(&self) -> usize {
+        self.atom_count
     }
 }
 

--- a/src/redisearch_rs/rqe_wildcard/tests/integration/fmt.rs
+++ b/src/redisearch_rs/rqe_wildcard/tests/integration/fmt.rs
@@ -23,6 +23,7 @@ fn test_wildcard_pattern_debug() {
         Token::Literal(br"baz"),
     ],
     expected_length: None,
+    atom_count: 11,
 }"#
     );
 }


### PR DESCRIPTION
## Describe the changes in the pull request

First PR in the `automaton-*` stack.

1. **Current**: `WildcardPattern::parse` returns the parsed token list; callers that need the total number of "atoms" (`?`, `*`, and per-byte literal positions) re-walk `tokens`.
2. **Change**: Maintain `atom_count` inline during `parse`, cache it on `WildcardPattern`, expose `WildcardPattern::atom_count()`, and surface it in `Debug`. A debug-assertion at the end of `parse` guards against future match arms that forget to bump the counter.
3. **Outcome**: O(1) atom-count queries, ready for downstream NFA-size dispatchers in later PRs in the stack.

#### Which additional issues this PR fixes
1. MOD-15522

#### Main objects this PR modified
1. `rqe_wildcard::WildcardPattern`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal parse bookkeeping and a new accessor; matching behavior is unchanged.
> 
> **Overview**
> **`WildcardPattern`** now tracks an **`atom_count`** during **`parse`**: one atom per `?`, per `*`, and per literal byte (including when literals are coalesced). Callers can use the new **`atom_count()`** accessor in O(1) instead of re-scanning **`tokens`**, which the PR positions for later NFA sizing in the automaton stack.
> 
> Parse match arms increment the counter alongside token pushes; a **debug-only** recompute **`debug_assert_eq!`** guards drift. **`Debug`** output includes **`atom_count`**, and the integration snapshot test is updated. **`.codespellrc`** skip paths are adjusted for the **`rqe_wildcard`** crate layout (replacing **`wildcard`** paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6a43b8ecd3cc82a33a6081f04c701121b52ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->