### PR TITLE
[MOD-15904] testInfoStats: stop comparing total_inverted_index_blocks across single/multi indexes

### DIFF
--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -529,7 +529,10 @@ def testInfoStats(env):
             conn.execute_command('JSON.SET', f'doc:single:{{{doc_created + i}}}', '$', json.dumps({'top': val_list[i]}))
         doc_created += val_count - 1
 
-    interesting_attr = ['num_records', 'total_inverted_index_blocks']
+    # Excludes `total_inverted_index_blocks`: per-spec since MOD-15781, and the
+    # two indexes scatter the same values across shards differently, so block
+    # counts legitimately diverge in cluster mode.
+    interesting_attr = ['num_records']
     info_single = keep_dict_keys(index_info(env, 'idx:single'), interesting_attr)
     info_multi = keep_dict_keys(index_info(env, 'idx:multi'), interesting_attr)
     env.assertEqual(info_single, info_multi)

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -532,10 +532,10 @@ def testInfoStats(env):
     # Excludes `total_inverted_index_blocks`: per-spec since MOD-15781, and the
     # two indexes scatter the same values across shards differently, so block
     # counts legitimately diverge in cluster mode.
-    interesting_attr = ['num_records']
-    info_single = keep_dict_keys(index_info(env, 'idx:single'), interesting_attr)
-    info_multi = keep_dict_keys(index_info(env, 'idx:multi'), interesting_attr)
-    env.assertEqual(info_single, info_multi)
+    env.assertEqual(
+        index_info(env, 'idx:single')['num_records'],
+        index_info(env, 'idx:multi')['num_records'],
+    )
 
 @skip(no_json=True)
 def testInfoStatsAndSearchAsSingle(env):


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `testInfoStats` in `test_json_multi_numeric.py` asserts that `total_inverted_index_blocks` is equal between `idx:single` and `idx:multi`. Before MOD-15781 this was a process-global counter, so the assertion was effectively `global == global` — trivially true regardless of layout.
2. **Change:** Drop `total_inverted_index_blocks` from the `interesting_attr` list compared between the two indexes. The sibling test `testInfoStatsAndSearchAsSingle` was already exempted in #9735 (MOD-15781); this one was missed.
3. **Outcome:** The flaky failure surfaced on `master` after #9735 merged (coordinator / OSS cluster, AddressSanitizer build) is fixed without weakening the test's real invariant (`num_records` parity).

### Why the test was failing (coordinator-only)

After MOD-15781, `total_inverted_index_blocks` is per-spec. `testInfoStats` builds two indexes with the same numeric schema and 200 records each, but the records are sharded differently. Take one iteration with `val_count=3`, `doc_created=1`:

| Key | Hash tag | Shard |
|-----|----------|-------|
| `doc:multi:{1}   = [v1, v2, v3]` | `{1}` | A |
| `doc:single:{1}  = v1` | `{1}` | A |
| `doc:single:{2}  = v2` | `{2}` | B |
| `doc:single:{3}  = v3` | `{3}` | C |

The multi index keeps each iteration's values on one shard. The single index scatters them across shards. Each shard builds its own numeric range tree from its local values, with its own inverted-index blocks. Aggregated across shards the totals differ (the CI failure showed 6 vs 7).

In standalone mode there's only one shard, both indexes see the same 200 values, and with the 100-entry block split threshold no leaf overflows — so block counts coincide by accident. That's not an invariant of the data model, which is why standalone passes and coordinator fails.

### Why drop rather than fix the layout

Per-spec block count under different per-shard value distributions is not a meaningful equality to assert. The alternative — anchoring all of an iteration's single docs to the multi doc's hash tag (e.g. `doc:single:1{1}`, `doc:single:2{1}`, …) — would make the comparison valid but changes the test's intent. `num_records` already covers the "same total data indexed" invariant this test cares about.

#### Which additional issues this PR fixes
1. MOD-15904

#### Main objects this PR modified
1. \`tests/pytests/test_json_multi_numeric.py\` — \`testInfoStats\`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; production indexing behavior is unchanged.
> 
> **Overview**
> **`testInfoStats`** in `test_json_multi_numeric.py` no longer requires **`total_inverted_index_blocks`** to match between **`idx:single`** and **`idx:multi`**. After MOD-15781 that stat is per-spec, and the test’s different key/hash-tag layout spreads the same numeric values across shards differently in cluster/coordinator runs, so block totals can diverge even when indexing is equivalent.
> 
> The test still asserts **`num_records`** parity between the two indexes—the invariant this case is meant to check. This mirrors the earlier exemption in **`testInfoStatsAndSearchAsSingle`** (#9735) that was missed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d82034e24e849e98782c3f49156967de89203b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->