### PR TITLE
skills: use manifest-path instead of cd into src/redisearch_rs

### DIFF
--- a/.skills/build/SKILL.md
+++ b/.skills/build/SKILL.md
@@ -26,7 +26,7 @@ Enables debug symbols and additional assertions. Use this when developing or deb
 
 ### Rust-Only Build (faster iteration)
 ```bash
-cd src/redisearch_rs && cargo build
+cargo build --manifest-path src/redisearch_rs/Cargo.toml
 ```
 Only use after the C code has been built at least **once** with `./build.sh`.
 If you update C code, run `./build.sh` again before the Rust-only build.
@@ -55,5 +55,5 @@ If you encounter strange build errors (stale artifacts, CMake cache issues):
 
 For Rust only:
 ```bash
-cd src/redisearch_rs && cargo clean && cargo build
+(cd src/redisearch_rs && cargo clean && cargo build)   # subshell keeps clean+build co-located
 ```

--- a/.skills/investigate-flaky-test/SKILL.md
+++ b/.skills/investigate-flaky-test/SKILL.md
@@ -115,7 +115,7 @@ Choose verification based on the proposed fix:
   ```
 - Rust test:
   ```bash
-  cd src/redisearch_rs && cargo nextest run -p <crate_name> <test_filter>
+  cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name> <test_filter>
   ```
 
 If the failure is timing-sensitive, recommend repeating the focused test enough times to gain

--- a/.skills/jj-fix-conflicts/SKILL.md
+++ b/.skills/jj-fix-conflicts/SKILL.md
@@ -123,7 +123,7 @@ Determine the scope of the conflict:
   ```
   Then format:
   ```bash
-  cd src/redisearch_rs && cargo fmt
+  cargo fmt --manifest-path src/redisearch_rs/Cargo.toml --all
   ```
 
 - **C code or mixed conflict** (any file outside `src/redisearch_rs/`):
@@ -166,7 +166,7 @@ jj new <tip-of-target-revset>
 
 - If any Rust files were touched:
   ```bash
-  cd src/redisearch_rs && cargo check && cargo fmt
+  (cd src/redisearch_rs && cargo check && cargo fmt)   # subshell keeps both cargo invocations co-located
   ```
 - If any C files were touched:
   ```bash

--- a/.skills/lint/SKILL.md
+++ b/.skills/lint/SKILL.md
@@ -52,7 +52,7 @@ Run this skill to check for lint errors and formatting issues.
 
 5. If license headers are missing, add them:
    ```bash
-   cd src/redisearch_rs && cargo license-fix
+   (cd src/redisearch_rs && cargo license-fix)   # subshell: custom subcommand, no --manifest-path
    ```
 
 ### Common Clippy Fixes
@@ -63,5 +63,5 @@ Run this skill to check for lint errors and formatting issues.
 ### Rust-Only Quick Check
 
 ```bash
-cd src/redisearch_rs && cargo clippy --all-targets --all-features
+cargo clippy --manifest-path src/redisearch_rs/Cargo.toml --all-targets --all-features
 ```

--- a/.skills/port-c-module/SKILL.md
+++ b/.skills/port-c-module/SKILL.md
@@ -44,8 +44,7 @@ For example:
 
 ### 3. Create the Rust Crate
 ```bash
-cd src/redisearch_rs
-cargo new $ARGUMENTS --lib
+cargo new src/redisearch_rs/$ARGUMENTS --lib
 ```
 
 ### 4. Implement Pure Rust Logic
@@ -65,8 +64,7 @@ cargo new $ARGUMENTS --lib
 ### 6. Create FFI Wrapper
 Create an FFI crate to expose the new Rust module to the C codebase:
 ```bash
