### PR TITLE
[MOD-14211] topk: vector: benches

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ RUST_TOOLCHAIN_MODIFIER="" # Rust toolchain to use (e.g., +nightly)
 
 # Rust code is built first, so exclude benchmarking crates that link C code,
 # since the static libraries they depend on haven't been built yet.
-EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher --exclude trie_bencher --exclude triemap_ffi --exclude ttl_table_bencher"
+EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher --exclude trie_bencher --exclude triemap_ffi --exclude ttl_table_bencher --exclude vector_score_source_bencher"
 
 # Retrieve our pinned nightly version.
 NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3475,6 +3475,7 @@ dependencies = [
  "redis_mock",
  "redisearch_rs",
  "rqe_iterators",
+ "rqe_iterators_test_utils",
  "top_k",
  "vector_score_source",
  "workspace_hack",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3465,6 +3465,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vector_score_source_bencher"
+version = "0.0.1"
+dependencies = [
+ "build_utils",
+ "cc",
+ "criterion",
+ "ffi",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_iterators",
+ "top_k",
+ "vector_score_source",
+ "workspace_hack",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "top_k",
     "top_k_bencher",
     "vector_score_source",
+    "vector_score_source_bencher",
     "trie_rs",
     "ttl_table",
     "ttl_table_bencher",

--- a/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
@@ -26,6 +26,7 @@ criterion.workspace = true
 ffi.workspace = true
 redis_mock.workspace = true
 rqe_iterators = { workspace = true }
+rqe_iterators_test_utils.workspace = true
 top_k = { path = "../top_k" }
 vector_score_source = { path = "../vector_score_source" }
 workspace_hack.workspace = true

--- a/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "vector_score_source_bencher"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+# Rust VectorTopKIterator vs the real C HybridIterator (apples-to-apples).
+[[bench]]
+name = "vector_top_k_hybrid"
+harness = false
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }
+cc.workspace = true
+
+[dependencies]
+criterion.workspace = true
+ffi.workspace = true
+redis_mock.workspace = true
+rqe_iterators = { workspace = true }
+top_k = { path = "../top_k" }
+vector_score_source = { path = "../vector_score_source" }
+workspace_hack.workspace = true
+# Crate required to invoke C symbols and keep Rust-defined FFI symbols alive.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+/*
+ * C baseline that drives the *real* HybridIterator (iterators/hybrid_reader.c),
+ * the production counterpart of the Rust VectorTopKIterator / VectorScoreSource.
+ *
+ *
+ * It links against libredisearch_all.a (bundled by build_utils), which provides
+ * NewHybridVectorIterator, the Rust-backed NewSortedIdListIterator child, the
+ * doc table, and the min-max heap.
+ *
+ * The HybridIterator only touches `sctx` in three spots:
+ *   - sctx->time.skipTimeoutChecks   (we set true to disable timeout checks)
+ *   - sctx->spec->diskSpec           (zeroed => RAM path)
+ *   - sctx->spec->docs.ttl           (zeroed/NULL => field-expiration gate off,
+ *                                     so the DocTable expiration calls are
+ *                                     never reached)
+ * A zeroed IndexSpec plus a tiny RedisSearchCtx therefore suffices; we do not
+ * need a fully-initialised index spec, keyspace, or Redis module context.
+ */
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include "redisearch.h"
+#include "search_ctx.h"
+#include "spec.h"
+#include "iterators/iterator_api.h"
+#include "iterators/hybrid_reader.h"
+#include "VecSim/vec_sim.h"
+#include "VecSim/query_results.h"
+
+/* Rust-backed child iterator (src/redisearch_rs/headers/iterators_ffi.h).
+ * Takes ownership of `ids` and frees them with RedisModule_Free, so the caller
+ * must allocate `ids` with RedisModule_Alloc (done Rust-side in the bench, so
+ * the alloc/free pair matches the mock allocator). */
+QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
+
+/* Run the real HybridIterator over a sorted-id child and count the results.
+ *
+ * `ids` is an owning pointer (allocated via RedisModule_Alloc by the caller),
+ * sorted ascending, of length `child_count`; ownership is transferred to the
+ * child iterator, which frees it via RedisModule_Free.
+ *
+ * force_adhoc: 0 => force VECSIM_HYBRID_BATCHES, non-zero => VECSIM_HYBRID_ADHOC_BF.
+ */
+size_t bench_c_hybrid(VecSimIndex *index, const void *query_vec, size_t dim, size_t k, t_docId *ids,
+                      size_t child_count, int force_adhoc) {
+  // Minimal mock context: zeroed spec gives RAM path + no TTL gate.
+  IndexSpec spec = {0};
+  RedisSearchCtx sctx = {0};
+  sctx.spec = &spec;
+  sctx.time.skipTimeoutChecks = true;
+
+  QueryIterator *child = NewSortedIdListIterator(ids, child_count, 1.0);
+
+  KNNVectorQuery query = {0};
+  query.vector = (void *)query_vec;
+  query.vecLen = dim * sizeof(float);
+  query.k = k;
+  query.order = BY_SCORE;
+
+  VecSimQueryParams qParams = {0};
+  // Force the execution mode through the supported path: NewHybridVectorIterator
+  // uses qParams.searchMode verbatim when it is non-zero.
+  // VecSimSearchMode (vector_index.h) intentionally mirrors VecSearchMode (VecSim);
+  // NewHybridVectorIterator performs the same cast internally.
+  qParams.searchMode =
+      (VecSearchMode)(force_adhoc ? VECSIM_HYBRID_ADHOC_BF : VECSIM_HYBRID_BATCHES);
+
+  FieldFilterContext filterCtx = {
+      .field = {.index_tag = FieldMaskOrIndex_Index, .index = RS_INVALID_FIELD_INDEX},
+      .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT,
+  };
+
+  HybridIteratorParams hParams = {
+      .sctx = &sctx,
+      .index = index,
+      .dim = dim,
+      .elementType = VecSimType_FLOAT32,
+      .spaceMetric = VecSimMetric_L2,
+      .query = query,
+      .qParams = qParams,
+      .vectorScoreField = (char *)"__v_score",
+      .canTrimDeepResults = true,
+      .childIt = child,
+      .timeout = {0, 0},
+      .filterCtx = &filterCtx,
+  };
+
+  QueryError err = QueryError_Default();
+  QueryIterator *it = NewHybridVectorIterator(hParams, &err);
+  if (it == NULL || QueryError_HasError(&err)) {
+    if (it)
+      it->Free(it);
+    else if (child)
+      child->Free(child);
+    QueryError_ClearError(&err);
+    return 0;
+  }
+
+  size_t count = 0;
+  while (it->Read(it) == ITERATOR_OK) {
+    count++;
+  }
+
+  it->Free(it);  // also frees the child iterator
+  return count;
+}

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -44,11 +44,13 @@ use std::cmp::Ordering;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ffi::{
-    HNSWParams, RedisModule_Alloc, VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex,
-    VecSimIndex_AddVector, VecSimIndex_Free, VecSimIndex_New, VecSimMetric_VecSimMetric_L2,
-    VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32, timespec,
+    HNSWParams, RedisModule_Alloc, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES,
+    VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex, VecSimIndex_AddVector, VecSimIndex_Free,
+    VecSimIndex_New, VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams,
+    VecSimType_VecSimType_FLOAT32, timespec,
 };
 use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{TopKIterator, TopKMode};
 use vector_score_source::VectorScoreSource;
 
@@ -170,12 +172,22 @@ fn run_rust(
     ids: &[u64],
     mode: TopKMode,
 ) -> usize {
+    // Pin the source's HYBRID_POLICY to match the forced `mode`, mirroring the C
+    // shim's `qParams.searchMode`. This keeps `batch_strategy` on the same path
+    // as production (and C) instead of the unset-policy heuristic.
+    // SAFETY: zeroed is a valid bit pattern; only `searchMode` is then set.
+    let mut query_params: VecSimQueryParams = unsafe { std::mem::zeroed() };
+    query_params.searchMode = match mode {
+        TopKMode::AdhocBF => VecSearchMode_HYBRID_ADHOC_BF,
+        _ => VecSearchMode_HYBRID_BATCHES,
+    };
+
     // SAFETY: `index` lives for the duration of this benchmark.
-    let source: VectorScoreSource = unsafe {
+    let source = unsafe {
         VectorScoreSource::new(
             std::ptr::NonNull::new(index).unwrap(),
             query_bytes(query),
-            std::mem::zeroed::<VecSimQueryParams>(),
+            query_params,
             k.get(),
             timespec {
                 tv_sec: 0,
@@ -184,7 +196,7 @@ fn run_rust(
             true,
             ids.len(),
             0,
-            None,
+            MockExpirationChecker::new(std::collections::HashSet::new()),
         )
     };
     let child: Box<dyn RQEIterator> = Box::new(IdList::<true>::new(ids.to_vec()));

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Apples-to-apples hybrid benchmark: Rust `VectorTopKIterator` vs the *real* C
+//! `HybridIterator` (`iterators/hybrid_reader.c`).
+//!
+//! Both sides:
+//! - drive the same HNSW index and the same sorted-id child filter,
+//! - maintain a real bounded top-k heap,
+//! - are forced into the same execution mode (batches / adhoc-BF).
+//!
+//! The C side builds a minimal mock `RedisSearchCtx` and wraps the child in
+//! `NewSortedIdListIterator` (the C twin of the Rust `IdList`). See
+//! `hybrid_shim.c` for details.
+//!
+//! Two groups × two sides (rust / c):
+//!
+//! - `vector_top_k_hybrid/batches` — hybrid, batches mode forced.
+//! - `vector_top_k_hybrid/adhoc`   — hybrid, adhoc-BF mode forced.
+//!
+//! Swept over index size and top-k width at a fixed vector dimension.
+//!
+//! Known asymmetry (MOD-14210): the C path pushes a vector-score metric per
+//! candidate (`ResultMetrics_Add`) that Rust's `build_result` doesn't yet — a
+//! small C-only cost that mildly favors Rust in small-k adhoc cases until parity
+//! lands.
+
+// Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
+use vector_score_source_bencher as _;
+
+use std::hint::black_box;
+use std::{
+    ffi::{c_int, c_void},
+    num::NonZeroUsize,
+};
+
+use std::cmp::Ordering;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::{
+    HNSWParams, RedisModule_Alloc, VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex,
+    VecSimIndex_AddVector, VecSimIndex_Free, VecSimIndex_New, VecSimMetric_VecSimMetric_L2,
+    VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32, timespec,
+};
+use rqe_iterators::{IdList, RQEIterator};
+use top_k::{TopKIterator, TopKMode};
+use vector_score_source::VectorScoreSource;
+
+/// Score order for vector distance: ascending (lower distance = better).
+/// Matches the comparator `vector_score_source` uses internally.
+fn asc_cmp(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+// ── C shim (from hybrid_shim.c, compiled by build.rs) ────────────────────────
+
+unsafe extern "C" {
+    /// Drive the real C `HybridIterator` over a sorted-id child and count
+    /// results. `force_adhoc != 0` forces adhoc-BF, otherwise batches mode.
+    fn bench_c_hybrid(
+        index: *mut VecSimIndex,
+        query_vec: *const c_void,
+        dim: usize,
+        k: usize,
+        ids: *mut u64,
+        child_count: usize,
+        force_adhoc: c_int,
+    ) -> usize;
+}
+
+/// Allocate a `RedisModule_Alloc`-owned copy of `ids`, so the child iterator's
+/// `OwnedSlice` can free it via the matching `RedisModule_Free` (same mock
+/// allocator pair). Ownership is transferred to `bench_c_hybrid`.
+fn alloc_owned_ids(ids: &[u64]) -> *mut u64 {
+    // SAFETY: `RedisModule_Alloc` is the mock allocator, initialised by linking
+    // redis_mock. We copy `ids.len()` u64s into the freshly allocated buffer.
+    unsafe {
+        let ptr = RedisModule_Alloc.unwrap()(std::mem::size_of_val(ids)) as *mut u64;
+        std::ptr::copy_nonoverlapping(ids.as_ptr(), ptr, ids.len());
+        ptr
+    }
+}
+
+const DIM: usize = 128;
+
+/// Create an HNSW index, populate it with `n` random FLOAT32 vectors, and
+/// return the raw pointer. Caller frees via `VecSimIndex_Free`.
+unsafe fn make_index(n: usize) -> *mut VecSimIndex {
+    let params = VecSimParams {
+        algo: VecSimAlgo_VecSimAlgo_HNSWLIB,
+        algoParams: ffi::AlgoParams {
+            hnswParams: HNSWParams {
+                type_: VecSimType_VecSimType_FLOAT32,
+                dim: DIM,
+                metric: VecSimMetric_VecSimMetric_L2,
+                multi: false,
+                initialCapacity: n,
+                blockSize: 1024,
+                M: 16,
+                efConstruction: 200,
+                efRuntime: 10,
+                epsilon: 0.01,
+            },
+        },
+        logCtx: std::ptr::null_mut(),
+    };
+    // SAFETY: `params` is fully initialised.
+    let index = unsafe { VecSimIndex_New(&params) };
+    assert!(!index.is_null(), "VecSimIndex_New failed");
+
+    let mut rng_state: u64 = 0xDEAD_BEEF_1234_5678;
+    for label in 1..=n {
+        let vec: Vec<f32> = (0..DIM)
+            .map(|_| {
+                rng_state ^= rng_state << 13;
+                rng_state ^= rng_state >> 7;
+                rng_state ^= rng_state << 17;
+                (rng_state as f32) / (u64::MAX as f32)
+            })
+            .collect();
+        // SAFETY: `index` is valid; `vec` is `DIM` f32s.
+        unsafe {
+            VecSimIndex_AddVector(index, vec.as_ptr() as *const c_void, label);
+        }
+    }
+    index
+}
+
+/// Generate a single random query vector of `DIM` f32s.
+fn random_query(seed: u64) -> Vec<f32> {
+    let mut s = seed;
+    (0..DIM)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            (s as f32) / (u64::MAX as f32)
+        })
+        .collect()
+}
+
+/// Generate `count` sorted child IDs drawn uniformly from `[1, n]`.
+fn child_ids(n: usize, count: usize) -> Vec<usize> {
+    let step = (n / count).max(1);
+    (0..count).map(|i| (i * step + 1).min(n)).collect()
+}
+
+/// Reinterpret `&[f32]` as `Vec<u8>` (byte blob for VectorScoreSource).
+/// One allocation; mirrored on the C side by `query_owned_copy` to keep
+/// per-iteration setup cost comparable.
+fn query_bytes(v: &[f32]) -> Vec<u8> {
+    let mut bytes = vec![0u8; v.len() * 4];
+    for (i, f) in v.iter().enumerate() {
+        bytes[i * 4..i * 4 + 4].copy_from_slice(&f.to_ne_bytes());
+    }
+    bytes
+}
+
+/// Run one Rust hybrid scan with the given explicit mode, returning result count.
+fn run_rust(
+    index: *mut VecSimIndex,
+    query: &[f32],
+    k: NonZeroUsize,
+    ids: &[u64],
+    mode: TopKMode,
+) -> usize {
+    // SAFETY: `index` lives for the duration of this benchmark.
+    let source: VectorScoreSource = unsafe {
+        VectorScoreSource::new(
+            std::ptr::NonNull::new(index).unwrap(),
+            query_bytes(query),
+            std::mem::zeroed::<VecSimQueryParams>(),
+            k.get(),
+            timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            },
+            true,
+            ids.len(),
+            0,
+            None,
+        )
+    };
+    let child: Box<dyn RQEIterator> = Box::new(IdList::<true>::new(ids.to_vec()));
+    let mut it = TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode);
+    let mut count = 0usize;
+    while it.read().unwrap().is_some() {
+        count += 1;
+    }
+    count
+}
+
+/// Run one C HybridIterator scan to depletion, returning result count.
+/// `force_adhoc` must match the `TopKMode` passed to `run_rust`.
+fn run_c(
+    index: *mut VecSimIndex,
+    query: &[f32],
+    k: NonZeroUsize,
+    ids: &[u64],
+    force_adhoc: bool,
+) -> usize {
+    // Fresh owned copy each call: the child iterator frees it via RedisModule_Free.
+    let ids_ptr = alloc_owned_ids(ids);
+    // Match Rust's per-iteration query allocation (VectorScoreSource owns a Vec<u8>).
+    let query_owned = query_bytes(query);
+    // SAFETY: `index` is valid; `ids_ptr` is a sorted, owned array of `ids.len()`
+    // ids whose ownership transfers to the call. `query_owned` outlives the call.
+    unsafe {
+        bench_c_hybrid(
+            index,
+            query_owned.as_ptr() as *const c_void,
+            DIM,
+            k.get(),
+            ids_ptr,
+            ids.len(),
+            force_adhoc as c_int,
+        )
+    }
+}
+
+/// Validate that both sides produce the expected result count before the timed
+/// loop starts.  Catches iterator bugs, shim error paths, and mode mismatches
+/// that would otherwise silently corrupt the Rust/C timing comparison.
+fn preflight(
+    index: *mut VecSimIndex,
+    query: &[f32],
+    k: NonZeroUsize,
+    ids: &[u64],
+    rust_mode: TopKMode,
+    force_adhoc: bool,
+) {
+    let expected = k.get().min(ids.len());
+
+    let rust_count = run_rust(index, query, k, ids, rust_mode);
+    assert_eq!(
+        rust_count,
+        expected,
+        "Rust iterator produced {rust_count} results (expected {expected}) \
+         for k={k}, ids.len()={len}, mode={rust_mode:?}",
+        len = ids.len()
+    );
+
+    let c_count = run_c(index, query, k, ids, force_adhoc);
+    assert_eq!(
+        c_count,
+        expected,
+        "C shim produced {c_count} results (expected {expected}) \
+         for k={k}, ids.len()={len}, force_adhoc={force_adhoc}",
+        len = ids.len()
+    );
+}
+
+// ── Batches ────────────────────────────────────────────────────────────────
+
+fn bench_batches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_top_k_hybrid/batches");
+
+    for n in [10_000usize, 100_000] {
+        // SAFETY: make_index + VecSimIndex_Free are paired.
+        let index = unsafe { make_index(n) };
+
+        for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+            // Mode is forced to Batches regardless of heuristics.
+            let child_count = (n / 10).max(k.get());
+            let ids: Vec<u64> = child_ids(n, child_count)
+                .iter()
+                .map(|&id| id as u64)
+                .collect();
+            let query = random_query(99);
+            let param_str = format!("n{n}_k{k}");
+
+            preflight(index, &query, k, &ids, TopKMode::ForcedBatches, false);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_rust(index, &query, k, &ids, TopKMode::ForcedBatches)))
+            });
+
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_c(index, &query, k, &ids, false)))
+            });
+        }
+
+        // SAFETY: `index` was created with make_index.
+        unsafe { VecSimIndex_Free(index) };
+    }
+
+    group.finish();
+}
+
+// ── Adhoc BF ─────────────────────────────────────────────────────────────────
+
+fn bench_adhoc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_top_k_hybrid/adhoc");
+
+    for n in [10_000usize, 100_000] {
+        let index = unsafe { make_index(n) };
+
+        for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+            // Mode is forced to AdhocBF regardless of heuristics.
+            let child_count = k.get() * 5;
+            let ids: Vec<u64> = child_ids(n, child_count)
+                .iter()
+                .map(|&id| id as u64)
+                .collect();
+            let query = random_query(7);
+            let param_str = format!("n{n}_k{k}");
+
+            preflight(index, &query, k, &ids, TopKMode::AdhocBF, true);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_rust(index, &query, k, &ids, TopKMode::AdhocBF)))
+            });
+
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_c(index, &query, k, &ids, true)))
+            });
+        }
+
+        unsafe { VecSimIndex_Free(index) };
+    }
+
+    group.finish();
+}
+
+// ── Adhoc vs Batches mode comparison ─────────────────────────────────────────
+//
+// At a fixed index size and top-k, sweep child-filter selectivity across the
+// crossover where the cheaper mode flips (see `MODE_CASES`):
+//
+//   adhoc_favored   — tiny filter: AdhocBF does few vector lookups while Batches
+//                     burns many HNSW rounds clearing a sparse pass filter.
+//   balanced        — comparable cost near the natural crossover point.
+//   batches_favored — loose filter: AdhocBF scans most of the index while
+//                     Batches' first HNSW candidates mostly pass.
+//
+// Each configuration benchmarks rust/adhoc, rust/batches, c/adhoc, c/batches.
+
+struct ModeCase {
+    label: &'static str,
+    child_count: usize,
+}
+
+const MODE_CASES: &[ModeCase] = &[
+    ModeCase {
+        label: "adhoc_favored",
+        child_count: 500,
+    },
+    ModeCase {
+        label: "balanced",
+        child_count: 8_000,
+    },
+    ModeCase {
+        label: "batches_favored",
+        child_count: 70_000,
+    },
+];
+
+fn bench_mode_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_top_k_hybrid/mode_comparison");
+
+    const N: usize = 100_000;
+    let k = NonZeroUsize::new(100).unwrap();
+
+    // Build a single index for all cases (same n).
+    // SAFETY: make_index + VecSimIndex_Free are paired.
+    let index = unsafe { make_index(N) };
+    let query = random_query(42);
+
+    for case in MODE_CASES {
+        let ids: Vec<u64> = child_ids(N, case.child_count)
+            .iter()
+            .map(|&id| id as u64)
+            .collect();
+
+        preflight(index, &query, k, &ids, TopKMode::AdhocBF, true);
+        preflight(index, &query, k, &ids, TopKMode::ForcedBatches, false);
+
+        group.bench_with_input(BenchmarkId::new("rust_adhoc", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_rust(index, &query, k, &ids, TopKMode::AdhocBF)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("rust_batches", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_rust(index, &query, k, &ids, TopKMode::ForcedBatches)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("c_adhoc", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_c(index, &query, k, &ids, true)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("c_batches", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_c(index, &query, k, &ids, false)));
+        });
+    }
+
+    // SAFETY: `index` was created with make_index.
+    unsafe { VecSimIndex_Free(index) };
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_batches, bench_adhoc, bench_mode_comparison);
+criterion_main!(benches);

