### PR TITLE
[MOD-15875] CI: bump remaining actions off Node 20

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -20,7 +20,8 @@ categories:
     labels:
       - 'x:docs'
   - title: 'Maintenance'
-    label: 'chore'
+    labels:
+      - 'chore'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -116,7 +116,7 @@ jobs:
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: install terraform
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: 1.11.1
           terraform_wrapper: false

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -96,7 +96,7 @@ jobs:
         run: .install/test_deps/common_installations.sh sudo
       - name: Download prebuilt redisearch.so
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.binary_artifact_name }}
           # Place the .so where `inputs.module_path` expects it, e.g.

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -334,14 +334,14 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
 
   notify-msmarco-failure:
     needs:
@@ -350,12 +350,12 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify MSMARCO Benchmark Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "repository": "${{ github.repository }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ci-reports-${{ steps.date.outputs.date }}
           path: merge-to-queue_${{ steps.date.outputs.date }}/

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Send reports to Slack
         if: always()
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ci-reports-${{ steps.date.outputs.date }}
           path: merge-to-queue_${{ steps.date.outputs.date }}/

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -27,8 +27,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "repository": "${{ github.repository }}",
@@ -36,5 +38,3 @@ jobs:
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -49,12 +49,12 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "repository": "${{ github.repository }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_name }}
           path: |

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: |

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -48,7 +48,7 @@ jobs:
           permission-administration: write
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ steps.generate-app-token.outputs.token }}
@@ -205,7 +205,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ steps.generate-app-token.outputs.token }}

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Download Latest Baseline Artifact from master
         id: get-artifact
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@4c1e823582f43b179e2cbb49c3eade4e41f992e2 # refs @v10
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # refs @v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -68,13 +68,13 @@ jobs:
 
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "rust-benchmark-results-master"
           path: bin/redisearch_rs/criterion
       - name: Upload benchmarks for PR comparison
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "rust-benchmark-results-pr-${{ github.event.pull_request.number }}"
           path: bin/redisearch_rs/criterion

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -68,13 +68,13 @@ jobs:
 
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: "rust-benchmark-results-master"
           path: bin/redisearch_rs/criterion
       - name: Upload benchmarks for PR comparison
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: "rust-benchmark-results-pr-${{ github.event.pull_request.number }}"
           path: bin/redisearch_rs/criterion

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Upload results on failure
       if: failure()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: link-check-results
         path: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Upload results on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: link-check-results
         path: |

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v10
         with:
             days-before-stale: 60
             days-before-close: -1

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -516,7 +516,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -516,7 +516,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -126,7 +126,7 @@ jobs:
           permission-administration: write
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ steps.generate-app-token.outputs.token }}
@@ -607,7 +607,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ steps.generate-app-token.outputs.token }}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Several `.github/workflows/*.yml` files still pin GHA actions whose latest pinned major declares `runs.using: node20` (and a few even-older holdovers on `node16`). GitHub announced Node 20 deprecation on hosted runners on 2025-09-19 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
2. **Change:** Bump the remaining tail off Node 20 / Node 16. Eight focused commits (one per action family); per-file diffs match the existing pin style.
3. **Outcome:** All RediSearch GHA workflows now resolve to actions whose pinned major declares `runs.using: node24` (or `composite`/`docker`). CI keeps working past the Node 20 deprecation deadline.

Followup to #9361 (MOD-15112).

### Per-commit summary

1. `actions/upload-artifact@v4 → @v7` (6 sites)
2. `actions/download-artifact@v4 → @v7` (1 site — `name:`-input only, v5 `artifact-ids:` break does not apply)
3. `actions/stale@v8 → @v10`
4. `slackapi/slack-github-action@v1/@v2 → @v3` (5 sites; 4 v1 sites need the v1→v2 input contract rewrite — `webhook:` + `webhook-type:` instead of the `SLACK_WEBHOOK_URL` env block; the v2 site is a pure version bump)
5. `hashicorp/setup-terraform@v2 → @v4.0.1`
6. `machulav/ec2-github-runner@v2.4.2 → @v2.6.1` (4 sites)
7. `release-drafter/release-drafter@v5 → @v7.3.1`
8. `dawidd6/action-download-artifact` SHA pin advanced from a v10 commit to a v21 commit (`b6e2e706…`); `# refs @v21` comment updated to match

