### PR TITLE
[2.6] MOD-15402: Prevent partial updates in SynonymMap_Update

### DIFF
--- a/src/synonym_map.c
+++ b/src/synonym_map.c
@@ -163,37 +163,75 @@ SynonymMapResult SynonymMap_Add(SynonymMap* smap, const char* groupId, const cha
 SynonymMapResult SynonymMap_Update(SynonymMap* smap, const char** synonyms, size_t size, const char* groupId) {
   RS_LOG_ASSERT(!smap->is_read_only, "SynonymMap should not be read only");
 
-  SynonymMapResult ret = SYNONYM_MAP_OK;
-  for (size_t i = 0; i < size; i++) {
-    // Check if we've reached the maximum number of terms
-    if (unlikely(dictSize(smap->h_table) >= MAX_SYNONYM_TERMS)) {
-      ret = SYNONYM_MAP_ERR_MAX_TERMS;
-      break;
-    }
+  if (size == 0) {
+    return SYNONYM_MAP_OK;
+  }
 
-    char *lowerSynonym = rm_strdup(synonyms[i]);
-    size_t newLen = unicode_tolower(lowerSynonym, strlen(lowerSynonym));
+  // Lowercase every input synonym up front. We will validate against the
+  // limits before mutating the dictionary, so a failure leaves the map
+  // unchanged.
+  char** lowered = rm_malloc(sizeof(char*) * size);
+  for (size_t i = 0; i < size; i++) {
+    char *s = rm_strdup(synonyms[i]);
+    size_t newLen = unicode_tolower(s, strlen(s));
     if (newLen) {
-      lowerSynonym[newLen] = '\0';
+      s[newLen] = '\0';
     }
-    TermData* termData = dictFetchValue(smap->h_table, lowerSynonym);
+    lowered[i] = s;
+  }
+
+  SynonymMapResult ret = SYNONYM_MAP_OK;
+
+  // Validation pass. Track distinct new terms via a temporary dict so we
+  // don't over-count duplicates within the input batch.
+  dict* pending_new = dictCreate(&dictTypeHeapStrings, NULL);
+  for (size_t i = 0; i < size; i++) {
+    TermData* termData = dictFetchValue(smap->h_table, lowered[i]);
     if (termData) {
-      // if term exists in dictionary, we should release the lower cased string
-      rm_free(lowerSynonym);
-    } else {
-      termData = TermData_New(lowerSynonym); //strtolower
-      dictAdd(smap->h_table, lowerSynonym, termData);
-    }
-    ret = TermData_AddId(termData, groupId);
-    if (ret != SYNONYM_MAP_OK) {
-      break;
+      // Existing term gains one group id iff it doesn't already have it.
+      if (!TermData_IdExists(termData, groupId) &&
+          array_len(termData->groupIds) >= MAX_SYNONYM_GROUP_IDS) {
+        ret = SYNONYM_MAP_ERR_MAX_GROUP_IDS;
+        break;
+      }
+    } else if (dictFind(pending_new, lowered[i]) == NULL) {
+      dictAdd(pending_new, lowered[i], NULL);
     }
   }
+  if (ret == SYNONYM_MAP_OK &&
+      unlikely(dictSize(smap->h_table) + dictSize(pending_new) > MAX_SYNONYM_TERMS)) {
+    ret = SYNONYM_MAP_ERR_MAX_TERMS;
+  }
+  dictRelease(pending_new);
+
+  if (ret != SYNONYM_MAP_OK) {
+    for (size_t i = 0; i < size; i++) {
+      rm_free(lowered[i]);
+    }
+    rm_free(lowered);
+    return ret;
+  }
+
+  // Apply pass. Validation guarantees TermData_AddId cannot fail here.
+  for (size_t i = 0; i < size; i++) {
+    TermData* termData = dictFetchValue(smap->h_table, lowered[i]);
+    if (termData) {
+      rm_free(lowered[i]);
+    } else {
+      termData = TermData_New(lowered[i]);
+      dictAdd(smap->h_table, lowered[i], termData);
+    }
+    SynonymMapResult r = TermData_AddId(termData, groupId);
+    RS_LOG_ASSERT(r == SYNONYM_MAP_OK,
+                  "SynonymMap_Update: TermData_AddId failed after validation");
+  }
+  rm_free(lowered);
+
   if (smap->read_only_copy) {
     SynonymMap_Free(smap->read_only_copy);
     smap->read_only_copy = NULL;
   }
-  return ret;
+  return SYNONYM_MAP_OK;
 }
 
 TermData* SynonymMap_GetIdsBySynonym(SynonymMap* smap, const char* synonym, size_t len) {

--- a/tests/pytests/test_limits.py
+++ b/tests/pytests/test_limits.py
@@ -108,22 +108,84 @@ def testMaxSynonymGroupIdsLimit(env):
 
 def testMaxSynonymTermsLimit(env):
     """Test that adding more than MAX_SYNONYM_TERMS (1,000,000) unique terms
-    to a synonym map fails (regardless of how many groups they belong to)"""
+    to a synonym map fails (regardless of how many groups they belong to),
+    and that a rejected batch is applied atomically (no partial insertion)."""
     MAX_SYNONYM_TERMS = 1_000_000
     BATCH_SIZE = 1000  # Add 1000 terms per FT.SYNUPDATE call for efficiency
 
     # Create an index
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'text').ok()
 
-    # Add terms in batches until we reach the limit
+    # Fill to MAX_SYNONYM_TERMS - 1 so the overflow batch below has one term
+    # that would succeed and one that would trip the limit -- this is what
+    # exercises atomicity.
     num_batches = MAX_SYNONYM_TERMS // BATCH_SIZE
     for batch in range(num_batches):
         terms = [f'term{batch * BATCH_SIZE + i}' for i in range(BATCH_SIZE)]
+        if batch == num_batches - 1:
+            terms = terms[:-1]  # leave exactly one free slot
         env.expect('FT.SYNUPDATE', 'idx', f'group{batch}', *terms).ok()
 
-    # Adding one more term should fail
-    env.expect('FT.SYNUPDATE', 'idx', 'overflow_group', 'overflow_term') \
+    # Verify we have MAX_SYNONYM_TERMS - 1 unique terms in the map.
+    dump = env.cmd('FT.SYNDUMP', 'idx')
+    dumped_terms = set(dump[::2])
+    env.assertEqual(len(dumped_terms), MAX_SYNONYM_TERMS - 1)
+
+    # A 2-term batch must fail AND leave neither term inserted.
+    env.expect('FT.SYNUPDATE', 'idx', 'overflow_group',
+               'overflow_a', 'overflow_b') \
         .error().contains('Maximum synonym terms limit reached')
+
+    # FT.SYNDUMP returns a flat [term, [ids...], term, [ids...], ...] list.
+    dump = env.cmd('FT.SYNDUMP', 'idx')
+    dumped_terms = set(dump[::2])
+    env.assertEqual(len(dumped_terms), MAX_SYNONYM_TERMS - 1)
+    env.assertNotIn('overflow_a', dumped_terms)
+    env.assertNotIn('overflow_b', dumped_terms)
+
+    # Fill the last remaining slot so the map sits at exactly MAX_SYNONYM_TERMS.
+    # Duplicated fresh terms count as one distinct pending term.
+    env.expect('FT.SYNUPDATE', 'idx', 'last_slot_group',
+            'fresh_term', 'fresh_term').ok()
+
+    dump = env.cmd('FT.SYNDUMP', 'idx')
+    pairs = dict(zip(dump[::2], dump[1::2]))
+    env.assertIn('fresh_term', pairs)
+    env.assertEqual(len(pairs), MAX_SYNONYM_TERMS)
+    env.assertEqual(pairs['fresh_term'], ['last_slot_group'])
+
+    # Any further new term must now fail with the limit error.
+    env.expect('FT.SYNUPDATE', 'idx', 'overflow_group2', 'overflow_c') \
+        .error().contains('Maximum synonym terms limit reached')
+
+    # An *existing* term can still be added to a new group even when the map
+    # is at MAX_SYNONYM_TERMS (no insertion happens, so the limit check
+    # must not trip).
+    env.expect('FT.SYNUPDATE', 'idx', 'reuse_group', 'term0').ok()
+
+
+def testMaxSynonymGroupIdsLimitAtomic(env):
+    """A batch that would push an existing term over MAX_SYNONYM_GROUP_IDS
+    must be rejected without applying any of its updates (atomicity)."""
+    MAX_SYNONYM_GROUP_IDS = 4096
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'text').ok()
+
+    # Saturate `crowded` with MAX_SYNONYM_GROUP_IDS distinct groups.
+    crowded = 'crowded'
+    for i in range(MAX_SYNONYM_GROUP_IDS):
+        env.expect('FT.SYNUPDATE', 'idx', f'g{i}', crowded).ok()
+
+    # FT.SYNUPDATE with a new term plus `crowded` (at the group-ID limit)
+    # must be rejected as a whole.
+    env.expect('FT.SYNUPDATE', 'idx', 'new_group', 'fresh_term', crowded) \
+        .error().contains('Maximum group IDs per term limit reached')
+
+    dump = env.cmd('FT.SYNDUMP', 'idx')
+    pairs = dict(zip(dump[::2], dump[1::2]))
+    env.assertNotIn('fresh_term', pairs)
+    # crowded must NOT have gained 'new_group'.
+    env.assertNotIn('new_group', pairs[crowded])
 
 
 def testMaxFieldsLimit(env):


### PR DESCRIPTION
# Description
Backport of #9782 to `2.6`.
(cherry picked from commit 1744c9890f670ea300ebc06ab59f5f931d7c30ae)

Conflicts solved:
- `unicode_tolower()` in `2.6` returns the size of the new string instead of the pointer to the new string as done in `master`.

### Description 
1. Current: `FT.SYNUPDATE` could partially mutate the synonym map when a multi-term update hit the maximum synonym terms limit or maximum group IDs per term limit.
2. Change: `SynonymMap_Update` now performs validation before applying changes, including lowercasing inputs up front and counting only distinct new terms in the batch.
3. Outcome: Rejected synonym updates are atomic: if the update exceeds synonym limits, no terms or group IDs from that batch are inserted.

#### Which additional issues this PR fixes

1. MOD-15402

#### Main objects this PR modified

1. `src/synonym_map.c`
2. `tests/pytests/test_limits.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core synonym-map mutation and limit semantics for FT.SYNUPDATE; wrong validation could reject valid updates or still allow partial state, but behavior is heavily covered by new limit tests.
> 
> **Overview**
> **`FT.SYNUPDATE`** no longer applies part of a multi-term batch when synonym limits are hit. **`SynonymMap_Update`** now lowercases all inputs first, runs a **validation pass** (distinct new terms in the batch, max terms, max group IDs per existing term), and only then mutates the map—so a failed update leaves the synonym map unchanged.
> 
> Limit checks are tightened: new unique terms in a batch are counted once (duplicates in the same call do not inflate the term cap), and an existing term at **`MAX_SYNONYM_TERMS`** can still join another group without tripping the term limit.
> 
> **`test_limits.py`** adds atomicity coverage for term and group-ID overflow batches, last-slot fill, and reuse of an existing term at the term cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849515aa17dadba4f94f6a3684c7946852fc7416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->