### PR TITLE
[MOD-15904] Revert "MOD-15781: FT.INFO: Make Total Block Count Value Be Per Schema" (#9735)

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1095,7 +1095,6 @@ DEBUG_COMMAND(GCCleanNumeric) {
   }
 
   rv = NumericRangeTree_TrimEmptyLeaves(rt);
-  IndexStats_BlockCountAdd(&sctx->spec->stats, rv.block_count_delta);
 
 end:
   SearchCtx_Free(sctx);

--- a/src/document.c
+++ b/src/document.c
@@ -600,14 +600,12 @@ FIELD_BULK_INDEXER(numericIndexer) {
     AddResult rv = NumericRangeTree_Add(rt, aCtx->doc->docId, fdata->numeric, false);
     ctx->spec->stats.invertedSize += rv.size_delta;
     ctx->spec->stats.numRecords += rv.num_records_delta;
-    IndexStats_BlockCountAdd(&ctx->spec->stats, rv.block_count_delta);
   } else {
     for (uint32_t i = 0; i < array_len(fdata->arrNumeric); ++i) {
       double numval = fdata->arrNumeric[i];
       AddResult rv = NumericRangeTree_Add(rt, aCtx->doc->docId, numval, true);
       ctx->spec->stats.invertedSize += rv.size_delta;
       ctx->spec->stats.numRecords += rv.num_records_delta;
-      IndexStats_BlockCountAdd(&ctx->spec->stats, rv.block_count_delta);
     }
   }
 

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -74,18 +74,15 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
 
   idx = sp->existingDocs;
 
-  InvertedIndex_ApplyGCDelta(idx, delta, &info);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
-  IndexStats_BlockCountAdd(&sp->stats, info.block_count_delta);
 
   // We don't count the records that we removed, because we also don't count
   // their addition (they are duplications so we have no such desire).
 
   if (InvertedIndex_NumDocs(idx) == 0) {
-    // Sample memory and block count before freeing the index — `InvertedIndex_Free`
-    // doesn't know about the owning spec.
+    // inverted index was cleaned entirely, let's free it
     info.bytes_freed += InvertedIndex_MemUsage(idx);
-    IndexStats_BlockCountAdd(&sp->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
     InvertedIndex_Free(idx);
     sp->existingDocs = NULL;
   }

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -91,15 +91,12 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGCDelta(idx, delta, &info);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
-  IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 
   if (InvertedIndex_NumDocs(idx) == 0) {
-    // Sample memory and block count before the destructor callback (InvIndFreeCb) frees
-    // the index without spec context.
+    // inverted index was cleaned entirely lets free it
     info.bytes_freed += InvertedIndex_MemUsage(idx);
-    IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
     dictDelete(sctx->spec->missingFieldDict, fieldName);
   }
   FGC_updateStats(gc, sctx, info.entries_removed, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);

--- a/src/fork_gc/numeric.c
+++ b/src/fork_gc/numeric.c
@@ -143,8 +143,6 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
                         r.gc_result.index_gc_info.bytes_freed,
                         r.gc_result.index_gc_info.bytes_allocated,
                         r.gc_result.index_gc_info.ignored_last_block);
-        IndexStats_BlockCountAdd(&_sctx.spec->stats,
-                                 r.gc_result.index_gc_info.block_count_delta);
         break;
       case NodeNotFound:
         gc->stats.gcNumericNodesMissed++;
@@ -176,7 +174,6 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     if (r.inverted_index_size_delta < 0) {
       FGC_updateStats(gc, &sctx2, 0, -r.inverted_index_size_delta, 0, 0);
     }
-    IndexStats_BlockCountAdd(&sctx2.spec->stats, r.block_count_delta);
     RedisSearchCtx_UnlockSpec(&sctx2);
     IndexSpecRef_Release(spec_ref);
   }

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -159,16 +159,13 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       goto loop_cleanup;
     }
 
-    InvertedIndex_ApplyGCDelta(idx, delta, &info);
+    InvertedIndex_ApplyGcDelta(idx, delta, &info);
     delta = NULL;
-    IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 
     // if tag value is empty, let's remove it.
     if (InvertedIndex_NumDocs(idx) == 0) {
-      // Sample memory and block count before the TrieMap destructor callback frees the
-      // index without spec context.
+      // get memory before deleting the inverted index
       info.bytes_freed += InvertedIndex_MemUsage(idx);
-      IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
       TrieMap_Delete(tagIdx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 
       if (tagIdx->suffix) {

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -96,22 +96,18 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
     goto cleanup;
   }
 
-  InvertedIndex_ApplyGCDelta(idx, delta, &info);
+  InvertedIndex_ApplyGcDelta(idx, delta, &info);
   delta = NULL;
-  IndexStats_BlockCountAdd(&sctx->spec->stats, info.block_count_delta);
 
   if (InvertedIndex_NumDocs(idx) == 0) {
 
     // inverted index was cleaned entirely lets free it
     if (sctx->spec->keysDict) {
       CharBuf termKey = {.buf = term, .len = len};
-      // Sample memory and block count before the destructor callback (InvIndFreeCb) frees
-      // the index without spec context.
+      // get memory before deleting the inverted index
       size_t inv_idx_size = InvertedIndex_MemUsage(idx);
-      size_t remaining_blocks = InvertedIndex_NumBlocks(idx);
       if (dictDelete(sctx->spec->keysDict, &termKey) == DICT_OK) {
         info.bytes_freed += inv_idx_size;
-        IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)remaining_blocks);
       }
     }
 

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -282,11 +282,8 @@ int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo
   return 0;
 }
 
