### PR TITLE
trie_rs: split iterator borrow lifetimes from pattern/filter/target

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -19,7 +19,7 @@ pub enum TrieMapIteratorImpl<'tm> {
     // Boxing to reduce the size of overall enum, since the contains variant
     // is much larger than the others due to how much space `memchr::memmem::Finder`
     // takes on the stack.
-    Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, *mut c_void>>),
+    Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, 'tm, *mut c_void>>),
     Wildcard(trie_rs::iter::LendingIter<'tm, *mut c_void, WildcardFilter<'tm>>),
 }
 

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -19,6 +19,10 @@ pub enum TrieMapIteratorImpl<'tm> {
     // Boxing to reduce the size of overall enum, since the contains variant
     // is much larger than the others due to how much space `memchr::memmem::Finder`
     // takes on the stack.
+    //
+    // Both lifetime parameters collapse to `'tm` at the FFI boundary: the
+    // trie reference and the target byte slice originate from the same
+    // C-side scope.
     Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, 'tm, *mut c_void>>),
     Wildcard(trie_rs::iter::LendingIter<'tm, *mut c_void, WildcardFilter<'tm>>),
 }

--- a/src/redisearch_rs/trie_rs/src/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/contains.rs
@@ -24,8 +24,8 @@ pub struct ContainsIter<'tm, 't, Data> {
     finder: Finder<'t>,
 }
 
-struct StackItem<'a, Data> {
-    node: &'a Node<Data>,
+struct StackItem<'tm, Data> {
+    node: &'tm Node<Data>,
     was_visited: bool,
     /// Set to `true` if we can skip checking if the current key contains the target fragment.
     ///

--- a/src/redisearch_rs/trie_rs/src/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/contains.rs
@@ -14,14 +14,14 @@ use memchr::memmem::Finder;
 /// in lexicographical order.
 ///
 /// Invoke [`TrieMap::contains_iter`](crate::TrieMap::contains_iter) to create an instance of this iterator.
-pub struct ContainsIter<'tm, Data> {
+pub struct ContainsIter<'tm, 't, Data> {
     /// Stack of nodes and whether they have been visited.
     stack: Vec<StackItem<'tm, Data>>,
     /// Concatenation of the labels of current node and its ancestors,
     /// i.e. the key of the current node.
     key: Vec<u8>,
     /// The target fragment we are looking for.
-    finder: Finder<'tm>,
+    finder: Finder<'t>,
 }
 
 struct StackItem<'a, Data> {
@@ -34,9 +34,9 @@ struct StackItem<'a, Data> {
     skip_check: bool,
 }
 
