### PR TITLE
AGENTS: document how to generate C headers from Rust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ cd src/redisearch_rs && cargo nextest run
 cd src/redisearch_rs && cargo nextest run -p <crate_name>
 ```
 
+## Header Generation
+
+```bash
+make generate-rust-headers                # Regenerate Rust → C FFI headers via cheadergen
+```
+
+Run this after changing `#[cheadergen::config(...)]` attributes or exported Rust types
+that produce C headers. Output goes to `src/redisearch_rs/headers/`.
+
 ## Linting & Formatting
 
 ```bash


### PR DESCRIPTION
Claude was confused by this so let's teach it the proper command.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime or API impact.
> 
> **Overview**
> Adds a **Header Generation** section to `AGENTS.md` so coding agents know how to refresh Rust→C FFI headers after `#[cheadergen::config(...)]` or exported type changes.
> 
> The documented workflow is `make generate-rust-headers`, with generated output under `src/redisearch_rs/headers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c246f14a6b539f12087404a7981fa9262fe6fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->