### PR TITLE
skill(verify): drop C clang-format step

### DIFF
--- a/.skills/verify/SKILL.md
+++ b/.skills/verify/SKILL.md
@@ -18,37 +18,31 @@ Determine which code was modified (C, Rust, or both) and run the appropriate che
 
 Run the following checks in order:
 
-#### 1. Format Check
-```bash
-clang-format --dry-run -Werror <modified .c and .h files>
-```
-If it fails, run `clang-format -i <files>` to fix formatting.
-
-#### 2. Build
+#### 1. Build
 ```bash
 ./build.sh
 ```
 Ensure the full project compiles without warnings promoted to errors.
 
-#### 3. C/C++ Unit Tests
+#### 2. C/C++ Unit Tests
 ```bash
 ./build.sh RUN_UNIT_TESTS ENABLE_ASSERT=1
 ```
 All unit tests must pass. Use [/run-c-unit-tests](../run-c-unit-tests/SKILL.md) for details
 on running specific tests.
 
-#### 4. Behavioral Tests
+#### 3. Behavioral Tests
 ```bash
 ./build.sh RUN_PYTEST ENABLE_ASSERT=1
 ```
 Required for changes to command handlers, query execution, indexing pipeline, or RDB serialization.
 
-#### 5. AddressSanitizer (recommended for memory-related changes)
+#### 4. AddressSanitizer (recommended for memory-related changes)
 ```bash
 ./build.sh RUN_UNIT_TESTS SAN=address
 ```
 
-#### 6. Coordinator Tests (if `coord/` code was modified)
+#### 5. Coordinator Tests (if `coord/` code was modified)
 
 Changes to the coordinator (`src/coord/`), distributed hybrid (`src/coord/hybrid/`), or
 the Map-Reduce layer (`src/coord/rmr/`) must be tested in a clustered environment:


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `/verify` skill (`.skills/verify/SKILL.md`) instructs agents to run `clang-format --dry-run -Werror` on modified C files as step 1.
2. **Change**: Remove the C format step; renumber the remaining C steps (Build / Unit Tests / Behavioral / ASan / Coordinator). The Rust format step (`make fmt CHECK=1`) is kept as-is.
3. **Outcome**: The skill matches CI reality (`.github/workflows/task-lint.yml` only enforces `make fmt CHECK=1` for Rust). The C codebase has ~35k pre-existing `.clang-format` violations, so the deleted step would always fail and push agents toward repo-wide reformats CI does not require.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `.skills/verify/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime, API, or CI behavior changes.
> 
> **Overview**
> Updates the **`/verify`** agent skill (`.skills/verify/SKILL.md`) so C verification no longer starts with a **`clang-format --dry-run -Werror`** step that would fail on widespread existing C formatting debt and isn’t enforced in CI (lint only runs **`make fmt CHECK=1`** for Rust).
> 
> The remaining C checks are unchanged in substance—**build**, **unit tests**, **pytest**, **ASan**, and **coordinator** tests—but are renumbered **1–5** after dropping the format step. The Rust format/lint/test flow is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6782c73a33e37c6d95dd60df13cd23f31a704f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->