### PR TITLE
[8.4] [MOD-15867] coord: `search.CLUSTERSET AUTH <pw>` short-form using module API

### DIFF
--- a/src/coord/rmr/cluster_topology.c
+++ b/src/coord/rmr/cluster_topology.c
@@ -13,6 +13,8 @@
 #include "slot_ranges.h"
 #include "rmutil/rm_assert.h"
 
+#include <arpa/inet.h>
+
 MRClusterShard MR_NewClusterShard(MRClusterNode *node, RedisModuleSlotRangeArray *slotRanges) {
   MRClusterShard ret = (MRClusterShard){
       .node = *node,
@@ -52,6 +54,93 @@ MRClusterTopology *MRClusterTopology_Clone(MRClusterTopology *t) {
 
     MRClusterTopology_AddShard(topo, &new_shard);
   }
+  return topo;
+}
+
+MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *auth, size_t auth_len, uint32_t *my_shard_idx) {
+  *my_shard_idx = UINT32_MAX;
+
+  size_t numNodes = 0;
+  char **node_ids = RedisModule_GetClusterNodesList(ctx, &numNodes);
+  if (!node_ids || numNodes == 0) {
+    if (node_ids) RedisModule_FreeClusterNodesList(node_ids);
+    RedisModule_Log(ctx, "warning", "Failed to get cluster nodes list");
+    return NULL;
+  }
+
+  bool saw_myself = false;
+
+  // Topology can contain at most one entry per node; replicas and slot-less
+  // masters will be skipped, so this is an upper bound on the final size.
+  MRClusterTopology *topo = MR_NewTopology(numNodes);
+
+  for (size_t i = 0; i < numNodes; i++) {
+    const char *node_id = node_ids[i];
+
+    char ip[INET6_ADDRSTRLEN] = {0};
+    int port = 0;
+    int flags = 0;
+    int rc = RedisModule_GetClusterNodeInfo(ctx, node_id, ip, NULL, &port, &flags);
+    // Skip unreachable nodes and nodes with no valid endpoint
+    if (rc != REDISMODULE_OK || port <= 0 || ip[0] == '\0') {
+      RedisModule_Log(ctx, "notice", "Failed to get info for cluster node `%.*s`", REDISMODULE_NODE_ID_LEN, node_id);
+      continue;
+    }
+
+    if (flags & REDISMODULE_NODE_MYSELF) saw_myself = true;
+
+    // Skip replicas
+    if (!(flags & REDISMODULE_NODE_MASTER)) {
+      continue;
+    }
+
+    // Fetch the slot ranges owned by this master node. Slot-less masters
+    // (e.g. fresh nodes not yet assigned slots) are excluded from the topology.
+    // The module API hands us ownership; we must explicitly free.
+    // The API contract guarantees non-NULL, but we still guard defensively.
+    RedisModuleSlotRangeArray *node_slots = RedisModule_GetClusterNodeSlotRanges(ctx, node_id);
+    if (!node_slots || node_slots->num_ranges <= 0) {
+      if (node_slots) RedisModule_ClusterFreeSlotRanges(ctx, node_slots);
+      continue;
+    }
+
+    MRClusterNode node = {
+      .id = rm_strndup(node_id, REDISMODULE_NODE_ID_LEN),
+      .endpoint = (MREndpoint){
+        .host = rm_strdup(ip),
+        .port = port,
+        .unixSock = NULL,
+        .password = (auth && auth_len > 0) ? rm_strndup(auth, auth_len) : NULL,
+      },
+    };
+
+    // The topology owns its slot range arrays and frees them with rm_free,
+    // so we must clone the module-owned array before freeing it.
+    RedisModuleSlotRangeArray *cloned_slots = SlotRangeArray_Clone(node_slots);
+    RedisModule_ClusterFreeSlotRanges(ctx, node_slots);
+
+    if (flags & REDISMODULE_NODE_MYSELF) *my_shard_idx = topo->numShards;
+    MRClusterShard shard = MR_NewClusterShard(&node, cloned_slots);
+    MRClusterTopology_AddShard(topo, &shard);
+  }
+
+  RedisModule_FreeClusterNodesList(node_ids);
+
+  if (topo->numShards == 0) {
+    RedisModule_Log(ctx, "warning", "Got no valid shards from cluster API");
+    MRClusterTopology_Free(topo);
+    return NULL;
+  }
+
+  // If we never saw ourselves in the node list, the topology is unusable for
+  // this node. A known replica or slot-less master is fine and leaves
+  // *my_shard_idx at UINT32_MAX (matching RedisEnterprise_ParseTopology).
+  if (!saw_myself) {
+    RedisModule_Log(ctx, "warning", "Local node not found in cluster nodes list");
+    MRClusterTopology_Free(topo);
+    return NULL;
+  }
+
   return topo;
 }
 

