### PR TITLE
[8.0] [MOD-15875] ci: use webhook-trigger for Slack workflow payloads

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -216,7 +216,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -26,7 +26,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "branch": "${{ github.ref_name }}",

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -52,7 +52,8 @@ jobs:
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
+          errors: true  # fail step on Slack delivery errors; v3 default silently retries
           payload: |
             {
               "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"


### PR DESCRIPTION
Followup to #9840 backport (#9853) and #9873 master fix.

The original Slack v1 → v3 migration picked `webhook-type: incoming-webhook` but the affected secrets are Slack Workflow Builder triggers. This fix flips `webhook-type` to `webhook-trigger` on the 3 sites that exist on 8.0 and adds `errors: true` to surface future webhook misconfiguration loudly.

Sites changed on 8.0 (the `notify-msmarco-failure` job that exists on master/8.8 is not present here). 

| File | Job |
|---|---|
| `event-deploy-snapshots.yml` | `notify-failure` |
| `event-nightly.yml` | `notify-failure` |
| `benchmark-runner.yml` | `notify-failure` |

See #9873 for the master fix and full context.

CI-only change; no user-visible impact.

- [ ] This PR requires release notes
- [x] This PR does not require release notes
