### PR TITLE
[MOD-15932] FT.SUGGET: accept queries at exactly the maximum length (100 runes)

### DIFF
--- a/src/suggest.c
+++ b/src/suggest.c
@@ -293,7 +293,7 @@ int RSSuggestGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   // get the string to search for
   size_t len = 0;
   const char *s = RedisModule_StringPtrLen(argv[2], &len);
-  if (len >= TRIE_MAX_PREFIX * sizeof(rune)) {
+  if (len > TRIE_MAX_PREFIX * sizeof(rune)) {
     return RedisModule_ReplyWithError(ctx, "Invalid query length");
   }
 

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -235,7 +235,7 @@ Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDi
   size_t rlen;
   rune *runes = strToSingleCodepointFoldedRunes(s, len, &rlen);
   // make sure query length does not overflow
-  if (!runes || rlen >= TRIE_MAX_PREFIX) {
+  if (!runes || rlen > TRIE_MAX_PREFIX) {
     rm_free(runes);
     return NULL;
   }

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -310,3 +310,31 @@ def testSuggestZeroScoreSortsLast(env):
     conn.execute_command('ft.sugadd', 'ac', 'foo two', 2)
     res = conn.execute_command('ft.sugget', 'ac', 'foo')
     env.assertEqual(['foo two', 'foo one', 'foo zero'], res)
+
+# TRIE_MAX_PREFIX (src/trie/trie_node.h) is the maximum rune length accepted by
+# the trie search path behind FT.SUGGET. The boundary is inclusive: a query of
+# exactly TRIE_MAX_PREFIX runes is accepted; one rune more is rejected.
+TRIE_MAX_PREFIX = 100
+
+def testSuggestGetAtMaxPrefixLength(env):
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    term = 'a' * TRIE_MAX_PREFIX
+    env.assertEqual(conn.execute_command('FT.SUGADD', 'ac', term, 1), 1)
+
+    res = conn.execute_command('FT.SUGGET', 'ac', term)
+    env.assertEqual(res, [term])
+
+def testSuggestGetOverMaxPrefixLength(env):
+    skipOnCrdtEnv(env)
+    conn = env.getClusterConnectionIfNeeded()
+
+    term = 'a' * (TRIE_MAX_PREFIX + 1)
+    env.assertEqual(conn.execute_command('FT.SUGADD', 'ac', term, 1), 1)
+
+    try:
+        conn.execute_command('FT.SUGGET', 'ac', term)
+        env.assertTrue(False)
+    except Exception as e:
+        env.assertContains('Invalid query', str(e))


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `Trie_Search` — the trie path behind FT.SUGGET fuzzy/prefix queries — rejected queries of exactly `TRIE_MAX_PREFIX` (100) runes with `rlen >= TRIE_MAX_PREFIX`. `Trie_Search` returned `NULL`, which `RSSuggestGetCommand` replies to with `Invalid query`. The sibling entry point `Trie_Iterate` used `rlen > TRIE_MAX_PREFIX` at the same boundary, so the two checks disagreed by one at the maximum-length edge.
2. **Change:** Unify the guard in `Trie_Search` to `rlen > TRIE_MAX_PREFIX`, matching `Trie_Iterate`. The constant's original motivation — avoiding `t_len = uint16_t` overflow during rune-to-utf8 expansion, introduced in 7639407c — is unchanged. 100 was the conservative pre-overflow boundary either way; the one-off `>=` was copy-paste drift, not intent. The same `>=` drift existed one layer up at the FT.SUGGET command entry (`RSSuggestGetCommand` in `src/suggest.c`), where the byte-length pre-check rejected at `len >= TRIE_MAX_PREFIX * sizeof(rune)`; aligned to `>` to match `Trie_Search`.
3. **Outcome:** `FT.SUGGET` no longer rejects queries of exactly 100 runes with `Invalid query`. 99-rune queries already worked; 101-rune queries still reject with `Invalid query`. Two pytest cases in `tests/pytests/test_suggest.py` pin the new boundary.

#### Which additional issues this PR fixes
n/a

#### Main objects this PR modified
1. `src/trie/trie.c` — `Trie_Search` query-length guard
2. `src/suggest.c` — `RSSuggestGetCommand` byte-length pre-check
3. `tests/pytests/test_suggest.py` — boundary regression tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow boundary fix in suggest/trie validation with regression tests; no auth, persistence, or API contract changes beyond allowing one previously rejected edge case.
> 
> **Overview**
> **FT.SUGGET** no longer rejects queries of exactly **100 runes** (`TRIE_MAX_PREFIX`) with `Invalid query length` / `Invalid query`.
> 
> The length guards in `RSSuggestGetCommand` and `Trie_Search` are changed from **reject at `>=` max** to **reject only when `>` max**, aligning `Trie_Search` with `Trie_Iterate` and making the limit **inclusive** at 100 runes. Queries longer than 100 runes still fail.
> 
> Pytests add cases for a 100-character ASCII prefix (accepted) and 101 characters (rejected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de20ca1c476bed8c9171af023695ab823ae33ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

