### PR TITLE
[MOD-15932] Trie - Fix possibly wrong lex-range query results after RDB reload

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -207,7 +207,7 @@ static int SpellCheckDictAuxLoad(RedisModuleIO *rdb, int encver, int when) {
   size_t len = LoadUnsigned_IOError(rdb, goto cleanup);
   for (size_t i = 0; i < len; i++) {
     char *key = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
-    Trie *val = TrieType_GenericLoad(rdb, false, false);
+    Trie *val = TrieType_GenericLoad(rdb, false, false, Trie_Sort_Lex);
     if (val == NULL) {
       RedisModule_Free(key);
       goto cleanup;

--- a/src/spec.c
+++ b/src/spec.c
@@ -3524,7 +3524,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
     if (sp->terms) {
       TrieType_Free(sp->terms);
     }
-    sp->terms = TrieType_GenericLoad(rdb, false, true);
+    sp->terms = TrieType_GenericLoad(rdb, false, true, Trie_Sort_Lex);
     RS_LOG_ASSERT(sp->terms, "Failed to load terms trie");
 
     // Load disk metadata (max_doc_id, deleted_ids) into the spec. Stashed
@@ -3675,7 +3675,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
   /* For version 3 or up - load the generic trie */
   if (encver >= 3) {
-    sp->terms = TrieType_GenericLoad(rdb, false, false);
+    sp->terms = TrieType_GenericLoad(rdb, false, false, Trie_Sort_Lex);
     if (sp->terms == NULL) {
       StrongRef_Release(spec_ref);
       return NULL;

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -387,16 +387,20 @@ void *TrieType_RdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver > TRIE_ENCVER_CURRENT) {
     return NULL;
   }
-  return TrieType_GenericLoad(rdb, encver >= TRIE_ENCVER_PAYLOADS, encver >= TRIE_ENCVER_NUMDOCS);
+  // The registered TrieType is used only by FT.SUGADD (suggest.c builds with Trie_Sort_Score),
+  // so the score-ordered children expected by SUGGET ranking are restored here.
+  return TrieType_GenericLoad(rdb, encver >= TRIE_ENCVER_PAYLOADS, encver >= TRIE_ENCVER_NUMDOCS,
+                              Trie_Sort_Score);
 }
 
-void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDocs) {
+void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDocs,
+                           TrieSortMode sortMode) {
 
   Trie *tree = NULL;
   char *str = NULL;
   uint64_t elements = LoadUnsigned_IOError(rdb, goto cleanup);
 
-  tree = NewTrie(NULL, Trie_Sort_Score);
+  tree = NewTrie(NULL, sortMode);
 
   while (elements--) {
     size_t len;

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -135,7 +135,8 @@ int Trie_RandomKey(Trie *t, char **str, t_len *len, double *score);
 
 /* Commands related to the redis TrieType registration */
 int TrieType_Register(RedisModuleCtx *ctx);
-void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDocs);
+void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDocs,
+                           TrieSortMode sortMode);
 void TrieType_GenericSave(RedisModuleIO *rdb, Trie *t, bool savePayloads, bool saveNumDocs);
 void *TrieType_RdbLoad(RedisModuleIO *rdb, int encver);
 void TrieType_RdbSave(RedisModuleIO *rdb, void *value);

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -591,7 +591,7 @@ TEST_F(RdbMockTest, testTrieRdbLoadMoreThan65535Elements) {
     io->read_pos = 0;
 
     // Load the trie from RDB
-    Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, 0, false);
+    Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, 0, false, Trie_Sort_Lex);
     ASSERT_TRUE(loadedTrie != nullptr) << "Failed to load trie with more than 65535 elements";
     std::unique_ptr<Trie, std::function<void(Trie *)>> loadedTriePtr(loadedTrie, [](Trie *t) {
         TrieType_Free(t);
@@ -625,7 +625,7 @@ TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
         RMCK_SaveStringBuffer(io, normal_payload, normal_len + 1);  // payload with null terminator
 
         io->read_pos = 0;
-        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
+        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false, Trie_Sort_Lex);  // loadPayloads = 1
         ASSERT_TRUE(trie != nullptr) << "Failed to load trie with normal payload";
         EXPECT_EQ(1, Trie_Size(trie));
         TrieType_Free(trie);
@@ -645,7 +645,7 @@ TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
         RMCK_SaveStringBuffer(io, large_payload.data(), large_size);  // payload with null terminator
 
         io->read_pos = 0;
-        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
+        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false, Trie_Sort_Lex);  // loadPayloads = 1
         ASSERT_TRUE(trie != nullptr) << "Failed to load trie with 1MB payload";
         EXPECT_EQ(1, Trie_Size(trie));
         TrieType_Free(trie);
@@ -666,7 +666,7 @@ TEST_F(RdbMockTest, testTriePayloadNoOverflow) {
         RMCK_SaveUnsigned(io, UINT32_MAX);
 
         io->read_pos = 0;
-        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false);  // loadPayloads = 1
+        Trie *trie = (Trie *)TrieType_GenericLoad(io, 1, false, Trie_Sort_Lex);  // loadPayloads = 1
 
         // The load should fail gracefully (return NULL) rather than crash
         // due to integer overflow in the allocation

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -840,12 +840,8 @@ static size_t trieGetNumDocs(Trie *t, const char *s) {
   return node->numDocs;
 }
 
-// Regression: TrieType_GenericLoad hardcodes the reloaded trie to Trie_Sort_Score,
-// so a Lex-sorted source trie comes back with score-ordered children. Trie_IterateRange
-// does binary search on children (trie_node.c:868) which is only sound on a Lex-ordered
-// trie, so range queries on the reloaded trie silently return the wrong subset.
-// Reachable in production via spec.c:3527 (disk-spec SST load) and spec.c:3678
-// (legacy encver>=3 load) where the source trie is built Lex (spec.c:2429).
+// Regression: TrieType_GenericLoad must preserve sort mode across reload,
+// or Trie_IterateRange's binary search breaks on Lex-sourced tries.
 TEST_F(TrieTest, testRdbSaveLoadLexRangePreservesQueries) {
   Trie *original = NewTrie(NULL, Trie_Sort_Lex);
   std::unique_ptr<Trie, std::function<void(Trie *)>> originalPtr(

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -839,6 +839,54 @@ static size_t trieGetNumDocs(Trie *t, const char *s) {
   return node->numDocs;
 }
 
+// Regression: TrieType_GenericLoad hardcodes the reloaded trie to Trie_Sort_Score,
+// so a Lex-sorted source trie comes back with score-ordered children. Trie_IterateRange
+// does binary search on children (trie_node.c:868) which is only sound on a Lex-ordered
+// trie, so range queries on the reloaded trie silently return the wrong subset.
+// Reachable in production via spec.c:3527 (disk-spec SST load) and spec.c:3678
+// (legacy encver>=3 load) where the source trie is built Lex (spec.c:2429).
+TEST_F(TrieTest, testRdbSaveLoadLexRangePreservesQueries) {
+  Trie *original = NewTrie(NULL, Trie_Sort_Lex);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> originalPtr(
+      original, [](Trie *t) { TrieType_Free(t); });
+
+  // Single-char top-level entries so they become direct children of root.
+  // Scores scrambled so score-descending order != lex-ascending order.
+  struct E { const char *term; float score; };
+  E entries[] = {
+      {"a", 5},  {"b", 11}, {"c", 2},  {"d", 8},  {"e", 13},
+      {"f", 1},  {"g", 7},  {"h", 4},  {"i", 10}, {"j", 6},
+      {"k", 12}, {"l", 3},  {"m", 9},
+  };
+  for (auto &e : entries) {
+    ASSERT_TRUE(Trie_InsertStringBuffer(original, e.term, 1, e.score, 1, NULL, 0));
+  }
+  ASSERT_EQ(13, Trie_Size(original));
+
+  // Ground truth: lex range [d, j) on the original Lex trie.
+  ElemSet expected = trieIterRange(original, "d", "j");
+  ASSERT_EQ((ElemSet{"d", "e", "f", "g", "h", "i"}), expected);
+
+  RedisModuleIO *io = RMCK_CreateRdbIO();
+  std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(
+      io, [](RedisModuleIO *p) { RMCK_FreeRdbIO(p); });
+  ASSERT_TRUE(io != nullptr);
+
+  // Round-trip via the generic loader (same path as disk-spec / legacy RDB load).
+  TrieType_GenericSave(io, original, false, false);
+  ASSERT_EQ(0, RMCK_IsIOError(io));
+  io->read_pos = 0;
+  Trie *loaded = (Trie *)TrieType_GenericLoad(io, false, false);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> loadedPtr(
+      loaded, [](Trie *t) { TrieType_Free(t); });
+  ASSERT_TRUE(loaded != nullptr);
+  ASSERT_EQ(Trie_Size(original), Trie_Size(loaded));
+
+  // Same range query on the same data must produce the same result set.
+  ElemSet actual = trieIterRange(loaded, "d", "j");
+  EXPECT_EQ(expected, actual);
+}
+
 TEST_F(TrieTest, testRdbSaveLoadWithNumDocs) {
   // Create a trie with numDocs values
   Trie *originalTrie = NewTrie(NULL, Trie_Sort_Score);

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -539,7 +539,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithPayloads) {
   io->read_pos = 0;
 
   // Load the trie from RDB (with payloads)
-  Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, true, true);
+  Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, true, true, Trie_Sort_Score);
   std::unique_ptr<Trie, std::function<void(Trie *)>> loadedTriePtr(loadedTrie, [](Trie *trie) {
     TrieType_Free(trie);
   });
@@ -605,7 +605,7 @@ TEST_F(TrieTest, testRdbSaveLoadPayloadsNotSerialized) {
   io->read_pos = 0;
 
   // Load the trie from RDB WITHOUT payloads (loadPayloads = false) and numDocs (loadNumDocs = false)
-  Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, false, false);
+  Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, false, false, Trie_Sort_Score);
   std::unique_ptr<Trie, std::function<void(Trie *)>> loadedTriePtr(loadedTrie, [](Trie *trie) {
     TrieType_Free(trie);
   });
@@ -666,7 +666,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithoutPayloads) {
   io->read_pos = 0;
 
   // Load the trie from RDB WITHOUT payloads (loadPayloads = false) and numDocs (loadNumDocs = false) to match the save operation
-  Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, false, false);
+  Trie *loadedTrie = (Trie *)TrieType_GenericLoad(io, false, false, Trie_Sort_Score);
   std::unique_ptr<Trie, std::function<void(Trie *)>> loadedTriePtr(loadedTrie, [](Trie *trie) {
     TrieType_Free(trie);
   });
