### PR TITLE
MOD-15579 Validate lazy SVS thread pool initialization in flow tests

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -269,30 +269,28 @@ def test_svs_threadpool_lazy_init():
     SVS index attach.
 
     Observed via the top-level SHARED_MEMORY field in FT.DEBUG VECSIM_INFO, which
-    mirrors VecSim_GetSharedMemory() — currently sourced exclusively from the
-    shared SVS thread pool's allocation size.
+    mirrors VecSim_GetSharedMemory(). That value is sourced exclusively from the
+    shared SVS thread pool and (VectorSimilarity #979) reports 0 until the first SVS
+    index attaches — so a server with no SVS index reports exactly 0.
     """
     workers = 4
     env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {workers}')
 
     # A non-SVS (HNSW) index exercises FT.DEBUG VECSIM_INFO without involving SVS
-    # at all. With lazy init no worker slots have been allocated yet, so
-    # SHARED_MEMORY (== VecSim_GetSharedMemory()) equals only the allocator's
-    # self-accounting baseline (sizeof(VecSimAllocator) — a single
-    # std::atomic_uint64_t, 8 bytes on standard platforms, see VecSimAllocator()
-    # ctor). The 32-byte threshold leaves headroom for platform variation but is
-    # well below the smallest realistic single ThreadSlot allocation
-    # (sizeof(svs::threads::Thread) + atomic<bool> + shared_ptr control block +
-    # allocation header).
+    # at all. No SVS index has attached, so the shared pool reports no memory:
+    # VecSim_GetSharedMemory() is gated on the pool's has_attached_index_ flag and
+    # returns exactly 0 until the first SVS index attaches (VectorSimilarity #979),
+    # even though VecSim_UpdateThreadPoolSize already recorded the requested size at
+    # module init.
     create_vector_index(env, dim=4, alg='HNSW')
     hnsw_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
     env.assertTrue('SHARED_MEMORY' in hnsw_info,
                    message=f"SHARED_MEMORY field must be present in VECSIM_INFO: {hnsw_info}")
     hnsw_baseline = int(hnsw_info['SHARED_MEMORY'])
-    env.assertLess(hnsw_baseline, 32,
-                   message=f"SHARED_MEMORY exceeds the allocator self-accounting baseline — "
-                           f"suggests SVS thread slots were allocated despite no SVS index: "
-                           f"got {hnsw_baseline}, info={hnsw_info}")
+    env.assertEqual(hnsw_baseline, 0,
+                    message=f"SHARED_MEMORY must be 0 before any SVS index attaches — "
+                            f"nonzero suggests SVS thread slots were allocated despite "
+                            f"no SVS index: got {hnsw_baseline}, info={hnsw_info}")
     env.execute_command('FT.DROPINDEX', DEFAULT_INDEX_NAME)
 
     # Creating the first SVS index triggers the lazy thread spawn at the size most

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -269,7 +269,7 @@ def test_svs_threadpool_lazy_init():
     SVS index attach.
 
     Observed via the top-level SHARED_MEMORY field in FT.DEBUG VECSIM_INFO, which
-    mirrors VecSim_GetGlobalMemory() — currently sourced exclusively from the
+    mirrors VecSim_GetSharedMemory() — currently sourced exclusively from the
     shared SVS thread pool's allocation size.
     """
     workers = 4
@@ -277,7 +277,7 @@ def test_svs_threadpool_lazy_init():
 
     # A non-SVS (HNSW) index exercises FT.DEBUG VECSIM_INFO without involving SVS
     # at all. With lazy init no worker slots have been allocated yet, so
-    # SHARED_MEMORY (== VecSim_GetGlobalMemory()) equals only the allocator's
+    # SHARED_MEMORY (== VecSim_GetSharedMemory()) equals only the allocator's
     # self-accounting baseline (sizeof(VecSimAllocator) — a single
     # std::atomic_uint64_t, 8 bytes on standard platforms, see VecSimAllocator()
     # ctor). The 32-byte threshold leaves headroom for platform variation but is

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -260,6 +260,57 @@ def test_memory_info():
         env.execute_command('FLUSHALL')
 
 @skip(cluster=True)
+def test_svs_threadpool_lazy_init():
+    """Verify the shared SVS thread pool is not allocated until an SVS index is created.
+
+    With lazy init (VectorSimilarity #971), VecSim_UpdateThreadPoolSize (called at
+    module init via workersThreadPool_CreatePool, and on every CONFIG SET WORKERS)
+    only records the requested size — OS worker threads are spawned on the first
+    SVS index attach.
+
+    Observed via the top-level SHARED_MEMORY field in FT.DEBUG VECSIM_INFO, which
+    mirrors VecSim_GetGlobalMemory() — currently sourced exclusively from the
+    shared SVS thread pool's allocation size.
+    """
+    workers = 4
+    env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {workers}')
+
+    # A non-SVS (HNSW) index exercises FT.DEBUG VECSIM_INFO without involving SVS
+    # at all. With lazy init no worker slots have been allocated yet, so
+    # SHARED_MEMORY (== VecSim_GetGlobalMemory()) equals only the allocator's
+    # self-accounting baseline (sizeof(VecSimAllocator) — a single
+    # std::atomic_uint64_t, 8 bytes on standard platforms, see VecSimAllocator()
+    # ctor). The 32-byte threshold leaves headroom for platform variation but is
+    # well below the smallest realistic single ThreadSlot allocation
+    # (sizeof(svs::threads::Thread) + atomic<bool> + shared_ptr control block +
+    # allocation header).
+    create_vector_index(env, dim=4, alg='HNSW')
+    hnsw_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.assertTrue('SHARED_MEMORY' in hnsw_info,
+                   message=f"SHARED_MEMORY field must be present in VECSIM_INFO: {hnsw_info}")
+    hnsw_baseline = int(hnsw_info['SHARED_MEMORY'])
+    env.assertLess(hnsw_baseline, 32,
+                   message=f"SHARED_MEMORY exceeds the allocator self-accounting baseline — "
+                           f"suggests SVS thread slots were allocated despite no SVS index: "
+                           f"got {hnsw_baseline}, info={hnsw_info}")
+    env.execute_command('FT.DROPINDEX', DEFAULT_INDEX_NAME)
+
+    # Creating the first SVS index triggers the lazy thread spawn at the size most
+    # recently recorded by VecSim_UpdateThreadPoolSize, growing SHARED_MEMORY by
+    # the per-slot allocation tracked by the pool (workers - 1 ThreadSlots plus
+    # the slots_ vector capacity).
+    create_vector_index(env, dim=4, alg='SVS-VAMANA')
+    svs_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.assertTrue('SHARED_MEMORY' in svs_info,
+                   message=f"SHARED_MEMORY field must be present in VECSIM_INFO: {svs_info}")
+    svs_pool_mem = int(svs_info['SHARED_MEMORY'])
+    env.assertGreater(svs_pool_mem, hnsw_baseline,
+                      message=f"SHARED_MEMORY should grow above the pre-attach baseline "
+                              f"({hnsw_baseline}) after first SVS index creation with "
+                              f"WORKERS={workers}: got {svs_pool_mem}, info={svs_info}")
+
+
+@skip(cluster=True)
 def test_svs_shared_threadpool_memory_info():
     """Verify shared SVS thread pool memory accounting:
       * FT.DEBUG VECSIM_INFO exposes it as the top-level SHARED_MEMORY field
@@ -276,15 +327,20 @@ def test_svs_shared_threadpool_memory_info():
     All observations are validated before and after growing the worker pool, which
     physically resizes the shared SVS pool.
     """
-    initial_workers = 1
+    # Use 2+ initial workers so the first SVS index allocates at least one worker
+    # slot (with lazy init, pool size 1 = zero worker slots = zero pool-tracked
+    # bytes, which would make the 'pool memory > 0' assertion below vacuous).
+    initial_workers = 2
     grown_workers = 4
     env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {initial_workers}')
     dim = 2
     shared_mem_field = 'SHARED_MEMORY'
 
-    # The shared SVS pool singleton is initialized at module init via
-    # workersThreadPool_CreatePool -> VecSim_UpdateThreadPoolSize, so the field is
-    # always present in the debug info once any SVS index exists.
+    # The shared SVS pool spawns OS threads lazily on the first SVS index creation
+    # (VectorSimilarity #971), using the size most recently passed to
+    # VecSim_UpdateThreadPoolSize (set at module init by
+    # workersThreadPool_CreatePool), so the field is present in the debug info
+    # once any SVS index exists.
     create_vector_index(env, dim, alg='SVS-VAMANA')
 
     def measure():


### PR DESCRIPTION
Validating the lazy SVS thread pool init introduced in [VectorSimilarity#971](https://github.com/RedisAI/VectorSimilarity/pull/971). No RediSearch production changes — the integration contract with VecSim is unchanged.

- **New `test_svs_threadpool_lazy_init`**: with `WORKERS=4` at module init, asserts `GLOBAL_MEMORY` stays at the allocator's self-accounting baseline (`< 32` bytes) while only an HNSW index exists, then grows to a matching `SHARED_SVS_THREADPOOL_MEMORY` after the first `SVS-VAMANA` index is created.
- **Updated `test_svs_shared_threadpool_memory_info`**: `initial_workers` bumped from 1 to 2 so the first SVS index allocates at least one worker slot (pool size 1 = zero workers under the new semantics, which would make the existing "memory > 0" assertion vacuous). Comments updated.

Stacked on top of #9858 (MOD-15578).

#### Which Jira ticket this PR addresses

1. MOD-15579

#### Main objects this PR modified

1. `tests/pytests/test_vecsim_svs.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in pytest SVS coverage; no API or production logic touched.
> 
> **Overview**
> Flow tests in `tests/pytests/test_vecsim_svs.py` now cover **lazy** shared SVS thread-pool allocation (VectorSimilarity lazy-init behavior), with no RediSearch production code changes.
> 
> **`test_svs_threadpool_lazy_init`** (new): with `WORKERS=4` at module load, an **HNSW-only** index must keep `GLOBAL_MEMORY` below a small baseline (no worker slots yet); creating the first **`SVS-VAMANA`** index must expose `SHARED_SVS_THREADPOOL_MEMORY` in backend debug info and align `GLOBAL_MEMORY` with that pool memory.
> 
> **`test_svs_shared_threadpool_memory_info`**: `initial_workers` raised from **1 → 2** so the first SVS index allocates at least one worker slot under lazy semantics (pool size 1 would make “pool memory > 0” meaningless). Comments now describe lazy spawn on first SVS index instead of pool creation at module init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0363a64d0c557eea3f505579f330551749dd8895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->