### PR TITLE
[8.6-rse] [MOD-15875] CI: bump remaining actions off Node 20

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -20,7 +20,8 @@ categories:
     labels:
       - 'x:docs'
   - title: 'Maintenance'
-    label: 'chore'
+    labels:
+      - 'chore'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -109,7 +109,7 @@ jobs:
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: install terraform
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: 1.11.1
           terraform_wrapper: false

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -294,14 +294,14 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
 
   notify-msmarco-failure:
     needs:
@@ -310,12 +310,12 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify MSMARCO Benchmark Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "repository": "${{ github.repository }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -294,10 +294,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
+        uses: slackapi/slack-github-action@v3 # NOSONAR
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
@@ -310,10 +311,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify MSMARCO Benchmark Failure
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
+        uses: slackapi/slack-github-action@v3 # NOSONAR
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
           webhook-type: incoming-webhook
@@ -310,7 +310,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify MSMARCO Benchmark Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
           webhook-type: incoming-webhook

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Handle collect failure
         if: steps.collect.outcome == 'failure'
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook
@@ -108,7 +108,7 @@ jobs:
 
       - name: Send reports to Slack
         if: steps.summary.outputs.summary_exists == 'true' || steps.failure_report.outputs.failure_exists == 'true'
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Handle collect failure
         if: steps.collect.outcome == 'failure'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
+        uses: slackapi/slack-github-action@v3 # NOSONAR
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook
@@ -108,7 +108,7 @@ jobs:
 
       - name: Send reports to Slack
         if: steps.summary.outputs.summary_exists == 'true' || steps.failure_report.outputs.failure_exists == 'true'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
+        uses: slackapi/slack-github-action@v3 # NOSONAR
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Handle collect failure
         if: steps.collect.outcome == 'failure'
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook
@@ -108,7 +108,7 @@ jobs:
 
       - name: Send reports to Slack
         if: steps.summary.outputs.summary_exists == 'true' || steps.failure_report.outputs.failure_exists == 'true'
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-reports-${{ steps.date.outputs.date }}
           path: merge-to-queue_${{ steps.date.outputs.date }}/

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
+        uses: slackapi/slack-github-action@v3 # NOSONAR
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "repository": "${{ github.repository }}",

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
           webhook-type: incoming-webhook

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -27,8 +27,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "repository": "${{ github.repository }}",
@@ -36,5 +38,3 @@ jobs:
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -48,10 +48,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
+        uses: slackapi/slack-github-action@v3 # NOSONAR
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -48,12 +48,12 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "repository": "${{ github.repository }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # refs @v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
           webhook-type: incoming-webhook

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -48,7 +48,7 @@ jobs:
           permission-administration: write
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ steps.generate-app-token.outputs.token }}
@@ -190,7 +190,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ steps.generate-app-token.outputs.token }}

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Download Latest Baseline Artifact from master
         id: get-artifact
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@4c1e823582f43b179e2cbb49c3eade4e41f992e2 # refs @v10
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # refs @v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
@@ -57,13 +57,13 @@ jobs:
 
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "rust-benchmark-results-master"
           path: bin/redisearch_rs/criterion
       - name: Upload benchmarks for PR comparison
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "rust-benchmark-results-pr-${{ github.event.pull_request.number }}"
           path: bin/redisearch_rs/criterion

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Upload results on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: link-check-results
         path: |

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -68,21 +68,21 @@ jobs:
           echo "Using cache ref: $CACHE_REF"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push (cached)
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v10
         with:
             days-before-stale: 60
             days-before-close: -1

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -122,7 +122,7 @@ jobs:
           permission-administration: write
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ steps.generate-app-token.outputs.token }}
@@ -537,7 +537,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -641,7 +641,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.2
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ steps.generate-app-token.outputs.token }}


### PR DESCRIPTION
Backport of #9840 to `8.6-rse`.

Auto-backport bot failed; manually resolved conflicts:

- Dropped 1 workflow file that does not exist on 8.6-rse: flow-build-benchmark-binary.
- Took branch's structure on 2 content-conflicted files; re-applied relevant version bumps:
  - benchmark-flow.yml: setup-terraform v2 → v4.0.1
  - daily-ci-report.yml (exists only on 8.6-rse): slack-github-action v2 → v3 (2 occurrences); upload-artifact v4 → v7. Branch's `if: steps.summary.outputs...` condition preserved (master changed to `if: always()`; taking branch context per backport policy).
- Auto-merged hunks preserved: release-drafter-config, benchmark-runner (slack v1→v3, 2 occurrences), event-deploy-snapshots (slack v1→v3), event-nightly (slack v1→v3), flow-micro-benchmarks-runner (upload-artifact v4→v7), flow-rust-micro-benchmarks (dawidd6 SHA v10→v21, upload-artifact v4→v7), link-check, task-release-drafter (release-drafter v5→v7.3.1), task-stale (stale v8→v10), task-test (upload-artifact v4→v7, ec2-github-runner v2.4.2→v2.6.1).

CI-only change; no user-visible impact.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to workflow YAML and release-drafter config; risk is mainly misconfigured Slack webhooks or action API differences until CI runs validate.
> 
> **Overview**
> This backport updates GitHub Actions and release-drafter config so CI no longer depends on Node 20–era action runtimes, with **no product/runtime behavior changes**.
> 
> **Slack notifications** move to `slackapi/slack-github-action@v3` in benchmark, snapshot, nightly, and daily CI workflows. Webhooks are passed via `with.webhook` and `webhook-type` instead of `env.SLACK_WEBHOOK_URL`; benchmark/snapshot/nightly failure steps add `errors: true` so Slack delivery failures surface in the job.
> 
> **Artifacts and runners**: `actions/upload-artifact` is bumped to **v7** (daily CI report, rust micro-benchmarks, link-check, test logs). `machulav/ec2-github-runner` goes to **v2.6.1** in micro-benchmark and test flows. `dawidd6/action-download-artifact` is pinned to the **v21** commit for PR baseline downloads.
> 
> **Other CI bumps**: `hashicorp/setup-terraform@v4.0.1` in benchmark flow; Docker build/login/qemu/buildx actions to v4/v7 in cached container builds; `release-drafter` **v7.3.1** and `actions/stale` **v10**. **Release drafter config** fixes the Maintenance category to use `labels:` (plural) for the `chore` label.
> 
> On **8.6-rse**, `daily-ci-report.yml` keeps its existing Slack send `if` (summary/failure file present) rather than master’s `always()` change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a97c93879a4c22f07c836ac30adb1f9edf4079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->