### PR TITLE
[MOD-15522] Bench the specialized wildcard iterators

### DIFF
--- a/src/redisearch_rs/trie_bencher/benches/iter.rs
+++ b/src/redisearch_rs/trie_bencher/benches/iter.rs
@@ -25,6 +25,7 @@ fn iter_benches_wiki1k(c: &mut Criterion) {
     bencher.wildcard_group(c, "Ab*");
     // Fixed length.
     bencher.wildcard_group(c, "Apollo ??");
+
     bencher.into_values_group(c, "IntoValues iterator");
 }
 
@@ -37,6 +38,40 @@ fn iter_benches_gutenberg(c: &mut Criterion) {
     bencher.find_prefixes_group(c, "everlastingly", "Find prefixes");
     // Requires backtracking to perform, de facto, suffix matching
     bencher.wildcard_group(c, "*ly");
+
+    // Patterns that exercise the two surviving NFA classes (`u64` ≤ 63
+    // atoms, `u128` ≤ 127). Anything larger routes through the filter
+    // fallback under `wildcard_specialized_iter` and would compare
+    // identical timings against `wildcard_iter`, so we don't bench it.
+    //
+    // For the `u128` class we run two shapes back-to-back so the contrast
+    // is visible:
+    //
+    // - High self-overlap (`*a×70*`): every position in the literal is a
+    //   valid match-start, so the NFA's active set fills the entire bitset
+    //   during traversal and `union_in_place` does maximum work per byte.
+    // - Low self-overlap (`*Zabc…×70*`): the literal starts with a
+    //   character (`Z`) that doesn't appear in the rest of the body, so
+    //   the active set stays narrow (≈ 3 positions) throughout. This is
+    //   the typical shape for real long patterns — e.g., codepoint-lifted
+    //   UTF-8 queries.
+    //
+    // The leading `*` defeats the literal-prefix shortcut, so the iterator
+    // walks the entire trie.
+    let high_overlap_70 = format!("*{}*", "a".repeat(70));
+    bencher.wildcard_group_labeled(
+        c,
+        "*a×70* (72 atoms, u128, high self-overlap)",
+        &high_overlap_70,
+    );
+    let low_overlap_70: String = std::iter::once('Z')
+        .chain((b'a'..=b'z').map(char::from).cycle().take(69))
+        .collect();
+    bencher.wildcard_group_labeled(
+        c,
+        "*Zabc…×70* (72 atoms, u128, low self-overlap)",
+        &format!("*{low_overlap_70}*"),
+    );
 
     bencher.range_group(
         c,

--- a/src/redisearch_rs/trie_bencher/src/bencher.rs
+++ b/src/redisearch_rs/trie_bencher/src/bencher.rs
@@ -14,7 +14,7 @@ use criterion::{
 use lending_iterator::LendingIterator;
 use rqe_wildcard::WildcardPattern;
 use std::{ffi::c_void, hint::black_box, ptr::NonNull, time::Duration};
-use trie_rs::iter::{ContainsLendingIter, LendingIter};
+use trie_rs::iter::{ContainsLendingIter, LendingIter, WildcardSpecializedLendingIter};
 use trie_rs::iter::{RangeFilter, RangeLendingIter};
 
 use crate::RustTrieMap;
@@ -166,12 +166,17 @@ impl OperationBencher {
     }
 
     /// Benchmark the wildcard iterator.
-    ///
-    /// The benchmark group will be marked with the given label.
     pub fn wildcard_group(&self, c: &mut Criterion, target: &str) {
-        let label = format!("Wildcard [{target}]");
-        let mut group = self.benchmark_group_immutable(c, &label);
-        wildcard_rust_benchmark(&mut group, &self.map, target);
+        self.wildcard_group_labeled(c, target, target);
+    }
+
+    /// Like [`Self::wildcard_group`] but separates the bench label from the
+    /// pattern bytes — useful when the pattern is long enough to be unwieldy
+    /// in the bench group title.
+    pub fn wildcard_group_labeled(&self, c: &mut Criterion, label: &str, pattern: &str) {
+        let group_label = format!("Wildcard [{label}]");
+        let mut group = self.benchmark_group_immutable(c, &group_label);
+        wildcard_rust_benchmark(&mut group, &self.map, pattern);
         group.finish();
     }
 
@@ -259,6 +264,16 @@ fn wildcard_rust_benchmark<M: Measurement>(
         b.iter(|| {
             let filter = WildcardPattern::parse(black_box(pattern.as_bytes()));
             let mut iter: LendingIter<'_, _, _> = map.wildcard_iter(filter).into();
+            while let Some(entry) = LendingIterator::next(&mut iter) {
+                black_box(entry);
+            }
+        })
+    });
+    c.bench_function("Rust-Specialized", |b| {
+        b.iter(|| {
+            let pattern = WildcardPattern::parse(black_box(pattern.as_bytes()));
+            let mut iter: WildcardSpecializedLendingIter<_> =
+                map.wildcard_specialized_iter(&pattern).into();
             while let Some(entry) = LendingIterator::next(&mut iter) {
                 black_box(entry);
             }


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on #9804.

1. **Current**: `trie_bencher` only exercises the filter-based `wildcard_iter`.
2. **Change**: Add `wildcard_group` / `wildcard_group_labeled` helpers and bench cases that cover each dispatch arm (`u64` NFA, `u128` NFA, filter fallback) on both Wiki-1K and Gutenberg corpora.
3. **Outcome**: Side-by-side filter-vs-specialized comparison on real workloads; the benchmark table in #9803 was generated with these.

#### Which additional issues this PR fixes
1. MOD-15522

#### Main objects this PR modified
1. `trie_bencher::Bencher::{wildcard_group, wildcard_group_labeled}` (new)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only changes in trie_bencher with no production API or runtime behavior impact.
> 
> **Overview**
> **Wildcard trie benchmarks** now run **filter-based** `wildcard_iter` and **dispatch-aware** `wildcard_specialized_iter` side by side in every wildcard group, so Criterion can compare the two paths on the same patterns.
> 
> `OperationBencher` gains **`wildcard_group_labeled`** so long patterns can use a short group title while still benching the full pattern string; **`wildcard_group`** delegates to it unchanged for callers.
> 
> On the **Gutenberg** corpus, two new **~72-atom** `*…*` patterns stress the **`u128` NFA** arm: one with **high literal self-overlap** and one with **low overlap** (leading `*` forces a full trie walk). Comments document why larger patterns are omitted (they fall back to the filter path and would duplicate timings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c892efcdfb03249ba0c54b31f9f60cc94da1d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->