### Highest-risk hunk

The Slack v1 → v3 webhook input rewrite (commit 4). Per-site translation against the upstream v3 README. The 5 changed sites split as:

| Workflow | Before | After |
|---|---|---|
| `event-deploy-snapshots.yml` | `@v1` + env webhook | `@v3` + `webhook:`+`webhook-type:` |
| `event-nightly.yml` | `@v1` + env webhook | `@v3` + `webhook:`+`webhook-type:` |
| `benchmark-runner.yml` (notify-benchmark-failure) | `@v1` + env webhook | `@v3` + `webhook:`+`webhook-type:` |
| `benchmark-runner.yml` (notify-msmarco-failure) | `@v1` + env webhook | `@v3` + `webhook:`+`webhook-type:` |
| `daily-ci-report.yml` | `@v2` + v2 contract | `@v3` + same v2 contract (no input change) |


### Verification

- YAML parse loader run after every commit — exit 0.
- No residual `@v[1-2]` slack, `@v4` artifact actions, `@v8/v9` stale, `@v2` terraform, `@v2.4.2` ec2-runner, `@v5/v6` release-drafter, or v10-era dawidd6 SHA anywhere under `.github/`.
- Dynamic dispatch tests (`gh workflow run event-nightly.yml`, `daily-ci-report.yml` on this branch) recommended pre-merge to exercise 2 of the 4 rewritten Slack sites; the remaining 2 (`benchmark-runner.yml`) covered by post-merge benchmark cron.

### Out of scope

- Node 24 deprecation tracking (future ticket).
- `mozilla-actions/sccache-action@v0.0.10` (already `node24` since v0.0.10).
- `self-hosted.yml.TEMPLATE`'s `machulav/ec2-github-runner@v2` (floating tag — already resolves to v2.6.1).
- MOD-15874 (VectorSimilarity sibling — separate repo).

#### Which additional issues this PR fixes

1. MOD-15875
2. Followup to #9361 (MOD-15112)

#### Main objects this PR modified

1. `.github/workflows/*.yml` (10 files across 8 commits)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Most changes are version pins; medium risk comes from Slack v1→v3 webhook input rewrites on failure-notification jobs—wrong wiring would silently break alerts until workflows run.
> 
> **Overview**
> Bumps remaining GitHub Actions in **10 workflow files** (plus a small **release-drafter** config fix) so CI stays compatible after GitHub’s **Node 20** runner deprecation—follow-up to MOD-15112.
> 
> **Artifact and tooling:** `actions/upload-artifact` and `actions/download-artifact` move to **v7**; `actions/stale` to **v10**; `hashicorp/setup-terraform` to **v4.0.1**; `machulav/ec2-github-runner` to **v2.6.1**; `release-drafter/release-drafter` to **v7.3.1**; `dawidd6/action-download-artifact` pin advances to the **v21** commit for Rust benchmark baselines.
> 
> **Slack notifications:** Five sites upgrade to **`slackapi/slack-github-action@v3`**. Four previously on **v1** switch from the `SLACK_WEBHOOK_URL` env pattern to **`webhook:`** + **`webhook-type: incoming-webhook`**; the daily CI report site was already on v2 and only bumps the version.
> 
> **Release notes config:** The Maintenance category now uses **`labels:`** (plural) with **`chore`** instead of a single **`label:`** key, matching release-drafter’s expected schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100d02ff9a69bde024c6192b1ba8d2873f4a5db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




