### PR TITLE
[8.4] [MOD-15113] Limit aggregate GROUPBY groups

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -343,10 +343,17 @@ void initializeAREQ(AREQ *req);
  */
 int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status);
 
+/** Creates the aggregation pipeline parameters derived from the request. */
+AggregationPipelineParams AREQ_MakeAggregationPipelineParams(AREQ *req,
+                                                             GroupByLimits groupByLimits);
+
 /**
  * Constructs the pipeline objects needed to actually start processing
  * the requests. This does not yet start iterating over the objects
  */
+int AREQ_BuildPipelineWithAggregationParams(AREQ *req,
+                                            const AggregationPipelineParams *aggregationParams,
+                                            QueryError *status);
 int AREQ_BuildPipeline(AREQ *req, QueryError *status);
 
 static inline QEFlags AREQ_RequestFlags(const AREQ *req) {
@@ -424,7 +431,8 @@ static inline AGGPlan *AREQ_AGGPlan(AREQ *req) {
  * ResultProcessors (and a grouper is a ResultProcessor) before the grouper
  * should write their data using `lksrc` as a reference point.
  */
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n);
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n,
+                     GroupByLimits groupByLimits);
 
 void Grouper_Free(Grouper *g);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1506,7 +1506,26 @@ void AREQ_Free(AREQ *req) {
 
 
 
-int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
+AggregationPipelineParams AREQ_MakeAggregationPipelineParams(AREQ *req,
+                                                             GroupByLimits groupByLimits) {
+  return (AggregationPipelineParams){
+    .common = {
+      .sctx = req->sctx,
+      .reqflags = req->reqflags,
+      .optimizer = req->optimizer,
+      // Score alias is not supposed to be used in the aggregation pipeline
+      .scoreAlias = NULL,
+    },
+    .outFields = &req->outFields,
+    .maxResultsLimit = IsSearch(req) ? req->maxSearchResults : req->maxAggregateResults,
+    .groupByLimits = groupByLimits,
+    .language = req->searchopts.language,
+  };
+}
+
+int AREQ_BuildPipelineWithAggregationParams(AREQ *req,
+                                            const AggregationPipelineParams *aggregationParams,
+                                            QueryError *status) {
   Pipeline_Initialize(&req->pipeline, req->reqConfig.timeoutPolicy, status);
   if (!(AREQ_RequestFlags(req) & QEXEC_F_BUILDPIPELINE_NO_ROOT)) {
     QueryPipelineParams params = {
@@ -1530,17 +1549,12 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
       return REDISMODULE_ERR;
     }
   }
-  AggregationPipelineParams params = {
-    .common = {
-      .sctx = req->sctx,
-      .reqflags = req->reqflags,
-      .optimizer = req->optimizer,
-      // Right now score alias is not supposed to be used in the aggregation pipeline
-      .scoreAlias = NULL,
-    },
-    .outFields = &req->outFields,
-    .maxResultsLimit = IsSearch(req) ? req->maxSearchResults : req->maxAggregateResults,
-    .language = req->searchopts.language,
-  };
-  return Pipeline_BuildAggregationPart(&req->pipeline, &params, &req->stateflags);
+  return Pipeline_BuildAggregationPart(&req->pipeline, aggregationParams, &req->stateflags);
+}
+
+int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
+  AggregationPipelineParams aggregationParams =
+      AREQ_MakeAggregationPipelineParams(
+          req, GroupByLimits_Default(RSGlobalConfig.maxAggregateGroups));
+  return AREQ_BuildPipelineWithAggregationParams(req, &aggregationParams, status);
 }

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -71,7 +71,6 @@ typedef struct Grouper {
   // array of reducers
   Reducer **reducers;
 
-  // GROUPBY materialization limit.
   GroupByLimits groupByLimits;
 
   // Used for maintaining state when yielding groups

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -8,6 +8,7 @@
 */
 #include <redisearch.h>
 #include <result_processor.h>
+#include "pipeline/pipeline.h"
 #include <util/block_alloc.h>
 #include <util/khash.h>
 #include "reducer.h"
@@ -70,9 +71,19 @@ typedef struct Grouper {
   // array of reducers
   Reducer **reducers;
 
+  // GROUPBY materialization limit.
+  GroupByLimits groupByLimits;
+
   // Used for maintaining state when yielding groups
   khiter_t iter;
 } Grouper;
+
+static void setAggregateGroupLimitError(const Grouper *g) {
+  QueryError_SetWithoutUserDataFmt(
+      g->base.parent->err, QUERY_ERROR_CODE_LIMIT,
+      "Aggregate GROUPBY exceeded MAX_AGGREGATE_GROUPS limit of %zu groups",
+      g->groupByLimits.maxGroups);
+}
 
 /**
  * Create a new group. groupvals is the key of the group. This will be the
@@ -152,8 +163,10 @@ static void invokeReducers(Grouper *g, Group *gr, RLookupRow *srcrow) {
  * @param hval current X-wise hash value. Note that members of the same Y array
  *  are not hashed together.
  * @param res the row is passed to each reducer
+ * @param rowExpansion the cartesian product size accumulated for the current row
  */
-static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t xlen, uint64_t hval, RLookupRow *res) {
+static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t xlen,
+                         uint64_t hval, RLookupRow *res, size_t rowExpansion) {
   // end of the line - create/add to group
   if (xpos == xlen) {
     Group *group = NULL;
@@ -161,6 +174,10 @@ static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t 
     // Get or create the group
     khiter_t k = kh_get(khid, g->groups, hval);  // first have to get ieter
     if (k == kh_end(g->groups)) {                // k will be equal to kh_end if key not present
+      if (kh_size(g->groups) >= g->groupByLimits.maxGroups) {
+        setAggregateGroupLimitError(g);
+        return RS_RESULT_ERROR;
+      }
       group = createGroup(g, xarr, xlen);
       kh_set(khid, g->groups, hval, group);
     } else {
@@ -169,7 +186,7 @@ static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t 
 
     // send the result to the group and its reducers
     invokeReducers(g, group, res);
-    return;
+    return RS_RESULT_OK;
   }
 
   // get the value
@@ -177,30 +194,44 @@ static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t 
   // regular value - just move one step -- increment XPOS
   if (!RSValue_IsArray(v)) {
     hval = RSValue_Hash(v, hval);
-    extractGroups(g, xarr, xpos + 1, xlen, hval, res);
+    return extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion);
   } else if (RSValue_ArrayLen(v) == 0) {
     // Empty array - hash as null
     hval = RSValue_Hash(RSValue_NullStatic(), hval);
     const RSValue *array = xarr[xpos];
     xarr[xpos] = RSValue_NullStatic();
-    extractGroups(g, xarr, xpos + 1, xlen, hval, res);
+    int rc = extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion);
     xarr[xpos] = array;
+    return rc;
   } else {
     // Array value. Replace current XPOS with child temporarily.
     // Each value in the array will be a separate group
     const RSValue *array = xarr[xpos];
-    for (size_t i = 0; i < RSValue_ArrayLen(v); i++) {
+    size_t len = RSValue_ArrayLen(v);
+    if (len > 1) {
+      if (rowExpansion > g->groupByLimits.maxGroups / len) {
+        setAggregateGroupLimitError(g);
+        return RS_RESULT_ERROR;
+      }
+      rowExpansion *= len;
+    }
+    for (size_t i = 0; i < len; i++) {
       const RSValue *elem = RSValue_ArrayItem(v, i);
       // hash the element, even if it's an array
       uint64_t hh = RSValue_Hash(elem, hval);
       xarr[xpos] = elem;
-      extractGroups(g, xarr, xpos + 1, xlen, hh, res);
+      int rc = extractGroups(g, xarr, xpos + 1, xlen, hh, res, rowExpansion);
+      if (rc != RS_RESULT_OK) {
+        xarr[xpos] = array;
+        return rc;
+      }
     }
     xarr[xpos] = array;
+    return RS_RESULT_OK;
   }
 }
 
