### PR TITLE
ci: retry transient 404s in periodic-master-validation gh_api calls

### DIFF
--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -49,12 +49,27 @@ jobs:
           import os
           import re
           import subprocess
+          import sys
+          import time
 
           WORKFLOW_FILE = "event-periodic-master-validation.yml"
           VALIDATION_JOB_PREFIX = "test-selected-platforms"
 
-          def gh_api(path):
-              return json.loads(subprocess.check_output(["gh", "api", path], text=True))
+          def gh_api(path, attempts=5):
+              # The Actions REST API (esp. /actions/runs/{id}/jobs) occasionally
+              # returns transient HTTP 404 / 5xx for resources that exist; retry
+              # with short backoff before giving up.
+              for attempt in range(1, attempts + 1):
+                  result = subprocess.run(
+                      ["gh", "api", path],
+                      capture_output=True, text=True, check=False,
+                  )
+                  if result.returncode == 0:
+                      return json.loads(result.stdout)
+                  if attempt == attempts:
+                      sys.stderr.write(result.stderr)
+                      result.check_returncode()
+                  time.sleep(2 * attempt)
 
           def validation_passed(run):
               jobs = gh_api(
@@ -182,6 +197,8 @@ jobs:
           import os
           import re
           import subprocess
+          import sys
+          import time
           import uuid
 
           FAILED_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required"}
@@ -191,8 +208,21 @@ jobs:
               with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
                   output.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
-          def gh_api(path):
-              return json.loads(subprocess.check_output(["gh", "api", path], text=True))
+          def gh_api(path, attempts=5):
+              # The Actions REST API (esp. /actions/runs/{id}/jobs) occasionally
+              # returns transient HTTP 404 / 5xx for resources that exist; retry
+              # with short backoff before giving up.
+              for attempt in range(1, attempts + 1):
+                  result = subprocess.run(
+                      ["gh", "api", path],
+                      capture_output=True, text=True, check=False,
+                  )
+                  if result.returncode == 0:
+                      return json.loads(result.stdout)
+                  if attempt == attempts:
+                      sys.stderr.write(result.stderr)
+                      result.check_returncode()
+                  time.sleep(2 * attempt)
 
           repository = os.environ["REPOSITORY"]
           run_id = os.environ["RUN_ID"]


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Both `gh_api()` helpers in `event-periodic-master-validation.yml` (used by the `should-run` gating job and by `notify-cie-failure` when assembling the Slack payload) call `subprocess.check_output(["gh", "api", ...])` with no retry. GitHub's Actions REST endpoint `/repos/{owner}/{repo}/actions/runs/{id}/jobs` occasionally returns a transient `HTTP 404` for a run that demonstrably exists. A single flaky 404 fails the gating job, which then cascades into `notify-cie-failure` — which itself 404's on the same endpoint while building the payload. Surfaced as https://github.com/RediSearch/RediSearch/actions/runs/26576756631 (the previous run of the same script on a9907c7c8 succeeded against the same data).

2. **Change:** Wrap both `gh_api()` helpers with a 5-attempt linear backoff (2s, 4s, 6s, 8s). Switch from `check_output` to `subprocess.run(..., check=False)` so the loop can inspect `returncode` and stderr. On final failure, write `gh`'s stderr (e.g. `gh: Not Found (HTTP 404)`) before raising, so future debugging shows the real GitHub error rather than just a Python traceback.

3. **Outcome:** Transient 404/5xx from the Actions API no longer fail the periodic-master-validation gating step or its failure-notification job. Real `404 Not Found` errors (e.g. a genuinely missing run id) still fail loudly after retries are exhausted, with the underlying gh error logged.

Reproduced the flakiness locally — 2 of 5 sequential identical calls returned `HTTP 404` against the same existing run id. After the change, the retry recovers on the next attempt.

#### Which additional issues this PR fixes
N/A (no Jira ticket)

#### Main objects this PR modified
1. `.github/workflows/event-periodic-master-validation.yml` — `gh_api()` helpers in `should-run.steps.check` and `notify-cie-failure.steps.failure-details`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-facing behavior.

## Test plan

- [ ] Merge and observe the next periodic-master-validation push run completes the `should-run` step (or, if it transiently 404s, that the retries kick in — logged on the runner).
- [ ] If a future failure exhausts retries, the step log should show `gh: ... (HTTP 4xx/5xx)` from `gh`'s stderr before the Python traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to workflow Python helpers; no product code, auth, or data paths.
> 
> **Overview**
> Both inline **`gh_api()`** helpers in **`event-periodic-master-validation.yml`** (the **`should-run`** gating step and **`notify-cie-failure`**) now call **`gh api`** with **up to five attempts** and **linear backoff** (`2s`, `4s`, …) instead of a single **`subprocess.check_output`**.
> 
> That targets **transient HTTP 404/5xx** from the Actions REST API (especially **`/actions/runs/{id}/jobs`**) so periodic validation gating and failure Slack prep are less likely to fail on flaky API responses. On the last failed attempt, **`gh`**’s **stderr** is written before the step raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c8cbdeff7c6be3055a9cc795523b9061600dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->