### PR TITLE
trie: source MAX_RUNE_STR_LEN from C via bindgen

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -682,7 +682,7 @@ static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   }
 }
 
-#define TRIE_STR_TOO_LONG_MSG "query string is too long. Maximum allowed length is " STRINGIFY(MAX_RUNESTR_LEN)
+#define TRIE_STR_TOO_LONG_MSG "query string is too long. Maximum allowed length is " STRINGIFY(MAX_RUNE_STR_LEN)
 
 /* Evaluate a prefix node by expanding all its possible matches and creating one big UNION on all
  * of them.

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -263,7 +263,7 @@ const HEADERS: &[HeaderAllowlist] = &[
         path: "src/trie/rune_util.h",
         fns: &["strToLowerRunes"],
         types: &[],
-        vars: &[],
+        vars: &["MAX_RUNE_STR_LEN"],
     },
     HeaderAllowlist {
         path: "src/trie/trie.h",

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -14,11 +14,11 @@ unittest = []
 build_utils.workspace = true
 
 [dependencies]
+ffi.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
-ffi.workspace = true
 proptest = { workspace = true, features = ["std"] }
 query_eval = { path = ".", features = ["unittest"] }
 redis_mock.workspace = true

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -25,7 +25,7 @@ pub fn unicode_tolower(s: &str) -> String {
 }
 
 /// Maximum number of runes (lowercased codepoints) allowed in a single
-/// conversion, matching the C `MAX_RUNESTR_LEN` constant.
+/// conversion, matching the C `MAX_RUNE_STR_LEN` constant.
 pub const MAX_RUNE_STR_LEN: usize = 1024;
 
 /// Error returned when the lowercased rune sequence exceeds

--- a/src/redisearch_rs/query_eval/src/string_utils.rs
+++ b/src/redisearch_rs/query_eval/src/string_utils.rs
@@ -24,9 +24,8 @@ pub fn unicode_tolower(s: &str) -> String {
     s.chars().flat_map(char::to_lowercase).collect()
 }
 
-/// Maximum number of runes (lowercased codepoints) allowed in a single
-/// conversion, matching the C `MAX_RUNE_STR_LEN` constant.
-pub const MAX_RUNE_STR_LEN: usize = 1024;
+/// Maximum number of runes (lowercased codepoints) allowed in a single conversion.
+pub const MAX_RUNE_STR_LEN: usize = ffi::MAX_RUNE_STR_LEN as usize;
 
 /// Error returned when the lowercased rune sequence exceeds
 /// [`MAX_RUNE_STR_LEN`].

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -30,7 +30,7 @@ rune runeFold(rune r) {
 }
 
 char *runesToStr(const rune *in, size_t len, size_t *utflen) {
-  if (len > MAX_RUNESTR_LEN) {
+  if (len > MAX_RUNE_STR_LEN) {
     if (utflen) *utflen = 0;
     return NULL;
   }
@@ -67,7 +67,7 @@ rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len) {
   // determine the length of the folded string
   ssize_t rlen = nu_strtransformnlen(str, utf8_len, nu_utf8_read,
                                      nu_tolower, nu_casemap_read);
-  if (rlen > MAX_RUNESTR_LEN) {
+  if (rlen > MAX_RUNE_STR_LEN) {
     *unicode_len = 0;
     return NULL;
   }
@@ -108,7 +108,7 @@ rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len) {
 rune *strToSingleCodepointFoldedRunes(const char *str, size_t utf8_len, size_t *len) {
 
   ssize_t rlen = nu_strnlen(str, utf8_len, nu_utf8_read);
-  if (rlen > MAX_RUNESTR_LEN) {
+  if (rlen > MAX_RUNE_STR_LEN) {
     if (len) *len = 0;
     return NULL;
   }
@@ -130,7 +130,7 @@ rune *strToSingleCodepointFoldedRunes(const char *str, size_t utf8_len, size_t *
 rune *strToRunes(const char *str, size_t *len) {
   // Determine the length
   ssize_t rlen = nu_strlen(str, nu_utf8_read);
-  if (rlen > MAX_RUNESTR_LEN) {
+  if (rlen > MAX_RUNE_STR_LEN) {
     if (len) *len = 0;
     return NULL;
   }

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -30,7 +30,7 @@ typedef struct {
 } runeBuf;
 
 // The maximum size we allow converting to at once
-#define MAX_RUNESTR_LEN 1024
+#define MAX_RUNE_STR_LEN 1024
 
 // Threshold for Small String Optimization (SSO)
 #define SSO_MAX_LENGTH 128


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `MAX_RUNESTR_LEN` (C, `src/trie/rune_util.h`) and `MAX_RUNE_STR_LEN` (Rust, `query_eval/src/string_utils.rs`) were two independent constants holding the same value (1024) with inconsistent spellings. Either side could drift from the other and a code-search for one spelling missed the other.
2. **Change**:
   - First commit renames the C macro to `MAX_RUNE_STR_LEN` so both sides agree on spelling.
   - Second commit adds the macro to the `ffi` crate's bindgen allowlist for `rune_util.h` and re-types it on the Rust side as `pub const MAX_RUNE_STR_LEN: usize = ffi::MAX_RUNE_STR_LEN as usize`. `query_eval` gains `ffi` as a regular (non-dev) dependency so lib code can read the binding.
3. **Outcome**: C is the single source of truth for the limit. The bindgen `verify_symbols` check in `ffi/build.rs` now enforces the contract at `cargo build` time — renaming or removing the C macro fails the Rust build with a precise error instead of silent drift. The user-facing error message produced by `src/query.c` is unchanged (still expands to `"1024"` via `STRINGIFY`).

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `src/trie/rune_util.h` — macro renamed.
2. `src/redisearch_rs/ffi/build.rs` — bindgen allowlist for `rune_util.h` gains `MAX_RUNE_STR_LEN`.
3. `src/redisearch_rs/query_eval/Cargo.toml` — `ffi` promoted from `[dev-dependencies]` to `[dependencies]`.
4. `src/redisearch_rs/query_eval/src/string_utils.rs` — constant derived from `ffi::MAX_RUNE_STR_LEN`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant rename and FFI wiring only; limit stays 1024 and user-facing query errors are unchanged.
> 
> **Overview**
> Unifies the trie/query **maximum rune string length** under one name and one definition. The C macro is renamed from `MAX_RUNESTR_LEN` to **`MAX_RUNE_STR_LEN`** in `rune_util.h` and all trie/query call sites (`rune_util.c`, `query.c` error text).
> 
> Rust **`query_eval`** no longer hardcodes `1024`: it defines `MAX_RUNE_STR_LEN` from **`ffi::MAX_RUNE_STR_LEN`** (bindgen allowlist on `rune_util.h`), with **`ffi`** moved from dev- to normal **`dependencies`** so library code can use the binding. Build-time **`verify_symbols`** in `ffi/build.rs` enforces that the C macro still exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db34bb68185a603eb1073b8e5a2b60c7f9b20996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->