### PR TITLE
[MOD-15522] Add streaming-automaton trie traversal framework

### DIFF
--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Generic iterator that drives an [`Automaton`] over a trie.
+//!
+//! Depth-first walk that carries the post-edge automaton state on its
+//! stack. At each node the driver consults [`Automaton::classify`] and
+//! branches on the returned [`StateClass`]; see that enum's doc for the
+//! four cases.
+
+use super::{Automaton, StateClass};
+use crate::trie_map::node::Node;
+use lending_iterator::prelude::*;
+
+/// Iterator that traverses a trie under the control of a streaming
+/// [`Automaton`].
+///
+/// Every byte stored in the trie is run through the automaton
+/// at most once per query, no matter how many keys share that byte.
+pub struct AutomatonIter<'tm, Data, A: Automaton> {
+    stack: Vec<Frame<'tm, Data, A::State>>,
+    /// The automaton state is **cloned** once per child when the current
+    /// stack frame is either in [`StateClass::Live`] or
+    /// [`StateClass::LiveAccepting`].
+    automaton: A,
+    /// Concatenated labels from the trie root to the current node. The
+    /// driver truncates and re-extends this in place as it descends and
+    /// backtracks, instead of allocating a fresh `Vec` per yield.
+    key: Vec<u8>,
+}
+
+/// One pending visit on the traversal stack.
+///
+/// `parent_key_len` is the length the iterator's `key` should have just
+/// before this node is processed — popping a frame truncates `key` to
+/// that length and then re-extends with `node.label()`. That folds DFS
+/// backtracking into the same `pop` that pulls the next frame, so we
+/// don't need separate "go back up" frames. (Stored as `u32` rather
+/// than `usize` to keep the frame compact; caps key length at 4 GiB.)
+///
+/// Two variants encode whether the automaton is still consulted at
+/// each descendant ([`Visit`]) or whether the subtree has already been
+/// declared a universal match by [`StateClass::Permanent`] on some
+/// ancestor ([`PermanentVisit`], no state carried — saves a clone per
+/// descendant and skips redundant `classify` calls).
+///
+/// [`Visit`]: Frame::Visit
+/// [`PermanentVisit`]: Frame::PermanentVisit
+enum Frame<'tm, Data, S> {
+    Visit {
+        node: &'tm Node<Data>,
+        state: S,
+        parent_key_len: u32,
+    },
+    PermanentVisit {
+        node: &'tm Node<Data>,
+        parent_key_len: u32,
+    },
+}
+
+impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
+    #[expect(dead_code, reason = "no callers yet in this PR")]
+    pub(crate) const fn empty(automaton: A) -> Self {
+        Self {
+            stack: Vec::new(),
+            automaton,
+            key: Vec::new(),
+        }
+    }
+
+    /// Construct an iterator that starts at `start_node`, treating `key_prefix`
+    /// as the trie path already consumed before reaching `start_node`'s parent.
+    ///
+    /// The automaton is advanced through `key_prefix + start_node.label()`
+    /// before the first frame is pushed, so the state on the stack reflects
+    /// the full path from the trie root.
+    ///
+    /// For a top-level traversal, pass the trie root with an empty prefix; for
+    /// a subtree jump (e.g., the literal-prefix shortcut), pass the subroot
+    /// with the path-to-its-parent.
+    #[expect(dead_code, reason = "no callers yet in this PR")]
+    pub(crate) fn new(
+        start_node: Option<&'tm Node<Data>>,
+        key_prefix: Vec<u8>,
+        automaton: A,
+    ) -> Self {
+        let mut iter = Self {
+            stack: Vec::new(),
+            automaton,
+            key: key_prefix,
+        };
+        if let Some(node) = start_node {
+            // Sequence the calls: `step_all` takes `&mut automaton`, so we
+            // can't chain it with `automaton.start()` (which holds an `&`
+            // borrow on the same field) on a single line.
+            let start = iter.automaton.start();
+            if let Some(pre_node) = iter.automaton.step_all(&start, &iter.key)
+                && let Some(state) = iter.automaton.step_all(&pre_node, node.label())
+            {
+                // The first frame's `parent_key_len` is the prefix we
+                // already have — popping it will truncate to that length
+                // (a no-op the first time) and re-extend with `node.label()`.
+                debug_assert!(iter.key.len() <= u32::MAX as usize);
+                let parent_key_len = iter.key.len() as u32;
+                iter.stack.push(Frame::Visit {
+                    node,
+                    state,
+                    parent_key_len,
+                });
+            }
+        }
+        iter
+    }
+
+    /// Advance to the next matching entry, returning a reference to its data.
+    pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
+        loop {
+            match self.stack.pop()? {
+                Frame::Visit {
+                    node,
+                    state,
+                    parent_key_len,
+                } => {
+                    // Restore the key to this node's parent depth, then
+                    // extend with its label. The truncate handles
+                    // backtracking inline — we don't push a separate revisit
+                    // frame for the way back up the stack.
+                    self.key.truncate(parent_key_len as usize);
+                    self.key.extend(node.label());
+                    debug_assert!(self.key.len() <= u32::MAX as usize);
+                    let key_len_after_node = self.key.len() as u32;
+
+                    let class = self.automaton.classify(&state);
+                    match class {
+                        StateClass::Permanent => {
+                            // Per `StateClass::Permanent`'s contract, the property is closed
+                            // under descent: every descendant is guaranteed accepting regardless
+                            // of label. We therefore never re-`classify` below this point — push
+                            // children as `PermanentVisit`, skipping both `state.clone()` and the
+                            // redundant `classify` call.
+                            for child in node.children().iter().rev() {
+                                self.stack.push(Frame::PermanentVisit {
+                                    node: child,
+                                    parent_key_len: key_len_after_node,
+                                });
+                            }
+                        }
+                        StateClass::Terminal => {
+                            // Sink: no descendant can match. Skip children.
+                        }
+                        StateClass::Live | StateClass::LiveAccepting => {
+                            // Standard path: step each child's label, push
+                            // survivors.
+                            for child in node.children().iter().rev() {
+                                if let Some(child_state) =
+                                    self.automaton.step_all(&state, child.label())
+                                {
+                                    self.stack.push(Frame::Visit {
+                                        node: child,
+                                        state: child_state,
+                                        parent_key_len: key_len_after_node,
+                                    });
+                                }
+                            }
+                        }
+                    }
+
+                    if class.is_accepting()
+                        && let Some(data) = node.data()
+                    {
+                        return Some(data);
+                    }
+                }
+                // `StateClass::Permanent` is closed under descent by contract, so
+                // every descendant inherits permanent-accepting status. Re-push as
+                // `PermanentVisit` without consulting the automaton.
+                Frame::PermanentVisit {
+                    node,
+                    parent_key_len,
+                } => {
+                    self.key.truncate(parent_key_len as usize);
+                    self.key.extend(node.label());
+                    debug_assert!(self.key.len() <= u32::MAX as usize);
+                    let key_len_after_node = self.key.len() as u32;
+
+                    // Every descendant is also in permanent mode — push as
+                    // `PermanentVisit` too.
+                    for child in node.children().iter().rev() {
+                        self.stack.push(Frame::PermanentVisit {
+                            node: child,
+                            parent_key_len: key_len_after_node,
+                        });
+                    }
+
+                    // In permanent mode the state is always accepting, so
+                    // any node with data yields.
+                    if let Some(data) = node.data() {
+                        return Some(data);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn key(&self) -> &[u8] {
+        &self.key
+    }
+}
+
+impl<'tm, Data, A: Automaton> Iterator for AutomatonIter<'tm, Data, A> {
+    type Item = (Vec<u8>, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.advance().map(|d| (self.key.clone(), d))
+    }
+}
+
+/// Lending-iterator wrapper around [`AutomatonIter`] that borrows the current
+/// key on each `next` call rather than cloning it.
+pub struct AutomatonLendingIter<'tm, Data, A: Automaton>(AutomatonIter<'tm, Data, A>);
+
+impl<'tm, Data, A: Automaton> From<AutomatonIter<'tm, Data, A>>
+    for AutomatonLendingIter<'tm, Data, A>
+{
+    fn from(iter: AutomatonIter<'tm, Data, A>) -> Self {
+        AutomatonLendingIter(iter)
+    }
+}
+
+#[gat]
+impl<'tm, Data, A: Automaton> LendingIterator for AutomatonLendingIter<'tm, Data, A> {
+    type Item<'next>
+    where
+        Self: 'next,
+    = (&'next [u8], &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        let item = self.0.advance()?;
+        Some((self.0.key(), item))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/mod.rs
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Streaming-automaton trie traversal.
+//!
+//! Walks a trie under the control of a byte-streaming state machine —
+//! the [`Automaton`] — instead of materialising each candidate key and
+//! re-testing it against a predicate (the
+//! [`TraversalFilter`](super::filter::TraversalFilter) approach). The
+//! payoff is *shared-prefix reuse*: the automaton state at any trie
+//! node is computed once, then reused for every descendant, so each
+//! byte of stored content costs at most one transition per query.
+//!
+//! ## How it works
+//!
+//! The [`Automaton`] trait abstracts the state machine. An
+//! implementation gives the driver three things —
+//!
+//! - [`start`](Automaton::start): the initial state.
+//! - [`step`](Automaton::step) / [`step_all`](Automaton::step_all):
+//!   advance the state by one byte or by a slice (a trie edge label).
+//!   Returning `None` from `step_all` tells the driver the subtree is
+//!   dead and can be pruned.
+//! - [`classify`](Automaton::classify): tag the current state with a
+//!   [`StateClass`] that tells the driver whether to yield the current
+//!   key and whether to keep recursing.
+//!
+//! [`driver::AutomatonIter`] is the generic iterator that drives any
+//! `Automaton` over a trie via a DFS that carries the post-edge state
+//! on its stack.
+//!
+//! ## Layout
+//!
+//! - This module: the [`Automaton`] trait and the [`StateClass`] enum.
+//! - [`driver`]: [`AutomatonIter`] and its lending variant.
+
+pub mod driver;
+
+pub use driver::{AutomatonIter, AutomatonLendingIter};
+
+/// Tells the driver what to do at the current trie node.
+///
+/// Returned from [`Automaton::classify`] once per node visit. The two
+/// non-`Live*` variants are *short-circuits*: they let the automaton
+/// tell the driver "I already know what every descendant of this node
+/// will look like, you don't need to step them through me."
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum StateClass {
+    /// Not accepting (no full match here). Step each child's edge label
+    /// through the automaton and recurse into the survivors; prune dead
+    /// children.
+    ///
+    /// Example: a pattern like `a*y` doesn't match `an` but it matches
+    /// `any`, one of its descendants. We shouldn't yield `an`,
+    /// but we must continue the traversal to find all matches.
+    Live,
+    /// Accepting (the current key matches the pattern). Yield it, then
+    /// continue stepping children normally — descendants may also match.
+    ///
+    /// Example: a pattern like `a*y` matches `any` but would also match
+    /// `anyany`, one of its descendants. We can't stop the traversal at
+    /// `any` if we want to find all matches.
+    LiveAccepting,
+    /// Accepting *and* every descendant is also guaranteed to match
+    /// regardless of label content. The driver yields the current key
+    /// and pushes every descendant without further `step_all` calls.
+    ///
+    /// Example: a wildcard pattern ending in `*`, after the trailing
+    /// `*`'s position has become permanently active.
+    Permanent,
+    /// Accepting but no outgoing transition is live — the state is a
+    /// sink. The driver yields the current key and prunes the whole
+    /// subtree.
+    ///
+    /// Example: the accept state of a fixed-length pattern.
+    Terminal,
+}
+
+impl StateClass {
+    /// Whether this class represents an accepting state (a hit to yield).
+    pub const fn is_accepting(self) -> bool {
+        matches!(self, Self::LiveAccepting | Self::Permanent | Self::Terminal)
+    }
+}
+
+/// A byte-streaming state machine that the trie driver can run.
+///
+/// Implementations expose a `start` state and a single-byte transition;
+/// the driver advances the state along each trie edge and asks
+/// [`Self::classify`] what to do at each node. See the module doc for
+/// how this fits with [`AutomatonIter`].
+///
+/// `step` / `step_all` take `&mut self` so implementations can recycle
+/// scratch buffers across transitions. The driver owns the automaton by
+/// value and never calls these concurrently, so the mutable receiver
+/// isn't a multi-borrow concern in practice.
+pub trait Automaton {
+    /// State carried across byte transitions and trie stack frames. The
+    /// driver clones it at branch points, so keep it cheap to clone.
+    type State: Clone;
+
+    /// The starting state, before any bytes have been consumed.
+    fn start(&self) -> Self::State;
+
+    /// Advance the state by one byte. `None` means the transition died
+    /// — the driver prunes the subtree.
+    fn step(&mut self, state: &Self::State, byte: u8) -> Option<Self::State>;
+
+    /// Tag `state` with how the driver should proceed at this node. See
+    /// [`StateClass`].
+    fn classify(&self, state: &Self::State) -> StateClass;
+
+    /// Step through a slice of bytes (a trie edge label), returning the
+    /// final state or `None` if any byte kills the transition.
+    ///
+    /// The default impl walks bytes through [`Self::step`]; implementers
+    /// can override to recycle scratch buffers across the bytes of a
+    /// multi-byte label.
+    fn step_all(&mut self, state: &Self::State, bytes: &[u8]) -> Option<Self::State> {
+        let mut s = state.clone();
+        for &b in bytes {
+            s = self.step(&s, b)?;
+        }
+        Some(s)
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/mod.rs
@@ -8,6 +8,7 @@
 */
 
 //! Different iterators to traverse a [`TrieMap`](crate::TrieMap).
+pub mod automaton;
 mod contains;
 pub mod filter;
 mod into_values;
@@ -20,6 +21,7 @@ mod unfiltered;
 mod values;
 mod wildcard;
 
+pub use automaton::{Automaton, AutomatonIter, AutomatonLendingIter, StateClass};
 pub use contains::ContainsIter;
 pub use into_values::IntoValues;
 pub use lending::LendingIter;


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on #9801.

1. **Current**: Trie traversals use `TraversalFilter` — each candidate key is materialised and re-tested against a predicate, so shared prefixes are re-tested per key.
2. **Change**: Introduce an `Automaton` trait + DFS driver (`AutomatonIter` / `AutomatonLendingIter`). A byte-streaming state machine walks the trie, sharing the post-edge state across descendants so each byte of stored content costs at most one transition per query. `StateClass` lets the automaton short-circuit terminal or permanently-accepting subtrees.
3. **Outcome**: Reusable infrastructure for any byte-level automaton; first user (the wildcard NFA) lands in the next PR.

#### Which additional issues this PR fixes
1. MOD-15522

#### Main objects this PR modified
1. `trie_rs::iter::automaton::{Automaton, StateClass, AutomatonIter, AutomatonLendingIter}` (new)

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New iterator infrastructure only; existing TraversalFilter paths are untouched and integration (e.g. wildcard NFA) is deferred.
> 
> **Overview**
> Adds a new **`iter::automaton`** module so trie walks can be driven by a byte-streaming state machine instead of materializing keys and re-running **`TraversalFilter`** predicates.
> 
> The **`Automaton`** trait defines **`start`**, **`step` / `step_all`**, and **`classify`**; **`StateClass`** (**`Live`**, **`LiveAccepting`**, **`Permanent`**, **`Terminal`**) lets implementations short-circuit whole subtrees (e.g. trailing `*` vs fixed-length accept). **`AutomatonIter`** runs a DFS with automaton state on the stack, reuses one in-place **`key`** buffer for backtracking, and uses **`PermanentVisit`** frames to skip redundant **`classify`** / clones under universal matches. **`AutomatonLendingIter`** exposes the current key by borrow. Constructors are **`pub(crate)`** with no in-crate callers yet; **`iter/mod.rs`** re-exports the new public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752e494520068b93f6d10987ecff47d867724246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->