@@ -797,8 +797,9 @@ TEST_F(TrieTest, testRdbSaveLoadLexSortedTrie) {
   // Compare the original and loaded tries
   EXPECT_EQ(Trie_Size(originalTrie), Trie_Size(loadedTrie));
 
-  // Note: The loaded trie will have Trie_Sort_Score (default from TrieType_GenericLoad)
-  // but all the entries should still be present, even though the sorting mode changed
+  // Note: TrieType_RdbLoad (the registered TrieType callback) always reconstructs
+  // with Trie_Sort_Score because the only producer of the registered type is FT.SUGADD.
+  // All entries should still be present, even though the sorting mode changed.
 
   // Verify all entries are present in the loaded trie
   EXPECT_TRUE(trieContains(loadedTrie, "test"));
@@ -876,7 +877,7 @@ TEST_F(TrieTest, testRdbSaveLoadLexRangePreservesQueries) {
   TrieType_GenericSave(io, original, false, false);
   ASSERT_EQ(0, RMCK_IsIOError(io));
   io->read_pos = 0;
-  Trie *loaded = (Trie *)TrieType_GenericLoad(io, false, false);
+  Trie *loaded = (Trie *)TrieType_GenericLoad(io, false, false, Trie_Sort_Lex);
   std::unique_ptr<Trie, std::function<void(Trie *)>> loadedPtr(
       loaded, [](Trie *t) { TrieType_Free(t); });
   ASSERT_TRUE(loaded != nullptr);


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current**: `TrieType_GenericLoad` always reconstructs the loaded trie with `Trie_Sort_Score`, regardless of how the source trie was built. The sort mode is not persisted in the RDB stream. `Trie_IterateRange` uses binary search on each node's children (`src/trie/trie_node.c:868`), which is sound only on lex-ordered children; on score-ordered children it picks arbitrary cut points. After an RDB reload of an index built lex-sorted, `FT.SEARCH` lex-range, wildcard brute-force, and contains brute-force queries silently return the wrong subset.

2. **Change**: Thread `TrieSortMode` as an explicit parameter through `TrieType_GenericLoad` rather than encoding the mode in the RDB stream — every caller already knows the right mode for its origin, and this avoids an encver bump. Each call site passes its source mode:
   - `src/spec.c:3527` (disk-spec SST load) → `Trie_Sort_Lex`
   - `src/spec.c:3678` (legacy encver≥3 load) → `Trie_Sort_Lex`
   - `src/dictionary.c:210` (spell-check dictionaries) → `Trie_Sort_Lex`
   - `TrieType_RdbLoad` (registered TrieType, used only by `FT.SUGADD`) → `Trie_Sort_Score`

3. **Outcome**: Lex-range, wildcard brute-force, and contains brute-force queries return correct results after RDB reload on disk-spec SST (Redis Enterprise) and legacy (encver 3–16) indexes. Modern in-memory indexes were already unaffected: `sp->terms` is rebuilt from documents via keyspace notifications on those paths. A new regression test (`TrieTest.testRdbSaveLoadLexRangePreservesQueries` in `tests/cpptests/test_cpp_trie.cpp`) reproduces the bug on `master` and passes after the fix.

#### Which additional issues this PR fixes

_None known. Happy to add a `MOD-xxx` reference if a ticket is opened._

#### Main objects this PR modified

1. `TrieType_GenericLoad` (`src/trie/trie.c`) — new `sortMode` parameter
2. `TrieType_RdbLoad` (`src/trie/trie.c`) — explicit `Trie_Sort_Score`
3. RDB load call sites in `src/spec.c` (disk-spec SST and legacy paths) and `src/dictionary.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RDB load behavior for index terms and dictionaries; wrong sort mode would silently skew search results, but scope is narrow and covered by a new regression test.
> 
> **Overview**
> **RDB reload** no longer forces every trie loaded through `TrieType_GenericLoad` to use **score-ordered** children. The loader now takes an explicit `TrieSortMode` (no RDB format change): **lex** for index terms, spell-check dictionaries, and legacy spec loads; **score** for the registered `TrieType` path used by **FT.SUGADD**.
> 
> That fixes wrong results after reload for queries that depend on lex-ordered child layout—**lex-range**, wildcard brute-force, and contains brute-force—because `Trie_IterateRange` binary-searches children assuming lex order.
> 
> Tests pass the new argument at each `TrieType_GenericLoad` call site; a C++ regression test round-trips a lex trie and checks range `[d, j)` matches before and after save/load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da76effbc17fda0f51ee5fbb7e740e8f5fc8ae80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->