### PR TITLE
ci: Avoid regenerating C headers in the test workflow

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -61,6 +61,8 @@ env:
   COV: ${{ inputs.coverage && 1 || 0 }} # convert the boolean input to numeric
   # Setting RUST_BACKTRACE here to ensure that we get a full report if something goes wrong.
   RUST_BACKTRACE: "full"
+  # Header freshness is checked in the lint job. No need to regenerate here.
+  REDISEARCH_GENERATE_HEADERS: "0"
   # Fail on warnings
   RUSTFLAGS: "-Dwarnings"
   BUILD_INTEL_SVS_OPT: "yes"


### PR DESCRIPTION
## Describe the changes in the pull request

Speed up testing by avoiding the header generation step. Freshness is already checked in the lint job.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only optimization with no product code or test logic changes; header checks stay on the lint path.
> 
> **Overview**
> The shared test workflow (`task-test.yml`) now sets **`REDISEARCH_GENERATE_HEADERS: "0"`** for all jobs that use this reusable workflow, so C header generation is skipped during test runs.
> 
> That avoids redundant work on every platform/matrix test job; header freshness remains enforced in the **lint** job, as noted in the inline comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6201c5fef5bed96b2f404669e1c04989e31d2ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->