-/** Write a forward-index entry to the index. Returns an `AddRecordOutcome` carrying the memory
- * growth and the number of new blocks the write created — callers maintaining per-spec
- * `total_inverted_index_blocks` should add `.blocks_added` to their counter.
- */
-AddRecordOutcome InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
+/** Write a forward-index entry to the index */
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
   RSIndexResult rec = {.data.term_tag = RSResultData_Term,
                        .data.term.borrowed.tag = RSTermRecord_Borrowed,
                        .docId = ent->docId,

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -87,11 +87,9 @@ ForwardIndexEntry *ForwardIndexIterator_Next(ForwardIndexIterator *iter);
 // Find an existing entry within the index
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash);
 
-/* Write a ForwardIndexEntry into an indexWriter. Returns an `AddRecordOutcome` carrying the
- * memory growth and the number of new blocks created — callers maintaining per-spec
- * `total_inverted_index_blocks` should add `.blocks_added` to their counter.
+/* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
  */
-AddRecordOutcome InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent);
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent);
 
 #ifdef __cplusplus
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -32,13 +32,12 @@ extern RedisModuleCtx *RSDummyContext;
 #include <unistd.h>
 
 static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEntry *entry) {
-  AddRecordOutcome r = InvertedIndex_WriteForwardIndexEntry(idx, entry);
+  size_t sz = InvertedIndex_WriteForwardIndexEntry(idx, entry);
 
   // Update index statistics:
 
   // Number of additional bytes
-  spec->stats.invertedSize += r.mem_growth;
-  IndexStats_BlockCountAdd(&spec->stats, r.blocks_added);
+  spec->stats.invertedSize += sz;
   // Number of records
   spec->stats.numRecords++;
 
@@ -392,9 +391,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     t_docId docId = aCtx->doc->docId;
     RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                          .metrics = MetricsVec_New()};
-    AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
-    aCtx->spec->stats.invertedSize += r.mem_growth;
-    IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
+    aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);
@@ -415,9 +412,7 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   t_docId docId = aCtx->doc->docId;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
-  AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
-  aCtx->spec->stats.invertedSize += r.mem_growth;
-  IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
+  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
 }
 
 /**

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -266,10 +266,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   // Vector indexes (e.g. HNSW) remain in memory even when the rest of the
   // index is stored on disk, so their memory must always be reported.
   size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
-  // FT.INFO reports per-spec block counts, not the process-global TotalIIBlocks (the latter
-  // is still exposed via Redis `INFO modules` for cluster-wide aggregation in spec.c).
-  size_t total_ii_blocks = isDisk ? 0
-      : __atomic_load_n(&sp->stats.totalInvertedIndexBlocks, __ATOMIC_RELAXED);
+  size_t total_ii_blocks = isDisk ? 0 : TotalIIBlocks();
   size_t offset_vecs_size = isDisk ? 0 : sp->stats.offsetVecsSize;
   size_t sortables_size = isDisk ? 0 : sp->docs.sortablesSize;
   size_t dt_tm_size = isDisk ? 0 : TrieMap_MemUsage(sp->docs.dim.tm);

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -24,9 +24,9 @@ use fork_gc::{InvertedIndexGCCallback, InvertedIndexGCReader, InvertedIndexGCWri
 use index_result::RSIndexResult;
 pub use inverted_index::opaque::InvertedIndex;
 use inverted_index::{
-    AddRecordOutcome, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader,
-    FilterMaskReader, FilterNumericReader, GcApplyInfo, GcScanDelta, IndexBlock, IndexReader as _,
-    NumericFilter, ReadFilter,
+    EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader, FilterMaskReader,
+    FilterNumericReader, GcApplyInfo, GcScanDelta, IndexBlock, IndexReader as _, NumericFilter,
+    ReadFilter,
     debug::{BlockSummary, Summary},
     doc_ids_only::DocIdsOnly,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
@@ -224,18 +224,19 @@ pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usi
     ii_dispatch!(ii, memory_usage)
 }
 
-/// Write a new numeric entry to the inverted index. This is only valid for numeric indexes
-/// created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting the memory
-/// growth and the number of new index blocks created.
+/// Write a new numeric entry to the inverted index. This is only valid for numeric indexes created
+/// with the `StoreNumeric` flag. The function returns the number of bytes the memory usage of the
+/// index grew by.
 ///
 /// # Safety
+/// The following invariant must be upheld when calling this function:
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii: *mut InvertedIndex,
     doc_id: t_docId,
     value: f64,
-) -> AddRecordOutcome {
+) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
 
     let record = RSIndexResult::build_numeric(value).doc_id(doc_id).build();
@@ -245,17 +246,18 @@ pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii_dispatch!(ii, add_record, &record).unwrap()
 }
 
-/// Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting the
-/// memory growth and the number of new index blocks created.
+/// Write a new entry to the inverted index. The function returns the number of bytes the memory
+/// usage of the index grew by.
 ///
 /// # Safety
+/// The following invariants must be upheld when calling this function:
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
 /// - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteEntryGeneric(
     ii: *mut InvertedIndex,
     record: *const RSIndexResult,
-) -> AddRecordOutcome {
+) -> usize {
     debug_assert!(!ii.is_null(), "ii must not be null");
     debug_assert!(!record.is_null(), "record must not be null");
 
@@ -588,7 +590,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Scan(
 }
 
 /// Read a GC delta from the provided reader. The returned pointer must be freed using
-/// [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGCDelta`].
+/// [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGcDelta`].
 ///
 /// # Safety
 ///
@@ -628,9 +630,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Free(deltas: *mut GcScanDelta) {
 }
 
 /// Apply a GC delta to the inverted index. The output parameter `apply_info` will be set to
-/// information about the applied delta — in particular, `apply_info.block_count_delta` carries
-/// the signed change in block count, which callers maintaining per-spec totals should add to
-/// their counter.
+/// information about the applied delta.
 ///
 /// This will take ownership of the `deltas` pointer and free it. Therefore, it should not be
 /// used or freed after calling this function.
@@ -643,7 +643,7 @@ pub unsafe extern "C" fn InvertedIndex_GcDelta_Free(deltas: *mut GcScanDelta) {
 ///   [`InvertedIndex_GcDelta_Read`].
 /// - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_ApplyGCDelta(
+pub unsafe extern "C" fn InvertedIndex_ApplyGcDelta(
     ii: *mut InvertedIndex,
     deltas: *mut GcScanDelta,
     apply_info: *mut GcApplyInfo,

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -102,20 +102,6 @@ typedef struct IIBlockSummary {
 } IIBlockSummary;
 
 /**
- * Outcome of [`InvertedIndex::add_record`]: how the index grew during the write.
- */
-typedef struct AddRecordOutcome {
-  /**
-   * Number of bytes the inverted index's memory usage grew by.
-   */
-  uint32_t mem_growth;
-  /**
-   * Number of new index blocks this write created.
-   */
-  uint32_t blocks_added;
-} AddRecordOutcome;
-
-/**
  * Filter to apply when reading from an index. Entries which don't match the filter will not be
  * returned by the reader.
  */
