### PR TITLE
deps: bump RLTest to 0.7.27 for failed-tests-file fix

### DIFF
--- a/tests/pytests/pyproject.toml
+++ b/tests/pytests/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "packaging<=24.2",
     "deepdiff==8.6.2",
     "redis>=5.2.1,<7.0.0", # Pin to avoid redis-py 7.x incompatibility (todo: update once fixed)
-    "rltest==0.7.26",
+    "rltest>=0.7.27,<0.8.0",
     "numpy<=2.2.4",
     "scipy<=1.15.2",
     "faker<=37.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [{ name = "pip" }]
 
 [[package]]
 name = "rltest"
-version = "0.7.26"
+version = "0.7.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distro" },
@@ -474,9 +474,9 @@ dependencies = [
     { name = "pytest-cov" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/54/a428d74cd68859a8a29897d04f95e2472f121bac8a898a2fca3a840478ea/rltest-0.7.26.tar.gz", hash = "sha256:288073a3540bb8888029c00578942065c7b0d0b50c0050513bb0fb0ca4bfc032", size = 45274, upload-time = "2026-05-25T13:49:27.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/4d/f68c25855b0133ffb0796693c5471cf239f088899af44545dc93183863eb/rltest-0.7.27.tar.gz", hash = "sha256:9bc916f6ab3701b1b7442be44670e3ac254935b4c37991e347774479d0a3850d", size = 45275, upload-time = "2026-05-29T12:39:55.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/41/a509c4161aa12d7e0b329c77aa2e30b457313339993019c6577e51092c1f/rltest-0.7.26-py3-none-any.whl", hash = "sha256:10706d25a7a05adf05f4b698041c3f783a33246c421c28e06907a5d4dd385f17", size = 50729, upload-time = "2026-05-25T13:49:28.287Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f2/32fcc55a1105e6e06d074f2595e6e7b1208235bc3be1cb355c069829971f/rltest-0.7.27-py3-none-any.whl", hash = "sha256:64973137cf541939c29930402de68180a8ab0af611bc7b2fa5546fe1889ff039", size = 50731, upload-time = "2026-05-29T12:39:56.352Z" },
 ]
 
 [[package]]
@@ -508,7 +508,7 @@ requires-dist = [
     { name = "orderly-set", specifier = "<=5.4.1" },
     { name = "packaging", specifier = "<=24.2" },
     { name = "redis", specifier = ">=5.2.1,<7.0.0" },
-    { name = "rltest", specifier = "==0.7.26" },
+    { name = "rltest", specifier = ">=0.7.27,<0.8.0" },
     { name = "scipy", specifier = "<=1.15.2" },
 ]
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: \`tests/pytests/pyproject.toml\` pins \`rltest==0.7.26\`. RLTest 0.7.26 has a latent bug in its \`--failed-tests-file\` (\`-F\`) writer — \`for test, _ in self.testsFailed:\` iterates a dict and tries to unpack each key (a string) into a 2-tuple, crashing with \`ValueError: too many values to unpack (expected 2)\` whenever a real test failure exists. The flaky-DB recording added in #9869 depends on this writer producing \`.failed_*.txt\`, so it silently reports "No results to record" on any failing CI run.
2. **Change**: Bump RLTest to 0.7.27 (which includes the upstream fix at RedisLabsModules/RLTest#251) and switch the exact pin to a \`>=0.7.27,<0.8.0\` range.
3. **Outcome**: The flaky-DB recording step will actually capture failures going forward. The range pin also means future RLTest patch fixes get picked up via \`uv lock --upgrade-package rltest\` without another \`pyproject.toml\` change. Reproducibility is still provided by \`uv.lock\`.

The bug has been dormant on master because recent CI runs have been green; this lands the fix before the next failure trips the writer.

#### Which additional issues this PR fixes
1. _follow-up to #9869 — same MOD-15952 area_

#### Main objects this PR modified

1. \`tests/pytests/pyproject.toml\` — \`rltest==0.7.26\` → \`rltest>=0.7.27,<0.8.0\`
2. \`uv.lock\` — \`rltest 0.7.26 → 0.7.27\` (only RLTest moved; no transitive dep changes on master)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only dependency and lockfile changes; no production code paths affected.
> 
> **Overview**
> Bumps the **RLTest** test harness from **0.7.26** to **0.7.27** so CI can rely on a fixed `--failed-tests-file` writer (0.7.26 could crash when recording real failures, which broke flaky-test capture downstream).
> 
> In `tests/pytests/pyproject.toml`, the exact pin `rltest==0.7.26` becomes **`rltest>=0.7.27,<0.8.0`**; **`uv.lock`** is updated to resolve **0.7.27** only (no other dependency churn in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11f61e3a4f7309afde903db0216d6eb253248c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->