### PR TITLE
Fix typo in 'foo' to appease codespell.

### DIFF
--- a/src/redisearch_rs/rqe_wildcard/tests/integration/fmt.rs
+++ b/src/redisearch_rs/rqe_wildcard/tests/integration/fmt.rs
@@ -39,6 +39,6 @@ fn test_wildcard_pattern_display() {
     assert_eq!(format!("{pattern_with_escapes}"), "foo*bar?baz");
 
     // Ensure invalid UTF-8 is replaced with the Unicode replacement character
-    let invalid_utf8 = WildcardPattern::parse(&[0x66, 0x6F, 0x80, b'*', b'b', b'a', b'z']);
-    assert_eq!(format!("{invalid_utf8}"), "fo�*baz");
+    let invalid_utf8 = WildcardPattern::parse(&[b'f', b'o', b'o', 0x80, b'*', b'b', b'a', b'z']);
+    assert_eq!(format!("{invalid_utf8}"), "foo�*baz");
 }


### PR DESCRIPTION
Tiny fix needed for codespell :

```
src/redisearch_rs/rqe_wildcard/tests/integration/fmt.rs:42: fo ==> of, for, to, do, go
```

spotted in https://github.com/RediSearch/RediSearch/actions/runs/26449647596/job/77866459795?pr=9447

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to byte literals and an assertion string; no runtime or API impact.
> 
> **Overview**
> Updates the **invalid UTF-8** display test in `fmt.rs` so the pattern bytes spell **`foo`** before the bad byte (`0x80`), and the expected `Display` output is **`foo*baz`** instead of **`fo*baz`**.
> 
> This is test-only; it aligns the fixture with the intended “three literal chars + invalid UTF-8 + wildcard” case and clears a codespell hit on `fo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81efa7b7fe2d24d5e05ff440bf15d257510ac2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->