--- a/src/coord/rmr/cluster_topology.h
+++ b/src/coord/rmr/cluster_topology.h
@@ -58,6 +58,8 @@ void MRClusterTopology_Free(MRClusterTopology *t);
 
 MRClusterTopology *MRClusterTopology_Clone(MRClusterTopology *t);
 
+MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *auth, size_t auth_len, uint32_t *my_shard_idx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/coord/rmr/redise.c
+++ b/src/coord/rmr/redise.c
@@ -72,20 +72,48 @@ static void MRTopology_AddRLShard(MRClusterTopology *t, RLShard *sh) {
     }                                               \
   })
 
-#define VERIFY_ARG(arg)                                   \
+#define VERIFY_ARG_OR(arg, or_blk)                        \
   ({                                                      \
     if (!AC_AdvanceIfMatch(&ac, arg)) {                   \
       const char *val = NULL;                             \
       AC_GetString(&ac, &val, NULL, AC_F_NOADVANCE);      \
       ERROR_EXPECTED("`" arg "`", (val ?: "(nil)"));      \
-      goto error;                                         \
+      or_blk;                                             \
     }                                                     \
   })
 
+#define VERIFY_ARG(arg) VERIFY_ARG_OR(arg, goto error)
+
 #define STR_MATCH(str, len, lit) (sizeof(lit) - 1 == len && strcasecmp(str, lit) == 0)
