### PR TITLE
ttl_table_ffi: reuse shared test helpers to fix musl build

### DIFF
--- a/src/redisearch_rs/c_entrypoint/ttl_table_ffi/tests/main.rs
+++ b/src/redisearch_rs/c_entrypoint/ttl_table_ffi/tests/main.rs
@@ -18,30 +18,16 @@
 
 use std::ptr;
 
-use ffi::{FieldExpiration, t_expirationTimePoint};
+use ffi::FieldExpiration;
 use field::FieldExpirationPredicate;
 use redis_mock::mock_or_stub_missing_redis_c_symbols;
 use ttl_table::FieldExpirations;
+use ttl_table::test_utils::{FUTURE, NOW, PAST, fe};
 use ttl_table_ffi::*;
 
 mock_or_stub_missing_redis_c_symbols!();
 
 const MAX_SIZE: usize = 1024;
-
-const fn ts(sec: i64, nsec: i64) -> t_expirationTimePoint {
-    t_expirationTimePoint {
-        tv_sec: sec as libc::time_t,
-        tv_nsec: nsec as libc::c_long,
-    }
-}
-
-const PAST: t_expirationTimePoint = ts(999, 0);
-const NOW: t_expirationTimePoint = ts(1000, 0);
-const FUTURE: t_expirationTimePoint = ts(1001, 0);
-
-const fn fe(index: u16, point: t_expirationTimePoint) -> FieldExpiration {
-    FieldExpiration { index, point }
-}
 
 /// Run `f` against a freshly initialized, automatically-destroyed table.
 fn with_table<F>(f: F)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The integration tests in `src/redisearch_rs/c_entrypoint/ttl_table_ffi/tests/main.rs` define a local `ts()` helper that builds a `t_expirationTimePoint` by casting through `libc::time_t`. After the `libc` bump from 0.2.182 → 0.2.186 in #8075, that alias is `#[deprecated]` on musl targets ([rust-lang/libc#1848](https://github.com/rust-lang/libc/issues/1848)), so the alpine:3.23 / musl CI job (e.g. [this run](https://github.com/RediSearch/RediSearch/actions/runs/26514525334/job/78088143736)) fails with `-D deprecated` implied by `-D warnings`:

   ```
   error: use of deprecated type alias `libc::time_t`: This type is changed to 64-bit in musl 1.2.0...
     --> c_entrypoint/ttl_table_ffi/tests/main.rs:33:30
   ```

   The musl target only runs in `event-periodic-master-validation.yml` and `event-merge-to-queue.yml`, not on PR CI, which is why #9518 ("[MOD-14980] ttl_table FFI") landed green despite shipping the un-annotated copy of the helper.

2. **Change**: Drop the duplicated `ts()` / `fe()` / `PAST` / `NOW` / `FUTURE` defs from `tests/main.rs` and import the canonical copies from `ttl_table::test_utils` (already in dev-dependencies, gated behind the `test-utils` feature). That module's `ts()` carries the right `#[cfg_attr(target_env = "musl", expect(deprecated))]` suppression and a comment pointing at libc#1848.

3. **Outcome**: Musl/alpine builds compile clean. No behavioural change — `test_utils::FUTURE` is `ts(1000, 1)` instead of the previous local `ts(1001, 0)`, but both are strictly after `NOW = ts(1000, 0)` so the `VerifyDocAndField` / `VerifyDocAndFieldMask` predicate assertions behave identically. All 9 tests pass locally. Bonus: no future drift between the two copies of the helper.

#### Which additional issues this PR fixes
1. n/a

#### Main objects this PR modified
1. `src/redisearch_rs/c_entrypoint/ttl_table_ffi/tests/main.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

[MOD-14980]: https://redislabs.atlassian.net/browse/MOD-14980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6150f7bc0cde2a2dd80e1cf1af1ffa6e130feb63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->