@@ -169,12 +155,6 @@ typedef struct II_GCScanStats {
    * The number of entries that were removed from the index including duplicates
    */
   size_t entries_removed;
-  /**
-   * Net change in the index's block count for this apply. Positive when blocks were added
-   * (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
-   * Callers maintaining per-spec totals should add this signed value to their counter.
-   */
-  int64_t block_count_delta;
   /**
    * Whether or not we ignored the last block in the index, since it changed
    * compared to the time we performed the scan

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -134,24 +134,26 @@ void InvertedIndex_Free(struct InvertedIndex *ii);
 size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
 
 /**
- * Write a new numeric entry to the inverted index. This is only valid for numeric indexes
- * created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting the memory
- * growth and the number of new index blocks created.
+ * Write a new numeric entry to the inverted index. This is only valid for numeric indexes created
+ * with the `StoreNumeric` flag. The function returns the number of bytes the memory usage of the
+ * index grew by.
  *
  * # Safety
+ * The following invariant must be upheld when calling this function:
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
+size_t InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
 
 /**
- * Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting the
- * memory growth and the number of new index blocks created.
+ * Write a new entry to the inverted index. The function returns the number of bytes the memory
+ * usage of the index grew by.
  *
  * # Safety
+ * The following invariants must be upheld when calling this function:
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
  */
-struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record);
+size_t InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const struct RSIndexResult *record);
 
 /**
  * Return the number of blocks in the inverted index.
@@ -292,7 +294,7 @@ bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, st
 
 /**
  * Read a GC delta from the provided reader. The returned pointer must be freed using
- * [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGCDelta`].
+ * [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGcDelta`].
  *
  * # Safety
  *
@@ -314,9 +316,7 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
 
 /**
  * Apply a GC delta to the inverted index. The output parameter `apply_info` will be set to
- * information about the applied delta — in particular, `apply_info.block_count_delta` carries
- * the signed change in block count, which callers maintaining per-spec totals should add to
- * their counter.
+ * information about the applied delta.
  *
  * This will take ownership of the `deltas` pointer and free it. Therefore, it should not be
  * used or freed after calling this function.
@@ -329,7 +329,7 @@ void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
  *   [`InvertedIndex_GcDelta_Read`].
  * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
  */
-void InvertedIndex_ApplyGCDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
+void InvertedIndex_ApplyGcDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
 
 /**
  * Get the index of the last block in the GC delta.

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -133,13 +133,6 @@ typedef struct AddResult {
    * Splitting a leaf adds one new leaf. Trimming decreases this.
    */
   int32_t num_leaves_delta;
-  /**
-   * The net change in the number of inverted-index blocks across all leaves touched by
-   * this add. Block growth (writes spilling into a new block, new leaves created by a
-   * split) contributes positively; range removals during rebalancing (`remove_range`,
-   * rotations dropping an internal node's retained range) contribute negatively.
-   */
-  int32_t block_count_delta;
 } AddResult;
 
 /**
@@ -174,11 +167,6 @@ typedef struct CompactIfSparseResult {
    * Positive values indicate growth, negative values indicate shrinkage.
    */
   int64_t node_size_delta;
-  /**
-   * Net change in inverted-index block count across all dropped leaves. Always non-positive
-   * (trimming only removes blocks).
-   */
-  int32_t block_count_delta;
 } CompactIfSparseResult;
 
 /**
@@ -208,9 +196,4 @@ typedef struct TrimEmptyLeavesResult {
    * The net change in the number of leaf nodes.
    */
   int32_t num_leaves_delta;
-  /**
-   * Net change in inverted-index block count across all dropped leaves. Always non-positive
-   * (trimming only removes blocks).
-   */
-  int32_t block_count_delta;
 } TrimEmptyLeavesResult;

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -85,11 +85,6 @@ pub struct GcApplyInfo {
     /// The number of entries that were removed from the index including duplicates
     pub entries_removed: usize,
 
-    /// Net change in the index's block count for this apply. Positive when blocks were added
-    /// (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
-    /// Callers maintaining per-spec totals should add this signed value to their counter.
-    pub block_count_delta: i64,
-
     /// Whether or not we ignored the last block in the index, since it changed
     /// compared to the time we performed the scan
     pub ignored_last_block: bool,
@@ -203,11 +198,8 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             bytes_freed: 0,
             bytes_allocated: 0,
             entries_removed: 0,
-            block_count_delta: 0,
             ignored_last_block: false,
         };
-
-        let blocks_before = self.blocks.len();
 
         // Check if the last block has changed since the scan was performed
         let last_block_changed = self
@@ -289,7 +281,6 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             }
         }
 
-        info.block_count_delta = self.blocks.len() as i64 - blocks_before as i64;
         self.gc_marker_inc();
 
         info

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -55,16 +55,6 @@ pub struct InvertedIndex<E> {
     pub(crate) _encoder: PhantomData<E>,
 }
 