+
+static MRClusterTopology *parse_topology_short_form(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                                    int argc, uint32_t *my_shard_idx) {
+  ArgsCursor ac; // Name is important for error macros, same goes for `ctx`
+  ArgsCursor_InitRString(&ac, argv, argc);
+  AC_Advance(&ac); // Skip command name
+  const char *auth;
+  size_t auth_len;
+
+  VERIFY_ARG_OR("AUTH", return NULL);
+  if (AC_GetString(&ac, &auth, &auth_len, 0) != AC_OK) {
+    ERROR_MISSING("AUTH");
+    return NULL;
+  }
+
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, auth, auth_len, my_shard_idx);
+  if (!topo) {
+    ERROR_FMT("%s", "Failed to parse topology using module API");
+    return NULL;
+  }
+
+  return topo;
+}
 
 MRClusterTopology *RedisEnterprise_ParseTopology(RedisModuleCtx *ctx, RedisModuleString **argv,
                                                  int argc, uint32_t *my_shard_idx) {
+  if (argc == 3 && RedisModule_GetClusterNodeSlotRanges) {
+    return parse_topology_short_form(ctx, argv, argc, my_shard_idx);
+  }
   ArgsCursor ac; // Name is important for error macros, same goes for `ctx`
   ArgsCursor_InitRString(&ac, argv, argc);
   AC_Advance(&ac); // Skip command name

--- a/src/module.c
+++ b/src/module.c
@@ -21,6 +21,7 @@
 #include "query.h"
 #include "redis_index.h"
 #include "redismodule.h"
+
 #include "rmutil/strings.h"
 #include "rmutil/util.h"
 #include "rmutil/args.h"
@@ -4019,26 +4020,10 @@ int SetClusterCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   // this means a parsing error, the parser already sent the explicit error to the client
   if (!topo) {
     RedisModule_Log(ctx, "warning", "Received invalid cluster topology");
-    for (int i = 1; i < argc; i++) {
-      size_t len;
-      const char *arg = RedisModule_StringPtrLen(argv[i], &len);
-      RedisModule_Log(ctx, "warning", " Arg %d: %.*s", i, (int)len, arg);
-    }
     return REDISMODULE_ERR;
   }
-  // Build a comma-separated list of ranges per shard
-  char ranges_info[256];
-  ranges_info[0] = '\0';
-  size_t offset = 0;
-  for (uint32_t i = 0; i < topo->numShards && offset < sizeof(ranges_info) - 2; i++) {
-    if (i > 0) {
-      offset += snprintf(ranges_info + offset, sizeof(ranges_info) - offset, ", ");
-    }
-    offset += snprintf(ranges_info + offset, sizeof(ranges_info) - offset, "%d",
-                      topo->shards[i].slotRanges ? topo->shards[i].slotRanges->num_ranges : 0);
-  }
 
-  RedisModule_Log(ctx, "notice", "Received new cluster topology with %u shards (%s)", topo->numShards, ranges_info);
+  RedisModule_Log(ctx, "notice", "Received new cluster topology with %u shards", topo->numShards);
 
   if (my_shard_idx != UINT32_MAX) {
     // Take a reference to our own shard slot ranges (MR_UpdateTopology won't consume it)
@@ -4179,7 +4164,6 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                        REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
-
   TracingRedisModule_Init(ctx);
   RustPanicHook_Init();
 

--- a/tests/cpptests/coord_tests/test_cpp_cluster_topology.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_cluster_topology.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "gtest/gtest.h"
+#include "redismock/redismock.h"
+#include "redismock/util.h"
+#include "redismodule.h"
+
+#include "rmr/cluster_topology.h"
+
+#include <climits>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Real Redis node IDs are 40 chars. Use distinct, padded IDs in tests so that
+// callers that copy exactly REDISMODULE_NODE_ID_LEN bytes don't get truncated
+// content.
+constexpr const char *NODE_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+constexpr const char *NODE_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+constexpr const char *NODE_C = "cccccccccccccccccccccccccccccccccccccccc";
+
+inline void addNode(const char *id, const char *ip, int port, int flags,
+                    const std::vector<RedisModuleSlotRange> &slots = {}) {
+  RMCK_ClusterMock_AddNode(id, ip, port, flags, slots);
+}
+
+int findShardByNodeId(const MRClusterTopology *topo, const char *id) {
+  for (uint32_t i = 0; i < topo->numShards; i++) {
+    if (std::strcmp(topo->shards[i].node.id, id) == 0) return static_cast<int>(i);
+  }
+  return -1;
+}
+
+}  // namespace
+
+class ClusterTopologyFromAPITest : public ::testing::Test {
+ protected:
+  RedisModuleCtx *ctx = nullptr;
+
+  void SetUp() override {
+    ctx = RedisModule_GetThreadSafeContext(nullptr);
+    RMCK_ClusterMock_Reset();
+  }
+
+  void TearDown() override {
+    RMCK_ClusterMock_Reset();
+    if (ctx) RedisModule_FreeThreadSafeContext(ctx);
+  }
+};
+
+// ============================================================================
+// Happy path: three masters with one slot range each, local node is shard A.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, ThreeMasters_LocalIsMaster) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 5460}});
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_MASTER, {{5461, 10922}});
+  addNode(NODE_C, "127.0.0.3", 6381, REDISMODULE_NODE_MASTER, {{10923, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, "hunter2", 7, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->numShards, 3u);
+  ASSERT_NE(my_shard_idx, UINT32_MAX);
+  EXPECT_STREQ(topo->shards[my_shard_idx].node.id, NODE_A);
+
+  // Verify each shard's content
+  int ia = findShardByNodeId(topo, NODE_A);
+  int ib = findShardByNodeId(topo, NODE_B);
+  int ic = findShardByNodeId(topo, NODE_C);
+  ASSERT_GE(ia, 0);
+  ASSERT_GE(ib, 0);
+  ASSERT_GE(ic, 0);
+
+  EXPECT_STREQ(topo->shards[ia].node.endpoint.host, "127.0.0.1");
+  EXPECT_EQ(topo->shards[ia].node.endpoint.port, 6379);
+  EXPECT_STREQ(topo->shards[ia].node.endpoint.password, "hunter2");
+  ASSERT_EQ(topo->shards[ia].slotRanges->num_ranges, 1);
+  EXPECT_EQ(topo->shards[ia].slotRanges->ranges[0].start, 0);
+  EXPECT_EQ(topo->shards[ia].slotRanges->ranges[0].end, 5460);
+
+  EXPECT_STREQ(topo->shards[ib].node.endpoint.host, "127.0.0.2");
+  EXPECT_EQ(topo->shards[ib].node.endpoint.port, 6380);
+  EXPECT_STREQ(topo->shards[ic].node.endpoint.host, "127.0.0.3");
+  EXPECT_EQ(topo->shards[ic].node.endpoint.port, 6381);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// Auth NULL/empty should leave the password unset on every shard.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, NoAuth_PasswordIsNull) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  ASSERT_EQ(topo->numShards, 1u);
+  EXPECT_EQ(topo->shards[0].node.endpoint.password, nullptr);
+
+  MRClusterTopology_Free(topo);
+}
+
+TEST_F(ClusterTopologyFromAPITest, EmptyAuthString_PasswordIsNull) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, "", 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->shards[0].node.endpoint.password, nullptr);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// Replicas (without REDISMODULE_NODE_MASTER) must be filtered out.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, ReplicaFilteredOut) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 16383}});
+  // Replica of A — slot ranges may still appear on it via the API, but it
+  // must be skipped because the MASTER flag is absent.
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_SLAVE, {{0, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->numShards, 1u);
+  EXPECT_STREQ(topo->shards[0].node.id, NODE_A);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// A master without slots (e.g., newly added node) is not part of the topology.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, SlotlessMasterFilteredOut) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 16383}});
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_MASTER, /* no slots */ {});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->numShards, 1u);
+  EXPECT_STREQ(topo->shards[0].node.id, NODE_A);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// Nodes with bad endpoints (port=0, missing IP) are skipped.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, InvalidEndpointsSkipped) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 5460}});
+  addNode(NODE_B, "127.0.0.2", 0 /* invalid port */, REDISMODULE_NODE_MASTER, {{5461, 10922}});
+  addNode(NODE_C, "", 6381 /* missing host */, REDISMODULE_NODE_MASTER, {{10923, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->numShards, 1u);
+  EXPECT_STREQ(topo->shards[0].node.id, NODE_A);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// Local node is a replica → my_shard_idx stays UINT32_MAX, NOT an error.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, LocalIsReplica_NotAnError) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER, {{0, 16383}});
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_SLAVE | REDISMODULE_NODE_MYSELF, {});
+
+  uint32_t my_shard_idx = 12345;  // start non-default to verify it gets reset
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->numShards, 1u);
+  EXPECT_EQ(my_shard_idx, UINT32_MAX);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ========================================================================================
+// Local node is a slot-less master → my_shard_idx stays UINT32_MAX (the node
+// is "known" so it's not an error), matching the standard RedisEnterprise_ParseTopology.
+// ========================================================================================
+TEST_F(ClusterTopologyFromAPITest, LocalIsSlotlessMaster_NotAnError) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER, {{0, 16383}});
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          /* no slots */ {});
+
+  uint32_t my_shard_idx = 12345;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  EXPECT_EQ(topo->numShards, 1u);
+  EXPECT_EQ(my_shard_idx, UINT32_MAX);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// Empty cluster (no nodes returned) → NULL.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, EmptyCluster_ReturnsNull) {
+  uint32_t my_shard_idx = 12345;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  EXPECT_EQ(topo, nullptr);
+  EXPECT_EQ(my_shard_idx, UINT32_MAX);
+}
+
+// ============================================================================
+// No master shards with slots → NULL.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, NoValidShards_ReturnsNull) {
+  // Local replica plus a slot-less master — nothing survives the filters.
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER, /* no slots */ {});
+  addNode(NODE_B, "127.0.0.2", 6380, REDISMODULE_NODE_SLAVE | REDISMODULE_NODE_MYSELF, {});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  EXPECT_EQ(topo, nullptr);
+}
+
+// ============================================================================
+// MYSELF flag missing entirely → error (local node not in cluster).
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, MyselfNotFound_ReturnsNull) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER, {{0, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  EXPECT_EQ(topo, nullptr);
+}
+
+// ============================================================================
+// Multiple slot ranges per shard are preserved in order.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, MultipleSlotRangesPerShard) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 100}, {500, 1000}, {12000, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+  ASSERT_EQ(topo->numShards, 1u);
+  ASSERT_EQ(topo->shards[0].slotRanges->num_ranges, 3);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[0].start, 0);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[0].end, 100);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[1].start, 500);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[1].end, 1000);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[2].start, 12000);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[2].end, 16383);
+
+  MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// FromAPI frees each module-owned slot-range array right after cloning it for
+// the topology, so the topology's data must come from the clone — not from a
+// borrowed pointer that's already invalid by the time FromAPI returns.
+// ============================================================================
+TEST_F(ClusterTopologyFromAPITest, SlotRangesAreOwned) {
+  addNode(NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+          {{0, 16383}});
+
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, nullptr, 0, &my_shard_idx);
+  ASSERT_NE(topo, nullptr);
+
+  // Drop the mock node table — the topology's slot ranges must survive
+  // because they were cloned out of the module-owned arrays (already freed
+  // inside FromAPI), not borrowed from the mock's source state.
+  RMCK_ClusterMock_Reset();
+
+  ASSERT_EQ(topo->numShards, 1u);
+  EXPECT_EQ(topo->shards[0].slotRanges->num_ranges, 1);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[0].start, 0);
+  EXPECT_EQ(topo->shards[0].slotRanges->ranges[0].end, 16383);
+
+  MRClusterTopology_Free(topo);
+}

