### PR TITLE
fix warning when generatin cheadergen header

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -166,7 +166,7 @@ type NotIteratorWrapper<'index> = RQEIteratorWrapper<NotIteratorEnum<'index>>;
 /// # Safety
 ///
 /// Caller must guarantee `q` and `q.sctx` are valid (FFI preconditions
-/// 3 and 4 of [`NewNotIterator`]). When `bc_timeout_areq` is non-null, it
+/// 3 and 4 of [`NewNotIterator()`]). When `bc_timeout_areq` is non-null, it
 /// must uphold the [`TimeoutContextBlockedClient::new`] safety contract for
 /// the lifetime of the returned context.
 unsafe fn build_timeout_context(


### PR DESCRIPTION
Fixing this warning:
  warning: `NewNotIterator` is both a function and an enum



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only rustdoc fix with no runtime or API behavior changes.
> 
> **Overview**
> Fixes a **cheadergen / rustdoc** warning in `not.rs` by changing the intra-doc link from `` [`NewNotIterator`] `` to `` [`NewNotIterator()`] `` in the `build_timeout_context` safety section.
> 
> That disambiguates the **FFI function** `NewNotIterator` from the imported **enum** `NewNotIterator` in `not_reducer`; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8917e7b1788443056b89e69dae50a52d26542bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->