### PR TITLE
[2.10] [MOD-15113] Limit aggregate GROUPBY groups

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -296,7 +296,8 @@ static int parseProfile(RedisModuleString **argv, int argc, AREQ *r) {
 }
 
 static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                         specialCaseCtx **knnCtx_ptr, QueryError *status) {
+                         specialCaseCtx **knnCtx_ptr, QueryError *status,
+                         struct ConcurrentCmdCtx *cmdCtx) {
   r->qiter.err = status;
   r->reqflags |= QEXEC_F_IS_AGGREGATE | QEXEC_F_BUILDPIPELINE_NO_ROOT;
   rs_wall_clock_init(&r->initClock);
@@ -335,7 +336,10 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   AREQDIST_UpstreamInfo us = {NULL};
-  rc = AREQ_BuildDistributedPipeline(r, &us, status);
+  size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
+  GroupByLimits groupByLimits =
+      GroupByLimits_ForCoordinator(RSGlobalConfig.maxAggregateGroups, numShards);
+  rc = AREQ_BuildDistributedPipeline(r, &us, &groupByLimits, status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   // Construct the command string
@@ -400,7 +404,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   QueryError status = {0};
   specialCaseCtx *knnCtx = NULL;
 
-  if (prepareForExecution(r, ctx, argv, argc, &knnCtx, &status) != REDISMODULE_OK) {
+  if (prepareForExecution(r, ctx, argv, argc, &knnCtx, &status, cmdCtx) != REDISMODULE_OK) {
     goto err;
   }
 
@@ -440,7 +444,8 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   AREQ_Debug_params debug_params = debug_req->debug_params;
 
   int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
-  if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, &knnCtx, &status) != REDISMODULE_OK) {
+  if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, &knnCtx, &status, cmdCtx) !=
+      REDISMODULE_OK) {
     goto err;
   }
 

--- a/coord/src/dist_plan.cpp
+++ b/coord/src/dist_plan.cpp
@@ -4,6 +4,7 @@
 #include "aggregate/reducer.h"
 #include "util/arr.h"
 #include "dist_plan.h"
+#include "config.h"
 
 #include <vector>
 #include <string>
@@ -549,13 +550,18 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
   array_free(tmp);
 }
 