-/// Outcome of [`InvertedIndex::add_record`]: how the index grew during the write.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
-pub struct AddRecordOutcome {
-    /// Number of bytes the inverted index's memory usage grew by.
-    pub mem_growth: u32,
-    /// Number of new index blocks this write created.
-    pub blocks_added: u32,
-}
-
 /// Each `IndexBlock` contains a set of entries for a specific range of document IDs. The entries
 /// are ordered by document ID, so the first entry in the block has the lowest document ID, and the
 /// last entry has the highest document ID. The block also contains a buffer that is used to
@@ -229,15 +219,9 @@ impl<E: Encoder> InvertedIndex<E> {
         blocks_heap + blocks_buffers + stack
     }
 
-    /// Add a new record to the index. Returns an [`AddRecordOutcome`] reporting how many bytes
-    /// the index's memory usage grew by and how many new index blocks the write created (0 in
-    /// the common case, up to 2 when a new block was needed for the encoded delta and/or the
-    /// previous block was full). Callers that maintain a per-spec block counter should add
-    /// `outcome.blocks_added` to it.
-    ///
-    /// It is expected that the document ID of the record is greater than or equal to the last
-    /// document ID in the index.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
+    /// Add a new record to the index and return by how much memory grew. It is expected that
+    /// the document ID of the record is greater than or equal the last document ID in the index.
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
         let doc_id = record.doc_id;
 
         let same_doc = match (
@@ -249,12 +233,10 @@ impl<E: Encoder> InvertedIndex<E> {
                 // Even though we might allow duplicate document IDs, this encoder does not allow
                 // it since it will contain redundant information. Therefore, we are skipping this
                 // record.
-                return Ok(AddRecordOutcome::default());
+                return Ok(0);
             }
             (_, false) => false,
         };
-
-        let blocks_before = self.blocks.len();
 
         // We take ownership of the block since we are going to keep using self. So we can't have a
         // mutable reference to the block we are working with at the same time.
@@ -306,17 +288,7 @@ impl<E: Encoder> InvertedIndex<E> {
             self.flags |= IndexFlags_Index_HasMultiValue;
         }
 
-        let total_mem_growth = buf_growth + mem_growth;
-        // A single add_record can grow memory by at most one block-buffer doubling plus the
-        // overhead of inserting one new block into the `blocks` ThinVec — comfortably below 4 GiB.
-        debug_assert!(
-            total_mem_growth <= u32::MAX as usize,
-            "AddRecordOutcome::mem_growth overflowed u32 ({total_mem_growth} bytes in one add)"
-        );
-        Ok(AddRecordOutcome {
-            mem_growth: total_mem_growth as u32,
-            blocks_added: (self.blocks.len() - blocks_before) as u32,
-        })
+        Ok(buf_growth + mem_growth)
     }
 
     /// Returns the last document ID in the index, if any.

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -8,7 +8,7 @@
 */
 
 use crate::{
-    AddRecordOutcome, DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
+    DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
@@ -36,16 +36,16 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
         }
     }
 
-    /// Add a new record to the index. See [`InvertedIndex::add_record`] for the meaning of the
-    /// returned `(memory_growth, blocks_added)` pair.
+    /// Add a new record to the index and return by how much memory grew. It is expected that
+    /// the document ID of the record is greater than or equal the last document ID in the index.
     ///
     /// The total number of entries in the index is incremented by one.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
-        let result = self.index.add_record(record)?;
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
+        let mem_growth = self.index.add_record(record)?;
 
         self.number_of_entries += 1;
 
-        Ok(result)
+        Ok(mem_growth)
     }
 
     /// The memory size of the index in bytes.

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -8,8 +8,7 @@
 */
 
 use crate::{
-    AddRecordOutcome, DecodedBy, Encoder, FilterMaskReader, GcApplyInfo, GcScanDelta, IndexBlock,
-    InvertedIndex,
+    DecodedBy, Encoder, FilterMaskReader, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
@@ -42,14 +41,14 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
         }
     }
 
-    /// Add a new record to the index. See [`InvertedIndex::add_record`] for the meaning of the
-    /// returned `(memory_growth, blocks_added)` pair.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
-        let result = self.index.add_record(record)?;
+    /// Add a new record to the index and return by how much memory grew. It is expected that
+    /// the document ID of the record is greater than or equal the last document ID in the index.
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
+        let mem_growth = self.index.add_record(record)?;
 
         self.field_mask |= record.field_mask;
 
-        Ok(result)
+        Ok(mem_growth)
     }
 
     /// The memory size of the index in bytes.

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -505,9 +505,7 @@ fn ii_apply_gc() {
             // The third and fifth block was split making 168 new bytes
             bytes_allocated: 168,
             entries_removed: 5,
-            // Removed 3, added back (split blocks) — see `apply_gc` for the exact net delta
-            block_count_delta: 0,
-            ignored_last_block: false,
+            ignored_last_block: false
         }
     );
 }
@@ -602,10 +600,8 @@ fn ii_apply_gc_last_block_updated() {
             // Nothing new was made in the end
             bytes_allocated: 0,
             entries_removed: 2,
-            // Removed one block
-            block_count_delta: -1,
             // Ignored the last block
-            ignored_last_block: true,
+            ignored_last_block: true
         }
     );
 }
@@ -657,7 +653,6 @@ fn ii_apply_gc_last_block_updated_no_delta() {
             bytes_freed: 56,
             bytes_allocated: 0,
             entries_removed: 2,
-            block_count_delta: -1,
             // The key assertion: ignored_last_block must be true even without
             // a delta for the last block.
             ignored_last_block: true,
@@ -788,8 +783,7 @@ fn ii_apply_gc_entries_tracking_index() {
             bytes_freed: 65,
             bytes_allocated: 56,
             entries_removed: 2,
-            block_count_delta: 0,
-            ignored_last_block: false,
+            ignored_last_block: false
         }
     );
 }

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -33,7 +33,7 @@ fn memory_usage() {
     assert_eq!(ii.memory_usage(), empty_size);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(ii.memory_usage(), empty_size + mem_growth);
 }