--- a/src/redisearch_rs/vector_score_source_bencher/build.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/build.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    // Emit hybrid_shim before redisearch_all: static archives resolve
+    // left-to-right, and the shim's symbols are defined in libredisearch_all.a.
+    compile_hybrid_shim();
+    build_utils::bind_foreign_c_symbols();
+}
+
+fn compile_hybrid_shim() {
+    use build_utils::repository_root;
+
+    let root = repository_root().expect("Could not find repository root");
+    let src = root.join("src");
+    let deps = root.join("deps");
+
+    cc::Build::new()
+        // Drives the real C HybridIterator from libredisearch_all.a, as a
+        // faithful counterpart to the Rust VectorTopKIterator.
+        .file("benches/hybrid_shim.c")
+        // Silence warnings originating from transitively-included RediSearch
+        // headers (static helpers, sign-compare in inline funcs, etc.) — they
+        // are not actionable from this shim and the main CMake build already
+        // suppresses them.
+        .flag_if_supported("-Wno-unused-function")
+        .flag_if_supported("-Wno-unused-variable")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-sign-compare")
+        .include(&src)
+        // `deps` (rmutil/*) and RedisModulesSDK (redismodule.h) are pulled in
+        // transitively by spec.h / search_ctx.h for the hybrid shim.
+        .include(&deps)
+        .include(deps.join("RedisModulesSDK"))
+        .include(src.join("iterators"))
+        .include(deps.join("VectorSimilarity").join("src"))
+        .include(deps.join("rmalloc"))
+        .include(src.join("redisearch_rs").join("headers"))
+        .include(src.join("buffer"))
+        .include(src.join("ttl_table"))
+        .include(src.join("trie"))
+        .compile("hybrid_shim");
+
+    println!("cargo:rerun-if-changed=benches/hybrid_shim.c");
+}

