### PR TITLE
MOD-15952: ci: add Redis-backed flaky-test DB and skip mechanism

### DIFF
--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -87,6 +87,10 @@ runs:
         REJSON_BRANCH: ${{ inputs.rejson-branch }}
         TEST_CONFIG: ${{ inputs.test-config }}
         VARIANT: ${{ inputs.variant }}
+        # Don't wipe tests/pytests/logs while listing — the coordinator
+        # listing runs after standalone tests, and otherwise the prior
+        # variant's failure logs would be deleted before artifact upload.
+        CLEAR_LOGS: "0"
       run: |
         if [ ! -s .flaky_skip.txt ]; then
           echo "No active flaky marks — running the full suite"

--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -38,6 +38,27 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Resolve target branch
+      # Merge-queue runs have empty github.base_ref and a synthetic ref_name
+      # (gh-readonly-queue/<target>/pr-...). The real target lives at
+      # github.event.merge_group.base_ref as `refs/heads/<branch>`.
+      # GH Actions expressions can't slice strings, so we strip the prefix in bash.
+      shell: bash -l -eo pipefail {0}
+      env:
+        MERGE_GROUP_BASE: ${{ github.event.merge_group.base_ref }}
+        BASE_REF: ${{ github.base_ref }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        if [ -n "$MERGE_GROUP_BASE" ]; then
+          branch="${MERGE_GROUP_BASE#refs/heads/}"
+        elif [ -n "$BASE_REF" ]; then
+          branch="$BASE_REF"
+        else
+          branch="$REF_NAME"
+        fi
+        echo "Resolved flaky target branch: $branch"
+        echo "FLAKY_BRANCH=$branch" >> "$GITHUB_ENV"
+
     - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
@@ -50,7 +71,7 @@ runs:
       env:
         REDIS_URL: ${{ inputs.redis-url }}
         REPO: ${{ github.repository }}
-        BRANCH: ${{ github.base_ref != '' && github.base_ref || github.ref_name }}
+        BRANCH: ${{ env.FLAKY_BRANCH }}
       run: |
         python3 ${{ github.action_path }}/../../scripts/flaky_db.py fetch \
           --output-json .flaky_skip.json \

--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -73,7 +73,12 @@ runs:
         REPO: ${{ github.repository }}
         BRANCH: ${{ env.FLAKY_BRANCH }}
       run: |
-        python3 ${{ github.action_path }}/../../scripts/flaky_db.py fetch \
+        # Use a workspace-relative path: `${{ github.action_path }}` expands to
+        # the runner host path, which doesn't exist when the step runs inside a
+        # Docker container (workspace is mounted at /__w/...). The composite
+        # action's working directory is $GITHUB_WORKSPACE, which is mapped
+        # correctly in both runner and container jobs.
+        python3 .github/scripts/flaky_db.py fetch \
           --output-json .flaky_skip.json \
           --output-list .flaky_skip.txt
 
@@ -103,7 +108,7 @@ runs:
           echo "::warning::LIST=1 enumeration failed — running full suite as fallback"
           exit 0
         }
-        python3 ${{ github.action_path }}/../../scripts/flaky_db.py filter \
+        python3 .github/scripts/flaky_db.py filter \
           --tests "$LIST_OUT" \
           --marks .flaky_skip.txt \
           --output "$TESTFILE_OUT"

--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -92,14 +92,9 @@ runs:
           echo "No active flaky marks — running the full suite"
           exit 0
         fi
-        # runtests.sh has a pre-existing bug: it calls `is_abspath` which is
-        # never defined, so every TESTFILE is treated as relative and gets
-        # $ROOT prepended. We therefore write the TESTFILE inside the workspace
-        # and pass a path relative to it. FAILEDFILE is unaffected because a
-        # separate typo in the same block (TESTFILE=… instead of FAILEDFILE=…)
-        # cancels the prepend out.
-        LIST_OUT=".flaky_list_${VARIANT}.raw"
-        TESTFILE_OUT=".flaky_testfile_${VARIANT}.txt"
+        mkdir -p /tmp/flaky
+        LIST_OUT="/tmp/flaky/list_${VARIANT}.raw"
+        TESTFILE_OUT="/tmp/flaky/run_${VARIANT}.txt"
         LIST=1 make pytest $TEST_CONFIG > "$LIST_OUT" 2>&1 || {
           echo "::warning::LIST=1 enumeration failed — running full suite as fallback"
           exit 0

--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -1,0 +1,96 @@
+name: Build TESTFILE excluding flaky tests
+description: |
+  Fetch active flaky marks for the current branch, enumerate tests with
+  `LIST=1 make pytest`, filter out marks (prefix match), and emit the path to
+  a TESTFILE the runner can consume.
+
+  Outputs an empty `testfile` if there are no active marks, or if any step
+  fails — callers should treat that as "run the full suite".
+
+inputs:
+  redis-url:
+    description: "Redis connection URL (rediss://...)"
+    required: true
+  variant:
+    description: "Label for filenames, e.g. 'standalone' or 'coordinator'"
+    required: true
+  redis-standalone:
+    description: "1 or 0 — propagated to runtests.sh as REDIS_STANDALONE"
+    required: true
+  test-config:
+    description: "Test config string forwarded to make (e.g. 'QUICK=1')"
+    required: true
+  rejson:
+    required: false
+    default: "1"
+  rejson-branch:
+    required: false
+    default: "master"
+  san:
+    required: false
+    default: ""
+
+outputs:
+  testfile:
+    description: "Filtered TESTFILE path; empty if no marks or any step failed"
+    value: ${{ steps.build.outputs.testfile }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - shell: bash -l -eo pipefail {0}
+      run: pip install 'redis>=6,<7'
+
+    - name: Fetch flaky skip list
+      shell: bash -l -eo pipefail {0}
+      env:
+        REDIS_URL: ${{ inputs.redis-url }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ github.base_ref != '' && github.base_ref || github.ref_name }}
+      run: |
+        python3 ${{ github.action_path }}/../../scripts/flaky_db.py fetch \
+          --output-json .flaky_skip.json \
+          --output-list .flaky_skip.txt
+
+    - name: Build TESTFILE
+      id: build
+      shell: bash -l -eo pipefail {0}
+      env:
+        SAN: ${{ inputs.san }}
+        REDIS_STANDALONE: ${{ inputs.redis-standalone }}
+        REJSON: ${{ inputs.rejson }}
+        REJSON_BRANCH: ${{ inputs.rejson-branch }}
+        TEST_CONFIG: ${{ inputs.test-config }}
+        VARIANT: ${{ inputs.variant }}
+      run: |
+        if [ ! -s .flaky_skip.txt ]; then
+          echo "No active flaky marks — running the full suite"
+          exit 0
+        fi
+        # runtests.sh has a pre-existing bug: it calls `is_abspath` which is
+        # never defined, so every TESTFILE is treated as relative and gets
+        # $ROOT prepended. We therefore write the TESTFILE inside the workspace
+        # and pass a path relative to it. FAILEDFILE is unaffected because a
+        # separate typo in the same block (TESTFILE=… instead of FAILEDFILE=…)
+        # cancels the prepend out.
+        LIST_OUT=".flaky_list_${VARIANT}.raw"
+        TESTFILE_OUT=".flaky_testfile_${VARIANT}.txt"
+        LIST=1 make pytest $TEST_CONFIG > "$LIST_OUT" 2>&1 || {
+          echo "::warning::LIST=1 enumeration failed — running full suite as fallback"
+          exit 0
+        }
+        python3 ${{ github.action_path }}/../../scripts/flaky_db.py filter \
+          --tests "$LIST_OUT" \
+          --marks .flaky_skip.txt \
+          --output "$TESTFILE_OUT"
+        if [ -s "$TESTFILE_OUT" ]; then
+          # The path is workspace-relative so runtests.sh's ROOT-prepend
+          # produces a valid absolute path.
+          echo "testfile=$TESTFILE_OUT" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::Filtered TESTFILE is empty — running full suite as fallback"
+        fi

--- a/.github/actions/flaky-record-results/action.yml
+++ b/.github/actions/flaky-record-results/action.yml
@@ -1,0 +1,60 @@
+name: Record test results to flaky DB
+description: |
+  Record test results from the current CI run to the flaky-test Redis DB.
+
+  Accepts two simple file inputs — one test id per line:
+    - failed-file: required for the failure side of the dataset
+    - passed-file: optional; only useful if your runner produces it (RLTest's
+      FAILEDFILE only gives failures, which is fine — pass counts can be added
+      later if needed)
+
+  This action never fails the job: it warns on connection errors so a flaky-DB
+  outage cannot break the test pipeline. The calling step should set
+  `if: always()` so failures are recorded even when tests fail.
+
+inputs:
+  redis-url:
+    description: "Redis connection URL (rediss://...)"
+    required: true
+  failed-file:
+    description: "Path to a file listing failing test ids, one per line"
+    required: false
+    default: ""
+  passed-file:
+    description: "Path to a file listing passing test ids, one per line"
+    required: false
+    default: ""
+  branch:
+    description: "Branch the run is associated with. Defaults to base_ref or ref_name."
+    required: false
+    default: ""
+  job-name:
+    description: "Short label for this job/shard, recorded with each result"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      shell: bash -l -eo pipefail {0}
+      run: pip install 'redis>=6,<7'
+
+    - name: Record results
+      shell: bash -l -eo pipefail {0}
+      env:
+        REDIS_URL: ${{ inputs.redis-url }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ inputs.branch != '' && inputs.branch || (github.base_ref != '' && github.base_ref || github.ref_name) }}
+        COMMIT: ${{ github.sha }}
+        WORKFLOW_RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+        JOB_NAME: ${{ inputs.job-name != '' && inputs.job-name || github.job }}
+        FAILED_FILE: ${{ inputs.failed-file }}
+        PASSED_FILE: ${{ inputs.passed-file }}
+      run: python ${{ github.action_path }}/../../scripts/flaky_db.py record

