### PR TITLE
remove unused RS_NO_U128

### DIFF
--- a/src/redisearch_types.h
+++ b/src/redisearch_types.h
@@ -20,7 +20,7 @@ typedef uint64_t t_docId;
 // Used to identify any field index within the spec, not just textual fields
 typedef uint16_t t_fieldIndex;
 
-#if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__)) && !defined(RS_NO_U128)
+#if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__))
 /* 64 bit architectures use 128 bit field masks and up to 128 fields */
 typedef __uint128_t t_fieldMask;
 #define RS_FIELDMASK_ALL (((__uint128_t)1 << 127) - (__uint128_t)1 + ((__uint128_t)1 << 127))

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1146,7 +1146,7 @@ TEST_F(IndexTest, testHugeSpec) {
   s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_TRUE(s == NULL);
   ASSERT_TRUE(QueryError_HasError(&err));
-#if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__)) && !defined(RS_NO_U128)
+#if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__))
   ASSERT_STREQ("SEARCH_LIMIT_OVER Schema is limited to 128 TEXT fields", QueryError_GetUserError(&err));
 #else
   ASSERT_STREQ("SEARCH_LIMIT_OVER Schema is limited to 64 TEXT fields", QueryError_GetUserError(&err));


### PR DESCRIPTION
Nothing actually set it in the build system.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; field-mask typing and schema limits stay tied to the same architecture macros as before.
> 
> **Overview**
> Removes the unused **`RS_NO_U128`** compile-time guard from architecture checks for **`t_fieldMask`** / **`__uint128_t`** (128 TEXT fields on 64-bit ARM/x86) vs **64-bit** masks on other platforms.
> 
> The same simplification is applied in **`testHugeSpec`**, which asserts the schema limit error message for oversized schemas—behavior is unchanged because nothing in the build ever defined **`RS_NO_U128`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8617b05818525bb30cf2eec9a70d70ed2f0d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->