-impl<'tm, Data> ContainsIter<'tm, Data> {
+impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     /// Creates a new contains iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &'tm [u8]) -> Self {
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &'t [u8]) -> Self {
         let finder = Finder::new(target);
         Self {
             stack: root
@@ -53,7 +53,7 @@ impl<'tm, Data> ContainsIter<'tm, Data> {
     }
 }
 
-impl<'tm, Data> ContainsIter<'tm, Data> {
+impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     /// The current key, obtained by concatenating the labels of the nodes
     /// between the root and the current node.
     pub(crate) fn key(&self) -> &[u8] {
@@ -106,7 +106,7 @@ impl<'tm, Data> ContainsIter<'tm, Data> {
     }
 }
 
-impl<'tm, Data> Iterator for ContainsIter<'tm, Data> {
+impl<'tm, 't, Data> Iterator for ContainsIter<'tm, 't, Data> {
     type Item = (Vec<u8>, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -25,9 +25,9 @@ pub struct Iter<'tm, Data, F> {
     key: Vec<u8>,
 }
 
-impl<'a, Data, F> Iter<'a, Data, F> {
+impl<'tm, Data, F> Iter<'tm, Data, F> {
     /// Change the traversal filter used by this iterator.
-    pub fn traversal_filter<F1>(self, f: F1) -> Iter<'a, Data, F1>
+    pub fn traversal_filter<F1>(self, f: F1) -> Iter<'tm, Data, F1>
     where
         F1: TraversalFilter,
     {

--- a/src/redisearch_rs/trie_rs/src/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending.rs
@@ -25,9 +25,9 @@ impl<'tm, Data, F> From<Iter<'tm, Data, F>> for LendingIter<'tm, Data, F> {
     }
 }
 
-impl<'a, Data, F> LendingIter<'a, Data, F> {
+impl<'tm, Data, F> LendingIter<'tm, Data, F> {
     /// Change the traversal filter used by this iterator.
-    pub fn traversal_filter<F1>(self, f: F1) -> LendingIter<'a, Data, F1>
+    pub fn traversal_filter<F1>(self, f: F1) -> LendingIter<'tm, Data, F1>
     where
         F1: TraversalFilter,
     {

--- a/src/redisearch_rs/trie_rs/src/iter/lending_contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending_contains.rs
@@ -14,10 +14,10 @@ use lending_iterator::prelude::*;
 /// in lexicographical order.
 ///
 /// Unlike [`ContainsIter`], this iterator lets you borrow the current key, rather than having to clone it.
-pub struct ContainsLendingIter<'tm, Data>(ContainsIter<'tm, Data>);
+pub struct ContainsLendingIter<'tm, 't, Data>(ContainsIter<'tm, 't, Data>);
 
-impl<'tm, Data> From<ContainsIter<'tm, Data>> for ContainsLendingIter<'tm, Data> {
-    fn from(iter: ContainsIter<'tm, Data>) -> Self {
+impl<'tm, 't, Data> From<ContainsIter<'tm, 't, Data>> for ContainsLendingIter<'tm, 't, Data> {
+    fn from(iter: ContainsIter<'tm, 't, Data>) -> Self {
         ContainsLendingIter(iter)
     }
 }
@@ -29,7 +29,7 @@ impl<'tm, Data> From<ContainsIter<'tm, Data>> for ContainsLendingIter<'tm, Data>
 //
 // Why do we need a crate? Well: <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats>
 #[gat]
-impl<'tm, Data> LendingIterator for ContainsLendingIter<'tm, Data> {
+impl<'tm, 't, Data> LendingIterator for ContainsLendingIter<'tm, 't, Data> {
     type Item<'next>
     where
         Self: 'next,

--- a/src/redisearch_rs/trie_rs/src/iter/lending_range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending_range.rs
@@ -14,10 +14,10 @@ use lending_iterator::prelude::*;
 /// in lexicographical order.
 ///
 /// Unlike [`RangeIter`], this iterator lets you borrow the current key, rather than having to clone it.
-pub struct RangeLendingIter<'tm, Data>(RangeIter<'tm, Data>);
+pub struct RangeLendingIter<'tm, 'f, Data>(RangeIter<'tm, 'f, Data>);
 
-impl<'tm, Data> From<RangeIter<'tm, Data>> for RangeLendingIter<'tm, Data> {
-    fn from(iter: RangeIter<'tm, Data>) -> Self {
+impl<'tm, 'f, Data> From<RangeIter<'tm, 'f, Data>> for RangeLendingIter<'tm, 'f, Data> {
+    fn from(iter: RangeIter<'tm, 'f, Data>) -> Self {
         RangeLendingIter(iter)
     }
 }
@@ -29,7 +29,7 @@ impl<'tm, Data> From<RangeIter<'tm, Data>> for RangeLendingIter<'tm, Data> {
 //
 // Why do we need a crate? Well: <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats>
 #[gat]
-impl<'tm, Data> LendingIterator for RangeLendingIter<'tm, Data> {
+impl<'tm, 'f, Data> LendingIterator for RangeLendingIter<'tm, 'f, Data> {
     type Item<'next>
     where
         Self: 'next,

--- a/src/redisearch_rs/trie_rs/src/iter/prefixes.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/prefixes.rs
@@ -13,16 +13,16 @@ use memchr::arch::all::is_prefix;
 /// Iterate over all trie entries whose key is a prefix of `target`.
 ///
 /// It can be instantiated by calling [`TrieMap::prefixes_iter`](crate::TrieMap::prefixes_iter).
-pub struct PrefixesIter<'tm, Data> {
+pub struct PrefixesIter<'tm, 't, Data> {
     /// The term whose prefixes we are looking for.
-    target: &'tm [u8],
+    target: &'t [u8],
     /// The node we are currently examining.
     current_node: Option<&'tm Node<Data>>,
 }
 
-impl<'tm, Data> PrefixesIter<'tm, Data> {
+impl<'tm, 't, Data> PrefixesIter<'tm, 't, Data> {
     /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    pub(crate) const fn new(root: Option<&'tm Node<Data>>, target: &'tm [u8]) -> Self {
+    pub(crate) const fn new(root: Option<&'tm Node<Data>>, target: &'t [u8]) -> Self {
         Self {
             current_node: root,
             target,
@@ -30,7 +30,7 @@ impl<'tm, Data> PrefixesIter<'tm, Data> {
     }
 }
 
-impl<'tm, Data> Iterator for PrefixesIter<'tm, Data> {
+impl<'tm, 't, Data> Iterator for PrefixesIter<'tm, 't, Data> {
     type Item = &'tm Data;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/trie_rs/src/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/range.rs
@@ -15,9 +15,9 @@ use crate::{node::Node, utils::longest_common_prefix};
 /// in lexicographical order.
 ///
 /// Invoke [`TrieMap::range_iter`](crate::TrieMap::range_iter) to create an instance of this iterator.
-pub struct RangeIter<'tm, Data> {
+pub struct RangeIter<'tm, 'f, Data> {
     /// Stack of nodes and whether they have been visited.
-    stack: Vec<StackEntry<'tm, Data>>,
+    stack: Vec<StackEntry<'tm, 'f, Data>>,
     /// Concatenation of the labels of current node and its ancestors,
     /// i.e. the key of the current node.
     key: Vec<u8>,
@@ -89,16 +89,16 @@ impl std::fmt::Display for RangeFilter<'_> {
     }
 }
 
-struct StackEntry<'a, Data> {
-    node: &'a Node<Data>,
+struct StackEntry<'tm, 'f, Data> {
+    node: &'tm Node<Data>,
     was_visited: bool,
-    min: Option<&'a [u8]>,
-    max: Option<&'a [u8]>,
+    min: Option<&'f [u8]>,
+    max: Option<&'f [u8]>,
 }
 
-impl<'tm, Data> RangeIter<'tm, Data> {
+impl<'tm, 'f, Data> RangeIter<'tm, 'f, Data> {
     /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    pub(crate) fn new(root: Option<&'tm Node<Data>>, filter: RangeFilter<'tm>) -> Self {
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, filter: RangeFilter<'f>) -> Self {
         let Some(root) = root else {
             return Self::empty();
         };
@@ -157,9 +157,9 @@ impl<'tm, Data> RangeIter<'tm, Data> {
     }
 }
 
-impl<'tm, Data> RangeIter<'tm, Data> {
+impl<'tm, 'f, Data> RangeIter<'tm, 'f, Data> {
     /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    fn filtered(root: Option<&'tm Node<Data>>, prefix: Vec<u8>, range: RangeFilter<'tm>) -> Self {
+    fn filtered(root: Option<&'tm Node<Data>>, prefix: Vec<u8>, range: RangeFilter<'f>) -> Self {
         Self {
             stack: root
                 .into_iter()
@@ -358,7 +358,7 @@ impl<'tm, Data> RangeIter<'tm, Data> {
     }
 }
 
-impl<'tm, Data> Iterator for RangeIter<'tm, Data> {
+impl<'tm, 'f, Data> Iterator for RangeIter<'tm, 'f, Data> {
     type Item = (Vec<u8>, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/trie_rs/src/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/range.rs
@@ -33,14 +33,14 @@ pub struct RangeIter<'tm, 'f, Data> {
 
 #[derive(Clone, Copy, Debug)]
 /// One of the bounds for a [`RangeFilter`].
-pub struct RangeBoundary<'a> {
-    pub value: &'a [u8],
+pub struct RangeBoundary<'f> {
+    pub value: &'f [u8],
     pub is_included: bool,
 }
 
-impl<'a> RangeBoundary<'a> {
+impl<'f> RangeBoundary<'f> {
     /// Create a new range boundary that includes its boundary value.
-    pub const fn included(value: &'a [u8]) -> Self {
+    pub const fn included(value: &'f [u8]) -> Self {
         Self {
             value,
             is_included: true,
@@ -48,7 +48,7 @@ impl<'a> RangeBoundary<'a> {
     }
 
     /// Create a new range boundary that doesn't include its boundary value.
-    pub const fn excluded(value: &'a [u8]) -> Self {
+    pub const fn excluded(value: &'f [u8]) -> Self {
         Self {
             value,
             is_included: false,
@@ -57,9 +57,9 @@ impl<'a> RangeBoundary<'a> {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct RangeFilter<'a> {
-    pub min: Option<RangeBoundary<'a>>,
-    pub max: Option<RangeBoundary<'a>>,
+pub struct RangeFilter<'f> {
+    pub min: Option<RangeBoundary<'f>>,
+    pub max: Option<RangeBoundary<'f>>,
 }
 
 impl RangeFilter<'_> {

--- a/src/redisearch_rs/trie_rs/src/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/wildcard.rs
@@ -60,7 +60,7 @@ impl<'tm, 'p, Data> From<WildcardIter<'tm, 'p, Data>>
 }
 
 /// Returns all trie entries that match the given wildcard pattern.
-pub struct WildcardFilter<'a>(WildcardPattern<'a>);
+pub struct WildcardFilter<'p>(WildcardPattern<'p>);
 
 impl TraversalFilter for WildcardFilter<'_> {
     fn filter(&self, key: &[u8]) -> FilterOutcome {

--- a/src/redisearch_rs/trie_rs/src/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/wildcard.rs
@@ -18,10 +18,10 @@ use rqe_wildcard::{MatchOutcome, WildcardPattern};
 /// An iterator over all entries that match the given wildcard pattern.
 ///
 /// It can be instantiated by calling [`TrieMap::wildcard_iter`](crate::TrieMap::wildcard_iter).
-pub struct WildcardIter<'a, Data>(Iter<'a, Data, WildcardFilter<'a>>);
+pub struct WildcardIter<'tm, 'p, Data>(Iter<'tm, Data, WildcardFilter<'p>>);
 
-impl<'a, Data> WildcardIter<'a, Data> {
-    pub(crate) fn new(root: Option<&'a Node<Data>>, pattern: WildcardPattern<'a>) -> Self {
+impl<'tm, 'p, Data> WildcardIter<'tm, 'p, Data> {
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, pattern: WildcardPattern<'p>) -> Self {
         let iter = match root {
             Some(root) => {
                 // If the first portion of the pattern is a literal, we can jumping directly
@@ -43,16 +43,18 @@ impl<'a, Data> WildcardIter<'a, Data> {
     }
 }
 
-impl<'a, Data> Iterator for WildcardIter<'a, Data> {
-    type Item = (Vec<u8>, &'a Data);
+impl<'tm, 'p, Data> Iterator for WildcardIter<'tm, 'p, Data> {
+    type Item = (Vec<u8>, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 }
 
-impl<'tm, Data> From<WildcardIter<'tm, Data>> for LendingIter<'tm, Data, WildcardFilter<'tm>> {
-    fn from(iter: WildcardIter<'tm, Data>) -> Self {
+impl<'tm, 'p, Data> From<WildcardIter<'tm, 'p, Data>>
+    for LendingIter<'tm, Data, WildcardFilter<'p>>
+{
+    fn from(iter: WildcardIter<'tm, 'p, Data>) -> Self {
         iter.0.into()
     }
 }

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -534,7 +534,7 @@ impl<Data> PtrWithMetadata<Data> {
 
 /// A struct that groups together methods to manipulate the buffer allocated
 /// to store this node's label.
-pub(super) struct LabelBuffer<'a, Data>(&'a PtrWithMetadata<Data>);
+pub(super) struct LabelBuffer<'meta, Data>(&'meta PtrWithMetadata<Data>);
 
 impl<Data> LabelBuffer<'_, Data> {
     /// Returns a pointer to beginning of the label buffer.
@@ -638,7 +638,7 @@ impl<Data> LabelBuffer<'_, Data> {
 
 /// A struct that groups together methods to manipulate the buffer allocated
 /// to store the first byte of the children of this node.
-pub(super) struct ChildrenFirstBytesBuffer<'a, Data>(&'a PtrWithMetadata<Data>);
+pub(super) struct ChildrenFirstBytesBuffer<'meta, Data>(&'meta PtrWithMetadata<Data>);
 
 impl<Data> ChildrenFirstBytesBuffer<'_, Data> {
     /// Returns a pointer to beginning of the children first-bytes buffer.
@@ -758,7 +758,7 @@ impl<Data> ChildrenFirstBytesBuffer<'_, Data> {
 
 /// A struct that groups together methods to manipulate the buffer allocated
 /// to store the children of this node.
-pub(super) struct ChildrenBuffer<'a, Data>(&'a PtrWithMetadata<Data>);
+pub(super) struct ChildrenBuffer<'meta, Data>(&'meta PtrWithMetadata<Data>);
 
 impl<Data> ChildrenBuffer<'_, Data> {
     /// Returns a pointer to beginning of the children buffer.

--- a/src/redisearch_rs/trie_rs/src/node/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/node/mod.rs
@@ -191,18 +191,18 @@ impl<Data> Node<Data> {
     {
         /// A guard that prevents the content of `target` from
         /// being dropped when active.
-        struct DropGuard<'a, Data> {
-            target: &'a mut Node<Data>,
+        struct DropGuard<'node, Data> {
+            target: &'node mut Node<Data>,
             active: bool,
         }
 
-        impl<'a, Data> DropGuard<'a, Data> {
+        impl<'node, Data> DropGuard<'node, Data> {
             /// Create a new active guard, returning the value of `target`
             /// alongside the guard.
             ///
             /// `target` will be populated with a placeholder node,
             /// which relies on a dangling pointer.
-            const fn new(target: &'a mut Node<Data>) -> (Self, Node<Data>) {
+            const fn new(target: &'node mut Node<Data>) -> (Self, Node<Data>) {
                 let node = std::mem::replace(
                     target,
                     Node {

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -202,7 +202,10 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterate over all trie entries whose key matches the specified pattern.
-    pub fn wildcard_iter<'a>(&'a self, pattern: WildcardPattern<'a>) -> WildcardIter<'a, Data> {
+    pub fn wildcard_iter<'tm, 'p>(
+        &'tm self,
+        pattern: WildcardPattern<'p>,
+    ) -> WildcardIter<'tm, 'p, Data> {
         WildcardIter::new(self.root.as_ref(), pattern)
     }
 
@@ -220,12 +223,12 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterates over the entries between the specified `min` and `max`, in lexicographical order.
-    pub fn range_iter<'a>(&'a self, filter: RangeFilter<'a>) -> RangeIter<'a, Data> {
+    pub fn range_iter<'tm, 'f>(&'tm self, filter: RangeFilter<'f>) -> RangeIter<'tm, 'f, Data> {
         RangeIter::new(self.root.as_ref(), filter)
     }
 
     /// Iterate over the entries that contain the target fragment, in lexicographical key order.
-    pub fn contains_iter<'a>(&'a self, target: &'a [u8]) -> ContainsIter<'a, Data> {
+    pub fn contains_iter<'tm, 't>(&'tm self, target: &'t [u8]) -> ContainsIter<'tm, 't, Data> {
         ContainsIter::new(self.root.as_ref(), target)
     }
 

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -197,7 +197,10 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterate over all trie entries whose key is a prefix of `target`.
-    pub const fn prefixes_iter<'a>(&'a self, target: &'a [u8]) -> PrefixesIter<'a, Data> {
+    pub const fn prefixes_iter<'tm, 't>(
+        &'tm self,
+        target: &'t [u8],
+    ) -> PrefixesIter<'tm, 't, Data> {
         PrefixesIter::new(self.root.as_ref(), target)
     }
 

--- a/src/redisearch_rs/trie_rs/src/utils.rs
+++ b/src/redisearch_rs/trie_rs/src/utils.rs
@@ -9,7 +9,7 @@
 
 /// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::all::is_prefix`].
 #[inline(always)]
-pub(crate) fn strip_prefix<'a>(haystack: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
+pub(crate) fn strip_prefix<'h>(haystack: &'h [u8], prefix: &[u8]) -> Option<&'h [u8]> {
     if !memchr::arch::all::is_prefix(haystack, prefix) {
         None
     } else {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The trie_rs iterators (`ContainsIter`, `RangeIter`, `WildcardIter`, `PrefixesIter` and their lending counterparts) fused two distinct borrows into a single lifetime parameter `'a`: the trie's heap storage and the caller's filter/pattern/target slice were forced to share one lifetime. This blocked any caller from pairing a long-lived trie with a short-lived input (e.g. a case-folded `Cow::Owned` pattern that only lives for the duration of the call). Many remaining lifetimes across the crate were also spelled `'a` even where a semantic name would resolve real ambiguity.
2. **Change**:
   - Split the fused `'a` on `ContainsIter`, `RangeIter`, `WildcardIter`, `PrefixesIter` and their lending wrappers into two independent parameters: `'tm` for the trie-map storage and `'t`/`'p`/`'f` for the target/pattern/filter.
   - Renamed all remaining cosmetic `'a` lifetimes across `trie_rs/src/` to semantic names: `WildcardFilter<'p>`, `RangeFilter<'f>`, `StackItem<'tm, Data>`, `strip_prefix<'h>`, `DropGuard<'node, Data>`, three `*Buffer<'meta, Data>` types in `node::metadata`, and two `traversal_filter` `impl` blocks.
   - Adjusted `triemap_ffi`'s `TrieMapIteratorImpl::Contains` variant to instantiate the new two-slot `ContainsLendingIter` with `'tm, 'tm` (both borrows originate from the same C-side scope at the FFI boundary) and documented the collapse inline so it doesn't read as a typo.
3. **Outcome**: Pure signature refactor; no behavior change and no API change visible to callers using lifetime elision (which is every in-repo caller). After the PR, zero `'a` lifetime parameters remain anywhere in `trie_rs/src/` — every lifetime carries a semantic name. Downstream slices that hold a long-lived trie alongside a short-lived input (e.g. the str-keyed wrapper layer with case-folded `Cow::Owned` patterns) now compile.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `src/redisearch_rs/trie_rs/src/iter/` — `contains.rs`, `range.rs`, `wildcard.rs`, `prefixes.rs`, `lending.rs`, `lending_contains.rs`, `lending_range.rs`, `iter_.rs`, `mod.rs` (no semantic changes; signature parameter renames and splits)
2. `src/redisearch_rs/trie_rs/src/trie.rs` — `contains_iter`, `range_iter`, `wildcard_iter`, `prefixes_iter` entry-point signatures
3. `src/redisearch_rs/trie_rs/src/utils.rs`, `src/redisearch_rs/trie_rs/src/node/mod.rs`, `src/redisearch_rs/trie_rs/src/node/metadata.rs` — semantic renames of single-lifetime parameters
4. `src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs` — instantiates the two-slot `ContainsLendingIter` at the FFI boundary

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature-only lifetime refactor with no logic changes; risk is limited to compile-time API/lifetime correctness for downstream crates.
> 
> **Overview**
> **Refactors `trie_rs` iterator lifetimes** so trie-map storage (`'tm`) is tracked separately from caller-owned query inputs (`'t` / `'p` / `'f` for contains targets, wildcard patterns, and range filters). Previously a single `'a` tied the trie borrow to the pattern/filter/target slice, which blocked pairing a long-lived trie with short-lived inputs (e.g. case-folded `Cow::Owned` patterns).
> 
> **Touches** `ContainsIter`, `RangeIter`, `WildcardIter`, `PrefixesIter`, and their lending wrappers, plus `TrieMap` entry points (`contains_iter`, `range_iter`, `wildcard_iter`, `prefixes_iter`). Remaining cosmetic `'a` names in `trie_rs` are renamed to semantic lifetimes (`WildcardFilter<'p>`, `RangeFilter<'f>`, node buffer helpers, etc.). **`triemap_ffi`** updates `ContainsLendingIter` to `'tm, 'tm` at the C boundary with an inline note that both borrows share the same scope there.
> 
> No runtime or behavioral change; callers using elision see the same API shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f73897b8a3e3358d4883f44229201659fd1b4f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->