### PR TITLE
[8.2] benchmarks: bump redisbench_admin to >=0.12.29

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.12.6
+redisbench_admin>=0.12.29
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `tests/benchmarks/requirements.txt` on 8.2 pins `redisbench_admin==0.12.6`. That version crashes in `redisbench_admin/run/metrics.py:52` (`extract_results_table`) when a metric value is `None`:

   ```
   TypeError: float() argument must be a string or a real number, not 'NoneType'
   ```

   This blows up `search-persist-doc-1000-seconds` (and any other benchmark that emits a `None` metric), failing the whole `benchmark-search-oss-standalone` job. The 8.2 benchmark workflow has been red on every push since at least 2026-05-25 — e.g. https://github.com/RediSearch/RediSearch/actions/runs/26712423651/attempts/1.

2. **Change:** Bump the pin to `redisbench_admin>=0.12.29`, matching what master and 8.8 already require. Master's #9292 added this lower bound when bringing back the expiration benchmarks because the same crash showed up there; that PR was never backported.

3. **Outcome:** The benchmark job picks up a `redisbench_admin` release with the fixed metric extraction and stops failing on missing metric values.

#### Which additional issues this PR fixes

1. None (CI-only).

#### Main objects this PR modified

1. `tests/benchmarks/requirements.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change with no product API or runtime behavior impact.
> 
> **Overview**
> Updates **`tests/benchmarks/requirements.txt`** so **`redisbench_admin`** is **`>=0.12.29`** instead of pinned at **`==0.12.6`**.
> 
> That older release could crash when a benchmark metric was **`None`** (`float(None)` in metric extraction), which broke jobs such as **`search-persist-doc-1000-seconds`**. Aligning with **master** / **8.8** lets CI install a release that tolerates missing metric values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070804bc8c7933d0ae913f7479e81b100e959de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->