### PR TITLE
[MOD-15934] aggregate.h: use __atomic_*_n builtins instead of <stdatomic.h>

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -35,9 +35,8 @@
 extern "C" {
 #else
 #define RS_Atomic(T) _Atomic(T)
-#include <stdatomic.h>
-#define RS_AtomicLoadRelaxed(p)     atomic_load_explicit((p), memory_order_relaxed)
-#define RS_AtomicStoreRelaxed(p, v) atomic_store_explicit((p), (v), memory_order_relaxed)
+#define RS_AtomicLoadRelaxed(p)     __atomic_load_n((bool *)(p), __ATOMIC_RELAXED)
+#define RS_AtomicStoreRelaxed(p, v) __atomic_store_n((bool *)(p), (v), __ATOMIC_RELAXED)
 #endif
 
 #define DEFAULT_LIMIT 10

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -30,13 +30,13 @@
 #ifdef __cplusplus
 #include <atomic>
 #define RS_Atomic(T) std::atomic<T>
-#define RS_AtomicLoadRelaxed(p)     ((p)->load(std::memory_order_relaxed))
-#define RS_AtomicStoreRelaxed(p, v) ((p)->store((v), std::memory_order_relaxed))
+#define RS_AtomicBoolLoadRelaxed(p)     (((std::atomic<bool> *)(p))->load(std::memory_order_relaxed))
+#define RS_AtomicBoolStoreRelaxed(p, v) (((std::atomic<bool> *)(p))->store((v), std::memory_order_relaxed))
 extern "C" {
 #else
 #define RS_Atomic(T) _Atomic(T)
-#define RS_AtomicLoadRelaxed(p)     __atomic_load_n((bool *)(p), __ATOMIC_RELAXED)
-#define RS_AtomicStoreRelaxed(p, v) __atomic_store_n((bool *)(p), (v), __ATOMIC_RELAXED)
+#define RS_AtomicBoolLoadRelaxed(p)     __atomic_load_n((bool *)(p), __ATOMIC_RELAXED)
+#define RS_AtomicBoolStoreRelaxed(p, v) __atomic_store_n((bool *)(p), (v), __ATOMIC_RELAXED)
 #endif
 
 #define DEFAULT_LIMIT 10
@@ -550,10 +550,10 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
 static inline bool AREQ_TimedOut(AREQ *req) {
-  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
+  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
 }
 static inline void AREQ_SetTimedOut(AREQ *req) {
-  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
 }
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1133,11 +1133,11 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
 }
 
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
-  RS_AtomicStoreRelaxed(&req->syncCtx.aggregatingResults, false);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.aggregatingResults, false);
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);
-  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, false);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, false);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {
     ((RPNet *)root)->drainOnly = false;

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -115,7 +115,7 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
 }
 
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
-  RS_AtomicStoreRelaxed(&ctx->timedOut, true);
+  RS_AtomicBoolStoreRelaxed(&ctx->timedOut, true);
   // Also propagate to the underlying request if set
   if (ctx->type == COMMAND_HYBRID) {
     if (ctx->hreq) HybridRequest_SetTimedOut(ctx->hreq);

--- a/src/coord/coord_request_ctx.h
+++ b/src/coord/coord_request_ctx.h
@@ -94,7 +94,7 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx);
  * Check if the coordinator request has timed out.
  */
 static inline bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return RS_AtomicLoadRelaxed(&ctx->timedOut);
+  return RS_AtomicBoolLoadRelaxed(&ctx->timedOut);
 }
 
 /**

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -81,10 +81,10 @@ typedef struct HybridRequest {
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
 static inline bool HybridRequest_TimedOut(HybridRequest *req) {
-  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
+  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
 }
 static inline void HybridRequest_SetTimedOut(HybridRequest *req) {
-  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
 }
 
 // Cursor mutex wrappers for synchronizing cursor creation with timeout callback


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes [MOD-15934](https://redislabs.atlassian.net/browse/MOD-15934).

1. **Current**: src/aggregate/aggregate.h (added in #9749) inlines AREQ_TimedOut / AREQ_SetTimedOut, whose bodies expand to atomic_load_explicit / atomic_store_explicit from stdatomic.h. Because aggregate.h is transitively reachable from the FFI headers bindgen parses, **libclang must successfully type-check those inline bodies**.
2. **Change**: Replace the stdatomic.h macros with __atomic_load_n / __atomic_store_n compiler builtins (no header required). A (bool *) cast strips _Atomic so clang strict __atomic_*_n accepts the pointer; the macros are only used on bool fields (timedOut, aggregatingResults). The _Atomic qualifier on the struct fields is **kept**, so type-checker enforcement is unchanged.
3. **Outcome**: The header parses cleanly under libclang-14 and the ce-testing packaging pipeline unblocks. Codegen is byte-identical (single-byte mov, no lock prefix on relaxed ops).

#### Background

Our CI forces LLVM 21 via .install/install_llvm.sh, which is why the regression was not caught here. The [ce-testing nightly run](https://github.com/redislabsdev/ce-testing/actions/runs/26490737083) uses each distro stock toolchain — Ubuntu 22.04 ships **libclang-14**, which cannot resolve atomic_load_explicit / memory_order_relaxed during the bindgen parse:

    /usr/include/.../stdatomic.h:... use of undeclared identifier atomic_load_explicit

A follow-up PR will add a small CI job that runs the FFI bindgen step against the distro stock libclang to prevent recurrence.

#### Which additional issues this PR fixes
1. Regression introduced by #9749
2. Unblocks ce-testing nightly: https://github.com/redislabsdev/ce-testing/actions/runs/26490737083

#### Main objects this PR modified
1. src/aggregate/aggregate.h — RS_AtomicLoadRelaxed / RS_AtomicStoreRelaxed macros

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Build-system / packaging fix only. Released module behavior, on-disk format, and public API are unchanged.

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=github&utm_medium=pr&utm_campaign=redisearch)


[MOD-15934]: https://redislabs.atlassian.net/browse/MOD-15934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