### PR TITLE
MOD-16002: Clean venv on retry

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -159,9 +159,7 @@ jobs:
       - name: install build artifacts req
         uses: ./.github/actions/retry-command
         with:
-          command: |
-            export UV_VENV_CLEAR=1
-            uv pip install -q -r .install/build_package_requirements.txt
+          command: uv pip install -q -r .install/build_package_requirements.txt
 
       - name: Build Redis (cached)
         uses: ./.github/actions/build-redis

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -159,7 +159,9 @@ jobs:
       - name: install build artifacts req
         uses: ./.github/actions/retry-command
         with:
-          command: uv pip install -q -r .install/build_package_requirements.txt
+          command: |
+            export UV_VENV_CLEAR=1
+            uv pip install -q -r .install/build_package_requirements.txt
 
       - name: Build Redis (cached)
         uses: ./.github/actions/build-redis

--- a/.install/test_deps/install_python_deps.sh
+++ b/.install/test_deps/install_python_deps.sh
@@ -29,8 +29,10 @@ activate_venv() {
 	fi
 }
 
-# Create a virtual environment for Python tests, with `pip` pre-installed (--seed)
-uv venv --seed
+# Create a virtual environment for Python tests, with `pip` pre-installed (--seed).
+# --clear ensures a partial .venv left behind by a failed (e.g. network-timed-out)
+# attempt is replaced rather than causing "virtual environment already exists" on retry.
+uv venv --seed --clear
 activate_venv
 source .venv/bin/activate
 uv sync --locked --all-packages


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `Setup test dependencies` step in `task-build-artifacts.yml` runs `install_python_deps.sh` (via `common_installations.sh`) through the `retry-command` action. That script creates the Python venv with `uv venv --seed`. When the first attempt fails partway — e.g. a PyPI network timeout while fetching the seed `pip` package — it leaves a **partial `.venv`** behind. Every subsequent retry then fails immediately with `error: Failed to create virtual environment / A virtual environment already exists at: .venv`, so the job exhausts all 5 retries and fails.
2. **Change**: Pass `--clear` to `uv venv --seed` in `install_python_deps.sh` so a leftover partial venv from a failed attempt is removed and recreated on the next attempt. The earlier (ineffective) `UV_VENV_CLEAR=1` export on the `uv pip install` step is reverted — that env var is only honored by `uv venv`, not by `uv pip install`, so it was a no-op.
3. **Outcome**: A transient failure during venv creation no longer poisons all remaining retries; the retry actually starts from a clean venv and can succeed.

#### Which additional issues this PR fixes
_None._

#### Main objects this PR modified
1. `.install/test_deps/install_python_deps.sh` — `uv venv --seed --clear`
2. `.github/workflows/task-build-artifacts.yml` — reverted the no-op `UV_VENV_CLEAR` export

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change (workflow/install retry behavior); no user-facing impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only install script change; no runtime or API impact.
> 
> **Overview**
> **Python test dependency install** now runs `uv venv --seed --clear` instead of `uv venv --seed`, with a short comment explaining why.
> 
> Each run (including CI retries after a failed `uv sync` or similar) **recreates** `.venv` instead of failing with “virtual environment already exists” or reusing a **partially populated** env from a timed-out or aborted attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1263317da7c588d46edfdefae853d0c257d80c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->