-cd src/redisearch_rs/c_entrypoint
-cargo new ${ARGUMENTS}_ffi --lib
+cargo new src/redisearch_rs/c_entrypoint/${ARGUMENTS}_ffi --lib
 ```
 
 FFI crate should:

--- a/.skills/run-rust-benchmarks/SKILL.md
+++ b/.skills/run-rust-benchmarks/SKILL.md
@@ -18,11 +18,11 @@ Arguments provided: `$ARGUMENTS`
 1. Check the arguments provided above:
    - If a crate name is provided, run benchmarks for that crate:
      ```bash
-     cd src/redisearch_rs && cargo bench -p <crate_name>
+     cargo bench --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name>
      ```
    - If both crate and bench name are provided, run the specific bench:
      ```bash
-     cd src/redisearch_rs && cargo bench -p <crate_name> <bench_name>
+     cargo bench --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name> <bench_name>
      ```
 2. **Run benchmarks only once.** If the output is too large or truncated, extract the timing data from the saved output file rather than re-running the benchmarks.
 3. Once the benchmarks are complete, generate a summary comparing the average run times between the Rust and C implementations.
@@ -32,9 +32,9 @@ Arguments provided: `$ARGUMENTS`
 
 ```bash
 # Bench given crate
-cd src/redisearch_rs && cargo bench -p rqe_iterators_bencher
-cd src/redisearch_rs && cargo bench -p inverted_index_bencher
+cargo bench --manifest-path src/redisearch_rs/Cargo.toml -p rqe_iterators_bencher
+cargo bench --manifest-path src/redisearch_rs/Cargo.toml -p inverted_index_bencher
 
 # Run a specific benchmark
-cd src/redisearch_rs && cargo bench -p rqe_iterators_bencher "Iterator - InvertedIndex - Numeric - Read Dense"
+cargo bench --manifest-path src/redisearch_rs/Cargo.toml -p rqe_iterators_bencher "Iterator - InvertedIndex - Numeric - Read Dense"
 ```

--- a/.skills/run-rust-tests/SKILL.md
+++ b/.skills/run-rust-tests/SKILL.md
@@ -26,20 +26,20 @@ Run this skill after modifying Rust code to ensure tests pass.
      2. Map each modified file to its crate (the directory name directly under `src/redisearch_rs/`, e.g., `src/redisearch_rs/hyperloglog/src/lib.rs` → `hyperloglog`)
      3. Run tests for each affected crate:
         ```bash
-        cd src/redisearch_rs && cargo nextest run -p <crate1> -p <crate2> ...
+        cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p <crate1> -p <crate2> ...
         ```
      4. If no Rust files were modified in `src/redisearch_rs/`, or if you cannot determine affected crates, run all tests
    - If `all` is provided, run all Rust tests:
      ```bash
-     cd src/redisearch_rs && cargo nextest run
+     cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml
      ```
    - If a crate name is provided, run tests for that crate:
      ```bash
-     cd src/redisearch_rs && cargo nextest run -p <crate_name>
+     cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name>
      ```
    - If both crate and test name are provided, run the specific test:
      ```bash
-     cd src/redisearch_rs && cargo nextest run -p <crate_name> <test_name>
+     cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name> <test_name>
      ```
 2. If tests fail:
    - Read the error output carefully
@@ -50,13 +50,13 @@ Run this skill after modifying Rust code to ensure tests pass.
 
 ```bash
 # Test specific crate
-cd src/redisearch_rs && cargo nextest run -p hyperloglog
-cd src/redisearch_rs && cargo nextest run -p inverted_index
-cd src/redisearch_rs && cargo nextest run -p trie_rs
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p hyperloglog
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p inverted_index
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p trie_rs
 
 # Run a specific test
-cd src/redisearch_rs && cargo nextest run -p <crate_name> <test_name>
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name> <test_name>
 
 # Run tests under miri (for undefined behavior detection)
-cd src/redisearch_rs && cargo +nightly miri test
+cargo +nightly miri test --manifest-path src/redisearch_rs/Cargo.toml
 ```

--- a/.skills/verify/SKILL.md
+++ b/.skills/verify/SKILL.md
@@ -81,7 +81,7 @@ Ensure the full project compiles.
 
 #### 4. Rust Tests
 ```bash
