### PR TITLE
[MOD-14000] Skip clock_gettime on timeout init when timeout checks are disabled

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -306,7 +306,7 @@ typedef struct AREQ {
   RequestSyncCtx syncCtx;
 
   // Flag to indicate whether to skip timeout checks using clock checks
-  bool skipTimeoutChecks;
+  bool skipClockTimeoutChecks;
 
   bool useReplyCallback;
 
@@ -595,15 +595,15 @@ void RequestSyncCtx_RegisterAbortWakeChannel(RequestSyncCtx *ctx, struct MRChann
 void RequestSyncCtx_UnregisterAbortWakeChannel(RequestSyncCtx *ctx);
 void RequestSyncCtx_WakeAbortChannel(RequestSyncCtx *ctx);
 
-static inline bool AREQ_ShouldCheckTimeout(AREQ *req) {
-  return !req->skipTimeoutChecks;
+static inline bool AREQ_ShouldCheckClockTimeout(AREQ *req) {
+  return !req->skipClockTimeoutChecks;
 }
 
-static inline void AREQ_SetSkipTimeoutChecks(AREQ *req, bool skipTimeoutChecks) {
-  req->skipTimeoutChecks = skipTimeoutChecks;
+static inline void AREQ_SetSkipClockTimeoutChecks(AREQ *req, bool skipClockTimeoutChecks) {
+  req->skipClockTimeoutChecks = skipClockTimeoutChecks;
   // Also propagate to the SearchCtx's SearchTime for timeout functions that access it directly
   if (req->sctx) {
-    req->sctx->time.skipTimeoutChecks = skipTimeoutChecks;
+    req->sctx->time.skipClockTimeoutChecks = skipClockTimeoutChecks;
   }
 }
 

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -142,7 +142,7 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
       // (rpidnext for SA, or RPNext for cluster)
       // Take this into account when adding more debug types that are modifying the rp pipeline.
       PipelineAddTimeoutAfterCount(AREQ_QueryProcessingCtx(&debug_req->r), AREQ_SearchCtx(&debug_req->r), results_count);
-      AREQ_SetSkipTimeoutChecks(&debug_req->r, false);
+      AREQ_SetSkipClockTimeoutChecks(&debug_req->r, false);
 
     } else if (internal_only) {
       // Coordinator with INTERNAL_ONLY: timeout applies only in the shard query pipeline, not the coordinator
@@ -155,10 +155,10 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
                             "to avoid infinite loop (RESP2 only)");
             debug_req->r.reqConfig.queryTimeoutMS = COORDINATOR_FORCED_TIMEOUT;
             SearchCtx_UpdateTime(debug_req->r.sctx, debug_req->r.reqConfig.queryTimeoutMS);
-            // The original TIMEOUT 0 caused skipTimeoutChecks=true. Now that we've
+            // The original TIMEOUT 0 caused skipClockTimeoutChecks=true. Now that we've
             // forced a real timeout, we must re-enable timeout checking so RPNet
             // actually respects the forced timeout.
-            AREQ_SetSkipTimeoutChecks(&debug_req->r, false);
+            AREQ_SetSkipClockTimeoutChecks(&debug_req->r, false);
           }
       }
     } else {
@@ -170,11 +170,11 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
       // Add timeout to the coordinator pipeline
       PipelineAddTimeoutAfterCount(AREQ_QueryProcessingCtx(&debug_req->r), AREQ_SearchCtx(&debug_req->r), results_count);
       // RPTimeoutAfterCount simulates a timeout by setting sctx->time.timeout to "now".
-      // RPNet checks skipTimeoutChecks before checking TimedOut, so we must ensure
+      // RPNet checks skipClockTimeoutChecks before checking TimedOut, so we must ensure
       // timeout checking is enabled for the simulation to be respected.
       // This is needed when queryTimeoutMS==0 (disabled), which causes
-      // shouldCheckInPipelineTimeout to return false and skipTimeoutChecks to be true.
-      AREQ_SetSkipTimeoutChecks(&debug_req->r, false);
+      // shouldCheckInPipelineTimeout to return false and skipClockTimeoutChecks to be true.
+      AREQ_SetSkipClockTimeoutChecks(&debug_req->r, false);
     }
     return REDISMODULE_OK;
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -401,7 +401,7 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
     .timeoutPolicy = req->reqConfig.timeoutPolicy,
     .timeout = &req->sctx->time.timeout,
     .oomPolicy = req->reqConfig.oomPolicy,
-    .skipTimeoutChecks = req->sctx->time.skipTimeoutChecks,
+    .skipClockTimeoutChecks = req->sctx->time.skipClockTimeoutChecks,
     .areq = req,
   };
 
@@ -1361,10 +1361,7 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   // TODO: this should be done in `AREQ_execute`, but some of the iterators needs the timeout's
   // value and some of the execution begins in `QAST_Iterate`.
   // Setting the timeout context should be done in the same thread that executes the query.
-  // Skip the clock_gettime syscalls when timeout checks are disabled: result processors and
-  // iterators initialize their timeout counters to REDISEARCH_UNINITIALIZED based on
-  // sctx->time.skipTimeoutChecks and never read sctx->time.timeout in that mode.
-  if (AREQ_ShouldCheckTimeout(req)) {
+  if (AREQ_ShouldCheckClockTimeout(req)) {
     SearchCtx_UpdateTime(sctx, req->reqConfig.queryTimeoutMS);
   }
 
@@ -1377,7 +1374,7 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     }
   }
 
-  if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
+  if (AREQ_ShouldCheckClockTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
     TimedOut_WithStatus(&sctx->time.timeout, status);
   }
 
@@ -1934,12 +1931,7 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   AREQ *req = cursor->execState;
   AREQ_ProfilePrinterCtx(req)->cursor_reads++;
