### PR TITLE
[MOD-15932] Trie: fix FT.SUGGEST TRIM abort when trim post-pass drops tail entries

### DIFF
--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -331,18 +331,19 @@ Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDi
       Vector_Get(ret, i, &h);
 
       if (maxScore && h->score < maxScore / SCORE_TRIM_FACTOR) {
-        // TODO: Fix trimming the vector
-        ret->top = i;
         break;
       }
       maxScore = MAX(maxScore, h->score);
     }
 
-    for (; i < n; ++i) {
+    // Free tail entries first; mutating ret->top before reading would make
+    // Vector_Get return 0 without writing h, leaving stack garbage to free.
+    for (int j = i; j < n; ++j) {
       TrieSearchResult *h;
-      Vector_Get(ret, i, &h);
+      Vector_Get(ret, j, &h);
       TrieSearchResult_Free(h);
     }
+    ret->top = i;
   }
 
   rm_free(runes);

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -1015,3 +1015,35 @@ TEST_F(TrieTest, testRdbSaveLoadWithNumDocs) {
   EXPECT_EQ(6, count);
   TrieIterator_Free(it);
 }
+
+// Regression: Trie_Search(trim=1) used to mutate ret->top before reading the
+// tail entries it was about to free. Vector_Get then returned 0 without
+// touching the out pointer, so TrieSearchResult_Free(h) ran on stack garbage
+// and the allocator aborted. This test forces the trim drop branch (one entry
+// whose score dominates the rest by > SCORE_TRIM_FACTOR) and asserts both
+// non-abort and the surviving count.
+TEST_F(TrieTest, testSearchTrimDropsTail) {
+  Trie *t = NewTrie(NULL, Trie_Sort_Score);
+
+  trieInsertByScore(t, "ha", 100.0f);
+  trieInsertByScore(t, "hb", 1.0f);
+  trieInsertByScore(t, "hc", 1.0f);
+  trieInsertByScore(t, "hd", 1.0f);
+  trieInsertByScore(t, "he", 1.0f);
+
+  // num=10, maxDist=0, prefixMode=1, trim=1, optimize=0
+  Vector *res = Trie_Search(t, "h", 1, 10, 0, 1, 1, 0);
+  ASSERT_TRUE(res != NULL);
+
+  // Only the dominant entry should survive the trim: 1.0 < 100.0 / 10.0.
+  ASSERT_EQ(1, Vector_Size(res));
+
+  TrieSearchResult *e;
+  ASSERT_EQ(1, Vector_Get(res, 0, &e));
+  ASSERT_EQ(2, e->len);
+  ASSERT_EQ(0, memcmp(e->str, "ha", 2));
+  TrieSearchResult_Free(e);
+  Vector_Free(res);
+
+  TrieType_Free(t);
+}

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -226,6 +226,29 @@ def testEmptySuggestionDict(env):
     res = conn.execute_command('ft.sugdel', 'sug', 'hello world')
     env.assertEqual(res, 0)
 
+def testSuggestTrimDropsTail(env):
+    # Regression for MOD-15932: FT.SUGGET ... TRIM used to double-free when the
+    # trim post-pass dropped tail entries. The first loop left `h` pointing at
+    # the last surviving entry; the second loop then re-freed it once per
+    # dropped entry. Reliable crash with one score-dominant entry and several
+    # entries below the SCORE_TRIM_FACTOR (10x) cutoff.
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    env.assertEqual(1, conn.execute_command('FT.SUGADD', 'sug', 'ha', '100'))
+    env.assertEqual(2, conn.execute_command('FT.SUGADD', 'sug', 'hb', '1'))
+    env.assertEqual(3, conn.execute_command('FT.SUGADD', 'sug', 'hc', '1'))
+    env.assertEqual(4, conn.execute_command('FT.SUGADD', 'sug', 'hd', '1'))
+    env.assertEqual(5, conn.execute_command('FT.SUGADD', 'sug', 'he', '1'))
+
+    res = conn.execute_command('FT.SUGGET', 'sug', 'h', 'MAX', '10', 'TRIM')
+    env.assertEqual(res, ['ha'])
+
+    # Server must still be alive and the trie intact: a follow-up SUGGET
+    # without TRIM still returns the full set.
+    res = conn.execute_command('FT.SUGGET', 'sug', 'h', 'MAX', '10')
+    env.assertEqual(sorted(res), ['ha', 'hb', 'hc', 'hd', 'he'])
+
 def testWrongType(env):
     skipOnCrdtEnv(env)
     conn = env.getClusterConnectionIfNeeded()


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `Trie_Search(..., trim=1, ...)` in `src/trie/trie.c` mutates `ret->top` *before* iterating the tail entries it is about to free. The subsequent `Vector_Get(ret, i, &h)` calls hit `i >= ret->top`, so `Vector_Get` returns `0` without writing `h` (see `deps/rmutil/vector.c`). The next line `TrieSearchResult_Free(h)` then frees whatever the local stack slot happened to hold, triggering libmalloc's "pointer being freed was not allocated" abort.
2. **Change**: Free the tail entries first, then truncate `ret->top`. The trim invariant (only entries whose score is within `SCORE_TRIM_FACTOR` of the running max remain) is preserved; every read still goes through the bounds-checked `Vector_Get`.
3. **Outcome**: `FT.SUGGEST ... TRIM` no longer aborts when the trim post-pass needs to drop any tail entry. Reachable in production code but dormant in normal traffic, because typical autocomplete fan-out rarely surfaces enough entries to fire the drop branch.

A regression test was added in `tests/cpptests/test_cpp_trie.cpp` (`TrieTest.testSearchTrimDropsTail`) that forces the drop branch (one score-dominant entry plus several entries below the cutoff) and asserts both the non-abort and the surviving count.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `Trie_Search` in `src/trie/trie.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering fix in trie search trim cleanup with targeted regression tests; no API or serialization changes.
> 
> **Overview**
> Fixes a crash in **`Trie_Search`** when **`trim=1`** drops low-scoring tail results: the trim pass no longer sets **`ret->top`** before reading entries to free. It frees indices **`[i, n)`** via **`Vector_Get`**, then truncates the vector so **`Vector_Get`** never runs past the shortened size (which previously left **`h`** uninitialized and **`TrieSearchResult_Free`** could abort).
> 
> **`FT.SUGGET ... TRIM`** (MOD-15932) is covered by a C++ regression (**`testSearchTrimDropsTail`**) and a Python integration test that asserts trim keeps only the dominant score and the server stays healthy on a follow-up query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e183f6720439713cb6b3bda55ab22b4962e8c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->