@@ -43,7 +43,7 @@ fn adding_records() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     let record = RSIndexResult::build_virt().doc_id(10).build();
 
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         mem_growth,
@@ -59,7 +59,7 @@ fn adding_records() {
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
 
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         mem_growth, 5,
@@ -84,7 +84,7 @@ fn adding_same_record_twice() {
     assert_eq!(ii.blocks[0].num_entries, 1);
     assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         mem_growth, 0,
@@ -129,7 +129,7 @@ fn adding_same_record_twice() {
     assert_eq!(ii.blocks[0].buffer, [255]);
     assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
-    ii.add_record(&record).unwrap();
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(
@@ -178,8 +178,7 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
 
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(10).build())
-        .unwrap()
-        .mem_growth as usize;
+        .unwrap();
     assert_eq!(
         mem_growth,
         8 + IndexBlock::STACK_SIZE + 1,
@@ -188,16 +187,14 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
     assert_eq!(ii.blocks.len(), 1);
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(11).build())
-        .unwrap()
-        .mem_growth as usize;
+        .unwrap();
     assert_eq!(mem_growth, 1, "buffer needs to grow for the new byte");
     assert_eq!(ii.blocks.len(), 1);
 
     // 3 entry should create a new block
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(12).build())
-        .unwrap()
-        .mem_growth as usize;
+        .unwrap();
     assert_eq!(
         mem_growth,
         IndexBlock::STACK_SIZE + 1,
@@ -210,16 +207,14 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
     );
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(13).build())
-        .unwrap()
-        .mem_growth as usize;
+        .unwrap();
     assert_eq!(mem_growth, 1, "buffer needs to grow for the new byte");
     assert_eq!(ii.blocks.len(), 2);
 
     // But duplicate entry does not go in new block even if the current block is full
     let mem_growth = ii
         .add_record(&RSIndexResult::build_virt().doc_id(13).build())
-        .unwrap()
-        .mem_growth as usize;
+        .unwrap();
     assert_eq!(mem_growth, 1, "buffer needs to grow again");
     assert_eq!(
         ii.blocks.len(),
@@ -237,7 +232,7 @@ fn adding_big_delta_makes_new_block() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     let record = RSIndexResult::build_virt().doc_id(10).build();
 
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         mem_growth,
@@ -255,7 +250,7 @@ fn adding_big_delta_makes_new_block() {
     let doc_id = (u32::MAX as u64) + 11;
     let record = RSIndexResult::build_virt().doc_id(doc_id).build();
 
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         mem_growth,
@@ -386,13 +381,13 @@ fn adding_tracks_entries() {
     assert_eq!(ii.number_of_entries(), 0);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(ii.memory_usage(), empty_size + mem_growth);
     assert_eq!(ii.number_of_entries(), 1);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(ii.number_of_entries(), 2);
 }
@@ -408,7 +403,7 @@ fn adding_track_field_mask() {
         .doc_id(10)
         .field_mask(0b101)
         .build();
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         mem_growth,
@@ -421,7 +416,7 @@ fn adding_track_field_mask() {
         .doc_id(11)
         .field_mask(0b101)
         .build();
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(mem_growth, 5);
     assert_eq!(ii.field_mask(), 0b101);
@@ -430,7 +425,7 @@ fn adding_track_field_mask() {
         .doc_id(12)
         .field_mask(0b011)
         .build();
-    let mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(mem_growth, 5);
     assert_eq!(ii.field_mask(), 0b111);
@@ -464,10 +459,10 @@ fn summary() {
     );
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         ii.summary(),
@@ -501,10 +496,10 @@ fn summary_store_numeric() {
     );
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     assert_eq!(
         ii.summary(),
@@ -548,13 +543,13 @@ fn blocks_summary() {
     assert_eq!(ii.blocks_summary().len(), 0);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let record = RSIndexResult::build_virt().doc_id(12).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let summaries = ii.blocks_summary();
     assert_eq!(
@@ -602,13 +597,13 @@ fn blocks_summary_store_numeric() {
     assert_eq!(ii.blocks_summary().len(), 0);
 
     let record = RSIndexResult::build_virt().doc_id(10).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let record = RSIndexResult::build_virt().doc_id(11).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let record = RSIndexResult::build_virt().doc_id(12).build();
-    let _mem_growth = ii.add_record(&record).unwrap().mem_growth as usize;
+    let _mem_growth = ii.add_record(&record).unwrap();
 
     let summaries = ii.blocks_summary();
     assert_eq!(

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -43,14 +43,13 @@ impl NumericIndex {
         }
     }
 
-    /// Add a record to the index. Returns `(memory_growth, blocks_added)` — see
-    /// [`InvertedIndex::add_record`][inverted_index::InvertedIndex::add_record].
+    /// Add a record to the index, returning bytes written.
     ///
     /// # Panics
     ///
     /// Panics if the underlying write fails. This should never happen with
     /// in-memory inverted indexes, so a panic indicates a bug.
-    pub fn add_record(&mut self, record: &RSIndexResult<'_>) -> inverted_index::AddRecordOutcome {
+    pub fn add_record(&mut self, record: &RSIndexResult<'_>) -> usize {
         let result = match self {
             NumericIndex::Uncompressed(idx) => idx.add_record(record),
             NumericIndex::Compressed(idx) => idx.add_record(record),

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -94,12 +94,9 @@ impl NumericRange {
 
     /// Add a (docId, value) entry to this range.
     ///
-    /// Updates min/max bounds and cardinality estimation. Returns an [`AddRecordOutcome`]
-    /// reporting how many bytes the inverted index grew by and how many new index blocks the
-    /// write created.
-    ///
-    /// [`AddRecordOutcome`]: inverted_index::AddRecordOutcome
-    pub fn add(&mut self, doc_id: t_docId, value: f64) -> inverted_index::AddRecordOutcome {
+    /// Updates min/max bounds and cardinality estimation.
+    /// Returns the number of bytes the inverted index grew by.
+    pub fn add(&mut self, doc_id: t_docId, value: f64) -> usize {
         self.hll.add(&value.into());
         self.add_without_cardinality(doc_id, value)
     }
@@ -108,7 +105,6 @@ impl NumericRange {
     ///
     /// This function DOES NOT update the cardinality of the range.
     /// Use [`add`][Self::add] to add an entry _and_ update cardinality of the range.
-    /// Returns `(memory_growth, blocks_added)` — see [`Self::add`].
     ///
     /// # Use Cases
     ///
@@ -116,11 +112,7 @@ impl NumericRange {
     ///   node, cardinality is already tracked at the leaf level.
     /// - **Splitting**: When redistributing entries during a split, the caller
     ///   explicitly updates cardinality for each destination range.
-    pub fn add_without_cardinality(
-        &mut self,
-        doc_id: t_docId,
-        value: f64,
-    ) -> inverted_index::AddRecordOutcome {
+    pub fn add_without_cardinality(&mut self, doc_id: t_docId, value: f64) -> usize {
         // Update bounds
         if value < self.min_val {
             self.min_val = value;

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -62,9 +62,6 @@ pub struct CompactIfSparseResult {
     /// The change in the tree's node memory usage, in bytes.
     /// Positive values indicate growth, negative values indicate shrinkage.
     pub node_size_delta: i64,
-    /// Net change in inverted-index block count across all dropped leaves. Always non-positive
-    /// (trimming only removes blocks).
-    pub block_count_delta: i32,
 }
 
 impl NumericRangeNode {
@@ -217,7 +214,6 @@ impl NumericRangeTree {
         CompactIfSparseResult {
             inverted_index_size_delta: rv.size_delta,
             node_size_delta: -(slab_freed as i64),
-            block_count_delta: rv.block_count_delta,
         }
     }
 
@@ -329,7 +325,6 @@ impl NumericRangeTree {
                 let br = Self::balance_node(nodes, node_idx);
                 rv.size_delta += br.size_delta;
                 rv.num_ranges_delta += br.num_ranges_delta;
-                rv.block_count_delta += br.block_count_delta;
                 if let NumericRangeNode::Internal(internal) = &mut nodes[node_idx] {
                     internal.max_depth = br.new_depth;
                 }
@@ -354,7 +349,6 @@ impl NumericRangeTree {
         if let Some(r) = nodes[node_idx].take_range() {
             rv.size_delta -= r.memory_usage() as i64;
             rv.num_ranges_delta -= 1;
-            rv.block_count_delta -= r.entries().num_blocks() as i32;
         }
 
         if right_empty {
@@ -388,13 +382,11 @@ impl NumericRangeTree {
                 rv.num_leaves_delta -= 1;
                 rv.size_delta -= leaf.range.memory_usage() as i64;
                 rv.num_ranges_delta -= 1;
-                rv.block_count_delta -= leaf.range.entries().num_blocks() as i32;
             }
             NumericRangeNode::Internal(internal) => {
                 if let Some(range) = internal.range.as_ref() {
                     rv.size_delta -= range.memory_usage() as i64;
                     rv.num_ranges_delta -= 1;
-                    rv.block_count_delta -= range.entries().num_blocks() as i32;
                 }
             }
         }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -192,9 +192,8 @@ impl NumericRangeTree {
                 if let NumericRangeNode::Internal(internal) = &mut nodes[node_idx]
                     && let Some(range) = internal.range.as_mut()
                 {
-                    let outcome = range.add_without_cardinality(doc_id, value);
-                    rv.size_delta += outcome.mem_growth as i64;
-                    rv.block_count_delta += outcome.blocks_added as i32;
+                    let size = range.add_without_cardinality(doc_id, value);
+                    rv.size_delta += size as i64;
                     rv.num_records_delta += 1;
                 }
 
@@ -204,7 +203,6 @@ impl NumericRangeTree {
                     rv.size_delta += br.size_delta;
                     rv.num_records_delta += br.num_records_delta;
                     rv.num_ranges_delta += br.num_ranges_delta;
-                    rv.block_count_delta += br.block_count_delta;
                     if let NumericRangeNode::Internal(internal) = &mut nodes[node_idx] {
                         internal.max_depth = br.new_depth;
                     }
@@ -229,14 +227,13 @@ impl NumericRangeTree {
                     *empty_leaves -= 1;
                 }
 
-                let outcome = leaf.range.add(doc_id, value);
+                let size = leaf.range.add(doc_id, value);
                 let mut rv = AddResult {
-                    size_delta: outcome.mem_growth as i64,
+                    size_delta: size as i64,
                     num_records_delta: 1,
                     changed: false,
                     num_ranges_delta: 0,
                     num_leaves_delta: 0,
-                    block_count_delta: outcome.blocks_added as i32,
                 };
 
                 let card = leaf.range.cardinality();
@@ -332,9 +329,8 @@ impl NumericRangeTree {
             };
 
             if let Some(target_range) = nodes[target_idx].range_mut() {
-                let outcome = target_range.add(result.doc_id, entry_value);
-                rv.size_delta += outcome.mem_growth as i64;
-                rv.block_count_delta += outcome.blocks_added as i32;
+                let size = target_range.add(result.doc_id, entry_value);
+                rv.size_delta += size as i64;
             }
             rv.num_records_delta += 1;
         }
@@ -382,7 +378,6 @@ impl NumericRangeTree {
             rv.size_delta -= range.memory_usage() as i64;
             rv.num_records_delta -= range.num_entries() as i32;
             rv.num_ranges_delta -= 1;
-            rv.block_count_delta -= range.entries().num_blocks() as i32;
         }
     }
 
@@ -440,7 +435,6 @@ impl NumericRangeTree {
                 result.size_delta -= range.memory_usage() as i64;
                 result.num_records_delta -= range.num_entries() as i32;
                 result.num_ranges_delta -= 1;
-                result.block_count_delta -= range.entries().num_blocks() as i32;
             }
         }
 
@@ -463,6 +457,4 @@ pub(super) struct BalanceResult {
     pub num_records_delta: i32,
     /// Change in range count from dropped ranges.
     pub num_ranges_delta: i32,
-    /// Change in inverted-index block count from dropped ranges (always ≤ 0).
-    pub block_count_delta: i32,
 }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -61,11 +61,6 @@ pub struct AddResult {
     /// The net change in the number of leaf nodes.
     /// Splitting a leaf adds one new leaf. Trimming decreases this.
     pub num_leaves_delta: i32,
-    /// The net change in the number of inverted-index blocks across all leaves touched by
-    /// this add. Block growth (writes spilling into a new block, new leaves created by a
-    /// split) contributes positively; range removals during rebalancing (`remove_range`,
-    /// rotations dropping an internal node's retained range) contribute negatively.
-    pub block_count_delta: i32,
 }
 
 /// Result of trimming empty leaves from the tree.
@@ -87,9 +82,6 @@ pub struct TrimEmptyLeavesResult {
     pub num_ranges_delta: i32,
     /// The net change in the number of leaf nodes.
     pub num_leaves_delta: i32,
-    /// Net change in inverted-index block count across all dropped leaves. Always non-positive
-    /// (trimming only removes blocks).
-    pub block_count_delta: i32,
 }
 
 /// Aggregate statistics for a [`NumericRangeTree`].

--- a/src/spec.h
+++ b/src/spec.h
@@ -165,25 +165,11 @@ typedef struct {
   size_t offsetVecsSize;
   size_t offsetVecRecords;
   size_t termsSize;
-  // Number of inverted-index blocks currently owned by this spec; reported by FT.INFO as
-  // `total_inverted_index_blocks`. Writes must go through `IndexStats_BlockCountAdd` (signed
-  // delta, atomic). Reads must use `__atomic_load_n`.
-  size_t totalInvertedIndexBlocks;
   rs_wall_clock_ns_t totalIndexTime;
   IndexError indexError;
   uint32_t activeQueries;
   uint32_t activeWrites;
 } IndexStats;
-
-// Atomically apply `delta` to `stats->totalInvertedIndexBlocks`. Accepts signed deltas:
-// negative values wrap via size_t two's-complement, producing the correct unsigned
-// subtraction.
-static inline void IndexStats_BlockCountAdd(IndexStats *stats, int64_t delta) {
-  if (delta) {
-    __atomic_add_fetch(&stats->totalInvertedIndexBlocks,
-                       (size_t)delta, __ATOMIC_RELAXED);
-  }
-}
 
 typedef enum {
   Index_StoreTermOffsets = 0x01,

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -207,15 +207,12 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // Encode a single docId into a specific tag value
 // Returns the number of bytes occupied by the encoded entry plus the size of
 // the inverted index (if a new inverted index was created)
-static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId,
-                                  IndexStats *stats) {
+static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
   size_t sz;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
-  AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iv, &rec);
-  IndexStats_BlockCountAdd(stats, r.blocks_added);
-  return r.mem_growth + sz;
+  return InvertedIndex_WriteEntryGeneric(iv, &rec) + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */
@@ -244,7 +241,7 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, const char **values, siz
     for (size_t ii = 0; ii < n; ++ii) {
       const char *tok = values[ii];
       if (tok) {
-        stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, stats);
+        stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId);
 
         if (idx->suffix && (*tok != '\0')) { // add to suffix TrieMap
           addSuffixTrieMap(idx->suffix, tok, strlen(tok));

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -392,7 +392,7 @@ TEST_F(IndexTest, testNumericInverted) {
     }
 
     // Check if the write matches the simulation
-    sz = InvertedIndex_WriteNumericEntry(idx, i + 1, (double)(i + 1)).mem_growth;
+    sz = InvertedIndex_WriteNumericEntry(idx, i + 1, (double)(i + 1));
     ASSERT_EQ(sz, expected_sz) << " at i=" << i;
   }
   ASSERT_EQ(75, InvertedIndex_LastId(idx));
@@ -429,7 +429,7 @@ TEST_F(IndexTest, testNumericVaried) {
   static const size_t numCount = sizeof(nums) / sizeof(double);
 
   for (size_t i = 0; i < numCount; i++) {
-    size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]).mem_growth;
+    size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
     // printf("[%lu]: Stored %lf\n", i, nums[i]);
   }
 
@@ -490,10 +490,10 @@ void testNumericEncodingHelper(bool isMulti) {
 
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
-    size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value).mem_growth;
+    size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 
     if (isMulti) {
-      size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value).mem_growth;
+      size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
     }
   }
 
@@ -1177,7 +1177,7 @@ TEST_F(IndexTest, testIndexFlags) {
   // storing fieldmask on idx             16
   ASSERT_EQ(40, index_memsize);
   ASSERT_TRUE(InvertedIndex_Flags(w) == flags);
-  size_t sz = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
+  size_t sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(73, sz);
   InvertedIndex_Free(w);
 
@@ -1185,7 +1185,7 @@ TEST_F(IndexTest, testIndexFlags) {
   w = NewInvertedIndex(IndexFlags(flags), &index_memsize);
   ASSERT_EQ(40, index_memsize);
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
-  size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
+  size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(sz2, 60);
   InvertedIndex_Free(w);
 
@@ -1194,7 +1194,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_EQ(40, index_memsize);
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
   h.fieldMask = 0xffffffffffff;
-  ASSERT_EQ(77, InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth);
+  ASSERT_EQ(77, InvertedIndex_WriteForwardIndexEntry(w, &h));
   InvertedIndex_Free(w);
 
   flags &= Index_StoreFreqs;
@@ -1206,7 +1206,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_EQ(24, index_memsize);
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreFieldFlags));
-  sz = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(59, sz);
   InvertedIndex_Free(w);
 
@@ -1216,7 +1216,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_StoreFieldFlags));
   h.fieldMask = 0xffffffffffff;
-  sz = InvertedIndex_WriteForwardIndexEntry(w, &h).mem_growth;
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(67, sz);
   InvertedIndex_Free(w);
 

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -155,46 +155,6 @@ def test_info_text_tag_overhead(env):
   env.assertEqual(float(res['tag_overhead_sz_mb']), 24. / 1024 / 1024)
   env.assertEqual(float(res['text_overhead_sz_mb']), 0)
 
-@skip(cluster=True)
-def test_total_inverted_index_blocks_per_spec(env):
-  """Regression test for MOD-15781: `FT.INFO total_inverted_index_blocks` must reflect only the
-  queried spec's blocks, not the process-global block count summed across all in-memory
-  indexes."""
-
-  conn = getConnectionByEnv(env)
-
-  # Two indexes with deliberately different sizes so a global-counter bug would surface as
-  # both reports having the same (summed) value. PREFIX keeps each spec isolated so each
-  # doc gets indexed into exactly one of them.
-  env.expect('FT.CREATE', 'small_idx', 'PREFIX', 1, 'small:', 'SCHEMA', 'tag1', 'TAG').ok()
-  env.expect('FT.CREATE', 'large_idx', 'PREFIX', 1, 'large:', 'SCHEMA', 'tag1', 'TAG').ok()
-
-  # Each unique tag value gets its own inverted index (with at least one block), so a unique
-  # tag per doc maximises block count per doc.
-  for i in range(50):
-    conn.execute_command('HSET', f'small:{i}', 'tag1', f'sm{i}')
-  for i in range(500):
-    conn.execute_command('HSET', f'large:{i}', 'tag1', f'lg{i}')
-
-  small_blocks = int(index_info(env, 'small_idx')['total_inverted_index_blocks'])
-  large_blocks = int(index_info(env, 'large_idx')['total_inverted_index_blocks'])
-
-  # Each unique tag yields one DocIdsOnly inverted index with a single block. With a
-  # process-global counter (the pre-fix bug) both reports would equal the sum and `small_blocks`
-  # would equal `large_blocks`; with a per-spec counter `large_blocks` is ~10x `small_blocks`.
-  env.assertGreaterEqual(small_blocks, 50, message=f'small={small_blocks}, large={large_blocks}')
-  env.assertGreaterEqual(large_blocks, 500, message=f'small={small_blocks}, large={large_blocks}')
-  env.assertGreater(large_blocks, small_blocks * 5,
-                    message=f'per-spec counter regressed to a global sum: '
-                            f'small={small_blocks}, large={large_blocks}')
-
-  # Dropping `large_idx` must not change `small_idx`'s block count.
-  env.expect('FT.DROPINDEX', 'large_idx', 'DD').ok()
-  small_blocks_after_drop = int(index_info(env, 'small_idx')['total_inverted_index_blocks'])
-  env.assertEqual(small_blocks_after_drop, small_blocks,
-                  message=f'dropping a sibling spec must not change this spec\'s block count: '
-                          f'before={small_blocks} after={small_blocks_after_drop}')
-
 def test_vecsim_info_stats_memory():
   env = Env(protocol=3)
   vec_size = 6

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -567,10 +567,8 @@ def testInfoStatsAndSearchAsSingle(env):
         json_val = {k:v for (k,v) in zip([f'val{i + 1}' for i in range(val_count)], val_list)}
         conn.execute_command('JSON.SET', f'doc:single:{{{doc}}}', '$', json.dumps(json_val))
 
-    # Compare INFO stats. `total_inverted_index_blocks` is per-spec (MOD-15781) and
-    # legitimately differs here: idx:single has 5 numeric trees (one per attribute),
-    # idx:multi has a single tree — same total records, different number of blocks.
-    interesting_attr = ['num_docs', 'max_doc_id', 'num_records']
+    # Compare INFO stats
+    interesting_attr = ['num_docs', 'max_doc_id', 'num_records', 'total_inverted_index_blocks']
     info_single = keep_dict_keys(index_info(env, 'idx:single'), interesting_attr)
     info_multi = keep_dict_keys(index_info(env, 'idx:multi'), interesting_attr)
     env.assertEqual(info_single, info_multi)


### PR DESCRIPTION

## Describe the changes in the pull request

Reverts PR #9735 ("MOD-15781: FT.INFO: Make Total Block Count Value Be Per Schema").

1. **Current:** After PR #9735 was merged (master SHA acb3239242a3ab7743edc49d9c9aad555fcff8b6), the first Periodic Master Validation CI run on that SHA failed in test_json_multi_numeric:testInfoStats with {"num_records": 200, "total_inverted_index_blocks": 6} == {"num_records": 200, "total_inverted_index_blocks": 7} (coordinator + ASan only; standalone was green on the same job). The previous validation run on 653b0f6a was fully green.
2. **Change:** Revert the squash-merge commit acb3239 of PR #9735 to restore the pre-change behavior of total_inverted_index_blocks accounting and unblock master CI while the per-schema design is fixed.
3. **Outcome:** Master Periodic Master Validation should go green again. The original change can be re-landed via a follow-up PR once the coordinator/per-schema accounting discrepancy is resolved and testInfoStats is updated/extended to cover both modes deterministically.

#### Which additional issues this PR fixes
1. MOD-15904 (flaky/regression report for test_json_multi_numeric:testInfoStats)
2. Reverts: #9735 (MOD-15781)

#### Main objects this PR modified
1. Reverts changes to total_inverted_index_blocks accounting introduced by #9735 (31 files, +117 / -327).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Revert of a user-visible FT.INFO change - total_inverted_index_blocks reverts to its prior (pre-#9735) semantics.

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=atlassian&utm_medium=jira_issue&utm_campaign=jira)
