### PR TITLE
concurrent_ctx: drop CMDCTX_KEEP_RCTX

### DIFF
--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -84,9 +84,7 @@ static void threadHandleCommand(void *p) {
 
   ctx->handler(ctx->ctx, ctx->argv, ctx->argc, ctx);
 
-  if (!(ctx->options & CMDCTX_KEEP_RCTX)) {
-    RedisModule_FreeThreadSafeContext(ctx->ctx);
-  }
+  RedisModule_FreeThreadSafeContext(ctx->ctx);
 
   if (!(ctx->options & CMDCTX_KEEP_BC)) {
     RedisModule_BlockedClientMeasureTimeEnd(ctx->bc);
@@ -96,10 +94,6 @@ static void threadHandleCommand(void *p) {
 
   rm_free(ctx->argv);
   rm_free(p);
-}
-
-void ConcurrentCmdCtx_KeepRedisCtx(ConcurrentCmdCtx *cctx) {
-  cctx->options |= CMDCTX_KEEP_RCTX;
 }
 
 void ConcurrentCmdCtx_KeepBlockedClient(ConcurrentCmdCtx *cctx) {

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -74,21 +74,7 @@ static inline void ConcurrentSearchHandlerCtx_Init(ConcurrentSearchHandlerCtx *c
   memset(ctx, 0, sizeof(*ctx));
 }
 
-#define CMDCTX_KEEP_RCTX 0x01
 #define CMDCTX_KEEP_BC   0x02
-
-/**
- * Take ownership of the underlying Redis command context. Once ownership is
- * claimed, the context needs to be freed (at some point in the future) via
- * RM_FreeThreadSafeContext()
- *
- * TODO/FIXME:
- * The context is tied to a BlockedCLient, but it shouldn't actually utilize it.
- * Need to add an API to Redis to better manage a thread safe context, or to
- * otherwise 'detach' it from the Client so that trying to perform I/O on it
- * would result in an error rather than simply using a dangling pointer.
- */
-void ConcurrentCmdCtx_KeepRedisCtx(struct ConcurrentCmdCtx *ctx);
 
 /**
  * Take ownership of the BlockedClient. After calling this, the handler is

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -572,8 +572,16 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
 static int executePlan(AREQ *r, struct ConcurrentCmdCtx *cmdCtx, RedisModule_Reply *reply, QueryError *status) {
   if (AREQ_RequestFlags(r) & QEXEC_F_IS_CURSOR) {
-    // Keep the original concurrent context
-    ConcurrentCmdCtx_KeepRedisCtx(cmdCtx);
+    // The AREQ persists across FT.CURSOR READ commands; the dispatcher's
+    // RedisModuleCtx (currently aliased in r->sctx->redisCtx) won't.
+    // Swap in a detached thread-safe ctx that AREQ owns — AREQ_Free's cursor
+    // branch already releases it via RedisModule_FreeThreadSafeContext.
+    // Mirrors the pattern used for hybrid subqueries (createThreadSafeSearchContext).
+    RedisSearchCtx *sctx = AREQ_SearchCtx(r);
+    RedisModuleCtx *dispatcherCtx = sctx->redisCtx;
+    RedisModuleCtx *detachedCtx = RedisModule_GetDetachedThreadSafeContext(dispatcherCtx);
+    RedisModule_SelectDb(detachedCtx, RedisModule_GetSelectedDb(dispatcherCtx));
+    sctx->redisCtx = detachedCtx;
 
     StrongRef dummy_spec_ref = {.rm = NULL};
 


### PR DESCRIPTION
## Describe the changes in the pull request

Removes `CMDCTX_KEEP_RCTX` entirely. Follow-up to #9868.

**Current**: After #9868 removed the hybrid use of `CMDCTX_KEEP_RCTX`, the only remaining caller was `dist_aggregate.c`'s cursor path at [`dist_aggregate.c:576`](src/coord/dist_aggregate.c#L576). It kept the dispatcher's `RedisModuleCtx` alive because:

1. `prepareExecutionPlan` stored the dispatcher's ctx in `r->sctx->redisCtx` ([`dist_aggregate.c:558-559`](src/coord/dist_aggregate.c#L558-L559)).
2. For cursor requests, the AREQ persists across `FT.CURSOR READ` commands, and `AREQ_Free`'s cursor branch ([`aggregate_request.c:1673-1676`](src/aggregate/aggregate_request.c#L1673-L1676)) frees `sctx->redisCtx` via `RedisModule_FreeThreadSafeContext`.

Without `CMDCTX_KEEP_RCTX`, `threadHandleCommand` would free the dispatcher's ctx on handler return; `AREQ_Free` would then double-free it when the cursor was closed.

The auto-memory borrow concern that motivated keeping the ctx alive for hybrid does not apply here — `AREQ_Compile` ([`aggregate_request.c:1232-1243`](src/aggregate/aggregate_request.c#L1232-L1243)) already always copies argv into owned sds (`req->args`) and parses through an SDS cursor, so no plan-step / RLookup pointers borrow from the dispatcher ctx's auto-memory.

**Change**: In `executePlan`, before `AREQ_StartCursor`, swap `r->sctx->redisCtx` for a detached thread-safe ctx (mirroring the pattern [`createThreadSafeSearchContext`](src/hybrid/hybrid_request.c#L426-L430) uses for hybrid subqueries). `AREQ_Free`'s existing cursor branch frees that detached ctx; the dispatcher's ctx is left for `threadHandleCommand` to free normally. Then drop:

- `ConcurrentCmdCtx_KeepRedisCtx` function + declaration
- `CMDCTX_KEEP_RCTX` macro
- The `!(ctx->options & CMDCTX_KEEP_RCTX)` guard in `threadHandleCommand` — the `RedisModule_FreeThreadSafeContext` call becomes unconditional.

**Outcome**: `ConcurrentCmdCtx`'s option flags shrink to just `CMDCTX_KEEP_BC`. Coord aggregate cursors now own a detached ctx independent of the dispatcher's lifetime, the same way hybrid subqueries already did.

### Verification

- `./build.sh DEBUG=1` — clean build.
- `./build.sh RUN_UNIT_TESTS SAN=address` — 862/862 pass, no leaks.
- `REDIS_STANDALONE=0 ./build.sh RUN_PYTEST TEST="test_aggregate.py test_cursors.py test_cluster_aggregate_timeout.py test_hybrid_timeout.py"` — 122/122 pass in cluster mode (including all cursor-path tests and the motivating hybrid soft-error test).

#### Which additional issues this PR fixes

Follow-up to #9868 (which dropped `qctxErr` and `dispatcherCtx` from `HybridDispatchCtx`). Mirrors the same lifecycle simplification on the aggregate-cursor path.

#### Main objects this PR modified

1. `executePlan` ([`dist_aggregate.c`](src/coord/dist_aggregate.c)) — install detached ctx into the cursor AREQ's `sctx->redisCtx` before persisting it.
2. `threadHandleCommand` ([`concurrent_ctx.c`](src/concurrent_ctx.c)) — unconditional `FreeThreadSafeContext`.
3. `ConcurrentCmdCtx_KeepRedisCtx`, `CMDCTX_KEEP_RCTX` — removed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