-cd src/redisearch_rs && cargo nextest run
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml
 ```
 All Rust tests must pass.
 
@@ -96,9 +96,9 @@ Run all checks from both sections above.
 
 ## Quick Verification
 
-For minor Rust-only changes:
+For minor Rust-only changes (subshell keeps the chain readable — one cwd hop, three commands):
 ```bash
-cd src/redisearch_rs && cargo fmt --check && cargo clippy --all-targets && cargo nextest run
+(cd src/redisearch_rs && cargo fmt --check && cargo clippy --all-targets && cargo nextest run)
 ```
 
 For minor C-only changes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,10 @@ cargo nextest run                             # Rust tests, from `src/redisearch
 cargo +nightly miri test                      # Rust tests under `miri`, from `src/redisearch_rs/`
 ```
 
-Run Rust tests from workspace root (`src/redisearch_rs/`):
+Run Rust tests by pointing cargo at the workspace manifest:
 ```bash
-cd src/redisearch_rs && cargo nextest run
-cd src/redisearch_rs && cargo nextest run -p <crate_name>
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml
+cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml -p <crate_name>
 ```
 
 ## Header Generation
@@ -47,7 +47,7 @@ that produce C headers. Output goes to `src/redisearch_rs/headers/`.
 make lint                                 # Run clippy and cargo doc checks
 make fmt                                  # Format all code
 make fmt CHECK=1                          # Check formatting without changes
-cd src/redisearch_rs && cargo license-fix # Add missing license headers
+(cd src/redisearch_rs && cargo license-fix) # Add missing license headers (subshell: custom subcommand, no --manifest-path)
 ```
 
 C code formatting is governed by `.clang-format` at the repo root (LLVM-derived, 100-column limit, 2-space indent). Apply with `clang-format -i <file>`.


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Skill snippets use bare `cd src/redisearch_rs && cargo …`. The Bash tool's cwd persists across calls, so the `cd` fails once the shell has drifted into a subdirectory.
2. Change: Replace with `cargo … --manifest-path src/redisearch_rs/Cargo.toml` for built-in cargo subcommands; use `cargo new src/redisearch_rs/<crate> --lib` for project creation; use annotated subshells `(cd src/redisearch_rs && cargo …)` only for chains and custom subcommands without `--manifest-path` support (e.g. `cargo license-fix`). `cargo fmt` also gains `--all` when invoked from outside the workspace.
3. Outcome: Skill examples are cwd-agnostic and no longer fail when the shell isn't at repo root.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `.skills/{build,investigate-flaky-test,jj-fix-conflicts,lint,port-c-module,run-rust-benchmarks,run-rust-tests,verify}/SKILL.md`
2. `AGENTS.md`
3. `build.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to skill snippets and AGENTS.md; no runtime, API, or build-script behavior is modified in the diff.
> 
> **Overview**
> Updates **agent skill docs** and **`AGENTS.md`** so Rust/cargo examples no longer rely on `cd src/redisearch_rs && …`, which breaks when the shell’s working directory has already changed.
> 
> **Built-in cargo subcommands** (`build`, `nextest`, `bench`, `clippy`, `fmt`, `miri`, etc.) now use **`--manifest-path src/redisearch_rs/Cargo.toml`** from the repo root. **`cargo new`** paths are written as `src/redisearch_rs/...` (and `c_entrypoint/..._ffi`) without changing directory first. Where **`--manifest-path` doesn’t apply** (e.g. custom **`cargo license-fix`**) or a **chained** sequence is clearer, examples use an **annotated subshell** `(cd src/redisearch_rs && …)`. **`cargo fmt`** from outside the workspace adds **`--all`** where noted.
> 
> Touched skill files include **build**, **run-rust-tests**, **run-rust-benchmarks**, **lint**, **verify**, **port-c-module**, **jj-fix-conflicts**, and **investigate-flaky-test**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b2e227c81329d152405917660c48b79a7d8e62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->