--- a/tests/cpptests/coord_tests/test_cpp_clusterset.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_clusterset.cpp
@@ -28,9 +28,11 @@ protected:
 
     void SetUp() override {
         ctx = RedisModule_GetThreadSafeContext(NULL);
+        RMCK_ClusterMock_Reset();
     }
 
     void TearDown() override {
+        RMCK_ClusterMock_Reset();
         if (ctx) {
             RedisModule_FreeThreadSafeContext(ctx);
         }
@@ -1046,4 +1048,107 @@ TEST_F(ClusterSetTest, EdgeCase_LocalShardReplica) {
     }
 
     MRClusterTopology_Free(topo);
+}
+
+// ============================================================================
+// Short-form (search.CLUSTERSET AUTH <pw>) dispatch tests
+// ----------------------------------------------------------------------------
+// RedisEnterprise_ParseTopology dispatches to parse_topology_short_form when
+// argc == 3 and the cluster API pointer is set. The short form parses AUTH
+// then defers to MRClusterTopology_FromAPI against the mocked cluster.
+// ============================================================================
+
+namespace {
+constexpr const char *SHORT_NODE_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+constexpr const char *SHORT_NODE_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+}  // namespace
+
+TEST_F(ClusterSetTest, ShortForm_HappyPath) {
+    RMCK_ClusterMock_AddNode(SHORT_NODE_A, "127.0.0.1", 6379,
+                             REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+                             {{0, 8191}});
+    RMCK_ClusterMock_AddNode(SHORT_NODE_B, "127.0.0.2", 6380,
+                             REDISMODULE_NODE_MASTER, {{8192, 16383}});
+
+    std::vector<std::string> args = {"search.CLUSTERSET", "AUTH", "hunter2"};
+    ArgvList argv(ctx, args);
+    uint32_t my_shard_idx = UINT32_MAX;
+    MRClusterTopology *topo = RedisEnterprise_ParseTopology(ctx, argv, argv.size(), &my_shard_idx);
+
+    ASSERT_NE(topo, nullptr);
+    EXPECT_EQ(topo->numShards, 2u);
+    ASSERT_NE(my_shard_idx, UINT32_MAX);
+    EXPECT_STREQ(topo->shards[my_shard_idx].node.id, SHORT_NODE_A);
+    // Auth value should land on every shard's endpoint password.
+    for (uint32_t i = 0; i < topo->numShards; i++) {
+        EXPECT_STREQ(topo->shards[i].node.endpoint.password, "hunter2");
+    }
+    MRClusterTopology_Free(topo);
+}
+
+TEST_F(ClusterSetTest, ShortForm_FirstArgNotAuth) {
+    // Mock has a valid cluster, but the first arg isn't "AUTH" so VERIFY_ARG
+    // rejects the command before we ever reach MRClusterTopology_FromAPI.
+    RMCK_ClusterMock_AddNode(SHORT_NODE_A, "127.0.0.1", 6379,
+                             REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+                             {{0, 16383}});
+
+    std::vector<std::string> args = {"search.CLUSTERSET", "NOTAUTH", "pw"};
+    ArgvList argv(ctx, args);
+    uint32_t my_shard_idx = UINT32_MAX;
+    MRClusterTopology *topo = RedisEnterprise_ParseTopology(ctx, argv, argv.size(), &my_shard_idx);
+
+    EXPECT_EQ(topo, nullptr);
+    EXPECT_EQ(RMCK_GetLastError(ctx), "Expected `AUTH` but got `NOTAUTH` at offset 1");
+}
+
+TEST_F(ClusterSetTest, ShortForm_FromAPIFails_NoLocalNode) {
+    // Cluster has shards but no node carries the MYSELF flag, so FromAPI
+    // returns NULL. parse_topology_short_form must translate that into the
+    // "Failed to parse topology using module API" reply.
+    RMCK_ClusterMock_AddNode(SHORT_NODE_A, "127.0.0.1", 6379, REDISMODULE_NODE_MASTER,
+                             {{0, 16383}});
+
+    std::vector<std::string> args = {"search.CLUSTERSET", "AUTH", "pw"};
+    ArgvList argv(ctx, args);
+    uint32_t my_shard_idx = UINT32_MAX;
+    MRClusterTopology *topo = RedisEnterprise_ParseTopology(ctx, argv, argv.size(), &my_shard_idx);
+
+    EXPECT_EQ(topo, nullptr);
+    EXPECT_EQ(RMCK_GetLastError(ctx),
+              "Failed to parse topology using module API at offset 3");
+}
+
+TEST_F(ClusterSetTest, ShortForm_FromAPIFails_EmptyCluster) {
+    // Empty mock cluster — RedisModule_GetClusterNodesList returns nothing, so
+    // FromAPI returns NULL. Same error reply as the no-local case.
+    std::vector<std::string> args = {"search.CLUSTERSET", "AUTH", "pw"};
+    ArgvList argv(ctx, args);
+    uint32_t my_shard_idx = UINT32_MAX;
+    MRClusterTopology *topo = RedisEnterprise_ParseTopology(ctx, argv, argv.size(), &my_shard_idx);
+
+    EXPECT_EQ(topo, nullptr);
+    EXPECT_EQ(RMCK_GetLastError(ctx),
+              "Failed to parse topology using module API at offset 3");
+}
+
+TEST_F(ClusterSetTest, ShortForm_DispatchBoundary_NotArgcThree) {
+    // argc != 3 must NOT dispatch to short form, even with a leading AUTH.
+    // We prove this by asserting we get the long-form parser's error, not
+    // the short-form parser's "Failed to parse topology" error.
+    RMCK_ClusterMock_AddNode(SHORT_NODE_A, "127.0.0.1", 6379,
+                             REDISMODULE_NODE_MASTER | REDISMODULE_NODE_MYSELF,
+                             {{0, 16383}});
+
+    std::vector<std::string> args = {"search.CLUSTERSET", "AUTH", "pw", "extra"};
+    ArgvList argv(ctx, args);
+    uint32_t my_shard_idx = UINT32_MAX;
+    MRClusterTopology *topo = RedisEnterprise_ParseTopology(ctx, argv, argv.size(), &my_shard_idx);
+
+    EXPECT_EQ(topo, nullptr);
+    // The exact message comes from the long-form parser (the AUTH/pw/extra
+    // tokens aren't valid long-form keywords). We only assert it's NOT the
+    // short-form message, which would mean dispatch leaked across the gate.
+    EXPECT_NE(RMCK_GetLastError(ctx),
+              "Failed to parse topology using module API at offset 3");
 }

