### PR TITLE
[2.8] [MOD-15875] CI: bump remaining actions off Node 20

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -20,7 +20,8 @@ categories:
     labels:
       - 'x:docs'
   - title: 'Maintenance'
-    label: 'chore'
+    labels:
+      - 'chore'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -66,7 +66,7 @@ jobs:
         run: REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh
       # it is best to install terraform last because it may cause issues with env.PATH
       - name: install terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: 1.11.1
           terraform_wrapper: false

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -209,11 +209,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "branch": "${{ github.ref_name }}",
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -277,7 +277,7 @@ jobs:
         if: >
           steps.node20.outputs.supported == 'true' &&
           (steps.unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure' || steps.coordinator_unit_tests.outcome == 'failure')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: tests/**/logs/*.log*


### PR DESCRIPTION
Backport of #9840 to `2.8`.

Auto-backport failed with cherry-pick conflicts. Manually resolved:

- Dropped 6 workflow files that don't exist on 2.8 (`daily-ci-report`, `flow-build-benchmark-binary`, `flow-micro-benchmarks-runner`, `flow-rust-micro-benchmarks`, `link-check`, `task-stale`).
- Took 2.8's structure on 4 content-conflicted files; re-applied only the relevant version bumps:
  - `benchmark-flow.yml`: `hashicorp/setup-terraform@v2 → @v4.0.1`
  - `benchmark-runner.yml`: `slack-github-action@v1 → @v3` (input rewrite to `webhook:`+`webhook-type:`)
  - `task-test.yml`: `actions/upload-artifact@v4 → @v7`
  - `event-nightly.yml`: no applicable bumps on 2.8 (Slack notify block doesn't exist here)
- Auto-merged hunks preserved:
  - `event-deploy-snapshots.yml`: `slack-github-action@v1 → @v3` input rewrite
  - `task-release-drafter.yml`: `release-drafter@v5 → @v7.3.1`
  - `release-drafter-config.yml`: `label: chore → labels: [chore]` syntax fix

CI-only change; no user-visible impact.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and release-drafter config only; no application code, auth, or data paths change.
> 
> **Overview**
> **Backports CI maintenance** to move remaining GitHub Actions off Node 20 on the `2.8` line, with no product or runtime changes.
> 
> Workflows now pin newer action versions: `hashicorp/setup-terraform` **v4.0.1** in benchmark flows, `actions/upload-artifact` **v7** for failed test logs, `release-drafter` **v7.3.1**, and `slackapi/slack-github-action` **v3** for benchmark and snapshot failure alerts. Slack steps switch from `SLACK_WEBHOOK_URL` env to **`webhook`** + **`webhook-type: incoming-webhook`** inputs.
> 
> **Release Drafter** config fixes the Maintenance category from invalid singular `label: chore` to **`labels: [chore]`** so chore PRs group correctly in draft release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fa0a9809127f00b9ebc6c5f98ee617b8fe6bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->