-static void invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
+static int invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
   uint64_t hval = 0;
   size_t nkeys = GROUPER_NSRCKEYS(g);
   const RSValue *groupvals[nkeys];
@@ -213,7 +244,7 @@ static void invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
     }
     groupvals[ii] = v;
   }
-  extractGroups(g, groupvals, 0, nkeys, 0, srcrow);
+  return extractGroups(g, groupvals, 0, nkeys, hval, srcrow, 1);
 }
 
 static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
@@ -223,8 +254,11 @@ static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
   int rc;
 
   while ((rc = base->upstream->Next(base->upstream, res)) == RS_RESULT_OK) {
-    invokeGroupReducers(g, SearchResult_GetRowDataMut(res));
+    rc = invokeGroupReducers(g, SearchResult_GetRowDataMut(res));
     SearchResult_Clear(res);
+    if (rc != RS_RESULT_OK) {
+      break;
+    }
   }
   base->parent->resultLimit = chunkLimit; // restore the limit
   if (rc == RS_RESULT_EOF) {
@@ -276,12 +310,14 @@ void Grouper_Free(Grouper *g) {
   g->base.Free(&g->base);
 }
 
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t nkeys) {
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t nkeys,
+                     GroupByLimits groupByLimits) {
   Grouper *g = rm_calloc(1, sizeof(*g));
   BlkAlloc_Init(&g->groupsAlloc);
   g->groups = kh_init(khid);
 
   g->nkeys = nkeys;
+  g->groupByLimits = groupByLimits;
   if (nkeys) {
     g->srckeys = rm_malloc(nkeys * sizeof(*g->srckeys));
     g->dstkeys = rm_malloc(nkeys * sizeof(*g->dstkeys));

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -80,7 +80,7 @@ typedef struct Grouper {
 
 static void setAggregateGroupLimitError(const Grouper *g) {
   QueryError_SetWithoutUserDataFmt(
-      g->base.parent->err, QUERY_ERROR_CODE_LIMIT,
+      g->base.parent->err, QUERY_ELIMIT,
       "Aggregate GROUPBY exceeded MAX_AGGREGATE_GROUPS limit of %zu groups",
       g->groupByLimits.maxGroups);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -475,7 +475,7 @@ CONFIG_SETTER(setMaxAggregateGroups) {
   int acrc = AC_GetLongLong(ac, &newSize, AC_F_GE1);
   CHECK_RETURN_PARSE_ERROR(acrc)
   if (newSize > MAX_AGGREGATE_GROUPS) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT,
+    QueryError_SetError(status, QUERY_ELIMIT,
                         "Value exceeds maximum possible aggregate groups");
     return REDISMODULE_ERR;
   }

--- a/src/config.c
+++ b/src/config.c
@@ -63,6 +63,7 @@ configPair_t __configPairs[] = {
   {"GC_POLICY",                       ""},
   {"GCSCANSIZE",                      "search-gc-scan-size"},
   {"INDEX_CURSOR_LIMIT",              "search-index-cursor-limit"},
+  {"MAX_AGGREGATE_GROUPS",            "search-max-aggregate-groups"},
   {"MAXAGGREGATERESULTS",             "search-max-aggregate-results"},
   {"MAXDOCTABLESIZE",                 "search-max-doctablesize"},
   {"MAXPREFIXEXPANSIONS",             "search-max-prefix-expansions"},
@@ -466,6 +467,25 @@ CONFIG_GETTER(getMaxAggregateResults) {
     return sdscatprintf(ss, "unlimited");
   }
   return sdscatprintf(ss, "%lu", config->maxAggregateResults);
+}
+
+// MAX_AGGREGATE_GROUPS
+CONFIG_SETTER(setMaxAggregateGroups) {
+  long long newSize = 0;
+  int acrc = AC_GetLongLong(ac, &newSize, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc)
+  if (newSize > MAX_AGGREGATE_GROUPS) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT,
+                        "Value exceeds maximum possible aggregate groups");
+    return REDISMODULE_ERR;
+  }
+  config->maxAggregateGroups = newSize;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getMaxAggregateGroups) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%lu", config->maxAggregateGroups);
 }
 
 // MAXEXPANSIONS MAXPREFIXEXPANSIONS
@@ -1385,6 +1405,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Maximum number of results from ft.aggregate command",
          .setValue = setMaxAggregateResults,
          .getValue = getMaxAggregateResults},
