### PR TITLE
ForkGC: replace RECV_BUFFER_EMPTY sentinel with SIZE_MAX len check

### DIFF
--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -36,14 +36,14 @@ void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
 FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
   FGCError status = FGC_COLLECTED;
 
-  size_t ei_len;
-  char *empty_indicator = NULL;
+  size_t len;
+  char *buf = NULL;
 
-  if (FGC_recvBuffer(gc, (void **)&empty_indicator, &ei_len) != REDISMODULE_OK) {
+  if (FGC_recvBuffer(gc, (void **)&buf, &len) != REDISMODULE_OK) {
     return FGC_CHILD_ERROR;
   }
 
-  if (ei_len == SIZE_MAX) {
+  if (len == NO_MORE_DATA) {
     return FGC_DONE;
   }
 
@@ -52,7 +52,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
   InvertedIndexGcDelta *delta = InvertedIndex_GcDelta_Read(&rd);
 
   if (delta == NULL) {
-    FGC_freeBuffer(empty_indicator, ei_len);
+    FGC_freeBuffer(buf, len);
     return FGC_CHILD_ERROR;
   }
 
@@ -92,7 +92,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
   FGC_updateStats(gc, sctx, 0, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);
 
 cleanup:
-  FGC_freeBuffer(empty_indicator, ei_len);
+  FGC_freeBuffer(buf, len);
   if (sp) {
     RedisSearchCtx_UnlockSpec(sctx);
     IndexSpecRef_Release(spec_ref);

--- a/src/fork_gc/existing_docs.c
+++ b/src/fork_gc/existing_docs.c
@@ -43,7 +43,7 @@ FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
     return FGC_CHILD_ERROR;
   }
 
-  if (empty_indicator == RECV_BUFFER_EMPTY) {
+  if (ei_len == SIZE_MAX) {
     return FGC_DONE;
   }
 

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -64,7 +64,7 @@ FGCError FGC_parentHandleFromChild(ForkGC *gc) {
   // Wait for the final terminator from the child, so it can finish post-processing chores before we kill it
   size_t terminator_check;
   int rc = FGC_recvFixed(gc, &terminator_check, sizeof(terminator_check)); // final status from child
-  if (rc != REDISMODULE_OK || terminator_check != SIZE_MAX) {
+  if (rc != REDISMODULE_OK || terminator_check != NO_MORE_DATA) {
     return FGC_CHILD_ERROR;
   }
   RedisModule_Log(gc->ctx, "debug", "ForkGC - parent ends applying changes");

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -60,7 +60,7 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     return FGC_CHILD_ERROR;
   }
 
-  if (fieldNameLen == SIZE_MAX) {
+  if (fieldNameLen == NO_MORE_DATA) {
     return FGC_DONE;
   }
 

--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -60,7 +60,7 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     return FGC_CHILD_ERROR;
   }
 
-  if (rawFieldName == RECV_BUFFER_EMPTY) {
+  if (fieldNameLen == SIZE_MAX) {
     return FGC_DONE;
   }
 

--- a/src/fork_gc/numeric.c
+++ b/src/fork_gc/numeric.c
@@ -86,8 +86,7 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc) {
       status = FGC_CHILD_ERROR;
       goto loop_cleanup;
     }
-    // Check if we received the sentinel terminator value
-    if (nodeLen == SIZE_MAX) {
+    if (nodeLen == NO_MORE_DATA) {
       break;
     }
 

--- a/src/fork_gc/pipe.c
+++ b/src/fork_gc/pipe.c
@@ -15,8 +15,6 @@
 #include <errno.h>
 #include <string.h>
 
-void *RECV_BUFFER_EMPTY = (void *)0x0deadbeef;
-
 // Assumes the spec is locked.
 void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
                      size_t recordsRemoved, size_t bytesCollected,

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -18,11 +18,9 @@
 #include "search_ctx.h"
 #include "inverted_index.h"
 #include <stddef.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <sys/uio.h>
-
-// Sentinel value indicating an empty/terminator buffer was received.
-extern void *RECV_BUFFER_EMPTY;
 
 //------------------------------------------------------------------------------
 // Pipe I/O primitives

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -28,6 +28,9 @@
 
 #define FGC_SEND_VAR(fgc, v) FGC_sendFixed(fgc, &v, sizeof v)
 
+// Sentinel length value sent over the pipe to signal end-of-stream.
+#define NO_MORE_DATA SIZE_MAX
+
 //------------------------------------------------------------------------------
 // Pipe read/write callbacks for II GC
 //------------------------------------------------------------------------------

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -64,7 +64,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
     return FGC_CHILD_ERROR;
   }
 
-  if (len == SIZE_MAX) {
+  if (len == NO_MORE_DATA) {
     return FGC_DONE;
   }
 

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -64,7 +64,7 @@ FGCError FGC_parentHandleTerms(ForkGC *gc) {
     return FGC_CHILD_ERROR;
   }
 
-  if (term == RECV_BUFFER_EMPTY) {
+  if (len == SIZE_MAX) {
     return FGC_DONE;
   }
 

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -27,13 +27,6 @@ use tracing_log_error::log_error;
 
 mod util;
 
-// Sentinel pointer defined in `src/fork_gc/pipe.c`, compared by pointer
-// identity in C callers (e.g. `recvFieldHeader`) to detect end-of-stream
-// frames returned through `FGC_recvBuffer`'s `buf` out-parameter.
-unsafe extern "C" {
-    static RECV_BUFFER_EMPTY: *mut c_void;
-}
-
 /// Status code returned by Fork GC parent-side pipe-receive operations.
 #[cheadergen::config(export)]
 #[repr(C)]
@@ -160,11 +153,12 @@ pub unsafe extern "C" fn FGC_recvFixed(
 
 /// Read a length-prefixed buffer frame from the FGC pipe.
 ///
-/// On receipt of a `SIZE_MAX` length prefix, writes `SIZE_MAX` to
-/// `*len` and the `RECV_BUFFER_EMPTY` sentinel pointer to `*buf`. On a
-/// zero-length prefix, writes `0` and a null pointer. Otherwise leaks a
-/// boxed payload slice, writing its pointer and length to `*buf` / `*len`;
-/// the caller is responsible for releasing it with [`FGC_freeBuffer`].
+/// On receipt of a `SIZE_MAX` length prefix (end-of-stream terminator), writes
+/// `SIZE_MAX` to `*len` and a null pointer to `*buf`. Callers detect
+/// end-of-stream by checking `*len == SIZE_MAX`. On a zero-length prefix,
+/// writes `0` and a null pointer. Otherwise leaks a boxed payload slice,
+/// writing its pointer and length to `*buf` / `*len`; the caller is
+/// responsible for releasing it with [`FGC_freeBuffer`].
 ///
 /// On read error (timeout, short stream, ...), returns `REDISMODULE_ERR`
 /// and leaves `*buf` / `*len` unchanged.
@@ -260,7 +254,7 @@ pub unsafe extern "C" fn recvFieldHeader(
 
 /// Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
 ///
-/// No-ops for the `RECV_BUFFER_EMPTY` sentinel and null pointers.
+/// No-ops for null pointers (returned for both the terminator and empty-frame cases).
 ///
 /// # Safety
 ///
@@ -268,8 +262,7 @@ pub unsafe extern "C" fn recvFieldHeader(
 ///    [`FGC_recvBuffer`] or [`recvFieldHeader`], and must not have been freed before.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_freeBuffer(buf: *mut c_void, len: usize) {
-    // SAFETY: `RECV_BUFFER_EMPTY` is a static defined in `pipe.c`.
-    if buf.is_null() || buf == unsafe { RECV_BUFFER_EMPTY } {
+    if buf.is_null() {
         return;
     }
 

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
@@ -15,17 +15,15 @@ use fork_gc::Frame;
 /// `FGC_recvBuffer` and `recvFieldHeader` API exposes through its
 /// out-parameters.
 ///
-/// - [`Frame::Terminator`] → `(RECV_BUFFER_EMPTY, usize::MAX)`.
+/// - [`Frame::Terminator`] → `(null, SIZE_MAX)`. Callers detect end-of-stream
+///   by checking `*len == SIZE_MAX`.
 /// - [`Frame::Empty`] → `(null, 0)`.
 /// - [`Frame::Data`] → leaks the boxed payload, transferring ownership
 ///   to the caller. The caller is responsible for releasing it with
 ///   [`super::FGC_freeBuffer`].
 pub(crate) fn frame_into_c_buffer(frame: Frame<Box<[u8]>>) -> (*mut c_void, usize) {
     match frame {
-        Frame::Terminator => {
-            // SAFETY: `RECV_BUFFER_EMPTY` is a static pointer defined in `pipe.c`.
-            (unsafe { super::RECV_BUFFER_EMPTY }, usize::MAX)
-        }
+        Frame::Terminator => (ptr::null_mut(), usize::MAX),
         Frame::Empty => (ptr::null_mut(), 0),
         Frame::Data(data) => {
             let len = data.len();

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -103,11 +103,12 @@ int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
 /**
  * Read a length-prefixed buffer frame from the FGC pipe.
  *
- * On receipt of a `SIZE_MAX` length prefix, writes `SIZE_MAX` to
- * `*len` and the `RECV_BUFFER_EMPTY` sentinel pointer to `*buf`. On a
- * zero-length prefix, writes `0` and a null pointer. Otherwise leaks a
- * boxed payload slice, writing its pointer and length to `*buf` / `*len`;
- * the caller is responsible for releasing it with [`FGC_freeBuffer`].
+ * On receipt of a `SIZE_MAX` length prefix (end-of-stream terminator), writes
+ * `SIZE_MAX` to `*len` and a null pointer to `*buf`. Callers detect
+ * end-of-stream by checking `*len == SIZE_MAX`. On a zero-length prefix,
+ * writes `0` and a null pointer. Otherwise leaks a boxed payload slice,
+ * writing its pointer and length to `*buf` / `*len`; the caller is
+ * responsible for releasing it with [`FGC_freeBuffer`].
  *
  * On read error (timeout, short stream, ...), returns `REDISMODULE_ERR`
  * and leaves `*buf` / `*len` unchanged.
@@ -140,7 +141,7 @@ enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_nam
 /**
  * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
  *
- * No-ops for the `RECV_BUFFER_EMPTY` sentinel and null pointers.
+ * No-ops for null pointers (returned for both the terminator and empty-frame cases).
  *
  * # Safety
  *


### PR DESCRIPTION
## Summary

- Removes the `RECV_BUFFER_EMPTY` magic pointer sentinel from `pipe.c`/`pipe.h` and the Rust FFI crate
- `FGC_recvBuffer` now returns `(NULL, SIZE_MAX)` for the end-of-stream terminator instead of `(RECV_BUFFER_EMPTY, SIZE_MAX)`
- Callers in `terms.c`, `missing_docs.c`, and `existing_docs.c` now check `len == SIZE_MAX` instead of comparing against the sentinel pointer
- Adds an explicit `#include <stdint.h>` to `pipe.h` so `SIZE_MAX` has a direct owner in the include chain

`RECV_BUFFER_EMPTY` was confusing because it sounds like it describes an empty/zero-length buffer, but it was actually the sentinel returned for the end-of-stream terminator (`Frame::Terminator`). The actual empty frame (`Frame::Empty`, zero-length buffer) returned a plain NULL pointer — the opposite of what the name implied. Checking `len == SIZE_MAX` maps directly to the on-wire encoding and is consistent with how the final all-done terminator is already checked in `FGC_parentHandleFromChild` (`terminator_check != SIZE_MAX`).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of internal pipe framing with unchanged on-wire encoding; no auth, data persistence, or user-facing API changes.
> 
> **Overview**
> Fork GC parent/child pipe handling no longer uses the **`RECV_BUFFER_EMPTY`** magic pointer to mark end-of-stream. The Rust FFI now exposes terminators as **`(NULL, SIZE_MAX)`**, and C callers detect completion with **`len == NO_MORE_DATA`** (`SIZE_MAX` in `pipe.h`), including terms, missing docs, existing docs, numeric node loops, and the final child terminator in **`FGC_parentHandleFromChild`**.
> 
> **`FGC_freeBuffer`** only no-ops on null pointers (terminator and zero-length frames). Docs and generated headers were updated to describe length-based EOF detection instead of pointer identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4f16f41bb0096f5b3b4eda7b3202fc0c1d8d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->