--- a/src/redisearch_rs/vector_score_source_bencher/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/src/lib.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Some of the missing C symbols are actually Rust-provided.
+
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;


### PR DESCRIPTION
- builds on https://github.com/RediSearch/RediSearch/pull/10192
- next: https://github.com/RediSearch/RediSearch/pull/10221

- To be noted I ran benchmarks after work from https://github.com/RediSearch/RediSearch/pull/10221 ; to anticipate any performance impacts.

# Vector TopK Benchmarks — Rust vs C HybridIterator (2026-06-24)

`cargo bench -p vector_score_source_bencher --bench vector_top_k_hybrid`, run 2026-06-24.

Both sides run the **actual iterators**: the Rust `VectorTopKIterator` / `VectorScoreSource`
vs the C `HybridIterator` (`iterators/hybrid_reader.c`). Both maintain a real bounded top-k
heap over the same sorted-id child, in the same **explicitly forced** execution mode.

- Bench: [vector_top_k_hybrid.rs](../../../../src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs)
- C shim: [hybrid_shim.c](../../../../src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c)

Times are Criterion's median point estimate. `ratio` = Rust / C (< 1 means Rust faster).

## Results

### `batches` — batches mode forced on both sides

| n       | k   | child  | Rust     | C        | ratio                   |
| ------- | --- | ------ | -------- | -------- | ----------------------- |
| 10 000  | 10  | 1 000  | 43.77 µs | 44.98 µs | **0.97×** (parity)      |
| 10 000  | 100 | 1 000  | 413.2 µs | 426.0 µs | **0.97×** (parity)      |
| 100 000 | 10  | 10 000 | 77.01 µs | 91.20 µs | **0.84×** (Rust faster) |
| 100 000 | 100 | 10 000 | 1.030 ms | 992.4 µs | **1.04×** (parity)      |

