### PR TITLE
[MOD-15894] Makefile: add make deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ MAKEFLAGS += --no-print-directory
 ROOT := $(shell pwd)
 BUILD_SCRIPT := $(ROOT)/build.sh
 
+export PATH := $(HOME)/.cargo/bin:$(HOME)/.local/bin:$(PATH)
+
 # Default target
 .DEFAULT_GOAL := build
 
@@ -147,8 +149,8 @@ define HELPTEXT
 RediSearch Build System
 
 Setup:
-  make bootstrap     Install build-time system dependencies, fetch submodules,
-                     and verify the result. Auto-prefixes `sudo` when not root.
+  make deps          Install build-time system dependencies.
+                     Auto-prefixes `sudo` when not root.
     SUDO=cmd           Override the privilege-escalation command (default: auto)
   make fetch         Download and prepare dependent modules
 
@@ -222,11 +224,9 @@ help:
 # or to force no prefix.
 SUDO ?= $(shell [ "$$(id -u)" -eq 0 ] || echo sudo)
 
-bootstrap:
+deps:
 	@echo "Installing build dependencies..."
 	@cd $(ROOT)/.install && ./install_script.sh $(SUDO)
-	@$(MAKE) fetch
-	@$(ROOT)/.install/verify_build_deps.sh
 
 fetch:
 	@echo "Fetching dependencies..."
@@ -469,7 +469,7 @@ test-linkcheck:
 	fi
 	@python3 scripts/test_link_checker.py
 
-.PHONY: help bootstrap fetch build clean test unit-tests rust-tests pytest
+.PHONY: help deps fetch build clean test unit-tests rust-tests pytest
 .PHONY: run lint fmt license-check pack upload-artifacts
 .PHONY: benchmark micro-benchmarks vecsim-bench callgrind parsers verify-deps
 .PHONY: check-links check-links-verbose test-linkcheck

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ define HELPTEXT
 RediSearch Build System
 
 Setup:
+  make bootstrap     Install build-time system dependencies, fetch submodules,
+                     and verify the result. Auto-prefixes `sudo` when not root.
+    SUDO=cmd           Override the privilege-escalation command (default: auto)
   make fetch         Download and prepare dependent modules
 
 Build:
@@ -213,6 +216,17 @@ endef # HELPTEXT
 help:
 	$(info $(HELPTEXT))
 	@:
+
+# Auto-detect: empty when running as root (containers/CI), "sudo" otherwise.
+# Override with SUDO= for environments that need a different prefix (e.g. doas)
+# or to force no prefix.
+SUDO ?= $(shell [ "$$(id -u)" -eq 0 ] || echo sudo)
+
+bootstrap:
+	@echo "Installing build dependencies..."
+	@cd $(ROOT)/.install && ./install_script.sh $(SUDO)
+	@$(MAKE) fetch
+	@$(ROOT)/.install/verify_build_deps.sh
 
 fetch:
 	@echo "Fetching dependencies..."
@@ -455,7 +469,7 @@ test-linkcheck:
 	fi
 	@python3 scripts/test_link_checker.py
 
-.PHONY: help build clean test unit-tests rust-tests pytest
+.PHONY: help bootstrap fetch build clean test unit-tests rust-tests pytest
 .PHONY: run lint fmt license-check pack upload-artifacts
 .PHONY: benchmark micro-benchmarks vecsim-bench callgrind parsers verify-deps
 .PHONY: check-links check-links-verbose test-linkcheck


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: RediSearch has no Make entry point that matches Redis's
   modernized module workflow for installing build-time dependencies.
   Callers either invoke `.install/install_script.sh` directly or use
   distro-specific package commands.
2. **Change**: Add a `deps` target to the root `Makefile` that wraps
   `.install/install_script.sh`. `SUDO` auto-detects: empty under root
   (containers/CI), `sudo` otherwise; overridable via `SUDO=<cmd>`.
   The existing `fetch` and `verify-deps` targets remain separate.
3. **Outcome**: Parent Redis can recurse into RediSearch with `make deps`
   as the module dependency-install API. Follow-up Make targets also see
   user-local tool paths such as `~/.cargo/bin` and `~/.local/bin`.

The existing `.install/install_script.sh` path, used by Dockerfile-style
flows, is unchanged.

#### Which additional issues this PR fixes

1. MOD-15894

#### Main objects this PR modified

1. `Makefile` - new `deps` target, `SUDO ?=` auto-detect, help text,
   `.PHONY` entry, and Make-exported PATH for user-local tools.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal build-workflow change with no user-facing behavior impact.

## Test plan

- [x] `make -n deps` prints the expected install command only.
- [x] `make -n deps SUDO=doas` honors the privilege-prefix override.
- [x] `make -n fetch` remains available as a separate source-dependency fetch target.
- [x] `make -n verify-deps` still runs the existing dependency checker.
- [x] `make -n build` still runs `verify-deps` before `build.sh`.
- [x] `make help` documents `make deps` and no longer documents `make bootstrap`.
- [x] `git diff --check`.
- [x] Ubuntu 24.04 Docker smoke test: `docker run --rm -v $PWD:/src -w /src ubuntu:24.04 bash -c "apt update && apt install -y make git && make deps && make verify-deps"`.