-  // Skip when useReplyCallback is set (coord+FAIL): the deadline is owned by
-  // the blocked-client timer, armed by buildPipelineAndExecute (initial
-  // WITHCURSOR) or CursorCommand (subsequent READ).
-  // Also skip when timeout checks are disabled: the timeout value is unused by
-  // the result-processor pipeline in that mode (counters are REDISEARCH_UNINITIALIZED).
-  if (!req->useReplyCallback && AREQ_ShouldCheckTimeout(req)) {
+  if (AREQ_ShouldCheckClockTimeout(req)) {
     SearchCtx_UpdateTime(AREQ_SearchCtx(req), req->reqConfig.queryTimeoutMS);
   }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1361,7 +1361,12 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   // TODO: this should be done in `AREQ_execute`, but some of the iterators needs the timeout's
   // value and some of the execution begins in `QAST_Iterate`.
   // Setting the timeout context should be done in the same thread that executes the query.
-  SearchCtx_UpdateTime(sctx, req->reqConfig.queryTimeoutMS);
+  // Skip the clock_gettime syscalls when timeout checks are disabled: result processors and
+  // iterators initialize their timeout counters to REDISEARCH_UNINITIALIZED based on
+  // sctx->time.skipTimeoutChecks and never read sctx->time.timeout in that mode.
+  if (AREQ_ShouldCheckTimeout(req)) {
+    SearchCtx_UpdateTime(sctx, req->reqConfig.queryTimeoutMS);
+  }
 
   req->rootiter = QAST_Iterate(ast, opts, sctx, AREQ_RequestFlags(req), status);
 
@@ -1932,7 +1937,9 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   // Skip when useReplyCallback is set (coord+FAIL): the deadline is owned by
   // the blocked-client timer, armed by buildPipelineAndExecute (initial
   // WITHCURSOR) or CursorCommand (subsequent READ).
-  if (!req->useReplyCallback) {
+  // Also skip when timeout checks are disabled: the timeout value is unused by
+  // the result-processor pipeline in that mode (counters are REDISEARCH_UNINITIALIZED).
+  if (!req->useReplyCallback && AREQ_ShouldCheckTimeout(req)) {
     SearchCtx_UpdateTime(AREQ_SearchCtx(req), req->reqConfig.queryTimeoutMS);
   }
 

--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -117,7 +117,7 @@ static inline void debugCheckAndPauseAfterAggregateResult(AREQ *areq) {}
      // Aggregate all results before populating the response
      *results = AggregateResults(rp, ctx->areq, rc);
      // Check timeout after aggregation
-     if (!ctx->skipTimeoutChecks && TimedOut(ctx->timeout) == TIMED_OUT) {
+     if (!ctx->skipClockTimeoutChecks && TimedOut(ctx->timeout) == TIMED_OUT) {
        *rc = RS_RESULT_TIMEDOUT;
      }
    } else {

--- a/src/aggregate/aggregate_exec_common.h
+++ b/src/aggregate/aggregate_exec_common.h
@@ -34,7 +34,7 @@ typedef struct CommonPipelineCtx {
   RSTimeoutPolicy timeoutPolicy;
   struct timespec *timeout;
   RSOomPolicy oomPolicy;
-  bool skipTimeoutChecks;
+  bool skipClockTimeoutChecks;
 
   // AREQ for the request being executed; consulted by AggregateResults (and
   // its debug pause loop) to bail when the main-thread timeout callback flips

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1295,7 +1295,7 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
   }
 
   // Check if we should check for timeout in pipeline
-  AREQ_SetSkipTimeoutChecks(req, !shouldCheckInPipelineTimeout(ctx, req));
+  AREQ_SetSkipClockTimeoutChecks(req, !shouldCheckInPipelineTimeout(ctx, req));
 
   return REDISMODULE_OK;
 
@@ -1484,11 +1484,11 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   IndexSpec *index = sctx->spec;
   RSSearchOptions *opts = &req->searchopts;
   req->sctx = sctx;
-  // Propagate skipTimeoutChecks from the request to the sctx. AREQ_Compile set
-  // req->skipTimeoutChecks before sctx existed, so the flag never reached the
-  // sctx. Pipeline stages (startPipelineCommon, result processor counters)
-  // read sctx->time.skipTimeoutChecks directly.
-  sctx->time.skipTimeoutChecks = req->skipTimeoutChecks;
+  // Propagate skipClockTimeoutChecks from the request to the sctx. AREQ_Compile
+  // set req->skipClockTimeoutChecks before sctx existed, so the flag never
+  // reached the sctx. Pipeline stages (startPipelineCommon, result processor
+  // counters) read sctx->time.skipClockTimeoutChecks directly.
+  sctx->time.skipClockTimeoutChecks = req->skipClockTimeoutChecks;
   // Borrow the request's timed-out flag onto the sctx so pipeline RPs can
   // observe a RETURN-STRICT main-thread timeout without holding an AREQ
   // back-pointer (read via SearchTime_IsTimedOut).

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1484,6 +1484,11 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   IndexSpec *index = sctx->spec;
   RSSearchOptions *opts = &req->searchopts;
   req->sctx = sctx;
+  // Propagate skipTimeoutChecks from the request to the sctx. AREQ_Compile set
+  // req->skipTimeoutChecks before sctx existed, so the flag never reached the
+  // sctx. Pipeline stages (startPipelineCommon, result processor counters)
+  // read sctx->time.skipTimeoutChecks directly.
+  sctx->time.skipTimeoutChecks = req->skipTimeoutChecks;
   // Borrow the request's timed-out flag onto the sctx so pipeline RPs can
   // observe a RETURN-STRICT main-thread timeout without holding an AREQ
   // back-pointer (read via SearchTime_IsTimedOut).

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -422,15 +422,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   r->sctx = rm_new(RedisSearchCtx);
   *r->sctx = SEARCH_CTX_STATIC(ctx, NULL);
   r->sctx->apiVersion = dialect;
-  // Skip the clock_gettime syscalls when timeout checks are disabled. RPNet and other
-  // pipeline stages gate their TimedOut checks on sctx->time.skipTimeoutChecks (set by
-  // AREQ_SetSkipTimeoutChecks below), so sctx->time.timeout is unused in that mode.
-  if (AREQ_ShouldCheckTimeout(r)) {
+  if (AREQ_ShouldCheckClockTimeout(r)) {
     SearchCtx_UpdateTime(r->sctx, r->reqConfig.queryTimeoutMS);
   }
   // r->sctx->expanded should be received from shards
 
-  AREQ_SetSkipTimeoutChecks(r, !shouldCheckInPipelineTimeoutCoord(r));
+  AREQ_SetSkipClockTimeoutChecks(r, !shouldCheckInPipelineTimeoutCoord(r));
 
   return REDISMODULE_OK;
 }

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -422,11 +422,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   r->sctx = rm_new(RedisSearchCtx);
   *r->sctx = SEARCH_CTX_STATIC(ctx, NULL);
   r->sctx->apiVersion = dialect;
-  SearchCtx_UpdateTime(r->sctx, r->reqConfig.queryTimeoutMS);
-  // Propagate skipTimeoutChecks from request to sctx.
-  // AREQ_Compile set req->skipTimeoutChecks before sctx existed, so the flag
-  // was not propagated. RPNet and startPipeline read from sctx->time.skipTimeoutChecks.
-  r->sctx->time.skipTimeoutChecks = r->skipTimeoutChecks;
+  // Skip the clock_gettime syscalls when timeout checks are disabled. RPNet and other
+  // pipeline stages gate their TimedOut checks on sctx->time.skipTimeoutChecks (set by
+  // AREQ_SetSkipTimeoutChecks below), so sctx->time.timeout is unused in that mode.
+  if (AREQ_ShouldCheckTimeout(r)) {
+    SearchCtx_UpdateTime(r->sctx, r->reqConfig.queryTimeoutMS);
+  }
   // r->sctx->expanded should be received from shards
 
   AREQ_SetSkipTimeoutChecks(r, !shouldCheckInPipelineTimeoutCoord(r));

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -619,7 +619,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     }
 
     // Set skip timeout
-    HybridRequest_SetSkipTimeoutChecks(hreq, !shouldCheckInPipelineTimeoutCoord(hreq));
+    HybridRequest_SetSkipClockTimeoutChecks(hreq, !shouldCheckInPipelineTimeoutCoord(hreq));
 
     rs_wall_clock parseClock;
     if (profileOptions != EXEC_NO_FLAGS) {
@@ -631,10 +631,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Initialize timeout for all subqueries BEFORE building pipelines
     // but after the parsing to know the timeout values.
-    // Skip the clock_gettime syscalls when timeout checks are disabled: RPNet and other
-    // pipeline stages gate their TimedOut checks on sctx->time.skipTimeoutChecks, so
-    // sctx->time.timeout is unused in that mode.
-    if (HybridRequest_ShouldCheckTimeout(hreq)) {
+    if (HybridRequest_ShouldCheckClockTimeout(hreq)) {
       for (int i = 0; i < hreq->nrequests; i++) {
           AREQ *subquery = hreq->requests[i];
           SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hreq->reqConfig.queryTimeoutMS);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -630,12 +630,17 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     }
 
     // Initialize timeout for all subqueries BEFORE building pipelines
-    // but after the parsing to know the timeout values
-    for (int i = 0; i < hreq->nrequests; i++) {
-        AREQ *subquery = hreq->requests[i];
-        SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hreq->reqConfig.queryTimeoutMS);
+    // but after the parsing to know the timeout values.
+    // Skip the clock_gettime syscalls when timeout checks are disabled: RPNet and other
+    // pipeline stages gate their TimedOut checks on sctx->time.skipTimeoutChecks, so
+    // sctx->time.timeout is unused in that mode.
+    if (HybridRequest_ShouldCheckTimeout(hreq)) {
+      for (int i = 0; i < hreq->nrequests; i++) {
+          AREQ *subquery = hreq->requests[i];
+          SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hreq->reqConfig.queryTimeoutMS);
+      }
+      SearchCtx_UpdateTime(hreq->sctx, hreq->reqConfig.queryTimeoutMS);
     }
-    SearchCtx_UpdateTime(hreq->sctx, hreq->reqConfig.queryTimeoutMS);
 
     // Set request flags from hybridParams
     hreq->reqflags = (QEFlags)hybridParams.aggregationParams.common.reqflags;

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -176,9 +176,9 @@ static void shardResponseBarrier_PendingReplies_Free(RPNet *nc) {
 }
 
 // Wall-clock deadline pointer for MRIterator_NextWithTimeout. NULL when
-// AREQ_ShouldCheckTimeout is false (e.g. RETURN-STRICT uses the abort flag).
+// AREQ_ShouldCheckClockTimeout is false (e.g. RETURN-STRICT uses the abort flag).
 static struct timespec *getAbsTimeout(RPNet *nc) {
-  if (!nc->areq || !nc->areq->sctx || !AREQ_ShouldCheckTimeout(nc->areq)) {
+  if (!nc->areq || !nc->areq->sctx || !AREQ_ShouldCheckClockTimeout(nc->areq)) {
     return NULL;
   }
   return (struct timespec *)&nc->areq->sctx->time.timeout;
@@ -291,8 +291,8 @@ int getNextReply(RPNet *nc) {
     while ((numShards = atomic_load(&nc->shardResponseBarrier->numShards)) == 0 ||
            atomic_load(&nc->shardResponseBarrier->numResponded) < numShards) {
 
-      // Check for timeout to avoid blocking indefinitely (respecting skipTimeoutChecks flag)
-      if (nc->areq && AREQ_ShouldCheckTimeout(nc->areq) && TimedOut(&nc->areq->sctx->time.timeout)) {
+      // Check for timeout to avoid blocking indefinitely (respecting skipClockTimeoutChecks flag)
+      if (nc->areq && AREQ_ShouldCheckClockTimeout(nc->areq) && TimedOut(&nc->areq->sctx->time.timeout)) {
         break;
       // Check for blocked client timeout
       } else if (nc->areq && AREQ_TimedOut(nc->areq)) {
@@ -603,11 +603,11 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
   // get the next reply from the channel
   while (!root) {
-    // Check for timeout (respecting skipTimeoutChecks flag). Under RETURN-STRICT
+    // Check for timeout (respecting skipClockTimeoutChecks flag). Under RETURN-STRICT
     // (the only policy that sets drainOnly) shouldCheckInPipelineTimeoutCoord
-    // already forces skipTimeoutChecks=true, so this branch is naturally bypassed
+    // already forces skipClockTimeoutChecks=true, so this branch is naturally bypassed
     // during a drain.
-    if (!nc->areq->sctx->time.skipTimeoutChecks && TimedOut(&nc->areq->sctx->time.timeout)) {
+    if (!nc->areq->sctx->time.skipClockTimeoutChecks && TimedOut(&nc->areq->sctx->time.timeout)) {
       // Set the `timedOut` flag in the MRIteratorCtx, later to be read by the
       // callback so that a `CURSOR DEL` command will be dispatched instead of
       // a `CURSOR READ` command.

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -308,8 +308,8 @@ auto RTree<cs>::query(const RedisSearchCtx *sctx, const FieldFilterContext* filt
     const auto results =
         std::ranges::subrange{qbegin, rtree_.qend()} | std::views::transform(get_id<cs>);
     const auto qi = std::allocator_traits<alloc_type>::allocate(alloc, 1);
-    // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks when skipTimeoutChecks is set
-    const uint32_t timeoutCounter = (sctx && sctx->time.skipTimeoutChecks) ? REDISEARCH_UNINITIALIZED : 0;
+    // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks when skipClockTimeoutChecks is set
+    const uint32_t timeoutCounter = (sctx && sctx->time.skipClockTimeoutChecks) ? REDISEARCH_UNINITIALIZED : 0;
     std::allocator_traits<alloc_type>::construct(alloc, qi, sctx, filterCtx, results, allocated_, timeoutCounter);
     return qi->base();
   } catch (const std::exception& e) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1144,12 +1144,17 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     hybridRequest->profileClocks.profileParseTime = rs_wall_clock_elapsed_ns(&hybridRequest->profileClocks.initClock);
   }
 
-  // Initialize timeout for all subqueries BEFORE building pipelines
-  for (int i = 0; i < hybridRequest->nrequests; i++) {
-    AREQ *subquery = hybridRequest->requests[i];
-    SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hybridRequest->reqConfig.queryTimeoutMS);
+  // Initialize timeout for all subqueries BEFORE building pipelines.
+  // Skip the clock_gettime syscalls when timeout checks are disabled: result processors
+  // and iterators initialize their timeout counters to REDISEARCH_UNINITIALIZED based on
+  // sctx->time.skipTimeoutChecks and never read sctx->time.timeout in that mode.
+  if (HybridRequest_ShouldCheckTimeout(hybridRequest)) {
+    for (int i = 0; i < hybridRequest->nrequests; i++) {
+      AREQ *subquery = hybridRequest->requests[i];
+      SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hybridRequest->reqConfig.queryTimeoutMS);
+    }
+    SearchCtx_UpdateTime(hybridRequest->sctx, hybridRequest->reqConfig.queryTimeoutMS);
   }
-  SearchCtx_UpdateTime(hybridRequest->sctx, hybridRequest->reqConfig.queryTimeoutMS);
 
   if (HybridRequest_BuildPipelineAndExecute(hybrid_ref, cmd.hybridParams, ctx, hybridRequest->sctx, &status, internal) != REDISMODULE_OK) {
     HybridRequest_GetError(hybridRequest, &status);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -193,7 +193,7 @@ static void startPipelineHybrid(HybridRequest *hreq, ResultProcessor *rp, Search
     .timeoutPolicy = hreq->reqConfig.timeoutPolicy,
     .timeout = &hreq->sctx->time.timeout,
     .oomPolicy = hreq->reqConfig.oomPolicy,
-    .skipTimeoutChecks = !HybridRequest_ShouldCheckTimeout(hreq),
+    .skipClockTimeoutChecks = !HybridRequest_ShouldCheckClockTimeout(hreq),
     .areq = NULL,
   };
   startPipelineCommon(&ctx, rp, results, r, rc);
@@ -1133,7 +1133,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
 
   // Check if we should check for timeout in pipeline
-  HybridRequest_SetSkipTimeoutChecks(hybridRequest, !shouldCheckInPipelineTimeoutHybrid(ctx, hybridRequest));
+  HybridRequest_SetSkipClockTimeoutChecks(hybridRequest, !shouldCheckInPipelineTimeoutHybrid(ctx, hybridRequest));
 
   // Copy dispatch time to each subquery AREQ for profile printing
   for (size_t i = 0; i < hybridRequest->nrequests; i++) {
@@ -1145,10 +1145,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   }
 
   // Initialize timeout for all subqueries BEFORE building pipelines.
-  // Skip the clock_gettime syscalls when timeout checks are disabled: result processors
-  // and iterators initialize their timeout counters to REDISEARCH_UNINITIALIZED based on
-  // sctx->time.skipTimeoutChecks and never read sctx->time.timeout in that mode.
-  if (HybridRequest_ShouldCheckTimeout(hybridRequest)) {
+  if (HybridRequest_ShouldCheckClockTimeout(hybridRequest)) {
     for (int i = 0; i < hybridRequest->nrequests; i++) {
       AREQ *subquery = hybridRequest->requests[i];
       SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hybridRequest->reqConfig.queryTimeoutMS);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -52,7 +52,7 @@ typedef struct HybridRequest {
     RequestSyncCtx syncCtx;
 
     // Flag to indicate whether to skip timeout checks using clock checks
-    bool skipTimeoutChecks;
+    bool skipClockTimeoutChecks;
 
     bool useReplyCallback;
 
@@ -96,20 +96,20 @@ static inline void HybridRequest_UnlockCursors(HybridRequest *req) {
   pthread_mutex_unlock(&req->cursorMutex);
 }
 
-static inline bool HybridRequest_ShouldCheckTimeout(HybridRequest *req) {
-  return !req->skipTimeoutChecks;
+static inline bool HybridRequest_ShouldCheckClockTimeout(HybridRequest *req) {
+  return !req->skipClockTimeoutChecks;
 }
 
-static inline void HybridRequest_SetSkipTimeoutChecks(HybridRequest *req, bool skipTimeoutChecks) {
-  req->skipTimeoutChecks = skipTimeoutChecks;
+static inline void HybridRequest_SetSkipClockTimeoutChecks(HybridRequest *req, bool skipClockTimeoutChecks) {
+  req->skipClockTimeoutChecks = skipClockTimeoutChecks;
   // Propagate to the SearchCtx's SearchTime for timeout functions that access it directly
   if (req->sctx) {
-    req->sctx->time.skipTimeoutChecks = skipTimeoutChecks;
+    req->sctx->time.skipClockTimeoutChecks = skipClockTimeoutChecks;
   }
   // Propagate to all AREQ subqueries
   for (size_t i = 0; i < req->nrequests; i++) {
     if (req->requests[i]) {
-      AREQ_SetSkipTimeoutChecks(req->requests[i], skipTimeoutChecks);
+      AREQ_SetSkipClockTimeoutChecks(req->requests[i], skipClockTimeoutChecks);
     }
   }
 }

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -623,7 +623,7 @@ QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   hi->maxBatchIteration = 0;
   hi->canTrimDeepResults = hParams.canTrimDeepResults;
   // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks
-  hi->timeoutCtx = (TimeoutCtx){ .timeout = hParams.timeout, .counter = hParams.sctx->time.skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0 };
+  hi->timeoutCtx = (TimeoutCtx){ .timeout = hParams.timeout, .counter = hParams.sctx->time.skipClockTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0 };
   hi->runtimeParams.timeoutCtx = &hi->timeoutCtx;
   hi->sctx = hParams.sctx;
   hi->filterCtx = *hParams.filterCtx;

--- a/src/query.c
+++ b/src/query.c
@@ -734,7 +734,7 @@ static QueryIterator *Query_EvalPrefixNode(QueryEvalCtx *q, QueryNode *qn) {
   } else {
     Trie_IterateContains(t, str, nstr, qn->pfx.prefix, qn->pfx.suffix,
                          runeIterCb, &ctx, &q->sctx->time.timeout,
-                         q->sctx->time.skipTimeoutChecks);
+                         q->sctx->time.skipClockTimeoutChecks);
   }
 
   rm_free(str);
@@ -785,7 +785,7 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
         .callback = charIterCb, // the difference is weather the function receives char or rune
         .cbCtx = &ctx,
         .timeout = &q->sctx->time.timeout,
-        .skipTimeoutChecks = q->sctx->time.skipTimeoutChecks,
+        .skipClockTimeoutChecks = q->sctx->time.skipClockTimeoutChecks,
       };
       if (Suffix_IterateWildcard(&sufCtx) == 0) {
         // if suffix trie cannot be used, use brute force
@@ -798,7 +798,7 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
 
   if (!spec->suffix || fallbackBruteForce) {
     Trie_IterateWildcard(t, str, nstr, runeIterCb, &ctx, &q->sctx->time.timeout,
-                         q->sctx->time.skipTimeoutChecks);
+                         q->sctx->time.skipClockTimeoutChecks);
   }
 
   rm_free(str);
@@ -1270,7 +1270,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     TrieMapIterator *it = TrieMap_IterateWithFilter(idx->values, tok->str, tok->len, iter_mode);
     // TrieMap_IterateWithFilter only returns NULL on allocation failure
     RS_ASSERT(it);
-    if (!q->sctx->time.skipTimeoutChecks) {
+    if (!q->sctx->time.skipClockTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, q->sctx->time.timeout);
     }
 
@@ -1301,7 +1301,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     TrieMapIterator_Free(it);
   } else {    // TAG field has suffix triemap
     arrayof(char**) arr = GetList_SuffixTrieMap(idx->suffix, tok->str, tok->len,
-                                                qn->pfx.prefix, q->sctx->time.timeout, q->sctx->time.skipTimeoutChecks);
+                                                qn->pfx.prefix, q->sctx->time.timeout, q->sctx->time.skipClockTimeoutChecks);
     if (!arr) {
       rm_free(its);
       return NULL;
@@ -1351,7 +1351,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   if (idx->suffix) {
     // with suffix
     arrayof(char*) arr = GetList_SuffixTrieMap_Wildcard(idx->suffix, tok->str, tok->len,
-                                                        q->sctx->time.timeout, q->config->maxPrefixExpansions, q->sctx->time.skipTimeoutChecks);
+                                                        q->sctx->time.timeout, q->config->maxPrefixExpansions, q->sctx->time.skipClockTimeoutChecks);
     if (!arr) {
       // No matching terms
       rm_free(its);
@@ -1382,7 +1382,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   if (!idx->suffix || fallbackBruteForce) {
     // brute force wildcard query
     TrieMapIterator *it = TrieMap_IterateWithFilter(idx->values, tok->str, tok->len, TM_WILDCARD_MODE);
-    if (!q->sctx->time.skipTimeoutChecks) {
+    if (!q->sctx->time.skipClockTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, q->sctx->time.timeout);
     }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn NewNotIterator(
         let q_ref = unsafe { query.as_ref() };
         // SAFETY: caller guarantees q.sctx is valid (4).
         let sctx = unsafe { &*q_ref.sctx };
-        if sctx.time.skipTimeoutChecks {
+        if sctx.time.skipClockTimeoutChecks {
             (std::time::Duration::ZERO, true)
         } else {
             match crate::timespec::duration_from_redis_timespec(timeout) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -404,7 +404,7 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
   ret->sctx = sctx;
   ret->base.type = RP_INDEX;
   // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks
-  ret->timeoutLimiter = sctx->time.skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0;
+  ret->timeoutLimiter = sctx->time.skipClockTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0;
 #ifdef ENABLE_ASSERT
   ret->firstRead = true;
 #endif
@@ -1784,8 +1784,8 @@ static void RPSafeDepleter_Deplete(void *arg) {
   rs_wall_clock depletionStart;
   rs_wall_clock_init(&depletionStart);
 
-  // Check if timeout was exceeded before starting execution (respecting skipTimeoutChecks flag)
-  if (self->depletingThreadCtx->time.skipTimeoutChecks || TimedOut(&self->depletingThreadCtx->time.timeout) == NOT_TIMED_OUT) {
+  // Check if timeout was exceeded before starting execution (respecting skipClockTimeoutChecks flag)
+  if (self->depletingThreadCtx->time.skipClockTimeoutChecks || TimedOut(&self->depletingThreadCtx->time.timeout) == NOT_TIMED_OUT) {
     RPSafeDepleter_DepleteFromUpstream(self, sync);
   } else {
     // Timeout before starting - no need to acquire lock or do any work
@@ -1909,8 +1909,8 @@ static int RPSafeDepleter_Next_Dispatch(ResultProcessor *base, SearchResult *r) 
   if (self->first_call) {
     self->first_call = false;
 
-    // Check timeout before attempting to start thread (respecting skipTimeoutChecks flag)
-    if (!self->nextThreadCtx->time.skipTimeoutChecks && TimedOut(&self->nextThreadCtx->time.timeout) == TIMED_OUT) {
+    // Check timeout before attempting to start thread (respecting skipClockTimeoutChecks flag)
+    if (!self->nextThreadCtx->time.skipClockTimeoutChecks && TimedOut(&self->nextThreadCtx->time.timeout) == TIMED_OUT) {
       base->Next = RPSafeDepleter_Next_Yield;
       self->last_rc = RS_RESULT_TIMEDOUT;
       return base->Next(base, r);
@@ -2333,7 +2333,7 @@ ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx,
   ret->sctx = sctx;
   // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks
   RS_ASSERT(sctx);
-  ret->timeoutCounter = sctx->time.skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0;
+  ret->timeoutCounter = sctx->time.skipClockTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0;
   RS_ASSERT(numUpstreams > 0);
   ret->numUpstreams = numUpstreams;
 

--- a/src/search_ctx.h
+++ b/src/search_ctx.h
@@ -37,7 +37,7 @@ typedef struct SearchTime {
   // when the query should timeout - monotonic raw clock, unrelated to real clock
   struct timespec timeout;
   // Flag to skip timeout checks (used in background thread mode with FAIL policy)
-  bool skipTimeoutChecks;
+  bool skipClockTimeoutChecks;
   // Borrowed RS_Atomic(bool) timed-out flag, wired in AREQ_ApplyContext.
   // Read via SearchTime_IsTimedOut. NULL on contexts without an owning AREQ.
   // TODO: move to QueryProcessingCtx.
@@ -75,7 +75,7 @@ static inline RedisSearchCtx SEARCH_CTX_STATIC(RedisModuleCtx *ctx, IndexSpec *s
                           .redisCtx = ctx,
                           .key_ = NULL,
                           .spec = sp,
-                          .time = {.current = { 0, 0 }, .timeout = { 0, 0 }, .skipTimeoutChecks = false, .timedOutFlag = NULL},
+                          .time = {.current = { 0, 0 }, .timeout = { 0, 0 }, .skipClockTimeoutChecks = false, .timedOutFlag = NULL},
                           .flags = RS_CTX_UNSET,};
   return sctx;
 }

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -362,7 +362,7 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
   token[toklen] = (rune)'\0';
 
   Trie_IterateWildcard(sufCtx->trie, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,
-                       sufCtx->skipTimeoutChecks);
+                       sufCtx->skipClockTimeoutChecks);
   return 1;
 }
 
@@ -439,7 +439,7 @@ void deleteSuffixTrieMap(TrieMap *trie, const char *str, uint32_t len) {
 }
 
 arrayof(char**) GetList_SuffixTrieMap(TrieMap *trie, const char *str, uint32_t len,
-                                          bool prefix, struct timespec timeout, bool skipTimeoutChecks) {
+                                          bool prefix, struct timespec timeout, bool skipClockTimeoutChecks) {
   arrayof(char**) arr = NULL;
   suffixData *data = NULL;
   if (!prefix) {
@@ -452,7 +452,7 @@ arrayof(char**) GetList_SuffixTrieMap(TrieMap *trie, const char *str, uint32_t l
     }
   } else {
     TrieMapIterator *it = TrieMap_IterateWithFilter(trie, str, len, TM_PREFIX_MODE);
-    if (!skipTimeoutChecks) {
+    if (!skipClockTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, timeout);
     }
     if (!it) {
@@ -500,7 +500,7 @@ end:
 }
 
 arrayof(char*) GetList_SuffixTrieMap_Wildcard(TrieMap *trie, const char *pattern, uint32_t len,
-                                              struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks) {
+                                              struct timespec timeout, long long maxPrefixExpansions, bool skipClockTimeoutChecks) {
   size_t idx[len];
   size_t lens[len];
   // find best token
@@ -516,7 +516,7 @@ arrayof(char*) GetList_SuffixTrieMap_Wildcard(TrieMap *trie, const char *pattern
 
   TrieMapIterator *it = TrieMap_IterateWithFilter(trie, pattern + tokenidx, tokenlen + prefix, TM_WILDCARD_MODE);
   if (!it) return NULL;
-  if (!skipTimeoutChecks) {
+  if (!skipClockTimeoutChecks) {
     TrieMapIterator_SetTimeout(it, timeout);
   }
 

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -38,7 +38,7 @@ typedef struct SuffixCtx {
     TrieSuffixCallback *callback;
     void *cbCtx;
     struct timespec *timeout;
-    bool skipTimeoutChecks;  // flag to skip timeout checks in trie iteration
+    bool skipClockTimeoutChecks;  // flag to skip timeout checks in trie iteration
 } SuffixCtx;
 
 typedef struct suffixData {
@@ -76,12 +76,12 @@ void suffixTrieMap_freeCallback(void *payload);
 
 /* Return a list of list of terms which match the suffix or contains term */
 arrayof(char**) GetList_SuffixTrieMap(TrieMap *trie, const char *str, uint32_t len,
-                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks);
+                                        bool prefix, struct timespec timeout, bool skipClockTimeoutChecks);
 
 /* Return a list of terms which match the wildcard pattern
  * If pattern does not match using suffix trie, return 0xBAAAAAAD */
 arrayof(char*) GetList_SuffixTrieMap_Wildcard(TrieMap *trie, const char *pattern, uint32_t len,
-                                               struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks);
+                                               struct timespec timeout, long long maxPrefixExpansions, bool skipClockTimeoutChecks);
 
 /* Breaks wildcard at '*'s and finds the best token to get iterate the suffix trie.
  * tokenIdx and tokenLen arrays should sufficient space for all tokens. Max (len / 2) + 1.

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -114,15 +114,15 @@ void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
 
 void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                          bool skipTimeoutChecks) {
+                          bool skipClockTimeoutChecks) {
   TrieNode_IterateContains(t->root, str, nstr, prefix, suffix, callback, ctx, timeout,
-                           skipTimeoutChecks);
+                           skipClockTimeoutChecks);
 }
 
 void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                          bool skipTimeoutChecks) {
-  TrieNode_IterateWildcard(t->root, str, nstr, callback, ctx, timeout, skipTimeoutChecks);
+                          bool skipClockTimeoutChecks) {
+  TrieNode_IterateWildcard(t->root, str, nstr, callback, ctx, timeout, skipClockTimeoutChecks);
 }
 
 // Forward declaration for the internal rune-based function

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -82,13 +82,13 @@ void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
  * parameter semantics. */
 void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                          bool skipTimeoutChecks);
+                          bool skipClockTimeoutChecks);
 
 /* Iterate all nodes matching a wildcard pattern. Wraps TrieNode_IterateWildcard on the
  * trie's root. See TrieNode_IterateWildcard for parameter semantics. */
 void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                          bool skipTimeoutChecks);
+                          bool skipClockTimeoutChecks);
 
 /* Number of terminal entries in the trie. Wraps the internal size counter. */
 size_t Trie_Size(const Trie *t);

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -1033,7 +1033,7 @@ static void containsIterate(TrieNode *n, t_len localOffset, t_len globalOffset, 
 // Contains iteration.
 void TrieNode_IterateContains(TrieNode *n, const rune *str, int nstr, bool prefix, bool suffix,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                              bool skipTimeoutChecks) {
+                              bool skipClockTimeoutChecks) {
   // exact match - should not be used. change to assert
   if (!prefix && !suffix) {
     TrieNode *node = TrieNode_Get(n, (rune *)str, nstr, true, NULL);
@@ -1048,7 +1048,7 @@ void TrieNode_IterateContains(TrieNode *n, const rune *str, int nstr, bool prefi
       .callback = callback,
       .cbctx = ctx,
       .timeout = timeout ? *timeout : (struct timespec){0},
-      .timeoutCounter = skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0,
+      .timeoutCounter = skipClockTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0,
   };
   r.buf = array_new(rune, TRIE_INITIAL_STRING_LEN);
 
@@ -1190,13 +1190,13 @@ static void wildcardIterate(TrieNode *n, RangeCtx *r) {
 
 void TrieNode_IterateWildcard(TrieNode *n, const rune *str, int nstr,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                              bool skipTimeoutChecks) {
+                              bool skipClockTimeoutChecks) {
   // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks
   RangeCtx r = {
       .callback = callback,
       .cbctx = ctx,
       .timeout = timeout ? *timeout : (struct timespec){0},
-      .timeoutCounter = skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0,
+      .timeoutCounter = skipClockTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0,
       .origStr = str,
       .lenOrigStr = nstr,
       .buf = array_new(rune, TRIE_INITIAL_STRING_LEN),

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -262,11 +262,11 @@ void TrieNode_IterateRange(TrieNode *n, const rune *min, int minlen, bool includ
  */
 void TrieNode_IterateContains(TrieNode *n, const rune *str, int nstr, bool prefix, bool suffix,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                              bool skipTimeoutChecks);
+                              bool skipClockTimeoutChecks);
 
 void TrieNode_IterateWildcard(TrieNode *n, const rune *str, int nstr,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
-                              bool skipTimeoutChecks);
+                              bool skipClockTimeoutChecks);
 
 #ifdef __cplusplus
 }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -199,10 +199,8 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
                                     &qParams, QUERY_TYPE_RANGE, q->status) != VecSim_OK)  {
         return NULL;
       }
-      // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks when the request
-      // has them disabled (mirrors the pattern in hybrid_reader / result processor init).
       qParams.timeoutCtx = &(TimeoutCtx){ .timeout = q->sctx->time.timeout,
-                                          .counter = q->sctx->time.skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0 };
+                                          .counter = q->sctx->time.skipClockTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0 };
       VecSimQueryReply *results =
           VecSimIndex_RangeQuery(vecsim, vq->range.vector, vq->range.radius,
                                  &qParams, vq->range.order);

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -199,7 +199,10 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
                                     &qParams, QUERY_TYPE_RANGE, q->status) != VecSim_OK)  {
         return NULL;
       }
-      qParams.timeoutCtx = &(TimeoutCtx){ .timeout = q->sctx->time.timeout, .counter = 0 };
+      // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks when the request
+      // has them disabled (mirrors the pattern in hybrid_reader / result processor init).
+      qParams.timeoutCtx = &(TimeoutCtx){ .timeout = q->sctx->time.timeout,
+                                          .counter = q->sctx->time.skipTimeoutChecks ? REDISEARCH_UNINITIALIZED : 0 };
       VecSimQueryReply *results =
           VecSimIndex_RangeQuery(vecsim, vq->range.vector, vq->range.radius,
                                  &qParams, vq->range.order);

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -63,7 +63,7 @@ public:
     // Initialize RedisSearchCtx
     sctx = {0};
     sctx.spec = &spec;
-    sctx.time = {.current = {0, 0}, .timeout = {0, 0}, .skipTimeoutChecks = true};
+    sctx.time = {.current = {0, 0}, .timeout = {0, 0}, .skipClockTimeoutChecks = true};
 
     // Initialize QueryEvalCtx
     qctx = {0};

--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -152,13 +152,13 @@ struct MockUpstream : public ResultProcessor {
 };
 
 // Static dummy RedisSearchCtx for tests - reused across all tests
-// The context has skipTimeoutChecks set to true to avoid timeout checks in tests
+// The context has skipClockTimeoutChecks set to true to avoid timeout checks in tests
 static RedisSearchCtx* GetDummySearchCtx() {
   static RedisSearchCtx dummySctx = {
     .redisCtx = NULL,
     .key_ = NULL,
     .spec = NULL,
-    .time = {.current = {0, 0}, .timeout = {0, 0}, .skipTimeoutChecks = true},
+    .time = {.current = {0, 0}, .timeout = {0, 0}, .skipClockTimeoutChecks = true},
     .apiVersion = 0,
     .expanded = 0,
     .flags = RS_CTX_UNSET,
@@ -221,7 +221,7 @@ ResultProcessor* CreateLinearHybridMerger(ResultProcessor **upstreams, size_t nu
   // Create dummy return codes array for tests that don't need to track return codes
   static RPStatus dummyReturnCodes[8] = {RS_RESULT_OK}; // Static array, supports up to 8 upstreams for tests
 
-  // Use static dummy search context for tests (with skipTimeoutChecks = true)
+  // Use static dummy search context for tests (with skipClockTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
   return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx);
@@ -236,7 +236,7 @@ ResultProcessor* CreateRRFHybridMerger(ResultProcessor **upstreams, size_t numUp
   // Create dummy return codes array for tests that don't need to track return codes
   static RPStatus dummyReturnCodes[8] = {RS_RESULT_OK}; // Static array, supports up to 8 upstreams for tests
 
-  // Use static dummy search context for tests (with skipTimeoutChecks = true)
+  // Use static dummy search context for tests (with skipClockTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
   return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx);
@@ -1444,7 +1444,7 @@ TEST_F(HybridMergerTest, testUpstreamReturnCodes) {
   // Create dummy lookup context
   HybridLookupContext *lookupCtx = CreateDummyLookupContext(3);
 
-  // Use static dummy search context for tests (with skipTimeoutChecks = true)
+  // Use static dummy search context for tests (with skipClockTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
   ResultProcessor *hybridMerger = RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, 3, NULL, NULL, returnCodes, lookupCtx);


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current**: Every aggregate / hybrid / coord query unconditionally calls `SearchCtx_UpdateTime(...)` to seed `sctx->time.timeout`. That helper issues `clock_gettime(CLOCK_MONOTONIC_RAW, ...)` even when the request is running with timeout checks disabled (`TIMEOUT 0`, or `FAIL` / `RETURN-STRICT` with workers), where the deadline is never read.
2. **Change**: Gate every call site on `AREQ_ShouldCheckTimeout(req)` / `HybridRequest_ShouldCheckTimeout(req)` so the syscall is skipped when timeout checks are off. To make this safe, also propagate `req->skipTimeoutChecks` to `sctx->time.skipTimeoutChecks` in `AREQ_ApplyContext` (`AREQ_Compile` sets the flag on the request before `sctx` is attached, so without this propagation `startPipelineCommon` and the pipeline counters would see `skipTimeoutChecks=false` and would read the uninitialised `sctx->time.timeout` (`{0,0}`) as an immediately-expired deadline). Fix the same latent issue in `vector_index.c` `VECSIM_QT_RANGE`: the `TimeoutCtx.counter` was hard-coded to `0`, so the deadline would be checked every 100 iterations regardless of `skipTimeoutChecks`; use `REDISEARCH_UNINITIALIZED` when the flag is set, matching the existing pattern in `hybrid_reader.c`.
3. **Outcome**: One fewer `clock_gettime` syscall per query when timeout checks are disabled. No behavior change for queries that do check timeouts. `TIMEOUT_AFTER_N` (debug) is unaffected — `aggregate_debug.c` already rejects the incompatible combos (`RETURN-STRICT`; `FAIL`+`WORKERS>0`) and forces `skipTimeoutChecks = false` on every surviving branch before the production `SearchCtx_UpdateTime` runs.

#### Which additional issues this PR fixes
1. MOD-14000

#### Main objects this PR modified
1. `src/aggregate/aggregate_exec.c` — gate `SearchCtx_UpdateTime` in `prepareExecutionPlan` and `runCursor`.
2. `src/aggregate/aggregate_request.c` — propagate `req->skipTimeoutChecks` to `sctx->time.skipTimeoutChecks` in `AREQ_ApplyContext`.
3. `src/coord/dist_aggregate.c` — gate `SearchCtx_UpdateTime` in `prepareForExecution`.
4. `src/hybrid/hybrid_exec.c` — gate the per-subquery and parent `SearchCtx_UpdateTime` calls in `hybridCommandHandler`.
5. `src/coord/hybrid/dist_hybrid.c` — same gate in `HybridRequest_prepareForExecution`.
6. `src/vector_index.c` — use `REDISEARCH_UNINITIALIZED` for the `VECSIM_QT_RANGE` `TimeoutCtx` counter when `skipTimeoutChecks` is set.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query timeout initialization and deadline checks across aggregate, coord, hybrid, and iterators; behavior should be unchanged when timeouts are active, but mis-gating could affect timeout or debug TIMEOUT_AFTER_N paths.
> 
> **Overview**
> Renames **`skipTimeoutChecks`** to **`skipClockTimeoutChecks`** across AREQ, hybrid, `SearchTime`, trie/suffix iteration, result processors, and Rust FFI so the flag clearly means “do not use the monotonic deadline,” distinct from abort/`timedOut` paths.
> 
> **`SearchCtx_UpdateTime`** (which calls `clock_gettime` to seed `sctx->time.timeout`) is now invoked only when clock timeout checks are enabled—e.g. **`prepareExecutionPlan`**, **`runCursor`**, coordinator **`prepareForExecution`**, and hybrid subquery/parent init—skipping the syscall for `TIMEOUT 0` and FAIL/RETURN-STRICT with workers where the deadline is unused.
> 
> **`AREQ_ApplyContext`** copies `req->skipClockTimeoutChecks` onto `sctx->time` so pipeline code that reads the search context directly sees the flag set during compile. **VecSim range** queries set the timeout counter to **`REDISEARCH_UNINITIALIZED`** when clock checks are skipped, matching hybrid/RP patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768a2196ddf473644a3fe79167fa2b640b3311c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->