### PR TITLE
[2.10] [MOD-15875] CI: bump remaining actions off Node 20

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -20,7 +20,8 @@ categories:
     labels:
       - 'x:docs'
   - title: 'Maintenance'
-    label: 'chore'
+    labels:
+      - 'chore'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -66,7 +66,7 @@ jobs:
         run: REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh
       # it is best to install terraform last because it may cause issues with env.PATH
       - name: install terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: 1.11.1
           terraform_wrapper: false

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -210,11 +210,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "branch": "${{ github.ref_name }}",
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v10
         with:
             days-before-stale: 60
             days-before-close: -1

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -294,7 +294,7 @@ jobs:
         if: >
           steps.node20.outputs.supported == 'true' &&
           (steps.unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure' || steps.coordinator_unit_tests.outcome == 'failure')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: tests/**/logs/*.log*


### PR DESCRIPTION
Backport of #9840 to `2.10`.

Auto-backport bot failed; manually resolved conflicts:

- Dropped 5 workflow files that do not exist on 2.10: daily-ci-report, flow-build-benchmark-binary, flow-micro-benchmarks-runner, flow-rust-micro-benchmarks, link-check.
- Took branch's structure on 4 content-conflicted files; re-applied relevant version bumps:
  - benchmark-flow.yml: setup-terraform v2 → v4.0.1
  - benchmark-runner.yml: slack-github-action v1 → v3 (input rewrite: drop env SLACK_WEBHOOK_URL, add webhook + webhook-type inputs)
  - event-nightly.yml: no applicable bumps on this branch (file unchanged after --ours)
  - task-test.yml: upload-artifact v4 → v7
- Auto-merged hunks preserved: release-drafter-config, event-deploy-snapshots (slack v1→v3), task-release-drafter (release-drafter v5→v7.3.1), task-stale (stale v8→v10).

CI-only change; no user-visible impact.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and third-party action version updates only; no application code, auth, or data paths change.
> 
> **Overview**
> Backports CI updates so remaining GitHub Actions run on runtimes newer than Node 20 (no product/runtime behavior change).
> 
> **Workflow action bumps:** `hashicorp/setup-terraform` v2 → v4.0.1 in benchmark flow; `slackapi/slack-github-action` v1 → v3 for benchmark and snapshot failure alerts (webhook moved from `env` to `webhook` + `webhook-type: incoming-webhook`); `release-drafter/release-drafter` v5 → v7.3.1; `actions/stale` v8 → v10; `actions/upload-artifact` v4 → v7 on failed test log uploads.
> 
> **Release drafter config:** Maintenance category now uses `labels:` (list) instead of deprecated singular `label:` for `chore`, matching release-drafter v7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4090c54563d87e1379a6c8cf2a97133f37ab7258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->