### PR TITLE
MOD-15540: Add CI Triage To Workflows

### DIFF
--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -19,14 +19,6 @@ inputs:
     description: Working directory for Codex execution.
     required: false
     default: .
-  sandbox:
-    description: Codex sandbox mode (read-only, workspace-write, danger-full-access).
-    required: false
-    default: read-only
-  safety-strategy:
-    description: Codex privilege restriction (drop-sudo, unprivileged-user, read-only, unsafe).
-    required: false
-    default: drop-sudo
 
 outputs:
   triage-exists:
@@ -51,8 +43,8 @@ runs:
         prompt-file: ${{ inputs.prompt-file }}
         output-file: ${{ inputs.output-file }}
         working-directory: ${{ inputs.working-directory }}
-        sandbox: ${{ inputs.sandbox }}
-        safety-strategy: ${{ inputs.safety-strategy }}
+        sandbox: read-only
+        safety-strategy: read-only
 
     - name: Read triage output
       id: read

--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -1,0 +1,77 @@
+name: Codex CI Triage
+description: >
+  Run Codex CLI to analyze CI failures and expose the result as outputs that can
+  be embedded into notifications (Slack, PR comments). Codex failures never fail
+  the calling job.
+
+inputs:
+  openai-api-key:
+    description: OpenAI API key for Codex.
+    required: true
+  prompt-file:
+    description: Path to the Codex prompt file (markdown).
+    required: true
+  output-file:
+    description: File where Codex writes its final message.
+    required: false
+    default: ai-triage.txt
+  working-directory:
+    description: Working directory for Codex execution.
+    required: false
+    default: .
+  sandbox:
+    description: Codex sandbox mode (read-only, workspace-write, danger-full-access).
+    required: false
+    default: read-only
+  safety-strategy:
+    description: Codex privilege restriction (drop-sudo, unprivileged-user, read-only, unsafe).
+    required: false
+    default: drop-sudo
+
+outputs:
+  triage-exists:
+    description: "true if Codex produced a non-empty triage output, false otherwise."
+    value: ${{ steps.read.outputs.triage_exists }}
+  triage-content:
+    description: Raw triage text (multiline). Empty when triage-exists is false.
+    value: ${{ steps.read.outputs.triage_content }}
+  triage-content-json:
+    description: JSON-escaped triage text suitable for direct embedding into a JSON payload.
+    value: ${{ steps.read.outputs.triage_content_json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run Codex
+      id: codex
+      continue-on-error: true
+      uses: openai/codex-action@v1
+      with:
+        openai-api-key: ${{ inputs.openai-api-key }}
+        prompt-file: ${{ inputs.prompt-file }}
+        output-file: ${{ inputs.output-file }}
+        working-directory: ${{ inputs.working-directory }}
+        sandbox: ${{ inputs.sandbox }}
+        safety-strategy: ${{ inputs.safety-strategy }}
+
+    - name: Read triage output
+      id: read
+      shell: bash
+      run: |
+        OUTFILE="${{ inputs.working-directory }}/${{ inputs.output-file }}"
+        if [ -f "$OUTFILE" ] && [ -s "$OUTFILE" ] && [ "${{ steps.codex.outcome }}" = "success" ]; then
+          echo "triage_exists=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "triage_content<<__EOF__"
+            cat "$OUTFILE"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "triage_content_json<<__EOF__"
+            jq -Rs . < "$OUTFILE"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+        else
+          echo "triage_exists=false" >> "$GITHUB_OUTPUT"
+          echo "⚠️ Codex triage did not produce output (codex outcome=${{ steps.codex.outcome }}, file=$OUTFILE)"
+        fi

--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -57,9 +57,13 @@ runs:
     - name: Read triage output
       id: read
       shell: bash
+      env:
+        TRIAGE_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        TRIAGE_OUTPUT_FILE: ${{ inputs.output-file }}
+        TRIAGE_CODEX_OUTCOME: ${{ steps.codex.outcome }}
       run: |
-        OUTFILE="${{ inputs.working-directory }}/${{ inputs.output-file }}"
-        if [ -f "$OUTFILE" ] && [ -s "$OUTFILE" ] && [ "${{ steps.codex.outcome }}" = "success" ]; then
+        OUTFILE="${TRIAGE_WORKING_DIRECTORY}/${TRIAGE_OUTPUT_FILE}"
+        if [ -f "$OUTFILE" ] && [ -s "$OUTFILE" ] && [ "$TRIAGE_CODEX_OUTCOME" = "success" ]; then
           echo "triage_exists=true" >> "$GITHUB_OUTPUT"
           {
             echo "triage_content<<__EOF__"
@@ -73,5 +77,5 @@ runs:
           } >> "$GITHUB_OUTPUT"
         else
           echo "triage_exists=false" >> "$GITHUB_OUTPUT"
-          echo "⚠️ Codex triage did not produce output (codex outcome=${{ steps.codex.outcome }}, file=$OUTFILE)"
+          echo "⚠️ Codex triage did not produce output (codex outcome=${TRIAGE_CODEX_OUTCOME}, file=${OUTFILE})"
         fi

--- a/.github/codex/prompts/benchmark-triage.md
+++ b/.github/codex/prompts/benchmark-triage.md
@@ -44,12 +44,15 @@ code fences, or bold.
 
 Structure:
 
-1. **One-line verdict** — what failed and at what stage.
-   Example: `MS MARCO benchmark crashed during indexing; cluster-08-primaries setup OK`
+1. **One-line verdict** — name the specific benchmark that failed (from the job
+   name or logs) and at what stage.
+   Example: `search-ftsb-10K-enwiki_abstract-hashes-fulltext-search-sortby crashed during query phase; oss-standalone setup OK`
 2. **Per-failure bullets** — group failures that share a root cause; one bullet per
    group. Each bullet has:
    - category in brackets, e.g. `[benchmark-crash]`
-   - short identifier (benchmark name / job name)
+   - the actual benchmark identifier from the logs (config name + topology, e.g.
+     `search-ftsb-10K-enwiki_abstract-...-oss-standalone`). If only a job name is
+     available, use that and say so.
    - one-line root-cause hypothesis with hedging where needed
    - recommended next step from: `investigate-now`, `rerun-and-watch`,
      `file-regression`, `ignore-infra`, `needs-more-evidence`
@@ -60,12 +63,12 @@ summarize the long tail in one line.
 ### Example output
 
 ```
-1 failure: MS MARCO benchmark crashed during result collection phase.
+1 failure: search-ftsb-10K-enwiki_abstract-hashes-fulltext-search-sortby crashed during the query phase.
 
-- [benchmark-crash] benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8 —
-  logs show the benchmark client exited with SIGSEGV after writing partial
-  results; likely a client-side parsing bug, not a Redis-side regression.
-  Next: investigate-now
+- [benchmark-crash] search-ftsb-10K-enwiki_abstract-hashes-fulltext-search-sortby-limit-0-100
+  on oss-standalone — logs show the benchmark client exited with SIGSEGV after
+  writing partial results; likely a client-side parsing bug, not a Redis-side
+  regression. Next: investigate-now
 ```
 
 ## Guardrails

--- a/.github/codex/prompts/benchmark-triage.md
+++ b/.github/codex/prompts/benchmark-triage.md
@@ -1,0 +1,76 @@
+# Benchmark Failure Triage
+
+You are analyzing a RediSearch benchmark workflow that has just failed. Your output
+is posted to Slack as the only failure-detail section in the message — be concise,
+scannable, and high-signal.
+
+## Input
+
+Failed-job logs from the current workflow run are dumped to a file in the working
+directory: `failed-logs.txt`. Each failed job is preceded by a line like:
+
+```
+##[group]<job_name>
+... log lines ...
+##[endgroup]
+```
+
+If the file is missing, empty, or unreadable, output one line saying so and stop.
+
+## Task
+
+Classify each distinct failure and produce a Slack-bound triage summary.
+
+### Categories
+
+Use exactly one of these labels per failure:
+
+- `benchmark-regression` — perf number is outside the accepted range vs baseline
+- `benchmark-crash` — benchmark binary segfaulted, panicked, or exited non-zero
+  before producing results
+- `setup-failure` — infra/setup before the benchmark itself (clone, build,
+  dependency install, Redis server start)
+- `timeout` — benchmark exceeded its time budget
+- `environment` — runner, network, S3/sccache, or external dependency issue
+- `unknown` — insufficient evidence
+
+Distinguish facts from inference. Use "the logs show" for facts and "likely" or
+"possible" for hypotheses. Do not invent test names, file paths, or numbers.
+
+### Output
+
+Plain text only. Slack renders the payload as-is — do not use markdown headers,
+code fences, or bold.
+
+Structure:
+
+1. **One-line verdict** — what failed and at what stage.
+   Example: `MS MARCO benchmark crashed during indexing; cluster-08-primaries setup OK`
+2. **Per-failure bullets** — group failures that share a root cause; one bullet per
+   group. Each bullet has:
+   - category in brackets, e.g. `[benchmark-crash]`
+   - short identifier (benchmark name / job name)
+   - one-line root-cause hypothesis with hedging where needed
+   - recommended next step from: `investigate-now`, `rerun-and-watch`,
+     `file-regression`, `ignore-infra`, `needs-more-evidence`
+
+Keep the whole output under ~10 lines. If you have more than 5 distinct failures,
+summarize the long tail in one line.
+
+### Example output
+
+```
+1 failure: MS MARCO benchmark crashed during result collection phase.
+
+- [benchmark-crash] benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8 —
+  logs show the benchmark client exited with SIGSEGV after writing partial
+  results; likely a client-side parsing bug, not a Redis-side regression.
+  Next: investigate-now
+```
+
+## Guardrails
+
+- Do not propose code changes.
+- Do not include raw log excerpts longer than one line in the output.
+- If logs are truncated and the failure root cause is past the truncation
+  boundary, say `needs-more-evidence` rather than guessing.

--- a/.github/codex/prompts/ci-triage.md
+++ b/.github/codex/prompts/ci-triage.md
@@ -76,4 +76,4 @@ groups, summarize the long tail in one line.
 - Do not invent test ids, file paths, or error messages. If unsure, say so.
 - Do not propose code fixes — the Slack message is for triage, not patching.
 - Do not include the raw failure report content; only your analysis.
-- If the failure report is empty or unparseable, output one line saying so.
+- If the failure report is empty or unparsable, output one line saying so.

--- a/.github/codex/prompts/ci-triage.md
+++ b/.github/codex/prompts/ci-triage.md
@@ -1,0 +1,79 @@
+# CI Failure Triage
+
+You are analyzing the RediSearch nightly CI failure report. Your output is the AI
+triage section of a Slack message read by engineers tomorrow morning. Be concise,
+scannable, and high-signal — prioritize correctness and brevity over completeness.
+
+## Input
+
+A failure report lives in the current working directory at:
+`merge-to-queue_<DATE>/merge-to-queue_<DATE>_failure_report.txt`
+
+Find it with `ls merge-to-queue_*/merge-to-queue_*_failure_report.txt`. The file has
+two sections:
+
+1. `SUMMARY BY BRANCH` — per-branch failure counts grouped by run, with the first
+   line of each error message. Read this to understand the shape of the night.
+2. `DETAILED FAILURE LOGS` — full per-job logs (asserts, stack traces, sanitizer
+   output, Redis logs). Read this to ground every classification in evidence.
+
+You must read the entire file, including the `DETAILED FAILURE LOGS` section.
+
+## Task
+
+Classify each unique failure and produce a Slack-bound summary.
+
+### Categories
+
+Use exactly one of these labels per failure:
+
+- `assertion-race` — nondeterministic ordering or timing
+- `timeout` — exceeded time budget or perf limit
+- `lifecycle` — Redis/RLTest save/reload, expiration, cursor reap, server shutdown
+- `coordinator` — cluster-only behavior
+- `sanitizer` — ASan / UBSan / MSan crash, panic, or memory safety
+- `environment` — runner, infra, network, or dependency issue
+- `regression` — looks like a real bug from recent code, not a known flake pattern
+- `unknown` — insufficient evidence to classify
+
+Distinguish facts from inference. Use "the logs show" for facts and "likely" /
+"possible" for hypotheses. Do not speculate beyond the evidence.
+
+### Output
+
+Plain text only. Slack renders the payload as-is, so do not use markdown headers,
+code fences, or bold. Use a leading bullet `-` for list items.
+
+Structure:
+
+1. **One-line verdict** — total failures and a quick read.
+   Example: `3 failures: 2 likely known flakes (assertion-race), 1 new sanitizer crash`
+2. **Per-failure bullets** — group failures that share a root cause; one bullet per
+   group. Each bullet has:
+   - category in brackets, e.g. `[sanitizer]`
+   - test id (`file.py::test_name`) or job name if not test-shaped
+   - one-line root-cause hypothesis
+   - recommended next step from: `report-flaky-test`, `investigate-flaky-test`,
+     `file-regression`, `ignore-infra`, `needs-more-evidence`
+
+Keep the whole output under ~12 lines. If you have more than 6 distinct failure
+groups, summarize the long tail in one line.
+
+### Example output
+
+```
+2 failures: 1 likely known flake (lifecycle), 1 new sanitizer crash on PR branch
+
+- [lifecycle] test_save_load.py::test_reload_with_expired_keys — logs show RDB
+  reload races with key expiration; matches prior flake signature. Next: report-flaky-test
+- [sanitizer] tests/cpptests/test_index.cpp::IndexTest.AddDuplicate — ASan
+  heap-use-after-free in DocTable_GetById; likely a real regression introduced
+  by recent indexer changes. Next: file-regression
+```
+
+## Guardrails
+
+- Do not invent test ids, file paths, or error messages. If unsure, say so.
+- Do not propose code fixes — the Slack message is for triage, not patching.
+- Do not include the raw failure report content; only your analysis.
+- If the failure report is empty or unparseable, output one line saying so.

--- a/.github/codex/prompts/post-merge-triage.md
+++ b/.github/codex/prompts/post-merge-triage.md
@@ -1,0 +1,90 @@
+# Post-Merge Validation Failure Triage
+
+You are analyzing a RediSearch post-merge selected-platform validation run that
+just failed. Your output is posted to the CIE Slack channel as the only
+failure-detail section in the message — be concise, scannable, and high-signal.
+
+## Input
+
+Failed-test (or failed-job) logs from the current workflow run are dumped to a
+file in the working directory: `failed-logs.txt`. Each section is preceded by a
+line like:
+
+```
+##[group]<section_name>
+... log lines ...
+##[endgroup]
+```
+
+The `<section_name>` is either a per-test log file path (preferred, focused on
+tests that actually failed) or a job/step name (fallback when no per-test logs
+were available — e.g. build-only failures). If the file is missing, empty, or
+unreadable, output one line saying so and stop.
+
+If a `failed-tests-*.txt` file is bundled inside the input, it contains the
+RLTest list of failed tests in `test_file.py:test_name` form — use it as the
+authoritative list of distinct failures.
+
+## Task
+
+Classify each distinct failure and produce a Slack-bound triage summary aimed at
+CIE oncall, who needs to know whether this is a platform issue, a real regression,
+or a flake from a covered PR.
+
+### Categories
+
+Use exactly one of these labels per failure:
+
+- `platform-build` — build failed on a specific platform (compiler, missing
+  dependency, toolchain mismatch)
+- `platform-test` — tests passed on master CI but fail on this platform
+- `regression` — looks like a real bug introduced by a recently merged PR (use
+  this only when the failure signature points at user code, not infra/platform)
+- `assertion-race` — nondeterministic ordering or timing
+- `timeout` — exceeded time budget
+- `sanitizer` — ASan / UBSan / MSan crash, panic, memory safety
+- `environment` — runner, infra, network, Redis tag, or dependency issue
+- `unknown` — insufficient evidence
+
+Distinguish facts from inference. Use "the logs show" for facts and "likely" or
+"possible" for hypotheses. Do not invent test names, file paths, or commits.
+
+### Output
+
+Plain text only. Slack renders the payload as-is — do not use markdown headers,
+code fences, or bold.
+
+Structure:
+
+1. **One-line verdict** — what failed and the most likely owner.
+   Example: `2 failures on alpine: 1 build issue (toolchain), 1 platform-only test`
+2. **Per-failure bullets** — group failures that share a root cause; one bullet per
+   group. Each bullet has:
+   - category in brackets, e.g. `[platform-build]`
+   - platform / job identifier (e.g. `alpine-3.20`, `ubi9-aarch64`)
+   - one-line root-cause hypothesis with hedging where needed
+   - recommended next step from: `cie-investigate`, `revert-candidate`,
+     `rerun-and-watch`, `needs-more-evidence`
+
+Keep the whole output under ~10 lines. If you have more than 5 distinct failures,
+summarize the long tail in one line.
+
+### Example output
+
+```
+2 failures on alpine: 1 build issue (toolchain), 1 platform-only test failure.
+
+- [platform-build] build-alpine-3.20 — the logs show ld errors for missing
+  __atomic_load_8; likely a libatomic linkage issue specific to musl. CIE-known
+  pattern. Next: cie-investigate
+- [platform-test] test-alpine-3.20::test_geo_index — assertion mismatch on a
+  lat/lng comparison; this test passes on glibc. Possible musl libm precision
+  diff. Next: needs-more-evidence
+```
+
+## Guardrails
+
+- Do not propose code changes.
+- Do not include raw log excerpts longer than one line in the output.
+- If the failure signature could equally be regression or platform issue, say so
+  and use `needs-more-evidence` rather than picking one.

--- a/.github/codex/prompts/snapshot-triage.md
+++ b/.github/codex/prompts/snapshot-triage.md
@@ -1,0 +1,92 @@
+# Snapshot Deploy Failure Triage
+
+You are analyzing a RediSearch snapshot-deploy workflow that just failed on a
+push to `master` or a release branch. The workflow builds module binaries for
+multiple platform/architecture combinations and uploads them. Your output is
+posted to Slack as the only failure-detail section in the message — be concise,
+scannable, and high-signal.
+
+## Input
+
+Failed-job logs from the current workflow run are dumped to a file in the
+working directory: `failed-logs.txt`. Each failed step is preceded by a line
+like:
+
+```
+##[group]<job_name> / <step_name>
+... log lines ...
+##[endgroup]
+```
+
+If the file is missing, empty, or unreadable, output one line saying so and
+stop.
+
+## Task
+
+Classify each distinct failure and produce a Slack-bound triage summary aimed at
+whoever owns RediSearch CI — they need to know whether to revert the head
+commit, fix the build infra, or rerun.
+
+### Categories
+
+Use exactly one of these labels per failure:
+
+- `build-failure` — compiler/linker error, missing dependency, toolchain
+  mismatch (real problem in the code or the build config)
+- `packaging-failure` — RPM/DEB/tarball/container packaging step failed after a
+  successful compile
+- `upload-failure` — S3, registry, or artifact-store upload step failed
+  (network, auth, quota); compile and package succeeded
+- `cache-failure` — sccache, container cache, or other cache backend issue
+- `environment` — runner image issue, transient network, dependency mirror
+  outage, or other infra problem outside the build itself
+- `regression` — looks like a real code bug introduced by the pushed commit
+  (e.g. compile error tied to recent changes, not a toolchain issue)
+- `unknown` — insufficient evidence
+
+Distinguish facts from inference. Use "the logs show" for facts and "likely" or
+"possible" for hypotheses. Do not invent compiler error messages, package
+names, or commits.
+
+### Output
+
+Plain text only. Slack renders the payload as-is — do not use markdown headers,
+code fences, or bold.
+
+Structure:
+
+1. **One-line verdict** — what failed and at what stage; suggest revert vs.
+   rerun if confidence is high.
+   Example: `Compile failed on all aarch64 builds; head commit likely regression — revert candidate`
+2. **Per-failure bullets** — group failures that share a root cause; one bullet
+   per group. Each bullet has:
+   - category in brackets, e.g. `[build-failure]`
+   - platform / architecture identifier (e.g. `ubuntu-22.04-aarch64`,
+     `alpine-3.20-x86_64`)
+   - one-line root-cause hypothesis with hedging where needed
+   - recommended next step from: `revert-candidate`, `investigate-now`,
+     `rerun-and-watch`, `cie-investigate`, `needs-more-evidence`
+
+Keep the whole output under ~10 lines. If you have more than 5 distinct failure
+groups, summarize the long tail in one line.
+
+### Example output
+
+```
+Compile failed on all aarch64 builds; head commit likely regression. Revert candidate.
+
+- [build-failure] all aarch64 platforms — the logs show "undefined reference to
+  rs_new_function" during link; matches symbol added in the head commit but
+  likely missing from the aarch64 build. Next: revert-candidate
+- [upload-failure] ubuntu-22.04 x86_64 — S3 PutObject returned 503 after
+  successful build/package; transient. Next: rerun-and-watch
+```
+
+## Guardrails
+
+- Do not propose code changes.
+- Do not include raw log excerpts longer than one line in the output.
+- Snapshot deploys are concurrency-cancelled when a newer push arrives; if the
+  logs look like a cancellation, say so and use `rerun-and-watch`.
+- If logs are truncated and the failure root cause is past the truncation
+  boundary, say `needs-more-evidence` rather than guessing.

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -314,7 +314,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
-  notify-failure:
+  triage-benchmark-failures:
     needs:
       - benchmark-search-oss-standalone
       - benchmark-search-oss-standalone-aarch64
@@ -331,6 +331,54 @@ jobs:
       - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
       - benchmark-hybrid-oss-standalone
     if: ${{ always() && contains(needs.*.result, 'failure') && inputs.notify_failure }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      triage-exists: ${{ steps.triage.outputs.triage-exists }}
+      triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fetch failed-job logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
+          # Cap at 200KB to bound Codex token spend
+          if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
+            tail -c 204800 failed-logs.txt > failed-logs.txt.tmp
+            printf '[truncated to last 200KB]\n' > failed-logs.txt
+            cat failed-logs.txt.tmp >> failed-logs.txt
+            rm failed-logs.txt.tmp
+          fi
+          exit 0
+      - name: Run Codex triage
+        id: triage
+        uses: ./.github/actions/codex-ci-triage
+        with:
+          openai-api-key: ${{ secrets.CI_TRIAGE_OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/benchmark-triage.md
+
+  notify-failure:
+    needs:
+      - benchmark-search-oss-standalone
+      - benchmark-search-oss-standalone-aarch64
+      - benchmark-search-oss-standalone-threads-6
+      - benchmark-vecsim-oss-standalone
+      - benchmark-vecsim-oss-standalone-threads-6
+      - benchmark-search-oss-cluster-02-primaries
+      - benchmark-search-oss-cluster-04-primaries
+      - benchmark-search-oss-cluster-04-primaries-threads-6
+      - benchmark-search-oss-cluster-08-primaries
+      - benchmark-search-oss-cluster-16-primaries
+      - benchmark-search-oss-cluster-20-primaries
+      - benchmark-search-oss-cluster-24-primaries
+      - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
+      - benchmark-hybrid-oss-standalone
+      - triage-benchmark-failures
+    if: ${{ always() && contains(needs.*.result, 'failure') && inputs.notify_failure }}
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
@@ -340,12 +388,14 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+              "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
+              "ai_triage": ${{ needs.triage-benchmark-failures.outputs.triage-exists == 'true' && needs.triage-benchmark-failures.outputs.triage-content-json || '""' }}
             }
 
   notify-msmarco-failure:
     needs:
       - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
+      - triage-benchmark-failures
     if: ${{ always() && needs.benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8.result == 'failure' && inputs.notify_failure }}
     runs-on: ubuntu-slim
     steps:
@@ -357,5 +407,6 @@ jobs:
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
-              "repository": "${{ github.repository }}"
+              "repository": "${{ github.repository }}",
+              "ai_triage": ${{ needs.triage-benchmark-failures.outputs.triage-exists == 'true' && needs.triage-benchmark-failures.outputs.triage-content-json || '""' }}
             }

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -22,6 +22,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
+      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
@@ -41,6 +42,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
+      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   generate-and-send-report:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -93,6 +95,14 @@ jobs:
             echo "⚠️ Failure report file not found: $FAILURE_FILE"
           fi
 
+      - name: Run Codex CI triage
+        id: ai_triage
+        if: steps.failure_report.outputs.failure_exists == 'true'
+        uses: ./.github/actions/codex-ci-triage
+        with:
+          openai-api-key: ${{ secrets.CI_TRIAGE_OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/ci-triage.md
+
       - name: Send reports to Slack
         if: always()
         uses: slackapi/slack-github-action@v3
@@ -105,6 +115,7 @@ jobs:
               "header": "${{ steps.collect.outcome == 'failure' && format('❌ CI Report Generation Failed - {0}', steps.date.outputs.date) || format('📊 Daily CI Report - {0}', steps.date.outputs.date) }}",
               "summary_report": ${{ steps.summary.outputs.summary_exists == 'true' && steps.summary.outputs.summary_content || '""' }},
               "failure_report": ${{ steps.failure_report.outputs.failure_exists == 'true' && steps.failure_report.outputs.failure_content || '""' }},
+              "ai_triage": ${{ steps.ai_triage.outputs.triage-exists == 'true' && steps.ai_triage.outputs.triage-content-json || '""' }},
               "error": "${{ steps.collect.outcome == 'failure' && 'The collect_nightly_results.py script failed. Check workflow logs for details.' || '' }}"
             }
 
@@ -113,5 +124,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ci-reports-${{ steps.date.outputs.date }}
-          path: merge-to-queue_${{ steps.date.outputs.date }}/
+          path: |
+            merge-to-queue_${{ steps.date.outputs.date }}/
+            ai-triage.txt
           retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -21,8 +21,41 @@ jobs:
       packages: write
     uses: ./.github/workflows/flow-build-artifacts.yml
 
-  notify-failure:
+  triage-failure:
     needs: deploy-snapshots
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      triage-exists: ${{ steps.triage.outputs.triage-exists }}
+      triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fetch failed-job logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
+          # Cap at 200KB to bound Codex token spend
+          if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
+            tail -c 204800 failed-logs.txt > failed-logs.txt.tmp
+            printf '[truncated to last 200KB]\n' > failed-logs.txt
+            cat failed-logs.txt.tmp >> failed-logs.txt
+            rm failed-logs.txt.tmp
+          fi
+          exit 0
+      - name: Run Codex triage
+        id: triage
+        uses: ./.github/actions/codex-ci-triage
+        with:
+          openai-api-key: ${{ secrets.CI_TRIAGE_OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/snapshot-triage.md
+
+  notify-failure:
+    needs: [deploy-snapshots, triage-failure]
     if: failure()
     runs-on: ubuntu-slim
     steps:
@@ -36,5 +69,6 @@ jobs:
               "repository": "${{ github.repository }}",
               "branch": "${{ github.ref_name }}",
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
-              "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+              "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
+              "ai_triage": ${{ needs.triage-failure.outputs.triage-exists == 'true' && needs.triage-failure.outputs.triage-content-json || '""' }}
             }

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -234,29 +234,35 @@ jobs:
           # Prefer the focused "Failed Test Logs *" artifacts produced by
           # task-test.yml — they contain only logs for tests that actually
           # failed, which is much higher signal than the full job stdout.
-          # Fall back to `gh run view --log-failed` when no such artifacts
-          # exist (e.g. build-only failures, non-pytest steps).
+          # Always also include `gh run view --log-failed` so non-pytest
+          # failures (build, sanitizer, Rust, etc.) still have context in
+          # mixed-failure runs.
           mkdir -p downloaded-failed-logs
           gh run download "$GITHUB_RUN_ID" \
             --repo "$GITHUB_REPOSITORY" \
             --pattern "Failed Test Logs *" \
             --dir downloaded-failed-logs 2>/dev/null
 
+          : > failed-logs.txt
           if [ -n "$(find downloaded-failed-logs -type f 2>/dev/null)" ]; then
-            echo "Using focused Failed Test Logs artifacts."
-            {
-              find downloaded-failed-logs -type f \
-                \( -name '*.log' -o -name '*.txt' \) -print0 |
-              while IFS= read -r -d '' f; do
-                printf '\n##[group]%s\n' "${f#downloaded-failed-logs/}"
-                cat "$f"
-                printf '\n##[endgroup]\n'
-              done
-            } > failed-logs.txt
+            echo "Including focused Failed Test Logs artifacts."
+            find downloaded-failed-logs -type f \
+              \( -name '*.log' -o -name '*.txt' \) -print0 |
+            while IFS= read -r -d '' f; do
+              printf '\n##[group]%s\n' "${f#downloaded-failed-logs/}"
+              cat "$f"
+              printf '\n##[endgroup]\n'
+            done >> failed-logs.txt
           else
-            echo "No Failed Test Logs artifacts found; falling back to gh run --log-failed."
-            gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
+            echo "No Failed Test Logs artifacts found."
           fi
+
+          # Also append job-level failed logs to cover non-pytest failures.
+          {
+            printf '\n##[group]gh run view --log-failed\n'
+            gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed 2>&1
+            printf '\n##[endgroup]\n'
+          } >> failed-logs.txt
 
           # Cap at 200KB to bound Codex token spend
           if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
@@ -275,6 +281,7 @@ jobs:
           prompt-file: .github/codex/prompts/post-merge-triage.md
 
       - name: Notify CIE failure triage
+        if: always()
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_POST_MERGE_VALIDATION_FAILED }}

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -223,6 +223,57 @@ jobs:
           append_output("failed_jobs", failed_jobs_text)
           append_output("covered_prs", covered_prs_text)
 
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Fetch failed-job logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          # Prefer the focused "Failed Test Logs *" artifacts produced by
+          # task-test.yml — they contain only logs for tests that actually
+          # failed, which is much higher signal than the full job stdout.
+          # Fall back to `gh run view --log-failed` when no such artifacts
+          # exist (e.g. build-only failures, non-pytest steps).
+          mkdir -p downloaded-failed-logs
+          gh run download "$GITHUB_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "Failed Test Logs *" \
+            --dir downloaded-failed-logs 2>/dev/null
+
+          if [ -n "$(find downloaded-failed-logs -type f 2>/dev/null)" ]; then
+            echo "Using focused Failed Test Logs artifacts."
+            {
+              find downloaded-failed-logs -type f \
+                \( -name '*.log' -o -name '*.txt' \) -print0 |
+              while IFS= read -r -d '' f; do
+                printf '\n##[group]%s\n' "${f#downloaded-failed-logs/}"
+                cat "$f"
+                printf '\n##[endgroup]\n'
+              done
+            } > failed-logs.txt
+          else
+            echo "No Failed Test Logs artifacts found; falling back to gh run --log-failed."
+            gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
+          fi
+
+          # Cap at 200KB to bound Codex token spend
+          if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
+            tail -c 204800 failed-logs.txt > failed-logs.txt.tmp
+            printf '[truncated to last 200KB]\n' > failed-logs.txt
+            cat failed-logs.txt.tmp >> failed-logs.txt
+            rm failed-logs.txt.tmp
+          fi
+          exit 0
+
+      - name: Run Codex triage
+        id: ai_triage
+        uses: ./.github/actions/codex-ci-triage
+        with:
+          openai-api-key: ${{ secrets.CI_TRIAGE_OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/post-merge-triage.md
+
       - name: Notify CIE failure triage
         uses: slackapi/slack-github-action@v3
         with:
@@ -234,6 +285,7 @@ jobs:
               "repository": "${{ github.repository }}",
               "covered_prs": ${{ toJson(steps.failure-details.outputs.covered_prs) }},
               "failed_jobs": ${{ toJson(steps.failure-details.outputs.failed_jobs) }},
+              "ai_triage": ${{ steps.ai_triage.outputs.triage-exists == 'true' && steps.ai_triage.outputs.triage-content-json || '""' }},
               "owner": "CIE",
               "expectation": "Post-merge selected-platform validation failure requires CIE triage"
             }

--- a/.github/workflows/event-periodic-msmarco-e2e-benchmarks.yml
+++ b/.github/workflows/event-periodic-msmarco-e2e-benchmarks.yml
@@ -8,6 +8,7 @@ jobs:
   run-benchmarks:
     permissions:
       contents: read
+      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -17,6 +17,7 @@ jobs:
     if: ${{ needs.check-what-changed.outputs.BENCHMARK_CHANGED == 'true' }}
     permissions:
       contents: read
+      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -10,6 +10,7 @@ jobs:
   run-benchmarks:
     permissions:
       contents: read
+      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -419,6 +419,7 @@ jobs:
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
+          FAILEDFILE: ${{ github.workspace }}/failed-tests-standalone.txt
         run: make pytest $TEST_CONFIG
 
       - name: Flow tests (coordinator)
@@ -435,6 +436,7 @@ jobs:
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
+          FAILEDFILE: ${{ github.workspace }}/failed-tests-coordinator.txt
         run: make pytest $TEST_CONFIG
 
       - name: Rust tests (MIRI)
@@ -524,6 +526,70 @@ jobs:
             bin/**/redisearch.so
             bin/**/redisearch.so.debug
 
+          if-no-files-found: ignore
+
+      - name: Collect failed-test-only logs
+        # Build a focused log bundle containing only logs for tests that actually
+        # failed, so downstream tools (e.g. Codex triage) get high-signal input.
+        # Driven by RLTest's FAILEDFILE output (test ids in `test_file.py:test_name`
+        # form). RLTest log filenames embed the test id as `..._<file>_<test>_...`,
+        # so we convert each failed id to a glob and copy matching files.
+        if: >
+          failure() || (
+            steps.standalone_tests.outcome == 'failure' ||
+            steps.coordinator_tests.outcome == 'failure'
+          )
+        run: |
+          set +e
+          DEST="failed-test-logs"
+          mkdir -p "$DEST"
+
+          copy_for_failed_list() {
+            local listfile="$1"
+            [ -f "$listfile" ] || return 0
+            while IFS= read -r test_id; do
+              [ -z "$test_id" ] && continue
+              local file_part="${test_id%%:*}"
+              local test_part="${test_id#*:}"
+              local file_no_py="${file_part%.py}"
+              local pattern="*-${file_no_py}_${test_part}-*.log*"
+              find tests -path '*/logs/*' -name "$pattern" -type f 2>/dev/null | \
+                while read -r log; do
+                  mkdir -p "$DEST/$(dirname "$log")"
+                  cp "$log" "$DEST/$log"
+                done
+            done < "$listfile"
+          }
+
+          copy_for_failed_list "${{ github.workspace }}/failed-tests-standalone.txt"
+          copy_for_failed_list "${{ github.workspace }}/failed-tests-coordinator.txt"
+
+          # Always include the run-level RLTest summary log if present — it gives
+          # session-level context that complements per-test logs.
+          find tests -path '*/logs/rstest*.log' -type f 2>/dev/null | while read -r log; do
+            mkdir -p "$DEST/$(dirname "$log")"
+            cp "$log" "$DEST/$log"
+          done
+
+          # Stash the failed-test lists alongside the logs for downstream consumers.
+          for f in failed-tests-standalone.txt failed-tests-coordinator.txt; do
+            [ -f "${{ github.workspace }}/$f" ] && cp "${{ github.workspace }}/$f" "$DEST/$f"
+          done
+
+          echo "Failed-test logs bundled:"
+          find "$DEST" -type f | wc -l
+          exit 0
+
+      - name: Upload Failed-Only Test Logs
+        if: >
+          failure() || (
+            steps.standalone_tests.outcome == 'failure' ||
+            steps.coordinator_tests.outcome == 'failure'
+          )
+        uses: actions/upload-artifact@v7
+        with:
+          name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
+          path: failed-test-logs/
           if-no-files-found: ignore
 
       - name: Fail flow if tests failed


### PR DESCRIPTION
Add CI Triaging using codex github action to analyze the failure and issue an output in the slack message we send.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect multiple production CI notification paths and send failure logs to an external OpenAI API via a new secret; misconfiguration could leak log content or add cost/latency, though triage is designed not to block jobs on Codex failure.
> 
> **Overview**
> Adds **Codex-based CI failure triage** so Slack notifications can include a short, classified summary instead of only links and raw reports.
> 
> A new composite action **`codex-ci-triage`** runs `openai/codex-action` in read-only mode, reads the triage output file, and exposes `triage-exists`, raw text, and **JSON-escaped** content for webhook payloads. Codex failures use `continue-on-error` so triage never fails the parent job.
> 
> Four **prompt templates** under `.github/codex/prompts/` tailor analysis for nightly CI reports, benchmarks, snapshot deploys, and post-merge platform validation (categories, plain-text Slack format, guardrails).
> 
> **Workflow wiring:** `daily-ci-report` triages when a failure report exists; `benchmark-runner` adds a `triage-benchmark-failures` job (failed logs via `gh run view --log-failed`, 200KB cap) before Slack notify; `event-deploy-snapshots` and `event-periodic-master-validation` add similar triage jobs. Several callers grant **`actions: read`** for log fetch. Slack payloads gain an **`ai_triage`** field; daily report artifacts can include `ai-triage.txt`.
> 
> **Higher-signal test logs for triage:** `task-test` sets **`FAILEDFILE`** for standalone/coordinator pytest, bundles failed-test-only logs from RLTest output, and uploads **`Failed Test Logs *`** artifacts. Post-merge failure notification prefers those artifacts plus job-level failed logs before Codex runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d9d3f1f3a7f244b811768cf749380bb2a13474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->