### PR TITLE
Fix nix feature set for redisearch_rs

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1344,15 +1344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metrics_ffi"
 version = "0.0.1"
 dependencies = [
@@ -1409,8 +1400,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
- "pin-utils",
 ]
 
 [[package]]
@@ -1582,12 +1571,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -172,7 +172,7 @@ insta = "1.46.1"
 itertools = "0.14.0"
 lending-iterator = "0.1.7"
 libc = "0.2.180"
-nix = { version = "0.26", features = ["poll"] }
+nix = { version = "0.26", default-features = false, features = ["poll"] }
 memchr = "2.7.6"
 pin-project = "1.1.10"
 pretty_assertions = "1.4.1"

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -22,7 +22,7 @@ insta = { version = "1", features = ["filters"] }
 itertools = { version = "0.13" }
 libc = { version = "0.2", features = ["extra_traits"] }
 memchr = { version = "2" }
-nix = { version = "0.26" }
+nix = { version = "0.26", default-features = false, features = ["poll"] }
 num-traits = { version = "0.2" }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
@@ -48,7 +48,7 @@ insta = { version = "1", features = ["filters"] }
 itertools = { version = "0.13" }
 libc = { version = "0.2", features = ["extra_traits"] }
 memchr = { version = "2" }
-nix = { version = "0.26" }
+nix = { version = "0.26", default-features = false, features = ["poll"] }
 num-traits = { version = "0.2" }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }


### PR DESCRIPTION
## Summary
- Disable default features for the workspace `nix` dependency and keep only `poll`.
- Regenerate the Hakari workspace hack.
- Remove now-unused `nix` transitive lockfile entries.

## Context
RSE deploy snapshot packaging started failing after the RediSearch bump in redislabsdev/RediSearchEnterprise#428. RAMP loads `redisearch.so` during `make pack`; on older platforms the shared object now contains unresolved symbols:

- Amazon Linux 2: `memfd_create`
- Ubuntu Focal: `timer_gettime`

Local symbol inspection traced those symbols to `libredisearch_rs.a`, specifically the Rust `nix` object. ForkGC only needs `nix::poll`, but default `nix` features were enabled through workspace feature unification and Hakari.

## Verification
- `cargo hakari generate --diff`
- `cargo hakari manage-deps --dry-run`

Full platform validation will be triggered from an RSE PR that bumps `deps/RediSearch` to this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/link behavior of the Rust static lib changes on Linux; wrong feature trimming could break fork-GC I/O at runtime, but scope is limited to dependency flags and matches existing `nix::poll` usage.
> 
> **Overview**
> Narrows the workspace **`nix`** dependency to **`default-features = false`** with only the **`poll`** feature, so the static Rust archive linked into **`redisearch.so`** no longer pulls in extra **`nix`** APIs that were breaking RSE deploy packaging on older Linux (unresolved **`memfd_create`** / **`timer_gettime`** symbols).
> 
> The generated **`workspace_hack`** Hakari manifest is updated to match, and **`Cargo.lock`** drops transitive crates (**`memoffset`**, **`pin-utils`**) that were only needed when **`nix`** default features were enabled. Runtime behavior for fork GC should stay the same—it already only uses **`nix::poll`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d64488f59eb55765bc6b45bedfd1c67d8559024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->