+        {.name = "MAX_AGGREGATE_GROUPS",
+         .helpText = "Maximum number of GROUPBY groups materialized by ft.aggregate command",
+         .setValue = setMaxAggregateGroups,
+         .getValue = getMaxAggregateGroups},
         {.name = "MAXEXPANSIONS",
          .helpText = "Maximum prefix expansions to be used in a query",
          .setValue = setMaxExpansions,
@@ -1954,6 +1978,15 @@ int RegisterModuleConfig(RedisModuleCtx *ctx) {
       REDISMODULE_CONFIG_UNPREFIXED, 0,
       MAX_AGGREGATE_REQUEST_RESULTS, get_size_t_numeric_config, set_size_t_numeric_config,
       NULL, (void *)&(RSGlobalConfig.maxAggregateResults)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterNumericConfig(
+      ctx, "search-max-aggregate-groups", DEFAULT_MAX_AGGREGATE_GROUPS,
+      REDISMODULE_CONFIG_UNPREFIXED, 1,
+      MAX_AGGREGATE_GROUPS, get_size_t_numeric_config, set_size_t_numeric_config,
+      NULL, (void *)&(RSGlobalConfig.maxAggregateGroups)
     )
   )
 

--- a/src/config.h
+++ b/src/config.h
@@ -138,6 +138,7 @@ typedef struct {
   size_t maxDocTableSize;
   size_t maxSearchResults;
   size_t maxAggregateResults;
+  size_t maxAggregateGroups;
 
   // MT configuration
   size_t numWorkerThreads;
@@ -307,6 +308,8 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
 #define DEFAULT_INDEX_CURSOR_LIMIT 128
 #define MAX_AGGREGATE_REQUEST_RESULTS (1ULL << 31)
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
+#define MAX_AGGREGATE_GROUPS (1ULL << 26)
+#define DEFAULT_MAX_AGGREGATE_GROUPS 1000000
 #define DEFAULT_MAX_CURSOR_IDLE 300000
 #define DEFAULT_MAX_PREFIX_EXPANSIONS 200
 #define DEFAULT_MAX_SEARCH_REQUEST_RESULTS 1000000
@@ -368,6 +371,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .filterCommands = 0,                                                       \
     .maxSearchResults = DEFAULT_MAX_SEARCH_REQUEST_RESULTS,                    \
     .maxAggregateResults = DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS,              \
+    .maxAggregateGroups = DEFAULT_MAX_AGGREGATE_GROUPS,                        \
     .iteratorsConfigParams.minUnionIterHeap = DEFAULT_UNION_ITERATOR_HEAP,     \
     .numericCompress = false,                                                  \
     .numericTreeMaxDepthRange = 0,                                             \

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -314,7 +314,8 @@ int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r) {
 }
 
 static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                         IndexSpec *sp, specialCaseCtx **knnCtx_ptr, QueryError *status) {
+                               IndexSpec *sp, specialCaseCtx **knnCtx_ptr, size_t numShards,
+                               QueryError *status) {
   AREQ_QueryProcessingCtx(r)->err = status;
   AREQ_AddRequestFlags(r, QEXEC_F_IS_AGGREGATE | QEXEC_F_BUILDPIPELINE_NO_ROOT);
   rs_wall_clock_init(&r->profileClocks.initClock);
@@ -363,8 +364,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   rc = AGGPLN_Distribute(AREQ_AGGPlan(r), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
+  // The coordinator merges shard-local groups, so allow one configured cap per shard.
+  AggregationPipelineParams aggregationParams = AREQ_MakeAggregationPipelineParams(
+      r, GroupByLimits_ForCoordinator(RSGlobalConfig.maxAggregateGroups, numShards));
+
   AREQDIST_UpstreamInfo us = {NULL};
-  rc = AREQ_BuildDistributedPipeline(r, &us, status);
+  rc = AREQ_BuildDistributedPipeline(r, &us, &aggregationParams, status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   // Construct the command string
@@ -432,6 +437,8 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   QueryError status = QueryError_Default();
   specialCaseCtx *knnCtx = NULL;
 
+  size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
+
   // Check if the index still exists, and promote the ref accordingly
   StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
   IndexSpec *sp = StrongRef_Get(strong_ref);
@@ -440,7 +447,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     goto err;
   }
 
-  if (prepareForExecution(r, ctx, argv, argc, sp, &knnCtx, &status) != REDISMODULE_OK) {
+  if (prepareForExecution(r, ctx, argv, argc, sp, &knnCtx, numShards, &status) != REDISMODULE_OK) {
     goto err;
   }
 
@@ -468,6 +475,11 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   AREQ *r = NULL;
   IndexSpec *sp = NULL;
   specialCaseCtx *knnCtx = NULL;
+  AREQ_Debug_params debug_params = {0};
+  StrongRef strong_ref = {0};
+  int debug_argv_count = 0;
+  MRCommand *cmd = NULL;
+  size_t numShards = 0;
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
@@ -478,22 +490,25 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   }
   // CMD, index, expr, args...
   r = &debug_req->r;
-  AREQ_Debug_params debug_params = debug_req->debug_params;
+
+  numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
+  debug_params = debug_req->debug_params;
   // Check if the index still exists, and promote the ref accordingly
-  StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
+  strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
   sp = StrongRef_Get(strong_ref);
   if (!sp) {
     QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
     goto err;
   }
 
-  int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
-  if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, sp, &knnCtx, &status) != REDISMODULE_OK) {
+  debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, sp, &knnCtx, numShards,
+                          &status) != REDISMODULE_OK) {
     goto err;
   }
 
   // rpnet now owns the command
-  MRCommand *cmd = &(((RPNet *)AREQ_QueryProcessingCtx(r)->rootProc)->cmd);
+  cmd = &(((RPNet *)AREQ_QueryProcessingCtx(r)->rootProc)->cmd);
 
   MRCommand_Insert(cmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
   // insert also debug params at the end

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -13,6 +13,7 @@
 #include "aggregate/reducer.h"
 #include "util/arr.h"
 #include "dist_plan.h"
+#include "config.h"
 
 #include <vector>
 #include <string>
@@ -568,14 +569,25 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
   AGPLN_Serialize(dstp->plan, &dstp->serialized);
 }
 
