### PR TITLE
[8.4] benchmarks: bump redisbench_admin to >=0.12.29

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.12.6
+redisbench_admin>=0.12.29
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `tests/benchmarks/requirements.txt` on 8.4 pins `redisbench_admin==0.12.6`. That version crashes in `redisbench_admin/run/metrics.py:52` (`extract_results_table`) when a metric value is `None`:

   ```
   TypeError: float() argument must be a string or a real number, not 'NoneType'
   ```

   This blows up benchmarks that emit a `None` metric, failing the whole `benchmark-search-oss-standalone` job. The 8.4 benchmark workflow has been red on every push for at least the last 4 runs (back to 2026-05-25).

2. **Change:** Bump the pin to `redisbench_admin>=0.12.29`, matching what master and 8.8 already require. Master's #9292 added this lower bound when bringing back the expiration benchmarks because the same crash showed up there; that PR was never backported. Companion PR for 8.2: #9918.

3. **Outcome:** The benchmark job picks up a `redisbench_admin` release with the fixed metric extraction and stops failing on missing metric values.

#### Which additional issues this PR fixes

1. None (CI-only).

#### Main objects this PR modified

1. `tests/benchmarks/requirements.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change with no product code or API impact.
> 
> **Overview**
> Updates the benchmark Python dependency pin from **`redisbench_admin==0.12.6`** to **`redisbench_admin>=0.12.29`** in `tests/benchmarks/requirements.txt`, aligning the 8.4 branch with master and 8.8.
> 
> This pulls in a release that handles **`None`** metric values in result extraction instead of crashing with a `TypeError`, so CI jobs like **`benchmark-search-oss-standalone`** can complete when a metric is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e01b4437069ca8f935ca5c334d29e21fe5842d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->