--- a/tests/cpptests/redismock/internal.h
+++ b/tests/cpptests/redismock/internal.h
@@ -308,6 +308,11 @@ struct RedisModuleCtx {
   bool automemory = false;
   std::set<RedisModuleString *> allocstrs;
   std::set<RedisModuleKey *> allockeys;
+  // Slot range arrays returned by RedisModule_ClusterGet{Local,ByNodeId}SlotRanges
+  // are tracked here while auto-memory is on; the ctx destructor frees them,
+  // mirroring the real Redis server's auto-memory behavior. Entries are removed
+  // when callers explicitly invoke RedisModule_ClusterFreeSlotRanges.
+  std::set<RedisModuleSlotRangeArray *> alloc_slot_ranges;
   std::vector<std::vector<std::string>> propagated_commands;
   KVDB *db = NULL;
   uint32_t dbid = 0;

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -843,11 +843,129 @@ RedisModuleSlotRangeArray *RMCK_ClusterGetLocalSlotRanges(RedisModuleCtx *ctx) {
   auto *array = reinterpret_cast<RedisModuleSlotRangeArray *>(RMCK_Alloc(sizeof(RedisModuleSlotRangeArray) + sizeof(dummy_ranges)));
   array->num_ranges = 2;
   std::memcpy(array->ranges, dummy_ranges, sizeof(dummy_ranges));
+  if (ctx && ctx->automemory) ctx->alloc_slot_ranges.insert(array);
   return array;
 }
 
 void RMCK_ClusterFreeSlotRanges(RedisModuleCtx *ctx, RedisModuleSlotRangeArray *slots) {
+  if (ctx) ctx->alloc_slot_ranges.erase(slots);
   RMCK_Free(slots);
+}
+
+// ============================================================================
+// Configurable cluster topology mock
+// ----------------------------------------------------------------------------
+// Tests populate `mockClusterNodes` via the RMCK_ClusterMock_* helpers below,
+// and the mocked cluster API entry points answer queries against that state.
+// Slot range arrays returned by the mocked APIs follow the real Redis
+// auto-memory contract: if `ctx->automemory` is on, they are freed by the ctx
+// destructor; otherwise the caller must free them via
+// RedisModule_ClusterFreeSlotRanges.
+// ============================================================================
+namespace {
+struct MockClusterNode {
+  std::string id;
+  std::string ip;
+  int port;
+  int flags;
+  std::vector<RedisModuleSlotRange> slots;
+};
+
+std::vector<MockClusterNode> mockClusterNodes;
+std::mutex mockClusterMutex;
+
+const MockClusterNode *findMockNode(const char *id) {
+  for (const auto &n : mockClusterNodes) {
+    if (n.id == id) return &n;
+  }
+  return nullptr;
+}
+}  // namespace
+
+void RMCK_ClusterMock_Reset() {
+  std::scoped_lock lock(mockClusterMutex);
+  mockClusterNodes.clear();
+}
+
+void RMCK_ClusterMock_AddNode(const char *id, const char *ip, int port, int flags,
+                              const std::vector<RedisModuleSlotRange> &slots) {
+  std::scoped_lock lock(mockClusterMutex);
+  MockClusterNode node;
+  node.id = id ? id : "";
+  node.ip = ip ? ip : "";
+  node.port = port;
+  node.flags = flags;
+  node.slots = slots;
+  mockClusterNodes.push_back(std::move(node));
+}
+
+static char **RMCK_GetClusterNodesList(RedisModuleCtx * /*ctx*/, size_t *numnodes) {
+  std::scoped_lock lock(mockClusterMutex);
+  *numnodes = mockClusterNodes.size();
+  if (*numnodes == 0) return nullptr;
+  // Real Redis null-terminates the list — mirror that so callers iterating
+  // with `while (ids[i])` still work even if they ignore `numnodes`.
+  auto **list = static_cast<char **>(RMCK_Alloc(sizeof(char *) * (*numnodes + 1)));
+  for (size_t i = 0; i < *numnodes; i++) {
+    list[i] = static_cast<char *>(RMCK_Alloc(REDISMODULE_NODE_ID_LEN + 1));
+    size_t copied = mockClusterNodes[i].id.copy(list[i], REDISMODULE_NODE_ID_LEN);
+    list[i][copied] = '\0';
+  }
+  list[*numnodes] = nullptr;
+  return list;
+}
+
+static void RMCK_FreeClusterNodesList(char **ids) {
+  if (!ids) return;
+  for (size_t i = 0; ids[i] != nullptr; i++) RMCK_Free(ids[i]);
+  RMCK_Free(ids);
+}
+
+static int RMCK_GetClusterNodeInfo(RedisModuleCtx * /*ctx*/, const char *id, char *ip,
+                                   char * /*master_id*/, int *port, int *flags) {
+  std::scoped_lock lock(mockClusterMutex);
+  const MockClusterNode *n = findMockNode(id);
+  if (!n) return REDISMODULE_ERR;
+  // The real API expects the caller to pass a buffer of at least
+  // NET_IP_STR_LEN (46) bytes; we copy at most that to match.
+  if (ip) {
+    size_t copied = n->ip.copy(ip, 46 - 1);
+    ip[copied] = '\0';
+  }
+  if (port) *port = n->port;
+  if (flags) *flags = n->flags;
+  return REDISMODULE_OK;
+}
+
+static const char *RMCK_GetMyClusterID(void) {
+  std::scoped_lock lock(mockClusterMutex);
+  for (const auto &n : mockClusterNodes) {
+    if (n.flags & REDISMODULE_NODE_MYSELF) return n.id.c_str();
+  }
+  return nullptr;
+}
+
+static size_t RMCK_GetClusterSize(void) {
+  std::scoped_lock lock(mockClusterMutex);
+  return mockClusterNodes.size();
+}
+
+static RedisModuleSlotRangeArray *RMCK_GetClusterNodeSlotRanges(RedisModuleCtx *ctx,
+                                                                const char *nodeid) {
+  std::scoped_lock lock(mockClusterMutex);
+  // Upstream contract (RM_GetClusterNodeSlotRanges): always returns a valid
+  // array — possibly empty — never NULL. An unknown nodeid yields an empty
+  // array, same as a known node with no assigned slots.
+  const MockClusterNode *n = findMockNode(nodeid);
+  size_t num_slots = n ? n->slots.size() : 0;
+  size_t buf_size = sizeof(RedisModuleSlotRangeArray) + num_slots * sizeof(RedisModuleSlotRange);
+  auto *arr = static_cast<RedisModuleSlotRangeArray *>(RMCK_Alloc(buf_size));
+  arr->num_ranges = static_cast<int32_t>(num_slots);
+  if (n && !n->slots.empty()) {
+    std::memcpy(arr->ranges, n->slots.data(), num_slots * sizeof(RedisModuleSlotRange));
+  }
+  if (ctx && ctx->automemory) ctx->alloc_slot_ranges.insert(arr);
+  return arr;
 }
 
 // Track contexts associated with IO objects
@@ -1344,6 +1462,9 @@ RedisModuleCtx::~RedisModuleCtx() {
     for (auto it : allocstrs) {
       delete it;
     }
+    for (auto *p : alloc_slot_ranges) {
+      RMCK_Free(p);
+    }
   }
 }
 
