### PR TITLE
[8.6] MOD-15952: ci: add Redis-backed flaky-test DB and skip mechanism

### DIFF
--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -1,0 +1,121 @@
+name: Build TESTFILE excluding flaky tests
+description: |
+  Fetch active flaky marks for the current branch, enumerate tests with
+  `LIST=1 make pytest`, filter out marks (prefix match), and emit the path to
+  a TESTFILE the runner can consume.
+
+  Outputs an empty `testfile` if there are no active marks, or if any step
+  fails — callers should treat that as "run the full suite".
+
+inputs:
+  redis-url:
+    description: "Redis connection URL (rediss://...)"
+    required: true
+  variant:
+    description: "Label for filenames, e.g. 'standalone' or 'coordinator'"
+    required: true
+  redis-standalone:
+    description: "1 or 0 — propagated to runtests.sh as REDIS_STANDALONE"
+    required: true
+  test-config:
+    description: "Test config string forwarded to make (e.g. 'QUICK=1')"
+    required: true
+  rejson:
+    required: false
+    default: "1"
+  rejson-branch:
+    required: false
+    default: "master"
+  san:
+    required: false
+    default: ""
+
+outputs:
+  testfile:
+    description: "Filtered TESTFILE path; empty if no marks or any step failed"
+    value: ${{ steps.build.outputs.testfile }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve target branch
+      # Merge-queue runs have empty github.base_ref and a synthetic ref_name
+      # (gh-readonly-queue/<target>/pr-...). The real target lives at
+      # github.event.merge_group.base_ref as `refs/heads/<branch>`.
+      # GH Actions expressions can't slice strings, so we strip the prefix in bash.
+      shell: bash -l -eo pipefail {0}
+      env:
+        MERGE_GROUP_BASE: ${{ github.event.merge_group.base_ref }}
+        BASE_REF: ${{ github.base_ref }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        if [ -n "$MERGE_GROUP_BASE" ]; then
+          branch="${MERGE_GROUP_BASE#refs/heads/}"
+        elif [ -n "$BASE_REF" ]; then
+          branch="$BASE_REF"
+        else
+          branch="$REF_NAME"
+        fi
+        echo "Resolved flaky target branch: $branch"
+        echo "FLAKY_BRANCH=$branch" >> "$GITHUB_ENV"
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - shell: bash -l -eo pipefail {0}
+      run: pip install 'redis>=6,<7'
+
+    - name: Fetch flaky skip list
+      shell: bash -l -eo pipefail {0}
+      env:
+        REDIS_URL: ${{ inputs.redis-url }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ env.FLAKY_BRANCH }}
+      run: |
+        # Use a workspace-relative path: `${{ github.action_path }}` expands to
+        # the runner host path, which doesn't exist when the step runs inside a
+        # Docker container (workspace is mounted at /__w/...). The composite
+        # action's working directory is $GITHUB_WORKSPACE, which is mapped
+        # correctly in both runner and container jobs.
+        python3 .github/scripts/flaky_db.py fetch \
+          --output-json .flaky_skip.json \
+          --output-list .flaky_skip.txt
+
+    - name: Build TESTFILE
+      id: build
+      shell: bash -l -eo pipefail {0}
+      env:
+        SAN: ${{ inputs.san }}
+        REDIS_STANDALONE: ${{ inputs.redis-standalone }}
+        REJSON: ${{ inputs.rejson }}
+        REJSON_BRANCH: ${{ inputs.rejson-branch }}
+        TEST_CONFIG: ${{ inputs.test-config }}
+        VARIANT: ${{ inputs.variant }}
+        # Don't wipe tests/pytests/logs while listing — the coordinator
+        # listing runs after standalone tests, and otherwise the prior
+        # variant's failure logs would be deleted before artifact upload.
+        CLEAR_LOGS: "0"
+      run: |
+        if [ ! -s .flaky_skip.txt ]; then
+          echo "No active flaky marks — running the full suite"
+          exit 0
+        fi
+        mkdir -p /tmp/flaky
+        LIST_OUT="/tmp/flaky/list_${VARIANT}.raw"
+        TESTFILE_OUT="/tmp/flaky/run_${VARIANT}.txt"
+        LIST=1 make pytest $TEST_CONFIG > "$LIST_OUT" 2>&1 || {
+          echo "::warning::LIST=1 enumeration failed — running full suite as fallback"
+          exit 0
+        }
+        python3 .github/scripts/flaky_db.py filter \
+          --tests "$LIST_OUT" \
+          --marks .flaky_skip.txt \
+          --output "$TESTFILE_OUT"
+        if [ -s "$TESTFILE_OUT" ]; then
+          # The path is workspace-relative so runtests.sh's ROOT-prepend
+          # produces a valid absolute path.
+          echo "testfile=$TESTFILE_OUT" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::Filtered TESTFILE is empty — running full suite as fallback"
+        fi

--- a/.github/actions/flaky-record-results/action.yml
+++ b/.github/actions/flaky-record-results/action.yml
@@ -1,0 +1,83 @@
+name: Record test results to flaky DB
+description: |
+  Record test results from the current CI run to the flaky-test Redis DB.
+
+  Accepts two simple file inputs — one test id per line:
+    - failed-file: required for the failure side of the dataset
+    - passed-file: optional; only useful if your runner produces it (RLTest's
+      FAILEDFILE only gives failures, which is fine — pass counts can be added
+      later if needed)
+
+  This action never fails the job: it warns on connection errors so a flaky-DB
+  outage cannot break the test pipeline. The calling step should set
+  `if: always()` so failures are recorded even when tests fail.
+
+inputs:
+  redis-url:
+    description: "Redis connection URL (rediss://...)"
+    required: true
+  failed-file:
+    description: "Path to a file listing failing test ids, one per line"
+    required: false
+    default: ""
+  passed-file:
+    description: "Path to a file listing passing test ids, one per line"
+    required: false
+    default: ""
+  branch:
+    description: "Branch the run is associated with. Defaults to base_ref or ref_name."
+    required: false
+    default: ""
+  job-name:
+    description: "Short label for this job/shard, recorded with each result"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve target branch
+      # See flaky-build-testfile for why merge_group.base_ref needs special handling.
+      shell: bash -l -eo pipefail {0}
+      env:
+        OVERRIDE: ${{ inputs.branch }}
+        MERGE_GROUP_BASE: ${{ github.event.merge_group.base_ref }}
+        BASE_REF: ${{ github.base_ref }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        if [ -n "$OVERRIDE" ]; then
+          branch="$OVERRIDE"
+        elif [ -n "$MERGE_GROUP_BASE" ]; then
+          branch="${MERGE_GROUP_BASE#refs/heads/}"
+        elif [ -n "$BASE_REF" ]; then
+          branch="$BASE_REF"
+        else
+          branch="$REF_NAME"
+        fi
+        echo "Resolved flaky target branch: $branch"
+        echo "FLAKY_BRANCH=$branch" >> "$GITHUB_ENV"
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      shell: bash -l -eo pipefail {0}
+      run: pip install 'redis>=6,<7'
+
+    - name: Record results
+      shell: bash -l -eo pipefail {0}
+      env:
+        REDIS_URL: ${{ inputs.redis-url }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ env.FLAKY_BRANCH }}
+        COMMIT: ${{ github.sha }}
+        WORKFLOW_RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+        JOB_NAME: ${{ inputs.job-name != '' && inputs.job-name || github.job }}
+        FAILED_FILE: ${{ inputs.failed-file }}
+        PASSED_FILE: ${{ inputs.passed-file }}
+      # See flaky-build-testfile for why a workspace-relative invocation is
+      # used here instead of ${{ github.action_path }}.
+      run: python3 .github/scripts/flaky_db.py record

--- a/.github/scripts/flaky_db.py
+++ b/.github/scripts/flaky_db.py
@@ -1,0 +1,465 @@
+"""Flaky-test DB CLI — single entry point for all flaky-test operations.
+
+Subcommands:
+  fetch    Pull active marks for $REPO/$BRANCH into local files.
+  filter   Filter a test list against a marks file (exact or variant-suffix match).
+  mark     Add a flaky mark.
+  unmark   Remove a flaky mark.
+  record   Record failed/passed test ids for the current run.
+
+Context inputs (env):
+  REDIS_URL                 connection string (rediss://...)
+  REPO                      e.g. RediSearch/RediSearch
+  BRANCH                    e.g. master, 2.10, or *
+  ACTOR                     github.actor — who triggered the action
+  COMMIT                    git sha (record only)
+  WORKFLOW_RUN_ID           gh run id (record only)
+  RUN_ATTEMPT               gh run attempt number (record only)
+  JOB_NAME                  short label for the run/shard (record only)
+  TEST_ID, REASON, JIRA_KEY, DAYS  (mark)
+  TEST_ID, REASON                  (unmark)
+  FAILED_FILE, PASSED_FILE         (record)
+
+Any operation that talks to Redis is a no-op when REDIS_URL is empty — keeps
+fork-PR CI green when secrets aren't available.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import redis
+from redis.commands.search.field import NumericField, TagField, TextField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+from redis.commands.search.query import Query
+
+
+INDEX_NAME = "idx:marks"
+INDEX_PREFIX = "mark:"
+RUN_TTL_SECONDS = 60 * 86400
+AUDIT_MAXLEN = 100_000
+FAILURES_MAXLEN = 50_000
+
+_TAG_ESCAPE_CHARS = set(',.<>{}[]"\':;!@#$%^&*()-+=~ \\/?')
+# RLTest LIST=1 emits "<test_file>:<test_name>" (no .py suffix, no variant
+# suffix). Class-based tests appear as "<test_file>:<Class>.<method>" — RLTest
+# joins them with a dot — so the name half must accept `.`. The variant bracket
+# is left in the parse regex in case a future RLTest version starts emitting
+# them; prefix matching handles both shapes.
+_TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_][\w.]*(?:\[[^\]]+\])?\s*$")
+# Marks must be variant-less: cmd_filter matches `test == mark` or
+# `test.startswith(mark + "[")`, so a mark with a `[variant]` suffix could
+# never match anything in current LIST=1 output and would silently no-op.
+_MARK_TEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+:[A-Za-z_][\w.]*\s*$")
+
+
+def _connect() -> redis.Redis | None:
+    """Connect using REDIS_URL. Returns None when the URL is unset (fork PR)."""
+    url = os.environ.get("REDIS_URL", "").strip()
+    if not url:
+        print("REDIS_URL not set — skipping DB operation")
+        return None
+    return redis.from_url(url, socket_timeout=10, decode_responses=True)
+
+
+def _escape_tag(value: str) -> str:
+    return "".join(("\\" + c) if c in _TAG_ESCAPE_CHARS else c for c in value)
+
+
+def _ensure_index(client: redis.Redis) -> None:
+    try:
+        client.ft(INDEX_NAME).info()
+        return
+    except redis.ResponseError:
+        pass
+
+    schema = (
+        TagField("repo", sortable=True),
+        TagField("branch", sortable=True),
+        TagField("test_id", sortable=True),
+        TagField("jira_key", sortable=True),
+        TagField("marked_by"),
+        NumericField("created_at", sortable=True),
+        NumericField("expires_at", sortable=True),
+        TextField("reason"),
+    )
+    definition = IndexDefinition(prefix=[INDEX_PREFIX], index_type=IndexType.HASH)
+    try:
+        client.ft(INDEX_NAME).create_index(schema, definition=definition)
+        print(f"Created {INDEX_NAME}")
+    except redis.ResponseError as exc:
+        if "already exists" not in str(exc).lower():
+            raise
+
+
+def _summary(lines: list[str]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------- fetch
+
+def cmd_fetch(args: argparse.Namespace) -> int:
+    repo = os.environ["REPO"]
+    branch = os.environ["BRANCH"]
+    now = int(time.time())
+
+    result = {"generated_at": now, "repo": repo, "branch": branch, "skips": [], "status": "ok"}
+    client = _connect()
+
+    if client is None:
+        result["status"] = "no-url"
+    else:
+        try:
+            _ensure_index(client)
+            query_str = (
+                f"@repo:{{{_escape_tag(repo)}}} "
+                f"(@branch:{{{_escape_tag(branch)}}} | @branch:{{{_escape_tag('*')}}}) "
+                f"@expires_at:[({now} +inf]"
+            )
+            q = (
+                Query(query_str)
+                .return_fields("test_id", "branch", "reason", "jira_key", "marked_by", "expires_at")
+                .paging(0, 10000)
+            )
+            res = client.ft(INDEX_NAME).search(q)
+            # Prefer branch-specific rows over wildcard rows for the same test_id.
+            docs = sorted(res.docs, key=lambda d: 0 if getattr(d, "branch", "") == branch else 1)
+            seen: set[str] = set()
+            for doc in docs:
+                tid = getattr(doc, "test_id", "")
+                if not tid or tid in seen:
+                    continue
+                seen.add(tid)
+                result["skips"].append({
+                    "test_id": tid,
+                    "reason": getattr(doc, "reason", ""),
+                    "jira_key": getattr(doc, "jira_key", ""),
+                    "marked_by": getattr(doc, "marked_by", ""),
+                    "expires_at": int(getattr(doc, "expires_at", 0) or 0),
+                    "applied_via": "branch" if getattr(doc, "branch", "") == branch else "wildcard",
+                })
+        except Exception as exc:  # noqa: BLE001
+            result["status"] = "error"
+            result["error"] = str(exc)
+            print(f"::warning::Could not fetch flaky list: {exc}")
+
+    Path(args.output_json).write_text(json.dumps(result, indent=2))
+    Path(args.output_list).write_text(
+        "\n".join(s["test_id"] for s in result["skips"]) + ("\n" if result["skips"] else "")
+    )
+
+    print(f"Wrote {len(result['skips'])} skip(s) to {args.output_json} / {args.output_list}")
+    for skip in result["skips"]:
+        jira = f" [{skip['jira_key']}]" if skip["jira_key"] else ""
+        scope = "" if skip["applied_via"] == "branch" else " (wildcard)"
+        print(f"  - {skip['test_id']}{jira}{scope}")
+
+    if result["skips"]:
+        _summary([
+            f"### Flaky tests skipped on `{branch}` ({len(result['skips'])})",
+            "",
+            "| Test | Jira | Reason | Scope |",
+            "|---|---|---|---|",
+            *(
+                f"| `{s['test_id']}` | {s['jira_key']} | {s['reason']} | {s['applied_via']} |"
+                for s in result["skips"]
+            ),
+        ])
+    return 0
+
+
+# ---------------------------------------------------------------- filter
+
+def cmd_filter(args: argparse.Namespace) -> int:
+    raw = Path(args.tests).read_text().splitlines()
+    tests = [l.strip() for l in raw if _TEST_ID_RE.match(l.strip())]
+    marks = [l.strip() for l in Path(args.marks).read_text().splitlines() if l.strip()]
+
+    print(f"Input: {len(raw)} lines, {len(tests)} look like test ids, {len(marks)} mark(s)")
+
+    if not tests:
+        print("::warning::No recognisable test ids; writing empty TESTFILE")
+        Path(args.output).write_text("")
+        return 0
+    if not marks:
+        Path(args.output).write_text("\n".join(tests) + "\n")
+        return 0
+
+    kept: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for t in tests:
+        m = next((mark for mark in marks if t == mark or t.startswith(mark + "[")), None)
+        if m:
+            skipped.append((t, m))
+        else:
+            kept.append(t)
+
+    Path(args.output).write_text("\n".join(kept) + ("\n" if kept else ""))
+    print(f"Filter: {len(tests)} -> {len(kept)} kept, {len(skipped)} skipped")
+    for tid, mark in skipped[:50]:
+        print(f"  - {tid}  (matched mark {mark!r})")
+    if len(skipped) > 50:
+        print(f"  ... and {len(skipped) - 50} more")
+
+    if skipped:
+        _summary([
+            "",
+            f"**Flaky-skipped from this run** ({len(skipped)}):",
+            *(f"- `{tid}` (mark `{mark}`)" for tid, mark in skipped[:50]),
+        ])
+    return 0
+
+
+# ---------------------------------------------------------------- mark / unmark
+
+def cmd_mark(args: argparse.Namespace) -> int:
+    repo, branch, actor = os.environ["REPO"], os.environ["BRANCH"], os.environ["ACTOR"]
+    test_id = os.environ["TEST_ID"].strip()
+    reason = os.environ["REASON"].strip()
+    jira_key = os.environ["JIRA_KEY"].strip()
+
+    for name, value in (("test_id", test_id), ("reason", reason), ("jira_key", jira_key)):
+        if not value:
+            print(f"::error::{name} is empty")
+            return 1
+
+    if not _MARK_TEST_ID_RE.match(test_id):
+        print(f"::error::test_id {test_id!r} doesn't match the RLTest format "
+              "'<test_file>:<test_name>' (no .py, no [variant])")
+        return 1
+
+    try:
+        days = int(os.environ["DAYS"])
+    except ValueError:
+        print(f"::error::expires_in_days must be an integer, got: {os.environ['DAYS']!r}")
+        return 1
+    if not 1 <= days <= 365:
+        print(f"::error::expires_in_days must be between 1 and 365, got {days}")
+        return 1
+
+    client = _connect()
+    if client is None:
+        print("::error::REDIS_URL is required for mark")
+        return 1
+
+    _ensure_index(client)
+
+    now = int(time.time())
+    expires = now + days * 86400
+    key = f"mark:{repo}:{branch}:{test_id}"
+
+    with client.pipeline() as pipe:
+        pipe.hset(key, mapping={
+            "repo": repo, "branch": branch, "test_id": test_id,
+            "reason": reason, "jira_key": jira_key, "marked_by": actor,
+            "created_at": now, "expires_at": expires,
+        })
+        pipe.expireat(key, expires)
+        pipe.xadd("marks:audit", {
+            "action": "mark", "repo": repo, "branch": branch, "test_id": test_id,
+            "by": actor, "reason": reason, "jira_key": jira_key, "expires_at": str(expires),
+        }, maxlen=AUDIT_MAXLEN, approximate=True)
+        pipe.execute()
+
+    print(f"Marked '{test_id}' as flaky on {repo}@{branch}")
+    print(f"  Reason:  {reason}")
+    print(f"  Jira:    {jira_key}")
+    print(f"  Expires: {time.strftime('%Y-%m-%d %H:%M UTC', time.gmtime(expires))} ({days}d)")
+    return 0
+
+
+def cmd_unmark(args: argparse.Namespace) -> int:
+    repo, branch, actor = os.environ["REPO"], os.environ["BRANCH"], os.environ["ACTOR"]
+    test_id = os.environ["TEST_ID"].strip()
+    reason = os.environ["REASON"].strip()
+
+    if not test_id or not reason:
+        print("::error::test_id and reason are required")
+        return 1
+
+    if not _MARK_TEST_ID_RE.match(test_id):
+        print(f"::error::test_id {test_id!r} doesn't match the RLTest format "
+              "'<test_file>:<test_name>' (no .py, no [variant])")
+        return 1
+
+    client = _connect()
+    if client is None:
+        print("::error::REDIS_URL is required for unmark")
+        return 1
+
+    key = f"mark:{repo}:{branch}:{test_id}"
+    prev = client.hgetall(key)
+    existed = bool(prev)
+
+    with client.pipeline() as pipe:
+        pipe.delete(key)
+        pipe.xadd("marks:audit", {
+            "action": "unmark", "repo": repo, "branch": branch, "test_id": test_id,
+            "by": actor, "reason": reason,
+            "prev_jira_key": prev.get("jira_key", ""),
+            "prev_marked_by": prev.get("marked_by", ""),
+        }, maxlen=AUDIT_MAXLEN, approximate=True)
+        pipe.execute()
+
+    if not existed:
+        print(f"::warning::'{test_id}' was not marked on {repo}@{branch} — nothing to remove")
+        print("Audit entry was still recorded.")
+        return 0
+
+    print(f"Unmarked '{test_id}' on {repo}@{branch}")
+    print(f"  Reason:        {reason}")
+    if prev.get("marked_by"):
+        print(f"  Was marked by: {prev['marked_by']}")
+    if prev.get("jira_key"):
+        print(f"  Original jira: {prev['jira_key']}")
+    return 0
+
+
+# ---------------------------------------------------------------- record
+
+def _read_lines(path: str) -> list[str]:
+    if not path:
+        return []
+    p = Path(path)
+    if not p.exists():
+        return []
+    return [line.strip() for line in p.read_text().splitlines() if line.strip()]
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    failed = _read_lines(os.environ.get("FAILED_FILE", ""))
+    passed = _read_lines(os.environ.get("PASSED_FILE", ""))
+    if not failed and not passed:
+        print("No results to record (FAILED_FILE/PASSED_FILE empty or unset)")
+        return 0
+
+    client = _connect()
+    if client is None:
+        return 0  # fork PR or DB unset; recording is best-effort
+
+    repo = os.environ["REPO"]
+    branch = os.environ["BRANCH"]
+    commit = os.environ.get("COMMIT", "")
+    workflow_run_id = os.environ.get("WORKFLOW_RUN_ID", "0")
+    run_attempt = os.environ.get("RUN_ATTEMPT", "1")
+    job = os.environ.get("JOB_NAME", "default")
+
+    print(f"Recording {len(failed)} failure(s), {len(passed)} pass(es)")
+
+    now = int(time.time())
+    expires_at = now + RUN_TTL_SECONDS
+
+    try:
+        with client.pipeline(transaction=False) as pipe:
+            for status, test_ids in (("failed", failed), ("passed", passed)):
+                for test_id in test_ids:
+                    key = f"run:{workflow_run_id}:{run_attempt}:{job}:{test_id}"
+                    pipe.hset(key, mapping={
+                        "repo": repo, "branch": branch, "test_id": test_id, "status": status,
+                        "commit": commit, "workflow_run_id": workflow_run_id,
+                        "run_attempt": run_attempt, "job": job, "recorded_at": now,
+                    })
+                    pipe.expireat(key, expires_at)
+                    if status == "failed":
+                        pipe.xadd(f"failures:{repo}:{branch}", {
+                            "test_id": test_id, "commit": commit,
+                            "workflow_run_id": workflow_run_id, "run_attempt": run_attempt,
+                            "job": job, "recorded_at": str(now),
+                        }, maxlen=FAILURES_MAXLEN, approximate=True)
+            pipe.execute()
+    except Exception as exc:  # noqa: BLE001
+        print(f"::warning::Failed writing results to flaky DB: {exc}")
+        return 0
+
+    _summary([
+        "### Flaky DB updated",
+        "",
+        "| | Count |",
+        "|---|---|",
+        f"| Failures recorded | {len(failed)} |",
+        f"| Passes recorded | {len(passed)} |",
+        f"| Job | `{job}` |",
+        f"| Branch | `{branch}` |",
+    ])
+    if failed:
+        _summary(["", "**Failed:**", *(f"- `{tid}`" for tid in failed[:50])])
+        if len(failed) > 50:
+            _summary([f"- … and {len(failed) - 50} more"])
+    return 0
+
+
+# ---------------------------------------------------------------- main
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="flaky_db.py")
+    # Context flags: override the matching env var when present. Lets local
+    # users run the script without exporting a pile of envs.
+    parser.add_argument("--redis-url", help="Overrides REDIS_URL")
+    parser.add_argument("--repo", help="Overrides REPO")
+    parser.add_argument("--branch", help="Overrides BRANCH")
+    parser.add_argument("--actor", help="Overrides ACTOR")
+
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("fetch", help="Fetch active marks into local files")
+    p.add_argument("--output-json", default=".flaky_skip.json")
+    p.add_argument("--output-list", default=".flaky_skip.txt")
+    p.set_defaults(func=cmd_fetch)
+
+    p = sub.add_parser("filter", help="Filter a test list against marks (exact or variant-suffix match)")
+    p.add_argument("--tests", required=True)
+    p.add_argument("--marks", required=True)
+    p.add_argument("--output", required=True)
+    p.set_defaults(func=cmd_filter)
+
+    p = sub.add_parser("mark", help="Add a flaky mark")
+    p.add_argument("--test-id", help="Overrides TEST_ID")
+    p.add_argument("--reason", help="Overrides REASON")
+    p.add_argument("--jira-key", help="Overrides JIRA_KEY")
+    p.add_argument("--expires-in-days", type=int, help="Overrides DAYS")
+    p.set_defaults(func=cmd_mark)
+
+    p = sub.add_parser("unmark", help="Remove a flaky mark")
+    p.add_argument("--test-id", help="Overrides TEST_ID")
+    p.add_argument("--reason", help="Overrides REASON")
+    p.set_defaults(func=cmd_unmark)
+
+    p = sub.add_parser("record", help="Record failed/passed test ids")
+    p.add_argument("--failed-file", help="Overrides FAILED_FILE")
+    p.add_argument("--passed-file", help="Overrides PASSED_FILE")
+    p.add_argument("--commit", help="Overrides COMMIT")
+    p.add_argument("--workflow-run-id", help="Overrides WORKFLOW_RUN_ID")
+    p.add_argument("--run-attempt", help="Overrides RUN_ATTEMPT")
+    p.add_argument("--job-name", help="Overrides JOB_NAME")
+    p.set_defaults(func=cmd_record)
+
+    args = parser.parse_args()
+
+    # Mirror provided CLI flags into env vars so the cmd_* functions can keep
+    # reading from os.environ (and CI workflows that set env vars keep working).
+    _arg_to_env = {
+        "redis_url": "REDIS_URL", "repo": "REPO", "branch": "BRANCH", "actor": "ACTOR",
+        "test_id": "TEST_ID", "reason": "REASON", "jira_key": "JIRA_KEY",
+        "expires_in_days": "DAYS",
+        "failed_file": "FAILED_FILE", "passed_file": "PASSED_FILE",
+        "commit": "COMMIT", "workflow_run_id": "WORKFLOW_RUN_ID",
+        "run_attempt": "RUN_ATTEMPT", "job_name": "JOB_NAME",
+    }
+    for attr, env_name in _arg_to_env.items():
+        value = getattr(args, attr, None)
+        if value is not None:
+            os.environ[env_name] = str(value)
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: 'Branch the mark applies to (e.g. master, 2.10, or * for all branches)'
         required: true
-        default: 'master'
+        default: '8.6'
         type: string
       test_id:
         description: "Test identifier in RLTest format: <test_file>:<test_name> (e.g. test_wildcard:testBasic — no .py, no [variant])"

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -1,0 +1,81 @@
+name: Flaky tests — mark
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch the mark applies to (e.g. master, 2.10, or * for all branches)'
+        required: true
+        default: 'master'
+        type: string
+      test_id:
+        description: "Test identifier in RLTest format: <test_file>:<test_name> (e.g. test_wildcard:testBasic — no .py, no [variant])"
+        required: true
+        type: string
+      reason:
+        description: 'Why is this being skipped?'
+        required: true
+        type: string
+      jira_key:
+        description: 'Jira ticket tracking the flake (e.g. MOD-12345)'
+        required: true
+        type: string
+      expires_in_days:
+        description: 'Days until the mark expires (1-365)'
+        required: true
+        default: '30'
+        type: string
+
+jobs:
+  mark:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install 'redis>=6,<7'
+
+      - name: Mark test as flaky
+        env:
+          REDIS_URL: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          REASON: ${{ inputs.reason }}
+          JIRA_KEY: ${{ inputs.jira_key }}
+          DAYS: ${{ inputs.expires_in_days }}
+          ACTOR: ${{ github.actor }}
+        run: python3 .github/scripts/flaky_db.py mark
+
+      - name: Summary
+        if: success()
+        env:
+          # Pass inputs through env so they're treated as data, not interpolated
+          # into the shell script by GitHub Actions before bash evaluates it.
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          JIRA_KEY: ${{ inputs.jira_key }}
+          REASON: ${{ inputs.reason }}
+          DAYS: ${{ inputs.expires_in_days }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          {
+            echo "### Flaky mark recorded :white_check_mark:"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Repo | \`$REPO\` |"
+            echo "| Branch | \`$BRANCH\` |"
+            echo "| Test | \`$TEST_ID\` |"
+            echo "| Jira | $JIRA_KEY |"
+            echo "| Reason | $REASON |"
+            echo "| Expires in | $DAYS days |"
+            echo "| Marked by | @$ACTOR |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -1,0 +1,66 @@
+name: Flaky tests — unmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch the mark applies to (must match the original mark — use * if it was a wildcard)'
+        required: true
+        default: 'master'
+        type: string
+      test_id:
+        description: "Test identifier in RLTest format: <test_file>:<test_name> (must match the original mark)"
+        required: true
+        type: string
+      reason:
+        description: 'Why are we unmarking? (e.g. "fixed in #1234")'
+        required: true
+        type: string
+
+jobs:
+  unmark:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install 'redis>=6,<7'
+
+      - name: Unmark flaky test
+        env:
+          REDIS_URL: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+        run: python3 .github/scripts/flaky_db.py unmark
+
+      - name: Summary
+        if: success()
+        env:
+          # Pass inputs through env so they're treated as data, not interpolated
+          # into the shell script by GitHub Actions before bash evaluates it.
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TEST_ID: ${{ inputs.test_id }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          {
+            echo "### Flaky mark removed :white_check_mark:"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Repo | \`$REPO\` |"
+            echo "| Branch | \`$BRANCH\` |"
+            echo "| Test | \`$TEST_ID\` |"
+            echo "| Reason | $REASON |"
+            echo "| Unmarked by | @$ACTOR |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: 'Branch the mark applies to (must match the original mark — use * if it was a wildcard)'
         required: true
-        default: 'master'
+        default: '8.6'
         type: string
       test_id:
         description: "Test identifier in RLTest format: <test_file>:<test_name> (must match the original mark)"

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -423,6 +423,20 @@ jobs:
           CLEAR_LOGS: 0
           ENABLE_ASSERT: 1
         run: make rust-tests
+      - name: Build TESTFILE excluding flaky tests (standalone)
+        id: standalone_testfile
+        if: ${{ inputs.standalone && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/flaky-build-testfile
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          variant: standalone
+          redis-standalone: "1"
+          test-config: ${{ inputs.test-config }}
+          rejson: ${{ env.REJSON }}
+          rejson-branch: ${{ inputs.rejson-branch }}
+          san: ${{ inputs.san }}
+
       - name: Flow tests (standalone)
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: standalone_tests
@@ -436,7 +450,36 @@ jobs:
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
-        run: make pytest ${{ inputs.test-config }}
+          TEST_CONFIG: ${{ inputs.test-config }}
+          # Relative path: ${{ github.workspace }} resolves to the runner host
+          # path, which is unreachable when the step runs in a container.
+          # runtests.sh prepends $ROOT for non-absolute FAILEDFILE values.
+          FAILEDFILE: .failed_standalone.txt
+          TESTFILE: ${{ steps.standalone_testfile.outputs.testfile }}
+        run: make pytest $TEST_CONFIG
+
+      - name: Record standalone failures to flaky DB
+        if: ${{ always() && inputs.standalone && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/flaky-record-results
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          failed-file: .failed_standalone.txt
+          job-name: ${{ needs.get-config.outputs.name }} standalone
+
+      - name: Build TESTFILE excluding flaky tests (coordinator)
+        id: coordinator_testfile
+        if: ${{ inputs.coordinator && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/flaky-build-testfile
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          variant: coordinator
+          redis-standalone: "0"
+          test-config: ${{ inputs.test-config }}
+          rejson: ${{ env.REJSON }}
+          rejson-branch: ${{ inputs.rejson-branch }}
+          san: ${{ inputs.san }}
 
       - name: Flow tests (coordinator)
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
@@ -451,7 +494,19 @@ jobs:
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
           ENABLE_ASSERT: 1
-        run: make pytest ${{ inputs.test-config }}
+          TEST_CONFIG: ${{ inputs.test-config }}
+          FAILEDFILE: .failed_coordinator.txt
+          TESTFILE: ${{ steps.coordinator_testfile.outputs.testfile }}
+        run: make pytest $TEST_CONFIG
+
+      - name: Record coordinator failures to flaky DB
+        if: ${{ always() && inputs.coordinator && env.IS_FORK_PR != 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/flaky-record-results
+        with:
+          redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
+          failed-file: .failed_coordinator.txt
+          job-name: ${{ needs.get-config.outputs.name }} coordinator
 
       - name: Rust tests (MIRI)
         if: inputs.san == 'address' && inputs.unit-tests

--- a/tests/pytests/pyproject.toml
+++ b/tests/pytests/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "packaging<=24.2",
     "deepdiff==8.6.1",
     "redis>=5.2.1,<7.0.0", # Pin to avoid redis-py 7.x incompatibility (todo: update once fixed)
-    "RLTest>=0.7.18,<0.8.0",
+    "RLTest>=0.7.27,<0.8.0",
     "numpy<=2.2.4",
     "scipy<=1.15.2",
     "faker<=37.1.0",

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -17,6 +17,14 @@ cd $HERE
 
 #----------------------------------------------------------------------------------------------
 
+# Returns 0 (success) if $1 is an absolute path, non-zero otherwise.
+# Used to decide whether to prepend $ROOT to user-supplied file arguments.
+is_abspath() {
+	[[ "$1" == /* ]]
+}
+
+#----------------------------------------------------------------------------------------------
+
 help() {
 	cat <<-'END'
 		Run Python tests using RLTest
@@ -451,7 +459,7 @@ fi
 
 if [[ -n $FAILEDFILE ]]; then
 	if ! is_abspath "$FAILEDFILE"; then
-		TESTFILE="$ROOT/$FAILEDFILE"
+		FAILEDFILE="$ROOT/$FAILEDFILE"
 	fi
 	RLTEST_TEST_ARGS+=" -F $FAILEDFILE"
 fi

--- a/uv.lock
+++ b/uv.lock
@@ -349,16 +349,30 @@ wheels = [
 
 [[package]]
 name = "psutil"
-version = "5.9.8"
+version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz", hash = "sha256:6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c", size = 503247, upload-time = "2024-01-19T20:47:09.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81", size = 248702, upload-time = "2024-01-19T20:47:36.303Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/bd/28c5f553667116b2598b9cc55908ec435cb7f77a34f2bff3e3ca765b0f78/psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421", size = 285242, upload-time = "2024-01-19T20:47:39.65Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4", size = 288191, upload-time = "2024-01-19T20:47:43.078Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/2aa3a4acdc1e5940b59d421742356f133185667dd190b166dbcfcf5d7b43/psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0", size = 251252, upload-time = "2024-01-19T20:47:52.88Z" },
-    { url = "https://files.pythonhosted.org/packages/93/52/3e39d26feae7df0aa0fd510b14012c3678b36ed068f7d78b8d8784d61f0e/psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf", size = 255090, upload-time = "2024-01-19T20:47:56.019Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8", size = 249898, upload-time = "2024-01-19T20:47:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -432,7 +446,7 @@ requires-dist = [{ name = "pip" }]
 
 [[package]]
 name = "rltest"
-version = "0.7.20"
+version = "0.7.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distro" },
@@ -442,9 +456,9 @@ dependencies = [
     { name = "pytest-cov" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/3a/8fe21974d449cefbd8b5b2faf264efe298402e4b18b8aa1317317ef05bc4/rltest-0.7.20.tar.gz", hash = "sha256:d29f2ce7d9b9956360d2d4e5467cd85380fc6bbcc6c31989c0352e6227a03b2b", size = 40982, upload-time = "2025-12-08T11:58:12.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/4d/f68c25855b0133ffb0796693c5471cf239f088899af44545dc93183863eb/rltest-0.7.27.tar.gz", hash = "sha256:9bc916f6ab3701b1b7442be44670e3ac254935b4c37991e347774479d0a3850d", size = 45275, upload-time = "2026-05-29T12:39:55.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/e4/a4df4833c607f84586550707a3c74afe7ac4dd1596e14d2072526fdfcc80/rltest-0.7.20-py3-none-any.whl", hash = "sha256:bcd6a6d04a2947aa868780fcd61d1bef79dded1184515b24d82a071910868b09", size = 46306, upload-time = "2025-12-08T11:58:11.434Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f2/32fcc55a1105e6e06d074f2595e6e7b1208235bc3be1cb355c069829971f/rltest-0.7.27-py3-none-any.whl", hash = "sha256:64973137cf541939c29930402de68180a8ab0af611bc7b2fa5546fe1889ff039", size = 50731, upload-time = "2026-05-29T12:39:56.352Z" },
 ]
 
 [[package]]
@@ -476,7 +490,7 @@ requires-dist = [
     { name = "orderly-set", specifier = "<=5.4.1" },
     { name = "packaging", specifier = "<=24.2" },
     { name = "redis", specifier = ">=5.2.1,<7.0.0" },
-    { name = "rltest", specifier = ">=0.7.18,<0.8.0" },
+    { name = "rltest", specifier = ">=0.7.27,<0.8.0" },
     { name = "scipy", specifier = "<=1.15.2" },
 ]
 


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9869 to 8.6.

Adds a Redis-backed flaky-test DB so flakes can be marked from a workflow, skipped on CI without a code change, and tracked over time.

## Original PR
https://github.com/RediSearch/RediSearch/pull/9869

## Changes from original
- Dropped the `Collect failed-test-only logs` / `Upload Failed-Only Test Logs` steps that the cherry-pick brought in — they came from a different master-only PR that isn't on 8.6.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which pytest cases run in CI and depend on a shared Redis secret; mitigations include full-suite fallback and no-op on fork PRs, but mis-marked tests could hide real regressions.
> 
> **Overview**
> This PR adds a **Redis-backed flaky-test registry** so CI can skip known flakes without code changes and operators can mark/unmark tests via workflows.
> 
> New pieces include `flaky_db.py` (fetch marks, filter `LIST=1` output, mark/unmark with Jira/expiry, record run results), composite actions `flaky-build-testfile` and `flaky-record-results`, and `workflow_dispatch` jobs **Flaky tests — mark/unmark**. `task-test.yml` wires these in for standalone and coordinator flow tests: build a filtered `TESTFILE`, run pytest with workspace-relative `FAILEDFILE`, and always record failures when not a fork PR (`IS_FORK_PR`). Empty Redis URL, missing marks, or action failures fall back to the full suite; recording steps use `continue-on-error` so DB outages do not fail the job.
> 
> Supporting fixes: `runtests.sh` gains `is_abspath` and corrects **`FAILEDFILE`** path handling (it previously overwrote `TESTFILE`). **RLTest** is bumped to `>=0.7.27` with lockfile updates (`psutil` transitively).
> 
> Compared to the master backport note in the description, this branch omits failed-test-only log upload steps that are not on 8.6.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b56a0fbccdf4b3a6c0a179fe45a649db744b64ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->