### PR TITLE
trie_rs: add mutable accessors (find_mut, child_starting_with_mut)

### DIFF
--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -261,8 +261,8 @@ impl<Data> Node<Data> {
         Some(unsafe { self.children().get_unchecked(i) })
     }
 
-    /// Get a mutable reference to the child node whose label starts with the
-    /// given byte. Returns `None` if there is no such child.
+    /// Get a mutable reference to the child node whose label starts with the given byte.
+    /// Returns `None` if there is no such child.
     pub fn child_starting_with_mut(&mut self, c: u8) -> Option<&mut Node<Data>> {
         let i = self.child_index_starting_with(c)?;
         // SAFETY:

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -206,6 +206,20 @@ impl<Data> Node<Data> {
         }
     }
 
+    /// Get a mutable reference to the value associated with a key.
+    /// Returns `None` if the key is not present.
+    pub fn find_mut(&mut self, mut key: &[u8]) -> Option<&mut Data> {
+        let mut current = self;
+        loop {
+            key = strip_prefix(key, current.label())?;
+            let Some(first_byte) = key.first().copied() else {
+                // The suffix is empty, so the key and the label are equal.
+                return current.data_mut().as_mut();
+            };
+            current = current.child_starting_with_mut(first_byte)?;
+        }
+    }
+
     /// Find the root of the subtree associated with a the given prefix—i.e. the root of the subtree
     /// containing all keys that start with the given prefix.
     ///
@@ -245,6 +259,15 @@ impl<Data> Node<Data> {
         // SAFETY:
         // Guaranteed by invariant 1. in [`Self::child_index_starting_with`].
         Some(unsafe { self.children().get_unchecked(i) })
+    }
+
+    /// Get a mutable reference to the child node whose label starts with the
+    /// given byte. Returns `None` if there is no such child.
+    pub fn child_starting_with_mut(&mut self, c: u8) -> Option<&mut Node<Data>> {
+        let i = self.child_index_starting_with(c)?;
+        // SAFETY:
+        // Guaranteed by invariant 1. in [`Self::child_index_starting_with`].
+        Some(unsafe { self.children_mut().get_unchecked_mut(i) })
     }
 
     /// Get the index of the child node whose label starts with the given byte.

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -212,11 +212,11 @@ impl<Data> Node<Data> {
         let mut current = self;
         loop {
             key = strip_prefix(key, current.label())?;
-            let Some(first_byte) = key.first().copied() else {
+            let Some(first_byte) = key.first() else {
                 // The suffix is empty, so the key and the label are equal.
                 return current.data_mut().as_mut();
             };
-            current = current.child_starting_with_mut(first_byte)?;
+            current = current.child_starting_with_mut(*first_byte)?;
         }
     }
 

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -109,6 +109,13 @@ impl<Data> TrieMap<Data> {
         self.root.as_ref().and_then(|n| n.find(key))
     }
 
+    /// Get a mutable reference to the value associated with a key.
+    ///
+    /// Returns `None` if there is no entry for the key.
+    pub fn find_mut(&mut self, key: &[u8]) -> Option<&mut Data> {
+        self.root.as_mut().and_then(|n| n.find_mut(key))
+    }
+
     /// Get a reference to the subtree associated with a key prefix.
     /// Returns `None` if the key prefix is not present.
     fn find_root_for_prefix(&self, key: &[u8]) -> Option<(&Node<Data>, Vec<u8>)> {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `trie_rs::TrieMap` and the underlying `Node` expose only `&self` accessors — `find`, `child_starting_with`. Callers that need to mutate a value in place must go through `insert_with`, which semantically replaces the entry and forces the payload through a closure.
2. **Change:** Add `&mut self` siblings to the existing accessor pair:
   - `Node::find_mut` — descends the trie, returns `Option<&mut Data>`.
   - `Node::child_starting_with_mut` — the descent-step helper `find_mut` needs (sibling of `child_starting_with`, same `child_index_starting_with` + `get_unchecked_mut` shape, same SAFETY invariant).
   - `TrieMap::find_mut` — public passthrough mirroring `TrieMap::find`.
3. **Outcome:** Callers can now read-modify a payload in place without re-inserting. First consumer is the upcoming tag-suffix index port (`str/tag_suffix.rs`), whose removal path needs to drop per-node back-refs from each suffix node, check `array.is_empty()`, and conditionally delete the node — a shape `insert_with` can't express cleanly because the closure can't call `inner.remove()` while holding `inner`.

The change is purely additive: no existing signatures, struct layouts, or call sites are touched. Codegen of existing trie operations is unchanged (verified via `trie_bencher` iter + operations: all deltas inside the documented ±3%/±6% Apple-silicon noise floor, and the shifts that *do* exceed it follow the thermal-drift pattern, not the changed code path).

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/redisearch_rs/trie_rs/src/node/trie_ops.rs` — `Node::find_mut`, `Node::child_starting_with_mut`
2. `src/redisearch_rs/trie_rs/src/trie.rs` — `TrieMap::find_mut`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API mirroring existing read paths; no changes to insert/remove or trie invariants beyond new mutable accessors.
> 
> **Overview**
> Adds **`&mut self` lookup** on `trie_rs` so callers can change stored payloads without going through `insert_with`.
> 
> **`TrieMap::find_mut`** delegates to **`Node::find_mut`**, which walks the trie the same way as `find` but uses **`child_starting_with_mut`** for descent. At a matching key it returns **`Option<&mut Data>`** via `data_mut()`. **`child_starting_with_mut`** mirrors **`child_starting_with`** (same `child_index_starting_with` + unchecked child access).
> 
> No existing APIs or layouts change; this is additive and intended for in-place updates (e.g. tag-suffix index cleanup) where a replace-via-closure insert is awkward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb0c8f0b2803bc9f26b275fd120fd9db9934d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->