### PR TITLE
[8.2] [MOD-15875] CI: bump docker/* actions off Node 20 (followup)

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -68,21 +68,21 @@ jobs:
           echo "Using cache ref: $CACHE_REF"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push (cached)
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .


### PR DESCRIPTION
Followup to #9854 (merged backport of #9840 to 8.2).

The original backport carried only the master-PR scope. After merge, CI surfaced the warning that the remaining `docker/*` actions on 8.2 still run on Node.js 20:

- `docker/build-push-action@v6` → `@v7`
- `docker/login-action@v3` → `@v4`
- `docker/setup-buildx-action@v3` → `@v4`
- `docker/setup-qemu-action@v3` → `@v4`

Master had these already on the node24 majors via the earlier MOD-15112 wave, so they were not part of the MOD-15875 backport diff. Bumping here so 8.2 is fully off Node 20.

CI-only change; no user-visible impact.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only version bumps with no application or runtime changes; residual risk is limited to possible Docker action behavior differences in image build/push.
> 
> **Overview**
> Bumps the **Docker-related GitHub Actions** in `task-build-cached-container.yml` so the 8.2 branch matches the Node 24–compatible majors already on master: `docker/login-action` **v3→v4**, `setup-qemu-action` and `setup-buildx-action` **v3→v4**, and `build-push-action` **v6→v7**.
> 
> Workflow inputs, build args, cache settings, and image tagging are unchanged—only action version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206aeead78f02617976694503ef5ee15f05cefce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->