### PR TITLE
[8.6] benchmarks: bump redisbench_admin to >=0.12.29

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin>=0.12.15
+redisbench_admin>=0.12.29
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `tests/benchmarks/requirements.txt` on 8.6 has `redisbench_admin>=0.12.15`. pip happens to resolve that to a release that contains the metric-extraction fix today, so the 8.6 benchmark workflow is currently green, but the lower bound itself does not guarantee the fix lands — a future older-release pin pulling in `<0.12.29` could regress.

   The bug we're guarding against is the `float(None)` crash in `redisbench_admin/run/metrics.py:52` (`extract_results_table`), which has been failing the 8.2 and 8.4 benchmark jobs.

2. **Change:** Tighten the floor to `redisbench_admin>=0.12.29`, matching what master and 8.8 already require. Master's #9292 added this lower bound when bringing back the expiration benchmarks; that PR was never backported. Companion PRs: #9918 (8.2), #9919 (8.4).

3. **Outcome:** No behavior change today, but the dependency floor is consistent with the other supported branches and the fix is contractually required.

#### Which additional issues this PR fixes

1. None (CI-only).

#### Main objects this PR modified

1. `tests/benchmarks/requirements.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin in benchmark requirements; no application code or user-facing behavior.
> 
> **Overview**
> Raises the minimum **`redisbench_admin`** version in **`tests/benchmarks/requirements.txt`** from **`>=0.12.15`** to **`>=0.12.29`**, matching other supported branches.
> 
> This locks in a release that includes the fix for a **`float(None)`** failure in benchmark metric extraction, so future pip resolves cannot pull an older package and break CI again. **No runtime or product behavior changes**—only the benchmark test dependency contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f0f265958d091e1c8ffd6b1b7d62d135226249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->