Parity across configurations, with Rust slightly ahead at n=100k/k=10.

### `adhoc` — adhoc-BF mode forced on both sides

| n       | k   | child | Rust     | C        | ratio                         |
| ------- | --- | ----- | -------- | -------- | ----------------------------- |
| 10 000  | 10  | 50    | 2.137 µs | 1.783 µs | **1.20×** (Rust 1.20× slower) |
| 10 000  | 100 | 500   | 24.73 µs | 31.16 µs | **0.79×** (Rust 1.26× faster) |
| 100 000 | 10  | 50    | 2.275 µs | 1.994 µs | **1.14×** (Rust 1.14× slower) |
| 100 000 | 100 | 500   | 25.84 µs | 31.60 µs | **0.82×** (Rust 1.22× faster) |

Mode choice splits by `k`. At **k=100** Rust leads by ~1.2× — the larger child (500 ids) means
the per-id distance call plus heap insert dominates, where Rust has lower overhead per result.
At **k=10** the child is tiny (50 ids) and the run is dominated by fixed per-call setup, where
Rust is ~1.1–1.2× slower.

:warning: there seems to be a small fixed cost in rust that we should look into in a future PR.

### `mode_comparison` — adhoc-BF vs batches, `n=100 000`, `k=100`

`cargo bench -p vector_score_source_bencher --bench vector_top_k_hybrid -- mode_comparison`, run 2026-06-24.

