### PR TITLE
[MOD-15505] Improve ~5% indexing throughput: switch background-indexing OOM check to direct ratio API

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -189,13 +189,13 @@ static void setMemoryInfo(RedisModuleCtx *ctx) {
 }
 
 // Return true if used_memory exceeds (indexingMemoryLimit % × memoryLimit); false if within bounds or limit is 0.
-static inline bool isBgIndexingMemoryOverLimit(RedisModuleCtx *ctx) {
+static inline bool isBgIndexingMemoryOverLimit(void) {
   // if memory limit is set to 0, we don't need to check for memory usage
   if(RSGlobalConfig.indexingMemoryLimit == 0) {
     return false;
   }
 
-  float used_memory_ratio = RedisMemory_GetUsedMemoryRatioUnified(ctx);
+  float used_memory_ratio = RedisMemory_GetUsedMemoryRatio();
   float memory_limit_ratio = (float)RSGlobalConfig.indexingMemoryLimit / 100;
 
   return (used_memory_ratio > memory_limit_ratio) ;
@@ -2867,7 +2867,7 @@ static void Indexes_ScanProc(RedisModuleCtx *ctx, RedisModuleString *keyname, Re
     return;
   }
 
-  if (isBgIndexingMemoryOverLimit(ctx)){
+  if (isBgIndexingMemoryOverLimit()){
     scanner->scanFailedOnOOM = true;
     if (scanner->OOMkey) {
       RedisModule_FreeString(RSDummyContext, scanner->OOMkey);
@@ -2980,7 +2980,7 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
         IF_DEBUG_PAUSE_CHECK_BEFORE_OOM_RETRY(scanner, ctx);
         // Call the wait function
         threadSleepByConfigTime(ctx, scanner);
-        if (!isBgIndexingMemoryOverLimit(ctx)) {
+        if (!isBgIndexingMemoryOverLimit()) {
           // We can continue the scan
           RedisModule_Log(ctx, "notice", "Scanning index %s in background: resuming after OOM due to memory limit increase",
                           scanner->spec_name_for_logs);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `Indexes_ScanProc` calls `isBgIndexingMemoryOverLimit(ctx)` once per scanned key during background reindex. The helper calls `RedisMemory_GetUsedMemoryRatioUnified(ctx)`, which does a full `RedisModule_GetServerInfo(ctx, "memory")` — that allocates a `RedisModuleServerInfoData`, parses the entire INFO memory section into strings, then extracts three integers. The same pattern was identified and fixed on the query-side path in #9792 (MOD-15504 / MOD-11156).
2. **Change**: Replace the call with `RedisMemory_GetUsedMemoryRatio()`, a `static inline` wrapper over `RedisModule_GetUsedMemoryRatio()` — a direct atomic read of `used_memory / maxmemory` from server state. No allocation, no parsing. `ctx` is no longer needed by the helper, so the parameter is dropped from `isBgIndexingMemoryOverLimit` and from both of its call sites in `src/spec.c`.
3. **Outcome**: Indexing throughput recovers an additional **~5%** on top of the ASCII fast-path fix (#9882) — a self-contained, monotonic gain on every supported version branch (table below).

This is the indexing-side counterpart of #9792. Together with the ASCII fast-path fix (#9882) it closes the second of the two `unicode_tolower` regression contributors investigated under MOD-15505.

#### Which additional issues this PR fixes

1. MOD-15505 — indexing regression investigation (separate from the ASCII fast-path PR #9882)
2. MOD-11156 — same TODO that #9792 was tracking, now also resolved on the indexing path

#### Main objects this PR modified

1. `src/spec.c` — `isBgIndexingMemoryOverLimit` (drop `ctx` arg, switch to cheap getter) and its two call sites in `Indexes_ScanProc` / `Indexes_ScanAndReindexTask`.

#### Performance — additive gain on top of the ASCII fast-path fix (#9882)

Drift-cancelled interleaved benchmark, `N_DOCS=30000`, MS-MARCO HSET ingest, `N_RUNS=5`, all 7 branches measured in a single sweep (so any system-wide drift is shared across labels in each epoch).

| branch     | ASCII-fix median | CV %  | ASCII + OOM-fix median | CV %  | Δ %      | paired wins |
|------------|-----------------:|------:|-----------------------:|------:|---------:|------------:|
| 2.10       |          20.256s | 1.27  |                19.197s | 0.70  | **−5.2 %** |       5 / 5 |
| 8.2        |          18.499s | 0.66  |                17.871s | 1.67  | **−3.4 %** |       5 / 5 |
| 8.4        |          19.163s | 0.80  |                18.008s | 1.19  | **−6.0 %** |       5 / 5 |
| 8.6        |          20.486s | 1.48  |                19.721s | 2.54  | **−3.7 %** |       5 / 5 |
| 8.6-rse    |          20.348s | 1.46  |                19.237s | 1.17  | **−5.5 %** |       5 / 5 |
| 8.8        |          20.029s | 1.20  |                18.828s | 0.76  | **−6.0 %** |       5 / 5 |
| master     |          20.343s | 0.65  |                19.272s | 1.08  | **−5.3 %** |       5 / 5 |

`v2.10.12` reference: median 19.307s (CV 0.98 %). Every paired iteration on every branch is faster with this fix applied (35 / 35 wins across 7 branches × 5 runs); CV ≤ 2.54 % on all 14 labels.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3f6cd8e30f6f6825fe646b62afcd5985b2a88c02. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->