--- a/.github/actions/flaky-record-results/action.yml
+++ b/.github/actions/flaky-record-results/action.yml
@@ -78,4 +78,4 @@ runs:
         JOB_NAME: ${{ inputs.job-name != '' && inputs.job-name || github.job }}
         FAILED_FILE: ${{ inputs.failed-file }}
         PASSED_FILE: ${{ inputs.passed-file }}
-      run: python ${{ github.action_path }}/../../scripts/flaky_db.py record
+      run: python3 ${{ github.action_path }}/../../scripts/flaky_db.py record

--- a/.github/actions/flaky-record-results/action.yml
+++ b/.github/actions/flaky-record-results/action.yml
@@ -78,4 +78,6 @@ runs:
         JOB_NAME: ${{ inputs.job-name != '' && inputs.job-name || github.job }}
         FAILED_FILE: ${{ inputs.failed-file }}
         PASSED_FILE: ${{ inputs.passed-file }}
-      run: python3 ${{ github.action_path }}/../../scripts/flaky_db.py record
+      # See flaky-build-testfile for why a workspace-relative invocation is
+      # used here instead of ${{ github.action_path }}.
+      run: python3 .github/scripts/flaky_db.py record

--- a/.github/actions/flaky-record-results/action.yml
+++ b/.github/actions/flaky-record-results/action.yml
@@ -36,6 +36,27 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve target branch
+      # See flaky-build-testfile for why merge_group.base_ref needs special handling.
+      shell: bash -l -eo pipefail {0}
+      env:
+        OVERRIDE: ${{ inputs.branch }}
+        MERGE_GROUP_BASE: ${{ github.event.merge_group.base_ref }}
+        BASE_REF: ${{ github.base_ref }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        if [ -n "$OVERRIDE" ]; then
+          branch="$OVERRIDE"
+        elif [ -n "$MERGE_GROUP_BASE" ]; then
+          branch="${MERGE_GROUP_BASE#refs/heads/}"
+        elif [ -n "$BASE_REF" ]; then
+          branch="$BASE_REF"
+        else
+          branch="$REF_NAME"
+        fi
+        echo "Resolved flaky target branch: $branch"
+        echo "FLAKY_BRANCH=$branch" >> "$GITHUB_ENV"
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -50,7 +71,7 @@ runs:
       env:
         REDIS_URL: ${{ inputs.redis-url }}
         REPO: ${{ github.repository }}
-        BRANCH: ${{ inputs.branch != '' && inputs.branch || (github.base_ref != '' && github.base_ref || github.ref_name) }}
+        BRANCH: ${{ env.FLAKY_BRANCH }}
         COMMIT: ${{ github.sha }}
         WORKFLOW_RUN_ID: ${{ github.run_id }}
         RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/scripts/flaky_db.py
+++ b/.github/scripts/flaky_db.py
@@ -46,9 +46,11 @@ FAILURES_MAXLEN = 50_000
 
 _TAG_ESCAPE_CHARS = set(',.<>{}[]"\':;!@#$%^&*()-+=~ \\/?')
 # RLTest LIST=1 emits "<test_file>:<test_name>" (no .py suffix, no variant
-# suffix). The variant bracket is left in the regex in case a future RLTest
-# version starts emitting them — prefix matching handles both shapes.
-_TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_]\w*(?:\[[^\]]+\])?\s*$")
+# suffix). Class-based tests appear as "<test_file>:<Class>.<method>" — RLTest
+# joins them with a dot — so the name half must accept `.`. The variant bracket
+# is left in the regex in case a future RLTest version starts emitting them;
+# prefix matching handles both shapes.
+_TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_][\w.]*(?:\[[^\]]+\])?\s*$")
 
 
 def _connect() -> redis.Redis | None:

