### PR TITLE
Enhance documentation skill to encourage documentation

### DIFF
--- a/.skills/docs-guidelines/SKILL.md
+++ b/.skills/docs-guidelines/SKILL.md
@@ -9,7 +9,7 @@ General guidelines for writing code documentation. Language-specific skills (e.g
 
 ## Guidelines
 
-- **Document every function, struct, field of structs, enum.** Make sure your code additions are well commented, with concise explanations for a new reader.
+- **Document every added component (e.g., struct, function, enum).** Make sure your code additions are well commented, with concise explanations for a new reader.
 - **Prefer code-enforced invariants over prose.** If an assertion, type, enum, or test can express the constraint, add it. Add a comment where a non-trivial statement that can help the reader is needed on top of the above. Comments can drift; code mostly doesn't.
 - **State each fact in exactly one place.** The owner is the definition, the interface, or the implementation — whichever is canonical. Other locations reference it by name, not by restating it.
 - **Focus on why, not how.** Don't restate what the code plainly does. Document non-obvious choices, invariants that are hard to infer, and constraints a maintainer would otherwise miss.

--- a/.skills/docs-guidelines/SKILL.md
+++ b/.skills/docs-guidelines/SKILL.md
@@ -9,14 +9,15 @@ General guidelines for writing code documentation. Language-specific skills (e.g
 
 ## Guidelines
 
-- **Prefer code-enforced invariants over prose.** If an assertion, type, enum, or test can express the constraint, use it instead of a comment. Comments drift; code doesn't.
+- **Document every function, struct, field of structs, enum.** Make sure your code additions are well commented, with concise explanations for a new reader.
+- **Prefer code-enforced invariants over prose.** If an assertion, type, enum, or test can express the constraint, add it. Add a comment where a non-trivial statement that can help the reader is needed on top of the above. Comments can drift; code mostly doesn't.
 - **State each fact in exactly one place.** The owner is the definition, the interface, or the implementation — whichever is canonical. Other locations reference it by name, not by restating it.
 - **Focus on why, not how.** Don't restate what the code plainly does. Document non-obvious choices, invariants that are hard to infer, and constraints a maintainer would otherwise miss.
 - **Do not document obvious behavior, callee implementation details, or duplicate the same detail across call sites.**
 
 ## Placement model
 
-Each fact belongs to exactly one of these layers — pick the one that owns it and don't restate it elsewhere:
+Each fact belongs to exactly one of these layers — pick the one that owns it and avoid restating it elsewhere:
 
 - **Call sites** — non-trivial local intent, assumptions, sequencing constraints, or edge cases specific to this usage.
 - **Definitions and interfaces** — the contract: inputs, outputs, errors, side effects, invariants.


### PR DESCRIPTION
Enhances the documentation skill to encourage documentation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates agent/documentation skill text; no runtime, API, or product code changes.
> 
> **Overview**
> Updates the shared **`docs-guidelines`** skill so agents and reviewers are pushed harder to document new code while still favoring types/tests over prose.
> 
> **New expectation:** every added **struct, function, or enum** should get concise comments aimed at a new reader. The **code-enforced invariants** rule is broadened: still add assertions/types/tests, but also add comments when something non-obvious remains worth saying; wording shifts from *comments drift; code doesn't* to *comments can drift; code mostly doesn't*.
> 
> The **placement model** intro now says to **avoid** restating facts elsewhere instead of **don't** restate—slightly softer, same single-owner idea.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde786fb5cb00538f35e1d1856ea3b1f29fa06a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->