### PR TITLE
[MOD-15875] ci: use webhook-trigger for Slack workflow payloads

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -338,7 +338,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
           webhook-type: webhook-trigger
-          errors: true
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
@@ -355,7 +355,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
           webhook-type: webhook-trigger
-          errors: true
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -337,7 +337,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
@@ -353,7 +354,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
           webhook-type: webhook-trigger
-          errors: true
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "repository": "${{ github.repository }}",

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -30,7 +30,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true
           payload: |
             {
               "repository": "${{ github.repository }}",

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
           webhook-type: webhook-trigger
-          errors: true
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -52,7 +52,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -228,7 +228,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_POST_MERGE_VALIDATION_FAILED }}
           webhook-type: webhook-trigger
-          errors: true
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -228,6 +228,7 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_POST_MERGE_VALIDATION_FAILED }}
           webhook-type: webhook-trigger
+          errors: true
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The v1 → v3 slack-github-action migration in #9840 picked `webhook-type: incoming-webhook`, but the affected secrets (`SLACK_WEBHOOK_URL_SNAPSHOT_FAILED`, `SLACK_WEBHOOK_URL_NIGHTLY_FAILED`, `SLACK_WEBHOOK_URL_BENCHMARK_FAILED`, `SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED`) are Slack **Workflow Builder triggers**. The custom payload keys (`failed_workflow`, `repository`, …) are Workflow Builder variables, not Slack chat fields.

2. **Change:** Switch `webhook-type` to `webhook-trigger` in the 4 sites the migration touched, and add `errors: true` so future misconfiguration fails loudly instead of being silently retried.

3. **Outcome:** Failure notifications actually reach Slack again. Steps that misconfigure the webhook will fail the job instead of green-painting a swallowed error.

### Sites changed (3 files, 4 sites)

| File | Job |
|---|---|
| `event-deploy-snapshots.yml` | `notify-failure` |
| `event-nightly.yml` | `notify-failure` |
| `benchmark-runner.yml` | `notify-failure` |
| `benchmark-runner.yml` | `notify-msmarco-failure` |

### Evidence the previous config was silently broken

Nightly Flow job `78191362552` (run `26538540894`): the v3 slack step ran for ~3.5 min (5 retries with backoff) and exited green without delivering a notification. In v3, `errors: false` is the default, so swallowed retries look like success.

### Out of scope

- `daily-ci-report.yml` was already on v2 with `webhook-type: incoming-webhook` before MOD-15875; not in this PR's scope. Will be audited separately.
- Backports to active release branches will follow once this PR merges.

#### Which additional issues this PR fixes

1. MOD-15875 followup to #9840

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Slack webhook configuration; no product code, APIs, or runtime behavior changes.
> 
> **Overview**
> Fixes **Slack failure notifications** that stopped working after the `slack-github-action` v3 migration by using **`webhook-type: webhook-trigger`** instead of **`incoming-webhook`** on the Workflow Builder URLs (snapshot, nightly, and benchmark notify jobs).
> 
> Also sets **`errors: true`** on those steps and on **post-merge CIE triage** in `event-periodic-master-validation.yml`, so Slack delivery failures fail the job instead of retrying silently and showing green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1359014d0fa4f772c10dd994d0155e6d92e35dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->