@@ -1568,7 +1689,13 @@ static void registerApis() {
   // Cluster
   REGISTER_API(ClusterPropagateForSlotMigration);
   REGISTER_API(ClusterGetLocalSlotRanges);
+  REGISTER_API(GetClusterNodeSlotRanges);
   REGISTER_API(ClusterFreeSlotRanges);
+  REGISTER_API(GetClusterNodesList);
+  REGISTER_API(FreeClusterNodesList);
+  REGISTER_API(GetClusterNodeInfo);
+  REGISTER_API(GetMyClusterID);
+  REGISTER_API(GetClusterSize);
 }
 
 static int RMCK_GetApi(const char *s, void *pp) {

--- a/tests/cpptests/redismock/redismock.h
+++ b/tests/cpptests/redismock/redismock.h
@@ -27,6 +27,15 @@ std::vector<std::vector<std::string>> &RMCK_GetPropagatedCommands(RedisModuleCtx
 
 std::string &RMCK_GetLastError(RedisModuleCtx *ctx);
 
+// Configure the mock cluster topology used by RedisModule_GetClusterNodesList /
+// GetClusterNodeInfo / GetClusterNodeSlotRanges / GetMyClusterID. Tests
+// should call RMCK_ClusterMock_Reset() between cases. Pass an empty `slots`
+// for a slot-less node. Mark the local node by including REDISMODULE_NODE_MYSELF
+// in `flags`.
+void RMCK_ClusterMock_Reset();
+void RMCK_ClusterMock_AddNode(const char *id, const char *ip, int port, int flags,
+                              const std::vector<RedisModuleSlotRange> &slots = {});
+
 extern "C" {
 #else
 struct RedisModuleIO;


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Backport of #9779 failed to cherry-pick cleanly onto `8.4` because this branch still uses `deps/RedisModulesSDK` instead of `src/redismodule.h`, and redismock registration context differs from master.
2. Change: Cherry-picked #9779 and resolved the conflicts by keeping the branch-specific SDK layout, loading the new `RedisModule_GetClusterNodeSlotRanges` API explicitly, and wiring redismock bootstrap for the focused unit tests.
3. Outcome: `search.CLUSTERSET AUTH <pw>` can use the cluster module API on `8.4` with matching topology/short-form test coverage.

#### Which additional issues this PR fixes
1. MOD-15867
2. #9779

#### Main objects this PR modified
1. `src/coord/rmr/cluster_topology.c`
2. `src/coord/rmr/redise.c`
3. `src/module.c`
4. `tests/cpptests/coord_tests/test_cpp_cluster_topology.cpp`
5. `tests/cpptests/coord_tests/test_cpp_clusterset.cpp`
6. `tests/cpptests/redismock/redismock.cpp`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Backport of #9779.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cluster topology is established for coordinators; incorrect filtering or API loading could mis-route queries, though behavior is gated on argc==3 and API presence with extensive tests.
> 
> **Overview**
> Adds a **short-form** `search.CLUSTERSET AUTH <password>` path: when the command has three arguments and `RedisModule_GetClusterNodeSlotRanges` is available at load time, parsing requires `AUTH` and builds topology from Redis cluster module APIs instead of the long `MYID` / `RANGES` / `SHARD` wire format.
> 
> **`MRClusterTopology_FromAPI`** walks `GetClusterNodesList`, keeps masters with valid endpoints and non-empty slot ranges (skips replicas, bad endpoints, slot-less masters), clones slot arrays for module ownership, applies the auth password to shard endpoints, and sets `my_shard_idx` when the local node is a slotted master—matching existing behavior for replicas or slot-less locals (`UINT32_MAX`). Topology is rejected if the local node never appears in the node list.
> 
> The slot-ranges API pointer is resolved via `RedisModule_GetApi` in **`RedisModule_OnLoad`** (and redismock bootstrap). **`SetClusterCommand`** logging on invalid topology is simplified. Tests add **`RMCK_ClusterMock_*`** and coverage for `FromAPI` and short-form dispatch boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc648b2136ca0747ccc0fed2fc0a2ed6904351e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->