Three child-size configurations show how the mode choice dominates performance.
Both Rust and C are forced into the same mode on each row.

| config            | child        | rust adhoc | rust batches | c adhoc  | c batches | faster mode      |
| ----------------- | ------------ | ---------- | ------------ | -------- | --------- | ---------------- |
| `adhoc_favored`   | 500 (0.5%)   | 25.06 µs   | 13.57 ms     | 30.05 µs | 13.77 ms  | **adhoc × 542**  |
| `balanced`        | 8 000 (8%)   | 382.1 µs   | 1.279 ms     | 260.6 µs | 1.197 ms  | **adhoc × 3.3**  |
| `batches_favored` | 70 000 (70%) | 2.978 ms   | 95.41 µs     | 2.773 ms | 113.3 µs  | **batches × 31** |

The `balanced` label reflects intent, not outcome; on
this machine adhoc wins there, but it may lose on another.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hybrid vector query execution (timeouts, expiration filtering, and adhoc scan loop); incorrect behavior could truncate results or leak past deadlines, though tests cover timeout and expiration paths.
> 
> **Overview**
> Aligns the Rust **vector top-k** stack with the C **`HybridIterator`**: adhoc-BF scans now **poll query deadlines** (via new C **`RS_VecSimCheckTimeout`** / mockable **`vecsimTimeoutCallback`**), and **`TopKIterator`** aborts with **`TimedOut`** instead of returning a partial top-k.
> 
> **`VectorScoreSource`** is parameterized with an optional **`ExpirationChecker`**: batch cursors and adhoc **`lookup_score`** skip expired field-level docs (tests use shared **`MockExpirationChecker`** in **`rqe_iterators_test_utils`**). **`FieldFilterContext`** / **`FieldExpirationChecker`** gain **`Copy`** for plumbing.
> 
> Adds **`vector_score_source_bencher`** with a C **`hybrid_shim`** driving the real **`HybridIterator`** vs Rust **`VectorTopKIterator`** (batches, adhoc-BF, mode-comparison sweeps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5770bbaebde49eea688e043673e3a7f0aba5b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->