### PR TITLE
[MOD-15522] Expose specialized wildcard iterators on TrieMap

### DIFF
--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
@@ -65,7 +65,6 @@ enum Frame<'tm, Data, S> {
 }
 
 impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
-    #[expect(dead_code, reason = "no callers yet in this PR")]
     pub(crate) const fn empty(automaton: A) -> Self {
         Self {
             stack: Vec::new(),
@@ -84,7 +83,6 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
     /// For a top-level traversal, pass the trie root with an empty prefix; for
     /// a subtree jump (e.g., the literal-prefix shortcut), pass the subroot
     /// with the path-to-its-parent.
-    #[expect(dead_code, reason = "no callers yet in this PR")]
     pub(crate) fn new(
         start_node: Option<&'tm Node<Data>>,
         key_prefix: Vec<u8>,

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/nfa.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/nfa.rs
@@ -190,10 +190,7 @@ impl<S: NfaBitSet> WildcardNfa<S> {
     /// Compile a pattern into an NFA backed by `S`.
     ///
     /// Callers should match the width to the atom count: `S = u64` for
-    /// ≤ 63 atoms, `S = u128` for ≤ 127. Past 127 the NFA backends lose
-    /// to the per-key filter fallback, so route
-    /// through [`super::WildcardSpecializedIter`] — it picks the right
-    /// backend automatically.
+    /// ≤ 63 atoms, `S = u128` for ≤ 127.
     ///
     /// # Panics
     ///
@@ -205,7 +202,7 @@ impl<S: NfaBitSet> WildcardNfa<S> {
     /// release builds (the underlying shift wraps modulo the type width
     /// in Rust). Going through [`super::WildcardSpecializedIter`]
     /// guarantees this never fires.
-    pub fn compile(pattern: &WildcardPattern<'_>) -> Self {
+    pub(crate) fn compile(pattern: &WildcardPattern<'_>) -> Self {
         assert!(
             pattern.atom_count() < S::CAPACITY,
             "WildcardNfa backend has capacity {} but pattern needs {} atoms; route through WildcardSpecializedIter for automatic backend selection",

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -15,8 +15,8 @@ mod utils;
 
 use crate::trie_map::{
     iter::{
-        Automaton, AutomatonIter, ContainsIter, IntoValues, Iter, LendingIter, NfaBitSet,
-        PrefixesIter, RangeFilter, RangeIter, Values, WildcardBackend, WildcardIter, WildcardNfa,
+        Automaton, AutomatonIter, ContainsIter, IntoValues, Iter, LendingIter, PrefixesIter,
+        RangeFilter, RangeIter, Values, WildcardBackend, WildcardIter, WildcardNfa,
         WildcardSpecializedIter, filter::VisitAll,
     },
     node::Node,
@@ -220,21 +220,6 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterate over all trie entries whose key matches the specified pattern,
-    /// using NFA-simulation streaming with the chosen bitset representation.
-    ///
-    /// Pick `S` based on the pattern's atom count: `u64` for ≤ 63 atoms and
-    /// `u128` for 64..=127. Patterns beyond 127 atoms should route through
-    /// [`Self::wildcard_specialized_iter`], which falls back to the
-    /// filter-based [`WildcardIter`] for those sizes.
-    pub fn wildcard_nfa_iter<S: NfaBitSet>(
-        &self,
-        pattern: &WildcardPattern<'_>,
-    ) -> AutomatonIter<'_, Data, WildcardNfa<S>> {
-        let nfa = WildcardNfa::<S>::compile(pattern);
-        self.automaton_iter_with_prefix_shortcut(pattern.tokens(), nfa)
-    }
-
-    /// Iterate over all trie entries whose key matches the specified pattern,
     /// auto-selecting the most efficient backend for the pattern's atom
     /// count:
     ///
@@ -250,15 +235,16 @@ impl<Data> TrieMap<Data> {
     ) -> WildcardSpecializedIter<'tm, 'p, Data> {
         match WildcardBackend::for_pattern(pattern) {
             WildcardBackend::U64 => {
-                WildcardSpecializedIter::U64(self.wildcard_nfa_iter::<u64>(pattern))
+                let nfa = WildcardNfa::<u64>::compile(pattern);
+                let iter = self.automaton_iter_with_prefix_shortcut(pattern.tokens(), nfa);
+                WildcardSpecializedIter::U64(iter)
             }
             WildcardBackend::U128 => {
-                WildcardSpecializedIter::U128(self.wildcard_nfa_iter::<u128>(pattern))
+                let nfa = WildcardNfa::<u128>::compile(pattern);
+                let iter = self.automaton_iter_with_prefix_shortcut(pattern.tokens(), nfa);
+                WildcardSpecializedIter::U128(iter)
             }
             WildcardBackend::Filter => {
-                // `WildcardIter::new` takes the pattern by value; clone is
-                // shallow (the parsed tokens borrow from the caller's
-                // slice).
                 WildcardSpecializedIter::Filter(self.wildcard_iter(pattern.clone()))
             }
         }

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -221,14 +221,7 @@ impl<Data> TrieMap<Data> {
 
     /// Iterate over all trie entries whose key matches the specified pattern,
     /// auto-selecting the most efficient backend for the pattern's atom
-    /// count:
-    ///
-    /// - ≤ 63 atoms → NFA backed by `u64`.
-    /// - 64..=127 atoms → NFA backed by `u128`.
-    /// - ≥ 128 atoms → filter-based [`WildcardIter`]. Wider bitset
-    ///   representations and a sparse-set automaton were prototyped for
-    ///   this range; neither beat the filter's
-    ///   SIMD-`memcmp`-per-literal approach on real workloads.
+    /// count.
     pub fn wildcard_specialized_iter<'tm, 'p>(
         &'tm self,
         pattern: &WildcardPattern<'p>,

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -15,13 +15,14 @@ mod utils;
 
 use crate::trie_map::{
     iter::{
-        ContainsIter, IntoValues, Iter, LendingIter, PrefixesIter, RangeFilter, RangeIter, Values,
-        WildcardIter, filter::VisitAll,
+        Automaton, AutomatonIter, ContainsIter, IntoValues, Iter, LendingIter, NfaBitSet,
+        PrefixesIter, RangeFilter, RangeIter, Values, WildcardBackend, WildcardIter, WildcardNfa,
+        WildcardSpecializedIter, filter::VisitAll,
     },
     node::Node,
     utils::strip_prefix,
 };
-use rqe_wildcard::WildcardPattern;
+use rqe_wildcard::{Token, WildcardPattern};
 use std::fmt;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -216,6 +217,74 @@ impl<Data> TrieMap<Data> {
         pattern: WildcardPattern<'p>,
     ) -> WildcardIter<'tm, 'p, Data> {
         WildcardIter::new(self.root.as_ref(), pattern)
+    }
+
+    /// Iterate over all trie entries whose key matches the specified pattern,
+    /// using NFA-simulation streaming with the chosen bitset representation.
+    ///
+    /// Pick `S` based on the pattern's atom count: `u64` for ≤ 63 atoms and
+    /// `u128` for 64..=127. Patterns beyond 127 atoms should route through
+    /// [`Self::wildcard_specialized_iter`], which falls back to the
+    /// filter-based [`WildcardIter`] for those sizes.
+    pub fn wildcard_nfa_iter<S: NfaBitSet>(
+        &self,
+        pattern: &WildcardPattern<'_>,
+    ) -> AutomatonIter<'_, Data, WildcardNfa<S>> {
+        let nfa = WildcardNfa::<S>::compile(pattern);
+        self.automaton_iter_with_prefix_shortcut(pattern.tokens(), nfa)
+    }
+
+    /// Iterate over all trie entries whose key matches the specified pattern,
+    /// auto-selecting the most efficient backend for the pattern's atom
+    /// count:
+    ///
+    /// - ≤ 63 atoms → NFA backed by `u64`.
+    /// - 64..=127 atoms → NFA backed by `u128`.
+    /// - ≥ 128 atoms → filter-based [`WildcardIter`]. Wider bitset
+    ///   representations and a sparse-set automaton were prototyped for
+    ///   this range; neither beat the filter's
+    ///   SIMD-`memcmp`-per-literal approach on real workloads.
+    pub fn wildcard_specialized_iter<'tm, 'p>(
+        &'tm self,
+        pattern: &WildcardPattern<'p>,
+    ) -> WildcardSpecializedIter<'tm, 'p, Data> {
+        match WildcardBackend::for_pattern(pattern) {
+            WildcardBackend::U64 => {
+                WildcardSpecializedIter::U64(self.wildcard_nfa_iter::<u64>(pattern))
+            }
+            WildcardBackend::U128 => {
+                WildcardSpecializedIter::U128(self.wildcard_nfa_iter::<u128>(pattern))
+            }
+            WildcardBackend::Filter => {
+                // `WildcardIter::new` takes the pattern by value; clone is
+                // shallow (the parsed tokens borrow from the caller's
+                // slice).
+                WildcardSpecializedIter::Filter(self.wildcard_iter(pattern.clone()))
+            }
+        }
+    }
+
+    fn automaton_iter_with_prefix_shortcut<A: Automaton>(
+        &self,
+        tokens: &[Token<'_>],
+        automaton: A,
+    ) -> AutomatonIter<'_, Data, A> {
+        let Some(root) = self.root.as_ref() else {
+            return AutomatonIter::empty(automaton);
+        };
+        // If the pattern starts with a literal, jump straight to the subtree
+        // containing every key with that prefix and let the iterator pick up
+        // from there.
+        if let Some(Token::Literal(lit)) = tokens.first() {
+            match root.find_root_for_prefix(lit) {
+                Some((subroot, subroot_prefix)) => {
+                    AutomatonIter::new(Some(subroot), subroot_prefix, automaton)
+                }
+                None => AutomatonIter::empty(automaton),
+            }
+        } else {
+            AutomatonIter::new(Some(root), Vec::new(), automaton)
+        }
     }
 
     /// Iterate over the entries that start with the given prefix, in lexicographical key order.

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/mod.rs
@@ -15,6 +15,7 @@ mod range;
 mod unfiltered;
 mod values;
 mod wildcard;
+mod wildcard_automaton;
 
 use trie_rs::TrieMap;
 

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/wildcard_automaton.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/wildcard_automaton.rs
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Cross-check that [`TrieMap::wildcard_specialized_iter`] produces the
+//! same matches as the filter-based [`TrieMap::wildcard_iter`] across the
+//! three backends it dispatches into (`u64` NFA, `u128` NFA, and the
+//! filter fallback at ≥ 128 atoms).
+
+use rqe_wildcard::WildcardPattern;
+use trie_rs::TrieMap;
+
+fn matches_filter<Data>(trie: &TrieMap<Data>, pattern: &str) -> Vec<Vec<u8>> {
+    let p = WildcardPattern::parse(pattern.as_bytes());
+    trie.wildcard_iter(p).map(|(k, _)| k).collect()
+}
+
+fn matches_specialized<Data>(trie: &TrieMap<Data>, pattern: &str) -> Vec<Vec<u8>> {
+    let p = WildcardPattern::parse(pattern.as_bytes());
+    trie.wildcard_specialized_iter(&p).map(|(k, _)| k).collect()
+}
+
+fn build_trie() -> TrieMap<Vec<u8>> {
+    let mut trie = TrieMap::new();
+    for word in [
+        b"apple".as_ref(),
+        b"ban",
+        b"banana",
+        b"apricot",
+        b"band",
+        b"car",
+        b"cart",
+        b"cartilage",
+        b"",
+    ] {
+        trie.insert(word, word.to_vec());
+    }
+    trie
+}
+
+#[test]
+fn matches_agree_on_seed_patterns() {
+    let trie = build_trie();
+    let patterns = [
+        "", "*", "ap*", "*an*", "apricot", "peach", "?ci", "ban*", "*", "ba?", "ba??", "*a*",
+        "*a*a*", "c*t", "?", "??", "*ar*", "ban?", "*cot",
+    ];
+    for p in patterns {
+        let f = matches_filter(&trie, p);
+        let s = matches_specialized(&trie, p);
+        assert_eq!(f, s, "Specialized disagrees on `{p}`");
+    }
+}
+
+#[test]
+fn empty_pattern_matches_empty_key_only() {
+    let mut trie = TrieMap::new();
+    trie.insert(b"", b"".to_vec());
+    trie.insert(b"apple", b"apple".to_vec());
+    assert_eq!(matches_specialized(&trie, ""), vec![b""]);
+}
+
+#[test]
+fn empty_trie_yields_nothing() {
+    let trie = TrieMap::<u64>::new();
+    assert!(matches_specialized(&trie, "*").is_empty());
+}
+
+#[cfg(not(miri))]
+mod property_based {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 256,
+            ..Default::default()
+        })]
+
+        /// Random ASCII keys + random pattern → filter and specialized must
+        /// agree. Pattern lengths stay ≤ 8 atoms so the dispatcher routes
+        /// through the `u64` NFA branch.
+        #[test]
+        fn agree_on_random_keys_and_patterns(
+            keys in prop::collection::vec("[a-d]{0,6}", 1..30),
+            pattern in "[a-d?*]{0,8}",
+        ) {
+            let mut trie = TrieMap::new();
+            for k in &keys {
+                trie.insert(k.as_bytes(), ());
+            }
+            let f = matches_filter(&trie, &pattern);
+            let s = matches_specialized(&trie, &pattern);
+            prop_assert_eq!(&f, &s, "filter vs specialized, pattern=`{}`", pattern);
+        }
+
+        /// Patterns with literals — exercise the prefix-shortcut path.
+        #[test]
+        fn agree_with_literal_prefixes(
+            keys in prop::collection::vec("[a-z]{0,6}", 1..30),
+            prefix in "[a-z]{1,3}",
+            suffix in "[a-z?*]{0,4}",
+        ) {
+            let pattern = format!("{prefix}{suffix}");
+            let mut trie = TrieMap::new();
+            for k in &keys {
+                trie.insert(k.as_bytes(), ());
+            }
+            let f = matches_filter(&trie, &pattern);
+            let s = matches_specialized(&trie, &pattern);
+            prop_assert_eq!(&f, &s, "filter vs specialized, pattern=`{}`", pattern);
+        }
+
+        /// Patterns with no `*` — the dispatcher still routes by atom count,
+        /// so these go through the `u64` NFA's `epsilon_table.is_none()`
+        /// fixed-length fast path.
+        #[test]
+        fn fixed_length_patterns_agree(
+            keys in prop::collection::vec("[a-d]{0,6}", 1..30),
+            pattern in "[a-d?]{1,8}",
+        ) {
+            let mut trie = TrieMap::new();
+            for k in &keys {
+                trie.insert(k.as_bytes(), ());
+            }
+            let f = matches_filter(&trie, &pattern);
+            let s = matches_specialized(&trie, &pattern);
+            prop_assert_eq!(&f, &s, "filter vs specialized (fixed), pattern=`{}`", pattern);
+        }
+    }
+}
+
+/// Long literal pattern (70 chars) — atom count exceeds the `u64` cap so
+/// the dispatcher routes through the `u128` NFA. Cross-check correctness
+/// against the filter.
+#[test]
+fn long_literal_patterns_route_to_u128() {
+    let prefix = "a".repeat(70);
+    let pattern_long_literal = format!("{prefix}*");
+    let pattern_long_fixed = prefix.clone();
+
+    let mut trie = TrieMap::new();
+    let matching_key = format!("{prefix}suffix");
+    trie.insert(matching_key.as_bytes(), 1u32);
+    trie.insert(b"unrelated", 2);
+    trie.insert(prefix.as_bytes(), 3);
+
+    let f = matches_filter(&trie, &pattern_long_literal);
+    let s = matches_specialized(&trie, &pattern_long_literal);
+    assert_eq!(f, s, "filter vs specialized, long literal + `*`");
+
+    let f = matches_filter(&trie, &pattern_long_fixed);
+    let s = matches_specialized(&trie, &pattern_long_fixed);
+    assert_eq!(f, s, "filter vs specialized, long literal alone");
+}
+
+/// Patterns past 127 atoms route to the filter-based fallback in the
+/// dispatcher. This exercises the `WildcardBackend::Filter` arm of
+/// [`WildcardSpecializedIter`] and confirms the dispatcher wraps
+/// [`WildcardIter`] correctly through its lending interface.
+#[test]
+fn long_patterns_route_to_filter_specialized() {
+    // 260-char literal pushes us past the `u128` boundary into the
+    // filter fallback (1 leading `*` + 260 + 1 trailing `*` + 1 accept
+    // = 263 positions).
+    let literal: String = "abcdefghij".repeat(26);
+    assert_eq!(literal.len(), 260);
+    let star_pattern = format!("*{literal}*");
+    let prefix_pattern = format!("ab*{literal}*");
+
+    let mut trie = TrieMap::new();
+    let direct_match = format!("xxx{literal}yyy");
+    trie.insert(direct_match.as_bytes(), 1u32);
+    trie.insert(format!("ab{literal}").as_bytes(), 2);
+    trie.insert(format!("abc{literal}post").as_bytes(), 3);
+    trie.insert(b"ab", 4);
+    trie.insert(b"abc", 5);
+    trie.insert(b"unrelated", 6);
+    trie.insert(b"", 7);
+
+    for pattern in [&star_pattern, &prefix_pattern] {
+        let f = matches_filter(&trie, pattern);
+        let s = matches_specialized(&trie, pattern);
+        assert_eq!(
+            f,
+            s,
+            "filter vs specialized → Filter, pattern (len={})",
+            pattern.len(),
+        );
+    }
+}
+
+/// Patterns with many `Any` atoms — the parser collapses consecutive `*`
+/// into one, so 50 `*the` segments produce ~250 atoms, comfortably in
+/// the filter-fallback range under the new dispatcher.
+#[test]
+fn many_any_atoms_route_to_filter() {
+    let pattern: String = std::iter::repeat_n("*the", 50).collect::<String>() + "*";
+
+    let mut trie = TrieMap::new();
+    trie.insert(b"thethethe", 1u32);
+    trie.insert(b"the_in_middle_the", 2);
+    trie.insert(b"the", 3);
+    trie.insert(b"unrelated", 4);
+    trie.insert(b"", 5);
+
+    let f = matches_filter(&trie, &pattern);
+    let s = matches_specialized(&trie, &pattern);
+    assert_eq!(f, s, "filter vs specialized, many-`Any` pattern");
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/wildcard_automaton.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/wildcard_automaton.rs
@@ -160,7 +160,7 @@ fn long_literal_patterns_route_to_u128() {
 }
 
 /// Patterns past 127 atoms route to the filter-based fallback in the
-/// dispatcher. This exercises the `WildcardBackend::Filter` arm of
+/// dispatcher. This exercises the [`WildcardBackend::Filter`] arm of
 /// [`WildcardSpecializedIter`] and confirms the dispatcher wraps
 /// [`WildcardIter`] correctly through its lending interface.
 #[test]


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on #9803.

1. **Current**: `TrieMap::wildcard_iter` is the only wildcard entry point and always routes through the filter-based iterator.
2. **Change**: Add `TrieMap::wildcard_specialized_iter` (auto-dispatching across `u64`/`u128` NFA and filter fallback) and `wildcard_nfa_iter<S: NfaBitSet>` (explicit backend). A literal-prefix shortcut skips trie walking when the pattern starts with a non-wildcard run. Cross-check integration tests (seed + property-based) verify each backend matches the filter baseline on the three dispatch arms.
3. **Outcome**: Callers can opt into the faster backends; correctness is checked end-to-end against the existing filter baseline.

#### Which additional issues this PR fixes
1. MOD-15522

#### Main objects this PR modified
1. `trie_rs::TrieMap::{wildcard_specialized_iter, wildcard_nfa_iter}` (new)

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New public iterator APIs and trie traversal shortcuts; behavior is validated against the existing filter iterator with no auth or persistence changes.
> 
> **Overview**
> **`TrieMap`** gains two wildcard entry points beyond the existing filter-only **`wildcard_iter`**: **`wildcard_nfa_iter`** (caller-chosen **`u64`** / **`u128`** NFA bitset) and **`wildcard_specialized_iter`**, which picks **`u64`**, **`u128`**, or the filter fallback from pattern atom count (≥128 atoms stay on **`WildcardIter`**).
> 
> Both NFA paths compile the pattern and traverse via **`AutomatonIter`**, with a **literal-prefix shortcut** that **`find_root_for_prefix`**es into the trie when the pattern starts with a literal. **`AutomatonIter::empty`** / **`new`** are now wired without **`dead_code`** suppression.
> 
> Integration tests in **`wildcard_automaton`** assert **`wildcard_specialized_iter`** matches **`wildcard_iter`** on seed patterns, property tests (NFA + prefix paths), and long patterns that hit **`u128`** and filter dispatch arms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 754a4b6940d87b503df6b388708c066e06332866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->