### PR TITLE
[MOD-15915] Add security guidance for agent reviews

### DIFF
--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -163,6 +163,10 @@ denial of service.
 Check especially for:
 - Memory ownership and lifetime bugs, including use-after-free, double-free, leaks on
   error paths, and raw buffer overflows.
+- NULL pointer dereferences, missing NULL checks, and missing documentation for any
+  non-NULL pointer preconditions that callers must uphold.
+- Uninitialized memory reads, especially when a pointer to uninitialized storage is
+  passed to another function that may not always write before the value is read.
 - Redis Module API misuse, especially calls without the GIL, stale `RedisModuleCtx`
   usage, and blocked-client/context lifetime bugs.
 - Allocation-size arithmetic overflow, integer truncation or sign bugs, and unchecked

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -154,7 +154,28 @@ Only applies when changes touch `src/rdb.c` or serialization logic:
 - No commented-out code left in the diff.
 - No `TODO` or `FIXME` comments without a tracking issue reference.
 
-#### 2i. PR description
+#### 2i. Security impact
+
+Treat security-sensitive C issues as in scope for automated review. Prioritize findings
+that can lead to crashes, memory corruption, data exposure, unauthorized access, or
+denial of service.
+
+Check especially for:
+- Memory ownership and lifetime bugs, including use-after-free, double-free, leaks on
+  error paths, and raw buffer overflows.
+- Redis Module API misuse, especially calls without the GIL, stale `RedisModuleCtx`
+  usage, and blocked-client/context lifetime bugs.
+- Allocation-size arithmetic overflow, integer truncation or sign bugs, and unchecked
+  casts before allocation, indexing, or serialization.
+- Missing input bound validation for user-controlled query, schema, vector, geoshape,
+  and RDB input.
+- Data exposure, ACL/auth bypass, concurrency races, and unbounded allocation, loops,
+  or recursion that can cause denial of service.
+
+For any security-sensitive finding, state the concrete impact and the input or code path
+that can trigger it.
+
+#### 2j. PR description
 
 Only applies when reviewing a PR (not files or commits directly):
 - Exactly one release notes checkbox is checked (`This PR requires release notes`

--- a/.skills/rust-review/SKILL.md
+++ b/.skills/rust-review/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: rust-review
-description: Review Rust code changes for unsafe correctness, documentation quality, and C-to-Rust porting fidelity. Use this when you want to review Rust changes before merging.
+description: Review Rust code changes for unsafe correctness, security and robustness, documentation quality, and C-to-Rust porting fidelity. Use this when you want to review Rust changes before merging.
 ---
 
 # Rust Review
 
-Review Rust code changes for unsafe correctness, documentation quality, and (when applicable) C-to-Rust porting fidelity.
+Review Rust code changes for unsafe correctness, security and robustness risks,
+documentation quality, and (when applicable) C-to-Rust porting fidelity.
 
 ## Arguments
 
@@ -29,6 +30,16 @@ If a path points to a directory, review all `.rs` files in that directory (recur
 (`jj diff` if `.jj/` is present, `git diff` otherwise).
 
 ## Instructions
+
+### 0. Avoid duplicate PR comments
+
+When reviewing a GitHub PR:
+
+- First inspect existing PR comments, review threads, and prior bot comments when available.
+- Treat an issue as already reported if an existing comment identifies the same root cause, even if it points to a different line.
+- Do not post or include duplicate findings for issues that were already raised.
+- If a previous comment is still accurate, do not restate it. Only mention it again if the new diff changes the issue, invalidates the previous fix, or introduces materially new evidence.
+- If the same issue appears in multiple places, report it once on the clearest example and state that the same pattern may apply elsewhere.
 
 ### 1. Collect the code to review
 
@@ -121,6 +132,27 @@ Violations:
 Exceptions: symbols that are not Rust items (e.g. C function names, Redis command names,
 field names used in prose) do not need intra-doc links.
 
+#### 3d. Security and robustness
+
+Treat security-sensitive Rust issues as in scope for automated review. Prioritize findings
+that can lead to panics, undefined behavior, memory unsoundness, data exposure,
+unauthorized access, or denial of service.
+
+Check especially for:
+- `unsafe` and FFI soundness bugs, including invalid pointer, NULL, lifetime, aliasing,
+  initialization, and ownership assumptions.
+- Panics on user-controlled input, unchecked indexing, unchecked `unwrap` / `expect`,
+  unsafe conversions, and unchecked UTF-8 or slice assumptions.
+- Allocation-size arithmetic overflow, integer truncation or sign bugs, and unchecked
+  casts before allocation, indexing, or serialization.
+- Missing input bound validation for user-controlled query, schema, vector, geoshape,
+  and RDB input.
+- Data exposure, ACL/auth bypass, concurrency races, and unbounded allocation, loops,
+  or recursion that can cause denial of service.
+
+For any security-sensitive finding, state the concrete impact and the input or code path
+that can trigger it.
+
 ### 4. Porting-mode checks (only when porting mode = true)
 
 #### 4a. Semantic equivalence
@@ -155,12 +187,25 @@ Violations:
 
 ### 5. Emit the report
 
-Present findings grouped by check (3a, 3b, 3c, 4a, 4b). For each group, list the
-violations or state "No issues found."
+Report only actionable, non-duplicate findings.
 
-At the end, provide a summary:
-- Total number of violations by severity (blocking vs. suggestion).
-- Whether the change is **ready to merge** or **needs revision**.
+For each finding include:
+- Severity: blocking or suggestion
+- File and line/range
+- Rule violated
+- Why it matters / impact
+- Suggested fix
 
-Blocking violations: any issue in 3a, 3b, 4a, or 4b.
-Suggestions: issues in 3c (intra-doc links).
+Omit checklist sections with no findings. Do not include "No issues found" for every section.
+If there are no findings at all, it is fine to give the normal approval, thumbs-up, or
+no-findings signal.
+
+At the end, provide a short summary:
+- Total blocking findings
+- Total suggestions
+- Whether the change is **ready to merge** or **needs revision**
+
+Blocking violations: any issue in 3a, 3b, 4a, or 4b, plus any 3d issue that
+can cause memory unsoundness, crashes, data exposure, unauthorized access, or
+denial of service.
+Suggestions: issues in 3c (intra-doc links) and low-risk robustness improvements in 3d.

--- a/.skills/rust-review/SKILL.md
+++ b/.skills/rust-review/SKILL.md
@@ -141,6 +141,17 @@ unauthorized access, or denial of service.
 Check especially for:
 - `unsafe` and FFI soundness bugs, including invalid pointer, NULL, lifetime, aliasing,
   initialization, and ownership assumptions.
+- Allocator mismatches across the FFI boundary: RediSearch C code uses `rm_malloc` /
+  `rm_free`, while Rust values must be released through the allocator and ownership
+  path that created them.
+- Rust-owned allocations passed to C, such as values exposed with `Box::into_raw`,
+  must have a clear path back to Rust and be converted with `Box::from_raw` exactly
+  once so they are cleaned up correctly.
+- FFI string handling must account for Redis strings being binary-safe and often
+  NUL-terminated; do not assume they map directly to Rust `String` / `str` or
+  `CString` / `CStr`.
+- Unsafe conversions such as `mem::transmute` and `from_raw_parts` must validate size,
+  alignment, initialized memory, lifetime, and valid-value requirements.
 - Panics on user-controlled input, unchecked indexing, unchecked `unwrap` / `expect`,
   unsafe conversions, and unchecked UTF-8 or slice assumptions.
 - Allocation-size arithmetic overflow, integer truncation or sign bugs, and unchecked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ When reviewing pull requests:
 - If an earlier comment is still relevant, avoid restating it. Only add a new comment when there is materially new information, a changed code location, or a distinct issue.
 - Prefer one comment per root cause. If the same pattern appears in several places, comment on the clearest instance and mention the pattern briefly.
 - Keep automated review comments high-signal: prioritize correctness, crashes, memory safety, undefined behavior, data loss, security, and clear test/CI failures.
+- Security-sensitive issues are in scope for automated review. Look for memory-safety bugs, unsafe/FFI soundness problems, malformed input handling gaps, data exposure, ACL/auth bypasses, concurrency races, and denial-of-service risks from unbounded allocation, loops, or recursion.
 - Do not comment on minor style, formatting, naming, or preference issues by default unless they violate an explicit project rule and would block maintainability.
 - If the review explicitly requests nits, style comments, or `--include-nits`, minor findings may be reported as non-blocking suggestions, but must still avoid duplicates and should be grouped by root cause.
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Agent review guidance did not explicitly cover security-sensitive findings consistently across AGENTS and the standalone Rust review skill.
2. Change: Add AGENTS security scope, C security-impact review guidance, and Rust security/robustness guidance with duplicate-comment and output-hygiene behavior aligned with code-review.
3. Outcome: Agent reviews can surface high-signal security issues while avoiding duplicate or noisy review comments.

#### Which additional issues this PR fixes
1. MOD-15915

#### Main objects this PR modified
1. `AGENTS.md`
2. `.skills/code-review/SKILL.md`
3. `.skills/rust-review/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agent/review skill markdown; no product code, APIs, or serialization behavior is modified.
> 
> **Overview**
> Aligns **agent/PR review** instructions so automated reviews explicitly cover **security-sensitive** issues and produce **less duplicate, higher-signal** output.
> 
> **`AGENTS.md`** now tells reviewers to flag memory safety, unsafe/FFI soundness, malformed input, data exposure, ACL/auth bypass, races, and DoS-style unbounded work—not only correctness and crashes.
> 
> **`.skills/code-review/SKILL.md`** adds a **Security impact** checklist for C (ownership, NULL/uninit, Redis Module API/GIL, integer/allocation bounds, user-controlled inputs, exposure/ACL/DoS) and requires stating concrete impact and trigger paths for those findings. The former PR-description section is renumbered accordingly.
> 
> **`.skills/rust-review/SKILL.md`** extends scope to security/robustness, adds **duplicate-comment avoidance** (same as C review), a **Security and robustness** section (FFI, allocators, `Box::into_raw`, Redis strings, `transmute`/`from_raw_parts`, panics on untrusted input, bounds, DoS), and tighter **report** rules: actionable non-duplicates only, skip empty “no issues” sections, and treat serious **3d** items as blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c61ffc6d4fd32a782f26136dc4948f958c7cf14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->