### PR TITLE
[MOD-15505] Improve ~23% indexing throughput: unicode_tolower: skip nunicode pipeline on ASCII-only tokens

### DIFF
--- a/.skills/bisect-perf-regression/SKILL.md
+++ b/.skills/bisect-perf-regression/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: bisect-perf-regression
+description: Systematically bisect an end-to-end performance regression between two refs (tags/branches/commits) down to the exact offending commit(s). Use this when CI/customer benchmarks show one version is measurably slower than another and you need to attribute the cost to specific PRs.
+---
+
+# Bisect a performance regression
+
+Pin a perf regression to specific commits using drift-cancelled, repeated, cold benchmarks.
+
+You will need (or need to build) a small harness around the workload of interest.
+The exact shape of the harness does not matter, as long as it satisfies the
+properties described in step 1 below (interleaved labels, cold per-iteration
+state, median + CV reporting).
+
+## Arguments
+
+`$ARGUMENTS` should identify:
+- A **good** ref (older / fast) and a **bad** ref (newer / slow)
+- A reproducible workload and its parameters (workload size, dataset, mode),
+  expressed as whatever the harness consumes (env vars, CLI flags, config file)
+- An expected gap (so you can stop early when a real step is found)
+
+## Instructions
+
+### 1. Reproduce the gap stably before bisecting
+
+Before bisecting anything, prove the two endpoints are reliably distinguishable.
+
+- Use an interleaved harness that restarts the server (or the system under
+  test) per iteration so any cached state is cold each run, drives the workload
+  round-robin across labels
+  (so environmental drift attaches equally to every label), and reports median +
+  CV per label. Sequential "all N runs of label A, then all N runs of label B"
+  attributes any host drift across the wall-clock window entirely to the second
+  label, and is the single largest source of false positives in perf bisection.
+- Pin CPU count (e.g. `--cpus=8` for a Docker harness) and run on a quiet Linux
+  host. Shared/laptop Docker setups (macOS Docker Desktop, Codespaces, noisy CI
+  runners) are generally too jittery for sub-3% deltas.
+- **Pick `N_RUNS` adaptively from observed CV — don't burn 5–8 runs by default.**
+  - Start at `N_RUNS=3` (the minimum that yields a stdev/CV).
+  - After the run, inspect the per-label CV printed by the harness:
+    | observed max CV across labels | action |
+    |-------------------------------|-------|
+    | ≤ 1.5 %                       | 3 runs is enough, accept the medians |
+    | 1.5 – 2.5 %                   | rerun with `N_RUNS=5` for the labels involved in the suspect step |
+    | 2.5 – 4 %                     | rerun with `N_RUNS=8`, and only trust deltas ≥ 2 × max CV |
+    | > 4 %                         | the host is too noisy — fix it before bisecting (see below) |
+  - A claim is "real" when the median gap exceeds `max(3 %, 2 × max CV across the two labels)`.
+- If CV stays > 4 % even at `N_RUNS=8`, increase the per-run workload size, or
+  fix the host (other processes, CPU governor, thermal throttling, neighbour VMs)
+  before continuing — bisection on noisy data attributes regressions to the
+  wrong commit.
+
+### 2. Bracket with version tags first, then commits
+
+Always start with broad strokes and narrow down — never start at the commit level.
+
+1. **Tag ladder** — list the released tags between good and bad and run them all
+   in one interleaved sweep so they share drift. For example, with a project
+   that has tags `v2.10.12 … v2.10.30`, run all of them as labels in a single
+   interleaved sweep at `N_RUNS=3`. Look for the **step** — the adjacent pair
+   with the largest jump. That's your new `[lo, hi]` interval.
+2. **First-parent commit bisect** within `[lo, hi]`. Enumerate evenly-spaced
+   first-parent commits that actually touched code (filter to `src/*`,
+   `deps/*`, or the relevant subtrees — skip pure CI / docs / vendoring
+   commits, since they cannot move performance). Build them, run the
+   interleaved bench `[lo, p1, p2, …, hi]`, and inspect adjacent deltas.
+   Start at `N_RUNS=3` and escalate per the CV table in step 1.
+3. **Iterate** — pick the adjacent pair with the largest delta, recurse on
+   that narrower interval. Stop when `[lo, hi]` is one commit, or when the
+   remaining interval is below the noise floor.
+
+### 3. Watch for compounding / multi-step regressions
+
+A single endpoint number like "+30% slower" can hide several smaller steps that
+may compound through the same code path. Always print the full per-tag /
+per-commit ladder, not just endpoint deltas — a smooth slope versus a single
+cliff have very different fixes.
+
+### 3a. Isolating residuals with the "fix-on-commit" technique
+
+When a known regression dominates the gap and a fix is already in flight,
+**apply that fix on top of every historical commit you benchmark**. This
+neutralises the known cost so the ladder surfaces only the *residual*
+regressions that arrived alongside it. Without this technique, a large dominant
+cost can mask smaller but still real per-commit jumps.
+
+Build the fix-on-commit variants by:
+1. Creating a `fix-on-<sha>` branch off `<sha>`.
+2. Applying the in-flight fix on top.
+3. Building and benching that branch the same way you would a stock commit.
+
+Use a **code injector** (a small script that locates the target function by
+signature regex, balances braces to find its body, and inserts the fix at a
+known anchor) rather than a static `git apply` patch when:
+- the target function's signature changes inside the bracketed range, or
+- surrounding code shifts line numbers across tags (3-line context is too
+  small to disambiguate, and `--ignore-whitespace` won't save you).
+
+Keep the injector **idempotent** (detect its own marker before injecting) so
+reruns are safe across rebuilds.
+
+### 4. Confirm the offender
+
+Once a single commit is suspected:
+
+- Read the diff. The change must plausibly cause the observed cost (e.g. new
+  syscalls per token, new allocations per doc, new Rust↔C boundary calls).
+- Run a **confirmation pair**: `[<commit>^, <commit>]` only. Here it's worth
+  spending more iterations than the bisect ladder used — start at `N_RUNS=5`
+  and escalate to 8 if max CV > 2.5 %. The delta should match the step size
+  found during bisection to within `2 × max CV`.
+- If you can, build a **revert candidate** (`<bad>` with just that commit reverted)
+  and confirm it returns to `<lo>` performance. This guards against picking up an
+  innocent commit that sits next to the real offender via a noisy run.
+
+### 5. Honest reporting
+
+Report only what the data supports:
+- Endpoint medians + CV
+- The bisection ladder with adjacent deltas
+- The candidate commit(s), with PR link, author, and a one-line cause hypothesis
+  grounded in the diff
+- Residual unexplained delta, if any, with the noise floor
+
+Do not round, do not collapse multi-step regressions into a single cause, and do
+not skip the confirmation step.
+
+## Common pitfalls
+
+- **Cold-cache leakage into the first iteration** — the first build in a
+  session is usually slow due to docker layer pulls or compiler-cache warm-up.
+  Pre-build all artifacts before starting the timed benchmark.
+- **Wrong runtime/base image for the branch under test** — each build must run
+  against the runtime version it was compiled against (different minor branches
+  often pin different runtime/host versions). Verify the harness picks the
+  correct base image / runtime per label.
+- **Auto-loaded bundled component** — some base images auto-load a bundled
+  version of the component under test via the entrypoint. Bypass that (e.g.
+  override the entrypoint) so the component you actually want to measure is the
+  only one loaded.
+- **Toolchain / dependency drift across the bisect range** — historical tags may
+  need patches (compiler / library API breakage on newer hosts) or a specific
+  toolchain pin (e.g. a particular nightly). Wrap the per-commit build in a
+  script that detects the tag and applies the required patches / toolchain pin
+  on demand.
+
+## Report Back
+
+End with:
+- The good→bad ladder (medians, CV, adjacent %)
+- The implicated commit(s), short SHA + PR + title
+- The confirmation-pair numbers
+- A diff-grounded hypothesis for *why* the commit costs what it does
+- Residual gap, if any, and what would be needed to attribute it

--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -120,21 +120,26 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
   // single-codepoint ASCII character. Standard ASCII case folding (A-Z -> a-z)
   // is byte-length preserving and matches what the nunicode pipeline would
   // produce for codepoints < 0x80, so we can lowercase in place and skip the
-  // multi-pass transform entirely. This is the common case for English /
-  // MS MARCO-style corpora; multibyte inputs fall through to the slow path
-  // at the first byte with bit 7 set, so the scan cost on multibyte inputs
-  // is bounded by the position of the first non-ASCII byte (often 0).
+  // multi-pass transform entirely. The scan also stops at an embedded NUL,
+  // because nu_utf8_read treats codepoint 0 as end-of-string and truncates
+  // the output there. Multibyte inputs fall through to the slow path at the
+  // first byte with bit 7 set.
   {
     size_t j = 0;
-    while (j < in_len && (unsigned char)encoded[j] < 0x80) {
+    while (j < in_len) {
+      unsigned char c = (unsigned char)encoded[j];
+      if (c == 0 || c >= 0x80) break;
       j++;
     }
-    if (j == in_len) {
-      for (size_t k = 0; k < in_len; k++) {
+    if (j == in_len || (unsigned char)encoded[j] == 0) {
+      for (size_t k = 0; k < j; k++) {
         unsigned char c = (unsigned char)encoded[k];
         if (c >= 'A' && c <= 'Z') {
           encoded[k] = (char)(c + ('a' - 'A'));
         }
+      }
+      if (j < in_len && j > 0) {
+        *inout_len = j;
       }
       return NULL;
     }

--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -131,7 +131,7 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
       if (c == 0 || c >= 0x80) break;
       j++;
     }
-    if (j == in_len || (unsigned char)encoded[j] == 0) {
+    if (j == in_len || encoded[j] == 0) {
       for (size_t k = 0; k < j; k++) {
         unsigned char c = (unsigned char)encoded[k];
         if (c >= 'A' && c <= 'Z') {

--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -116,6 +116,30 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
 
   size_t in_len = *inout_len;
 
+  // ASCII fast-path: when no byte has the high bit set, every byte is a
+  // single-codepoint ASCII character. Standard ASCII case folding (A-Z -> a-z)
+  // is byte-length preserving and matches what the nunicode pipeline would
+  // produce for codepoints < 0x80, so we can lowercase in place and skip the
+  // multi-pass transform entirely. This is the common case for English /
+  // MS MARCO-style corpora; multibyte inputs fall through to the slow path
+  // at the first byte with bit 7 set, so the scan cost on multibyte inputs
+  // is bounded by the position of the first non-ASCII byte (often 0).
+  {
+    size_t j = 0;
+    while (j < in_len && (unsigned char)encoded[j] < 0x80) {
+      j++;
+    }
+    if (j == in_len) {
+      for (size_t k = 0; k < in_len; k++) {
+        unsigned char c = (unsigned char)encoded[k];
+        if (c >= 'A' && c <= 'Z') {
+          encoded[k] = (char)(c + ('a' - 'A'));
+        }
+      }
+      return NULL;
+    }
+  }
+
   uint32_t u_stack_buffer[SSO_MAX_LENGTH];
   uint32_t *u_buffer = u_stack_buffer;
   char *longer_dst = NULL;

--- a/tests/cpptests/micro-benchmarks/CMakeLists.txt
+++ b/tests/cpptests/micro-benchmarks/CMakeLists.txt
@@ -39,3 +39,7 @@ foreach(benchmark_file ${BENCHMARK_ITER_SOURCES})
   add_executable(${benchmark_name} ${benchmark_file} ../index_utils.cpp ../llapi_test_helpers.cpp ../iterator_util.cpp)
   target_link_libraries(${benchmark_name} redisearch redismock benchmark::benchmark)
 endforeach()
+
+# Standalone micro-benchmarks (no iterator/index_utils dependency).
+add_executable(benchmark_unicode_tolower benchmark_unicode_tolower.cpp)
+target_link_libraries(benchmark_unicode_tolower redisearch redismock benchmark::benchmark)

--- a/tests/cpptests/micro-benchmarks/benchmark_unicode_tolower.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_unicode_tolower.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "benchmark/benchmark.h"
+#include "redismock/util.h"
+#include "util/strconv.h"
+#include "rmalloc.h"
+
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+// Token corpora for the unicode_tolower benchmark.
+//
+// MS MARCO and other English document/query workloads feed the tokenizer with
+// short, mixed-case ASCII tokens. We synthesize equivalents here (deterministic
+// PRNG) so the benchmark is self-contained and reproducible:
+//   - ascii:   ~7-byte uppercase/mixed-case ASCII words ([A-Za-z]+)
+//   - cyrillic: ~12-byte Cyrillic words (each codepoint 2 bytes UTF-8)
+//   - mixed:    ASCII tokens with one Latin-1 accented codepoint mid-token
+//
+// The bench measures the per-token cost of unicode_tolower in a tight loop,
+// re-copying the input each iteration since unicode_tolower mutates in place.
+
+namespace {
+
+constexpr size_t kNumTokens = 4096;
+
+std::vector<std::string> MakeAsciiCorpus(uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> len_dist(3, 12);
+  std::uniform_int_distribution<int> case_dist(0, 1);
+  std::uniform_int_distribution<int> letter_dist(0, 25);
+  std::vector<std::string> out;
+  out.reserve(kNumTokens);
+  for (size_t i = 0; i < kNumTokens; ++i) {
+    int n = len_dist(rng);
+    std::string s;
+    s.reserve(n);
+    for (int j = 0; j < n; ++j) {
+      char base = case_dist(rng) ? 'A' : 'a';
+      s.push_back(base + letter_dist(rng));
+    }
+    out.emplace_back(std::move(s));
+  }
+  return out;
+}
+
+std::vector<std::string> MakeCyrillicCorpus(uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> len_dist(3, 12);
+  // Cyrillic uppercase range U+0410..U+042F (32 letters).
+  std::uniform_int_distribution<uint32_t> cp_dist(0x0410, 0x042F);
+  std::vector<std::string> out;
+  out.reserve(kNumTokens);
+  for (size_t i = 0; i < kNumTokens; ++i) {
+    int n = len_dist(rng);
+    std::string s;
+    s.reserve(n * 2);
+    for (int j = 0; j < n; ++j) {
+      uint32_t cp = cp_dist(rng);
+      // Encode 2-byte UTF-8: 110xxxxx 10xxxxxx
+      s.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+      s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    out.emplace_back(std::move(s));
+  }
+  return out;
+}
+
+std::vector<std::string> MakeMixedCorpus(uint32_t seed) {
+  // ASCII token with a single Latin-1 accented codepoint (e.g. U+00C9 É)
+  // inserted at a random position. Models the realistic "mostly-ASCII corpus
+  // with occasional accented word" pattern.
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> len_dist(3, 12);
+  std::uniform_int_distribution<int> case_dist(0, 1);
+  std::uniform_int_distribution<int> letter_dist(0, 25);
+  // U+00C0..U+00DE without U+00D7 (Latin-1 uppercase block).
+  std::uniform_int_distribution<uint32_t> cp_dist(0x00C0, 0x00DE);
+  std::vector<std::string> out;
+  out.reserve(kNumTokens);
+  for (size_t i = 0; i < kNumTokens; ++i) {
+    int n = len_dist(rng);
+    std::string s;
+    s.reserve(n + 2);
+    int accent_pos = std::uniform_int_distribution<int>(0, n - 1)(rng);
+    for (int j = 0; j < n; ++j) {
+      if (j == accent_pos) {
+        uint32_t cp = cp_dist(rng);
+        if (cp == 0x00D7) cp = 0x00C0; // skip multiplication sign
+        s.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+        s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+      } else {
+        char base = case_dist(rng) ? 'A' : 'a';
+        s.push_back(base + letter_dist(rng));
+      }
+    }
+    out.emplace_back(std::move(s));
+  }
+  return out;
+}
+
+enum class Corpus { kAscii, kCyrillic, kMixed };
+
+const std::vector<std::string>& GetCorpus(Corpus c) {
+  static const std::vector<std::string> ascii = MakeAsciiCorpus(0xA5C11A11);
+  static const std::vector<std::string> cyr = MakeCyrillicCorpus(0xC7B1110C);
+  static const std::vector<std::string> mix = MakeMixedCorpus(0x111E4ED1);
+  switch (c) {
+    case Corpus::kAscii: return ascii;
+    case Corpus::kCyrillic: return cyr;
+    case Corpus::kMixed: return mix;
+  }
+  return ascii;
+}
+
+void RunCorpus(benchmark::State& state, Corpus c) {
+  RMCK::init();
+  const auto& tokens = GetCorpus(c);
+  // Compute total bytes processed per iteration for throughput reporting.
+  size_t total_bytes = 0;
+  for (const auto& t : tokens) total_bytes += t.size();
+
+  // Pre-allocate a working buffer large enough for the longest token plus one
+  // (unicode_tolower may write up to the same byte length on its in-place path).
+  size_t max_len = 0;
+  for (const auto& t : tokens) max_len = std::max(max_len, t.size());
+  std::vector<char> buf(max_len + 1);
+
+  for (auto _ : state) {
+    for (const auto& t : tokens) {
+      std::memcpy(buf.data(), t.data(), t.size());
+      size_t len = t.size();
+      char* longer = unicode_tolower(buf.data(), &len);
+      if (longer) {
+        benchmark::DoNotOptimize(longer);
+        rm_free(longer);
+      } else {
+        benchmark::DoNotOptimize(buf.data());
+      }
+    }
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * total_bytes);
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * tokens.size());
+}
+
+void BM_UnicodeToLower_Ascii(benchmark::State& state) { RunCorpus(state, Corpus::kAscii); }
+void BM_UnicodeToLower_Cyrillic(benchmark::State& state) { RunCorpus(state, Corpus::kCyrillic); }
+void BM_UnicodeToLower_Mixed(benchmark::State& state) { RunCorpus(state, Corpus::kMixed); }
+
+}  // namespace
+
+BENCHMARK(BM_UnicodeToLower_Ascii)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_UnicodeToLower_Cyrillic)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_UnicodeToLower_Mixed)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();

--- a/tests/cpptests/test_cpp_unicode_tolower.cpp
+++ b/tests/cpptests/test_cpp_unicode_tolower.cpp
@@ -179,3 +179,70 @@ TEST_F(UnicodeToLowerTest, testSupplementaryPlaneNoBit12) {
   ASSERT_EQ(newLen, 4u);
   ASSERT_STREQ(str, "\xF0\x90\x90\xA8");
 }
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulAsciiPrefix) {
+  // Embedded NUL terminates the conversion at the NUL position and the ASCII
+  // prefix is lowercased in place. Bytes past the NUL are not touched.
+  char str[] = {'F', 'O', 'O', '\0', 'B', 'A', 'R'};
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 3u);
+  ASSERT_EQ(str[0], 'f');
+  ASSERT_EQ(str[1], 'o');
+  ASSERT_EQ(str[2], 'o');
+  ASSERT_EQ(str[3], '\0');
+  ASSERT_EQ(str[4], 'B');
+  ASSERT_EQ(str[5], 'A');
+  ASSERT_EQ(str[6], 'R');
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulAtStart) {
+  // NUL at offset 0: no output codepoints, inout_len is left untouched and the
+  // buffer is unchanged.
+  char str[] = {'\0', 'A', 'B', 'C'};
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], '\0');
+  ASSERT_EQ(str[1], 'A');
+  ASSERT_EQ(str[2], 'B');
+  ASSERT_EQ(str[3], 'C');
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulBeforeMultibyte) {
+  // ASCII prefix, NUL, then a multibyte suffix. The NUL terminates the
+  // conversion before the multibyte bytes are ever inspected.
+  char str[] = {'F', 'O', 'O', '\0', '\xC3', '\x89'}; // ..\0É
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 3u);
+  ASSERT_EQ(str[0], 'f');
+  ASSERT_EQ(str[1], 'o');
+  ASSERT_EQ(str[2], 'o');
+  ASSERT_EQ(str[3], '\0');
+  ASSERT_EQ((unsigned char)str[4], 0xC3);
+  ASSERT_EQ((unsigned char)str[5], 0x89);
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulAfterMultibyte) {
+  // Multibyte prefix, NUL, then an ASCII suffix. This routes through the slow
+  // path (first byte has bit 7 set), and the slow path also truncates at NUL.
+  char str[] = {'\xC3', '\x89', 'A', '\0', 'B', 'C'}; // ÉA\0BC
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 3u);
+  ASSERT_EQ((unsigned char)str[0], 0xC3);
+  ASSERT_EQ((unsigned char)str[1], 0xA9); // é
+  ASSERT_EQ(str[2], 'a');
+  ASSERT_EQ(str[3], '\0');
+  ASSERT_EQ(str[4], 'B');
+  ASSERT_EQ(str[5], 'C');
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `unicode_tolower` (called once per indexed token by the tokenizer, stopword filter, and tag normalizer) always runs the full four-pass nunicode case-fold pipeline (`nu_strtransformnlen` size pre-pass → read/transform loop → `nu_bytenlen` → `nu_writenstr`) even when every byte in the token is plain ASCII. The MOD-7944 multi-byte support introduced this in 2.10.13, which accounts for the largest single step in the 2.10.x indexing regression on ASCII-only corpora (e.g. MS MARCO).
2. **Change**: Add an ASCII fast-path inside `unicode_tolower`. A short early-exit scan looks for a byte with the high bit set; when none is found, the token is lowercased in place with a trivial `A-Z → a-z` loop and the function returns. Multi-byte inputs fall through to the existing nunicode path on the first byte ≥ `0x80`, so the scan cost is bounded by the position of that byte and is typically zero for pure-multi-byte tokens.
3. **Outcome**:
   - Micro-benchmark (`benchmark_unicode_tolower`, 4096-token batches, single core, CV < 1%):
     - ASCII: 1033 µs → 177 µs (**−83%**)
     - Cyrillic: 922 µs → 951 µs (+3.1%; scan cost on every byte being multi-byte)
     - Mixed: 1114 µs → 1138 µs (+2.2%; scan up to first multi-byte byte)
   - End-to-end MS MARCO 30k HSET indexing (8 interleaved runs, baseline vs fix on the same master tip, CV < 2.5%):
     - baseline median 27.06 s → fix median 20.81 s (**−23.1%**)
     - fix wins all 8 interleaved iterations
   - Functional: `UnicodeToLowerTest` (8/8) and `TokenizerTest` (4/4) pass unchanged.

A new Google-Benchmark micro-benchmark (`tests/cpptests/micro-benchmarks/benchmark_unicode_tolower.cpp`) is added to keep the per-corpus cost numbers reproducible and to make it easy to regression-check future refactors of the case-folding hot path.

#### Which additional issues this PR fixes
1. MOD-15505

#### Main objects this PR modified
1. `unicode_tolower` in `src/util/strconv.h`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Recovers ~23% of the ASCII-corpus indexing regression that was introduced when multi-byte character support was added, by skipping the multi-byte case-folding pipeline for tokens that contain only ASCII characters. Behavior on multi-byte inputs is unchanged.

---

### Cross-branch backport validation (MS MARCO 30k HSET, MODE=index, 3 interleaved runs)

The same hunk cherry-picks cleanly onto `2.10`, `8.2`, `8.4`, `8.6`, and `8.6-rse`. With all 11 modules interleaved on one 8-vCPU host (`--cpus=8`, Redis 7.4 for 2.10, Redis 8.6 for 8.x):

| Variant | n | Median (s) | CV% | Δ vs v2.10.12 |
|---|---:|---:|---:|---:|
| **v2.10.12 (reference)** | 3 | **18.664** | 1.42 | **+0.0%** |
| 2.10 tip baseline | 3 | 27.388 | 0.78 | **+46.7%** |
| 2.10 tip + fix | 3 | 19.753 | 3.03 | **+5.8%** |
| 8.2 tip baseline | 3 | 26.284 | 1.18 | **+40.8%** |
| 8.2 tip + fix | 3 | 18.623 | 4.26 | **−0.2%** |
| 8.4 tip baseline | 3 | 26.291 | 1.82 | **+40.9%** |
| 8.4 tip + fix | 3 | 18.897 | 0.81 | **+1.2%** |
| 8.6 tip baseline | 3 | 27.695 | 0.11 | **+48.4%** |
| 8.6 tip + fix | 3 | 19.979 | 0.90 | **+7.0%** |
| 8.6-rse tip baseline | 3 | 27.861 | 0.94 | **+49.3%** |
| 8.6-rse tip + fix | 3 | 19.873 | 3.45 | **+6.5%** |

Per-branch recovery: 8.2 −29.1%, 8.4 −28.1%, 2.10 −27.9%, 8.6 −27.9%, 8.6-rse −28.7%. Every branch tip with the fix lands within **≤7%** of v2.10.12 (8.2/8.4 are statistically indistinguishable); the small residual on 2.10/8.6/8.6-rse is consistent with the previously-identified +4.6% from `a8e9b3c47` ("Switch to rust ii") plus a few smaller non-tolower 8.x changes.

#### Why the 2.10.x regression had two steps and one PR fixes both

Both 2.10.x regression steps funnel into the **same** `unicode_tolower`, from different call sites:

| Step | Version step | PR | What it changed | Hot path |
|---|---|---|---|---|
| **A** | v2.10.12 → v2.10.13 (+21.8%) | #5646 / `3053af3eb` "multi-byte char terms" | Introduced `unicode_tolower` and switched the per-token case-fold callers (`rm_normalize` ex `rm_strdupcase`) to it. | Tokenizer, tag normalizer, synonym/stemmer, trie folding. |
| **B** | v2.10.18 → v2.10.19 (+46.7%) | #6330 / `205c30af2` "multi-byte stopwords" | Replaced ASCII `strtolower` / per-char `tolower` loops in `StopWordList_Contains` and `NewStopWordListCStr` with `unicode_tolower(...)`. | Stopword filter — a **second** per-token invocation of the same heavy pipeline. |

The ASCII fast-path patches `unicode_tolower` once. Both call sites — tokenizer/tag/synonym/stemmer/trie *and* stopword filter — pick it up automatically.

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-token case folding used across tokenizer, stopwords, and normalization; behavior must stay aligned with nunicode for ASCII and NUL truncation, though tests and benchmarks reduce risk.
> 
> **Overview**
> Adds an **ASCII fast-path** to `unicode_tolower` in `strconv.h`: pure-ASCII tokens (no high bit, respecting embedded NUL like the nunicode path) are lowercased in place with a simple `A–Z` loop and skip the full libnu pipeline; anything with multibyte UTF-8 still uses the existing slow path.
> 
> **Tests and tooling:** new unit cases for embedded NUL on ASCII and multibyte inputs; a Google Benchmark target (`benchmark_unicode_tolower`) with ASCII, Cyrillic, and mixed corpora; and a new agent skill doc (`.skills/bisect-perf-regression`) describing how to bisect perf regressions with interleaved runs and CV thresholds.
> 
> **Expected impact:** large win on ASCII-heavy indexing/tokenization workloads; small overhead on already-multibyte tokens from the prefix scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42949887459a446dd3492282b44806b1fa5d05a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