-int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError *status) {
+int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us,
+                                  const GroupByLimits *groupByLimits, QueryError *status) {
 
   auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(&r->ap, NULL, NULL, PLN_T_DISTRIBUTE);
   RS_ASSERT(dstp);
 
   dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;
-  int rc = AREQ_BuildPipeline(r, status);
+  GroupByLimits defaultGroupByLimits = GroupByLimits_Default(RSGlobalConfig.maxAggregateGroups);
+  if (!groupByLimits) {
+    groupByLimits = &defaultGroupByLimits;
+  }
+  int rc = AREQ_BuildPipelineWithGroupByLimits(r, *groupByLimits, status);
   dstp->lk.options &= ~RLOOKUP_OPT_UNRESOLVED_OK;
   if (rc != REDISMODULE_OK) {
     return REDISMODULE_ERR;

--- a/coord/src/dist_plan.h
+++ b/coord/src/dist_plan.h
@@ -43,9 +43,12 @@ typedef struct {
  * Builds the static portion of the distributed pipeline
  * @param r the request
  * @param[out] us upstream parameters
+ * @param groupByLimits effective GROUPBY limits for the coordinator aggregation pipeline.
+ *                      If NULL, defaults are derived from the request.
  * @param status if there is an error
  */
-int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError *status);
+int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us,
+                                  const GroupByLimits *groupByLimits, QueryError *status);
 
 #ifdef __cplusplus
 }

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1688,8 +1688,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  return ConcurrentSearch_HandleRedisCommandEx(DIST_AGG_THREADPOOL, CMDCTX_NO_GIL,
-                                               dist_callback, ctx, argv, argc);
+  return ConcurrentSearch_HandleRedisCommandExWithNumShards(
+      DIST_AGG_THREADPOOL, CMDCTX_NO_GIL, dist_callback, ctx, argv, argc, NumShards);
 }
 
 static void CursorCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, struct ConcurrentCmdCtx *cmdCtx) {

--- a/coord/tests/unit/test_distagg.cpp
+++ b/coord/tests/unit/test_distagg.cpp
@@ -93,7 +93,7 @@ static void testCountDistinct() {
   assert(dstp);
 
   AREQDIST_UpstreamInfo us = {0};
-  rc = AREQ_BuildDistributedPipeline(r, &us, &status);
+  rc = AREQ_BuildDistributedPipeline(r, &us, NULL, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't build distributed pipeline: %s\n", QueryError_GetUserError(&status));
   }
@@ -125,7 +125,7 @@ static void testSplit() {
   assert(dstp);
 
   AREQDIST_UpstreamInfo us = {0};
-  rc = AREQ_BuildDistributedPipeline(r, &us, &status);
+  rc = AREQ_BuildDistributedPipeline(r, &us, NULL, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't build distributed pipeline: %s\n", QueryError_GetUserError(&status));
   }

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -27,6 +27,26 @@ extern "C" {
 typedef struct Grouper Grouper;
 struct QOptimizer;
 
+typedef struct GroupByLimits {
+  /** Effective maximum number of GROUPBY groups this pipeline may materialize. */
+  size_t maxGroups;
+} GroupByLimits;
+
+static inline GroupByLimits GroupByLimits_Default(size_t maxGroups) {
+  GroupByLimits limits = {0};
+  limits.maxGroups = maxGroups;
+  return limits;
+}
+
+static inline GroupByLimits GroupByLimits_ForCoordinator(size_t maxGroups, size_t shardCount) {
+  GroupByLimits limits = GroupByLimits_Default(maxGroups);
+  if (shardCount == 0) {
+    shardCount = 1;
+  }
+  limits.maxGroups *= shardCount;
+  return limits;
+}
+
 typedef enum {
   QEXEC_F_IS_AGGREGATE = 0x01,    // Is an aggregate command
   QEXEC_F_SEND_SCORES = 0x02,     // Output: Send scores with each result
@@ -285,6 +305,8 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status);
  * Constructs the pipeline objects needed to actually start processing
  * the requests. This does not yet start iterating over the objects
  */
+int AREQ_BuildPipelineWithGroupByLimits(AREQ *req, GroupByLimits groupByLimits,
+                                        QueryError *status);
 int AREQ_BuildPipeline(AREQ *req, QueryError *status);
 
 static inline QEFlags AREQ_RequestFlags(const AREQ *req) {
@@ -346,7 +368,8 @@ static inline void AREQ_RemoveRequestFlags(AREQ *req, QEFlags flags) {
  * ResultProcessors (and a grouper is a ResultProcessor) before the grouper
  * should write their data using `lksrc` as a reference point.
  */
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n);
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n,
+                     GroupByLimits groupByLimits);
 
 void Grouper_Free(Grouper *g);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1155,7 +1155,8 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
 }
 
 static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
-                                     const RLookupKey ***loadKeys, QueryError *err) {
+                                     const RLookupKey ***loadKeys, GroupByLimits groupByLimits,
+                                     QueryError *err) {
   const RLookupKey *srckeys[gstp->nproperties], *dstkeys[gstp->nproperties];
   for (size_t ii = 0; ii < gstp->nproperties; ++ii) {
     const char *fldname = gstp->properties[ii] + 1;  // account for the @-
@@ -1181,7 +1182,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
     }
   }
 
-  Grouper *grp = Grouper_New(srckeys, dstkeys, gstp->nproperties);
+  Grouper *grp = Grouper_New(srckeys, dstkeys, gstp->nproperties, groupByLimits);
 
   size_t nreducers = array_len(gstp->reducers);
   for (size_t ii = 0; ii < nreducers; ++ii) {
@@ -1230,12 +1231,15 @@ static ResultProcessor *pushRP(AREQ *req, ResultProcessor *rp, ResultProcessor *
 }
 
 static ResultProcessor *getGroupRP(AREQ *req, PLN_GroupStep *gstp, ResultProcessor *rpUpstream,
-                                   QueryError *status, bool forceLoad) {
+                                   GroupByLimits groupByLimits, QueryError *status,
+                                   bool forceLoad) {
   AGGPlan *pln = &req->ap;
   RLookup *lookup = AGPLN_GetLookup(pln, &gstp->base, AGPLN_GETLOOKUP_PREV);
   RLookup *firstLk = AGPLN_GetLookup(pln, &gstp->base, AGPLN_GETLOOKUP_FIRST); // first lookup can load fields from redis
   const RLookupKey **loadKeys = NULL;
-  ResultProcessor *groupRP = buildGroupRP(gstp, lookup, (firstLk == lookup && firstLk->spcache) ? &loadKeys : NULL, status);
+  ResultProcessor *groupRP = buildGroupRP(
+      gstp, lookup, (firstLk == lookup && firstLk->spcache) ? &loadKeys : NULL, groupByLimits,
+      status);
 
   if (!groupRP) {
     array_free(loadKeys);
@@ -1554,7 +1558,8 @@ error:
   return REDISMODULE_ERR;
 }
 
-int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
+int AREQ_BuildPipelineWithGroupByLimits(AREQ *req, GroupByLimits groupByLimits,
+                                        QueryError *status) {
   if (!(req->reqflags & QEXEC_F_BUILDPIPELINE_NO_ROOT)) {
     buildImplicitPipeline(req, status);
     if (status->code != QUERY_OK) {
@@ -1579,7 +1584,8 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
     switch (stp->type) {
       case PLN_T_GROUP: {
         // Adds group result processor and loader if needed.
-        rpUpstream = getGroupRP(req, (PLN_GroupStep *)stp, rpUpstream, status, forceLoad);
+        rpUpstream =
+            getGroupRP(req, (PLN_GroupStep *)stp, rpUpstream, groupByLimits, status, forceLoad);
         if (!rpUpstream) {
           goto error;
         }
@@ -1720,6 +1726,11 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
   return REDISMODULE_OK;
 error:
   return REDISMODULE_ERR;
+}
+
+int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
+  return AREQ_BuildPipelineWithGroupByLimits(
+      req, GroupByLimits_Default(RSGlobalConfig.maxAggregateGroups), status);
 }
 
 void AREQ_Free(AREQ *req) {

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -8,6 +8,7 @@
 #include <result_processor.h>
 #include <util/block_alloc.h>
 #include <util/khash.h>
+#include "aggregate.h"
 #include "reducer.h"
 
 /**
@@ -68,9 +69,19 @@ typedef struct Grouper {
   // array of reducers
   Reducer **reducers;
 
+  // GROUPBY materialization limit.
+  GroupByLimits groupByLimits;
+
   // Used for maintaining state when yielding groups
   khiter_t iter;
 } Grouper;
+
+static void setAggregateGroupLimitError(const Grouper *g) {
+  QueryError_SetWithoutUserDataFmt(
+      g->base.parent->err, QUERY_ERROR_CODE_LIMIT,
+      "Aggregate GROUPBY exceeded MAX_AGGREGATE_GROUPS limit of %zu groups",
+      g->groupByLimits.maxGroups);
+}
 
 /**
  * Create a new group. groupvals is the key of the group. This will be the
@@ -150,8 +161,10 @@ static void invokeReducers(Grouper *g, Group *gr, RLookupRow *srcrow) {
  * @param hval current X-wise hash value. Note that members of the same Y array
  *  are not hashed together.
  * @param res the row is passed to each reducer
+ * @param rowExpansion the cartesian product size accumulated for the current row
  */
-static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t xlen, uint64_t hval, RLookupRow *res) {
+static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t xlen,
+                         uint64_t hval, RLookupRow *res, size_t rowExpansion) {
   // end of the line - create/add to group
   if (xpos == xlen) {
     Group *group = NULL;
@@ -159,6 +172,10 @@ static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t 
     // Get or create the group
     khiter_t k = kh_get(khid, g->groups, hval);  // first have to get ieter
     if (k == kh_end(g->groups)) {                // k will be equal to kh_end if key not present
+      if (kh_size(g->groups) >= g->groupByLimits.maxGroups) {
+        setAggregateGroupLimitError(g);
+        return RS_RESULT_ERROR;
+      }
       group = createGroup(g, xarr, xlen);
       kh_set(khid, g->groups, hval, group);
     } else {
@@ -167,7 +184,7 @@ static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t 
 
     // send the result to the group and its reducers
     invokeReducers(g, group, res);
-    return;
+    return RS_RESULT_OK;
   }
 
   // get the value
@@ -175,30 +192,44 @@ static void extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t 
   // regular value - just move one step -- increment XPOS
   if (v->t != RSValue_Array) {
     hval = RSValue_Hash(v, hval);
-    extractGroups(g, xarr, xpos + 1, xlen, hval, res);
+    return extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion);
   } else if (RSValue_ArrayLen(v) == 0) {
     // Empty array - hash as null
     hval = RSValue_Hash(RS_NullVal(), hval);
     const RSValue *array = xarr[xpos];
     xarr[xpos] = RS_NullVal();
-    extractGroups(g, xarr, xpos + 1, xlen, hval, res);
+    int rc = extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion);
     xarr[xpos] = array;
+    return rc;
   } else {
     // Array value. Replace current XPOS with child temporarily.
     // Each value in the array will be a separate group
     const RSValue *array = xarr[xpos];
-    for (size_t i = 0; i < RSValue_ArrayLen(v); i++) {
+    size_t len = RSValue_ArrayLen(v);
+    if (len > 1) {
+      if (rowExpansion > g->groupByLimits.maxGroups / len) {
+        setAggregateGroupLimitError(g);
+        return RS_RESULT_ERROR;
+      }
+      rowExpansion *= len;
+    }
+    for (size_t i = 0; i < len; i++) {
       const RSValue *elem = RSValue_ArrayItem(v, i);
       // hash the element, even if it's an array
       uint64_t hh = RSValue_Hash(elem, hval);
       xarr[xpos] = elem;
-      extractGroups(g, xarr, xpos + 1, xlen, hh, res);
+      int rc = extractGroups(g, xarr, xpos + 1, xlen, hh, res, rowExpansion);
+      if (rc != RS_RESULT_OK) {
+        xarr[xpos] = array;
+        return rc;
+      }
     }
     xarr[xpos] = array;
+    return RS_RESULT_OK;
   }
 }
 
-static void invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
+static int invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
   uint64_t hval = 0;
   size_t nkeys = GROUPER_NSRCKEYS(g);
   const RSValue *groupvals[nkeys];
@@ -211,7 +242,7 @@ static void invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
     }
     groupvals[ii] = v;
   }
-  extractGroups(g, groupvals, 0, nkeys, 0, srcrow);
+  return extractGroups(g, groupvals, 0, nkeys, hval, srcrow, 1);
 }
 
 static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
@@ -221,8 +252,11 @@ static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
   int rc;
 
   while ((rc = base->upstream->Next(base->upstream, res)) == RS_RESULT_OK) {
-    invokeGroupReducers(g, &res->rowdata);
+    rc = invokeGroupReducers(g, &res->rowdata);
     SearchResult_Clear(res);
+    if (rc != RS_RESULT_OK) {
+      break;
+    }
   }
   base->parent->resultLimit = chunkLimit; // restore the limit
   if (rc == RS_RESULT_EOF) {
@@ -274,12 +308,14 @@ void Grouper_Free(Grouper *g) {
   g->base.Free(&g->base);
 }
 
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t nkeys) {
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t nkeys,
+                     GroupByLimits groupByLimits) {
   Grouper *g = rm_calloc(1, sizeof(*g));
   BlkAlloc_Init(&g->groupsAlloc);
   g->groups = kh_init(khid);
 
   g->nkeys = nkeys;
+  g->groupByLimits = groupByLimits;
   if (nkeys) {
     g->srckeys = rm_malloc(nkeys * sizeof(*g->srckeys));
     g->dstkeys = rm_malloc(nkeys * sizeof(*g->dstkeys));

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -44,6 +44,7 @@ typedef struct ConcurrentCmdCtx {
   RedisModuleString **argv;
   int argc;
   int options;
+  size_t numShards;
 } ConcurrentCmdCtx;
 
 /* Run a function on the concurrent thread pool */
@@ -104,9 +105,16 @@ void ConcurrentCmdCtx_KeepRedisCtx(ConcurrentCmdCtx *cctx) {
   cctx->options |= CMDCTX_KEEP_RCTX;
 }
 
+size_t ConcurrentCmdCtx_GetNumShards(const ConcurrentCmdCtx *cctx) {
+  return cctx->numShards;
+}
+
 // Used by RSCordinator
-int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentCmdHandler handler,
-                                          RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int ConcurrentSearch_HandleRedisCommandExWithNumShards(int poolType, int options,
+                                                       ConcurrentCmdHandler handler,
+                                                       RedisModuleCtx *ctx,
+                                                       RedisModuleString **argv, int argc,
+                                                       size_t numShards) {
   ConcurrentCmdCtx *cmdCtx = rm_malloc(sizeof(*cmdCtx));
   cmdCtx->bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
   cmdCtx->argc = argc;
@@ -114,6 +122,7 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentC
   RS_AutoMemory(cmdCtx->ctx);
   cmdCtx->handler = handler;
   cmdCtx->options = options;
+  cmdCtx->numShards = numShards;
   // Copy command arguments so they can be released by the calling thread
   cmdCtx->argv = rm_calloc(argc, sizeof(RedisModuleString *));
   for (int i = 0; i < argc; i++) {
@@ -124,6 +133,12 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentC
 
   ConcurrentSearch_ThreadPoolRun(threadHandleCommand, cmdCtx, poolType);
   return REDISMODULE_OK;
+}
+
+int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentCmdHandler handler,
+                                          RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return ConcurrentSearch_HandleRedisCommandExWithNumShards(poolType, options, handler, ctx, argv,
+                                                            argc, 0);
 }
 
 int ConcurrentSearch_HandleRedisCommand(int poolType, ConcurrentCmdHandler handler,

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -175,12 +175,20 @@ typedef void (*ConcurrentCmdHandler)(RedisModuleCtx *, RedisModuleString **, int
  */
 void ConcurrentCmdCtx_KeepRedisCtx(struct ConcurrentCmdCtx *ctx);
 
+size_t ConcurrentCmdCtx_GetNumShards(const struct ConcurrentCmdCtx *ctx);
+
 int ConcurrentSearch_HandleRedisCommand(int poolType, ConcurrentCmdHandler handler,
                                         RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /* Same as handleRedis command, but set flags for the concurrent context */
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+int ConcurrentSearch_HandleRedisCommandExWithNumShards(int poolType, int options,
+                                                       ConcurrentCmdHandler handler,
+                                                       RedisModuleCtx *ctx,
+                                                       RedisModuleString **argv, int argc,
+                                                       size_t numShards);
 
 /** This macro is called by concurrent executors (currently the query only).
  * It checks if enough time has passed and releases the global lock if that is the case.

--- a/src/config.c
+++ b/src/config.c
@@ -161,6 +161,24 @@ CONFIG_GETTER(getMaxAggregateResults) {
   return sdscatprintf(ss, "%lu", config->maxAggregateResults);
 }
 
+// MAX_AGGREGATE_GROUPS
+CONFIG_SETTER(setMaxAggregateGroups) {
+  size_t newSize = 0;
+  int acrc = AC_GetSize(ac, &newSize, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc)
+  if (newSize > MAX_AGGREGATE_GROUPS) {
+    QueryError_SetError(status, QUERY_ELIMIT, "Value exceeds maximum possible aggregate groups");
+    return REDISMODULE_ERR;
+  }
+  config->maxAggregateGroups = newSize;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getMaxAggregateGroups) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%lu", config->maxAggregateGroups);
+}
+
 // MAXEXPANSIONS MAXPREFIXEXPANSIONS
 CONFIG_SETTER(setMaxExpansions) {
   int acrc = AC_GetLongLong(ac, &config->iteratorsConfigParams.maxPrefixExpansions, AC_F_GE1);
@@ -849,6 +867,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Maximum number of results from ft.aggregate command",
          .setValue = setMaxAggregateResults,
          .getValue = getMaxAggregateResults},
+        {.name = "MAX_AGGREGATE_GROUPS",
+         .helpText = "Maximum number of groups from ft.aggregate GROUPBY",
+         .setValue = setMaxAggregateGroups,
+         .getValue = getMaxAggregateGroups},
         {.name = "MAXEXPANSIONS",
          .helpText = "Maximum prefix expansions to be used in a query",
          .setValue = setMaxExpansions,

--- a/src/config.h
+++ b/src/config.h
@@ -102,6 +102,7 @@ typedef struct {
   size_t maxDocTableSize;
   size_t maxSearchResults;
   size_t maxAggregateResults;
+  size_t maxAggregateGroups;
 
 #ifdef MT_BUILD
   size_t numWorkerThreads;
@@ -240,6 +241,8 @@ void UpgradeDeprecatedMTConfigs();
 #define DEFAULT_INDEX_CURSOR_LIMIT 128
 #define MAX_AGGREGATE_REQUEST_RESULTS (1ULL << 31)
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
+#define MAX_AGGREGATE_GROUPS (1ULL << 26)
+#define DEFAULT_MAX_AGGREGATE_GROUPS 1000000
 #define DEFAULT_MAX_SEARCH_REQUEST_RESULTS 1000000
 #define MAX_SEARCH_REQUEST_RESULTS (1ULL << 31)
 #define MAX_KNN_K (1ULL << 58)
@@ -295,6 +298,7 @@ void UpgradeDeprecatedMTConfigs();
     .filterCommands = 0,                                                        \
     .maxSearchResults = DEFAULT_MAX_SEARCH_REQUEST_RESULTS,                     \
     .maxAggregateResults = DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS,               \
+    .maxAggregateGroups = DEFAULT_MAX_AGGREGATE_GROUPS,                         \
     .iteratorsConfigParams.minUnionIterHeap = 20,                               \
     .numericCompress = false,                                                   \
     .numericTreeMaxDepthRange = 0,                                              \

--- a/src/info/info_redis.c
+++ b/src/info/info_redis.c
@@ -319,6 +319,8 @@ void AddToInfo_RSConfig(RedisModuleInfoCtx *ctx) {
   RedisModule_InfoAddFieldLongLong(ctx, "max_search_results", RSGlobalConfig.maxSearchResults);
   RedisModule_InfoAddFieldLongLong(ctx, "max_aggregate_results",
                                    RSGlobalConfig.maxAggregateResults);
+  RedisModule_InfoAddFieldLongLong(ctx, "max_aggregate_groups",
+                                   RSGlobalConfig.maxAggregateGroups);
   RedisModule_InfoAddFieldLongLong(ctx, "gc_scan_size", RSGlobalConfig.gcConfigParams.gcScanSize);
   RedisModule_InfoAddFieldLongLong(ctx, "min_phonetic_term_length",
                                    RSGlobalConfig.minPhoneticTermLen);

--- a/tests/cpptests/redismock/CMakeLists.txt
+++ b/tests/cpptests/redismock/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_library(redismock STATIC redismock.cpp util.cpp)
+target_compile_features(redismock PUBLIC cxx_std_17)

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -8,6 +8,7 @@
 #include "common.h"
 #include "module.h"
 #include "version.h"
+#include "config.h"
 
 #include <vector>
 #include <array>
@@ -157,7 +158,8 @@ TEST_F(AggTest, testGroupBy) {
   RLookupKey *score_out = RLookup_GetKey(&rk_out, "SCORE", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
   RLookupKey *count_out = RLookup_GetKey(&rk_out, "COUNT", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
 
-  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1);
+  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1,
+                            GroupByLimits_Default(DEFAULT_MAX_AGGREGATE_GROUPS));
   ASSERT_TRUE(gr != NULL);
 
   ArgsCursor args = {0};
@@ -201,7 +203,8 @@ TEST_F(AggTest, testGroupSplit) {
   gen.kvalue = RLookup_GetKey(&lk_in, "value", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
   RLookupKey *val_out = RLookup_GetKey(&lk_out, "value", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
   RLookupKey *count_out = RLookup_GetKey(&lk_out, "COUNT", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1);
+  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1,
+                            GroupByLimits_Default(DEFAULT_MAX_AGGREGATE_GROUPS));
   ArgsCursor args = {0};
   ReducerOptions opt = {0};
   opt.args = &args;

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -755,6 +755,99 @@ def test_groupby_array(env: Env):
     env.assertContains(row, exp)
   env.assertEqual(len(res), len(exp), message=f'{res} != {exp}')
 
+def test_groupby_array_group_limit_boundary():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 4')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    con.execute_command('HSET', 'doc1', 't1', 'foo,bar', 't2', 'baz,qux')
+
+  res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                'APPLY', 'split(@t1, ",")', 'AS', 't1',
+                'APPLY', 'split(@t2, ",")', 'AS', 't2',
+                'GROUPBY', '2', '@t1', '@t2',
+                'REDUCE', 'COUNT', '0', 'AS', 'count')
+
+  env.assertEqual(res[0], 4)
+  env.assertEqual(len(res), 5)
+
+def test_groupby_tag_group_limit_boundary():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 4')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'TAG', 'SORTABLE').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    for i in range(4):
+      con.execute_command('HSET', f'doc{i}', 'g', f'g{i}')
+
+  res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                'GROUPBY', '1', '@g',
+                'REDUCE', 'COUNT', '0', 'AS', 'count')
+
+  env.assertEqual(res[0], 4)
+  env.assertEqual(len(res), 5)
+
+@skip(cluster=True)
+def test_groupby_array_row_expansion_limit():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 3')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA',
+             't1', 'TEXT', 'SORTABLE',
+             't2', 'TEXT', 'SORTABLE',
+             'tag1', 'TAG',
+             'tag2', 'TAG').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    con.execute_command('HSET', 'doc1',
+                        't1', 'foo,bar',
+                        't2', 'baz,qux',
+                        'tag1', 'red,blue',
+                        'tag2', 'circle,square')
+
+  env.expect('FT.AGGREGATE', 'idx', '*',
+             'LOAD', '2', '@tag1', '@tag2',
+             'APPLY', 'split(@tag1, ",")', 'AS', 'tag1_values',
+             'APPLY', 'split(@tag2, ",")', 'AS', 'tag2_values',
+             'GROUPBY', '2', '@tag1_values', '@tag2_values',
+             'REDUCE', 'COUNT', '0', 'AS', 'count').error() \
+      .contains('MAX_AGGREGATE_GROUPS') \
+      .contains('3')
+
+  env.expect('FT.AGGREGATE', 'idx', '*',
+             'APPLY', 'split(@t1, ",")', 'AS', 't1',
+             'APPLY', 'split(@t2, ",")', 'AS', 't2',
+             'GROUPBY', '2', '@t1', '@t2',
+             'REDUCE', 'COUNT', '0', 'AS', 'count').error() \
+      .contains('MAX_AGGREGATE_GROUPS') \
+      .contains('3')
+
+@skip(cluster=True)
+def test_groupby_total_group_limit():
+  env = Env(moduleArgs='MAX_AGGREGATE_GROUPS 3')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'TAG', 'SORTABLE').ok()
+  with env.getClusterConnectionIfNeeded() as con:
+    for i in range(4):
+      con.execute_command('HSET', f'doc{i}', 'g', f'g{i}')
+
+  env.expect('FT.AGGREGATE', 'idx', '*',
+             'GROUPBY', '1', '@g',
+             'REDUCE', 'COUNT', '0', 'AS', 'count').error() \
+      .contains('MAX_AGGREGATE_GROUPS') \
+      .contains('3')
+
+@skip(cluster=False)
+def test_groupby_coordinator_group_limit_uses_shard_count():
+  env = Env(shardsCount=3, protocol=3, moduleArgs='MAX_AGGREGATE_GROUPS 2')
+
+  env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'g', 'TAG', 'SORTABLE').ok()
+  shard_tags = ['shard:0', 'shard:1', 'shard:3']
+  conn = getConnectionByEnv(env)
+  for i, shard_tag in enumerate(shard_tags):
+    conn.execute_command('HSET', f'doc:{i}{{{shard_tag}}}', 'g', f'g{i}')
+
+  res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                'GROUPBY', '1', '@g',
+                'REDUCE', 'COUNT', '0', 'AS', 'count')
+
+  env.assertEqual(len(res['results']), 3)
+  env.assertEqual(sorted(row['extra_attributes']['g'] for row in res['results']),
+                  ['g0', 'g1', 'g2'])
+
 def testMultiSortBy(env):
     enable_unstable_features(env)
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -20,6 +20,8 @@ def testConfigErrors(env):
         .equal('Max depth for range cannot be higher than max depth for balance')
     env.expect('ft.config', 'set', 'MINSTEMLEN', 1).error()\
         .contains('Minimum stem length cannot be lower than')
+    env.expect(config_cmd(), 'set', 'MAX_AGGREGATE_GROUPS', 0).error()\
+        .contains('Value is outside acceptable bounds')
     if MT_BUILD:
         env.expect('ft.config', 'set', 'WORKERS', 1_000_000).error()\
             .contains('Number of worker threads cannot exceed')
@@ -48,6 +50,7 @@ def testGetConfigOptions(env):
     check_config('FRISOINI')
     check_config('MAXSEARCHRESULTS')
     check_config('MAXAGGREGATERESULTS')
+    check_config('MAX_AGGREGATE_GROUPS')
     check_config('ON_TIMEOUT')
     check_config('GCSCANSIZE')
     check_config('MIN_PHONETIC_TERM_LEN')
@@ -139,6 +142,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['MAXDOCTABLESIZE'][0], '1000000')
     env.assertEqual(res_dict['MAXSEARCHRESULTS'][0], '1000000')
     env.assertEqual(res_dict['MAXAGGREGATERESULTS'][0], 'unlimited')
+    env.assertEqual(res_dict['MAX_AGGREGATE_GROUPS'][0], '1000000')
     env.assertEqual(res_dict['MAXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['MAXPREFIXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['DEFAULT_SCORER'][0], 'TFIDF')
@@ -187,6 +191,7 @@ def testInitConfig():
         env.stop()
 
     test_arg_num('MAXDOCTABLESIZE', 123456)
+    test_arg_num('MAX_AGGREGATE_GROUPS', 100)
     test_arg_num('TIMEOUT', 0)
     test_arg_num('MINPREFIX', 3)
     test_arg_num('FORKGC_SLEEP_BEFORE_EXIT', 5)


### PR DESCRIPTION
## Backport notes

Backport of https://github.com/RediSearch/RediSearch/pull/9830.

Conflict resolutions:
1. Applied coordinator changes under `coord/src` instead of the newer `src/coord` layout.
2. Omitted FT.HYBRID and shared pipeline changes/tests because this branch has neither subsystem.
3. Preserved the branch's `AREQ_BuildPipeline(req, status)` API and added the group-limit variant around that signature.
4. Added a branch-local concurrent command wrapper to capture shard count for distributed aggregate without importing newer timeout/callback code.
5. Wired `MAX_AGGREGATE_GROUPS` through the branch's existing FT.CONFIG/module-args path without importing newer Redis module config alias machinery.

## Describe the changes in the pull request

Current: FT.AGGREGATE GROUPBY did not have a dedicated cap for materialized groups.
Change: Add `MAX_AGGREGATE_GROUPS` with a 1,000,000 default and a `1 << 26` maximum, enforce it in GROUPBY creation and row expansion, and scale coordinator max groups by shard count for distributed aggregate.
Outcome: GROUPBY work is bounded by a configurable limit and returns a limit error when exceeded.

#### Which additional issues this PR fixes
1. MOD-15113
2. Backport of #9830

#### Main objects this PR modified
1. GROUPBY result processor
2. Runtime configuration
3. Aggregate pipeline limit plumbing
4. Python and C++ tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
