### PR TITLE
query: remove unused QueryEvalCtx::numTokens

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1602,7 +1602,6 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
                             uint32_t reqflags, QueryError *status) {
   QueryEvalCtx qectx = {
       .opts = opts,
-      .numTokens = qast->numTokens,
       .docTable = &sctx->spec->docs,
       .sctx = sctx,
       .status = status,

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -18,7 +18,6 @@ typedef struct QueryEvalCtx {
   const RSSearchOptions *opts;
   QueryError *status;
   struct MetricRequest **metricRequestsP;
-  size_t numTokens;
   uint32_t tokenId;
   DocTable *docTable;
   uint32_t reqFlags;


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-field removal with no behavior change; query evaluation and APIs are unaffected.
> 
> **Overview**
> Removes the unused `numTokens` field from `QueryEvalCtx` and stops copying `qast->numTokens` into that context when building iterators in `QAST_Iterate`.
> 
> Parse-time token counting on `QueryAST` / `QueryParseCtx` is unchanged; evaluation already assigns per-reader IDs via `tokenId` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d72f4497e6e2ad3414a7bc08efb6f2a49b449202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->