### PR TITLE
build: make FORCE wipe entire build directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -685,6 +685,13 @@ prepare_cmake_arguments() {
 # Run CMake to configure the build
 #-----------------------------------------------------------------------------
 run_cmake() {
+  # Full wipe: nested CMakeFiles/*.dir/*.o under subdirectories aren't reached
+  # by removing only the top-level CMakeCache.txt and CMakeFiles/.
+  if [[ "$FORCE" == "1" ]]; then
+    echo "Cleaning build directory: $BINDIR"
+    rm -rf "$BINDIR"
+  fi
+
   # Create build directory and ensure any parent directories exist
   mkdir -p "$BINDIR"
   cd "$BINDIR"
@@ -695,13 +702,6 @@ run_cmake() {
       echo "Creating compatibility symlink: $ARM64V8_BINROOT -> ${BINROOT}/${FULL_VARIANT}"
       ln -sf "${FULL_VARIANT}" "$ARM64V8_BINROOT"
     fi
-  fi
-
-  # Clean up any cached CMake configuration if force is enabled
-  if [[ "$FORCE" == "1" ]]; then
-    echo "Cleaning CMake cache..."
-    rm -f CMakeCache.txt
-    rm -rf CMakeFiles
   fi
 
   echo "Configuring CMake..."


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `./build.sh FORCE` runs `rm -f CMakeCache.txt && rm -rf CMakeFiles` from within `$BINDIR`. That clears the top-level CMake bookkeeping but leaves nested object files under subdirectory `CMakeFiles/<target>.dir/` intact. Because CMake decides whether to recompile a `.o` by comparing source vs. object mtime, switching branches that diverge in test sources can leave the new (older-on-disk) source file paired with the previous branch's `.o`. The linked binary then runs tests that no longer exist in the current checkout — a confusing, hard-to-debug failure mode.
2. **Change**: Replace the surgical cleanup with `rm -rf "$BINDIR"` and move the wipe to before `mkdir -p "$BINDIR"`. FORCE now does what its name suggests: discard the entire build tree and reconfigure from scratch.
3. **Outcome**: After `./build.sh FORCE`, all build outputs are guaranteed to come from the currently checked-out sources. Rebuild cost is dominated by linking and Rust; **_sccache keeps the C/C++ recompile fast._** The Rust target directory lives outside `$BINDIR` (`src/redisearch_rs/.cargo/config.toml` redirects to `bin/redisearch_rs/`) so cargo incremental compilation is unaffected, as are sibling dep build directories like `bin/<platform>/RedisJSON/`.

#### Concrete trigger

While verifying an unrelated PR, unit tests reported a failure for `TrieTest.testRangeBoundaryPrefix` referencing identifiers (`retMin.duplicates`) that `rg` could not find anywhere in the current source tree. That test lives only on sibling branches (`memark-trie-rangeiterate-dedup` et al.). The stale `rstest` binary, built earlier from one of those branches, had survived a `./build.sh FORCE` on the current branch. After `rm -rf bin/<platform>/`, the rebuild produced a binary aligned with the checked-out sources and all 858 unit tests passed.

#### Which additional issues this PR fixes
1. N/A — internal build-tooling improvement, no Jira ticket.

#### Main objects this PR modified
1. `build.sh` — `run_cmake()` FORCE handling.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change; slightly longer rebuilds on FORCE but no runtime or API impact.
> 
> **Overview**
> **`./build.sh FORCE`** now deletes the entire **`$BINDIR`** tree before reconfiguring, instead of only removing top-level **`CMakeCache.txt`** and **`CMakeFiles/`**.
> 
> That fixes stale nested object files under subdirectory **`CMakeFiles/<target>.dir/`**, which could survive a “force” clean and leave binaries (e.g. unit tests) linked against sources from another branch. The wipe runs **before** **`mkdir -p "$BINDIR"`** so the next configure/build is fully from the current checkout; Rust’s cargo target dir and sibling dep dirs under **`bin/`** outside **`$BINDIR`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469884ce3809e0888feb34082524926c5bb4fe86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->