--- a/.github/scripts/flaky_db.py
+++ b/.github/scripts/flaky_db.py
@@ -1,0 +1,447 @@
+"""Flaky-test DB CLI — single entry point for all flaky-test operations.
+
+Subcommands:
+  fetch    Pull active marks for $REPO/$BRANCH into local files.
+  filter   Filter a test list against a marks file (prefix match).
+  mark     Add a flaky mark.
+  unmark   Remove a flaky mark.
+  record   Record failed/passed test ids for the current run.
+
+Context inputs (env):
+  REDIS_URL                 connection string (rediss://...)
+  REPO                      e.g. RediSearch/RediSearch
+  BRANCH                    e.g. master, 2.10, or *
+  ACTOR                     github.actor — who triggered the action
+  COMMIT                    git sha (record only)
+  WORKFLOW_RUN_ID           gh run id (record only)
+  RUN_ATTEMPT               gh run attempt number (record only)
+  JOB_NAME                  short label for the run/shard (record only)
+  TEST_ID, REASON, JIRA_KEY, DAYS  (mark)
+  TEST_ID, REASON                  (unmark)
+  FAILED_FILE, PASSED_FILE         (record)
+
+Any operation that talks to Redis is a no-op when REDIS_URL is empty — keeps
+fork-PR CI green when secrets aren't available.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import redis
+from redis.commands.search.field import NumericField, TagField, TextField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+from redis.commands.search.query import Query
+
+
+INDEX_NAME = "idx:marks"
+INDEX_PREFIX = "mark:"
+RUN_TTL_SECONDS = 60 * 86400
+AUDIT_MAXLEN = 100_000
+FAILURES_MAXLEN = 50_000
+
+_TAG_ESCAPE_CHARS = set(',.<>{}[]"\':;!@#$%^&*()-+=~ \\/?')
+# RLTest LIST=1 emits "<test_file>:<test_name>" (no .py suffix, no variant
+# suffix). The variant bracket is left in the regex in case a future RLTest
+# version starts emitting them — prefix matching handles both shapes.
+_TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_]\w*(?:\[[^\]]+\])?\s*$")
+
+
+def _connect() -> redis.Redis | None:
+    """Connect using REDIS_URL. Returns None when the URL is unset (fork PR)."""
+    url = os.environ.get("REDIS_URL", "").strip()
+    if not url:
+        print("REDIS_URL not set — skipping DB operation")
+        return None
+    return redis.from_url(url, socket_timeout=10, decode_responses=True)
+
+
+def _escape_tag(value: str) -> str:
+    return "".join(("\\" + c) if c in _TAG_ESCAPE_CHARS else c for c in value)
+
+
+def _ensure_index(client: redis.Redis) -> None:
+    try:
+        client.ft(INDEX_NAME).info()
+        return
+    except redis.ResponseError:
+        pass
+
+    schema = (
+        TagField("repo", sortable=True),
+        TagField("branch", sortable=True),
+        TagField("test_id", sortable=True),
+        TagField("jira_key", sortable=True),
+        TagField("marked_by"),
+        NumericField("created_at", sortable=True),
+        NumericField("expires_at", sortable=True),
+        TextField("reason"),
+    )
+    definition = IndexDefinition(prefix=[INDEX_PREFIX], index_type=IndexType.HASH)
+    try:
+        client.ft(INDEX_NAME).create_index(schema, definition=definition)
+        print(f"Created {INDEX_NAME}")
+    except redis.ResponseError as exc:
+        if "already exists" not in str(exc).lower():
+            raise
+
+
+def _summary(lines: list[str]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------- fetch
+
+def cmd_fetch(args: argparse.Namespace) -> int:
+    repo = os.environ["REPO"]
+    branch = os.environ["BRANCH"]
+    now = int(time.time())
+
+    result = {"generated_at": now, "repo": repo, "branch": branch, "skips": [], "status": "ok"}
+    client = _connect()
+
+    if client is None:
+        result["status"] = "no-url"
+    else:
+        try:
+            _ensure_index(client)
+            query_str = (
+                f"@repo:{{{_escape_tag(repo)}}} "
+                f"(@branch:{{{_escape_tag(branch)}}} | @branch:{{{_escape_tag('*')}}}) "
+                f"@expires_at:[({now} +inf]"
+            )
+            q = (
+                Query(query_str)
+                .return_fields("test_id", "branch", "reason", "jira_key", "marked_by", "expires_at")
+                .paging(0, 10000)
+            )
+            res = client.ft(INDEX_NAME).search(q)
+            # Prefer branch-specific rows over wildcard rows for the same test_id.
+            docs = sorted(res.docs, key=lambda d: 0 if getattr(d, "branch", "") == branch else 1)
+            seen: set[str] = set()
+            for doc in docs:
+                tid = getattr(doc, "test_id", "")
+                if not tid or tid in seen:
+                    continue
+                seen.add(tid)
+                result["skips"].append({
+                    "test_id": tid,
+                    "reason": getattr(doc, "reason", ""),
+                    "jira_key": getattr(doc, "jira_key", ""),
+                    "marked_by": getattr(doc, "marked_by", ""),
+                    "expires_at": int(getattr(doc, "expires_at", 0) or 0),
+                    "applied_via": "branch" if getattr(doc, "branch", "") == branch else "wildcard",
+                })
+        except Exception as exc:  # noqa: BLE001
+            result["status"] = "error"
+            result["error"] = str(exc)
+            print(f"::warning::Could not fetch flaky list: {exc}")
+
+    Path(args.output_json).write_text(json.dumps(result, indent=2))
+    Path(args.output_list).write_text(
+        "\n".join(s["test_id"] for s in result["skips"]) + ("\n" if result["skips"] else "")
+    )
+
+    print(f"Wrote {len(result['skips'])} skip(s) to {args.output_json} / {args.output_list}")
+    for skip in result["skips"]:
+        jira = f" [{skip['jira_key']}]" if skip["jira_key"] else ""
+        scope = "" if skip["applied_via"] == "branch" else " (wildcard)"
+        print(f"  - {skip['test_id']}{jira}{scope}")
+
+    if result["skips"]:
+        _summary([
+            f"### Flaky tests skipped on `{branch}` ({len(result['skips'])})",
+            "",
+            "| Test | Jira | Reason | Scope |",
+            "|---|---|---|---|",
+            *(
+                f"| `{s['test_id']}` | {s['jira_key']} | {s['reason']} | {s['applied_via']} |"
+                for s in result["skips"]
+            ),
+        ])
+    return 0
+
+
+# ---------------------------------------------------------------- filter
+
+def cmd_filter(args: argparse.Namespace) -> int:
+    raw = Path(args.tests).read_text().splitlines()
+    tests = [l.strip() for l in raw if _TEST_ID_RE.match(l.strip())]
+    marks = [l.strip() for l in Path(args.marks).read_text().splitlines() if l.strip()]
+
+    print(f"Input: {len(raw)} lines, {len(tests)} look like test ids, {len(marks)} mark(s)")
+
+    if not tests:
+        print("::warning::No recognisable test ids; writing empty TESTFILE")
+        Path(args.output).write_text("")
+        return 0
+    if not marks:
+        Path(args.output).write_text("\n".join(tests) + "\n")
+        return 0
+
+    kept: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for t in tests:
+        m = next((mark for mark in marks if t == mark or t.startswith(mark + "[")), None)
+        if m:
+            skipped.append((t, m))
+        else:
+            kept.append(t)
+
+    Path(args.output).write_text("\n".join(kept) + ("\n" if kept else ""))
+    print(f"Filter: {len(tests)} -> {len(kept)} kept, {len(skipped)} skipped")
+    for tid, mark in skipped[:50]:
+        print(f"  - {tid}  (matched mark {mark!r})")
+    if len(skipped) > 50:
+        print(f"  ... and {len(skipped) - 50} more")
+
+    if skipped:
+        _summary([
+            "",
+            f"**Flaky-skipped from this run** ({len(skipped)}):",
+            *(f"- `{tid}` (mark `{mark}`)" for tid, mark in skipped[:50]),
+        ])
+    return 0
+
+
+# ---------------------------------------------------------------- mark / unmark
+
+def cmd_mark(args: argparse.Namespace) -> int:
+    repo, branch, actor = os.environ["REPO"], os.environ["BRANCH"], os.environ["ACTOR"]
+    test_id = os.environ["TEST_ID"].strip()
+    reason = os.environ["REASON"].strip()
+    jira_key = os.environ["JIRA_KEY"].strip()
+
+    for name, value in (("test_id", test_id), ("reason", reason), ("jira_key", jira_key)):
+        if not value:
+            print(f"::error::{name} is empty")
+            return 1
+
+    try:
+        days = int(os.environ["DAYS"])
+    except ValueError:
+        print(f"::error::expires_in_days must be an integer, got: {os.environ['DAYS']!r}")
+        return 1
+    if not 1 <= days <= 365:
+        print(f"::error::expires_in_days must be between 1 and 365, got {days}")
+        return 1
+
+    client = _connect()
+    if client is None:
+        print("::error::REDIS_URL is required for mark")
+        return 1
+
+    now = int(time.time())
+    expires = now + days * 86400
+    key = f"mark:{repo}:{branch}:{test_id}"
+
+    with client.pipeline() as pipe:
+        pipe.hset(key, mapping={
+            "repo": repo, "branch": branch, "test_id": test_id,
+            "reason": reason, "jira_key": jira_key, "marked_by": actor,
+            "created_at": now, "expires_at": expires,
+        })
+        pipe.expireat(key, expires)
+        pipe.xadd("marks:audit", {
+            "action": "mark", "repo": repo, "branch": branch, "test_id": test_id,
+            "by": actor, "reason": reason, "jira_key": jira_key, "expires_at": str(expires),
+        }, maxlen=AUDIT_MAXLEN, approximate=True)
+        pipe.execute()
+
+    print(f"Marked '{test_id}' as flaky on {repo}@{branch}")
+    print(f"  Reason:  {reason}")
+    print(f"  Jira:    {jira_key}")
+    print(f"  Expires: {time.strftime('%Y-%m-%d %H:%M UTC', time.gmtime(expires))} ({days}d)")
+    return 0
+
+
+def cmd_unmark(args: argparse.Namespace) -> int:
+    repo, branch, actor = os.environ["REPO"], os.environ["BRANCH"], os.environ["ACTOR"]
+    test_id = os.environ["TEST_ID"].strip()
+    reason = os.environ["REASON"].strip()
+
+    if not test_id or not reason:
+        print("::error::test_id and reason are required")
+        return 1
+
+    client = _connect()
+    if client is None:
+        print("::error::REDIS_URL is required for unmark")
+        return 1
+
+    key = f"mark:{repo}:{branch}:{test_id}"
+    prev = client.hgetall(key)
+    existed = bool(prev)
+
+    with client.pipeline() as pipe:
+        pipe.delete(key)
+        pipe.xadd("marks:audit", {
+            "action": "unmark", "repo": repo, "branch": branch, "test_id": test_id,
+            "by": actor, "reason": reason,
+            "prev_jira_key": prev.get("jira_key", ""),
+            "prev_marked_by": prev.get("marked_by", ""),
+        }, maxlen=AUDIT_MAXLEN, approximate=True)
+        pipe.execute()
+
+    if not existed:
+        print(f"::warning::'{test_id}' was not marked on {repo}@{branch} — nothing to remove")
+        print("Audit entry was still recorded.")
+        return 0
+
+    print(f"Unmarked '{test_id}' on {repo}@{branch}")
+    print(f"  Reason:        {reason}")
+    if prev.get("marked_by"):
+        print(f"  Was marked by: {prev['marked_by']}")
+    if prev.get("jira_key"):
+        print(f"  Original jira: {prev['jira_key']}")
+    return 0
+
+
+# ---------------------------------------------------------------- record
+
+def _read_lines(path: str) -> list[str]:
+    if not path:
+        return []
+    p = Path(path)
+    if not p.exists():
+        return []
+    return [line.strip() for line in p.read_text().splitlines() if line.strip()]
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    failed = _read_lines(os.environ.get("FAILED_FILE", ""))
+    passed = _read_lines(os.environ.get("PASSED_FILE", ""))
+    if not failed and not passed:
+        print("No results to record (FAILED_FILE/PASSED_FILE empty or unset)")
+        return 0
+
+    client = _connect()
+    if client is None:
+        return 0  # fork PR or DB unset; recording is best-effort
+
+    repo = os.environ["REPO"]
+    branch = os.environ["BRANCH"]
+    commit = os.environ.get("COMMIT", "")
+    workflow_run_id = os.environ.get("WORKFLOW_RUN_ID", "0")
+    run_attempt = os.environ.get("RUN_ATTEMPT", "1")
+    job = os.environ.get("JOB_NAME", "default")
+
+    print(f"Recording {len(failed)} failure(s), {len(passed)} pass(es)")
+
+    now = int(time.time())
+    expires_at = now + RUN_TTL_SECONDS
+
+    try:
+        with client.pipeline(transaction=False) as pipe:
+            for status, test_ids in (("failed", failed), ("passed", passed)):
+                for test_id in test_ids:
+                    key = f"run:{workflow_run_id}:{run_attempt}:{job}:{test_id}"
+                    pipe.hset(key, mapping={
+                        "repo": repo, "branch": branch, "test_id": test_id, "status": status,
+                        "commit": commit, "workflow_run_id": workflow_run_id,
+                        "run_attempt": run_attempt, "job": job, "started_at": now,
+                    })
+                    pipe.expireat(key, expires_at)
+                    if status == "failed":
+                        pipe.xadd(f"failures:{repo}:{branch}", {
+                            "test_id": test_id, "commit": commit,
+                            "workflow_run_id": workflow_run_id, "run_attempt": run_attempt,
+                            "job": job, "started_at": str(now),
+                        }, maxlen=FAILURES_MAXLEN, approximate=True)
+            pipe.execute()
+    except Exception as exc:  # noqa: BLE001
+        print(f"::warning::Failed writing results to flaky DB: {exc}")
+        return 0
+
+    _summary([
+        "### Flaky DB updated",
+        "",
+        "| | Count |",
+        "|---|---|",
+        f"| Failures recorded | {len(failed)} |",
+        f"| Passes recorded | {len(passed)} |",
+        f"| Job | `{job}` |",
+        f"| Branch | `{branch}` |",
+    ])
+    if failed:
+        _summary(["", "**Failed:**", *(f"- `{tid}`" for tid in failed[:50])])
+        if len(failed) > 50:
+            _summary([f"- … and {len(failed) - 50} more"])
+    return 0
+
+
+# ---------------------------------------------------------------- main
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="flaky_db.py")
+    # Context flags: override the matching env var when present. Lets local
+    # users run the script without exporting a pile of envs.
+    parser.add_argument("--redis-url", help="Overrides REDIS_URL")
+    parser.add_argument("--repo", help="Overrides REPO")
+    parser.add_argument("--branch", help="Overrides BRANCH")
+    parser.add_argument("--actor", help="Overrides ACTOR")
+
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("fetch", help="Fetch active marks into local files")
+    p.add_argument("--output-json", default=".flaky_skip.json")
+    p.add_argument("--output-list", default=".flaky_skip.txt")
+    p.set_defaults(func=cmd_fetch)
+
+    p = sub.add_parser("filter", help="Filter a test list against marks (prefix match)")
+    p.add_argument("--tests", required=True)
+    p.add_argument("--marks", required=True)
+    p.add_argument("--output", required=True)
+    p.set_defaults(func=cmd_filter)
+
+    p = sub.add_parser("mark", help="Add a flaky mark")
+    p.add_argument("--test-id", help="Overrides TEST_ID")
+    p.add_argument("--reason", help="Overrides REASON")
+    p.add_argument("--jira-key", help="Overrides JIRA_KEY")
+    p.add_argument("--expires-in-days", type=int, help="Overrides DAYS")
+    p.set_defaults(func=cmd_mark)
+
+    p = sub.add_parser("unmark", help="Remove a flaky mark")
+    p.add_argument("--test-id", help="Overrides TEST_ID")
+    p.add_argument("--reason", help="Overrides REASON")
+    p.set_defaults(func=cmd_unmark)
+
+    p = sub.add_parser("record", help="Record failed/passed test ids")
+    p.add_argument("--failed-file", help="Overrides FAILED_FILE")
+    p.add_argument("--passed-file", help="Overrides PASSED_FILE")
+    p.add_argument("--commit", help="Overrides COMMIT")
+    p.add_argument("--workflow-run-id", help="Overrides WORKFLOW_RUN_ID")
+    p.add_argument("--run-attempt", help="Overrides RUN_ATTEMPT")
+    p.add_argument("--job-name", help="Overrides JOB_NAME")
+    p.set_defaults(func=cmd_record)
+
+    args = parser.parse_args()
+
+    # Mirror provided CLI flags into env vars so the cmd_* functions can keep
+    # reading from os.environ (and CI workflows that set env vars keep working).
+    _arg_to_env = {
+        "redis_url": "REDIS_URL", "repo": "REPO", "branch": "BRANCH", "actor": "ACTOR",
+        "test_id": "TEST_ID", "reason": "REASON", "jira_key": "JIRA_KEY",
+        "expires_in_days": "DAYS",
+        "failed_file": "FAILED_FILE", "passed_file": "PASSED_FILE",
+        "commit": "COMMIT", "workflow_run_id": "WORKFLOW_RUN_ID",
+        "run_attempt": "RUN_ATTEMPT", "job_name": "JOB_NAME",
+    }
+    for attr, env_name in _arg_to_env.items():
+        value = getattr(args, attr, None)
+        if value is not None:
+            os.environ[env_name] = str(value)
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/flaky_db.py
+++ b/.github/scripts/flaky_db.py
@@ -48,9 +48,13 @@ _TAG_ESCAPE_CHARS = set(',.<>{}[]"\':;!@#$%^&*()-+=~ \\/?')
 # RLTest LIST=1 emits "<test_file>:<test_name>" (no .py suffix, no variant
 # suffix). Class-based tests appear as "<test_file>:<Class>.<method>" — RLTest
 # joins them with a dot — so the name half must accept `.`. The variant bracket
-# is left in the regex in case a future RLTest version starts emitting them;
-# prefix matching handles both shapes.
+# is left in the parse regex in case a future RLTest version starts emitting
+# them; prefix matching handles both shapes.
 _TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_][\w.]*(?:\[[^\]]+\])?\s*$")
+# Marks must be variant-less: cmd_filter matches `test == mark` or
+# `test.startswith(mark + "[")`, so a mark with a `[variant]` suffix could
+# never match anything in current LIST=1 output and would silently no-op.
+_MARK_TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_][\w.]*\s*$")
 
 
 def _connect() -> redis.Redis | None:
@@ -227,7 +231,7 @@ def cmd_mark(args: argparse.Namespace) -> int:
             print(f"::error::{name} is empty")
             return 1
 
-    if not _TEST_ID_RE.match(test_id):
+    if not _MARK_TEST_ID_RE.match(test_id):
         print(f"::error::test_id {test_id!r} doesn't match the RLTest format "
               "'<test_file>:<test_name>' (no .py, no [variant])")
         return 1
@@ -281,7 +285,7 @@ def cmd_unmark(args: argparse.Namespace) -> int:
         print("::error::test_id and reason are required")
         return 1
 
-    if not _TEST_ID_RE.match(test_id):
+    if not _MARK_TEST_ID_RE.match(test_id):
         print(f"::error::test_id {test_id!r} doesn't match the RLTest format "
               "'<test_file>:<test_name>' (no .py, no [variant])")
         return 1

--- a/.github/scripts/flaky_db.py
+++ b/.github/scripts/flaky_db.py
@@ -2,7 +2,7 @@
 
 Subcommands:
   fetch    Pull active marks for $REPO/$BRANCH into local files.
-  filter   Filter a test list against a marks file (prefix match).
+  filter   Filter a test list against a marks file (exact or variant-suffix match).
   mark     Add a flaky mark.
   unmark   Remove a flaky mark.
   record   Record failed/passed test ids for the current run.
@@ -227,6 +227,11 @@ def cmd_mark(args: argparse.Namespace) -> int:
             print(f"::error::{name} is empty")
             return 1
 
+    if not _TEST_ID_RE.match(test_id):
+        print(f"::error::test_id {test_id!r} doesn't match the RLTest format "
+              "'<test_file>:<test_name>' (no .py, no [variant])")
+        return 1
+
     try:
         days = int(os.environ["DAYS"])
     except ValueError:
@@ -240,6 +245,8 @@ def cmd_mark(args: argparse.Namespace) -> int:
     if client is None:
         print("::error::REDIS_URL is required for mark")
         return 1
+
+    _ensure_index(client)
 
     now = int(time.time())
     expires = now + days * 86400
@@ -272,6 +279,11 @@ def cmd_unmark(args: argparse.Namespace) -> int:
 
     if not test_id or not reason:
         print("::error::test_id and reason are required")
+        return 1
+
+    if not _TEST_ID_RE.match(test_id):
+        print(f"::error::test_id {test_id!r} doesn't match the RLTest format "
+              "'<test_file>:<test_name>' (no .py, no [variant])")
         return 1
 
     client = _connect()
@@ -349,14 +361,14 @@ def cmd_record(args: argparse.Namespace) -> int:
                     pipe.hset(key, mapping={
                         "repo": repo, "branch": branch, "test_id": test_id, "status": status,
                         "commit": commit, "workflow_run_id": workflow_run_id,
-                        "run_attempt": run_attempt, "job": job, "started_at": now,
+                        "run_attempt": run_attempt, "job": job, "recorded_at": now,
                     })
                     pipe.expireat(key, expires_at)
                     if status == "failed":
                         pipe.xadd(f"failures:{repo}:{branch}", {
                             "test_id": test_id, "commit": commit,
                             "workflow_run_id": workflow_run_id, "run_attempt": run_attempt,
-                            "job": job, "started_at": str(now),
+                            "job": job, "recorded_at": str(now),
                         }, maxlen=FAILURES_MAXLEN, approximate=True)
             pipe.execute()
     except Exception as exc:  # noqa: BLE001
@@ -398,7 +410,7 @@ def main() -> int:
     p.add_argument("--output-list", default=".flaky_skip.txt")
     p.set_defaults(func=cmd_fetch)
 
-    p = sub.add_parser("filter", help="Filter a test list against marks (prefix match)")
+    p = sub.add_parser("filter", help="Filter a test list against marks (exact or variant-suffix match)")
     p.add_argument("--tests", required=True)
     p.add_argument("--marks", required=True)
     p.add_argument("--output", required=True)

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -1,0 +1,69 @@
+name: Flaky tests — mark
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch the mark applies to (e.g. master, 2.10, or * for all branches)'
+        required: true
+        default: 'master'
+        type: string
+      test_id:
+        description: 'Test identifier (e.g. tests/pytests/test_foo.py::test_bar)'
+        required: true
+        type: string
+      reason:
+        description: 'Why is this being skipped?'
+        required: true
+        type: string
+      jira_key:
+        description: 'Jira ticket tracking the flake (e.g. MOD-12345)'
+        required: true
+        type: string
+      expires_in_days:
+        description: 'Days until the mark expires (1-365)'
+        required: true
+        default: '30'
+        type: string
+
+jobs:
+  mark:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install 'redis>=6,<7'
+
+      - name: Mark test as flaky
+        env:
+          REDIS_URL: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          REASON: ${{ inputs.reason }}
+          JIRA_KEY: ${{ inputs.jira_key }}
+          DAYS: ${{ inputs.expires_in_days }}
+          ACTOR: ${{ github.actor }}
+        run: python .github/scripts/flaky_db.py mark
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "### Flaky mark recorded :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repo | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch | \`${{ inputs.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Test | \`${{ inputs.test_id }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Jira | ${{ inputs.jira_key }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reason | ${{ inputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Expires in | ${{ inputs.expires_in_days }} days |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Marked by | @${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -9,7 +9,7 @@ on:
         default: 'master'
         type: string
       test_id:
-        description: 'Test identifier (e.g. tests/pytests/test_foo.py::test_bar)'
+        description: "Test identifier in RLTest format: <test_file>:<test_name> (e.g. test_wildcard:testBasic — no .py, no [variant])"
         required: true
         type: string
       reason:
@@ -55,15 +55,27 @@ jobs:
 
       - name: Summary
         if: success()
+        env:
+          # Pass inputs through env so they're treated as data, not interpolated
+          # into the shell script by GitHub Actions before bash evaluates it.
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          JIRA_KEY: ${{ inputs.jira_key }}
+          REASON: ${{ inputs.reason }}
+          DAYS: ${{ inputs.expires_in_days }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "### Flaky mark recorded :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repo | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Branch | \`${{ inputs.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Test | \`${{ inputs.test_id }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Jira | ${{ inputs.jira_key }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Reason | ${{ inputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Expires in | ${{ inputs.expires_in_days }} days |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Marked by | @${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Flaky mark recorded :white_check_mark:"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Repo | \`$REPO\` |"
+            echo "| Branch | \`$BRANCH\` |"
+            echo "| Test | \`$TEST_ID\` |"
+            echo "| Jira | $JIRA_KEY |"
+            echo "| Reason | $REASON |"
+            echo "| Expires in | $DAYS days |"
+            echo "| Marked by | @$ACTOR |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -51,7 +51,7 @@ jobs:
           JIRA_KEY: ${{ inputs.jira_key }}
           DAYS: ${{ inputs.expires_in_days }}
           ACTOR: ${{ github.actor }}
-        run: python .github/scripts/flaky_db.py mark
+        run: python3 .github/scripts/flaky_db.py mark
 
       - name: Summary
         if: success()

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -9,7 +9,7 @@ on:
         default: 'master'
         type: string
       test_id:
-        description: 'Test identifier (must match exactly)'
+        description: "Test identifier in RLTest format: <test_file>:<test_name> (must match the original mark)"
         required: true
         type: string
       reason:
@@ -44,13 +44,23 @@ jobs:
 
       - name: Summary
         if: success()
+        env:
+          # Pass inputs through env so they're treated as data, not interpolated
+          # into the shell script by GitHub Actions before bash evaluates it.
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "### Flaky mark removed :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repo | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Branch | \`${{ inputs.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Test | \`${{ inputs.test_id }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Reason | ${{ inputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Unmarked by | @${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Flaky mark removed :white_check_mark:"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Repo | \`$REPO\` |"
+            echo "| Branch | \`$BRANCH\` |"
+            echo "| Test | \`$TEST_ID\` |"
+            echo "| Reason | $REASON |"
+            echo "| Unmarked by | @$ACTOR |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -1,0 +1,56 @@
+name: Flaky tests — unmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch the mark applies to (must match the original mark — use * if it was a wildcard)'
+        required: true
+        default: 'master'
+        type: string
+      test_id:
+        description: 'Test identifier (must match exactly)'
+        required: true
+        type: string
+      reason:
+        description: 'Why are we unmarking? (e.g. "fixed in #1234")'
+        required: true
+        type: string
+
+jobs:
+  unmark:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install 'redis>=6,<7'
+
+      - name: Unmark flaky test
+        env:
+          REDIS_URL: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+        run: python .github/scripts/flaky_db.py unmark
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "### Flaky mark removed :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repo | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch | \`${{ inputs.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Test | \`${{ inputs.test_id }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reason | ${{ inputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Unmarked by | @${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -40,7 +40,7 @@ jobs:
           TEST_ID: ${{ inputs.test_id }}
           REASON: ${{ inputs.reason }}
           ACTOR: ${{ github.actor }}
-        run: python .github/scripts/flaky_db.py unmark
+        run: python3 .github/scripts/flaky_db.py unmark
 
       - name: Summary
         if: success()

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -435,7 +435,10 @@ jobs:
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
-          FAILEDFILE: ${{ github.workspace }}/.failed_standalone.txt
+          # Relative path: ${{ github.workspace }} resolves to the runner host
+          # path, which is unreachable when the step runs in a container.
+          # runtests.sh prepends $ROOT for non-absolute FAILEDFILE values.
+          FAILEDFILE: .failed_standalone.txt
           TESTFILE: ${{ steps.standalone_testfile.outputs.testfile }}
         run: make pytest $TEST_CONFIG
 
@@ -445,7 +448,7 @@ jobs:
         uses: ./.github/actions/flaky-record-results
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
-          failed-file: ${{ github.workspace }}/.failed_standalone.txt
+          failed-file: .failed_standalone.txt
           job-name: ${{ needs.get-config.outputs.name }} standalone
 
       - name: Build TESTFILE excluding flaky tests (coordinator)
@@ -476,7 +479,7 @@ jobs:
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
-          FAILEDFILE: ${{ github.workspace }}/.failed_coordinator.txt
+          FAILEDFILE: .failed_coordinator.txt
           TESTFILE: ${{ steps.coordinator_testfile.outputs.testfile }}
         run: make pytest $TEST_CONFIG
 
@@ -486,7 +489,7 @@ jobs:
         uses: ./.github/actions/flaky-record-results
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
-          failed-file: ${{ github.workspace }}/.failed_coordinator.txt
+          failed-file: .failed_coordinator.txt
           job-name: ${{ needs.get-config.outputs.name }} coordinator
 
       - name: Rust tests (MIRI)
@@ -611,8 +614,8 @@ jobs:
             done < "$listfile"
           }
 
-          copy_for_failed_list "${{ github.workspace }}/.failed_standalone.txt"
-          copy_for_failed_list "${{ github.workspace }}/.failed_coordinator.txt"
+          copy_for_failed_list ".failed_standalone.txt"
+          copy_for_failed_list ".failed_coordinator.txt"
 
           # Always include the run-level RLTest summary log if present — it gives
           # session-level context that complements per-test logs.
@@ -623,7 +626,7 @@ jobs:
 
           # Stash the failed-test lists alongside the logs for downstream consumers.
           for f in .failed_standalone.txt .failed_coordinator.txt; do
-            [ -f "${{ github.workspace }}/$f" ] && cp "${{ github.workspace }}/$f" "$DEST/$f"
+            [ -f "$f" ] && cp "$f" "$DEST/$f"
           done
 
           echo "Failed-test logs bundled:"

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -441,6 +441,7 @@ jobs:
 
       - name: Record standalone failures to flaky DB
         if: ${{ always() && inputs.standalone && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
         uses: ./.github/actions/flaky-record-results
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
@@ -481,6 +482,7 @@ jobs:
 
       - name: Record coordinator failures to flaky DB
         if: ${{ always() && inputs.coordinator && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
         uses: ./.github/actions/flaky-record-results
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -407,6 +407,20 @@ jobs:
           CLEAR_LOGS: 0
           ENABLE_ASSERT: 1
         run: make rust-tests
+      - name: Build TESTFILE excluding flaky tests (standalone)
+        id: standalone_testfile
+        if: ${{ inputs.standalone && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/flaky-build-testfile
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          variant: standalone
+          redis-standalone: "1"
+          test-config: ${{ inputs.test-config }}
+          rejson: ${{ env.REJSON }}
+          rejson-branch: ${{ inputs.rejson-branch }}
+          san: ${{ inputs.san }}
+
       - name: Flow tests (standalone)
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: standalone_tests
@@ -421,7 +435,31 @@ jobs:
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
+          FAILEDFILE: ${{ github.workspace }}/.failed_standalone.txt
+          TESTFILE: ${{ steps.standalone_testfile.outputs.testfile }}
         run: make pytest $TEST_CONFIG
+
+      - name: Record standalone failures to flaky DB
+        if: ${{ always() && inputs.standalone && env.IS_FORK_PR != 'true' }}
+        uses: ./.github/actions/flaky-record-results
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          failed-file: ${{ github.workspace }}/.failed_standalone.txt
+          job-name: ${{ needs.get-config.outputs.name }} standalone
+
+      - name: Build TESTFILE excluding flaky tests (coordinator)
+        id: coordinator_testfile
+        if: ${{ inputs.coordinator && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/flaky-build-testfile
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          variant: coordinator
+          redis-standalone: "0"
+          test-config: ${{ inputs.test-config }}
+          rejson: ${{ env.REJSON }}
+          rejson-branch: ${{ inputs.rejson-branch }}
+          san: ${{ inputs.san }}
 
       - name: Flow tests (coordinator)
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
@@ -437,7 +475,17 @@ jobs:
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
+          FAILEDFILE: ${{ github.workspace }}/.failed_coordinator.txt
+          TESTFILE: ${{ steps.coordinator_testfile.outputs.testfile }}
         run: make pytest $TEST_CONFIG
+
+      - name: Record coordinator failures to flaky DB
+        if: ${{ always() && inputs.coordinator && env.IS_FORK_PR != 'true' }}
+        uses: ./.github/actions/flaky-record-results
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          failed-file: ${{ github.workspace }}/.failed_coordinator.txt
+          job-name: ${{ needs.get-config.outputs.name }} coordinator
 
       - name: Rust tests (MIRI)
         if: inputs.san == 'address' && inputs.unit-tests

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -17,6 +17,14 @@ cd $HERE
 
 #----------------------------------------------------------------------------------------------
 
+# Returns 0 (success) if $1 is an absolute path, non-zero otherwise.
+# Used to decide whether to prepend $ROOT to user-supplied file arguments.
+is_abspath() {
+	[[ "$1" == /* ]]
+}
+
+#----------------------------------------------------------------------------------------------
+
 help() {
 	cat <<-'END'
 		Run Python tests using RLTest
@@ -462,7 +470,7 @@ fi
 
 if [[ -n $FAILEDFILE ]]; then
 	if ! is_abspath "$FAILEDFILE"; then
-		TESTFILE="$ROOT/$FAILEDFILE"
+		FAILEDFILE="$ROOT/$FAILEDFILE"
 	fi
 	RLTEST_TEST_ARGS+=" -F $FAILEDFILE"
 fi


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: There is no shared place to record CI test failures over time, and no way to suppress a known-flaky test on a branch without a code change.
2. **Change**: Add a small Redis-backed flaky-test DB (stored in a Redis Cloud instance via `secrets.FLAKY_TESTS_REDIS_URL`) plus the workflows / composite actions to read and write it.
3. **Outcome**:
   * Anyone can mark a test as flaky from the Actions tab (per-branch), and it stops failing PRs targeting that branch until the mark expires.
   * Every flow-test failure is recorded with branch / commit / job / variant context, so we have history to point at when reasoning about flakes.
   * Branch isolation is honored — a mark on `master` does not skip the same test on `2.10` or `2.8`, and vice-versa. A wildcard `*` branch is supported for the rare case of "broken everywhere." Merge-queue runs resolve to the target branch via `github.event.merge_group.base_ref`.

#### Which additional issues this PR fixes
1. _none — no Jira ticket opened yet_

#### Main objects this PR modified

1. `.github/scripts/flaky_db.py` — single CLI with subcommands `fetch | filter | mark | unmark | record`. Uses a HASH per mark plus `FT.SEARCH idx:marks` (the index is auto-created if missing). Audit stream `marks:audit` captures both mark and unmark events; per-branch `failures:<repo>:<branch>` streams capture run-level failures with a 60d TTL.
2. `.github/workflows/task-flaky-mark.yml` / `task-flaky-unmark.yml` — `workflow_dispatch` forms. Inputs include `branch` (e.g. `master`, `2.10`, or `*`), `test_id`, `reason`, `jira_key`, and `expires_in_days`. User-supplied inputs flow through `env:` rather than `${{ inputs.* }}` substitution to keep the Summary steps safe from script injection.
3. `.github/actions/flaky-build-testfile/` — composite action that fetches active marks, runs `LIST=1 make pytest`, filters out marked tests by prefix (variant-suffix-aware), and emits a TESTFILE that `runtests.sh` consumes. Falls back to running the full suite on any error. Runs the listing with `CLEAR_LOGS=0` so a preceding variant's failure logs survive to artifact upload.
4. `.github/actions/flaky-record-results/` — composite action that writes the contents of `FAILEDFILE` to Redis (HASH per failure + per-branch stream).
5. `.github/workflows/task-test.yml` — wires the two composite actions around the standalone and coordinator flow-test steps. Recording uses `if: always() && continue-on-error: true` so failures are captured on red runs and a Redis blip can't red a green job. Fork PRs (no secret access) silently skip both sides.
6. `tests/pytests/runtests.sh` — defines the missing `is_abspath` function that was referenced but never declared (causing every `TESTFILE` to be treated as relative and `$ROOT`-prepended) and fixes an adjacent typo where the `FAILEDFILE` block was assigning to `TESTFILE`.

#### Notes / known limitations

* Only the python flow tests are wired up. C/C++ and Rust unit tests aren't tracked yet — different runners, different output formats; can be added in a follow-up.
* Required ahead of this landing: the Redis Cloud database referenced by `FLAKY_TESTS_REDIS_URL` must have the RediSearch module enabled (it already does on the instance I tested against — confirmed `MODULE LIST` shows `search`).
* Test-id format follows what RLTest's `LIST=1` emits: `test_file:test_name` for free function tests and `test_file:Class.method` for class-based tests (no `.py`, no variant suffix). Mark inputs should match this shape. The prefix match leaves room for future variant suffixes if RLTest ever starts emitting them.

#### Local validation done

* `flaky_db.py fetch | mark | unmark` round-tripped against the real Redis Cloud DB (index auto-created, FT.SEARCH branch filtering verified, branch isolation between `master` and `2.10` confirmed).
* Prefix filter run against a real `LIST=1` output of 2001 lines — 1 mark excluded the matching test and left siblings intact. After widening the test-id regex to accept `.` in the test name, the filter now recognises all 1982 tests (including ~308 class-based tests that the original regex was silently dropping).
* `LIST=1 ... TESTFILE=/tmp/...txt` against `runtests.sh` confirmed RLTest only enumerates the tests listed in the file. Both absolute and relative TESTFILE paths now work (was previously broken for absolute paths by the missing `is_abspath`).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tests run in CI (skipped flakes) and depend on a shared secret/Redis service; failures are best-effort and fall back to full suite, but mis-marked tests could hide real regressions on protected branches.
> 
> **Overview**
> Adds a **Redis-backed flaky-test system** for Python flow tests in CI: marks can suppress known flakes per branch (or `*`), failures are recorded for history, and operators manage marks via `workflow_dispatch` without code changes.
> 
> **`flaky_db.py`** is the single CLI (`fetch`, `filter`, `mark`, `unmark`, `record`) using RediSearch on `mark:*` hashes, audit streams, and per-branch failure streams. Empty `REDIS_URL` no-ops so fork PRs stay green.
> 
> **Composite actions** `flaky-build-testfile` (resolve merge-queue target branch → fetch marks → `LIST=1` enumerate → filter → optional `TESTFILE`) and `flaky-record-results` (write `FAILEDFILE` to Redis, never fail the job). Both use workspace-relative paths for container jobs.
> 
> **`task-test.yml`** wires these around standalone and coordinator `make pytest`, with `continue-on-error` / `if: always()` so Redis issues do not block the pipeline. **`runtests.sh`** adds missing `is_abspath` and fixes `FAILEDFILE` being wrongly assigned to `TESTFILE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b21988fd50cdc9677202f3da4aba8e2ab3d00b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->