### PR TITLE
top_k: drop phantom 'index lifetime from ScoreSource trait

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -59,7 +59,7 @@ enum Phase {
 /// A generic top-k iterator parameterized over a [`ScoreSource`].
 ///
 /// Implements [`Unfiltered`](TopKMode::Unfiltered).
-pub struct TopKIterator<'index, S: ScoreSource<'index>> {
+pub struct TopKIterator<'index, S: ScoreSource> {
     source: S,
     child: Option<Box<dyn RQEIterator<'index> + 'index>>,
     mode: TopKMode,
@@ -74,7 +74,7 @@ pub struct TopKIterator<'index, S: ScoreSource<'index>> {
     at_eof: bool,
 }
 
-impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
+impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// Create a new [`TopKIterator`].
     ///
     /// The execution mode is always Unfiltered.
@@ -171,7 +171,7 @@ impl<'index, S: ScoreSource<'index>> TopKIterator<'index, S> {
     }
 }
 
-impl<'index, S: ScoreSource<'index>> RQEIterator<'index> for TopKIterator<'index, S> {
+impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'index, S> {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.current.as_mut()

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -92,7 +92,7 @@ impl MockScoreSource {
     }
 }
 
-impl<'index> ScoreSource<'index> for MockScoreSource {
+impl ScoreSource for MockScoreSource {
     type Batch = MockScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
@@ -115,7 +115,10 @@ impl<'index> ScoreSource<'index> for MockScoreSource {
         self.batch_pos = 0;
     }
 
-    fn build_result(&self, doc_id: t_docId, _score: f64) -> RSIndexResult<'index> {
+    fn build_result<'r>(&self, doc_id: t_docId, _score: f64) -> RSIndexResult<'r>
+    where
+        Self: 'r,
+    {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -35,10 +35,20 @@ pub trait ScoreBatch {
 /// 1. Produce score-ordered batches ([`next_batch`]).
 /// 2. Build the final [`RSIndexResult`] for a `(doc_id, score)` pair ([`build_result`]).
 ///
+/// # Result lifetime
+///
+/// The trait is intentionally unparameterized. [`build_result`] uses an
+/// HRTB-on-method with `where Self: 'r` so the caller picks the result
+/// lifetime, bounded by the source's own lifetime: a `'static` source admits
+/// any `'r`, while a hypothetical source borrowing into the index (e.g.
+/// `VectorScoreSource<'index>`) constrains `'r ⊆ 'index`. That source would
+/// declare its own lifetime parameter on the concrete type and handle refresh
+/// internally — none of that leaks into this trait.
+///
 /// [`TopKIterator`]: crate::TopKIterator
 /// [`next_batch`]: ScoreSource::next_batch
 /// [`build_result`]: ScoreSource::build_result
-pub trait ScoreSource<'index> {
+pub trait ScoreSource {
     /// The type of batch cursor this source produces.
     type Batch: ScoreBatch;
 
@@ -70,8 +80,15 @@ pub trait ScoreSource<'index> {
     /// Build the [`RSIndexResult`] that the [`TopKIterator`] will yield for a
     /// given `(doc_id, score)` pair.
     ///
+    /// `'r` is the caller-chosen lifetime of the returned result. The
+    /// `where Self: 'r` bound forces `'r` to be no longer than the source
+    /// itself, so any borrows the source might embed in the result stay
+    /// valid. For `'static` sources, `'r` is unconstrained.
+    ///
     /// [`TopKIterator`]: crate::TopKIterator
-    fn build_result(&self, doc_id: t_docId, score: f64) -> RSIndexResult<'index>;
+    fn build_result<'r>(&self, doc_id: t_docId, score: f64) -> RSIndexResult<'r>
+    where
+        Self: 'r;
 
     /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
     ///

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -79,7 +79,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
 /// Used to verify that timeout errors propagate correctly through [`TopKIterator`].
 struct TimingOutSource;
 
-impl<'index> ScoreSource<'index> for TimingOutSource {
+impl ScoreSource for TimingOutSource {
     type Batch = MockScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
@@ -92,7 +92,10 @@ impl<'index> ScoreSource<'index> for TimingOutSource {
 
     fn rewind(&mut self) {}
 
-    fn build_result(&self, doc_id: ffi::t_docId, _: f64) -> RSIndexResult<'index> {
+    fn build_result<'r>(&self, doc_id: ffi::t_docId, _: f64) -> RSIndexResult<'r>
+    where
+        Self: 'r,
+    {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 


### PR DESCRIPTION
## Describe the changes in the pull request

The 'index parameter on the ScoreSource trait was phantom: it appeared only as the return-type lifetime of build_result(...) -> RSIndexResult<'index>, and every existing impl returns a heap-owned/virtual result that doesn't borrow from the index. The caller was free to pick any 'index.

Drop the trait-level parameter and instead express the result lifetime via HRTB-on-method with a 'where Self: 'r' bound:

    fn build_result<'r>(&self, doc_id, score) -> RSIndexResult<'r>
        where Self: 'r;

This is identical to RSIndexResult<'static> for current ('static) mocks but permits a future source borrowing into the index (e.g. VectorScoreSource<'index>) to return RSIndexResult<'index> carrying index-borrowed data. The Self: 'r bound is what carries that constraint through build_result.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal trait and lifetime refactor in the top_k module only; no change to query semantics for existing static mocks.
> 
> **Overview**
> Removes the phantom **`'index`** lifetime from **`ScoreSource`** and moves result lifetime control onto **`build_result`** via an HRTB: **`fn build_result<'r>(...) -> RSIndexResult<'r> where Self: 'r`**. Callers (e.g. **`TopKIterator`**) still use **`'index`** for the child iterator and stored **`RSIndexResult<'index>`**; **`TopKIterator`** now bounds the source as **`S: ScoreSource + 'index`** instead of **`ScoreSource<'index>`**.
> 
> **`MockScoreSource`**, **`TimingOutSource`**, and trait docs are updated to describe how **`'static`** sources vs future index-borrowing sources (e.g. **`VectorScoreSource<'index>`**) would constrain **`'r`**. Behavior for current heap/virtual results is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05feb46d836d32b6c5b00f95ed40cbc3aef2ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->