### PR TITLE
[2.6] [MOD-15875] CI: bump remaining actions off Node 20

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -20,7 +20,8 @@ categories:
     labels:
       - 'x:docs'
   - title: 'Maintenance'
-    label: 'chore'
+    labels:
+      - 'chore'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -77,7 +77,7 @@ jobs:
           pip3 install --upgrade pip
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: install terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: 1.11.1
           terraform_wrapper: false

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -210,11 +210,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "branch": "${{ github.ref_name }}",
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -257,7 +257,7 @@ jobs:
         if: >
           steps.node20.outputs.supported == 'true' &&
           (steps.unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure' || steps.coordinator_unit_tests.outcome == 'failure')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: tests/**/logs/*.log*


### PR DESCRIPTION
Backport of #9840 to `2.6`.

Auto-backport bot failed; manually resolved conflicts:

- Dropped 6 workflow files that do not exist on 2.6: daily-ci-report, flow-build-benchmark-binary, flow-micro-benchmarks-runner, flow-rust-micro-benchmarks, link-check, task-stale.
- Took branch's structure on 4 content-conflicted files; re-applied relevant version bumps:
  - benchmark-flow.yml: setup-terraform v2 → v4.0.1
  - benchmark-runner.yml: slack-github-action v1 → v3 (input rewrite: drop env SLACK_WEBHOOK_URL, add webhook + webhook-type inputs)
  - event-nightly.yml: no applicable bumps on this branch (file unchanged after --ours)
  - task-test.yml: upload-artifact v4 → v7
- Auto-merged hunks preserved: release-drafter-config, event-deploy-snapshots (slack v1→v3), task-release-drafter (release-drafter v5→v7.3.1).

CI-only change; no user-visible impact.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to `.github` workflows and release-drafter config; Slack webhook wiring must match v3 inputs but does not touch application code.
> 
> **Overview**
> Backports CI maintenance to the **2.6** branch so GitHub Actions keep running on supported runtimes (moving off Node 20–era action versions). **No product or runtime behavior changes.**
> 
> **Release drafter:** `release-drafter-config.yml` fixes the Maintenance category to use `labels:` (plural) with `chore` instead of the invalid singular `label:`. `task-release-drafter.yml` pins **release-drafter** from v5 to **v7.3.1**.
> 
> **Benchmarks:** `benchmark-flow.yml` upgrades **hashicorp/setup-terraform** from v2 to **v4.0.1**. `benchmark-runner.yml` upgrades **slack-github-action** from v1 to **v3**, passing the webhook via `webhook` and `webhook-type: incoming-webhook` instead of `SLACK_WEBHOOK_URL` in `env`.
> 
> **Snapshots & tests:** `event-deploy-snapshots.yml` applies the same Slack action v3 + input migration for snapshot failure alerts. `task-test.yml` bumps failed-test log uploads from **upload-artifact** v4 to **v7** on Node 20–capable runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e35d51927a50adb29ef067a30b37631d0b75edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->