-int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError *status) {
+int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us,
+                                  const AggregationPipelineParams *aggregationParams,
+                                  QueryError *status) {
 
   auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(AREQ_AGGPlan(r), NULL, NULL, PLN_T_DISTRIBUTE);
   RS_ASSERT(dstp);
 
   dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;
-  int rc = AREQ_BuildPipeline(r, status);
+
+  AggregationPipelineParams defaultAggregationParams = {};
+  if (!aggregationParams) {
+    defaultAggregationParams = AREQ_MakeAggregationPipelineParams(
+        r, GroupByLimits_Default(RSGlobalConfig.maxAggregateGroups));
+    aggregationParams = &defaultAggregationParams;
+  }
+
+  int rc = AREQ_BuildPipelineWithAggregationParams(r, aggregationParams, status);
   dstp->lk.options &= ~RLOOKUP_OPT_UNRESOLVED_OK;
+
   if (rc != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }

--- a/src/coord/dist_plan.h
+++ b/src/coord/dist_plan.h
@@ -38,9 +38,13 @@ typedef struct {
  * Builds the static portion of the distributed pipeline
  * @param r the request
  * @param[out] us upstream parameters
+ * @param aggregationParams parameters for building the coordinator aggregation pipeline.
+ *                          If NULL, defaults are derived from the request.
  * @param status if there is an error
  */
-int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError *status);
+int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us,
+                                  const AggregationPipelineParams *aggregationParams,
+                                  QueryError *status);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -603,9 +603,6 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     if (rc != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
-    hybridParams.aggregationParams.groupByLimits =
-        GroupByLimits_ForCoordinator(RSGlobalConfig.maxAggregateGroups, numShards);
-
     rs_wall_clock parseClock;
     if (profileOptions != EXEC_NO_FLAGS) {
       // Initialize parseClock after parsing is done, we want that to be accounted in the parsing timing

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -803,6 +803,7 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
         DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
         return;
     }
+    QueryError_ClearError(&status);
     WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
     IndexSpecRef_Release(strong_ref);
     RedisModule_EndReply(reply);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -603,6 +603,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     if (rc != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
+    hybridParams.aggregationParams.groupByLimits =
+        GroupByLimits_ForCoordinator(RSGlobalConfig.maxAggregateGroups, numShards);
 
     rs_wall_clock parseClock;
     if (profileOptions != EXEC_NO_FLAGS) {
@@ -792,7 +794,6 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
     HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
 
-    // Get numShards captured from main thread for thread-safe access and to compute effective K
     size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
 
     if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status) != REDISMODULE_OK) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -933,6 +933,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
           },
       .outFields = NULL,
       .maxResultsLimit = maxHybridResults,
+      .groupByLimits = GroupByLimits_Default(RSGlobalConfig.maxAggregateGroups),
       .language = searchRequest->searchopts.language,
   };
 

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -373,6 +373,8 @@ void AddToInfo_RSConfig(RedisModuleInfoCtx *ctx) {
   RedisModule_InfoAddFieldLongLong(ctx, "max_search_results", RSGlobalConfig.maxSearchResults);
   RedisModule_InfoAddFieldLongLong(ctx, "max_aggregate_results",
                                    RSGlobalConfig.maxAggregateResults);
+  RedisModule_InfoAddFieldLongLong(ctx, "max_aggregate_groups",
+                                   RSGlobalConfig.maxAggregateGroups);
   RedisModule_InfoAddFieldLongLong(ctx, "gc_scan_size", RSGlobalConfig.gcConfigParams.gcScanSize);
   RedisModule_InfoAddFieldLongLong(ctx, "min_phonetic_term_length",
                                    RSGlobalConfig.minPhoneticTermLen);

--- a/src/module.c
+++ b/src/module.c
@@ -3505,7 +3505,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   }
 
   ConcurrentSearchHandlerCtx handlerCtx = {
-    .spec_ref = StrongRef_Demote(spec_ref)
+    .spec_ref = StrongRef_Demote(spec_ref),
+    .numShards = NumShards
   };
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -32,6 +32,26 @@ typedef struct CommonPipelineParams {
   const char* scoreAlias;
 } CommonPipelineParams;
 
+typedef struct GroupByLimits {
+  /** Effective maximum number of GROUPBY groups this pipeline may materialize. */
+  size_t maxGroups;
+} GroupByLimits;
+
+static inline GroupByLimits GroupByLimits_Default(size_t maxGroups) {
+  GroupByLimits limits = {0};
+  limits.maxGroups = maxGroups;
+  return limits;
+}
+
+static inline GroupByLimits GroupByLimits_ForCoordinator(size_t maxGroups, size_t shardCount) {
+  GroupByLimits limits = GroupByLimits_Default(maxGroups);
+  if (shardCount == 0) {
+    shardCount = 1;
+  }
+  limits.maxGroups *= shardCount;
+  return limits;
+}
+
 /**
  * Parameters specific to result processing and output formatting pipeline construction.
  * This struct extends CommonPipelineParams with additional configuration needed for
@@ -54,12 +74,14 @@ typedef struct AggregationPipelineParams {
    *  over individual step limits when smaller. */
   size_t maxResultsLimit;
 
+  /** GROUPBY materialization limits for this pipeline. */
+  GroupByLimits groupByLimits;
+
   /** Language setting for text highlighting and language-specific processing.
    *  Used by highlighting result processors to apply proper stemming,
    *  tokenization, and markup for the specified language. */
   RSLanguage language;
 } AggregationPipelineParams;
