### PR TITLE
hybrid coord: drop qctxErr and dispatcherCtx

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -600,15 +600,29 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     cmd.reqConfig = &hreq->reqConfig;
     cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
-    ArgsCursor ac = {0};
-    ArgsCursor_InitRString(&ac, argv, argc);
+    // Parse the FT.PROFILE prefix (if any) from the dispatcher's RString argv.
+    // This cursor is used only to detect the profile flag and to count how many
+    // tokens ParseProfile consumed; we do NOT pass it to parseHybridCommand,
+    // because AC_GetString on an RString cursor returns pointers into the
+    // dispatcher ctx's auto-memory, which is freed when the handler returns.
+    ArgsCursor profileAc = {0};
+    ArgsCursor_InitRString(&profileAc, argv, argc);
     ProfileOptions profileOptions = EXEC_NO_FLAGS;
-    int rc = ParseProfile(&ac, status, &profileOptions);
+    int rc = ParseProfile(&profileAc, status, &profileOptions);
     if (rc == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-    if (profileOptions == EXEC_NO_FLAGS) {
-      // No profile args, we can use the original args cursor to skip past the command name and index
-      HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
+    // Build an SDS-backed cursor covering argv[2:] (skips command + index).
+    // parseHybridCommand and the plan/RLookup machinery it feeds borrow string
+    // pointers from this cursor; backing them with hreq-owned sds copies (whose
+    // lifetime matches hreq) frees us from keeping the dispatcher ctx alive.
+    ArgsCursor ac = {0};
+    HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
+
+    if (profileOptions != EXEC_NO_FLAGS) {
+        // ParseProfile advanced profileAc past "FT.PROFILE <index> <cmd> [LIMITED] QUERY".
+        // The SDS cursor starts at argv[2:] (post command + index), so advance it
+        // by the remainder ParseProfile consumed: <cmd> [LIMITED] QUERY.
+        AC_AdvanceBy(&ac, profileAc.offset - 2);
     }
 
     hreq->tailPipeline->qctx.isProfile = profileOptions != EXEC_NO_FLAGS;
@@ -779,58 +793,21 @@ typedef struct {
     HybridRequest *hreq;
     StrongRef indexSpecRef;
     RedisModuleBlockedClient *bc;
-    // The dispatcher's thread-safe ctx. Must outlive the entire tail execution
-    // because two invariants tie it to live memory:
-    //
-    // 1. ConcurrentSearch_HandleRedisCommandEx allocates argv copies as
-    //    RedisModuleString objects in this ctx's auto-memory (concurrent_ctx.c:162).
-    //    RLookup keys built during pipeline construction store Cow::Borrowed
-    //    pointers into those strings' embedded data. Depleter threads walk the
-    //    KeyList while these pointers are live. Freeing dispatcherCtx before the
-    //    pipeline is torn down leaves the key-name pointers dangling.
-    //
-    // 2. A thread-safe ctx created from a BC must be freed before the BC is
-    //    unblocked. dispatcherCtx is freed in HybridDispatchCtx_Free after
-    //    HybridRequest_DecrRef (which tears down the pipeline and the RLookup)
-    //    and before UnblockClient.
-    //
-    // The tail does NOT issue Redis API calls through dispatcherCtx — it
-    // creates its own replyCtx for the reply path.
-    RedisModuleCtx *dispatcherCtx;
-    // Storage for hreq->tailPipeline->qctx.err during tail execution.
-    // Kept separate from hreq->tailPipelineError so that non-fatal error codes
-    // written into qctx->err by tail result-processors (e.g. QUERY_ERROR_CODE_NO_PROP_VAL
-    // from an APPLY step referencing a property absent from the merged result set)
-    // are emitted as warnings by finishSendChunkReply_hybrid rather than surfaced
-    // as fatal replies by HybridRequest_GetError. This matches the intended
-    // "soft-error" semantics of NoPropVal: the default message for that code is
-    // "Value not found in result (not a hard error)".
-    QueryError qctxErr;
 } HybridDispatchCtx;
 
 static void HybridDispatchCtx_Free(HybridDispatchCtx *dispatch) {
     HybridRequest *hreq = dispatch->hreq;
     StrongRef indexSpecRef = dispatch->indexSpecRef;
     RedisModuleBlockedClient *bc = dispatch->bc;
-    RedisModuleCtx *dispatcherCtx = dispatch->dispatcherCtx;
 
-    // DecrRef may run Pipeline_Clean → QITR_FreeChain on the tail pipeline,
-    // whose qctx->err still points into dispatch->qctxErr. Tear down hreq
-    // first so any RP Free that reads or writes through err sees live storage,
-    // then clear any error contents it may have left behind, then free dispatch.
     if (hreq) {
         HybridRequest_DecrRef(hreq);
     }
-    QueryError_ClearError(&dispatch->qctxErr);
     rm_free(dispatch);
     // The dispatcher thread already called CurrentThread_ClearIndexSpec() after
     // transferring strong_ref ownership here, so only release the strong ref.
     StrongRef_Release(indexSpecRef);
 
-    // Free the dispatcher ctx after tearing down the pipeline (which holds
-    // Cow::Borrowed pointers into the ctx's auto-memory) and before unblocking
-    // the client (a BC-derived ctx must be released before UnblockClient).
-    RedisModule_FreeThreadSafeContext(dispatcherCtx);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     void *privdata = RedisModule_BlockClientGetPrivateData(bc);
     RedisModule_UnblockClient(bc, privdata);
@@ -890,12 +867,15 @@ static void HybridDispatchCtx_Tail(void *arg) {
         return;
     }
 
-    // Dedicated thread-safe ctx for this worker's reply. The dispatcher's ctx
-    // is retained in dispatch->dispatcherCtx to keep argv-backed RLookup key
-    // name pointers alive (see struct comment), but Redis API calls in the tail
-    // go through `replyCtx` so the dispatcher and tail workers never call APIs
-    // on the same RedisModuleCtx.
+    // Dedicated thread-safe ctx for this worker's reply path. Also installed
+    // as hreq->sctx->redisCtx for the duration of the tail so any pipeline RP
+    // that uses sctx->redisCtx (e.g. document loading in a tail LOAD step) has
+    // a live ctx on this thread. This mirrors the shard background worker
+    // pattern (hybrid_exec.c:1200-1203). The dispatcher's original ctx was
+    // freed by threadHandleCommand when the handler returned; scheduleHybridTail
+    // already cleared sctx->redisCtx to NULL before submitting this job.
     RedisModuleCtx *replyCtx = RedisModule_GetThreadSafeContext(dispatch->bc);
+    hreq->sctx->redisCtx = replyCtx;
     RedisModule_Reply _reply = RedisModule_NewReply(replyCtx);
     RedisModule_Reply *reply = &_reply;
 
@@ -906,6 +886,12 @@ static void HybridDispatchCtx_Tail(void *arg) {
     };
     sendChunk_hybrid(hreq, reply, UINT64_MAX, cv);
     RedisModule_EndReply(reply);
+    // Clear the alias before freeing replyCtx so HybridDispatchCtx_Free's
+    // teardown of hreq (which calls SearchCtx_Free) never sees a dangling
+    // ctx pointer. SearchCtx_CleanUp doesn't currently read sctx->redisCtx
+    // unless sctx->key_ is set, but defensively NULLing it removes the
+    // footgun if either of those invariants changes.
+    hreq->sctx->redisCtx = NULL;
     RedisModule_FreeThreadSafeContext(replyCtx);
 
     // Belt-and-braces: sendChunk_hybrid normally drains depleters via the
@@ -920,21 +906,15 @@ static void HybridDispatchCtx_Tail(void *arg) {
 }
 
 // Hand off ownership of dispatcher-owned state (hreq pin, spec indexSpecRef,
-// BC, dispatcher ctx) to a heap dispatch context, mark cmdCtx so
-// threadHandleCommand stops auto-freeing the Redis ctx and auto-unblocking the
-// client, and submit the tail continuation to the coord pool. Caller must not
-// touch any of the moved resources after this returns.
+// BC) to a heap dispatch context, mark cmdCtx so threadHandleCommand stops
+// auto-unblocking the client, and submit the tail continuation to the coord
+// pool. Caller must not touch any of the moved resources after this returns.
 //
-// `ctx` (the dispatcher's thread-safe ctx) is stored in the dispatch context
-// and freed in HybridDispatchCtx_Free, after the pipeline is torn down but
-// before UnblockClient. This ordering satisfies two invariants:
-//
-//   1. argv copies created in ConcurrentSearch_HandleRedisCommandEx live in
-//      ctx's auto-memory. The RLookup key list holds Cow::Borrowed pointers
-//      into those strings' embedded data; freeing ctx while a depleter is
-//      walking the key list causes a use-after-free.
-//
-//   2. A BC-derived thread-safe ctx must be freed before UnblockClient.
+// The dispatcher's RedisModuleCtx is NOT carried forward: parsing copied argv
+// into hreq-owned sds strings (see HybridRequest_prepareForExecution), so
+// nothing in hreq references that ctx's auto-memory after parsing completes.
+// threadHandleCommand frees the ctx normally when the handler returns; the
+// tail installs its own replyCtx into hreq->sctx->redisCtx before running.
 //
 // The cmdCtx's inherited spec WeakRef is released here: the indexSpecRef
 // transferred to the tail keeps both the spec and its RefManager alive,
@@ -942,37 +922,33 @@ static void HybridDispatchCtx_Tail(void *arg) {
 //
 // `dispatcherStatus` is the dispatcher-thread QueryError that ProcessHybridCursorMappings
 // may have stamped non-fatal warnings onto (e.g. COORD OOM under OomPolicy_Return).
-// We forward those warning bits into the tail's qctxErr so finishSendChunkReply_hybrid
-// can emit them.
+// We forward those warning bits onto hreq->tailPipelineError so
+// finishSendChunkReply_hybrid (which reads qctx->err, aliased to that field) can
+// emit them. Warning bits are independent of the error code, so this does not
+// trip HybridRequest_GetError into a fatal reply.
 static void scheduleHybridTail(HybridRequest *hreq, StrongRef indexSpecRef,
-                             struct ConcurrentCmdCtx *cmdCtx, RedisModuleCtx *ctx,
+                             struct ConcurrentCmdCtx *cmdCtx,
                              const QueryError *dispatcherStatus) {
     HybridDispatchCtx *dispatch = rm_calloc(1, sizeof(*dispatch));
     dispatch->hreq = hreq;
     dispatch->indexSpecRef = indexSpecRef;
     dispatch->bc = ConcurrentCmdCtx_GetBlockedClient(cmdCtx);
-    dispatch->dispatcherCtx = ctx;
-    dispatch->qctxErr = QueryError_Default();
 
     // Carry forward any non-fatal warnings the dispatcher recorded during cursor
     // establishment. Without this, the warning is lost when `dispatcherStatus`
     // (a stack QueryError on RSExecDistHybrid) goes out of scope.
     if (QueryError_HasQueryOOMWarning(dispatcherStatus)) {
-        QueryError_SetQueryOOMWarning(&dispatch->qctxErr);
+        QueryError_SetQueryOOMWarning(&hreq->tailPipelineError);
     }
 
-    // Re-point qctx->err at the dispatch context's own QueryError so the tail
-    // pipeline's soft errors (e.g. QUERY_ERROR_CODE_NO_PROP_VAL from APPLY on a
-    // property absent from the merged result) are emitted as warnings by
-    // finishSendChunkReply_hybrid rather than picked up by HybridRequest_GetError
-    // as fatal errors. See the qctxErr field comment in HybridDispatchCtx.
-    hreq->tailPipeline->qctx.err = &dispatch->qctxErr;
+    // The dispatcher's ctx is about to be freed by threadHandleCommand when the
+    // handler returns. Clear the alias so the tail never sees a dangling pointer
+    // before it installs its own replyCtx (or the timeout early-exit path tears
+    // down hreq without touching redisCtx).
+    hreq->sctx->redisCtx = NULL;
 
-    // Keep ctx alive past the handler return (CMDCTX_KEEP_RCTX prevents
-    // threadHandleCommand from calling RedisModule_FreeThreadSafeContext).
-    // Ownership is transferred to dispatch->dispatcherCtx; freed in
-    // HybridDispatchCtx_Free after the pipeline is torn down.
-    ConcurrentCmdCtx_KeepRedisCtx(cmdCtx);
+    // Defer the BC unblock to HybridDispatchCtx_Free so the tail (which still
+    // needs the BC for its replyCtx and the reply) outlives the handler return.
     ConcurrentCmdCtx_KeepBlockedClient(cmdCtx);
 
     ConcurrentSearch_ThreadPoolRun(HybridDispatchCtx_Tail, dispatch, hreq->poolId);
@@ -1089,7 +1065,7 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     // ordering ensures depleters are picked up first; the tail's cv-wait on
     // their completion can therefore always make progress.
     scheduleDepleters(hreq);
-    scheduleHybridTail(hreq, strong_ref, cmdCtx, ctx, &status);
+    scheduleHybridTail(hreq, strong_ref, cmdCtx, &status);
 
     // IndexSpecRef_Promote set the TLS on this (dispatcher) thread.
     // scheduleHybridTail transferred strong_ref ownership to the tail, so we
@@ -1169,7 +1145,7 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     }
 
     scheduleDepleters(hreq);
-    scheduleHybridTail(hreq, strong_ref, cmdCtx, ctx, &status);
+    scheduleHybridTail(hreq, strong_ref, cmdCtx, &status);
     CurrentThread_ClearIndexSpec();
 }
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -600,28 +600,24 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     cmd.reqConfig = &hreq->reqConfig;
     cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
-    // Parse the FT.PROFILE prefix (if any) from the dispatcher's RString argv.
-    // This cursor is used only to detect the profile flag and to count how many
-    // tokens ParseProfile consumed; we do NOT pass it to parseHybridCommand,
-    // because AC_GetString on an RString cursor returns pointers into the
-    // dispatcher ctx's auto-memory, which is freed when the handler returns.
+    // RString cursor used only to detect the profile prefix and count tokens
+    // consumed. We don't feed it to parseHybridCommand because AC_GetString on
+    // an RString cursor returns pointers into auto-memory that dies with the
+    // dispatcher ctx.
     ArgsCursor profileAc = {0};
     ArgsCursor_InitRString(&profileAc, argv, argc);
     ProfileOptions profileOptions = EXEC_NO_FLAGS;
     int rc = ParseProfile(&profileAc, status, &profileOptions);
     if (rc == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-    // Build an SDS-backed cursor covering argv[2:] (skips command + index).
-    // parseHybridCommand and the plan/RLookup machinery it feeds borrow string
-    // pointers from this cursor; backing them with hreq-owned sds copies (whose
-    // lifetime matches hreq) frees us from keeping the dispatcher ctx alive.
+    // Hreq-owned sds copies of argv[2:] (skips command + index). parseHybridCommand
+    // and the RLookup machinery borrow pointers into this cursor's strings, so they
+    // must outlive the dispatcher ctx.
     ArgsCursor ac = {0};
     HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
 
     if (profileOptions != EXEC_NO_FLAGS) {
-        // ParseProfile advanced profileAc past "FT.PROFILE <index> <cmd> [LIMITED] QUERY".
-        // The SDS cursor starts at argv[2:] (post command + index), so advance it
-        // by the remainder ParseProfile consumed: <cmd> [LIMITED] QUERY.
+        // Skip the tokens ParseProfile consumed beyond command + index.
         AC_AdvanceBy(&ac, profileAc.offset - 2);
     }
 
@@ -867,13 +863,10 @@ static void HybridDispatchCtx_Tail(void *arg) {
         return;
     }
 
-    // Dedicated thread-safe ctx for this worker's reply path. Also installed
-    // as hreq->sctx->redisCtx for the duration of the tail so any pipeline RP
-    // that uses sctx->redisCtx (e.g. document loading in a tail LOAD step) has
-    // a live ctx on this thread. This mirrors the shard background worker
-    // pattern (hybrid_exec.c:1200-1203). The dispatcher's original ctx was
-    // freed by threadHandleCommand when the handler returned; scheduleHybridTail
-    // already cleared sctx->redisCtx to NULL before submitting this job.
+    // Dedicated thread-safe ctx for this worker. Aliased into sctx->redisCtx
+    // so pipeline RPs that read it (e.g. document loading in a tail LOAD step)
+    // see a live ctx on this thread — mirrors the shard background worker
+    // pattern in hybrid_exec.c.
     RedisModuleCtx *replyCtx = RedisModule_GetThreadSafeContext(dispatch->bc);
     hreq->sctx->redisCtx = replyCtx;
     RedisModule_Reply _reply = RedisModule_NewReply(replyCtx);
@@ -886,11 +879,8 @@ static void HybridDispatchCtx_Tail(void *arg) {
     };
     sendChunk_hybrid(hreq, reply, UINT64_MAX, cv);
     RedisModule_EndReply(reply);
-    // Clear the alias before freeing replyCtx so HybridDispatchCtx_Free's
-    // teardown of hreq (which calls SearchCtx_Free) never sees a dangling
-    // ctx pointer. SearchCtx_CleanUp doesn't currently read sctx->redisCtx
-    // unless sctx->key_ is set, but defensively NULLing it removes the
-    // footgun if either of those invariants changes.
+    // Drop the alias before freeing replyCtx so the hreq teardown below can't
+    // see a dangling pointer if SearchCtx ever starts reading sctx->redisCtx.
     hreq->sctx->redisCtx = NULL;
     RedisModule_FreeThreadSafeContext(replyCtx);
 
@@ -905,27 +895,19 @@ static void HybridDispatchCtx_Tail(void *arg) {
     HybridDispatchCtx_Free(dispatch);
 }
 
-// Hand off ownership of dispatcher-owned state (hreq pin, spec indexSpecRef,
-// BC) to a heap dispatch context, mark cmdCtx so threadHandleCommand stops
-// auto-unblocking the client, and submit the tail continuation to the coord
-// pool. Caller must not touch any of the moved resources after this returns.
+// Hand off dispatcher-owned state (hreq, indexSpecRef, BC) to a heap dispatch
+// ctx and submit the tail to the coord pool. Caller must not touch the moved
+// resources after this returns.
 //
 // The dispatcher's RedisModuleCtx is NOT carried forward: parsing copied argv
-// into hreq-owned sds strings (see HybridRequest_prepareForExecution), so
-// nothing in hreq references that ctx's auto-memory after parsing completes.
-// threadHandleCommand frees the ctx normally when the handler returns; the
-// tail installs its own replyCtx into hreq->sctx->redisCtx before running.
+// into hreq-owned sds (see HybridRequest_prepareForExecution), so the ctx can
+// be freed normally when the handler returns. The tail installs its own
+// replyCtx into hreq->sctx->redisCtx.
 //
-// The cmdCtx's inherited spec WeakRef is released here: the indexSpecRef
-// transferred to the tail keeps both the spec and its RefManager alive,
-// so the standalone weak ref no longer needs to be carried forward.
-//
-// `dispatcherStatus` is the dispatcher-thread QueryError that ProcessHybridCursorMappings
-// may have stamped non-fatal warnings onto (e.g. COORD OOM under OomPolicy_Return).
-// We forward those warning bits onto hreq->tailPipelineError so
-// finishSendChunkReply_hybrid (which reads qctx->err, aliased to that field) can
-// emit them. Warning bits are independent of the error code, so this does not
-// trip HybridRequest_GetError into a fatal reply.
+// `dispatcherStatus` carries any non-fatal warnings ProcessHybridCursorMappings
+// stamped (e.g. COORD OOM under OomPolicy_Return). We forward the warning bits
+// onto hreq->tailPipelineError so finishSendChunkReply_hybrid emits them; bits
+// are independent of the error code, so HybridRequest_GetError stays non-fatal.
 static void scheduleHybridTail(HybridRequest *hreq, StrongRef indexSpecRef,
                              struct ConcurrentCmdCtx *cmdCtx,
                              const QueryError *dispatcherStatus) {
@@ -934,31 +916,22 @@ static void scheduleHybridTail(HybridRequest *hreq, StrongRef indexSpecRef,
     dispatch->indexSpecRef = indexSpecRef;
     dispatch->bc = ConcurrentCmdCtx_GetBlockedClient(cmdCtx);
 
-    // Carry forward any non-fatal warnings the dispatcher recorded during cursor
-    // establishment. Without this, the warning is lost when `dispatcherStatus`
-    // (a stack QueryError on RSExecDistHybrid) goes out of scope.
+    // Forward warnings out of the dispatcher's stack QueryError before it dies.
     if (QueryError_HasQueryOOMWarning(dispatcherStatus)) {
         QueryError_SetQueryOOMWarning(&hreq->tailPipelineError);
     }
 
-    // The dispatcher's ctx is about to be freed by threadHandleCommand when the
-    // handler returns. Clear the alias so the tail never sees a dangling pointer
-    // before it installs its own replyCtx (or the timeout early-exit path tears
-    // down hreq without touching redisCtx).
+    // Drop the alias to the dispatcher's ctx before threadHandleCommand frees it.
     hreq->sctx->redisCtx = NULL;
 
-    // Defer the BC unblock to HybridDispatchCtx_Free so the tail (which still
-    // needs the BC for its replyCtx and the reply) outlives the handler return.
+    // Tail needs the BC for replyCtx; defer unblock to HybridDispatchCtx_Free.
     ConcurrentCmdCtx_KeepBlockedClient(cmdCtx);
 
     ConcurrentSearch_ThreadPoolRun(HybridDispatchCtx_Tail, dispatch, hreq->poolId);
 
-    // Drop the cmdCtx's inherited weak ref. The indexSpecRef transferred to
-    // the tail keeps the RefManager alive via its internal weak count, so
-    // this release does not free anything. Use Take rather than Get so the
-    // cmdCtx->spec_ref field is also cleared: it has been logically returned,
-    // and any subsequent accessor would otherwise see a weak ref whose count
-    // has already been decremented (risking a double-release).
+    // Drop the cmdCtx's inherited weak ref (the tail's indexSpecRef keeps the
+    // RefManager alive). Take rather than Get clears cmdCtx->spec_ref so a
+    // later accessor can't see an already-decremented weak ref.
     WeakRef_Release(ConcurrentCmdCtx_TakeWeakRef(cmdCtx));
 }
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -383,10 +383,24 @@ void HybridRequest_DecrRef(HybridRequest *req) {
   }
 }
 
+// Codes that the tail pipeline may write to qctx->err but which should be
+// surfaced as warnings on the reply path rather than as a fatal error. The
+// canonical example is QUERY_ERROR_CODE_NO_PROP_VAL ("Value not found in
+// result (not a hard error)"), emitted by APPLY when a referenced property
+// is absent from the merged result set. On standalone the same code is
+// reported as a fatal error; on the coordinator the test suite documents
+// the "warning" behavior (see test_tail_property_not_loaded_warning_coordinator).
+static bool isSoftTailPipelineErrorCode(QueryErrorCode code) {
+    return code == QUERY_ERROR_CODE_NO_PROP_VAL;
+}
+
 /**
  * Get error information from a HybridRequest.
  * This function checks for errors in priority order:
- * 1. Tail pipeline errors (affects final result processing)
+ * 1. Tail pipeline errors (affects final result processing) — soft codes
+ *    (see isSoftTailPipelineErrorCode) are intentionally skipped so they
+ *    can be emitted as warnings by finishSendChunkReply_hybrid instead
+ *    of forcing a fatal reply.
  * 2. Individual AREQ errors (sub-query failures)
  *
  * @param hreq The HybridRequest to check for errors
@@ -398,8 +412,10 @@ int HybridRequest_GetError(HybridRequest *hreq, QueryError *status) {
         return REDISMODULE_ERR;
     }
 
-    // Priority 1: Tail pipeline error (affects final result processing)
-    if (QueryError_HasError(&hreq->tailPipelineError)) {
+    // Priority 1: Tail pipeline error (affects final result processing).
+    // Skip soft codes so the reply path can render them as warnings.
+    if (QueryError_HasError(&hreq->tailPipelineError) &&
+        !isSoftTailPipelineErrorCode(QueryError_GetCode(&hreq->tailPipelineError))) {
         QueryError_CloneFrom(&hreq->tailPipelineError, status);
         return REDISMODULE_ERR;
     }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -383,13 +383,10 @@ void HybridRequest_DecrRef(HybridRequest *req) {
   }
 }
 
-// Codes that the tail pipeline may write to qctx->err but which should be
-// surfaced as warnings on the reply path rather than as a fatal error. The
-// canonical example is QUERY_ERROR_CODE_NO_PROP_VAL ("Value not found in
-// result (not a hard error)"), emitted by APPLY when a referenced property
-// is absent from the merged result set. On standalone the same code is
-// reported as a fatal error; on the coordinator the test suite documents
-// the "warning" behavior (see test_tail_property_not_loaded_warning_coordinator).
+// Tail pipeline error codes that the coordinator should emit as warnings
+// rather than fatal errors. NO_PROP_VAL is the canonical case: standalone
+// treats it as fatal, but on the coordinator
+// test_tail_property_not_loaded_warning_coordinator pins it to "warning".
 static bool isSoftTailPipelineErrorCode(QueryErrorCode code) {
     return code == QUERY_ERROR_CODE_NO_PROP_VAL;
 }
@@ -397,10 +394,7 @@ static bool isSoftTailPipelineErrorCode(QueryErrorCode code) {
 /**
  * Get error information from a HybridRequest.
  * This function checks for errors in priority order:
- * 1. Tail pipeline errors (affects final result processing) — soft codes
- *    (see isSoftTailPipelineErrorCode) are intentionally skipped so they
- *    can be emitted as warnings by finishSendChunkReply_hybrid instead
- *    of forcing a fatal reply.
+ * 1. Tail pipeline errors (soft codes skipped — emitted as warnings instead)
  * 2. Individual AREQ errors (sub-query failures)
  *
  * @param hreq The HybridRequest to check for errors
@@ -412,7 +406,6 @@ int HybridRequest_GetError(HybridRequest *hreq, QueryError *status) {
         return REDISMODULE_ERR;
     }
 
-    // Priority 1: Tail pipeline error (affects final result processing).
     // Skip soft codes so the reply path can render them as warnings.
     if (QueryError_HasError(&hreq->tailPipelineError) &&
         !isSoftTailPipelineErrorCode(QueryError_GetCode(&hreq->tailPipelineError))) {


### PR DESCRIPTION
## Describe the changes in the pull request

Two follow-on cleanups to the hybrid split-pipeline PR (#9478) that remove the `qctxErr` and `dispatcherCtx` fields from `HybridDispatchCtx`. The fields aren't structurally needed — they're consequences of avoidable design choices in the parse path and the error-classification logic.

### 1. `qctxErr` → soft-code allowlist in `HybridRequest_GetError`

**Current**: the tail-pipeline error stream is routed through a separate `QueryError` on `HybridDispatchCtx` so that `QUERY_ERROR_CODE_NO_PROP_VAL` (the documented "soft" APPLY error on coord) doesn't trip `HybridRequest_GetError` into a fatal reply. As a side effect, **every** hard tail-RP error code (`NO_PROP_KEY`, `NUMERIC_VALUE_INVALID`, `EXPR`, …) is silently demoted to a warning on coord — even ones the test suite expects to be fatal on standalone. No test catches this drift because it only matters for codes that aren't NO_PROP_VAL.

**Change**: drop the field. Add a small `isSoftTailPipelineErrorCode` allowlist (just `QUERY_ERROR_CODE_NO_PROP_VAL` for now) consulted by `HybridRequest_GetError`. The tail pipeline writes to `tailPipelineError` as before; `HybridRequest_GetError` skips soft codes so the reply path can emit them as warnings.

**Outcome**: same observable behavior for the documented case (`test_tail_property_not_loaded_warning_coordinator` still passes); other hard codes from the merger correctly surface as fatal replies on both coord and standalone. The decision lives in one named function instead of being implicit in the routing.

### 2. `dispatcherCtx` removed; parsing always goes through an SDS cursor

**Current**: the dispatcher's `RedisModuleCtx` was kept alive across the dispatcher→tail handoff (via `CMDCTX_KEEP_RCTX` and a `dispatcherCtx` field on `HybridDispatchCtx`) because of an argv→RLookup borrowed-pointer chain: `AC_GetString` on an RString cursor returns pointers into the dispatcher ctx's auto-memory ([`concurrent_ctx.c:162`](src/concurrent_ctx.c#L162) `RedisModule_CreateStringFromString`), and plan steps + RLookup keys stored those pointers without copying. Freeing the ctx before pipeline teardown UAFed (Ivan's [previous attempt](https://github.com/RediSearch/RediSearch/pull/9478#discussion_r3309967963) tripped ASAN exactly on this).

The current `HybridRequest_prepareForExecution` already reinitializes the cursor to an SDS-backed cursor — but only on the non-profile path. With `FT.PROFILE`-prefixed argv it leaves the cursor as RString, which is where the borrowed pointers come from.

**Change**: in `HybridRequest_prepareForExecution`, always parse `parseHybridCommand` from an SDS cursor backed by `hreq->args` (whose lifetime matches `hreq`). The RString cursor is still used briefly by `ParseProfile` to detect the profile flag, then discarded; we advance the SDS cursor by the same number of tokens `ParseProfile` consumed. After this, no plan step or RLookup key borrows from the dispatcher ctx's auto-memory.

With that invariant in place:
- Drop `CMDCTX_KEEP_RCTX` from the hybrid path. `threadHandleCommand` frees the dispatcher's ctx normally when the handler returns.
- `HybridDispatchCtx_Tail` installs its own replyCtx into `hreq->sctx->redisCtx` for the merge run, mirroring the shard background-worker pattern at [`hybrid_exec.c:1200-1203`](src/hybrid/hybrid_exec.c#L1200-L1203) (which is explicitly documented at [`hybrid_request.h:134`](src/hybrid/hybrid_request.h#L134): "the redisCtx inside can change if moving to different thread").
- Drop `dispatcherCtx` field from `HybridDispatchCtx`.

**Outcome**:
- `HybridDispatchCtx` shrinks from 5 fields to 3.
- `HybridDispatchCtx_Free` shrinks to: tear down `hreq` → free dispatch → unblock BC. No more ctx-before-BC ordering choreography.
- Only `CMDCTX_KEEP_BC` is needed (defer BC unblock until the tail finishes); `CMDCTX_KEEP_RCTX` is now used only by `dist_aggregate.c`.

### Verification

- `./build.sh DEBUG=1` — clean build.
- `./build.sh RUN_UNIT_TESTS SAN=address` — 863/863 pass, no leaks. This builds the Rust+C side under ASAN and runs all C/C++ unit tests including the hybrid suite (`test_cpp_hybrid`, `test_cpp_rpdepleter`, `test_cpp_hybridmerger`, `test_cpp_parse_hybrid`, etc.) and the coordinator unit tests (109/109).
- `REDIS_STANDALONE=0 ./build.sh RUN_PYTEST TEST=test_hybrid_timeout.py` — 29/29 pass, including `test_tail_property_not_loaded_warning_coordinator`.
- `REDIS_STANDALONE=0 ./build.sh RUN_PYTEST TEST=test_hybrid` — 25/25 pass.
- `REDIS_STANDALONE=0 ./build.sh RUN_PYTEST TEST="test_hybrid_dist test_hybrid_apply_filter test_hybrid_filter test_hybrid_distance test_hybrid_groupby test_hybrid_json test_hybrid_field_validation test_hybrid_linear test_hybrid_dialect"` — 37/37 pass.

#### Which additional issues this PR fixes

Follow-up to #9478 (Split hybrid command pipeline and use only the coordinator thread pool). Addresses the structural questions raised in [this comment thread](https://github.com/RediSearch/RediSearch/pull/9478#discussion_r3309233533) and [this one](https://github.com/RediSearch/RediSearch/pull/9478#discussion_r3309305860).

#### Main objects this PR modified

1. `HybridDispatchCtx` — dropped `dispatcherCtx` and `qctxErr` fields.
2. `HybridRequest_GetError` — added soft-code allowlist (`isSoftTailPipelineErrorCode`).
3. `HybridRequest_prepareForExecution` — split RString cursor (profile detection only) from SDS cursor (parser).
4. `scheduleHybridTail` / `HybridDispatchCtx_Tail` / `HybridDispatchCtx_Free` — simplified lifecycle: no `CMDCTX_KEEP_RCTX`, no dispatcher-ctx ownership transfer, redisCtx swapped to per-tail replyCtx.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-threaded hybrid coordinator lifecycle (ctx aliasing, parse cursors, error/warning routing); behavior is intentionally corrected for profile argv and hard tail errors, but regressions would show up in FT.HYBRID/PROFILE on cluster.
> 
> **Overview**
> This follow-up to the hybrid split-pipeline work simplifies coordinator dispatch and tightens how tail-pipeline errors are classified.
> 
> **Parsing and lifetime:** `HybridRequest_prepareForExecution` always feeds `parseHybridCommand` from an **hreq-owned SDS** args cursor (including `FT.PROFILE`), using a short-lived RString cursor only for `ParseProfile` and advancing the SDS cursor by the same token count. Plan/RLookup no longer borrow from the dispatcher thread’s Redis auto-memory, so the hybrid path stops retaining the dispatcher `RedisModuleCtx` (`CMDCTX_KEEP_RCTX` / `dispatcherCtx` removed). The tail worker sets `hreq->sctx->redisCtx` to its own thread-safe reply context for merge/reply, then clears it before teardown.
> 
> **Errors:** Tail pipeline errors go to `tailPipelineError` again; `HybridRequest_GetError` skips **`QUERY_ERROR_CODE_NO_PROP_VAL`** via `isSoftTailPipelineErrorCode` so the reply path can emit it as a warning instead of treating every tail error as non-fatal. `HybridDispatchCtx` drops to **hreq, index spec ref, and blocked client**; free path is decr hreq → free dispatch → unblock BC.
> 
> **Warnings:** Coordinator OOM warnings from cursor setup are copied onto `tailPipelineError` before the dispatcher stack `QueryError` goes away.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf94660869c718bc93ea7962d577d2d5d7a83dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->