### PR TITLE
Nudge agents towards piping output to a file rather than rerunning expensive commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,38 @@ cd src/redisearch_rs && cargo license-fix # Add missing license headers
 
 C code formatting is governed by `.clang-format` at the repo root (LLVM-derived, 100-column limit, 2-space indent). Apply with `clang-format -i <file>`.
 
+## Running Expensive Commands
+
+Builds, full test runs, benchmarks, and `make lint` here take minutes. Two failure modes waste the most time, and both are easy to avoid:
+
+### Capture output to a log file; do not re-run to see more
+
+For anything that takes longer than ~30s, pipe through `tee` to a temp log file and only show a tail for live feedback. If you need to inspect a specific failure later, `grep`/`rg` the saved log — **do not re-execute the command with a different filter** to "see more output". Each rerun also wastes warm caches.
+
+```bash
+set -o pipefail
+LOG=$(mktemp /tmp/pytest.XXXXXX.log)
+echo "Log: $LOG"
+./build.sh RUN_PYTEST ENABLE_ASSERT=1 2>&1 | tee "$LOG" | tail -80
+# Later, from a separate Bash call:
+grep -n 'FAILED\|Error\|assert' /tmp/pytest.abc123.log
+```
+
+Notes:
+- **Always enable `set -o pipefail`** (or check `${PIPESTATUS[0]}` after the pipeline). Without it, the pipeline's exit code is `tail`'s, so a failing build/test will look like success. Each Bash tool call runs in a fresh shell, so re-set it per call (or use `bash -o pipefail -c '...'`).
+- Shell variables do **not** persist between Bash tool calls. Capture the `Log: …` path from the first call's output and substitute it literally into later calls.
+- Avoid `| head` on long runs: it can cause SIGPIPE to abort the producer before it finishes. Use `| tee LOG | tail -N` instead.
+- `.skills/check-flow-coverage/SKILL.md` (lines 60-105) is the canonical worked example of this pattern, including a freshness marker for log files.
+
+### Do not run build/test/lint commands in parallel
+
+`./build.sh`, `make` (lint/fmt/build), and `cargo` (build/test/clippy/nextest/bench) all share `src/redisearch_rs/target/` and the Cargo build-directory lock. Concurrent invocations either block on the lock or fail with `Blocking waiting for file lock on build directory`. Running benchmarks concurrently with anything else also skews timings.
+
+Rules:
+- Run these sequentially in a single Bash call chained with `&&`, or wait for one to finish before starting the next.
+- Do not use `run_in_background: true` to fire a second cargo/make/`./build.sh` while another is still running.
+- Safe to run alongside an in-flight build: reading files, `git status`/`git log`, `rg`/`grep`, analysing already-captured logs. Only the cargo/make/`./build.sh` family contends.
+
 ## Code Style
 
 ### C


### PR DESCRIPTION
## Describe the changes in the pull request

Claude will often rerun tests or builds (with `FORCE`) using different `tail`/`head` configurations. It's wasteful and slows things down.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime, API, or product behavior changes.
> 
> **Overview**
> Adds a new **Running Expensive Commands** section to `AGENTS.md` aimed at coding agents, not human contributors.
> 
> It documents how to run long builds/tests: use `set -o pipefail`, `tee` to a temp log, show only a `tail` for live output, and search the saved log instead of re-running the same command with different `tail`/`head` filters. It also warns against `| head` on long pipelines (SIGPIPE) and notes that shell variables do not persist across separate Bash tool calls.
> 
> A second subsection tells agents not to run `./build.sh`, `make`, or `cargo` in parallel because they contend on `src/redisearch_rs/target/` and the Cargo build lock, and points to `.skills/check-flow-coverage/SKILL.md` as the worked example for log capture and freshness checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03fa58c0792bb7c8d363b6499c099396ed208410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->