### PR TITLE
docs: add general docs-guidelines skill

### DIFF
--- a/.skills/docs-guidelines/SKILL.md
+++ b/.skills/docs-guidelines/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: docs-guidelines
+description: General documentation guidelines that apply across all languages. Use this when writing or reviewing comments, docstrings, or doc headers in any code.
+---
+
+# Documentation Guidelines
+
+General guidelines for writing code documentation. Language-specific skills (e.g. [`rust-docs-guidelines`](../rust-docs-guidelines/SKILL.md)) layer on top of these.
+
+## Guidelines
+
+- **Prefer code-enforced invariants over prose.** If an assertion, type, enum, or test can express the constraint, use it instead of a comment. Comments drift; code doesn't.
+- **State each fact in exactly one place.** The owner is the definition, the interface, or the implementation — whichever is canonical. Other locations reference it by name, not by restating it.
+- **Focus on why, not how.** Don't restate what the code plainly does. Document non-obvious choices, invariants that are hard to infer, and constraints a maintainer would otherwise miss.
+- **Do not document obvious behavior, callee implementation details, or duplicate the same detail across call sites.**
+
+## Placement model
+
+Each fact belongs to exactly one of these layers — pick the one that owns it and don't restate it elsewhere:
+
+- **Call sites** — non-trivial local intent, assumptions, sequencing constraints, or edge cases specific to this usage.
+- **Definitions and interfaces** — the contract: inputs, outputs, errors, side effects, invariants.
+- **Implementations** — non-obvious internal choices, tradeoffs, workarounds.
+- **READMEs** — module-level context and architectural decisions.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: We have `rust-docs-guidelines` for Rust documentation but no equivalent for general or C documentation. PR reviews repeatedly surface the same documentation issues — verbose comments, restated callee details at call sites, duplicated facts across files, prose invariants that should be enforced in code — with no shared skill to point at.
2. **Change**: Add a new `.skills/docs-guidelines/SKILL.md` capturing the universal rules: prefer code-enforced invariants over prose, state each fact in one place, focus on why not how, avoid documenting obvious behavior or callee internals. Includes an explicit placement model (call sites / definitions / implementations / READMEs).
3. **Outcome**: A short (~25 lines), language-agnostic skill that complements the existing `rust-docs-guidelines` and can be referenced from `code-review` / `rust-review` going forward.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `.skills/docs-guidelines/SKILL.md` (new)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under .skills with no runtime, API, or serialization impact.
> 
> **Overview**
> Adds a new **`.skills/docs-guidelines/SKILL.md`** skill with language-agnostic documentation rules for writing and reviewing comments, docstrings, and headers.
> 
> It encodes four core rules—prefer **code-enforced invariants** over prose, **single ownership** of each fact, document **why** not how, and avoid obvious behavior, callee internals, and duplicated call-site detail—and a **placement model** (call sites, definitions/interfaces, implementations, READMEs). The skill is positioned as the base layer that **`rust-docs-guidelines`** builds on, so reviews can cite one shared standard beyond Rust-only guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a622d056802e3ea8a4d72c6eb51ffb0125f9629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->