-
 
 /**
  * Parameters specific to the document retrieval and scoring pipeline construction.

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -12,7 +12,8 @@ extern "C" {
 #endif
 
 static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
-                                     const RLookupKey ***loadKeys, QueryError *err) {
+                                     GroupByLimits groupByLimits,
+                                     QueryError *err) {
   arrayof(const char*) properties = PLNGroupStep_GetProperties(gstp);
   size_t nproperties = array_len(properties);
   const RLookupKey *srckeys[nproperties], *dstkeys[nproperties];
@@ -40,7 +41,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
     }
   }
 
-  Grouper *grp = Grouper_New(srckeys, dstkeys, nproperties);
+  Grouper *grp = Grouper_New(srckeys, dstkeys, nproperties, groupByLimits);
 
   size_t nreducers = array_len(gstp->reducers);
   for (size_t ii = 0; ii < nreducers; ++ii) {
@@ -93,7 +94,9 @@ static ResultProcessor *getGroupRP(Pipeline *pipeline, const AggregationPipeline
   RLookup *lookup = AGPLN_GetLookup(&pipeline->ap, &gstp->base, AGPLN_GETLOOKUP_PREV);
   RLookup *firstLk = AGPLN_GetLookup(&pipeline->ap, &gstp->base, AGPLN_GETLOOKUP_FIRST); // first lookup can load fields from redis
   const RLookupKey **loadKeys = NULL;
-  ResultProcessor *groupRP = buildGroupRP(gstp, lookup, (firstLk == lookup && firstLk->spcache) ? &loadKeys : NULL, status);
+  ResultProcessor *groupRP = buildGroupRP(
+      gstp, lookup, (firstLk == lookup && firstLk->spcache) ? &loadKeys : NULL,
+      params->groupByLimits, status);
 
   if (!groupRP) {
     array_free(loadKeys);

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
-                                     GroupByLimits groupByLimits,
+                                     const RLookupKey ***loadKeys, GroupByLimits groupByLimits,
                                      QueryError *err) {
   arrayof(const char*) properties = PLNGroupStep_GetProperties(gstp);
   size_t nproperties = array_len(properties);

--- a/tests/cpptests/redismock/CMakeLists.txt
+++ b/tests/cpptests/redismock/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_library(redismock STATIC redismock.cpp util.cpp)
+target_compile_features(redismock PUBLIC cxx_std_17)

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -167,7 +167,8 @@ TEST_F(AggTest, testGroupBy) {
   RLookupKey *score_out = RLookup_GetKey_Write(&rk_out, "SCORE", RLOOKUP_F_NOFLAGS);
   RLookupKey *count_out = RLookup_GetKey_Write(&rk_out, "COUNT", RLOOKUP_F_NOFLAGS);
 
-  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1);
+  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1,
+                            GroupByLimits_Default(DEFAULT_MAX_AGGREGATE_GROUPS));
   ASSERT_TRUE(gr != NULL);
 
   ArgsCursor args = {0};
@@ -211,7 +212,8 @@ TEST_F(AggTest, testGroupSplit) {
   gen.kvalue = RLookup_GetKey_Write(&lk_in, "value", RLOOKUP_F_NOFLAGS);
   RLookupKey *val_out = RLookup_GetKey_Write(&lk_out, "value", RLOOKUP_F_NOFLAGS);
   RLookupKey *count_out = RLookup_GetKey_Write(&lk_out, "COUNT", RLOOKUP_F_NOFLAGS);
-  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1);
+  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1,
+                            GroupByLimits_Default(DEFAULT_MAX_AGGREGATE_GROUPS));
   ArgsCursor args = {0};
   ReducerOptions opt = {0};
   opt.args = &args;

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -119,7 +119,7 @@ static void testCountDistinct() {
   assert(dstp);
 
   AREQDIST_UpstreamInfo us = {0};
-  rc = AREQ_BuildDistributedPipeline(r, &us, &status);
+  rc = AREQ_BuildDistributedPipeline(r, &us, NULL, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't build distributed pipeline: %s\n", QueryError_GetUserError(&status));
   }
@@ -157,7 +157,7 @@ static void testSplit() {
   assert(dstp);
 
   AREQDIST_UpstreamInfo us = {0};
-  rc = AREQ_BuildDistributedPipeline(r, &us, &status);
+  rc = AREQ_BuildDistributedPipeline(r, &us, NULL, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't build distributed pipeline: %s\n", QueryError_GetUserError(&status));
   }

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -825,6 +825,99 @@ def test_groupby_array(env: Env):
     env.assertContains(row, exp)
   env.assertEqual(len(res), len(exp), message=f'{res} != {exp}')
 
+def test_groupby_array_group_limit_boundary():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 4')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    con.execute_command('HSET', 'doc1', 't1', 'foo,bar', 't2', 'baz,qux')
+
+  res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                'APPLY', 'split(@t1, ",")', 'AS', 't1',
+                'APPLY', 'split(@t2, ",")', 'AS', 't2',
+                'GROUPBY', '2', '@t1', '@t2',
+                'REDUCE', 'COUNT', '0', 'AS', 'count')
+
+  env.assertEqual(res[0], 4)
+  env.assertEqual(len(res), 5)
+
+def test_groupby_tag_group_limit_boundary():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 4')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'TAG', 'SORTABLE').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    for i in range(4):
+      con.execute_command('HSET', f'doc{i}', 'g', f'g{i}')
+
+  res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                'GROUPBY', '1', '@g',
+                'REDUCE', 'COUNT', '0', 'AS', 'count')
+
+  env.assertEqual(res[0], 4)
+  env.assertEqual(len(res), 5)
+
+@skip(cluster=True)
+def test_groupby_array_row_expansion_limit():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 3')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA',
+             't1', 'TEXT', 'SORTABLE',
+             't2', 'TEXT', 'SORTABLE',
+             'tag1', 'TAG',
+             'tag2', 'TAG').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    con.execute_command('HSET', 'doc1',
+                        't1', 'foo,bar',
+                        't2', 'baz,qux',
+                        'tag1', 'red,blue',
+                        'tag2', 'circle,square')
+
+  env.expect('FT.AGGREGATE', 'idx', '*',
+             'LOAD', '2', '@tag1', '@tag2',
+             'APPLY', 'split(@tag1, ",")', 'AS', 'tag1_values',
+             'APPLY', 'split(@tag2, ",")', 'AS', 'tag2_values',
+             'GROUPBY', '2', '@tag1_values', '@tag2_values',
+             'REDUCE', 'COUNT', '0', 'AS', 'count').error() \
+      .contains('MAX_AGGREGATE_GROUPS') \
+      .contains('3')
+
+  env.expect('FT.AGGREGATE', 'idx', '*',
+             'APPLY', 'split(@t1, ",")', 'AS', 't1',
+             'APPLY', 'split(@t2, ",")', 'AS', 't2',
+             'GROUPBY', '2', '@t1', '@t2',
+             'REDUCE', 'COUNT', '0', 'AS', 'count').error() \
+      .contains('MAX_AGGREGATE_GROUPS') \
+      .contains('3')
+
+@skip(cluster=True)
+def test_groupby_total_group_limit():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 3')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'TAG', 'SORTABLE').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    for i in range(4):
+      con.execute_command('HSET', f'doc{i}', 'g', f'g{i}')
+
+  env.expect('FT.AGGREGATE', 'idx', '*',
+             'GROUPBY', '1', '@g',
+             'REDUCE', 'COUNT', '0', 'AS', 'count').error() \
+      .contains('MAX_AGGREGATE_GROUPS') \
+      .contains('3')
+
+@skip(cluster=False)
+def test_groupby_coordinator_group_limit_uses_shard_count():
+  env = Env(shardsCount=3, protocol=3, moduleArgs='MAX_AGGREGATE_GROUPS 2')
+
+  env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'g', 'TAG', 'SORTABLE').ok()
+  shard_tags = ['shard:0', 'shard:1', 'shard:3']
+  conn = getConnectionByEnv(env)
+  for i, shard_tag in enumerate(shard_tags):
+    conn.execute_command('HSET', f'doc:{i}{{{shard_tag}}}', 'g', f'g{i}')
+
+  res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                'GROUPBY', '1', '@g',
+                'REDUCE', 'COUNT', '0', 'AS', 'count')
+
+  env.assertEqual(len(res['results']), 3)
+  env.assertEqual(sorted(row['extra_attributes']['g'] for row in res['results']),
+                  ['g0', 'g1', 'g2'])
+
 def testMultiSortBy(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'sb_idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -45,6 +45,8 @@ def testConfigErrors(env):
         .contains('Minimum stem length cannot be lower than')
     env.expect(config_cmd(), 'set', 'WORKERS', 1_000_000).error()\
         .contains('Number of worker threads cannot exceed')
+    env.expect(config_cmd(), 'set', 'MAX_AGGREGATE_GROUPS', 0).error()\
+        .contains('SEARCH_PARSE_ARGS')
 
 @skip(cluster=True)
 def testGetConfigOptions(env):
@@ -69,6 +71,7 @@ def testGetConfigOptions(env):
     check_config('FRISOINI')
     check_config('MAXSEARCHRESULTS')
     check_config('MAXAGGREGATERESULTS')
+    check_config('MAX_AGGREGATE_GROUPS')
     check_config('ON_TIMEOUT')
     check_config('GCSCANSIZE')
     check_config('MIN_PHONETIC_TERM_LEN')
@@ -531,6 +534,8 @@ UINT64_MAX = (1 << 64) - 1
 UINT32_MAX = (1 << 32) - 1
 MAX_AGGREGATE_REQUEST_RESULTS = (1 << 31)
 DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS = MAX_AGGREGATE_REQUEST_RESULTS
+MAX_AGGREGATE_GROUPS = (1 << 26)
+DEFAULT_MAX_AGGREGATE_GROUPS = 1_000_000
 
 MAX_SEARCH_REQUEST_RESULTS = (1 << 31)
 DEFAULT_MAX_SEARCH_REQUEST_RESULTS = 1_000_000
@@ -548,6 +553,7 @@ numericConfigs = [
     ('search-fork-gc-sleep-before-exit', 'FORKGC_SLEEP_BEFORE_EXIT', 0, 0, LLONG_MAX, False, False),
     ('search-gc-scan-size', 'GCSCANSIZE', 100, 1, LLONG_MAX, True, False),
     ('search-index-cursor-limit', 'INDEX_CURSOR_LIMIT', 128, 0, LLONG_MAX, False, False),
+    ('search-max-aggregate-groups', 'MAX_AGGREGATE_GROUPS', DEFAULT_MAX_AGGREGATE_GROUPS, 1, MAX_AGGREGATE_GROUPS, False, False),
     ('search-max-aggregate-results', 'MAXAGGREGATERESULTS', DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS, 0, MAX_AGGREGATE_REQUEST_RESULTS, False, False),
     ('search-max-doctablesize', 'MAXDOCTABLESIZE', 1_000_000, 1, 100_000_000, True, False),
     ('search-max-prefix-expansions', 'MAXPREFIXEXPANSIONS', 200, 1, LLONG_MAX, False, False),

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -45,8 +45,7 @@ def testConfigErrors(env):
         .contains('Minimum stem length cannot be lower than')
     env.expect(config_cmd(), 'set', 'WORKERS', 1_000_000).error()\
         .contains('Number of worker threads cannot exceed')
-    env.expect(config_cmd(), 'set', 'MAX_AGGREGATE_GROUPS', 0).error()\
-        .contains('SEARCH_PARSE_ARGS')
+    env.expect(config_cmd(), 'set', 'MAX_AGGREGATE_GROUPS', 0).error()
 
 @skip(cluster=True)
 def testGetConfigOptions(env):

--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -102,20 +102,15 @@ def test_hybrid_groupby_total_group_limit():
                              'embedding', vector)
 
     query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
-    res = env.cmd('FT.HYBRID', 'idx',
-                  'SEARCH', 'nomatch',
-                  'VSIM', '@embedding', '$BLOB',
-                      'RANGE', '2', 'RADIUS', '16',
-                  'GROUPBY', '1', '@__key',
-                      'REDUCE', 'COUNT', '0', 'AS', 'count',
-                  'PARAMS', '2', 'BLOB', query_vector)
-
-    warnings = res.get('warnings', [])
-    env.assertTrue(len(warnings) > 0, message=f'Expected GROUPBY limit warning, got: {res}')
-    warning = warnings[0]
-    env.assertContains('MAX_AGGREGATE_GROUPS', warning)
-    env.assertContains('2', warning)
-    env.assertEqual(res['results'], [])
+    env.expect('FT.HYBRID', 'idx',
+               'SEARCH', 'nomatch',
+               'VSIM', '@embedding', '$BLOB',
+                   'RANGE', '2', 'RADIUS', '16',
+               'GROUPBY', '1', '@__key',
+                   'REDUCE', 'COUNT', '0', 'AS', 'count',
+               'PARAMS', '2', 'BLOB', query_vector).error() \
+        .contains('MAX_AGGREGATE_GROUPS') \
+        .contains('2')
 
 @skip(cluster=False)
 def test_hybrid_groupby_coordinator_group_limit():

--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -84,6 +84,65 @@ def l2_from_bytes(a_bytes, b_bytes) -> float:
     b = np.frombuffer(b_bytes, dtype=np.float32)
     return np.linalg.norm(a - b)
 
+@skip(cluster=True)
+def test_hybrid_groupby_total_group_limit():
+    env = Env(protocol=3, moduleArgs='MAX_AGGREGATE_GROUPS 2')
+
+    env.expect('FT.CREATE', 'idx',
+               'SCHEMA',
+               'description', 'TEXT',
+               'embedding', 'VECTOR', 'FLAT', '6',
+               'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
+    conn = getConnectionByEnv(env)
+    for i in range(3):
+        vector = np.array([float(i + 1), 0.0], dtype=np.float32).tobytes()
+        conn.execute_command('HSET', f'doc:{i}',
+                             'description', 'red',
+                             'embedding', vector)
+
+    query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+    env.expect('FT.HYBRID', 'idx',
+               'SEARCH', 'nomatch',
+               'VSIM', '@embedding', '$BLOB',
+                   'RANGE', '2', 'RADIUS', '16',
+               'GROUPBY', '1', '@__key',
+                   'REDUCE', 'COUNT', '0', 'AS', 'count',
+               'PARAMS', '2', 'BLOB', query_vector).error() \
+        .contains('MAX_AGGREGATE_GROUPS') \
+        .contains('2')
+
+@skip(cluster=False)
+def test_hybrid_groupby_coordinator_group_limit_uses_shard_count():
+    env = Env(shardsCount=3, protocol=3, moduleArgs='MAX_AGGREGATE_GROUPS 2')
+
+    env.expect('FT.CREATE', 'idx',
+               'SCHEMA',
+               'description', 'TEXT',
+               'embedding', 'VECTOR', 'FLAT', '6',
+               'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
+    conn = getConnectionByEnv(env)
+    shard_tags = ['shard:0', 'shard:1', 'shard:3']
+    for i, shard_tag in enumerate(shard_tags):
+        vector = np.array([float(i + 1), 0.0], dtype=np.float32).tobytes()
+        conn.execute_command('HSET', f'doc:{i}{{{shard_tag}}}',
+                             'description', 'red',
+                             'embedding', vector)
+
+    query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+    res = env.cmd('FT.HYBRID', 'idx',
+                  'SEARCH', 'nomatch',
+                  'VSIM', '@embedding', '$BLOB',
+                      'RANGE', '2', 'RADIUS', '16',
+                  'GROUPBY', '1', '@__key',
+                      'REDUCE', 'COUNT', '0', 'AS', 'count',
+                  'PARAMS', '2', 'BLOB', query_vector)
+
+    env.assertEqual(len(res['results']), 3)
+    for row in res['results']:
+        env.assertEqual(row['count'], '1')
+
 def test_hybrid_groupby_small():
     """Test hybrid search with small result set (3 docs) + groupby"""
     env = Env()

--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -102,15 +102,20 @@ def test_hybrid_groupby_total_group_limit():
                              'embedding', vector)
 
     query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
-    env.expect('FT.HYBRID', 'idx',
-               'SEARCH', 'nomatch',
-               'VSIM', '@embedding', '$BLOB',
-                   'RANGE', '2', 'RADIUS', '16',
-               'GROUPBY', '1', '@__key',
-                   'REDUCE', 'COUNT', '0', 'AS', 'count',
-               'PARAMS', '2', 'BLOB', query_vector).error() \
-        .contains('MAX_AGGREGATE_GROUPS') \
-        .contains('2')
+    res = env.cmd('FT.HYBRID', 'idx',
+                  'SEARCH', 'nomatch',
+                  'VSIM', '@embedding', '$BLOB',
+                      'RANGE', '2', 'RADIUS', '16',
+                  'GROUPBY', '1', '@__key',
+                      'REDUCE', 'COUNT', '0', 'AS', 'count',
+                  'PARAMS', '2', 'BLOB', query_vector)
+
+    warnings = res.get('warnings', [])
+    env.assertTrue(len(warnings) > 0, message=f'Expected GROUPBY limit warning, got: {res}')
+    warning = warnings[0]
+    env.assertContains('MAX_AGGREGATE_GROUPS', warning)
+    env.assertContains('2', warning)
+    env.assertEqual(res['results'], [])
 
 @skip(cluster=False)
 def test_hybrid_groupby_coordinator_group_limit():
@@ -131,15 +136,20 @@ def test_hybrid_groupby_coordinator_group_limit():
                              'embedding', vector)
 
     query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
-    env.expect('FT.HYBRID', 'idx',
-               'SEARCH', 'nomatch',
-               'VSIM', '@embedding', '$BLOB',
-                   'RANGE', '2', 'RADIUS', '16',
-               'GROUPBY', '1', '@__key',
-                   'REDUCE', 'COUNT', '0', 'AS', 'count',
-               'PARAMS', '2', 'BLOB', query_vector).error() \
-        .contains('MAX_AGGREGATE_GROUPS') \
-        .contains('2')
+    res = env.cmd('FT.HYBRID', 'idx',
+                  'SEARCH', 'nomatch',
+                  'VSIM', '@embedding', '$BLOB',
+                      'RANGE', '2', 'RADIUS', '16',
+                  'GROUPBY', '1', '@__key',
+                      'REDUCE', 'COUNT', '0', 'AS', 'count',
+                  'PARAMS', '2', 'BLOB', query_vector)
+
+    warnings = res.get('warnings', [])
+    env.assertTrue(len(warnings) > 0, message=f'Expected GROUPBY limit warning, got: {res}')
+    warning = warnings[0]
+    env.assertContains('MAX_AGGREGATE_GROUPS', warning)
+    env.assertContains('2', warning)
+    env.assertEqual(res['results'], [])
 
 def test_hybrid_groupby_small():
     """Test hybrid search with small result set (3 docs) + groupby"""

--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -113,7 +113,7 @@ def test_hybrid_groupby_total_group_limit():
         .contains('2')
 
 @skip(cluster=False)
-def test_hybrid_groupby_coordinator_group_limit_uses_shard_count():
+def test_hybrid_groupby_coordinator_group_limit():
     env = Env(shardsCount=3, protocol=3, moduleArgs='MAX_AGGREGATE_GROUPS 2')
 
     env.expect('FT.CREATE', 'idx',
@@ -131,17 +131,15 @@ def test_hybrid_groupby_coordinator_group_limit_uses_shard_count():
                              'embedding', vector)
 
     query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
-    res = env.cmd('FT.HYBRID', 'idx',
-                  'SEARCH', 'nomatch',
-                  'VSIM', '@embedding', '$BLOB',
-                      'RANGE', '2', 'RADIUS', '16',
-                  'GROUPBY', '1', '@__key',
-                      'REDUCE', 'COUNT', '0', 'AS', 'count',
-                  'PARAMS', '2', 'BLOB', query_vector)
-
-    env.assertEqual(len(res['results']), 3)
-    for row in res['results']:
-        env.assertEqual(row['count'], '1')
+    env.expect('FT.HYBRID', 'idx',
+               'SEARCH', 'nomatch',
+               'VSIM', '@embedding', '$BLOB',
+                   'RANGE', '2', 'RADIUS', '16',
+               'GROUPBY', '1', '@__key',
+                   'REDUCE', 'COUNT', '0', 'AS', 'count',
+               'PARAMS', '2', 'BLOB', query_vector).error() \
+        .contains('MAX_AGGREGATE_GROUPS') \
+        .contains('2')
 
 def test_hybrid_groupby_small():
     """Test hybrid search with small result set (3 docs) + groupby"""


### PR DESCRIPTION
## Backport notes

Backport of https://github.com/RediSearch/RediSearch/pull/9830.

Reviewer guide: if you already approved #9830, review this PR mainly for the branch-specific adaptations below. The distributed aggregate GROUPBY limit behavior follows the original PR: `MAX_AGGREGATE_GROUPS`, `GroupByLimits`, grouper enforcement, coordinator shard scaling, and aggregate tests. FT.HYBRID tail GROUPBY intentionally keeps the configured cap on the coordinator because it runs after hybrid merge and is not a distributed GROUPBY.

Branch-specific conflict resolutions and follow-up fixes:
1. Aggregate pipeline construction: adapted aggregation pipeline params to 8.4's older pipeline and reducer option APIs.
2. Distributed hybrid paths: preserved branch-local distributed hybrid code and omitted newer coordinator profile-clock plumbing that depends on `ConcurrentCmdCtx_GetCoordStartTime`.
3. Coordinator aggregate paths: captured `NumShards` in the existing concurrent handler context for shard-scaled distributed aggregate GROUPBY limits.
4. Follow-up build fix: kept the branch-local `loadKeys` parameter in `buildGroupRP` while adding `GroupByLimits`.
5. Follow-up build fix: used branch-local `QUERY_ELIMIT` naming instead of newer `QUERY_ERROR_CODE_LIMIT`.
6. Follow-up test fix: relaxed invalid `MAX_AGGREGATE_GROUPS 0` config test to assert an error without depending on the exact config-layer error message.
7. Follow-up review fix: removed shard-scaled GROUPBY limits for FT.HYBRID tail GROUPBY; the parser-provided default cap is used.
8. Follow-up style fix: removed the redundant comment before the `GroupByLimits` field.

## Describe the changes in the pull request

Current: FT.AGGREGATE / FT.HYBRID GROUPBY did not have a dedicated cap for materialized groups.
Change: Add `MAX_AGGREGATE_GROUPS` / `search-max-aggregate-groups` with a 1,000,000 default and a `1 << 26` maximum, enforce it in GROUPBY creation and row expansion, and scale coordinator max groups by shard count for distributed aggregate. FT.HYBRID GROUPBY uses the configured cap in both standalone and coordinator mode.
Outcome: GROUPBY work is bounded by a configurable limit and returns `SEARCH_LIMIT_OVER` when exceeded.

#### Which additional issues this PR fixes
1. MOD-15113
2. Backport of #9830

#### Main objects this PR modified
1. GROUPBY result processor
2. Runtime configuration
3. Aggregate and hybrid pipeline limit plumbing
4. Python and C++ tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes aggregate and hybrid query execution and cluster merge behavior; mis-tuned limits could reject valid GROUPBY workloads or still allow high memory use until the cap is hit.
> 
> **Overview**
> Adds **`MAX_AGGREGATE_GROUPS`** / `search-max-aggregate-groups` (default **1,000,000**, max **2²⁶**) to cap how many **GROUPBY** groups a query may materialize.
> 
> **GROUPBY** now fails with **`QUERY_ELIMIT`** when the distinct-group count or **array-driven row expansion** (cartesian product) would exceed the effective limit. Limits flow through new **`GroupByLimits`** on **`AggregationPipelineParams`**, with **`AREQ_MakeAggregationPipelineParams`** / **`AREQ_BuildPipelineWithAggregationParams`** so callers can override defaults.
> 
> On the **coordinator**, distributed **`FT.AGGREGATE`** scales the cap by **shard count** (`GroupByLimits_ForCoordinator`) because it merges shard-local groups. **`FT.HYBRID`** tail **GROUPBY** keeps the configured cap without shard scaling.
> 
> Config is exposed via **FT.CONFIG**, **Redis module CONFIG**, and **INFO**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4568037ad5ee64718574c15c6c76ad386cbc973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->