### PR TITLE
[MOD-15720] Fix fork-GC crash on empty tag value with WITHSUFFIXTRIE

### DIFF
--- a/src/suffix.c
+++ b/src/suffix.c
@@ -400,9 +400,9 @@ void addSuffixTrieMap(TrieMap *trie, const char *str, uint32_t len) {
     data->array = array_ensure_append_1(data->array, copyStr);
   }
 
-  // Save string copy to all suffixes of it
-  // If it exists, move to the next field
-  for (int j = 1; j < len - MIN_SUFFIX + 1; ++j) {
+  // Save string copy to all suffixes of it.
+  // `j + MIN_SUFFIX <= len` avoids unsigned underflow when len < MIN_SUFFIX.
+  for (size_t j = 1; j + MIN_SUFFIX <= (size_t)len; ++j) {
     data = TrieMap_Find(trie, copyStr + j, len - j);
 
     if (data == TRIEMAP_NOTFOUND) {
@@ -418,18 +418,33 @@ void addSuffixTrieMap(TrieMap *trie, const char *str, uint32_t len) {
 void deleteSuffixTrieMap(TrieMap *trie, const char *str, uint32_t len) {
   char *oldTerm = NULL;
 
-  // iterate all matching terms and remove word
-  for (int j = 0; j < len - MIN_SUFFIX + 1; ++j) {
-    suffixData *data = TrieMap_Find(trie, str + j, len - j);
-    RS_LOG_ASSERT(data != TRIEMAP_NOTFOUND, "all suffixes must exist");
-    if (j == 0) {
-      // keep pointer to word string to free after it was found in all sub tokens.
+  // Full-term entry (always inserted by addSuffixTrieMap).
+  if (len > 0) {
+    suffixData *data = TrieMap_Find(trie, str, len);
+    if (data == TRIEMAP_NOTFOUND) {
+      // values and suffix TrieMaps should mirror each other. A miss here means
+      // a value reached TagIndex->values without going through addSuffixTrieMap
+      // (e.g. the empty-string regression fixed in MOD-15720). Log and keep
+      // going so a single inconsistency doesn't crash the fork GC thread.
+      RedisModule_Log(RSDummyContext, "warning",
+                      "deleteSuffixTrieMap: tag value missing from suffix trie "
+                      "(values/suffix out of sync)");
+    } else {
       oldTerm = data->term;
       data->term = NULL;
+      removeSuffix(str, len, data->array);
+      if (array_len(data->array) == 0) {
+        RS_LOG_ASSERT(!data->term, "array should contain a pointer to the string");
+        TrieMap_Delete(trie, str, len, (freeCB)freeSuffixNode);
+      }
     }
-    // remove from array
+  }
+
+  // Sub-suffix entries. Same underflow-safe bound as addSuffixTrieMap above.
+  for (size_t j = 1; j + MIN_SUFFIX <= (size_t)len; ++j) {
+    suffixData *data = TrieMap_Find(trie, str + j, len - j);
+    if (data == TRIEMAP_NOTFOUND) continue;
     removeSuffix(str, len, data->array);
-    // if array is empty, remove the node
     if (array_len(data->array) == 0) {
       RS_LOG_ASSERT(!data->term, "array should contain a pointer to the string");
       TrieMap_Delete(trie, str + j, len - j, (freeCB)freeSuffixNode);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -234,7 +234,9 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, const char **values, siz
       if (tok) {
         TrieMap_Add(idx->values, tok, strlen(tok), NULL, NULL);
 
-        if (idx->suffix && (*tok != '\0')) {
+        // MOD-15720: idx->values and idx->suffix must stay coherent so that
+        // fork-GC cleanup of an emptied tag value finds the matching entry.
+        if (idx->suffix) {
           addSuffixTrieMap(idx->suffix, tok, strlen(tok));
         }
       }
@@ -246,7 +248,8 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, const char **values, siz
       if (tok) {
         stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, stats);
 
-        if (idx->suffix && (*tok != '\0')) { // add to suffix TrieMap
+        // MOD-15720: see comment in the disk branch above.
+        if (idx->suffix) {
           addSuffixTrieMap(idx->suffix, tok, strlen(tok));
         }
       }

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -654,3 +654,112 @@ def testForceGCBypassesThreshold(env):
     forceInvokeGC(env, 'idx')
     env.expect(debug_cmd(), 'DUMP_INVIDX', 'idx', 'hello').equal([10])
 
+
+# MOD-15720: TAG `INDEXEMPTY WITHSUFFIXTRIE` adds "" to TagIndex->values but
+# skips TagIndex->suffix because TagIndex_Index gates `addSuffixTrieMap` on
+# `*tok != '\0'`. When the last doc holding "" is deleted and fork GC runs,
+# FGC_parentHandleTags calls deleteSuffixTrieMap(tagIdx->suffix, "", 0); the
+# TrieMap_Find misses, returns TRIEMAP_NOTFOUND (the .rodata string
+# "NOT FOUND"), and the next statement writes through it -> SIGSEGV
+# (SEGV_ACCERR). The crash is triggered by any code path that delivers an
+# empty token to TagIndex_Index. The tests below cover each distinct path.
+
+def _gcCrashCheckHash(env, hset_value):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
+    waitForIndex(env, 'idx')
+    env.cmd('HSET', 'doc1', 't', hset_value)
+    env.expect('DEL', 'doc1').equal(1)
+    forceInvokeGC(env, 'idx')
+    env.expect('PING').equal(True)
+    env.flush()
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_emptyValue_MOD_15720():
+    # FLD_VAR_T_CSTR + tokenizeTagString empty-input branch:
+    #   "" -> array contains ""
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    _gcCrashCheckHash(env, '')
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_consecutiveSeparators_MOD_15720():
+    # tokenizeTagString separator-split branch produces an empty middle token:
+    #   "a,,b" -> ["a", "", "b"]
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    _gcCrashCheckHash(env, 'a,,b')
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_trailingSeparator_MOD_15720():
+    # tokenizeTagString last_is_sep branch:
+    #   "x," -> ["x", ""]
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    _gcCrashCheckHash(env, 'x,')
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_leadingSeparator_MOD_15720():
+    # tokenizeTagString first-char-is-sep branch:
+    #   ",y" -> ["", "y"]
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    _gcCrashCheckHash(env, ',y')
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_whitespaceOnly_MOD_15720():
+    # tokenizeTagString whitespace-then-NUL branch:
+    #   "   " -> [""]
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    _gcCrashCheckHash(env, '   ')
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_multiDoc_MOD_15720():
+    # Multiple docs share the empty value; crash triggers only when the inv
+    # index for "" hits numDocs==0. Exercises the FGC accumulation path.
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
+    waitForIndex(env, 'idx')
+    for i in range(5):
+        env.cmd('HSET', f'doc{i}', 't', '')
+    for i in range(5):
+        env.expect('DEL', f'doc{i}').equal(1)
+    forceInvokeGC(env, 'idx')
+    env.expect('PING').equal(True)
+
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_sortable_MOD_15720():
+    # SORTABLE attaches a separate sortable-vector path but TagIndex_Index is
+    # unchanged. Same crash signature.
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE', 'SORTABLE').ok()
+    waitForIndex(env, 'idx')
+    env.cmd('HSET', 'doc1', 't', '')
+    env.expect('DEL', 'doc1').equal(1)
+    forceInvokeGC(env, 'idx')
+    env.expect('PING').equal(True)
+
+@skip(cluster=True, no_json=True)
+def testForkGCEmptyTagSuffixTrie_jsonScalar_MOD_15720():
+    # FLD_VAR_T_CSTR via JSON scalar path. JSON default separator skips
+    # tokenizeTagString's separator loop and rm_strdup's the value directly,
+    # so "" arrives at TagIndex_Index unchanged.
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA',
+               '$t', 'AS', 't', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
+    waitForIndex(env, 'jidx')
+    env.expect('JSON.SET', 'j1', '$', '{"t":""}').ok()
+    env.expect('DEL', 'j1').equal(1)
+    forceInvokeGC(env, 'jidx')
+    env.expect('PING').equal(True)
+
+@skip(cluster=True, no_json=True)
+def testForkGCEmptyTagSuffixTrie_jsonArrayWithEmpty_MOD_15720():
+    # FLD_VAR_T_ARRAY: tokenizeTagString runs per element, an "" element
+    # propagates through.
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA',
+               '$arr[*]', 'AS', 'arr', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
+    waitForIndex(env, 'jidx')
+    env.expect('JSON.SET', 'j1', '$', '{"arr":["a","","b"]}').ok()
+    env.expect('DEL', 'j1').equal(1)
+    forceInvokeGC(env, 'jidx')
+    env.expect('PING').equal(True)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: A `TAG INDEXEMPTY WITHSUFFIXTRIE` field crashes the server in the fork-GC thread when the last document holding an empty (`\"\"`) tag value is deleted. Stack:
   ```
   deleteSuffixTrieMap        src/suffix.c
   FGC_parentHandleTags       src/fork_gc.c
   FGC_parentHandleFromChild  src/fork_gc.c
   periodicCb                 src/fork_gc.c
   taskCallback               src/gc.c
   ```
   The crash is `SIGSEGV` with `si_code: 2` (`SEGV_ACCERR`) on a read-only address inside the loaded module — observed as a crash-loop on AOF replay (e.g. a customer cluster crashed 11 times in 23 minutes with bit-identical stacks).

2. **Change**:
   - `src/tag_index.c`: drop the `*tok != '\\0'` gate on the `addSuffixTrieMap` call so that `idx->values` and `idx->suffix` stay coherent for every value (including the empty string when the field has `INDEXEMPTY`).
   - `src/suffix.c`: peel the `j=0` (term) case out of `deleteSuffixTrieMap`, restore the `TRIEMAP_NOTFOUND` guard with a `RedisModule_Log(\"warning\", …)` so that any future divergence between `values` and `suffix` surfaces in logs instead of crashing, and switch the suffix loops in both `addSuffixTrieMap` and `deleteSuffixTrieMap` to the underflow-safe bound `j + MIN_SUFFIX <= len` that's already used by the TEXT counterparts at [src/suffix.c:84](src/suffix.c#L84) and [src/suffix.c:141](src/suffix.c#L141).
   - `tests/pytests/test_gc.py`: nine regression tests covering every tokenizer branch that delivers an empty token to `TagIndex_Index`.

3. **Outcome**: The crash is fixed at its root (no more `values`/`suffix` divergence). The defensive log+`continue` and the underflow-safe loop bound prevent the same crash class from being reintroduced silently by future refactors.

### Root cause

`TagIndex_Index` ([src/tag_index.c:237-251](src/tag_index.c#L237-L251)) added every tag value to `tagIdx->values` unconditionally but gated the corresponding `addSuffixTrieMap` call on `*tok != '\\0'`. For an `INDEXEMPTY` TAG field the empty value `\"\"` therefore entered `tagIdx->values` but never `tagIdx->suffix`. When fork GC eventually emptied that value's inverted index, `FGC_parentHandleTags` called `deleteSuffixTrieMap(tagIdx->suffix, \"\", 0)`. `TrieMap_Find` missed and returned the `TRIEMAP_NOTFOUND` sentinel — which is declared in `deps/triemap/triemap.c` as `void *TRIEMAP_NOTFOUND = \"NOT FOUND\";`, i.e. a pointer into the loaded module's `.rodata`. The next line in `deleteSuffixTrieMap` was `data->term = NULL;`, writing through that read-only pointer and producing `SEGV_ACCERR`.

A latent unsigned-underflow bug compounded this: the loop bound `j < len - MIN_SUFFIX + 1` is `uint32_t` arithmetic, so for `len = 0` it evaluates to `0xFFFFFFFF`, meaning `addSuffixTrieMap(\"\", 0)` would have wedged on an infinite/wild-read loop even if the gate were simply dropped. Switching to the `j + MIN_SUFFIX <= len` form (already used by the TEXT helpers in the same file) removes this latent bug while keeping the behavior identical for `len >= MIN_SUFFIX`.

### Regressing change

PR #4554 (MOD-5902, merged 2024-04) removed the `if (data == TRIEMAP_NOTFOUND) continue;` guard from `deleteSuffixTrieMap` on the (incorrect) assumption that it was a vestigial TEXT-only check. The TEXT counterpart `deleteSuffixTrie` retained its guard and was unaffected.

### Necessary conditions for the bug

1. TAG field declared with both `INDEXEMPTY` and `WITHSUFFIXTRIE` — without `INDEXEMPTY` the tokenizer filters empty tokens out before they reach `TagIndex_Index`; without `WITHSUFFIXTRIE` the call site in `FGC_parentHandleTags` is guarded out by `if (tagIdx->suffix)`.
2. At least one document indexed an empty token, either directly (`HSET k t \"\"`) or via tokenization (`\"a,,b\"`, `\",x\"`, `\"x,\"`, whitespace-only).
3. The last document holding that empty token is deleted or has its tag field overwritten with a non-empty value, bringing the empty-value inverted index's `numDocs` to 0.
4. Fork GC runs.

No dependence on dataset size, dialect, sortable, JSON-vs-hash, or any other index state.

### TEXT side

`deleteSuffixTrie` (TEXT) does not need a parallel fix: it guards the term lookup on `if (rlen > 0)`, uses the underflow-safe loop bound, and defends each suffix iteration with `if (!data) continue;`. The same divergence pattern exists on the add side ([src/indexer.c:138](src/indexer.c#L138) gates on `strlen(entry->term) != 0`) but is harmless because the consumer is defensive.

### Tests

`tests/pytests/test_gc.py` adds nine regression tests, each driving an empty token through a different upstream tokenizer branch and then forcing fork GC:

| Test | Tokenizer branch |
|---|---|
| `_emptyValue_MOD_15720` | empty-input |
| `_consecutiveSeparators_MOD_15720` | separator split mid-string |
| `_trailingSeparator_MOD_15720` | `last_is_sep` |
| `_leadingSeparator_MOD_15720` | first-char-is-sep |
| `_whitespaceOnly_MOD_15720` | whitespace-then-NUL |
| `_multiDoc_MOD_15720` | inv-index `numDocs` accumulation before GC |
| `_sortable_MOD_15720` | `SORTABLE` adjunct path |
| `_jsonScalar_MOD_15720` | JSON scalar (`FLD_VAR_T_CSTR`) |
| `_jsonArrayWithEmpty_MOD_15720` | JSON array (`FLD_VAR_T_ARRAY`) |

Each crashes on pre-fix master and passes after the fix.

### Workaround (no code change)

Recreate the affected indexes without `WITHSUFFIXTRIE` (or without `INDEXEMPTY`) on the TAG fields. `FT.ALTER` cannot change a field's attributes, so it requires `FT.DROPINDEX` + `FT.CREATE` (or alias swap). To unblock a shard stuck in a crash loop: load with `FORK_GC_RUN_INTERVAL 0` via module args, replay AOF, then rebuild and re-enable GC.

#### Which additional issues this PR fixes
1. MOD-15720

#### Main objects this PR modified
1. `addSuffixTrieMap` / `deleteSuffixTrieMap` in [src/suffix.c](src/suffix.c)
2. `TagIndex_Index` in [src/tag_index.c](src/tag_index.c)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes a fork-GC thread SIGSEGV from values/suffix divergence on empty tags; changes run during background GC cleanup on tag indexes.
> 
> **Overview**
> Fixes a **fork-GC crash** when the last document with an **empty tag value** is removed on a `TAG` field using **`INDEXEMPTY`** and **`WITHSUFFIXTRIE`**.
> 
> **`TagIndex_Index`** no longer skips **`addSuffixTrieMap`** for `""`, so **`idx->values`** and **`idx->suffix`** stay aligned for every indexed token (including empty strings).
> 
> **`deleteSuffixTrieMap`** handles the full-term path separately, **logs and continues** on a suffix-trie miss instead of dereferencing the **`TRIEMAP_NOTFOUND`** sentinel, and uses the same **underflow-safe** suffix loop bound as the TEXT helpers (`j + MIN_SUFFIX <= len`).
> 
> Nine **pytest** scenarios force fork GC after indexing/deleting empty tags via hash, separators, whitespace, multi-doc, sortable, and JSON paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ba1802f47642d5726fcbfd8f0854367e9bc8c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->