### PR TITLE
stop using core types from ffi crates

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -655,6 +655,7 @@ version = "0.0.1"
 dependencies = [
  "cheadergen",
  "ffi",
+ "rqe_core",
  "workspace_hack",
 ]
 
@@ -1056,6 +1057,7 @@ dependencies = [
  "enumflags2",
  "ffi",
  "query_term",
+ "rqe_core",
  "thin_vec",
  "varint",
  "workspace_hack",
@@ -1144,6 +1146,7 @@ dependencies = [
  "query_term",
  "redis-module",
  "redis_mock",
+ "rqe_core",
  "workspace_hack",
 ]
 
@@ -1157,6 +1160,7 @@ dependencies = [
  "inverted_index",
  "libc",
  "rmp-serde",
+ "rqe_core",
  "serde",
  "workspace_hack",
 ]
@@ -1176,6 +1180,7 @@ dependencies = [
  "numeric_range_tree_ffi",
  "query_node_type",
  "redis_reply",
+ "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",
  "workspace_hack",
@@ -1482,6 +1487,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "rqe_core",
  "rstest",
  "tracing",
  "workspace_hack",
@@ -1501,6 +1507,7 @@ dependencies = [
  "redis-module",
  "redis_mock",
  "rmp-serde",
+ "rqe_core",
  "serde",
  "tracing",
  "workspace_hack",
@@ -2242,6 +2249,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",
  "rqe_iterators_test_utils",
@@ -2275,6 +2283,7 @@ dependencies = [
  "rand 0.10.1",
  "redis_mock",
  "redisearch_rs",
+ "rqe_core",
  "rqe_iterators",
  "rqe_iterators_test_utils",
  "workspace_hack",
@@ -2295,6 +2304,7 @@ dependencies = [
  "numeric_range_tree_ffi",
  "query_error",
  "redis_mock",
+ "rqe_core",
  "rqe_iterators",
  "varint_ffi",
  "workspace_hack",
@@ -2496,6 +2506,7 @@ dependencies = [
  "index_result",
  "inverted_index",
  "rlookup",
+ "rqe_core",
  "workspace_hack",
 ]
 
@@ -2879,6 +2890,7 @@ dependencies = [
  "inverted_index",
  "redis_mock",
  "redisearch_rs",
+ "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",
  "rqe_iterators_test_utils",
@@ -3234,6 +3246,7 @@ dependencies = [
  "buffer",
  "cheadergen",
  "ffi",
+ "rqe_core",
  "varint",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 cheadergen.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
 libc.workspace = true

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -17,8 +17,9 @@ use std::ffi::{c_char, c_void};
 use ffi::{
     DocTable_Exists, IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreNumeric, IndexFlags_Index_StoreTermOffsets,
-    IndexFlags_Index_WideSchema, RedisSearchCtx, t_docId, t_fieldMask,
+    IndexFlags_Index_WideSchema, RedisSearchCtx,
 };
+use rqe_core::{DocId, FieldMask};
 
 use fork_gc::{InvertedIndexGCCallback, InvertedIndexGCReader, InvertedIndexGCWriter};
 use index_result::RSIndexResult;
@@ -233,7 +234,7 @@ pub unsafe extern "C" fn InvertedIndex_MemUsage(ii: *const InvertedIndex) -> usi
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn InvertedIndex_WriteNumericEntry(
     ii: *mut InvertedIndex,
-    doc_id: t_docId,
+    doc_id: DocId,
     value: f64,
 ) -> AddRecordOutcome {
     debug_assert!(!ii.is_null(), "ii must not be null");
@@ -380,7 +381,7 @@ pub unsafe extern "C" fn InvertedIndex_BlocksSummaryFree(blocks: *mut BlockSumma
 /// The following invariant must be upheld when calling this function:
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_FieldMask(ii: *const InvertedIndex) -> t_fieldMask {
+pub unsafe extern "C" fn InvertedIndex_FieldMask(ii: *const InvertedIndex) -> FieldMask {
     debug_assert!(!ii.is_null(), "ii must not be null");
 
     // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
@@ -462,7 +463,7 @@ pub unsafe extern "C" fn InvertedIndex_BlockRef<'index>(
 /// The following invariant must be upheld when calling this function:
 /// - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_LastId(ii: *const InvertedIndex) -> t_docId {
+pub unsafe extern "C" fn InvertedIndex_LastId(ii: *const InvertedIndex) -> DocId {
     debug_assert!(!ii.is_null(), "ii must not be null");
 
     // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
@@ -688,7 +689,7 @@ pub unsafe extern "C" fn GcScanDelta_LastBlockIdx(gc_scan_delta: *const GcScanDe
 /// The following invariant must be upheld when calling this function:
 /// - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexBlock_FirstId(ib: *const IndexBlock) -> t_docId {
+pub unsafe extern "C" fn IndexBlock_FirstId(ib: *const IndexBlock) -> DocId {
     debug_assert!(!ib.is_null(), "ib must not be null");
 
     // SAFETY: The caller must ensure that `ib` is a valid pointer to an `IndexBlock`
@@ -704,7 +705,7 @@ pub unsafe extern "C" fn IndexBlock_FirstId(ib: *const IndexBlock) -> t_docId {
 /// The following invariant must be upheld when calling this function:
 /// - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexBlock_LastId(ib: *const IndexBlock) -> t_docId {
+pub unsafe extern "C" fn IndexBlock_LastId(ib: *const IndexBlock) -> DocId {
     debug_assert!(!ib.is_null(), "ib must not be null");
 
     // SAFETY: The caller must ensure that `ib` is a valid pointer to an `IndexBlock`
@@ -1114,7 +1115,7 @@ pub unsafe extern "C" fn IndexReader_Next<'index>(
 /// The following invariant must be upheld when calling this function:
 /// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: t_docId) -> bool {
+pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: DocId) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
 
     // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
@@ -1136,7 +1137,7 @@ pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: t_docI
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_Seek<'index>(
     ir: *mut IndexReader<'index>,
-    doc_id: t_docId,
+    doc_id: DocId,
     res: *mut RSIndexResult<'index>,
 ) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -21,6 +21,7 @@ bench = false
 
 [dependencies]
 ffi.workspace = true
+rqe_core.workspace = true
 libc.workspace = true
 field.workspace = true
 index_result.workspace = true

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -7,8 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{QueryIterator, t_docId};
+use ffi::QueryIterator;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{id_list::IdList, utils::OwnedSlice};
 
@@ -17,13 +18,13 @@ use rqe_iterators::{id_list::IdList, utils::OwnedSlice};
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
 ///    The array must be sorted in ascending order.
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
 pub unsafe extern "C" fn NewSortedIdListIterator(
-    ids: *mut t_docId,
+    ids: *mut DocId,
     num: u64,
     weight: f64,
 ) -> *mut QueryIterator {
@@ -36,12 +37,12 @@ pub unsafe extern "C" fn NewSortedIdListIterator(
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
 pub unsafe extern "C" fn NewUnsortedIdListIterator(
-    ids: *mut t_docId,
+    ids: *mut DocId,
     num: u64,
     weight: f64,
 ) -> *mut QueryIterator {
@@ -51,12 +52,12 @@ pub unsafe extern "C" fn NewUnsortedIdListIterator(
 
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
 unsafe fn new_id_list_iterator<const SORTED: bool>(
-    ids: *mut t_docId,
+    ids: *mut DocId,
     num: u64,
     weight: f64,
 ) -> *mut QueryIterator {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -11,9 +11,8 @@ use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::RSIndexResult;
-use inverted_index::{
-    DocId, IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly,
-};
+use inverted_index::{IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
+use rqe_core::{DocId, FieldIndex};
 use rqe_iterators::{
     FieldExpirationChecker, IteratorType, interop::RQEIteratorWrapper, inverted_index::Missing,
     profile_print,
@@ -136,7 +135,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
 pub unsafe extern "C" fn NewInvIndIterator_MissingQuery(
     idx: *const ffi::InvertedIndex,
     sctx: *const ffi::RedisSearchCtx,
-    field_index: ffi::t_fieldIndex,
+    field_index: FieldIndex,
 ) -> *mut ffi::QueryIterator {
     debug_assert!(!idx.is_null(), "idx must not be null");
     debug_assert!(!sctx.is_null(), "sctx must not be null");

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -11,9 +11,8 @@ use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSQueryTerm};
-use inverted_index::{
-    DocId, IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly,
-};
+use inverted_index::{IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
+use rqe_core::DocId;
 use rqe_iterators::{
     FieldExpirationChecker, IteratorType, interop::RQEIteratorWrapper, inverted_index::Tag,
     profile_print,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -12,10 +12,11 @@ use std::ptr::NonNull;
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSQueryTerm};
 use inverted_index::{
-    DocId, FilterMaskReader, IndexReader, IndexReaderCore, TermReader, doc_ids_only::DocIdsOnly,
+    FilterMaskReader, IndexReader, IndexReaderCore, TermReader, doc_ids_only::DocIdsOnly,
     fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only, full, offsets_only,
     raw_doc_ids_only::RawDocIdsOnly,
 };
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{FieldExpirationChecker, inverted_index::Term};
 
@@ -169,7 +170,7 @@ pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     // differently via the expiration checker).
     let mask = match field_mask_or_index {
         FieldMaskOrIndex::Mask(m) => m,
-        FieldMaskOrIndex::Index(_) => ffi::RS_FIELDMASK_ALL,
+        FieldMaskOrIndex::Index(_) => RS_FIELDMASK_ALL,
     };
 
     // Create the appropriate reader based on the encoding type

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -7,7 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{QueryIterator, RLookupKey, RLookupKeyHandle, t_docId};
+use ffi::{QueryIterator, RLookupKey, RLookupKeyHandle};
+use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::{
@@ -20,14 +21,14 @@ use rqe_iterators::{
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
 ///    The array must be sorted in ascending order.
 /// 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
 /// 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
 /// 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that these pointers were allocated in a compatible manner.
 pub unsafe extern "C" fn NewMetricIteratorSortedById(
-    ids: *mut t_docId,
+    ids: *mut DocId,
     metric_list: *mut f64,
     num: usize,
     type_: MetricType,
@@ -41,13 +42,13 @@ pub unsafe extern "C" fn NewMetricIteratorSortedById(
 ///
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
 /// 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
 /// 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
 /// 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that these pointers were allocated in a compatible manner.
 pub unsafe extern "C" fn NewMetricIteratorSortedByScore(
-    ids: *mut t_docId,
+    ids: *mut DocId,
     metric_list: *mut f64,
     num: usize,
     type_: MetricType,
@@ -58,13 +59,13 @@ pub unsafe extern "C" fn NewMetricIteratorSortedByScore(
 
 /// # Safety
 ///
-/// 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+/// 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
 /// 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
 /// 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
 /// 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that these pointers were allocated in a compatible manner.
 unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
-    ids: *mut t_docId,
+    ids: *mut DocId,
     metrics: *mut f64,
     num: usize,
     _type: MetricType,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -9,7 +9,8 @@
 
 use std::ptr::NonNull;
 
-use ffi::{AREQ, QueryIterator, t_docId, timespec};
+use ffi::{AREQ, QueryIterator, timespec};
+use rqe_core::DocId;
 use rqe_iterators::{
     NewWildcardIterator, RQEIterator,
     c2rust::CRQEIterator,
@@ -75,7 +76,7 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
     {
         match self {
@@ -112,7 +113,7 @@ impl<'index> RQEIterator<'index> for NotIteratorEnum<'index> {
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         match self {
             Self::Not(it) => it.last_doc_id(),
             Self::NotOptimized(it) => it.last_doc_id(),
@@ -230,7 +231,7 @@ unsafe fn build_timeout_context(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewNotIterator(
     child: *mut QueryIterator,
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     weight: f64,
     timeout: timespec,
     bc_timeout_areq: *mut AREQ,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/optional.rs
@@ -9,7 +9,8 @@
 
 use std::ptr::NonNull;
 
-use ffi::{QueryEvalCtx, QueryIterator, t_docId};
+use ffi::{QueryEvalCtx, QueryIterator};
+use rqe_core::DocId;
 use rqe_iterators::c2rust::CRQEIterator;
 use rqe_iterators::interop::RQEIteratorWrapper;
 use rqe_iterators::optional_reducer::{
@@ -32,7 +33,7 @@ use rqe_iterators::optional_reducer::{
 pub unsafe extern "C" fn NewOptionalIterator(
     child: *mut QueryIterator,
     q: *mut QueryEvalCtx,
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     weight: f64,
 ) -> *mut QueryIterator {
     let query = NonNull::new(q).expect("q is null");

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -9,14 +9,15 @@
 
 use std::ptr::NonNull;
 
-use ffi::{QueryIterator, t_docId};
+use ffi::QueryIterator;
+use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{NewWildcardIterator, Wildcard, interop::RQEIteratorWrapper};
 
 /// Creates a new non-optimized wildcard iterator over the `[0, max_id]` document id range.
 #[unsafe(no_mangle)]
 pub extern "C" fn NewWildcardIterator_NonOptimized(
-    max_id: t_docId,
+    max_id: DocId,
     weight: f64,
 ) -> *mut QueryIterator {
     let it = NewWildcardIterator::NotOptimized(Wildcard::new(max_id, weight));

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
@@ -23,6 +23,7 @@ inverted_index_ffi = { path = "../inverted_index_ffi" }
 generational_slab.workspace = true
 hyperloglog.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 tracing.workspace = true
 workspace_hack.workspace = true
 serde.workspace = true

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs
@@ -15,6 +15,7 @@ use numeric_range_tree::{
     CompactIfSparseResult, IndexedReversePreOrderDfsIterator, NodeGcDelta, NodeIndex,
     NumericRangeTree, SingleNodeGcResult,
 };
+use rqe_core::DocId;
 use serde::{Deserialize, Serialize};
 
 /// Conditionally trim empty leaves and compact the node slab.
@@ -75,7 +76,7 @@ pub struct NumericGcNodeEntry {
 /// avoiding buffering all deltas in memory.
 pub struct NumericGcScanner<'tree> {
     iter: IndexedReversePreOrderDfsIterator<'tree>,
-    doc_exists: Box<dyn Fn(ffi::t_docId) -> bool>,
+    doc_exists: Box<dyn Fn(DocId) -> bool>,
     /// Reusable buffer for serializing the current entry.
     buffer: Vec<u8>,
 }
@@ -108,7 +109,7 @@ pub unsafe extern "C" fn NumericGcScanner_New<'tree>(
     // SAFETY: tree is a valid pointer; caller guarantees it outlives the scanner
     let tree_ref = unsafe { &*tree };
 
-    let doc_exists: Box<dyn Fn(ffi::t_docId) -> bool> = Box::new(move |id| {
+    let doc_exists: Box<dyn Fn(DocId) -> bool> = Box::new(move |id| {
         // SAFETY: doc_table is valid from spec for the lifetime of the scanner
         unsafe { DocTable_Exists(&spec.docs, id) }
     });

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
@@ -41,7 +41,7 @@ pub use range::*;
 pub use tree::*;
 
 use ::inverted_index::NumericFilter;
-use ffi::t_docId;
+use rqe_core::DocId;
 use std::ffi::c_int;
 
 // Re-export IndexReader type from inverted_index_ffi for C code to use.
@@ -108,7 +108,7 @@ pub extern "C" fn NewNumericRangeTree(compress_floats: bool) -> *mut NumericRang
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _NumericRangeTree_Add(
     t: *mut NumericRangeTree,
-    doc_id: t_docId,
+    doc_id: DocId,
     value: f64,
     isMulti: c_int,
     maxDepthRange: usize,

--- a/src/redisearch_rs/c_entrypoint/ttl_table_ffi/tests/main.rs
+++ b/src/redisearch_rs/c_entrypoint/ttl_table_ffi/tests/main.rs
@@ -20,6 +20,7 @@ use std::ptr;
 
 use field::FieldExpirationPredicate;
 use redis_mock::mock_or_stub_missing_redis_c_symbols;
+use rqe_core::FieldMask;
 use ttl_table::test_utils::{FUTURE, NOW, PAST, fe};
 use ttl_table::{FieldExpiration, FieldExpirations};
 use ttl_table_ffi::*;
@@ -190,8 +191,8 @@ fn verify_doc_and_wide_field_mask_uses_active_width() {
 
         // Construct the mask via a u64 value the FFI accepts under either
         // typedef width (u64 or u128 — both can hold `1 << 5` losslessly).
-        // `t_fieldMask` is `ffi::FieldMask`; build it from a u64 literal.
-        let mask: ffi::FieldMask = (1u64 << BIT) as ffi::FieldMask;
+        // `FieldMask` is `FieldMask`; build it from a u64 literal.
+        let mask: FieldMask = (1u64 << BIT) as FieldMask;
 
         assert!(!unsafe {
             TimeToLiveTable_VerifyDocAndWideFieldMask(

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 ffi = { workspace = true }
+rqe_core.workspace = true
 buffer = { workspace = true }
 cheadergen = { workspace = true }
 varint = { workspace = true }

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/field_mask.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/field_mask.rs
@@ -8,6 +8,7 @@
 */
 
 use buffer::{BufferReader, BufferWriter};
+use rqe_core::FieldMask;
 use std::ptr::NonNull;
 use varint::VarintEncode;
 
@@ -22,7 +23,7 @@ use varint::VarintEncode;
 /// 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
 /// 2. The caller must have exclusive access to the buffer reader.
 #[unsafe(no_mangle)]
-pub extern "C" fn ReadVarintFieldMask(b: Option<NonNull<BufferReader>>) -> ffi::t_fieldMask {
+pub extern "C" fn ReadVarintFieldMask(b: Option<NonNull<BufferReader>>) -> FieldMask {
     let mut buffer_reader = b.unwrap();
     // Safety: Safe thanks to invariants 1. and 2.
     let buffer_reader = unsafe { buffer_reader.as_mut() };
@@ -44,7 +45,7 @@ pub extern "C" fn ReadVarintFieldMask(b: Option<NonNull<BufferReader>>) -> ffi::
 /// 2. The caller must have exclusive access to the buffer writer.
 #[unsafe(no_mangle)]
 pub extern "C" fn WriteVarintFieldMask(
-    value: ffi::t_fieldMask,
+    value: FieldMask,
     writer: Option<NonNull<BufferWriter>>,
 ) -> usize {
     let mut writer = writer.unwrap();

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -351,7 +351,9 @@ const HEADERS: &[HeaderAllowlist] = &[
 /// `src/redis_index.h` for `InvertedIndex` or `src/spec.h` for `QueryError`.
 const PERMITTED_GENERATED_HEADERS: &[&str] = &[
     // Fundamental type aliases (t_docId, t_fieldIndex, t_fieldMask) used
-    // across both C code and Rust-generated headers.
+    // across both C code and Rust-generated headers. Bindgen emits these
+    // as `pub type t_docId = u64` etc.; user code should import the
+    // canonical names (`DocId`, `FieldIndex`, `FieldMask`) from `rqe_core`.
     "rqe_core.h",
     // `DocumentType` is used as a bitfield in `RSDocumentMetadata`
     // (src/redisearch.h) — the full enum definition is required.

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -117,5 +117,3 @@ impl QueryProcessingCtx {
         unsafe { *self.endProc.get() = result_processor_ptr };
     }
 }
-
-pub use rqe_core::{FieldMask, RS_FIELDMASK_ALL, RS_INVALID_FIELD_INDEX};

--- a/src/redisearch_rs/field/Cargo.toml
+++ b/src/redisearch_rs/field/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 [dependencies]
 cheadergen.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 workspace_hack.workspace = true
 
 [lints]

--- a/src/redisearch_rs/field/src/lib.rs
+++ b/src/redisearch_rs/field/src/lib.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{RS_FIELDMASK_ALL, RS_INVALID_FIELD_INDEX, t_fieldIndex, t_fieldMask};
+use rqe_core::{FieldIndex, FieldMask, RS_FIELDMASK_ALL, RS_INVALID_FIELD_INDEX};
 
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -15,9 +15,9 @@ use ffi::{RS_FIELDMASK_ALL, RS_INVALID_FIELD_INDEX, t_fieldIndex, t_fieldMask};
 /// Type representing either a field mask or field index.
 pub enum FieldMaskOrIndex {
     /// For textual fields, allows to host multiple field indices at once.
-    Index(t_fieldIndex) = 0,
+    Index(FieldIndex) = 0,
     /// For the other fields, allows a single field to be referenced.
-    Mask(t_fieldMask) = 1,
+    Mask(FieldMask) = 1,
 }
 
 impl FieldMaskOrIndex {

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -26,15 +26,15 @@ typedef struct AREQ AREQ;
 
 
 /**
- * Filter details to apply to numeric values
- */
-typedef struct NumericFilter NumericFilter;
-
-/**
  * Smart pointer handle for [`RLookupKey`] that can be
  * invalidated when the iterator that owns the key is freed.
  */
 typedef struct RLookupKeyHandle RLookupKeyHandle;
+
+/**
+ * Filter details to apply to numeric values
+ */
+typedef struct NumericFilter NumericFilter;
 
 /**
  * Builder for Redis maps.
@@ -126,7 +126,7 @@ QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
  *    The array must be sorted in ascending order.
  * 2. The caller must ensure that `ids` is not null unless `num` is zero.
  * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
@@ -154,7 +154,7 @@ QueryIterator *IntoProfiled(QueryIterator *iter);
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
  *    The array must be sorted in ascending order.
  * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
  * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
@@ -225,7 +225,7 @@ QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, con
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
  * 2. The caller must ensure that `ids` is not null unless `num` is zero.
  * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that the pointer was allocated in a compatible manner.
@@ -252,7 +252,7 @@ void Profile_AddIters(QueryIterator * *root);
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `t_docId` with at least `num` elements.
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
  * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
  * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
  * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -197,6 +197,20 @@ const struct NumericRange *NumericRangeNode_GetRange(const struct NumericRangeNo
 void NumericRangeTree_DebugSummary(RedisModuleCtx *ctx, const struct NumericRangeTree *t);
 
 /**
+ * Get the estimated cardinality (number of distinct values) for a range.
+ *
+ * This uses HyperLogLog estimation and may have some error margin.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `range` must point to a valid [`NumericRange`] obtained from
+ *   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
+ * - The tree from which this range came must still be valid.
+ */
+size_t NumericRange_GetCardinality(const struct NumericRange *range);
+
+/**
  * Conditionally trim empty leaves and compact the node slab.
  *
  * Checks if the number of empty leaves exceeds half the total number of
@@ -210,20 +224,6 @@ void NumericRangeTree_DebugSummary(RedisModuleCtx *ctx, const struct NumericRang
  * - No iterators should be active on this tree while calling this function.
  */
 struct CompactIfSparseResult NumericRangeTree_CompactIfSparse(struct NumericRangeTree *t);
-
-/**
- * Get the estimated cardinality (number of distinct values) for a range.
- *
- * This uses HyperLogLog estimation and may have some error margin.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `range` must point to a valid [`NumericRange`] obtained from
- *   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
- * - The tree from which this range came must still be valid.
- */
-size_t NumericRange_GetCardinality(const struct NumericRange *range);
 
 /**
  * Get the minimum value in a range.

--- a/src/redisearch_rs/headers/varint_ffi.h
+++ b/src/redisearch_rs/headers/varint_ffi.h
@@ -37,20 +37,6 @@ extern "C" {
 struct VarintVectorWriter *NewVarintVectorWriter(size_t cap);
 
 /**
- * Read a varint-encoded field mask from the given buffer.
- *
- * # Panics
- *
- * Panics if the buffer doesn't contain a valid varint-encoded field mask.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
- * 2. The caller must have exclusive access to the buffer reader.
- */
-t_fieldMask ReadVarintFieldMask(BufferReader *b);
-
-/**
  * Read a varint-encoded value from the given buffer.
  *
  * # Panics
@@ -63,6 +49,20 @@ t_fieldMask ReadVarintFieldMask(BufferReader *b);
  * 2. The caller must have exclusive access to the buffer reader.
  */
 uint32_t ReadVarint(BufferReader *b);
+
+/**
+ * Read a varint-encoded field mask from the given buffer.
+ *
+ * # Panics
+ *
+ * Panics if the buffer doesn't contain a valid varint-encoded field mask.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * 1. `b` must point to a valid `BufferReader` instance and cannot be NULL.
+ * 2. The caller must have exclusive access to the buffer reader.
+ */
+t_fieldMask ReadVarintFieldMask(BufferReader *b);
 
 /**
  * Delta-encode an integer and write it into the vector.
@@ -80,23 +80,6 @@ uint32_t ReadVarint(BufferReader *b);
 size_t VVW_Write(struct VarintVectorWriter *writer, uint32_t value);
 
 /**
- * Write a varint-encoded field mask into the given buffer writer.
- * It returns the number of bytes that have been added to the capacity of
- * the underlying buffer.
- *
- * # Panics
- *
- * Panics if the buffer can't grow its capacity to fit the encoded field mask.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
- * 2. The caller must have exclusive access to the buffer writer.
- */
-size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *writer);
-
-/**
  * Write a varint-encoded value into the given buffer writer.
  * It returns the number of bytes that have been added to the capacity of
  * the underlying buffer.
@@ -112,6 +95,23 @@ size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *writer);
  * 2. The caller must have exclusive access to the buffer writer.
  */
 size_t WriteVarint(uint32_t value, BufferWriter *writer);
+
+/**
+ * Write a varint-encoded field mask into the given buffer writer.
+ * It returns the number of bytes that have been added to the capacity of
+ * the underlying buffer.
+ *
+ * # Panics
+ *
+ * Panics if the buffer can't grow its capacity to fit the encoded field mask.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+ * 2. The caller must have exclusive access to the buffer writer.
+ */
+size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *writer);
 
 /**
  * Get a reference to the underlying byte buffer.

--- a/src/redisearch_rs/index_result/Cargo.toml
+++ b/src/redisearch_rs/index_result/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 cheadergen.workspace = true
 enumflags2.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 query_term.workspace = true
 thin_vec.workspace = true
 varint.workspace = true

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -11,8 +11,9 @@ mod proximity;
 
 use std::ptr;
 
-use ffi::{FieldMask, RS_FIELDMASK_ALL, RSDocumentMetadata, t_docId, t_fieldMask};
+use ffi::RSDocumentMetadata;
 use query_term::RSQueryTerm;
+use rqe_core::{DocId, FieldMask, RS_FIELDMASK_ALL};
 
 use super::aggregate::RSAggregateResult;
 use super::kind::RSResultKind;
@@ -28,8 +29,8 @@ use super::term_record::RSTermRecord;
 /// specialized [`RSTermResultBuilder`] with additional setters for
 /// term-specific fields.
 pub struct RSIndexResultBuilder<'index> {
-    doc_id: t_docId,
-    field_mask: t_fieldMask,
+    doc_id: DocId,
+    field_mask: FieldMask,
     freq: u32,
     data: RSResultData<'index>,
     weight: f64,
@@ -42,8 +43,8 @@ pub struct RSIndexResultBuilder<'index> {
 /// or [`Self::owned_record`] to set the term record data before calling
 /// [`Self::build`].
 pub struct RSTermResultBuilder<'index> {
-    doc_id: t_docId,
-    field_mask: t_fieldMask,
+    doc_id: DocId,
+    field_mask: FieldMask,
     freq: u32,
     weight: f64,
     record: TermBuilderRecord<'index>,
@@ -67,7 +68,7 @@ enum TermBuilderRecord<'index> {
 
 impl<'index> RSIndexResultBuilder<'index> {
     /// Set the document ID of this record
-    pub const fn doc_id(mut self, doc_id: t_docId) -> Self {
+    pub const fn doc_id(mut self, doc_id: DocId) -> Self {
         self.doc_id = doc_id;
         self
     }
@@ -187,7 +188,7 @@ impl<'index> RSTermResultBuilder<'index> {
     }
 
     /// Set the document ID of this record
-    pub const fn doc_id(mut self, doc_id: t_docId) -> Self {
+    pub const fn doc_id(mut self, doc_id: DocId) -> Self {
         self.doc_id = doc_id;
         self
     }
@@ -287,13 +288,13 @@ impl<'index> RSTermResultBuilder<'index> {
 #[cheadergen::config(export, rename_all = "camelCase")]
 pub struct RSIndexResult<'index> {
     /// The document ID of the result
-    pub doc_id: t_docId,
+    pub doc_id: DocId,
 
     /// Some metadata about the result document
     pub dmd: *const RSDocumentMetadata,
 
     /// The aggregate field mask of all the records in this result
-    pub field_mask: t_fieldMask,
+    pub field_mask: FieldMask,
 
     /// The total frequency of all the records in this result
     pub freq: u32,

--- a/src/redisearch_rs/inverted_index/src/codec/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/doc_ids_only.rs
@@ -9,7 +9,7 @@
 
 use std::io::{Cursor, Seek, Write};
 
-use ffi::t_docId;
+use rqe_core::DocId;
 use varint::VarintEncode;
 
 use crate::{Decoder, DocIdsDecoder, Encoder, TermDecoder};
@@ -39,12 +39,12 @@ impl Decoder for DocIdsOnly {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let delta = u32::read_as_varint(cursor)?;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + delta as DocId;
         Ok(())
     }
 

--- a/src/redisearch_rs/inverted_index/src/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/fields_offsets.rs
@@ -9,7 +9,6 @@
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
-use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
@@ -18,6 +17,7 @@ use crate::{
     full::{decode_term_record_offsets, offsets},
 };
 use index_result::RSIndexResult;
+use rqe_core::{DocId, FieldMask};
 
 /// Encode and decode the delta, field mask and offsets of a term record.
 ///
@@ -62,7 +62,7 @@ impl Decoder for FieldsOffsets {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
@@ -72,7 +72,7 @@ impl Decoder for FieldsOffsets {
             cursor,
             base,
             delta,
-            field_mask as t_fieldMask,
+            field_mask as FieldMask,
             1,
             offsets_sz,
             result,
@@ -85,8 +85,8 @@ impl Decoder for FieldsOffsets {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (field_mask, offsets_sz) = loop {
@@ -98,7 +98,7 @@ impl Decoder for FieldsOffsets {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break (field_mask, offsets_sz);
@@ -112,7 +112,7 @@ impl Decoder for FieldsOffsets {
             cursor,
             base,
             0,
-            field_mask as t_fieldMask,
+            field_mask as FieldMask,
             1,
             offsets_sz,
             result,
@@ -159,18 +159,18 @@ impl Decoder for FieldsOffsetsWide {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, offsets_sz] = decoded_values;
-        let field_mask = t_fieldMask::read_as_varint(cursor)?;
+        let field_mask = FieldMask::read_as_varint(cursor)?;
 
         decode_term_record_offsets(
             cursor,
             base,
             delta,
-            field_mask as t_fieldMask,
+            field_mask as FieldMask,
             1,
             offsets_sz,
             result,
@@ -183,8 +183,8 @@ impl Decoder for FieldsOffsetsWide {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (field_mask, offsets_sz) = loop {
@@ -195,9 +195,9 @@ impl Decoder for FieldsOffsetsWide {
                 }
                 Err(error) => return Err(error),
             };
-            let field_mask = t_fieldMask::read_as_varint(cursor)?;
+            let field_mask = FieldMask::read_as_varint(cursor)?;
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break (field_mask, offsets_sz);
@@ -211,7 +211,7 @@ impl Decoder for FieldsOffsetsWide {
             cursor,
             base,
             0,
-            field_mask as t_fieldMask,
+            field_mask as FieldMask,
             1,
             offsets_sz,
             result,

--- a/src/redisearch_rs/inverted_index/src/codec/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/fields_only.rs
@@ -9,12 +9,12 @@
 
 use std::io::{Cursor, Seek, Write};
 
-use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{Decoder, Encoder, TermDecoder};
 use index_result::RSIndexResult;
+use rqe_core::{DocId, FieldMask};
 
 /// Encode and decode the delta and field mask of a record.
 ///
@@ -49,14 +49,14 @@ impl Decoder for FieldsOnly {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
-        result.doc_id = base + delta as t_docId;
-        result.field_mask = field_mask as t_fieldMask;
+        result.doc_id = base + delta as DocId;
+        result.field_mask = field_mask as FieldMask;
         Ok(())
     }
 
@@ -66,8 +66,8 @@ impl Decoder for FieldsOnly {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let field_mask = loop {
@@ -79,7 +79,7 @@ impl Decoder for FieldsOnly {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break field_mask;
@@ -87,7 +87,7 @@ impl Decoder for FieldsOnly {
         };
 
         result.doc_id = base;
-        result.field_mask = field_mask as t_fieldMask;
+        result.field_mask = field_mask as FieldMask;
         Ok(true)
     }
 }
@@ -121,13 +121,13 @@ impl Decoder for FieldsOnlyWide {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + delta as DocId;
         result.field_mask = field_mask;
         Ok(())
     }
@@ -138,8 +138,8 @@ impl Decoder for FieldsOnlyWide {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let field_mask = loop {
@@ -152,7 +152,7 @@ impl Decoder for FieldsOnlyWide {
             };
             let field_mask = u128::read_as_varint(cursor)?;
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break field_mask;

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_fields.rs
@@ -9,12 +9,12 @@
 
 use std::io::{Cursor, Seek, Write};
 
-use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{Decoder, Encoder, TermDecoder};
 use index_result::RSIndexResult;
+use rqe_core::{DocId, FieldMask};
 
 /// Encode and decode the delta, frequency and field mask of a record.
 ///
@@ -50,14 +50,14 @@ impl Decoder for FreqsFields {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
-        result.doc_id = base + delta as t_docId;
-        result.field_mask = field_mask as t_fieldMask;
+        result.doc_id = base + delta as DocId;
+        result.field_mask = field_mask as FieldMask;
         result.freq = freq;
         Ok(())
     }
@@ -68,8 +68,8 @@ impl Decoder for FreqsFields {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (freq, field_mask) = loop {
@@ -81,7 +81,7 @@ impl Decoder for FreqsFields {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break (freq, field_mask);
@@ -89,7 +89,7 @@ impl Decoder for FreqsFields {
         };
 
         result.doc_id = base;
-        result.field_mask = field_mask as t_fieldMask;
+        result.field_mask = field_mask as FieldMask;
         result.freq = freq;
         Ok(true)
     }
@@ -126,14 +126,14 @@ impl Decoder for FreqsFieldsWide {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
-        let field_mask = t_fieldMask::read_as_varint(cursor)?;
+        let field_mask = FieldMask::read_as_varint(cursor)?;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + delta as DocId;
         result.field_mask = field_mask;
         result.freq = freq;
         Ok(())
@@ -145,8 +145,8 @@ impl Decoder for FreqsFieldsWide {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (freq, field_mask) = loop {
@@ -157,9 +157,9 @@ impl Decoder for FreqsFieldsWide {
                 }
                 Err(error) => return Err(error),
             };
-            let field_mask = t_fieldMask::read_as_varint(cursor)?;
+            let field_mask = FieldMask::read_as_varint(cursor)?;
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break (freq, field_mask);

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_offsets.rs
@@ -9,8 +9,8 @@
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
-use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
+use rqe_core::DocId;
 
 use crate::{
     Decoder, Encoder, TermDecoder,
@@ -53,7 +53,7 @@ impl Decoder for FreqsOffsets {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
@@ -68,8 +68,8 @@ impl Decoder for FreqsOffsets {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (freq, offsets_sz) = loop {
@@ -81,7 +81,7 @@ impl Decoder for FreqsOffsets {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break (freq, offsets_sz);

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_only.rs
@@ -9,8 +9,8 @@
 
 use std::io::{Cursor, Seek, Write};
 
-use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
+use rqe_core::DocId;
 
 use crate::{Decoder, Encoder, TermDecoder};
 use index_result::RSIndexResult;
@@ -38,13 +38,13 @@ impl Decoder for FreqsOnly {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + delta as DocId;
         result.freq = freq;
         Ok(())
     }
@@ -55,8 +55,8 @@ impl Decoder for FreqsOnly {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let freq = loop {
@@ -68,7 +68,7 @@ impl Decoder for FreqsOnly {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break freq;

--- a/src/redisearch_rs/inverted_index/src/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/full.rs
@@ -9,12 +9,12 @@
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
-use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{Decoder, Encoder, TermDecoder};
 use index_result::{RSIndexResult, RSOffsetSlice};
+use rqe_core::{DocId, FieldMask};
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
 ///
@@ -77,9 +77,9 @@ impl Encoder for Full {
 #[inline(always)]
 pub fn decode_term_record_offsets<'index>(
     cursor: &mut Cursor<&'index [u8]>,
-    base: t_docId,
+    base: DocId,
     delta: u32,
-    field_mask: t_fieldMask,
+    field_mask: FieldMask,
     freq: u32,
     offsets_sz: u32,
     result: &mut RSIndexResult<'index>,
@@ -103,7 +103,7 @@ pub fn decode_term_record_offsets<'index>(
 
     cursor.set_position(end as u64);
 
-    result.doc_id = base + delta as t_docId;
+    result.doc_id = base + delta as DocId;
     result.field_mask = field_mask;
     result.freq = freq;
 
@@ -118,7 +118,7 @@ impl Decoder for Full {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<4, _>(cursor)?;
@@ -128,7 +128,7 @@ impl Decoder for Full {
             cursor,
             base,
             delta,
-            field_mask as t_fieldMask,
+            field_mask as FieldMask,
             freq,
             offsets_sz,
             result,
@@ -141,8 +141,8 @@ impl Decoder for Full {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (freq, field_mask, offsets_sz) = loop {
@@ -154,10 +154,10 @@ impl Decoder for Full {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
-                break (freq, field_mask as t_fieldMask, offsets_sz);
+                break (freq, field_mask as FieldMask, offsets_sz);
             }
 
             // Skip offsets
@@ -168,7 +168,7 @@ impl Decoder for Full {
             cursor,
             base,
             0,
-            field_mask as t_fieldMask,
+            field_mask as FieldMask,
             freq,
             offsets_sz,
             result,
@@ -217,12 +217,12 @@ impl Decoder for FullWide {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
-        let field_mask = t_fieldMask::read_as_varint(cursor)?;
+        let field_mask = FieldMask::read_as_varint(cursor)?;
 
         decode_term_record_offsets(cursor, base, delta, field_mask, freq, offsets_sz, result)
     }
@@ -233,8 +233,8 @@ impl Decoder for FullWide {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let (freq, field_mask, offsets_sz) = loop {
@@ -245,9 +245,9 @@ impl Decoder for FullWide {
                 }
                 Err(error) => return Err(error),
             };
-            let field_mask = t_fieldMask::read_as_varint(cursor)?;
+            let field_mask = FieldMask::read_as_varint(cursor)?;
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break (freq, field_mask, offsets_sz);

--- a/src/redisearch_rs/inverted_index/src/codec/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/mod.rs
@@ -20,7 +20,7 @@ pub mod raw_doc_ids_only;
 
 use std::io::{Cursor, Seek, Write};
 
-use ffi::t_docId;
+use rqe_core::DocId;
 
 use crate::IndexBlock;
 use index_result::RSIndexResult;
@@ -78,7 +78,7 @@ pub trait Encoder {
     ) -> std::io::Result<usize>;
 
     /// Returns the base value that should be used for any delta calculations
-    fn delta_base(block: &IndexBlock) -> t_docId {
+    fn delta_base(block: &IndexBlock) -> DocId {
         block.last_doc_id
     }
 }
@@ -98,7 +98,7 @@ pub trait Decoder {
     /// add to the `base` document ID to get the actual document ID.
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()>;
 
@@ -109,7 +109,7 @@ pub trait Decoder {
     /// an existing one.
     fn decode_new<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
     ) -> std::io::Result<RSIndexResult<'index>> {
         let mut result = Self::base_result();
         Self::decode(cursor, base, &mut result)?;
@@ -127,8 +127,8 @@ pub trait Decoder {
     /// than the target.
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         loop {
@@ -147,7 +147,7 @@ pub trait Decoder {
     }
 
     /// Returns the base value to use for any delta calculations
-    fn base_id(_block: &IndexBlock, last_doc_id: t_docId) -> t_docId {
+    fn base_id(_block: &IndexBlock, last_doc_id: DocId) -> DocId {
         last_doc_id
     }
 }

--- a/src/redisearch_rs/inverted_index/src/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/numeric.rs
@@ -142,7 +142,7 @@
 
 use std::io::{Cursor, IoSlice, Read, Write};
 
-use ffi::t_docId;
+use rqe_core::DocId;
 
 use crate::{Decoder, Encoder, IdDelta, NumericDecoder};
 use index_result::RSIndexResult;
@@ -412,7 +412,7 @@ impl Decoder for Numeric {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         decode(cursor, base, result)
@@ -433,7 +433,7 @@ impl Decoder for NumericFloatCompression {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         decode(cursor, base, result)
@@ -446,7 +446,7 @@ impl Decoder for NumericFloatCompression {
 
 fn decode<'index>(
     cursor: &mut Cursor<&'index [u8]>,
-    base: t_docId,
+    base: DocId,
     result: &mut RSIndexResult<'index>,
 ) -> Result<(), std::io::Error> {
     let mut header = [0; 1];

--- a/src/redisearch_rs/inverted_index/src/codec/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/offsets_only.rs
@@ -9,8 +9,8 @@
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
-use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
+use rqe_core::DocId;
 
 use crate::{
     Decoder, Encoder, TermDecoder,
@@ -53,7 +53,7 @@ impl Decoder for OffsetsOnly {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
@@ -68,8 +68,8 @@ impl Decoder for OffsetsOnly {
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        mut base: t_docId,
-        target: t_docId,
+        mut base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let offsets_sz = loop {
@@ -81,7 +81,7 @@ impl Decoder for OffsetsOnly {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += delta as DocId;
 
             if base >= target {
                 break offsets_sz;

--- a/src/redisearch_rs/inverted_index/src/codec/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/raw_doc_ids_only.rs
@@ -9,7 +9,7 @@
 
 use std::io::{Cursor, Seek, Write};
 
-use ffi::t_docId;
+use rqe_core::DocId;
 
 use crate::{Decoder, DocIdsDecoder, Encoder, IndexBlock, TermDecoder};
 use index_result::RSIndexResult;
@@ -36,7 +36,7 @@ impl Encoder for RawDocIdsOnly {
         Ok(4)
     }
 
-    fn delta_base(block: &IndexBlock) -> t_docId {
+    fn delta_base(block: &IndexBlock) -> DocId {
         block.first_doc_id
     }
 }
@@ -45,32 +45,32 @@ impl Decoder for RawDocIdsOnly {
     #[inline(always)]
     fn decode<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
+        base: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<()> {
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + delta as DocId;
         Ok(())
     }
 
-    fn base_id(block: &IndexBlock, _last_doc_id: t_docId) -> t_docId {
+    fn base_id(block: &IndexBlock, _last_doc_id: DocId) -> DocId {
         block.first_doc_id
     }
 
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
-        base: t_docId,
-        target: t_docId,
+        base: DocId,
+        target: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         // Check if the very next record is the target before starting a binary search
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
-        let mut doc_id = base + delta as t_docId;
+        let mut doc_id = base + delta as DocId;
 
         if doc_id >= target {
             result.doc_id = doc_id;
@@ -88,7 +88,7 @@ impl Decoder for RawDocIdsOnly {
             cursor.set_position(mid * 4);
             std::io::Read::read_exact(cursor, &mut delta_bytes)?;
             let delta = u32::from_ne_bytes(delta_bytes);
-            doc_id = base + delta as t_docId;
+            doc_id = base + delta as DocId;
 
             if doc_id < target {
                 left = mid + 1;
@@ -106,7 +106,7 @@ impl Decoder for RawDocIdsOnly {
         cursor.set_position(left * 4);
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
-        doc_id = base + delta as t_docId;
+        doc_id = base + delta as DocId;
 
         result.doc_id = doc_id;
         Ok(true)

--- a/src/redisearch_rs/inverted_index/src/debug.rs
+++ b/src/redisearch_rs/inverted_index/src/debug.rs
@@ -9,8 +9,8 @@
 
 //! This module contains the debug information for an inverted index.
 
-use ffi::t_docId;
 use redis_reply::ArrayBuilder;
+use rqe_core::DocId;
 
 /// Summary information about an inverted index containing all key metrics
 #[cheadergen::config(export, rename = "IISummary")]
@@ -19,7 +19,7 @@ use redis_reply::ArrayBuilder;
 pub struct Summary {
     pub number_of_docs: u32,
     pub number_of_entries: usize,
-    pub last_doc_id: t_docId,
+    pub last_doc_id: DocId,
     pub flags: u64,
     pub number_of_blocks: usize,
     pub block_efficiency: f64,
@@ -53,7 +53,7 @@ impl Summary {
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub struct BlockSummary {
-    pub first_doc_id: t_docId,
-    pub last_doc_id: t_docId,
+    pub first_doc_id: DocId,
+    pub last_doc_id: DocId,
     pub number_of_entries: u16,
 }

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -11,8 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 use crate::{BlockCapacity, DecodedBy, Decoder, Encoder, IndexBlock, InvertedIndex};
-use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 use smallvec::SmallVec;
 use thin_vec::{Header, ThinVec};
 
@@ -102,7 +103,7 @@ impl IndexBlock {
     /// `None` is returned when there is nothing to repair in this block.
     pub(crate) fn repair<'index, E: Encoder + DecodedBy<Decoder = D>, D: Decoder>(
         &'index self,
-        doc_exist: impl Fn(t_docId) -> bool,
+        doc_exist: impl Fn(DocId) -> bool,
         mut repair: Option<impl FnMut(&RSIndexResult<'index>, &IndexBlock)>,
         _encoder: PhantomData<E>,
     ) -> std::io::Result<Option<RepairType>> {
@@ -166,7 +167,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     /// This function returns a delta if GC is needed, or `None` if no GC is needed.
     pub fn scan_gc<'index>(
         &'index self,
-        doc_exist: impl Fn(t_docId) -> bool,
+        doc_exist: impl Fn(DocId) -> bool,
         mut repair: Option<impl FnMut(&RSIndexResult<'index>, &IndexBlock)>,
     ) -> std::io::Result<Option<GcScanDelta>> {
         let mut results = Vec::new();

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -20,8 +20,9 @@ use crate::{
     controlled_cursor::ControlledCursor,
     debug::{BlockSummary, Summary},
 };
-use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue, t_docId};
+use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue};
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 /// An inverted index is a data structure that maps terms to their occurrences in documents. It is
 /// used to efficiently search for documents that contain specific terms.
@@ -74,11 +75,11 @@ pub struct AddRecordOutcome {
 pub struct IndexBlock {
     /// The first document ID in this block. This is used to determine the range of document IDs
     /// that this block covers.
-    pub(crate) first_doc_id: t_docId,
+    pub(crate) first_doc_id: DocId,
 
     /// The last document ID in this block. This is used to determine the range of document IDs
     /// that this block covers.
-    pub(crate) last_doc_id: t_docId,
+    pub(crate) last_doc_id: DocId,
 
     /// The total number of non-unique entries in this block
     pub(crate) num_entries: u16,
@@ -97,8 +98,8 @@ impl<'de> Deserialize<'de> for IndexBlock {
     {
         #[derive(Deserialize)]
         struct IB {
-            first_doc_id: t_docId,
-            last_doc_id: t_docId,
+            first_doc_id: DocId,
+            last_doc_id: DocId,
             num_entries: u16,
             buffer: Vec<u8>,
         }
@@ -124,7 +125,7 @@ impl IndexBlock {
 
     /// Make a new index block with primed with the initial doc ID. The next entry written into
     /// the block should be for this doc ID else the block will contain incoherent data.
-    pub(crate) fn new(doc_id: t_docId) -> Self {
+    pub(crate) fn new(doc_id: DocId) -> Self {
         let this = Self {
             first_doc_id: doc_id,
             last_doc_id: doc_id,
@@ -142,12 +143,12 @@ impl IndexBlock {
     }
 
     /// Get the first document ID in this block. This is only needed for some C tests.
-    pub const fn first_block_id(&self) -> t_docId {
+    pub const fn first_block_id(&self) -> DocId {
         self.first_doc_id
     }
 
     /// Get the last document ID in the block. This is only needed for some C tests.
-    pub const fn last_block_id(&self) -> t_docId {
+    pub const fn last_block_id(&self) -> DocId {
         self.last_doc_id
     }
 
@@ -320,12 +321,12 @@ impl<E: Encoder> InvertedIndex<E> {
     }
 
     /// Returns the last document ID in the index, if any.
-    pub fn last_doc_id(&self) -> Option<t_docId> {
+    pub fn last_doc_id(&self) -> Option<DocId> {
         self.blocks.last().map(|b| b.last_doc_id)
     }
 
     /// Take a block that can be written to.
-    fn take_block(&mut self, doc_id: t_docId, same_doc: bool) -> IndexBlock {
+    fn take_block(&mut self, doc_id: DocId, same_doc: bool) -> IndexBlock {
         if self.blocks.is_empty()
             || (
                 // If the block is full

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -12,8 +12,9 @@ use crate::{
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
-use ffi::{IndexFlags, t_docId};
+use ffi::IndexFlags;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 /// A wrapper around the inverted index to track the total number of entries in the index.
 /// Unlike [`InvertedIndex::unique_docs()`], this counts all entries, including duplicates.
@@ -60,7 +61,7 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
     }
 
     /// Returns the last document ID in the index, if any.
-    pub fn last_doc_id(&self) -> Option<t_docId> {
+    pub fn last_doc_id(&self) -> Option<DocId> {
         self.index.last_doc_id()
     }
 
@@ -141,7 +142,7 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
     /// This function returns a delta if GC is needed, or `None` if no GC is needed.
     pub fn scan_gc<'index>(
         &'index self,
-        doc_exist: impl Fn(t_docId) -> bool,
+        doc_exist: impl Fn(DocId) -> bool,
         repair: Option<impl FnMut(&RSIndexResult<'index>, &IndexBlock)>,
     ) -> std::io::Result<Option<GcScanDelta>> {
         self.index.scan_gc(doc_exist, repair)

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -13,8 +13,9 @@ use crate::{
     debug::{BlockSummary, Summary},
     reader::IndexReaderCore,
 };
-use ffi::{IndexFlags, IndexFlags_Index_StoreFieldFlags, t_docId, t_fieldMask};
+use ffi::{IndexFlags, IndexFlags_Index_StoreFieldFlags};
 use index_result::RSIndexResult;
+use rqe_core::{DocId, FieldMask};
 
 /// A wrapper around the inverted index which tracks the fields for all the records in the index
 /// using a mask. This makes is easy to know if the index has any records for a specific field.
@@ -25,7 +26,7 @@ pub struct FieldMaskTrackingIndex<E> {
 
     /// A field mask of all the entries in the index. This is used to quickly determine if a
     /// record with a specific field mask exists in the index.
-    field_mask: t_fieldMask,
+    field_mask: FieldMask,
 }
 
 impl<E: Encoder> FieldMaskTrackingIndex<E> {
@@ -54,11 +55,11 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
 
     /// The memory size of the index in bytes.
     pub fn memory_usage(&self) -> usize {
-        self.index.memory_usage() + std::mem::size_of::<t_fieldMask>()
+        self.index.memory_usage() + std::mem::size_of::<FieldMask>()
     }
 
     /// Returns the last document ID in the index, if any.
-    pub fn last_doc_id(&self) -> Option<t_docId> {
+    pub fn last_doc_id(&self) -> Option<DocId> {
         self.index.last_doc_id()
     }
 
@@ -73,7 +74,7 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
     }
 
     /// Get the combined field mask of all records in the index.
-    pub const fn field_mask(&self) -> t_fieldMask {
+    pub const fn field_mask(&self) -> FieldMask {
         self.field_mask
     }
 
@@ -121,7 +122,7 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
 
 impl<E: Encoder + DecodedBy> FieldMaskTrackingIndex<E> {
     /// Create a new [`crate::reader::IndexReader`] for this inverted index.
-    pub fn reader(&self, mask: t_fieldMask) -> FilterMaskReader<IndexReaderCore<'_, E>> {
+    pub fn reader(&self, mask: FieldMask) -> FilterMaskReader<IndexReaderCore<'_, E>> {
         FilterMaskReader::new(mask, self.index.reader())
     }
 
@@ -135,7 +136,7 @@ impl<E: Encoder + DecodedBy> FieldMaskTrackingIndex<E> {
     /// This function returns a delta if GC is needed, or `None` if no GC is needed.
     pub fn scan_gc<'index>(
         &'index self,
-        doc_exist: impl Fn(t_docId) -> bool,
+        doc_exist: impl Fn(DocId) -> bool,
         repair: Option<impl FnMut(&RSIndexResult<'index>, &IndexBlock)>,
     ) -> std::io::Result<Option<GcScanDelta>> {
         self.index.scan_gc(doc_exist, repair)

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -14,8 +14,9 @@ use crate::{
     DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, TermDecoder,
     index::unique_id::IndexUniqueId, opaque::OpaqueEncoding,
 };
-use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue, t_docId};
+use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue};
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 /// Reader that is able to read the records from an [`InvertedIndex`]
 pub struct IndexReaderCore<'index, E> {
@@ -32,7 +33,7 @@ pub struct IndexReaderCore<'index, E> {
 
     /// The last document ID that was read from the index. This is used to determine the base
     /// document ID for delta calculations.
-    pub(crate) last_doc_id: t_docId,
+    pub(crate) last_doc_id: DocId,
 
     /// The marker of the inverted index when this reader last read from it. This is used to
     /// detect if the index has been modified since the last read, in which case the reader
@@ -90,7 +91,7 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
     #[inline(always)]
     fn seek_record(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         if !self.skip_to(doc_id) {
@@ -107,7 +108,7 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
         Ok(success)
     }
 
-    fn skip_to(&mut self, doc_id: t_docId) -> bool {
+    fn skip_to(&mut self, doc_id: DocId) -> bool {
         if self.ii.blocks.is_empty() {
             return false;
         }

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -11,15 +11,16 @@ use super::{IndexReader, IndexReaderCore, TermReader};
 use crate::{
     DecodedBy, Decoder, HasInnerIndex, InvertedIndex, TermDecoder, opaque::OpaqueEncoding,
 };
-use ffi::{IndexFlags, t_docId, t_fieldMask};
+use ffi::IndexFlags;
 use index_result::RSIndexResult;
+use rqe_core::{DocId, FieldMask};
 
 /// A reader that filters out records that do not match a given field mask. It is used to
 /// filter records in an index based on their field mask, allowing only those that match the
 /// specified mask to be returned.
 pub struct FilterMaskReader<IR> {
     /// Mask which a record needs to match to be valid
-    mask: t_fieldMask,
+    mask: FieldMask,
 
     /// The inner reader that will be used to read the records from the index.
     inner: IR,
@@ -27,7 +28,7 @@ pub struct FilterMaskReader<IR> {
 
 impl<'index, IR: IndexReader<'index>> FilterMaskReader<IR> {
     /// Create a new filter mask reader with the given mask and inner iterator
-    pub const fn new(mask: t_fieldMask, inner: IR) -> Self {
+    pub const fn new(mask: FieldMask, inner: IR) -> Self {
         Self { mask, inner }
     }
 }
@@ -51,7 +52,7 @@ impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterMaskReader<I
     #[inline(always)]
     fn seek_record(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let success = self.inner.seek_record(doc_id, result)?;
@@ -67,7 +68,7 @@ impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterMaskReader<I
         }
     }
 
-    fn skip_to(&mut self, doc_id: t_docId) -> bool {
+    fn skip_to(&mut self, doc_id: DocId) -> bool {
         self.inner.skip_to(doc_id)
     }
 

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -9,8 +9,9 @@
 
 use super::{IndexReader, IndexReaderCore, NumericFilter, NumericReader};
 use crate::{DecodedBy, Decoder, InvertedIndex};
-use ffi::{GeoFilter, IndexFlags, t_docId};
+use ffi::{GeoFilter, IndexFlags};
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 // Manually define some C functions, because we'll create a circular dependency if we use the FFI
 // crate to make them automatically.
@@ -116,7 +117,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<
     #[inline(always)]
     fn seek_record(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let success = self.inner.seek_record(doc_id, result)?;
@@ -138,7 +139,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterGeoReader<
         }
     }
 
-    fn skip_to(&mut self, doc_id: t_docId) -> bool {
+    fn skip_to(&mut self, doc_id: DocId) -> bool {
         self.inner.skip_to(doc_id)
     }
 

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -12,8 +12,9 @@ mod field_mask;
 mod geo;
 mod numeric;
 
-use ffi::{IndexFlags, t_docId, t_fieldMask};
+use ffi::IndexFlags;
 use index_result::RSIndexResult;
+use rqe_core::{DocId, FieldMask};
 
 pub use self::core::*;
 pub use field_mask::FilterMaskReader;
@@ -31,13 +32,13 @@ pub trait IndexReader<'index> {
     /// is returned.
     fn seek_record(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool>;
 
     /// Skip forward to the block containing the given document ID. Returns false if the end of the
     /// index was reached and true otherwise.
-    fn skip_to(&mut self, doc_id: t_docId) -> bool;
+    fn skip_to(&mut self, doc_id: DocId) -> bool;
 
     /// Reset the reader to the beginning of the index.
     fn reset(&mut self);
@@ -79,7 +80,7 @@ pub enum ReadFilter<'numeric_filter> {
     None,
 
     /// Accepts entries matching this field mask
-    FieldMask(t_fieldMask),
+    FieldMask(FieldMask),
 
     /// Accepts entries matching this numeric filter
     Numeric(&'numeric_filter NumericFilter),

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -11,8 +11,9 @@ use std::ffi::c_void;
 
 use super::{IndexReader, IndexReaderCore, NumericReader};
 use crate::{DecodedBy, Decoder, InvertedIndex};
-use ffi::{FieldSpec, IndexFlags, t_docId};
+use ffi::{FieldSpec, IndexFlags};
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 /// Filter details to apply to numeric values
 #[derive(Debug, Clone, Copy)]
@@ -138,7 +139,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterNumericRea
     #[inline(always)]
     fn seek_record(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         let success = self.inner.seek_record(doc_id, result)?;
@@ -157,7 +158,7 @@ impl<'index, IR: NumericReader<'index>> IndexReader<'index> for FilterNumericRea
         }
     }
 
-    fn skip_to(&mut self, doc_id: t_docId) -> bool {
+    fn skip_to(&mut self, doc_id: DocId) -> bool {
         self.inner.skip_to(doc_id)
     }
 

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -9,8 +9,8 @@
 
 //! Utilities used only in tests and benchmarks.
 
-use ffi::t_fieldMask;
 use query_term::RSQueryTerm;
+use rqe_core::FieldMask;
 
 use index_result::{RSIndexResult, RSOffsetSlice};
 
@@ -23,7 +23,7 @@ pub struct TestTermRecord<'index> {
 
 impl<'a> TestTermRecord<'a> {
     /// Create a new `TestTermRecord` with the given parameters.
-    pub fn new(doc_id: u64, field_mask: t_fieldMask, freq: u32, offsets: &'a [u8]) -> Self {
+    pub fn new(doc_id: u64, field_mask: FieldMask, freq: u32, offsets: &'a [u8]) -> Self {
         let mut term = RSQueryTerm::new("test", 1, 0);
         term.set_idf(5.0);
         term.set_bm25_idf(10.0);

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -16,9 +16,10 @@ use crate::{
     Decoder, Encoder, EntriesTrackingIndex, GcApplyInfo, GcScanDelta, IdDelta, IndexBlock,
     InvertedIndex, gc::BlockGcScanResult, gc::RepairType,
 };
-use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
+use rqe_core::DocId;
 use smallvec::smallvec;
 use thin_vec::medium_thin_vec;
 
@@ -34,7 +35,7 @@ fn index_block_repair_delete() {
         last_doc_id: 11,
     };
 
-    fn cb(doc_id: t_docId) -> bool {
+    fn cb(doc_id: DocId) -> bool {
         ![10, 11].contains(&doc_id)
     }
 
@@ -64,7 +65,7 @@ fn index_block_repair_unchanged() {
         last_doc_id: 11,
     };
 
-    fn cb(_doc_id: t_docId) -> bool {
+    fn cb(_doc_id: DocId) -> bool {
         true
     }
 
@@ -89,7 +90,7 @@ fn index_block_repair_some_deletions() {
         last_doc_id: 12,
     };
 
-    fn cb(doc_id: t_docId) -> bool {
+    fn cb(doc_id: DocId) -> bool {
         [11].contains(&doc_id)
     }
 
@@ -153,7 +154,7 @@ fn index_block_repair_delta_too_big() {
     impl Decoder for SmallDeltaDummy {
         fn decode<'index>(
             cursor: &mut Cursor<&'index [u8]>,
-            base: t_docId,
+            base: DocId,
             result: &mut RSIndexResult<'index>,
         ) -> std::io::Result<()> {
             let mut buffer = [0; 1];
@@ -198,7 +199,7 @@ fn index_block_repair_delta_too_big() {
         last_doc_id: 42,
     };
 
-    fn cb(doc_id: t_docId) -> bool {
+    fn cb(doc_id: DocId) -> bool {
         ![41].contains(&doc_id)
     }
 
@@ -288,7 +289,7 @@ fn ii_scan_gc() {
 
     let ii = InvertedIndex::<Dummy>::from_blocks(IndexFlags_Index_DocIdsOnly, blocks);
 
-    fn cb(doc_id: t_docId) -> bool {
+    fn cb(doc_id: DocId) -> bool {
         [21, 22, 30, 40].contains(&doc_id)
     }
 
@@ -345,7 +346,7 @@ fn ii_scan_gc_no_change() {
     ];
     let ii = InvertedIndex::<Dummy>::from_blocks(IndexFlags_Index_DocIdsOnly, blocks);
 
-    fn cb(_doc_id: t_docId) -> bool {
+    fn cb(_doc_id: DocId) -> bool {
         true
     }
 

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -18,10 +18,11 @@ use crate::{
 };
 use ffi::{
     IndexFlags_Index_DocIdsOnly, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
-    IndexFlags_Index_StoreNumeric, t_docId,
+    IndexFlags_Index_StoreNumeric,
 };
 use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
+use rqe_core::DocId;
 
 use super::Dummy;
 
@@ -299,7 +300,7 @@ fn adding_ii_blocks_growth_strategy() {
     impl Decoder for SmallBlocksDummy {
         fn decode<'index>(
             _cursor: &mut Cursor<&'index [u8]>,
-            _base: t_docId,
+            _base: DocId,
             _result: &mut RSIndexResult<'index>,
         ) -> std::io::Result<()> {
             unimplemented!("not used by this test")

--- a/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/core.rs
@@ -16,6 +16,7 @@ use ffi::{
 };
 use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
+use rqe_core::DocId;
 use thin_vec::medium_thin_vec;
 
 use super::super::Dummy;
@@ -267,7 +268,7 @@ fn reader_has_duplicates() {
     impl Decoder for AllowDupsDummy {
         fn decode<'index>(
             _cursor: &mut Cursor<&'index [u8]>,
-            _base: ffi::t_docId,
+            _base: DocId,
             _result: &mut RSIndexResult<'index>,
         ) -> std::io::Result<()> {
             panic!("This test won't decode anything")
@@ -444,7 +445,7 @@ fn read_using_the_first_block_id_as_the_base() {
             RSIndexResult::build_virt().build()
         }
 
-        fn base_id(block: &IndexBlock, _last_doc_id: ffi::t_docId) -> ffi::t_docId {
+        fn base_id(block: &IndexBlock, _last_doc_id: DocId) -> DocId {
             block.first_doc_id
         }
     }
@@ -492,13 +493,13 @@ impl<'index, I: Iterator<Item = RSIndexResult<'index>>> IndexReader<'index> for 
 
     fn seek_record(
         &mut self,
-        _doc_id: ffi::t_docId,
+        _doc_id: DocId,
         _result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         unimplemented!("This tests won't seek anything")
     }
 
-    fn skip_to(&mut self, _doc_id: ffi::t_docId) -> bool {
+    fn skip_to(&mut self, _doc_id: DocId) -> bool {
         unimplemented!("This test won't skip to anything")
     }
 

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
@@ -9,13 +9,13 @@
 
 use std::io::Cursor;
 
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
     test_utils::{TermRecordCompare, TestTermRecord},
 };
+use rqe_core::FieldMask;
 
 #[test]
 fn test_encode_fields_offsets() {
@@ -25,7 +25,7 @@ fn test_encode_fields_offsets() {
         (0, 1, vec![1u8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
         (
             10,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1u8, 2, 3, 4],
             vec![12, 10, 255, 255, 255, 255, 4, 1, 2, 3, 4],
         ),
@@ -81,7 +81,7 @@ fn test_encode_fields_offsets_wide() {
         (0, 1, vec![1u8, 2, 3], vec![0, 0, 3, 1, 1, 2, 3]),
         (
             10,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1u8, 2, 3, 4],
             vec![0, 10, 4, 142, 254, 254, 254, 127, 1, 2, 3, 4],
         ),
@@ -103,7 +103,7 @@ fn test_encode_fields_offsets_wide() {
         #[cfg(target_pointer_width = "64")]
         (
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1; 100],
             vec![
                 3, 255, 255, 255, 255, 100, 142, 254, 254, 254, 127, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -165,7 +165,7 @@ fn test_encode_fields_offsets_field_mask_overflow() {
     let mut cursor = Cursor::new(buf);
 
     let record = index_result::RSIndexResult::build_term()
-        .field_mask(u32::MAX as t_fieldMask + 1)
+        .field_mask(u32::MAX as FieldMask + 1)
         .build();
     let _res = FieldsOffsets::encode(&mut cursor, 0, &record);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/fields_only.rs
@@ -9,19 +9,19 @@
 
 use std::io::Cursor;
 
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
     fields_only::{FieldsOnly, FieldsOnlyWide},
 };
+use rqe_core::FieldMask;
 
 /// Helper to encode a sequence of (delta, field_mask) records using FieldsOnly.
 fn encode_fields_only(records: &[(u32, u32)]) -> Vec<u8> {
     let mut buf = Cursor::new(Vec::new());
     for &(delta, field_mask) in records {
         let record = RSIndexResult::build_term()
-            .field_mask(field_mask as t_fieldMask)
+            .field_mask(field_mask as FieldMask)
             .build();
         FieldsOnly::encode(&mut buf, delta, &record).expect("to encode");
     }
@@ -44,18 +44,14 @@ fn test_encode_fields_only() {
     let tests = [
         // (delta, field mask, expected encoding)
         (0, 1, vec![0, 0, 1]),
-        (
-            10,
-            u32::MAX as t_fieldMask,
-            vec![12, 10, 255, 255, 255, 255],
-        ),
+        (10, u32::MAX as FieldMask, vec![12, 10, 255, 255, 255, 255]),
         (256, 1, vec![1, 0, 1, 1]),
         (65536, 1, vec![2, 0, 0, 1, 1]),
         (u16::MAX as u32, 1, vec![1, 255, 255, 1]),
         (u32::MAX, 1, vec![3, 255, 255, 255, 255, 1]),
         (
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![15, 255, 255, 255, 255, 255, 255, 255, 255],
         ),
     ];
@@ -92,25 +88,21 @@ fn test_encode_fields_only_wide() {
     let tests = [
         // (delta, field mask, expected encoding)
         (0, 1, vec![0, 1]),
-        (
-            10,
-            u32::MAX as t_fieldMask,
-            vec![10, 142, 254, 254, 254, 127],
-        ),
+        (10, u32::MAX as FieldMask, vec![10, 142, 254, 254, 254, 127]),
         (256, 1, vec![129, 0, 1]),
         (65536, 1, vec![130, 255, 0, 1]),
         (u16::MAX as u32, 1, vec![130, 254, 127, 1]),
         (u32::MAX, 1, vec![142, 254, 254, 254, 127, 1]),
         (
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![142, 254, 254, 254, 127, 142, 254, 254, 254, 127],
         ),
         // field mask larger than 32 bits
         #[cfg(target_pointer_width = "64")]
         (
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![142, 254, 254, 254, 127, 142, 254, 254, 254, 127],
         ),
         #[cfg(target_pointer_width = "64")]

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_fields.rs
@@ -9,19 +9,19 @@
 
 use std::io::Cursor;
 
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
     freqs_fields::{FreqsFields, FreqsFieldsWide},
 };
+use rqe_core::FieldMask;
 
 /// Helper to encode a sequence of (delta, freq, field_mask) records using FreqsFields.
 fn encode_freqs_fields(records: &[(u32, u32, u32)]) -> Vec<u8> {
     let mut buf = Cursor::new(Vec::new());
     for &(delta, freq, field_mask) in records {
         let record = RSIndexResult::build_term()
-            .field_mask(field_mask as t_fieldMask)
+            .field_mask(field_mask as FieldMask)
             .frequency(freq)
             .build();
         FreqsFields::encode(&mut buf, delta, &record).expect("to encode");
@@ -51,7 +51,7 @@ fn test_encode_freqs_fields() {
         (
             10,
             5,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![48, 10, 5, 255, 255, 255, 255],
         ),
         (256, 1, 1, vec![1, 0, 1, 1, 1]),
@@ -61,7 +61,7 @@ fn test_encode_freqs_fields() {
         (
             u32::MAX,
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![
                 63, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             ],
@@ -105,7 +105,7 @@ fn test_encode_freqs_fields_wide() {
         (
             10,
             5,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![0, 10, 5, 142, 254, 254, 254, 127],
         ),
         (256, 1, 1, vec![1, 0, 1, 1, 1]),
@@ -117,7 +117,7 @@ fn test_encode_freqs_fields_wide() {
         (
             u32::MAX,
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![
                 15, 255, 255, 255, 255, 255, 255, 255, 255, 142, 254, 254, 254, 127,
             ],
@@ -170,7 +170,7 @@ fn test_encode_freqs_fields_field_mask_overflow() {
     let mut cursor = Cursor::new(buf);
 
     let record = RSIndexResult::build_term()
-        .field_mask(u32::MAX as t_fieldMask + 1)
+        .field_mask(u32::MAX as FieldMask + 1)
         .build();
     let _res = FreqsFields::encode(&mut cursor, 0, &record);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
@@ -9,13 +9,13 @@
 
 use std::io::Cursor;
 
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
     full::{Full, FullWide},
     test_utils::{TermRecordCompare, TestTermRecord},
 };
+use rqe_core::FieldMask;
 
 #[test]
 fn test_encode_full() {
@@ -26,7 +26,7 @@ fn test_encode_full() {
         (
             10,
             5,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1u8, 2, 3, 4],
             vec![48, 10, 5, 255, 255, 255, 255, 4, 1, 2, 3, 4],
         ),
@@ -55,7 +55,7 @@ fn test_encode_full() {
         (
             u32::MAX,
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1; 100],
             vec![
                 63, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 100, 1, 1, 1, 1, 1,
@@ -104,7 +104,7 @@ fn test_encode_full_wide() {
         (
             10,
             5,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1u8, 2, 3, 4],
             vec![0, 10, 5, 4, 142, 254, 254, 254, 127, 1, 2, 3, 4],
         ),
@@ -135,7 +135,7 @@ fn test_encode_full_wide() {
         (
             u32::MAX as u32,
             u32::MAX,
-            u32::MAX as t_fieldMask,
+            u32::MAX as FieldMask,
             vec![1; 100],
             vec![
                 15, 255, 255, 255, 255, 255, 255, 255, 255, 100, 142, 254, 254, 254, 127, 1, 1, 1,
@@ -196,7 +196,7 @@ fn test_encode_full_field_mask_overflow() {
     let buf = [0u8; 100];
     let mut cursor = Cursor::new(buf);
 
-    let record = TestTermRecord::new(10, u32::MAX as t_fieldMask + 1, 1, &[1]);
+    let record = TestTermRecord::new(10, u32::MAX as FieldMask + 1, 1, &[1]);
     let _res = Full::encode(&mut cursor, 0, &record.record);
 }
 

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/raw_doc_ids_only.rs
@@ -129,8 +129,9 @@ fn test_seek_raw_doc_ids_only() {
 #[test]
 #[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn test_inverted_index_raw_doc_ids_gc() {
-    use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+    use ffi::IndexFlags_Index_DocIdsOnly;
     use inverted_index::{IndexBlock, IndexReader, InvertedIndex, raw_doc_ids_only::RawDocIdsOnly};
+    use rqe_core::DocId;
 
     let mut ii = InvertedIndex::<RawDocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
 
@@ -222,7 +223,7 @@ fn test_inverted_index_raw_doc_ids_gc() {
     for i in 0..100 {
         ii.add_record(
             &RSIndexResult::build_virt()
-                .doc_id(i * (u32::MAX as t_docId))
+                .doc_id(i * (u32::MAX as DocId))
                 .build(),
         )
         .unwrap();
@@ -233,7 +234,7 @@ fn test_inverted_index_raw_doc_ids_gc() {
     // GC every second entry (causes large deltas after GC)
     let delta = ii
         .scan_gc(
-            |doc_id| doc_id % (u32::MAX as t_docId * 2) == 0,
+            |doc_id| doc_id % (u32::MAX as DocId * 2) == 0,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
         .expect("scan_gc should not fail for valid index")
@@ -249,7 +250,7 @@ fn test_inverted_index_raw_doc_ids_gc() {
         let mut result = RSIndexResult::build_virt().build();
 
         for i in 0..50 {
-            let target_id = i * (u32::MAX as t_docId * 2);
+            let target_id = i * (u32::MAX as DocId * 2);
             let found = reader.seek_record(target_id, &mut result).unwrap();
             assert!(found, "expected to find doc_id {}", target_id);
             assert_eq!(result.doc_id, target_id);

--- a/src/redisearch_rs/inverted_index/tests/integration/index.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index.rs
@@ -7,9 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use inverted_index::{IndexBlock, IndexReader, InvertedIndex, doc_ids_only::DocIdsOnly};
+use rqe_core::DocId;
 
 #[test]
 #[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
@@ -125,7 +126,7 @@ fn test_inverted_index_usage() {
     for i in 0..1_002 {
         ii.add_record(
             &RSIndexResult::build_virt()
-                .doc_id(i * (u32::MAX as t_docId))
+                .doc_id(i * (u32::MAX as DocId))
                 .build(),
         )
         .unwrap();
@@ -136,7 +137,7 @@ fn test_inverted_index_usage() {
 
     let delta = ii
         .scan_gc(
-            |doc_id| doc_id % (u32::MAX as t_docId * 2) == 0,
+            |doc_id| doc_id % (u32::MAX as DocId * 2) == 0,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
         .unwrap()
@@ -159,7 +160,7 @@ fn test_inverted_index_usage() {
             let found = reader.next_record(&mut result).unwrap();
 
             assert!(found);
-            assert_eq!(result.doc_id, i * (u32::MAX as t_docId * 2));
+            assert_eq!(result.doc_id, i * (u32::MAX as DocId * 2));
         }
 
         assert!(!reader.next_record(&mut result).unwrap(), "no more records");

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -7,12 +7,12 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::RS_FIELDMASK_ALL;
 use index_result::{
     MetricsVec, RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSResultKind,
     RSResultKindMask,
 };
 use query_term::RSQueryTerm;
+use rqe_core::RS_FIELDMASK_ALL;
 
 #[test]
 fn pushing_to_aggregate_result() {

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 buffer.workspace = true
 criterion.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
 query_term.workspace = true

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -10,7 +10,6 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
@@ -18,6 +17,7 @@ use inverted_index::{
     test_utils::TestTermRecord,
 };
 use itertools::Itertools;
+use rqe_core::FieldMask;
 
 pub struct Bencher {
     test_values: Vec<TestValue>,
@@ -27,7 +27,7 @@ pub struct Bencher {
 #[derive(Debug)]
 struct TestValue {
     delta: u32,
-    field_mask: t_fieldMask,
+    field_mask: FieldMask,
     term_offsets: Vec<u8>,
 
     encoded: Vec<u8>,
@@ -46,11 +46,11 @@ impl Bencher {
 
     fn new(wide: bool) -> Self {
         let deltas = vec![0, u32::MAX];
-        let mut field_masks_values = vec![0, 10, 100, 1_000, 10_000, u32::MAX as t_fieldMask - 1];
+        let mut field_masks_values = vec![0, 10, 100, 1_000, 10_000, u32::MAX as FieldMask - 1];
         #[cfg(target_pointer_width = "64")]
         if wide {
             // Add a larger field mask for wide mode
-            field_masks_values.extend(vec![u32::MAX as t_fieldMask, u128::MAX]);
+            field_masks_values.extend(vec![u32::MAX as FieldMask, u128::MAX]);
         }
         let term_offsets_values = vec![
             vec![0],

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
@@ -10,13 +10,13 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
     fields_only::{FieldsOnly, FieldsOnlyWide},
 };
 use itertools::Itertools;
+use rqe_core::FieldMask;
 
 pub struct Bencher {
     test_values: Vec<TestValue>,
@@ -26,7 +26,7 @@ pub struct Bencher {
 #[derive(Debug)]
 struct TestValue {
     delta: u32,
-    field_mask: t_fieldMask,
+    field_mask: FieldMask,
 
     encoded: Vec<u8>,
 }
@@ -48,7 +48,7 @@ impl Bencher {
         #[cfg(target_pointer_width = "64")]
         if wide {
             // Add a larger field mask for wide mode
-            field_masks_values.extend(vec![u32::MAX as t_fieldMask, u128::MAX as t_fieldMask]);
+            field_masks_values.extend(vec![u32::MAX as FieldMask, u128::MAX as FieldMask]);
         }
 
         let test_values = deltas

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
@@ -10,13 +10,13 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
     freqs_fields::{FreqsFields, FreqsFieldsWide},
 };
 use itertools::Itertools;
+use rqe_core::FieldMask;
 
 pub struct Bencher {
     test_values: Vec<TestValue>,
@@ -27,7 +27,7 @@ pub struct Bencher {
 struct TestValue {
     delta: u32,
     freq: u32,
-    field_mask: t_fieldMask,
+    field_mask: FieldMask,
 
     encoded: Vec<u8>,
 }
@@ -46,13 +46,12 @@ impl Bencher {
     fn new(wide: bool) -> Self {
         let freq_values = vec![0, 2, 256, u16::MAX as u32, u32::MAX];
         let deltas = vec![0, 1, 256, 65536, u16::MAX as u32, u32::MAX];
-        let mut field_masks_values =
-            vec![0, 1, 10, 100, 1_000, 10_000, u32::MAX as t_fieldMask - 1];
+        let mut field_masks_values = vec![0, 1, 10, 100, 1_000, 10_000, u32::MAX as FieldMask - 1];
         // field mask larger than 32 bits are only supported on 64-bit systems
         #[cfg(target_pointer_width = "64")]
         if wide {
             // Add a larger field mask for wide mode
-            field_masks_values.extend(vec![u32::MAX as t_fieldMask, u128::MAX]);
+            field_masks_values.extend(vec![u32::MAX as FieldMask, u128::MAX]);
         }
 
         let test_values = freq_values

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
@@ -10,7 +10,6 @@
 use std::{hint::black_box, io::Cursor, vec};
 
 use criterion::{BatchSize, Criterion};
-use ffi::t_fieldMask;
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder,
@@ -18,6 +17,7 @@ use inverted_index::{
     test_utils::TestTermRecord,
 };
 use itertools::Itertools;
+use rqe_core::FieldMask;
 
 pub struct Bencher {
     test_values: Vec<TestValue>,
@@ -28,7 +28,7 @@ pub struct Bencher {
 struct TestValue {
     delta: u32,
     freq: u32,
-    field_mask: t_fieldMask,
+    field_mask: FieldMask,
     term_offsets: Vec<u8>,
 
     encoded: Vec<u8>,
@@ -48,11 +48,11 @@ impl Bencher {
     fn new(wide: bool) -> Self {
         let freq_values = vec![0, u32::MAX];
         let deltas = vec![0, u32::MAX];
-        let mut field_masks_values = vec![0, 10, 100, 1_000, 10_000, u32::MAX as t_fieldMask - 1];
+        let mut field_masks_values = vec![0, 10, 100, 1_000, 10_000, u32::MAX as FieldMask - 1];
         #[cfg(target_pointer_width = "64")]
         if wide {
             // Add a larger field mask for wide mode
-            field_masks_values.extend(vec![u32::MAX as t_fieldMask, u128::MAX]);
+            field_masks_values.extend(vec![u32::MAX as FieldMask, u128::MAX]);
         }
         let term_offsets_values = vec![
             vec![0],

--- a/src/redisearch_rs/inverted_index_bencher/src/lib.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/lib.rs
@@ -13,6 +13,8 @@
     clippy::multiple_unsafe_ops_per_block
 )]
 
+use rqe_core::DocId;
+
 pub mod benchers;
 
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
@@ -27,6 +29,6 @@ pub extern "C" fn isWithinRadius(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn DocTable_Exists(_dt: *const ::ffi::DocTable, _d: ::ffi::t_docId) -> bool {
+pub extern "C" fn DocTable_Exists(_dt: *const ::ffi::DocTable, _d: DocId) -> bool {
     panic!("DocTable_Exists should not be called by any of the benchmarks");
 }

--- a/src/redisearch_rs/numeric_range_tree/Cargo.toml
+++ b/src/redisearch_rs/numeric_range_tree/Cargo.toml
@@ -24,6 +24,7 @@ build_utils = { path = "../build_utils" }
 [dependencies]
 cheadergen.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 hyperloglog.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -19,6 +19,7 @@ use inverted_index::{
     debug::Summary,
     numeric::{Numeric, NumericFloatCompression},
 };
+use rqe_core::DocId;
 
 /// Enum to hold either compressed or uncompressed numeric index.
 #[cheadergen::config(rename = "InvertedIndexNumeric")]
@@ -131,7 +132,7 @@ impl NumericIndex {
     /// Get the first document ID in a specific block.
     ///
     /// Returns `None` if the block index is out of bounds.
-    pub(crate) fn block_first_id(&self, block_idx: usize) -> Option<ffi::t_docId> {
+    pub(crate) fn block_first_id(&self, block_idx: usize) -> Option<DocId> {
         match self {
             NumericIndex::Uncompressed(idx) => idx.block_ref(block_idx).map(|b| b.first_block_id()),
             NumericIndex::Compressed(idx) => idx.block_ref(block_idx).map(|b| b.first_block_id()),
@@ -154,7 +155,7 @@ impl NumericIndex {
     /// Returns `Ok(Some(delta))` if GC is needed, `Ok(None)` otherwise.
     pub fn scan_gc<F>(
         &self,
-        doc_exist: impl Fn(ffi::t_docId) -> bool,
+        doc_exist: impl Fn(DocId) -> bool,
         repair_fn: Option<F>,
     ) -> std::io::Result<Option<inverted_index::GcScanDelta>>
     where
@@ -190,7 +191,7 @@ impl<'a> IndexReader<'a> for NumericIndexReader<'a> {
 
     fn seek_record(
         &mut self,
-        doc_id: ffi::t_docId,
+        doc_id: DocId,
         result: &mut RSIndexResult<'a>,
     ) -> std::io::Result<bool> {
         match self {
@@ -199,7 +200,7 @@ impl<'a> IndexReader<'a> for NumericIndexReader<'a> {
         }
     }
 
-    fn skip_to(&mut self, doc_id: ffi::t_docId) -> bool {
+    fn skip_to(&mut self, doc_id: DocId) -> bool {
         match self {
             Self::Uncompressed(r) => r.skip_to(doc_id),
             Self::Compressed(r) => r.skip_to(doc_id),

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -13,10 +13,10 @@
 //! document-value entries in an inverted index format. Ranges track their
 //! value bounds and estimate cardinality using HyperLogLog.
 
-use ffi::t_docId;
 use hyperloglog::{HyperLogLog6, WyHasher};
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use rqe_core::DocId;
 
 use crate::index::{NumericIndex, NumericIndexReader};
 
@@ -99,7 +99,7 @@ impl NumericRange {
     /// write created.
     ///
     /// [`AddRecordOutcome`]: inverted_index::AddRecordOutcome
-    pub fn add(&mut self, doc_id: t_docId, value: f64) -> inverted_index::AddRecordOutcome {
+    pub fn add(&mut self, doc_id: DocId, value: f64) -> inverted_index::AddRecordOutcome {
         self.hll.add(&value.into());
         self.add_without_cardinality(doc_id, value)
     }
@@ -118,7 +118,7 @@ impl NumericRange {
     ///   explicitly updates cardinality for each destination range.
     pub fn add_without_cardinality(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         value: f64,
     ) -> inverted_index::AddRecordOutcome {
         // Update bounds

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -13,6 +13,7 @@
 //! the normal insert/query hot paths. It handles applying GC deltas from
 //! child processes, trimming empty leaves, and compacting the node slab.
 
+use rqe_core::DocId;
 use std::collections::HashMap;
 
 use index_result::RSIndexResult;
@@ -75,7 +76,7 @@ impl NumericRangeNode {
     ///
     /// Returns `Some(NodeGcDelta)` if the node had GC work, `None` otherwise
     /// (either the node has no range, or no documents were deleted).
-    pub fn scan_gc(&self, doc_exists: &dyn Fn(ffi::t_docId) -> bool) -> Option<NodeGcDelta> {
+    pub fn scan_gc(&self, doc_exists: &dyn Fn(DocId) -> bool) -> Option<NodeGcDelta> {
         let range = self.range()?;
 
         // Pointer to the last block of the index. Used inside the repair

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -13,9 +13,9 @@
 //! descends to the appropriate leaf, inserts the entry, and may trigger
 //! splitting and AVL-like rebalancing on the way back up.
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use rqe_core::DocId;
 
 use super::{AddResult, CheckedCount, NumericRangeTree};
 use crate::arena::{NodeArena, NodeIndex};
@@ -58,7 +58,7 @@ impl NumericRangeTree {
     /// that are an ancestor of the node that stored the new value.
     pub fn add(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         value: f64,
         is_multivalued: bool,
         max_depth_range: usize,
@@ -84,7 +84,7 @@ impl NumericRangeTree {
 
     fn _add(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         value: f64,
         is_multivalued: bool,
         max_depth_range: usize,
@@ -158,7 +158,7 @@ impl NumericRangeTree {
     fn node_add(
         nodes: &mut NodeArena,
         node_idx: NodeIndex,
-        doc_id: t_docId,
+        doc_id: DocId,
         value: f64,
         depth: usize,
         max_depth_range: usize,

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use util::CheckedCount;
 
 pub use gc::{CompactIfSparseResult, NodeGcDelta, SingleNodeGcResult};
 
-use ffi::t_docId;
+use rqe_core::DocId;
 
 use crate::NumericRangeNode;
 use crate::arena::{NodeArena, NodeIndex};
@@ -151,7 +151,7 @@ pub struct NumericRangeTree {
     /// Aggregate statistics for the tree.
     stats: TreeStats,
     /// The last document ID added to the tree.
-    last_doc_id: t_docId,
+    last_doc_id: DocId,
     /// Revision ID, incremented when the tree structure changes (splits/rotations).
     ///
     /// When `revision_id != 0`, it indicates the tree nodes have changed and
@@ -266,7 +266,7 @@ impl NumericRangeTree {
     }
 
     /// Get the last document ID added to the tree.
-    pub const fn last_doc_id(&self) -> t_docId {
+    pub const fn last_doc_id(&self) -> DocId {
         self.last_doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -16,6 +16,7 @@ build_utils = { path = "../build_utils" }
 [dependencies]
 cheadergen.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 geo.workspace = true
 rqe_iterator_type.workspace = true
 field.workspace = true

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -11,8 +11,9 @@
 use ffi::{
     IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND, IteratorStatus_ITERATOR_OK,
     IteratorStatus_ITERATOR_TIMEOUT, IteratorType, QueryIterator, ValidateStatus_VALIDATE_ABORTED,
-    ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK, t_docId,
+    ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK,
 };
+use rqe_core::DocId;
 
 use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, interop::RQEIteratorWrapper,
@@ -210,7 +211,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         let callback = self
             .SkipTo
@@ -295,7 +296,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         unsafe { callback(self.header.as_ptr()) }
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.lastDocId
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -9,9 +9,9 @@
 
 //! Supporting types for [`Empty`].
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -38,7 +38,7 @@ impl<'index> RQEIterator<'index> for Empty {
     #[inline(always)]
     fn skip_to(
         &mut self,
-        _doc_id: t_docId,
+        _doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         Ok(None)
     }
@@ -52,7 +52,7 @@ impl<'index> RQEIterator<'index> for Empty {
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         0
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
@@ -13,9 +13,10 @@
 
 use std::ptr::NonNull;
 
-use ffi::{IndexFlags_Index_WideSchema, RS_INVALID_FIELD_INDEX, RedisSearchCtx};
+use ffi::{IndexFlags_Index_WideSchema, RedisSearchCtx};
 use field::{FieldFilterContext, FieldMaskOrIndex};
 use index_result::RSIndexResult;
+use rqe_core::RS_INVALID_FIELD_INDEX;
 
 /// Trait for checking if a document has expired.
 ///

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -9,9 +9,9 @@
 
 //! Supporting types for [`IdList`].
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 use std::cmp::Ordering;
 
 use crate::{
@@ -30,7 +30,7 @@ pub type IdListUnsorted<'index> = IdList<'index, false>;
 pub struct IdList<'index, const SORTED: bool> {
     /// The list of document IDs to iterate over.
     /// There must be no duplicates. The list must be sorted if `SORTED` is set to `true`.
-    ids: OwnedSlice<t_docId>,
+    ids: OwnedSlice<DocId>,
     /// The current position of the iterator (a.k.a the next document ID to return by [`read`](RQEIterator::read)).
     /// When `offset` is equal to the length of `ids`, the iterator is at EOF.
     offset: usize,
@@ -44,7 +44,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// The list of document IDs cannot contain duplicates.
     /// If `SORTED` is set to `true`, the list must be sorted.
     #[inline(always)]
-    pub fn new(ids: impl Into<OwnedSlice<t_docId>>) -> Self {
+    pub fn new(ids: impl Into<OwnedSlice<DocId>>) -> Self {
         Self::with_result(ids, RSIndexResult::build_virt().build())
     }
 
@@ -59,7 +59,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
 
     /// Same as [`IdList::new`] but with a custom [`RSIndexResult`],
     /// useful when wrapping this iterator and requiring a non-virtual result.
-    pub fn with_result(ids: impl Into<OwnedSlice<t_docId>>, result: RSIndexResult<'index>) -> Self {
+    pub fn with_result(ids: impl Into<OwnedSlice<DocId>>, result: RSIndexResult<'index>) -> Self {
         let ids = ids.into();
 
         if SORTED {
@@ -79,7 +79,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
 
 impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     #[inline(always)]
-    fn get_current(&self) -> Option<t_docId> {
+    fn get_current(&self) -> Option<DocId> {
         self.ids.get(self.offset).copied()
     }
 
@@ -105,7 +105,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// Returns `Some(true)` if there is a document with the given ID in the list.
     /// Returns `Some(false)` if there is no document with the given ID in the list.
     /// Returns `None` if the iterator has been advanced past the end of the ID list.
-    pub(super) fn _skip_to(&mut self, target_id: t_docId) -> Option<bool> {
+    pub(super) fn _skip_to(&mut self, target_id: DocId) -> Option<bool> {
         if !SORTED {
             panic!("Can't skip when working with unsorted document ids");
         }
@@ -153,7 +153,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
         // This assumption might have to be re-evaluated in the future.
         let mut i = 0usize;
         let mut undershot = false;
-        let mut current_id: t_docId = 0;
+        let mut current_id: DocId = 0;
 
         while bottom < top {
             i = (bottom + top) >> 1;
@@ -210,7 +210,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         Ok(self._skip_to(doc_id).map(|found| {
             if found {
@@ -233,7 +233,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -11,9 +11,9 @@ use ffi::{
     IteratorStatus, IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND,
     IteratorStatus_ITERATOR_OK, IteratorStatus_ITERATOR_TIMEOUT, QueryIterator, ValidateStatus,
     ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK,
-    t_docId,
 };
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, profile_print::ProfilePrint,
@@ -250,7 +250,7 @@ extern "C" fn read<'index, I: RQEIterator<'index> + 'index>(
 
 extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
-    doc_id: t_docId,
+    doc_id: DocId,
 ) -> IteratorStatus {
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -18,9 +18,9 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
 ///
@@ -36,7 +36,7 @@ pub struct Intersection<'index, I> {
     /// Child iterators, sorted by estimated count (smallest first) unless `in_order` is set.
     children: Vec<I>,
     /// Last doc_id successfully found in ALL children (returned by [`last_doc_id()`](Self::last_doc_id)).
-    last_doc_id: t_docId,
+    last_doc_id: DocId,
     num_expected: usize,
     is_eof: bool,
     /// Maximum allowed slop (distance) between term positions. `None` disables proximity
@@ -53,7 +53,7 @@ enum AgreeResult {
     /// All children have the target doc_id as their current position.
     Agreed,
     /// A child skipped past the target to a higher doc_id; consensus must restart from this new ID.
-    Ahead(t_docId),
+    Ahead(DocId),
     /// A child reached EOF; no more documents can match.
     Eof,
 }
@@ -209,8 +209,8 @@ where
     /// child and retries until a relevant result is found or EOF is reached.
     fn find_consensus_with_relevancy_check(
         &mut self,
-        mut target: t_docId,
-    ) -> Result<Option<t_docId>, RQEIteratorError> {
+        mut target: DocId,
+    ) -> Result<Option<DocId>, RQEIteratorError> {
         loop {
             match self.find_consensus(target)? {
                 Some(doc_id) => {
@@ -231,7 +231,7 @@ where
     }
 
     /// Reads from the first child. Returns the doc_id or None if EOF.
-    fn read_from_first_child(&mut self) -> Result<Option<t_docId>, RQEIteratorError> {
+    fn read_from_first_child(&mut self) -> Result<Option<DocId>, RQEIteratorError> {
         match self.children[0].read()? {
             Some(r) => Ok(Some(r.doc_id)),
             None => {
@@ -242,7 +242,7 @@ where
     }
 
     /// Tries to get all children to agree on the target doc_id.
-    fn agree_on_doc_id(&mut self, target: t_docId) -> Result<AgreeResult, RQEIteratorError> {
+    fn agree_on_doc_id(&mut self, target: DocId) -> Result<AgreeResult, RQEIteratorError> {
         for child in &mut self.children {
             // Use child's cached last_doc_id instead of maintaining a parallel array
             if child.last_doc_id() == target {
@@ -266,7 +266,7 @@ where
     }
 
     /// Loops until all children agree on a doc_id, or EOF is reached.
-    fn find_consensus(&mut self, mut target: t_docId) -> Result<Option<t_docId>, RQEIteratorError> {
+    fn find_consensus(&mut self, mut target: DocId) -> Result<Option<DocId>, RQEIteratorError> {
         loop {
             match self.agree_on_doc_id(target)? {
                 AgreeResult::Agreed => return Ok(Some(target)),
@@ -299,7 +299,7 @@ where
     /// - Store owned copies instead of borrowed references (memory/perf tradeoff)
     /// - Restructure [`RSAggregateResult`](index_result::RSAggregateResult) to not require `'index` on stored references
     /// - Use a different aggregate pattern that doesn't store child references
-    fn build_aggregate_result(&mut self, doc_id: t_docId) {
+    fn build_aggregate_result(&mut self, doc_id: DocId) {
         // Reset all per-document accumulating fields before building the new aggregate.
         self.result.freq = 0;
         self.result.field_mask = 0;
@@ -442,7 +442,7 @@ where
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         if self.is_eof {
             return Ok(None);
@@ -510,7 +510,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.last_doc_id
     }
 
@@ -524,7 +524,7 @@ where
         spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         let mut any_child_moved = false;
-        let mut max_child_doc_id: t_docId = 0;
+        let mut max_child_doc_id: DocId = 0;
         let mut moved_to_eof = false;
 
         for child in &mut self.children {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -7,10 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::IndexReader;
+use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -32,7 +32,7 @@ pub struct InvIndIterator<'index, R, E = NoOpChecker> {
     /// if we reached the end of the index.
     at_eos: bool,
     /// the last document ID read by the iterator.
-    last_doc_id: t_docId,
+    last_doc_id: DocId,
     /// A reusable result object to avoid allocations on each `read` call.
     pub(super) result: RSIndexResult<'index>,
 
@@ -45,7 +45,7 @@ pub struct InvIndIterator<'index, R, E = NoOpChecker> {
     read_impl: fn(&mut Self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError>,
     /// The implementation of the [`skip_to`](RQEIterator::skip_to) method.
     skip_to_impl:
-        fn(&mut Self, t_docId) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError>,
+        fn(&mut Self, DocId) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError>,
 }
 
 impl<'index, R, E> InvIndIterator<'index, R, E>
@@ -174,7 +174,7 @@ where
     // SkipTo implementation that uses a seeker to find the next valid docId, no additional filtering.
     fn skip_to_default(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         if self.at_eos {
             return Ok(None);
@@ -200,7 +200,7 @@ where
     // SkipTo implementation that uses a seeker and checks for field expiration.
     fn skip_to_check_expiration(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         if self.at_eos {
             return Ok(None);
@@ -261,7 +261,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         // cannot be called with an id smaller than the last one returned by the iterator, see
         // [`RQEIterator::skip_to`].
@@ -280,7 +280,7 @@ where
         self.reader.unique_docs() as usize
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.last_doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -12,10 +12,11 @@ use std::{
     ptr::NonNull,
 };
 
-use ffi::{RedisSearchCtx, t_docId, t_fieldIndex};
+use ffi::RedisSearchCtx;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
+use rqe_core::{DocId, FieldIndex, RS_FIELDMASK_ALL};
 
 use crate::{
     ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
@@ -42,7 +43,7 @@ use super::InvIndIterator;
 /// * `C` - The expiration checker type.
 pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
     it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
-    field_index: t_fieldIndex,
+    field_index: FieldIndex,
     /// Owned copy of the field name, extracted from the spec at construction
     /// time. Owning the string means the iterator no longer borrows from
     /// `spec.fields`, therefore `context`/`spec` only need to be valid at
@@ -74,7 +75,7 @@ where
     pub unsafe fn new(
         reader: IndexReaderCore<'index, E>,
         context: NonNull<RedisSearchCtx>,
-        field_index: t_fieldIndex,
+        field_index: FieldIndex,
         expiration_checker: C,
     ) -> Self {
         debug_assert!(
@@ -84,7 +85,7 @@ where
         );
         let result = RSIndexResult::build_virt()
             .weight(0.0)
-            .field_mask(ffi::RS_FIELDMASK_ALL)
+            .field_mask(RS_FIELDMASK_ALL)
             .frequency(1)
             .build();
 
@@ -190,7 +191,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.it.skip_to(doc_id)
     }
@@ -206,7 +207,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.it.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -15,13 +15,14 @@ use crate::{
     expiration_checker::{ExpirationChecker, NoOpChecker},
     profile_print::{ProfilePrint, ProfilePrintCtx, format_g},
 };
-use ffi::{FieldType_INDEXFLD_T_GEO, FieldType_INDEXFLD_T_NUMERIC, IndexFlags, t_docId};
+use ffi::{FieldType_INDEXFLD_T_GEO, FieldType_INDEXFLD_T_NUMERIC, IndexFlags};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
+use rqe_core::DocId;
 
 use super::core::InvIndIterator;
 
@@ -158,7 +159,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.it.skip_to(doc_id)
     }
@@ -174,7 +175,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.it.last_doc_id()
     }
 
@@ -472,7 +473,7 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         match self {
             Self::Unfiltered(iter) => iter.skip_to(doc_id),
@@ -500,7 +501,7 @@ impl<'index> RQEIterator<'index> for NumericIteratorVariant<'index> {
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         match self {
             Self::Unfiltered(iter) => iter.last_doc_id(),
             Self::Filtered(iter) => iter.last_doc_id(),

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -9,13 +9,14 @@
 
 use std::ptr::NonNull;
 
-use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, TagIndex, t_docId};
+use ffi::{RedisSearchCtx, TagIndex};
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, opaque::OpaqueEncoding,
 };
 use query_term::RSQueryTerm;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
     ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
@@ -203,7 +204,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.it.skip_to(doc_id)
     }
@@ -219,7 +220,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.it.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -9,11 +9,12 @@
 
 use std::ptr::NonNull;
 
-use ffi::{RS_FIELDMASK_ALL, RedisSearchCtx, t_docId};
+use ffi::RedisSearchCtx;
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::TermReader;
 use query_term::RSQueryTerm;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -186,7 +187,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.it.skip_to(doc_id)
     }
@@ -202,7 +203,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.it.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -7,10 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
+use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -19,6 +19,7 @@ use crate::{
 };
 
 use super::core::InvIndIterator;
+use rqe_core::RS_FIELDMASK_ALL;
 
 /// An iterator over all existing documents in an index.
 ///
@@ -48,8 +49,6 @@ where
     ///
     /// `weight` is the score weight applied to every returned result.
     pub fn new(reader: IndexReaderCore<'index, E>, weight: f64) -> Self {
-        use ffi::RS_FIELDMASK_ALL;
-
         let result = RSIndexResult::build_virt()
             .weight(weight)
             .field_mask(RS_FIELDMASK_ALL)
@@ -115,7 +114,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.it.skip_to(doc_id)
     }
@@ -131,7 +130,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.it.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -19,8 +19,8 @@ unsafe extern "C" fn AREQ_CheckTimedOut(_areq: *mut ffi::AREQ) -> bool {
 
 use std::sync::OnceLock;
 
-use ffi::t_docId;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::{DocId, FieldIndex};
 use thiserror::Error;
 
 use ::inverted_index::FieldMask;
@@ -142,7 +142,7 @@ pub trait RQEIterator<'index> {
     /// if the iterator found a result greater than `docId`. `None` will be returned if the iterator has reached the end of the index.
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError>;
 
     /// Called when the iterator is being revalidated after a concurrent index change.
@@ -168,7 +168,7 @@ pub trait RQEIterator<'index> {
     /**************** properties ****************/
 
     /// Returns the last doc id that was read or skipped to.
-    fn last_doc_id(&self) -> t_docId;
+    fn last_doc_id(&self) -> DocId;
 
     /// Returns `false` if the iterator can yield more results.
     /// The iterator implementation must ensure that [`at_eof`](Self::at_eof) returns `true`
@@ -212,7 +212,7 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         (**self).skip_to(doc_id)
     }
@@ -232,7 +232,7 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
         (**self).num_estimated()
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         (**self).last_doc_id()
     }
 
@@ -269,7 +269,7 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         (**self).skip_to(doc_id)
     }
@@ -289,7 +289,7 @@ impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
         (**self).num_estimated()
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         (**self).last_doc_id()
     }
 
@@ -361,7 +361,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
         &self,
         index: &'index mut ffi::RedisSearchDiskIndexSpec,
         token: &ffi::RSToken,
-        field_index: ffi::t_fieldIndex,
+        field_index: FieldIndex,
         weight: f64,
     ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>>;
 }

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -9,9 +9,9 @@
 
 //! Helper wrapping either [`Empty`] or the provided [`RQEIterator`].
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty,
@@ -109,7 +109,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         match &mut self.0 {
             MaybeEmptyOption::None(empty) => empty.skip_to(doc_id),
@@ -145,7 +145,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         match &self.0 {
             MaybeEmptyOption::None(empty) => empty.last_doc_id(),
             MaybeEmptyOption::Some(it) => it.last_doc_id(),

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -15,9 +15,10 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
 };
-use ffi::{RLookupKey, RLookupKeyHandle, t_docId};
+use ffi::{RLookupKey, RLookupKeyHandle};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 
 /// The different types of metrics.
 /// At the moment, only vector distance is supported.
@@ -84,10 +85,7 @@ fn set_result_metrics(result: &mut RSIndexResult, val: f64, key: *mut RLookupKey
 }
 
 impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
-    pub fn new(
-        ids: impl Into<OwnedSlice<t_docId>>,
-        metric_data: impl Into<OwnedSlice<f64>>,
-    ) -> Self {
+    pub fn new(ids: impl Into<OwnedSlice<DocId>>, metric_data: impl Into<OwnedSlice<f64>>) -> Self {
         let ids = ids.into();
         let metric_data = metric_data.into();
 
@@ -147,7 +145,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         let Some(found) = self.base._skip_to(doc_id) else {
             return Ok(None);
@@ -178,7 +176,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.base.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -9,7 +9,6 @@
 
 //! Supporting types for [`Not`].
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 
 use crate::{
@@ -20,6 +19,7 @@ use crate::{
 };
 
 use index_spec::IndexSpecReadGuard;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// An iterator that negates the results of its child iterator.
 ///
 /// Yields all document IDs from 1 to `max_doc_id` (inclusive) that are **not**
@@ -35,7 +35,7 @@ pub struct Not<'index, I, TC> {
     /// The child iterator whose results are negated.
     child: MaybeEmpty<I>,
     /// The maximum document ID to iterate up to (inclusive).
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     /// Set to `true` in case the NOT Iterator
     /// detected using the [`TimeoutContext`] a timeout,
     /// and reset to `false` at [`RQEIterator::rewind`].
@@ -61,7 +61,7 @@ where
     /// `timeout_ctx` is the [`TimeoutContext`] implementation to use. Pass
     /// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
     /// entirely on this iterator's hot path.
-    pub fn new(child: I, max_doc_id: t_docId, weight: f64, timeout_ctx: TC) -> Self {
+    pub fn new(child: I, max_doc_id: DocId, weight: f64, timeout_ctx: TC) -> Self {
         Self {
             child: MaybeEmpty::new(child),
             max_doc_id,
@@ -146,7 +146,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         debug_assert!(self.last_doc_id() < doc_id);
 
@@ -212,7 +212,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -9,7 +9,6 @@
 
 //! Supporting types for [`NotOptimized`].
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 
 use crate::{
@@ -20,6 +19,7 @@ use crate::{
     utils::TimeoutContext,
 };
 use index_spec::IndexSpecReadGuard;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 /// An optimized NOT iterator that uses a wildcard inverted index iterator.
 ///
@@ -46,7 +46,7 @@ pub struct NotOptimized<'index, W, I, TC> {
     /// The child iterator whose results are negated.
     child: MaybeEmpty<I>,
     /// The maximum document ID (used as upper bound guard).
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     /// Sticky EOF flag, set when iteration completes.
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
@@ -72,7 +72,7 @@ where
     /// `timeout_ctx` is the [`TimeoutContext`] implementation to use; pass
     /// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
     /// entirely.
-    pub fn new(wcii: W, child: I, max_doc_id: t_docId, weight: f64, timeout_ctx: TC) -> Self {
+    pub fn new(wcii: W, child: I, max_doc_id: DocId, weight: f64, timeout_ctx: TC) -> Self {
         Self {
             wcii,
             child: MaybeEmpty::new(child),
@@ -115,7 +115,7 @@ where
     /// (already advanced beyond it) or fully exhausted, meaning `doc_id`
     /// cannot be in the child without performing additional reads.
     #[inline(always)]
-    fn child_is_ahead_or_depleted(&self, doc_id: t_docId) -> bool {
+    fn child_is_ahead_or_depleted(&self, doc_id: DocId) -> bool {
         doc_id < self.child.last_doc_id()
             || (self.child.at_eof() && doc_id > self.child.last_doc_id())
     }
@@ -195,7 +195,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         debug_assert!(self.last_doc_id() < doc_id);
 
@@ -253,7 +253,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
@@ -12,7 +12,7 @@
 
 use std::ptr::NonNull;
 
-use ffi::t_docId;
+use rqe_core::DocId;
 
 use crate::{
     Empty, IteratorType, NewWildcardIterator, RQEIterator,
@@ -134,7 +134,7 @@ pub enum NewNotIterator<'index, I, TC> {
 ///    empty).
 pub unsafe fn new_not_iterator<'index, I, TC>(
     child: I,
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     weight: f64,
     timeout_ctx: TC,
     query: NonNull<ffi::QueryEvalCtx>,

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -9,7 +9,6 @@
 
 //! Supporting types for [`Optional`].
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 use std::cmp;
 
@@ -18,6 +17,7 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 use index_spec::IndexSpecReadGuard;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 /// An iterator that emits a sequence of results with no gaps, up to a given document id.
 /// Results are pulled from an underlying [`RQEIterator`] instance. If there is no entry
@@ -27,7 +27,7 @@ pub struct Optional<'index, I> {
     /// Reads from the [`Optional::child`] beyond this bound are ignored.
     /// If the [`Optional::child`] ends before this bound, this [`Optional`] iterator yields virtual
     /// results with no [`Optional::weight`] applied until [`Optional::max_doc_id`] is reached.
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
 
     /// Weight applied to results produced by the inner [`Optional::child`] iterator.
     /// This weight is not applied to virtual results.
@@ -64,7 +64,7 @@ where
     ///   child [`RQEIterator`]. When the child is exhausted, the iterator
     ///   yields virtual [`RSIndexResult`] values without weight until `max_id` is reached.
     /// * `child` [`RQEIterator`] used and wrapped around by this [`Optional`] iterator
-    pub fn new(max_id: t_docId, weight: f64, child: I) -> Self {
+    pub fn new(max_id: DocId, weight: f64, child: I) -> Self {
         Self {
             max_doc_id: max_id,
             weight,
@@ -139,7 +139,7 @@ where
     /// Otherwise, return a virtual hit.
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         debug_assert!(doc_id > self.result.doc_id);
 
@@ -217,7 +217,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -14,7 +14,6 @@
 //! `spec.existingDocs` to visit only real document IDs, yielding real or virtual
 //! results accordingly.
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 
 use crate::{
@@ -25,6 +24,7 @@ use crate::{
 };
 
 use index_spec::IndexSpecReadGuard;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// An iterator that emits results for all document IDs present in the index,
 /// driven by a [wildcard iterator](crate::wildcard) over the existing-documents inverted index.
 ///
@@ -46,14 +46,14 @@ pub struct OptionalOptimized<'index, W, I> {
     /// Virtual result returned when `wcii` has a doc but `child` does not.
     virt: RSIndexResult<'index>,
     /// Inclusive upper bound (matches C `maxDocId`).
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     /// Weight applied to real results from `child`.
     weight: f64,
     /// Tracks the doc ID of the last result yielded.
     ///
     /// `0` in the initial state and after [`rewind`](RQEIterator::rewind),
     /// which is treated as virtual. Doc IDs start from 1, so 0 is a safe sentinel.
-    last_doc_id: t_docId,
+    last_doc_id: DocId,
     /// Whether the iterator has reached EOF.
     at_eof: bool,
 }
@@ -80,7 +80,7 @@ where
     /// * `child` — query child iterator that provides real hits.
     /// * `max_doc_id` — inclusive upper bound on doc IDs.
     /// * `weight` — applied to results produced by `child`.
-    pub fn new(wcii: W, child: I, max_doc_id: t_docId, weight: f64) -> Self {
+    pub fn new(wcii: W, child: I, max_doc_id: DocId, weight: f64) -> Self {
         Self {
             wcii,
             child: MaybeEmpty::new(child),
@@ -160,7 +160,7 @@ where
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         debug_assert!(doc_id > self.last_doc_id);
 
@@ -324,7 +324,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.last_doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
@@ -12,7 +12,8 @@
 
 use std::ptr::NonNull;
 
-use ffi::{IteratorType, t_docId};
+use ffi::IteratorType;
+use rqe_core::DocId;
 
 use crate::{
     NewWildcardIterator, RQEIterator,
@@ -60,7 +61,7 @@ pub unsafe fn new_optional_iterator<'index, I>(
     mut child: I,
     weight: f64,
     query: NonNull<ffi::QueryEvalCtx>,
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
 ) -> NewOptionalIterator<'index, I>
 where
     I: RQEIterator<'index> + 'index,

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -16,9 +16,9 @@
 use std::time::{Duration, Instant};
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 
 /// Profile counters collected during query execution.
 ///
@@ -116,7 +116,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         let start = Instant::now();
         let result = self.child.skip_to(doc_id);
@@ -137,7 +137,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for Profile<'index, I> 
         self.child.num_estimated()
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.child.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -9,8 +9,8 @@
 
 //! Flat array variant of the union iterator with O(n) min-finding.
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use index_spec::IndexSpecReadGuard;
@@ -153,9 +153,9 @@ where
     /// Advances all active children whose `last_doc_id` equals `current_id` and finds the
     /// minimum doc_id in a single pass.
     ///
-    /// Returns the minimum doc_id among active children, or `t_docId::MAX` if all are exhausted.
-    fn advance_and_find_min(&mut self, current_id: t_docId) -> Result<t_docId, RQEIteratorError> {
-        let mut min_id: t_docId = t_docId::MAX;
+    /// Returns the minimum doc_id among active children, or `DocId::MAX` if all are exhausted.
+    fn advance_and_find_min(&mut self, current_id: DocId) -> Result<DocId, RQEIteratorError> {
+        let mut min_id: DocId = DocId::MAX;
         let mut i = 0;
 
         while i < self.num_active {
@@ -198,7 +198,7 @@ where
 
     /// Builds the result from active children whose `last_doc_id` equals `min_id`.
     /// Only used in Full mode - aggregates ALL matching children.
-    fn build_aggregate_result(&mut self, min_id: t_docId) {
+    fn build_aggregate_result(&mut self, min_id: DocId) {
         self.result.reset_aggregate();
         self.result.doc_id = min_id;
 
@@ -220,9 +220,9 @@ where
 
     /// Performs initial read on all children to position them at their first document.
     /// Removes any children that are immediately exhausted (empty iterators).
-    /// Returns the minimum doc_id among active children, or `t_docId::MAX` if all are exhausted.
-    fn initialize_children(&mut self) -> Result<t_docId, RQEIteratorError> {
-        let mut min_id: t_docId = t_docId::MAX;
+    /// Returns the minimum doc_id among active children, or `DocId::MAX` if all are exhausted.
+    fn initialize_children(&mut self) -> Result<DocId, RQEIteratorError> {
+        let mut min_id: DocId = DocId::MAX;
         let mut i = 0;
         while i < self.num_active {
             let child = &mut self.children[i];
@@ -259,7 +259,7 @@ where
             self.advance_and_find_min(self.last_doc_id())?
         };
 
-        if min_id == t_docId::MAX {
+        if min_id == DocId::MAX {
             self.is_eof = true;
             return Ok(None);
         }
@@ -285,9 +285,9 @@ where
     /// This avoids a second pass when the target is found (matching C's `UI_Skip_Full_Flat`).
     fn skip_to_full(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
-        let mut min_id: t_docId = t_docId::MAX;
+        let mut min_id: DocId = DocId::MAX;
         let mut i = 0;
 
         // Reset aggregate before potentially adding children during the loop
@@ -334,7 +334,7 @@ where
             i += 1;
         }
 
-        if min_id == t_docId::MAX {
+        if min_id == DocId::MAX {
             self.is_eof = true;
             return Ok(None);
         }
@@ -353,10 +353,10 @@ where
     /// Tracks minimum doc_id among non-matches for NotFound case.
     fn skip_to_quick(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         // Use MAX as sentinel like C uses DOCID_MAX - avoids Option overhead
-        let mut min_id: t_docId = t_docId::MAX;
+        let mut min_id: DocId = DocId::MAX;
         let mut min_child_idx: usize = 0;
         let mut i = 0;
 
@@ -402,7 +402,7 @@ where
         }
 
         // No exact match found - use minimum if available
-        if min_id != t_docId::MAX {
+        if min_id != DocId::MAX {
             self.quick_set_from_child(min_child_idx);
             Ok(Some(SkipToOutcome::NotFound(&mut self.result)))
         } else {
@@ -466,7 +466,7 @@ where
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         if self.is_eof {
             return Ok(None);
@@ -497,7 +497,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 
@@ -555,7 +555,7 @@ where
         // Sync num_active and find minimum doc_id.
         // Use swap_remove_child to move EOF children out of the active region.
         self.num_active = self.children.len();
-        let mut min_doc_id: t_docId = t_docId::MAX;
+        let mut min_doc_id: DocId = DocId::MAX;
         let mut min_child_idx: usize = 0;
         let mut i = 0;
         while i < self.num_active {

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -9,8 +9,8 @@
 
 //! Heap variant of the union iterator with O(log n) min-finding.
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 use crate::utils::DocIdMinHeap;
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
@@ -126,7 +126,7 @@ where
     }
 
     /// Advances children at the heap root whose `last_doc_id` equals `current_id`.
-    fn advance_matching_children(&mut self, current_id: t_docId) -> Result<(), RQEIteratorError> {
+    fn advance_matching_children(&mut self, current_id: DocId) -> Result<(), RQEIteratorError> {
         if self.heap.is_empty() {
             return Ok(());
         }
@@ -154,7 +154,7 @@ where
     ///
     /// Uses DFS over the heap array, pruning subtrees where `doc_id > min_id`
     /// (heap property guarantees all descendants are also `>= doc_id`).
-    fn build_aggregate_result(&mut self, min_id: t_docId) {
+    fn build_aggregate_result(&mut self, min_id: DocId) {
         self.result.reset_aggregate();
         self.result.doc_id = min_id;
 
@@ -230,7 +230,7 @@ where
     /// In `QUICK_EXIT` mode, returns the child index on an exact match,
     /// leaving remaining lagging children for the next call.
     /// Returns `usize::MAX` if no exact match was found.
-    fn advance_lagging_children(&mut self, doc_id: t_docId) -> Result<usize, RQEIteratorError> {
+    fn advance_lagging_children(&mut self, doc_id: DocId) -> Result<usize, RQEIteratorError> {
         if self.heap.is_empty() {
             return Ok(usize::MAX);
         }
@@ -268,7 +268,7 @@ where
     /// On the first call (heap empty), initializes the heap by skipping every
     /// child to the target. Otherwise delegates to [`Self::advance_lagging_children`].
     /// Returns a child index on early match, or `usize::MAX` if none.
-    fn advance_to(&mut self, doc_id: t_docId) -> Result<usize, RQEIteratorError> {
+    fn advance_to(&mut self, doc_id: DocId) -> Result<usize, RQEIteratorError> {
         if self.heap.is_empty() && self.last_doc_id() == 0 {
             for (idx, child) in self.children.iter_mut().enumerate() {
                 if child.at_eof() {
@@ -362,7 +362,7 @@ where
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         if self.is_eof {
             return Ok(None);
@@ -410,7 +410,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -23,8 +23,9 @@
 
 use std::ffi::c_char;
 
-use ffi::{QueryNodeType, t_docId};
+use ffi::QueryNodeType;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,
@@ -162,7 +163,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     #[inline(always)]
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         delegate_variant_ref_mut!(self, skip_to, doc_id)
     }
@@ -186,7 +187,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for UnionOpaque<'index,
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         delegate_variant_ref!(self, last_doc_id)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -45,8 +45,8 @@
 //! via [`UnionTrimmed::child_at`], so trimmed-away children must remain
 //! accessible even though they are inactive.
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use index_spec::IndexSpecReadGuard;
@@ -254,7 +254,7 @@ where
     #[inline(always)]
     fn skip_to(
         &mut self,
-        _doc_id: t_docId,
+        _doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         // UnionTrimmed drains children sequentially, not in doc-id order,
         // so skip_to has no meaningful semantics. Panic to surface misuse
@@ -302,7 +302,7 @@ where
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/utils/min_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/min_heap.rs
@@ -15,14 +15,14 @@
 //!
 //! - [`DocIdMinHeap::replace_root`]: O(log n) in-place root replacement with single sift-down
 //! - [`DocIdMinHeap::as_slice`]: Direct access to heap data for manual traversal
-use ffi::t_docId;
+use rqe_core::DocId;
 
 /// An entry in the [`DocIdMinHeap`], pairing a document ID with the index of
 /// the child iterator that produced it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HeapEntry {
     /// The document ID at this position.
-    pub doc_id: t_docId,
+    pub doc_id: DocId,
     /// Index into the parent union's `children` vector.
     pub child_idx: usize,
 }
@@ -117,7 +117,7 @@ impl DocIdMinHeap {
     /// # Complexity
     ///
     /// O(log n) - bubbles up to restore heap property.
-    pub fn push(&mut self, doc_id: t_docId, child_idx: usize) {
+    pub fn push(&mut self, doc_id: DocId, child_idx: usize) {
         self.data.push(HeapEntry { doc_id, child_idx });
         self.sift_up(self.data.len() - 1);
     }
@@ -160,7 +160,7 @@ impl DocIdMinHeap {
     /// # Complexity
     ///
     /// O(log n) - single sift-down operation.
-    pub fn replace_root(&mut self, doc_id: t_docId, child_idx: usize) {
+    pub fn replace_root(&mut self, doc_id: DocId, child_idx: usize) {
         debug_assert!(!self.data.is_empty(), "cannot replace root of empty heap");
         self.data[0] = HeapEntry { doc_id, child_idx };
         self.sift_down(0);

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -11,11 +11,12 @@
 
 use std::ptr::NonNull;
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, opaque};
+
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::IteratorType;
 use crate::{
@@ -28,14 +29,14 @@ use crate::{
 #[derive(Default)]
 pub struct Wildcard<'index> {
     // Supposed to be the max id in the index
-    top_id: t_docId,
+    top_id: DocId,
 
     /// A reusable result object to avoid allocations on each `read` call.
     result: RSIndexResult<'index>,
 }
 
 impl Wildcard<'_> {
-    pub fn new(top_id: t_docId, weight: f64) -> Self {
+    pub fn new(top_id: DocId, weight: f64) -> Self {
         Wildcard {
             top_id,
             result: RSIndexResult::build_virt()
@@ -64,7 +65,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         if self.at_eof() {
             return Ok(None);
@@ -90,7 +91,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
         self.top_id as usize
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 
@@ -154,7 +155,7 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         (**self).skip_to(doc_id)
     }
@@ -174,7 +175,7 @@ impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> 
         (**self).num_estimated()
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         (**self).last_doc_id()
     }
 
@@ -244,7 +245,7 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         delegate_rqe_iterator!(self, skip_to, doc_id)
     }
@@ -257,7 +258,7 @@ impl<'index> RQEIterator<'index> for OptimizedWildcard<'index> {
         delegate_rqe_iterator!(self, num_estimated)
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         delegate_rqe_iterator!(self, last_doc_id)
     }
 
@@ -321,7 +322,7 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         delegate_wildcard_iterator!(self, skip_to, doc_id)
     }
@@ -334,7 +335,7 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
         delegate_wildcard_iterator!(self, num_estimated)
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         delegate_wildcard_iterator!(self, last_doc_id)
     }
 
@@ -547,7 +548,7 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.0.skip_to(doc_id)
     }
@@ -567,7 +568,7 @@ impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
         self.0.num_estimated()
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.0.last_doc_id()
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -9,7 +9,7 @@
 
 //! Integration tests for the Intersection iterator.
 
-use ffi::t_docId;
+use rqe_core::DocId;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome, id_list::IdListSorted,
     intersection::Intersection, profile::Profile,
@@ -25,9 +25,9 @@ use crate::utils::{Mock, MockRevalidateResult};
 /// - Some unique document IDs specific to that child
 ///
 /// This ensures the intersection of all children equals exactly the result set.
-fn create_children(num_children: usize, result_set: &[t_docId]) -> Vec<IdListSorted<'static>> {
+fn create_children(num_children: usize, result_set: &[DocId]) -> Vec<IdListSorted<'static>> {
     let mut children = Vec::with_capacity(num_children);
-    let mut next_unique_id: t_docId = 1;
+    let mut next_unique_id: DocId = 1;
 
     for _ in 0..num_children {
         // Start with the result set as base
@@ -63,7 +63,7 @@ fn type_() {
 const NUM_CHILDREN_CASES: &[usize] = &[2, 5, 25];
 
 /// Result sets to test with
-const RESULT_SET_CASES: &[&[t_docId]] = &[
+const RESULT_SET_CASES: &[&[DocId]] = &[
     &[1, 2, 3, 40, 50],
     &[
         5, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345, 3456, 4567, 5678, 6789, 7890, 8901,
@@ -85,7 +85,7 @@ fn read_all_combinations() {
     }
 }
 
-fn read_test_case(num_children: usize, result_set: &[t_docId]) {
+fn read_test_case(num_children: usize, result_set: &[DocId]) {
     let children = create_children(num_children, result_set);
 
     // Compute expected num_estimated (minimum of all children's sizes)
@@ -154,12 +154,12 @@ fn skip_to_all_combinations() {
     }
 }
 
-fn skip_to_test_case(num_children: usize, result_set: &[t_docId]) {
+fn skip_to_test_case(num_children: usize, result_set: &[DocId]) {
     let children = create_children(num_children, result_set);
     let mut ii = Intersection::new(children, 1.0, false);
 
     // Test skipping to any id between 1 and the last id
-    let mut i: t_docId = 1;
+    let mut i: DocId = 1;
     for &id in result_set {
         // Skip to IDs that don't exist in result set (should return NotFound)
         while i < id {
@@ -280,7 +280,7 @@ fn rewind_all_combinations() {
     }
 }
 
-fn rewind_test_case(num_children: usize, result_set: &[t_docId]) {
+fn rewind_test_case(num_children: usize, result_set: &[DocId]) {
     let children = create_children(num_children, result_set);
     let mut ii = Intersection::new(children, 1.0, false);
 
@@ -527,7 +527,7 @@ fn many_children() {
         .map(|i| {
             // Each child has the common docs + some unique ones
             let mut ids = doc_ids.clone();
-            ids.push(i as t_docId + 1); // Unique to this child
+            ids.push(i as DocId + 1); // Unique to this child
             ids.sort();
             IdListSorted::new(ids)
         })
@@ -1054,7 +1054,7 @@ fn num_estimated_is_minimum_in_order() {
 fn children_sorted_by_estimated() {
     // Create children where the smallest (by count) would lead to fastest termination
     // Large child: has docs 1-1000
-    let large_child: Vec<t_docId> = (1..=1000).collect();
+    let large_child: Vec<DocId> = (1..=1000).collect();
     // Small child: only has doc 500
     let small_child = vec![500];
     // Medium child: has docs 100, 200, 300, 400, 500, 600, 700
@@ -1372,7 +1372,7 @@ mod slop_and_order {
 /// reduced `1/num_children` weight is preserved even through the wrapper.
 #[test]
 fn sort_weight_profile_wrapped_nested_intersection_sorts_first() {
-    let docs: Vec<t_docId> = (1..=10).collect();
+    let docs: Vec<DocId> = (1..=10).collect();
 
     // Inner intersection: 5 children, num_estimated = 10 → sort key 10 * (1/5) = 2.0.
     // Wrapped in Profile → intersection_sort_weight forwards to child, so sort key is still 2.0.
@@ -1407,7 +1407,7 @@ fn sort_weight_profile_wrapped_nested_intersection_sorts_first() {
 /// plain child with equal `num_estimated` (sort key `num_estimated * 1.0`).
 #[test]
 fn sort_weight_nested_intersection_sorts_first() {
-    let docs: Vec<t_docId> = (1..=10).collect();
+    let docs: Vec<DocId> = (1..=10).collect();
 
     // Inner intersection: 5 children, num_estimated = 10 → sort key 10 * (1/5) = 2.0.
     let inner_children_count = 5;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -9,9 +9,10 @@
 
 //! Tests for the missing-field inverted index iterator.
 
-use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use inverted_index::doc_ids_only::DocIdsOnly;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Missing};
 use rqe_iterators_test_utils::MockContext;
 
@@ -22,7 +23,7 @@ struct MissingBaseTest {
 }
 
 impl MissingBaseTest {
-    fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+    fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
         RSIndexResult::build_virt()
             .doc_id(doc_id)
             .field_mask(RS_FIELDMASK_ALL)
@@ -98,7 +99,7 @@ mod not_miri {
     }
 
     impl MissingRevalidateTest {
-        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
             RSIndexResult::build_virt()
                 .doc_id(doc_id)
                 .field_mask(RS_FIELDMASK_ALL)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -9,11 +9,12 @@
 
 use std::ptr::{self, NonNull};
 
-use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, IndexFlags_Index_StoreNumeric, t_docId};
+use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, IndexFlags_Index_StoreNumeric};
 use index_result::RSIndexResult;
 use inverted_index::{
     FilterNumericReader, IndexReader, InvertedIndex, NumericFilter, NumericReader,
 };
+use rqe_core::DocId;
 use rqe_iterators::{
     IteratorType, NoOpChecker, RQEIterator, RQEValidateStatus, SkipToOutcome,
     inverted_index::Numeric,
@@ -118,7 +119,7 @@ struct NumericBaseTest {
 }
 
 impl NumericBaseTest {
-    fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+    fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
         // The numeric record has a value of `doc_id * 2.0`.
         RSIndexResult::build_numeric(doc_id as f64 * 2.0)
             .doc_id(doc_id)
@@ -429,10 +430,10 @@ pub fn geo_filter_stub() -> GeoFilter {
 }
 
 mod from_tree {
-    use ffi::t_docId;
     use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
     use inverted_index::NumericFilter;
     use numeric_range_tree::NumericRangeTree;
+    use rqe_core::DocId;
     use rqe_iterators::{NumericIteratorVariant, RQEIterator, RQEValidateStatus};
     use rqe_iterators_test_utils::MockContext;
 
@@ -453,7 +454,7 @@ mod from_tree {
         }
     }
 
-    fn build_tree(entries: &[(t_docId, f64)]) -> NumericRangeTree {
+    fn build_tree(entries: &[(DocId, f64)]) -> NumericRangeTree {
         let mut tree = NumericRangeTree::new(false);
         for (doc_id, value) in entries {
             tree.add(*doc_id, *value, false, 0);
@@ -827,7 +828,7 @@ mod not_miri {
     }
 
     impl NumericExpirationTest {
-        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
             // The numeric record has a value of `doc_id * 2.0`.
             RSIndexResult::build_numeric(doc_id as f64 * 2.0)
                 .doc_id(doc_id)
@@ -1016,7 +1017,7 @@ mod not_miri {
     }
 
     impl NumericRevalidateTest {
-        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
             // The numeric record has a value of `doc_id * 2.0`.
             RSIndexResult::build_numeric(doc_id as f64 * 2.0)
                 .doc_id(doc_id)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -9,10 +9,11 @@
 
 //! Tests for the tag inverted index iterator.
 
-use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use inverted_index::doc_ids_only::DocIdsOnly;
 use query_term::RSQueryTerm;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Tag};
 use rqe_iterators_test_utils::MockContext;
 
@@ -23,7 +24,7 @@ struct TagBaseTest {
 }
 
 impl TagBaseTest {
-    fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+    fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
         RSIndexResult::build_term()
             .doc_id(doc_id)
             .field_mask(RS_FIELDMASK_ALL)
@@ -124,7 +125,7 @@ mod not_miri {
     }
 
     impl TagRevalidateTest {
-        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
             RSIndexResult::build_term()
                 .doc_id(doc_id)
                 .field_mask(RS_FIELDMASK_ALL)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -11,19 +11,19 @@ use approx::assert_abs_diff_eq;
 use ffi::{
     IndexFlags_Index_StoreByteOffsets, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets, IndexFlags_Index_WideSchema,
-    t_docId, t_fieldMask,
 };
 use field::FieldMaskOrIndex;
 use index_result::{RSIndexResult, RSOffsetSlice};
 use inverted_index::{FilterMaskReader, full::Full};
 use query_term::RSQueryTerm;
+use rqe_core::{DocId, FieldMask};
 use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Term};
 
 use crate::inverted_index::utils::{BaseTest, RevalidateIndexType, RevalidateTest};
 
 fn expected_record(
-    doc_id: t_docId,
-    field_mask: t_fieldMask,
+    doc_id: DocId,
+    field_mask: FieldMask,
     term: Box<query_term::RSQueryTerm>,
     offsets: &'static [u8],
 ) -> RSIndexResult<'static> {
@@ -56,7 +56,7 @@ impl TermBaseTest {
                     term.set_idf(5.0);
                     term.set_bm25_idf(10.0);
                     // Use doc_id as field_mask so we can test FilterMaskReader
-                    expected_record(doc_id, doc_id as t_fieldMask, term, OFFSETS)
+                    expected_record(doc_id, doc_id as FieldMask, term, OFFSETS)
                 }),
                 n_docs,
             ),
@@ -166,7 +166,7 @@ mod not_miri {
                         // Use a field mask with all bits set so all docs match the filter
                         // and expiration is actually tested (not just field mask filtering).
                         // Use u32::MAX for non-wide tests to avoid overflow in the encoder.
-                        expected_record(doc_id, u32::MAX as t_fieldMask, term, OFFSETS)
+                        expected_record(doc_id, u32::MAX as FieldMask, term, OFFSETS)
                     }),
                     n_docs,
                     multi,
@@ -308,7 +308,7 @@ mod not_miri {
                         term.set_idf(5.0);
                         term.set_bm25_idf(10.0);
                         // Use a field mask with all bits set so all docs match the filter.
-                        expected_record(doc_id, u32::MAX as t_fieldMask, term, OFFSETS)
+                        expected_record(doc_id, u32::MAX as FieldMask, term, OFFSETS)
                     }),
                     n_docs,
                 ),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -10,12 +10,12 @@
 use ffi::{
     IndexFlags, IndexFlags_Index_StoreByteOffsets, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets, IndexFlags_Index_WideSchema,
-    t_docId,
 };
 use field::FieldMaskOrIndex;
 use index_result::{RSIndexResult, RSResultKind};
 use inverted_index::{DecodedBy, Encoder, InvertedIndex, test_utils::TermRecordCompare};
 use numeric_range_tree::NumericIndex;
+use rqe_core::{DocId, FieldMask};
 use rqe_iterators::{ExpirationChecker, RQEIterator, RQEValidateStatus, SkipToOutcome};
 use rqe_iterators_test_utils::MockContext;
 use std::collections::HashSet;
@@ -25,9 +25,9 @@ pub use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
 /// Test basic read and skip_to functionality for a given iterator.
 pub(super) struct BaseTest<E> {
-    doc_ids: Vec<t_docId>,
+    doc_ids: Vec<DocId>,
     pub(super) ii: InvertedIndex<E>,
-    expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+    expected_record: Box<dyn Fn(DocId) -> RSIndexResult<'static>>,
     pub(super) mock_ctx: MockContext,
 }
 
@@ -44,13 +44,13 @@ pub fn check_record(record: &RSIndexResult, expected: &RSIndexResult) {
 impl<E: Encoder> BaseTest<E> {
     pub(super) fn new(
         ii_flags: IndexFlags,
-        expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+        expected_record: Box<dyn Fn(DocId) -> RSIndexResult<'static>>,
         n_docs: u64,
     ) -> Self {
         let create_record = &*expected_record;
         // Generate a set of odd document IDs for testing, starting from 1.
         let doc_ids = (0..=n_docs)
-            .map(|i| (2 * i + 1) as t_docId)
+            .map(|i| (2 * i + 1) as DocId)
             .collect::<Vec<_>>();
 
         let mut ii = InvertedIndex::<E>::new(ii_flags);
@@ -195,15 +195,15 @@ impl<E: Encoder> BaseTest<E> {
 /// instead of in the TTL tables.
 #[derive(Debug, Clone)]
 pub struct MockExpirationChecker {
-    expired_docs: HashSet<t_docId>,
+    expired_docs: HashSet<DocId>,
 }
 
 impl MockExpirationChecker {
-    pub fn new(expired_docs: HashSet<t_docId>) -> Self {
+    pub fn new(expired_docs: HashSet<DocId>) -> Self {
         Self { expired_docs }
     }
 
-    pub fn mark_expired(&mut self, doc_id: t_docId) {
+    pub fn mark_expired(&mut self, doc_id: DocId) {
         self.expired_docs.insert(doc_id);
     }
 }
@@ -229,8 +229,8 @@ enum ExpirationIndexType {
 /// Supports both numeric and term index types.
 /// Uses a `MockExpirationChecker` instead of TTL tables for expiration tracking.
 pub struct ExpirationTest {
-    pub(crate) doc_ids: Vec<t_docId>,
-    expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+    pub(crate) doc_ids: Vec<DocId>,
+    expected_record: Box<dyn Fn(DocId) -> RSIndexResult<'static>>,
     pub(crate) context: TestContext,
     index_type: ExpirationIndexType,
     mock_checker: MockExpirationChecker,
@@ -240,13 +240,13 @@ pub struct ExpirationTest {
 impl ExpirationTest {
     /// Create a new numeric expiration test.
     pub(crate) fn numeric(
-        expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+        expected_record: Box<dyn Fn(DocId) -> RSIndexResult<'static>>,
         n_docs: u64,
         multi: bool,
     ) -> Self {
         let create_record = &*expected_record;
         // Generate a set of document IDs for testing.
-        let doc_ids = (1..=n_docs).map(|i| i as t_docId).collect::<Vec<_>>();
+        let doc_ids = (1..=n_docs).map(|i| i as DocId).collect::<Vec<_>>();
 
         // Create a TestContext which creates the inverted index via NumericRangeTree
         let context = TestContext::numeric(doc_ids.iter().map(|id| create_record(*id)), multi);
@@ -264,13 +264,13 @@ impl ExpirationTest {
     /// Create a new term expiration test.
     pub(crate) fn term(
         ii_flags: IndexFlags,
-        expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+        expected_record: Box<dyn Fn(DocId) -> RSIndexResult<'static>>,
         n_docs: u64,
         multi: bool,
     ) -> Self {
         let create_record = &*expected_record;
         // Generate a set of document IDs for testing.
-        let doc_ids = (1..=n_docs).map(|i| i as t_docId).collect::<Vec<_>>();
+        let doc_ids = (1..=n_docs).map(|i| i as DocId).collect::<Vec<_>>();
 
         // Create a TestContext which creates the inverted index
         let context =
@@ -315,7 +315,7 @@ impl ExpirationTest {
     }
 
     /// Get the text field bit from the TestContext.
-    pub(crate) fn text_field_bit(&self) -> ffi::t_fieldMask {
+    pub(crate) fn text_field_bit(&self) -> FieldMask {
         self.context.text_field_bit()
     }
 
@@ -336,7 +336,7 @@ impl ExpirationTest {
 
     /// Mark the index as expired for the given document IDs.
     /// This updates the mock expiration checker instead of the TTL tables.
-    pub(crate) fn mark_index_expired(&mut self, ids: Vec<t_docId>, _field: FieldMaskOrIndex) {
+    pub(crate) fn mark_index_expired(&mut self, ids: Vec<DocId>, _field: FieldMaskOrIndex) {
         for id in ids {
             self.mock_checker.mark_expired(id);
         }
@@ -451,7 +451,7 @@ pub enum RevalidateIndexType {
 /// Test the revalidation of the iterator.
 pub struct RevalidateTest {
     #[allow(dead_code)]
-    doc_ids: Vec<t_docId>,
+    doc_ids: Vec<DocId>,
     pub context: TestContext,
     _guard: GlobalGuard,
 }
@@ -459,12 +459,12 @@ pub struct RevalidateTest {
 impl RevalidateTest {
     pub fn new(
         index_type: RevalidateIndexType,
-        expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+        expected_record: Box<dyn Fn(DocId) -> RSIndexResult<'static>>,
         n_docs: u64,
     ) -> Self {
         // Generate a set of odd document IDs for testing, starting from 1.
         let doc_ids = (0..=n_docs)
-            .map(|i| (2 * i + 1) as t_docId)
+            .map(|i| (2 * i + 1) as DocId)
             .collect::<Vec<_>>();
 
         let context = match index_type {
@@ -524,7 +524,7 @@ impl RevalidateTest {
     pub fn remove_document<E: Encoder + DecodedBy>(
         &self,
         ii: &mut InvertedIndex<E>,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) {
         let scan_delta = ii
             .scan_gc(
@@ -538,7 +538,7 @@ impl RevalidateTest {
     }
 
     /// Remove the document with the given id from a numeric inverted index.
-    pub fn remove_document_numeric(&self, ii: &mut NumericIndex, doc_id: t_docId) {
+    pub fn remove_document_numeric(&self, ii: &mut NumericIndex, doc_id: DocId) {
         match ii {
             NumericIndex::Uncompressed(ii) => self.remove_document(ii.inner_mut(), doc_id),
             NumericIndex::Compressed(ii) => self.remove_document(ii.inner_mut(), doc_id),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -9,9 +9,10 @@
 
 //! Tests for the wildcard inverted index iterator.
 
-use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use inverted_index::doc_ids_only::DocIdsOnly;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{IteratorType, RQEIterator, inverted_index::Wildcard};
 
 use crate::inverted_index::utils::BaseTest;
@@ -21,7 +22,7 @@ pub struct WildcardBaseTest {
 }
 
 impl WildcardBaseTest {
-    fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+    fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
         RSIndexResult::build_virt()
             .doc_id(doc_id)
             .field_mask(RS_FIELDMASK_ALL)
@@ -89,7 +90,7 @@ mod not_miri {
     }
 
     impl WildcardRevalidateTest {
-        fn expected_record(doc_id: t_docId) -> RSIndexResult<'static> {
+        fn expected_record(doc_id: DocId) -> RSIndexResult<'static> {
             RSIndexResult::build_virt()
                 .doc_id(doc_id)
                 .field_mask(RS_FIELDMASK_ALL)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use rqe_core::DocId;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     maybe_empty::MaybeEmpty,
@@ -29,7 +30,7 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: ffi::t_docId,
+        doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.0.doc_id = doc_id;
         Ok(Some(SkipToOutcome::Found(&mut self.0)))
@@ -43,7 +44,7 @@ impl<'index> RQEIterator<'index> for Infinite<'index> {
         usize::MAX
     }
 
-    fn last_doc_id(&self) -> ffi::t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.0.doc_id
     }
 
@@ -140,7 +141,7 @@ fn skip_to_not_empty() {
     let mut it = MaybeEmpty::new(Infinite::default());
 
     for i in 1..=5 {
-        let id = (i * 5) as ffi::t_docId;
+        let id = (i * 5) as DocId;
         let outcome = it.skip_to(id).unwrap();
         assert_eq!(
             outcome,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use ffi::t_docId;
+use rqe_core::DocId;
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     id_list::IdListSorted,
@@ -518,7 +518,7 @@ fn skip_to_child_behind_child_skip_returns_eof() {
 fn read_timeout_via_timeout_ctx() {
     let mut child_doc_ids = [0; 5_000];
     for i in 0..5_000 {
-        child_doc_ids[i] = (i + 1) as t_docId;
+        child_doc_ids[i] = (i + 1) as DocId;
     }
     let child = Mock::new(child_doc_ids);
     let mut data = child.data();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -9,8 +9,8 @@
 
 use std::time::Duration;
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 use rqe_iterators::{
     RQEIterator, RQEIteratorError, SkipToOutcome,
     not_optimized::NotOptimized,
@@ -26,7 +26,7 @@ use crate::utils::{Mock, MockIteratorError, MockVec, WildcardHelper};
 ///
 /// Returns all doc IDs in `wc_ids` that are NOT in `child_ids` and are at
 /// most `max_doc_id` (inclusive).
-fn compute_result_set(wc_ids: &[t_docId], child_ids: &[t_docId], max_doc_id: t_docId) -> Vec<u64> {
+fn compute_result_set(wc_ids: &[DocId], child_ids: &[DocId], max_doc_id: DocId) -> Vec<u64> {
     wc_ids
         .iter()
         .copied()
@@ -40,7 +40,7 @@ fn compute_result_set(wc_ids: &[t_docId], child_ids: &[t_docId], max_doc_id: t_d
 
 /// Read all results from the NOT-optimized iterator and compare against
 /// expected complement.
-fn read_test(wc_ids: Vec<t_docId>, child_ids: Vec<t_docId>, max_doc_id: t_docId) {
+fn read_test(wc_ids: Vec<DocId>, child_ids: Vec<DocId>, max_doc_id: DocId) {
     let expected = compute_result_set(&wc_ids, &child_ids, max_doc_id);
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
@@ -213,7 +213,7 @@ fn skip_to_not_in_wc_returns_not_found() {
 }
 
 /// SkipTo all doc IDs from 1 to max, checking Found/NotFound/EOF.
-fn skip_to_all_test(wc_ids: Vec<t_docId>, child_ids: Vec<t_docId>, max_doc_id: t_docId) {
+fn skip_to_all_test(wc_ids: Vec<DocId>, child_ids: Vec<DocId>, max_doc_id: DocId) {
     let expected = compute_result_set(&wc_ids, &child_ids, max_doc_id);
 
     for id in 1..max_doc_id {
@@ -520,11 +520,11 @@ fn child_timeout_on_skip_to() {
 fn read_timeout_via_timeout_ctx() {
     // Create child and wildcard with the same IDs so the loop runs many times
     // (every doc in wc matches child, so read_inner loops without returning).
-    let ids: Vec<t_docId> = (1..=5500).collect();
+    let ids: Vec<DocId> = (1..=5500).collect();
     let wc_helper = WildcardHelper::new(&ids);
     let wcii = wc_helper.create_wildcard();
 
-    let child_ids: [t_docId; 5500] = std::array::from_fn(|i| (i + 1) as t_docId);
+    let child_ids: [DocId; 5500] = std::array::from_fn(|i| (i + 1) as DocId);
     let child = Mock::new(child_ids);
     let mut child_data = child.data();
     child_data.add_delay_since_index(1, Duration::from_micros(100));
@@ -554,12 +554,12 @@ mod revalidate {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     /// Wildcard doc IDs used by the revalidate tests.
-    const WC_IDS: [t_docId; 20] = [
+    const WC_IDS: [DocId; 20] = [
         1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
     ];
 
     /// Child doc IDs used by the revalidate tests.
-    const CHILD_IDS: [t_docId; 4] = [10, 30, 50, 70];
+    const CHILD_IDS: [DocId; 4] = [10, 30, 50, 70];
 
     /// Create the context and guard for revalidate tests.
     fn make_revalidate_context() -> (GlobalGuard, TestContext) {
@@ -591,7 +591,7 @@ mod revalidate {
     }
 
     /// Helper: GC `doc_id` from the wildcard inverted index.
-    fn gc_document(context: &TestContext, doc_id: t_docId) {
+    fn gc_document(context: &TestContext, doc_id: DocId) {
         let ii = DocIdsOnly::from_mut_opaque(context.wildcard_inverted_index());
         let scan_delta = ii
             .scan_gc(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -9,7 +9,7 @@
 
 //! Tests for [`new_not_iterator`].
 
-use ffi::t_docId;
+use rqe_core::DocId;
 use rqe_iterators::{
     Empty, IteratorType, RQEIterator, SkipToOutcome, Wildcard,
     not_reducer::{NewNotIterator, new_not_iterator},
@@ -23,7 +23,7 @@ use crate::utils::Mock;
 /// returning the result alongside the context (to keep it alive).
 fn call_new_not_iterator<'a, I>(
     child: I,
-    max_doc_id: t_docId,
+    max_doc_id: DocId,
     ctx: &'a MockContext,
 ) -> NewNotIterator<'a, I, NoTimeout>
 where

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, optional::Optional,
     wildcard::Wildcard,
@@ -61,11 +61,11 @@ mod optional_iterator_skip_backward_panics {
 mod optional_iterator_tests {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 100;
+    const MAX_DOC_ID: DocId = 100;
     const WEIGHT: f64 = 2.;
 
     const NUM_DOCS: usize = 5;
-    const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30, 50, 80];
+    const CHILD_DOCS: [DocId; NUM_DOCS] = [10, 20, 30, 50, 80];
 
     fn setup_optional_iterator_with_mock_child<'index>()
     -> Optional<'index, utils::Mock<'index, NUM_DOCS>> {
@@ -126,7 +126,7 @@ mod optional_iterator_tests {
     fn test_skip_to_real_hit() {
         let mut it = setup_optional_iterator_with_mock_child();
 
-        const SKIP_TO_DOC_ID: t_docId = 20;
+        const SKIP_TO_DOC_ID: DocId = 20;
 
         // Skip to a docId that exists in child
         match it
@@ -155,7 +155,7 @@ mod optional_iterator_tests {
     fn test_skip_to_virtual_hit() {
         let mut it = setup_optional_iterator_with_mock_child();
 
-        const SKIP_TO_DOC_ID: t_docId = 25;
+        const SKIP_TO_DOC_ID: DocId = 25;
 
         // Skip to a docId that doesn't exist in child
         match it
@@ -185,7 +185,7 @@ mod optional_iterator_tests {
         let mut it = setup_optional_iterator_with_mock_child();
 
         // Test skipping to various docIds in sequence
-        const TARGETS: [t_docId; 10] = [5, 15, 25, 35, 45, 55, 65, 75, 85, 95];
+        const TARGETS: [DocId; 10] = [5, 15, 25, 35, 45, 55, 65, 75, 85, 95];
 
         for target in TARGETS {
             // Skip to the target docId
@@ -342,11 +342,11 @@ mod optional_iterator_tests {
 mod optional_iterator_timeout_tests {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 100;
+    const MAX_DOC_ID: DocId = 100;
     const WEIGHT: f64 = 2.;
 
     const NUM_DOCS: usize = 3;
-    const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30];
+    const CHILD_DOCS: [DocId; NUM_DOCS] = [10, 20, 30];
 
     fn setup_optional_iterator_with_mock_child<'index>()
     -> Optional<'index, utils::Mock<'index, NUM_DOCS>> {
@@ -462,7 +462,7 @@ mod optional_iterator_timeout_tests {
 mod optional_iterator_with_empty_child_test {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 50;
+    const MAX_DOC_ID: DocId = 50;
     const WEIGHT: f64 = 3.;
 
     fn setup_optional_iterator_with_empty_child<'index>() -> Optional<'index, Empty> {
@@ -512,7 +512,7 @@ mod optional_iterator_with_empty_child_test {
         let mut it = setup_optional_iterator_with_empty_child();
 
         // Skip to various docIds - all should be virtual hits
-        const TARGETS: [t_docId; 5] = [5, 15, 25, 35, 45];
+        const TARGETS: [DocId; 5] = [5, 15, 25, 35, 45];
 
         for target in TARGETS {
             match it
@@ -646,11 +646,11 @@ mod optional_iterator_with_empty_child_test {
 mod optional_iterator_revalidate_test {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 100;
+    const MAX_DOC_ID: DocId = 100;
     const WEIGHT: f64 = 2.;
 
     const NUM_DOCS: usize = 5;
-    const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30, 50, 80];
+    const CHILD_DOCS: [DocId; NUM_DOCS] = [10, 20, 30, 50, 80];
 
     fn setup_optional_iterator_with_mock_child_and_data<'index>() -> (
         Optional<'index, utils::Mock<'index, NUM_DOCS>>,
@@ -736,7 +736,7 @@ mod optional_iterator_revalidate_test {
         data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         // Read to a real hit (document from child)
-        const DOC_ID: t_docId = 10;
+        const DOC_ID: DocId = 10;
         match it
             .skip_to(DOC_ID)
             .expect("no error to be returned while skipping")
@@ -774,7 +774,7 @@ mod optional_iterator_revalidate_test {
         data.set_revalidate_result(utils::MockRevalidateResult::Move);
 
         // Read to a virtual hit (document not in child)
-        const DOC_ID: t_docId = 15;
+        const DOC_ID: DocId = 15;
         match it
             .skip_to(DOC_ID)
             .expect("no error to be returned while skipping")
@@ -806,7 +806,7 @@ mod optional_iterator_revalidate_test {
 mod optional_iterator_revalidate_after_abort {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 20;
+    const MAX_DOC_ID: DocId = 20;
     const WEIGHT: f64 = 2.;
 
     /// After child abort + a second revalidate, the child is `None` and
@@ -903,13 +903,13 @@ mod optional_iterator_non_sequential_reads {
     use super::*;
 
     struct ReadStepIterator<'index, const N: usize> {
-        read_steps: [t_docId; N],
+        read_steps: [DocId; N],
         read_step: usize,
         result: index_result::RSIndexResult<'index>,
     }
 
     impl<'index, const N: usize> ReadStepIterator<'index, N> {
-        fn new(read_steps: [t_docId; N]) -> Self {
+        fn new(read_steps: [DocId; N]) -> Self {
             Self {
                 read_steps,
                 read_step: 0,
@@ -938,7 +938,7 @@ mod optional_iterator_non_sequential_reads {
 
         fn skip_to(
             &mut self,
-            doc_id: ffi::t_docId,
+            doc_id: DocId,
         ) -> Result<Option<SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError> {
             while !self.at_eof() && self.result.doc_id < doc_id {
                 self.result.doc_id = self.read_steps[self.read_step];
@@ -961,7 +961,7 @@ mod optional_iterator_non_sequential_reads {
             unimplemented!()
         }
 
-        fn last_doc_id(&self) -> ffi::t_docId {
+        fn last_doc_id(&self) -> DocId {
             self.result.doc_id
         }
 
@@ -988,7 +988,7 @@ mod optional_iterator_non_sequential_reads {
 
     fn assert_numeric_read<'index>(
         it: &mut impl RQEIterator<'index>,
-        expected_id: t_docId,
+        expected_id: DocId,
         expected_weight: f64,
     ) {
         assert!(!it.at_eof());
@@ -1008,7 +1008,7 @@ mod optional_iterator_non_sequential_reads {
         assert_eq!(it.last_doc_id(), expected_id);
     }
 
-    fn assert_virtual_read<'index>(it: &mut impl RQEIterator<'index>, expected_id: t_docId) {
+    fn assert_virtual_read<'index>(it: &mut impl RQEIterator<'index>, expected_id: DocId) {
         assert!(!it.at_eof());
         let outcome = it
             .read()

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -7,9 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{IndexFlags_Index_DocIdsOnly, RS_FIELDMASK_ALL, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::{RSIndexResult, RSResultKind};
 use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{
     RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, inverted_index::Wildcard,
     optional_optimized::OptionalOptimized,
@@ -31,7 +32,7 @@ struct WildcardIndex {
 }
 
 impl WildcardIndex {
-    fn new(max_doc_id: t_docId) -> Self {
+    fn new(max_doc_id: DocId) -> Self {
         let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
         for doc_id in 1..=max_doc_id {
             let record = RSIndexResult::build_virt()
@@ -54,10 +55,10 @@ mod optional_optimized_iterator_tests {
 
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 100;
+    const MAX_DOC_ID: DocId = 100;
     const WEIGHT: f64 = 2.;
     const NUM_DOCS: usize = 5;
-    const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30, 50, 80];
+    const CHILD_DOCS: [DocId; NUM_DOCS] = [10, 20, 30, 50, 80];
 
     fn setup() -> WildcardIndex {
         WildcardIndex::new(MAX_DOC_ID)
@@ -106,7 +107,7 @@ mod optional_optimized_iterator_tests {
         let wcii_index = setup();
         let mut it = create_optional_optimized(&wcii_index);
 
-        const TARGET: t_docId = 20;
+        const TARGET: DocId = 20;
         match it.skip_to(TARGET).expect("no error") {
             Some(SkipToOutcome::Found(r)) => {
                 assert_eq!(r.doc_id, TARGET);
@@ -127,7 +128,7 @@ mod optional_optimized_iterator_tests {
         let mut it = create_optional_optimized(&wcii_index);
 
         // 25 is not in CHILD_DOCS but is present in wcii (covers 1..=100)
-        const TARGET: t_docId = 25;
+        const TARGET: DocId = 25;
         match it.skip_to(TARGET).expect("no error") {
             Some(SkipToOutcome::Found(r)) => {
                 assert_eq!(r.doc_id, TARGET);
@@ -219,7 +220,7 @@ mod optional_optimized_iterator_tests {
     fn test_read_stops_at_max_doc_id() {
         // wcii has docs [5, 150] and max_doc_id is 100.
         // Doc 150 must never be returned; after doc 5 the next read must be EOF.
-        const WCII_DOCS: [t_docId; 2] = [5, 150];
+        const WCII_DOCS: [DocId; 2] = [5, 150];
         let wcii = utils::Mock::new(WCII_DOCS);
         let child: Empty = Empty;
         let mut it = OptionalOptimized::new(wcii, child, 100, WEIGHT);
@@ -237,7 +238,7 @@ mod optional_optimized_iterator_tests {
     fn test_skip_to_stops_at_max_doc_id() {
         // wcii has docs [5, 150] and max_doc_id is 100.
         // Skipping to 10 causes wcii to land on 150 > max_doc_id → EOF.
-        const WCII_DOCS: [t_docId; 2] = [5, 150];
+        const WCII_DOCS: [DocId; 2] = [5, 150];
         let wcii = utils::Mock::new(WCII_DOCS);
         let child: Empty = Empty;
         let mut it = OptionalOptimized::new(wcii, child, 100, WEIGHT);
@@ -260,12 +261,12 @@ mod optional_optimized_iterator_tests {
     fn test_skip_to_exhaustive() {
         // Mirror the C++ fixture: wildcard = multiples of 5 in [5..=95],
         // child = even multiples of 10 in [20..=90].
-        const WILDCARD_DOCS: [t_docId; 19] = [
+        const WILDCARD_DOCS: [DocId; 19] = [
             5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
         ];
-        const CHILD_DOCS_EXH: [t_docId; 8] = [20, 30, 40, 50, 60, 70, 80, 90];
+        const CHILD_DOCS_EXH: [DocId; 8] = [20, 30, 40, 50, 60, 70, 80, 90];
         const WEIGHT_EXH: f64 = 4.6;
-        const MAX_EXH: t_docId = 95;
+        const MAX_EXH: DocId = 95;
 
         let wcii = utils::Mock::new(WILDCARD_DOCS);
         let child = utils::Mock::new(CHILD_DOCS_EXH);
@@ -333,7 +334,7 @@ mod optional_optimized_iterator_with_empty_child_tests {
 
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 50;
+    const MAX_DOC_ID: DocId = 50;
     const WEIGHT: f64 = 3.;
 
     fn setup() -> WildcardIndex {
@@ -411,7 +412,7 @@ mod optional_optimized_iterator_with_empty_child_tests {
 mod optional_optimized_iterator_sparse_wcii_tests {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 100;
+    const MAX_DOC_ID: DocId = 100;
     const WEIGHT: f64 = 1.5;
 
     /// `read()` returns `None` and sets `at_eof` when `wcii` runs out of documents
@@ -595,10 +596,10 @@ mod optional_optimized_iterator_sparse_wcii_tests {
 mod optional_optimized_iterator_revalidate_tests {
     use super::*;
 
-    const MAX_DOC_ID: t_docId = 100;
+    const MAX_DOC_ID: DocId = 100;
     const WEIGHT: f64 = 2.;
     const NUM_DOCS: usize = 5;
-    const CHILD_DOCS: [t_docId; NUM_DOCS] = [10, 20, 30, 50, 80];
+    const CHILD_DOCS: [DocId; NUM_DOCS] = [10, 20, 30, 50, 80];
 
     /// Tests using [`Wildcard`] as the wildcard iterator,
     /// requiring [`TestContext::wildcard`] which touches global C state and is not
@@ -713,7 +714,7 @@ mod optional_optimized_iterator_revalidate_tests {
     fn test_revalidate_wcii_aborted() {
         // Use Mock as wcii so we can configure it to abort.
         const WCII_DOCS: usize = 10;
-        let wcii_docs: [t_docId; WCII_DOCS] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let wcii_docs: [DocId; WCII_DOCS] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let wcii = utils::Mock::new(wcii_docs);
         let mut wcii_data = wcii.data();
         let child = utils::Mock::new(CHILD_DOCS);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_reducer.rs
@@ -10,6 +10,7 @@
 use std::ptr::NonNull;
 
 use index_result::RSResultKind;
+use rqe_core::DocId;
 use rqe_iterators::{
     RQEIterator,
     empty::Empty,
@@ -27,7 +28,7 @@ mod optional_reducer_tests {
     /// and returns a wildcard that covers the full document range.
     #[test]
     fn shortcircuit_1_empty_child_returns_wildcard_fallback() {
-        const MAX_DOC_ID: ffi::t_docId = 10;
+        const MAX_DOC_ID: DocId = 10;
 
         let ctx = MockContext::new(MAX_DOC_ID, 0);
 
@@ -67,7 +68,7 @@ mod optional_reducer_tests {
     fn shortcircuit_2_wildcard_child_returned_as_passthrough_with_weight_applied() {
         const INITIAL_WEIGHT: f64 = 1.0;
         const NEW_WEIGHT: f64 = 3.5;
-        const MAX_DOC_ID: ffi::t_docId = 100;
+        const MAX_DOC_ID: DocId = 100;
 
         let mut child = Wildcard::new(100, INITIAL_WEIGHT);
         // Advance the child so that `current()` holds a real document result.
@@ -104,7 +105,7 @@ mod optional_reducer_tests {
         use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
         use rqe_iterators::{IteratorType, inverted_index::Wildcard as InvIdxWildcard};
 
-        const MAX_DOC_ID: ffi::t_docId = 1000;
+        const MAX_DOC_ID: DocId = 1000;
         const INITIAL_WEIGHT: f64 = 1.0;
         const NEW_WEIGHT: f64 = 2.0;
 
@@ -154,9 +155,9 @@ mod optional_reducer_tests {
     /// wraps it in a plain [`Optional`].
     #[test]
     fn regular_non_optimized_child_wrapped_in_optional() {
-        const MAX_DOC_ID: ffi::t_docId = 100;
+        const MAX_DOC_ID: DocId = 100;
         const WEIGHT: f64 = 2.0;
-        const DOCS: [ffi::t_docId; 3] = [10, 20, 30];
+        const DOCS: [DocId; 3] = [10, 20, 30];
 
         let ctx = MockContext::new(MAX_DOC_ID, 0);
         let child = Mock::new(DOCS);
@@ -183,9 +184,9 @@ mod optional_reducer_tests {
     /// [`MOCK_DISK_WILDCARD_TOP_ID`] as the sentinel `top_id`.
     #[test]
     fn regular_disk_index_child_wrapped_in_optional_optimized_via_disk_wildcard() {
-        const MAX_DOC_ID: ffi::t_docId = 100;
+        const MAX_DOC_ID: DocId = 100;
         const WEIGHT: f64 = 1.5;
-        const DOCS: [ffi::t_docId; 3] = [10, 20, 30];
+        const DOCS: [DocId; 3] = [10, 20, 30];
 
         // Ensure the global enterprise-iterator registry is populated.
         init_enterprise_iterators();
@@ -223,9 +224,9 @@ mod optional_reducer_tests {
     /// `existingDocs` is null in the [`MockContext`]).
     #[test]
     fn regular_optimized_child_wrapped_in_optional_optimized() {
-        const MAX_DOC_ID: ffi::t_docId = 100;
+        const MAX_DOC_ID: DocId = 100;
         const WEIGHT: f64 = 2.0;
-        const DOCS: [ffi::t_docId; 3] = [10, 20, 30];
+        const DOCS: [DocId; 3] = [10, 20, 30];
 
         let ctx = MockContext::new(MAX_DOC_ID, 0);
         // SAFETY: no iterator from `ctx` is alive at this point.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -390,12 +390,13 @@ fn tag_with_query_term() {
     use ffi::IndexFlags_Index_DocIdsOnly;
     use inverted_index::doc_ids_only::DocIdsOnly;
     use query_term::RSQueryTerm;
+    use rqe_core::RS_FIELDMASK_ALL;
 
     let mut replier = init();
     let mut ii = inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
     let record = index_result::RSIndexResult::build_term()
         .doc_id(1)
-        .field_mask(ffi::RS_FIELDMASK_ALL)
+        .field_mask(RS_FIELDMASK_ALL)
         .build();
     ii.add_record(&record).expect("add_record");
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(1, 1);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -14,6 +14,7 @@
 //! test suite to exercise code paths that depend on [`SEARCH_ENTERPRISE_ITERATORS`]
 //! without requiring the actual enterprise implementation.
 
+use rqe_core::{DocId, FieldIndex};
 use rqe_iterators::{
     RQEIterator, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators, wildcard::Wildcard,
 };
@@ -24,7 +25,7 @@ use rqe_iterators::{
 /// Tests that exercise the disk-wildcard path can call `num_estimated()` on the
 /// resulting iterator and compare against this sentinel to confirm the disk path
 /// was taken.
-pub(crate) const MOCK_DISK_WILDCARD_TOP_ID: ffi::t_docId = 53596;
+pub(crate) const MOCK_DISK_WILDCARD_TOP_ID: DocId = 53596;
 
 /// Minimal [`SearchEnterpriseIterators`] stub for tests that exercise the
 /// disk-index code paths.
@@ -71,7 +72,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
         &self,
         _index: &'index mut ffi::RedisSearchDiskIndexSpec,
         _token: &ffi::RSToken,
-        _field_index: ffi::t_fieldIndex,
+        _field_index: FieldIndex,
         _weight: f64,
     ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
         unimplemented!("MockEnterpriseIterators::new_tag_on_disk not used in these tests")

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -9,8 +9,8 @@
 
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use ffi::{RS_FIELDMASK_ALL, t_docId};
 use index_result::{RSIndexResult, RSOffsetSlice};
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 
 /// Test iterator used in unit tests that expect an [`RQEIterator`]
@@ -49,7 +49,7 @@ use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 /// `tests/cpptests/iterator_util.h`.
 pub struct Mock<'index, const N: usize> {
     result: RSIndexResult<'index>,
-    doc_ids: [t_docId; N],
+    doc_ids: [DocId; N],
     /// One term position per document, or `None` for a virtual (non-term) result.
     ///
     /// Each value must be in the range `1..=127`: values in that range are their own
@@ -157,7 +157,7 @@ impl MockData {
     /// Configure a delay that should be introduced since the given index,
     /// either in a [`RQEIterator::read`] or [`RQEIterator::skip_to`] call
     /// for the [`Mock`] iterator.
-    pub fn add_delay_since_index(&mut self, index: t_docId, delay: Duration) -> &mut Self {
+    pub fn add_delay_since_index(&mut self, index: DocId, delay: Duration) -> &mut Self {
         {
             let mut data = self.0.borrow_mut();
             data.delays.push((index, delay));
@@ -206,14 +206,14 @@ struct MockDataInternal {
     validation_count: usize,
     read_count: usize,
     error_at_done: Option<MockIteratorError>,
-    delays: Vec<(t_docId, Duration)>,
+    delays: Vec<(DocId, Duration)>,
     /// If true, the next call to `read()` will return `None` even if not at EOF.
     /// Simulates Inverted Index iterators that discover EOF only when `read()` is called.
     force_read_none: bool,
 }
 
 impl MockDataInternal {
-    fn delay_if_index_limit_reached(&mut self, idx: t_docId) {
+    fn delay_if_index_limit_reached(&mut self, idx: DocId) {
         // assumes that these delays are sorted in ascending order,
         // as guaranteed by the [`MockData::add_delay_since_index`] method.
 
@@ -250,7 +250,7 @@ impl<'index, const N: usize> Mock<'index, N> {
     /// with weight equal to `1.0` and field mask set to
     /// `RS_FIELDMASK_ALL`.  Each call to `read` or `skip_to` overwrites
     /// `doc_id` in that single result instance.
-    pub fn new(doc_ids: [t_docId; N]) -> Self {
+    pub fn new(doc_ids: [DocId; N]) -> Self {
         debug_assert!(doc_ids.is_sorted(), "Mock Iterator API assumes sorted list");
         Self {
             result: RSIndexResult::build_virt()
@@ -266,7 +266,7 @@ impl<'index, const N: usize> Mock<'index, N> {
 
     /// Like [`Mock::new`], but each document carries a term position (valid range `1..=127`).
     /// The result produced for each document will be a `Term` record instead of a virtual one,
-    pub fn new_with_positions(doc_ids: [t_docId; N], positions: [u8; N]) -> Self {
+    pub fn new_with_positions(doc_ids: [DocId; N], positions: [u8; N]) -> Self {
         debug_assert!(
             positions.iter().all(|&p| (1..=127).contains(&p)),
             "positions must be in 1..=127 (single-byte varint range)"
@@ -348,7 +348,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
     {
         let mut data = self.data.0.borrow_mut();
@@ -423,7 +423,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
         N
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 
@@ -458,7 +458,7 @@ impl<const N: usize> rqe_iterators::profile_print::ProfilePrint for Mock<'_, N> 
 /// This is useful when the document IDs are determined at runtime.
 pub struct MockVec<'index> {
     result: RSIndexResult<'index>,
-    doc_ids: Vec<t_docId>,
+    doc_ids: Vec<DocId>,
     next_index: usize,
     data: MockData,
 }
@@ -467,7 +467,7 @@ impl<'index> MockVec<'index> {
     /// Create a new [`MockVec`] from a vector of document ids.
     ///
     /// The ids must be sorted in increasing order.
-    pub fn new(doc_ids: Vec<t_docId>) -> Self {
+    pub fn new(doc_ids: Vec<DocId>) -> Self {
         debug_assert!(doc_ids.is_sorted(), "MockVec API assumes sorted list");
         Self {
             result: RSIndexResult::build_virt()
@@ -481,7 +481,7 @@ impl<'index> MockVec<'index> {
     }
 
     /// Create a boxed [`MockVec`] as a trait object.
-    pub fn new_boxed(doc_ids: Vec<t_docId>) -> Box<dyn RQEIterator<'index> + 'index> {
+    pub fn new_boxed(doc_ids: Vec<DocId>) -> Box<dyn RQEIterator<'index> + 'index> {
         Box::new(Self::new(doc_ids))
     }
 }
@@ -525,7 +525,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
 
     fn skip_to(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
     ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
     {
         let mut data = self.data.0.borrow_mut();
@@ -599,7 +599,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
         self.doc_ids.len()
     }
 
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.result.doc_id
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -108,11 +108,11 @@ impl RQEIterator<'static> for FieldMaskMock {
     }
 }
 
-use ffi::t_docId;
+use rqe_core::DocId;
 use std::collections::BTreeSet;
 
 /// Drain all documents from an iterator and return their doc_ids.
-pub(crate) fn drain_doc_ids<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<t_docId> {
+pub(crate) fn drain_doc_ids<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<DocId> {
     let mut docs = Vec::new();
     while let Some(r) = it.read().unwrap() {
         docs.push(r.doc_id);
@@ -123,7 +123,7 @@ pub(crate) fn drain_doc_ids<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<t
 /// Create a single [`Mock`] child and return it as a boxed trait object
 /// together with a handle to its [`MockData`].
 pub(crate) fn create_mock_1<const N: usize>(
-    doc_ids: [t_docId; N],
+    doc_ids: [DocId; N],
 ) -> (Box<dyn RQEIterator<'static>>, MockData) {
     let mock = Mock::new(doc_ids);
     let data = mock.data();
@@ -133,8 +133,8 @@ pub(crate) fn create_mock_1<const N: usize>(
 /// Create two [`Mock`] children and return them as a `Vec` of boxed trait
 /// objects together with a two-element array of [`MockData`] handles.
 pub(crate) fn create_mock_2<const A: usize, const B: usize>(
-    a: [t_docId; A],
-    b: [t_docId; B],
+    a: [DocId; A],
+    b: [DocId; B],
 ) -> (Vec<Box<dyn RQEIterator<'static>>>, [MockData; 2]) {
     let m1 = Mock::new(a);
     let m2 = Mock::new(b);
@@ -146,9 +146,9 @@ pub(crate) fn create_mock_2<const A: usize, const B: usize>(
 /// Create three [`Mock`] children and return them as a `Vec` of boxed trait
 /// objects together with a three-element array of [`MockData`] handles.
 pub(crate) fn create_mock_3<const A: usize, const B: usize, const C: usize>(
-    a: [t_docId; A],
-    b: [t_docId; B],
-    c: [t_docId; C],
+    a: [DocId; A],
+    b: [DocId; B],
+    c: [DocId; C],
 ) -> (Vec<Box<dyn RQEIterator<'static>>>, [MockData; 3]) {
     let m1 = Mock::new(a);
     let m2 = Mock::new(b);
@@ -166,11 +166,11 @@ pub(crate) fn create_mock_3<const A: usize, const B: usize, const C: usize>(
 pub(crate) fn create_union_children(
     num_children: usize,
     base_result_set: &[u64],
-) -> (Vec<Box<dyn RQEIterator<'static>>>, Vec<t_docId>) {
+) -> (Vec<Box<dyn RQEIterator<'static>>>, Vec<DocId>) {
     let mut expected = BTreeSet::new();
     let children: Vec<Box<dyn RQEIterator<'static>>> = (1..=num_children)
         .map(|i| {
-            let doc_ids: Vec<t_docId> = base_result_set.iter().map(|&x| x * i as u64).collect();
+            let doc_ids: Vec<DocId> = base_result_set.iter().map(|&x| x * i as u64).collect();
             expected.extend(doc_ids.iter().copied());
             MockVec::new_boxed(doc_ids)
         })

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/wildcard_helper.rs
@@ -7,9 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
+use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
+use rqe_core::DocId;
 
 /// Holds an [`InvertedIndex`] so a
 /// [`Wildcard`](rqe_iterators::inverted_index::Wildcard) iterator can be
@@ -20,7 +21,7 @@ pub(crate) struct WildcardHelper {
 
 impl WildcardHelper {
     /// Create a new helper populated with the given `doc_ids`.
-    pub(crate) fn new(doc_ids: &[t_docId]) -> Self {
+    pub(crate) fn new(doc_ids: &[DocId]) -> Self {
         let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
         for &doc_id in doc_ids {
             let record = RSIndexResult::build_virt().doc_id(doc_id).build();

--- a/src/redisearch_rs/rqe_iterators_bencher/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators_bencher/Cargo.toml
@@ -23,6 +23,7 @@ build_utils = { path = "../build_utils" }
 [dependencies]
 criterion.workspace = true
 ffi.workspace = true
+rqe_core.workspace = true
 field.workspace = true
 index_result.workspace = true
 query_term.workspace = true

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -11,10 +11,11 @@ pub use ffi::{
     IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreByteOffsets,
     IndexFlags_Index_StoreFieldFlags, IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreNumeric,
     IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_OK,
-    RedisModule_Alloc, RedisModule_Free, ValidateStatus, t_docId,
+    RedisModule_Alloc, RedisModule_Free, ValidateStatus,
 };
 use index_result::{RSIndexResult, RSQueryTerm};
 use iterators_ffi::intersection::NewIntersectionIterator;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use std::{ffi::c_void, ptr};
 
 /// Simple wrapper around the C `QueryIterator` type.
@@ -84,7 +85,7 @@ impl QueryIterator {
             iterators_ffi::inverted_index::NewInvIndIterator_TermQuery(
                 ii.cast_const(),
                 sctx,
-                field::FieldMaskOrIndex::Mask(ffi::RS_FIELDMASK_ALL),
+                field::FieldMaskOrIndex::Mask(RS_FIELDMASK_ALL),
                 term,
                 1.0,
             )
@@ -97,7 +98,7 @@ impl QueryIterator {
     /// * `children_ids` - A slice of vectors, each containing sorted document IDs for a child iterator
     /// * `weight` - The weight for the intersection result
     #[inline(always)]
-    pub fn new_intersection(children_ids: &[Vec<t_docId>], weight: f64) -> Self {
+    pub fn new_intersection(children_ids: &[Vec<DocId>], weight: f64) -> Self {
         let num_children = children_ids.len();
 
         // Allocate array of child iterator pointers using RedisModule_Alloc
@@ -110,8 +111,7 @@ impl QueryIterator {
         for (i, ids) in children_ids.iter().enumerate() {
             // Allocate and copy IDs using RedisModule_Alloc (required by NewSortedIdListIterator)
             let ids_ptr = unsafe {
-                RedisModule_Alloc.unwrap()(ids.len() * std::mem::size_of::<t_docId>())
-                    as *mut t_docId
+                RedisModule_Alloc.unwrap()(ids.len() * std::mem::size_of::<DocId>()) as *mut DocId
             };
             unsafe {
                 std::ptr::copy_nonoverlapping(ids.as_ptr(), ids_ptr, ids.len());

--- a/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 ffi.workspace = true
+rqe_core.workspace = true
 field.workspace = true
 index_result.workspace = true
 index_spec.workspace = true

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_context.rs
@@ -9,8 +9,9 @@
 
 use std::ptr::NonNull;
 
-use ffi::{QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId};
+use ffi::{QueryEvalCtx, RedisSearchCtx, SchemaRule};
 use numeric_range_tree::NumericRangeTree;
+use rqe_core::DocId;
 
 /// Mock search context creating fake objects for testing.
 /// It can be used to test expiration but not validation.
@@ -63,7 +64,7 @@ impl Drop for MockContext {
 }
 
 impl MockContext {
-    pub fn new(max_doc_id: t_docId, num_docs: usize) -> Self {
+    pub fn new(max_doc_id: DocId, num_docs: usize) -> Self {
         // Allocate each struct using Box::into_raw to get raw pointers.
         // We store raw pointers (not Boxes) because the library code creates
         // references through the pointer chain which would invalidate Box's

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -18,7 +18,8 @@ use std::{
     },
 };
 
-use ffi::{IndexFlags, IndexFlags_Index_WideSchema, t_docId};
+use ffi::{IndexFlags, IndexFlags_Index_WideSchema};
+use rqe_core::{DocId, FieldMask};
 
 /// Global counter for generating unique index names across tests.
 static INDEX_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -230,10 +231,10 @@ impl TestContext {
         // Add numeric data to the range tree
         for record in records {
             let record_val = record.as_numeric().unwrap();
-            numeric_range_tree.add(record.doc_id as t_docId, record_val, false, 0);
+            numeric_range_tree.add(record.doc_id as DocId, record_val, false, 0);
 
             if multi {
-                numeric_range_tree.add(record.doc_id as t_docId, record_val, true, 0);
+                numeric_range_tree.add(record.doc_id as DocId, record_val, true, 0);
             }
         }
 
@@ -648,7 +649,7 @@ impl TestContext {
     ///
     /// The `ftId` is the full-text field ID, distinct from the general `index` field.
     /// Use this when filtering term records by field or marking field expiration.
-    pub const fn text_field_bit(&self) -> ffi::t_fieldMask {
+    pub const fn text_field_bit(&self) -> FieldMask {
         1 << self.field_spec().ftId
     }
 
@@ -757,7 +758,7 @@ impl TestContext {
     /// Add a TTL entry for the given field in the given document.
     fn ttl_add(
         &mut self,
-        doc_id: t_docId,
+        doc_id: DocId,
         field: FieldMaskOrIndex,
         expiration: ffi::t_expirationTimePoint,
     ) {
@@ -817,7 +818,7 @@ impl TestContext {
     ///
     /// Sets the field expiration time to the past and the current query time
     /// to the future, so expiration checks will consider these fields expired.
-    pub fn mark_index_expired(&mut self, ids: Vec<t_docId>, field: FieldMaskOrIndex) {
+    pub fn mark_index_expired(&mut self, ids: Vec<DocId>, field: FieldMaskOrIndex) {
         // Expiration time in the past
         let expiration = ffi::t_expirationTimePoint {
             tv_sec: 1,

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -10,6 +10,7 @@ test = false
 
 [dependencies]
 ffi.workspace = true
+rqe_core.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
 rlookup.workspace = true

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -10,6 +10,7 @@
 use enumflags2::{BitFlags, bitflags};
 use index_result::RSIndexResult;
 use rlookup::RLookupRow;
+use rqe_core::DocId;
 use std::ptr::NonNull;
 
 use document_metadata::{DocumentMetadata, OwnedDocumentMetadata};
@@ -29,7 +30,7 @@ pub type SearchResultFlags = enumflags2::BitFlags<SearchResultFlag>;
 #[derive(Debug)]
 #[repr(C)]
 pub struct SearchResult<'index> {
-    _doc_id: ffi::t_docId,
+    _doc_id: DocId,
     // not all results have score - TBD
     _score: f64,
 
@@ -109,12 +110,12 @@ impl<'index> SearchResult<'index> {
     }
 
     /// Sets the document ID of this search result.
-    pub const fn doc_id(&self) -> ffi::t_docId {
+    pub const fn doc_id(&self) -> DocId {
         self._doc_id
     }
 
     /// Sets the document ID of this search result.
-    pub const fn set_doc_id(&mut self, doc_id: ffi::t_docId) {
+    pub const fn set_doc_id(&mut self, doc_id: DocId) {
         self._doc_id = doc_id;
     }
 

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -21,6 +21,7 @@ build_utils = { path = "../build_utils" }
 
 [dependencies]
 ffi.workspace = true
+rqe_core.workspace = true
 inverted_index.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -13,13 +13,13 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 
-use ffi::t_docId;
+use rqe_core::DocId;
 
 /// A (doc_id, score) pair stored in the heap.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScoredResult {
     /// Document identifier.
-    pub doc_id: t_docId,
+    pub doc_id: DocId,
     /// Score for the document (lower or higher is "better" depending on the comparator).
     pub score: f64,
 }
@@ -132,7 +132,7 @@ impl TopKHeap {
     /// - Otherwise the element is discarded.
     ///
     /// Returns `true` if the element was inserted.
-    pub fn push(&mut self, doc_id: t_docId, score: f64) -> bool {
+    pub fn push(&mut self, doc_id: DocId, score: f64) -> bool {
         let entry = HeapEntry {
             result: ScoredResult { doc_id, score },
             compare: self.compare,
@@ -271,7 +271,7 @@ mod tests {
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie)
 
         let results = heap.drain_sorted();
-        let ids: Vec<t_docId> = results.iter().map(|r| r.doc_id).collect();
+        let ids: Vec<DocId> = results.iter().map(|r| r.doc_id).collect();
 
         assert!(ids.contains(&3));
         assert!(ids.contains(&5));
@@ -301,7 +301,7 @@ mod tests {
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie, regardless of sort direction)
 
         let results = heap.drain_sorted();
-        let ids: Vec<t_docId> = results.iter().map(|r| r.doc_id).collect();
+        let ids: Vec<DocId> = results.iter().map(|r| r.doc_id).collect();
 
         assert!(ids.contains(&3));
         assert!(ids.contains(&5));

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -11,9 +11,9 @@
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
@@ -78,7 +78,7 @@ pub struct TopKIterator<'index, S: ScoreSource> {
     results: Vec<ScoredResult>,
     yield_pos: usize,
     current: Option<RSIndexResult<'index>>,
-    last_doc_id: t_docId,
+    last_doc_id: DocId,
     at_eof: bool,
 }
 
@@ -270,7 +270,7 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
 
     fn skip_to(
         &mut self,
-        _doc_id: t_docId,
+        _doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         // TopKIterator is a root-only iterator that yields results sorted by
         // score, not by doc_id.  It cannot be used as a child in a larger
@@ -312,7 +312,7 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
     }
 
     #[inline(always)]
-    fn last_doc_id(&self) -> t_docId {
+    fn last_doc_id(&self) -> DocId {
         self.last_doc_id
     }
 

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -12,17 +12,17 @@
 //!
 //! Gated behind the `test-utils` feature.
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 use rqe_iterators::RQEIteratorError;
 
 use crate::traits::{CollectionStrategy, ScoreBatch, ScoreSource};
 
-/// A [`ScoreBatch`] backed by a pre-sorted `Vec<(t_docId, f64)>`.
+/// A [`ScoreBatch`] backed by a pre-sorted `Vec<(DocId, f64)>`.
 ///
 /// Doc IDs must be strictly increasing; this is validated in debug builds.
 pub struct MockScoreBatch {
-    items: Vec<(t_docId, f64)>,
+    items: Vec<(DocId, f64)>,
     pos: usize,
 }
 
@@ -30,7 +30,7 @@ impl MockScoreBatch {
     /// Creates a batch from a vector of `(doc_id, score)` pairs.
     ///
     /// The pairs must be sorted by `doc_id` in strictly ascending order (asserted in debug builds).
-    pub fn new(items: Vec<(t_docId, f64)>) -> Self {
+    pub fn new(items: Vec<(DocId, f64)>) -> Self {
         debug_assert!(
             items.windows(2).all(|w| w[0].0 < w[1].0),
             "MockScoreBatch: doc IDs must be strictly increasing"
@@ -40,7 +40,7 @@ impl MockScoreBatch {
 }
 
 impl ScoreBatch for MockScoreBatch {
-    fn next(&mut self) -> Option<(t_docId, f64)> {
+    fn next(&mut self) -> Option<(DocId, f64)> {
         let item = self.items.get(self.pos).copied();
         if item.is_some() {
             self.pos += 1;
@@ -48,7 +48,7 @@ impl ScoreBatch for MockScoreBatch {
         item
     }
 
-    fn skip_to(&mut self, target: t_docId) -> Option<(t_docId, f64)> {
+    fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)> {
         self.pos += self.items[self.pos..].partition_point(|(id, _)| *id < target);
         self.next()
     }
@@ -72,7 +72,7 @@ impl ScoreBatch for MockScoreBatch {
 /// );
 /// ```
 pub struct MockScoreSource {
-    batches: Vec<Vec<(t_docId, f64)>>,
+    batches: Vec<Vec<(DocId, f64)>>,
     batch_pos: usize,
     strategy: Box<dyn FnMut(usize, usize) -> CollectionStrategy>,
     num_estimated: usize,
@@ -86,7 +86,7 @@ impl MockScoreSource {
     ///
     /// `num_estimated` defaults to the total number of entries across all batches.
     pub fn new(
-        batches: Vec<Vec<(t_docId, f64)>>,
+        batches: Vec<Vec<(DocId, f64)>>,
         strategy: impl FnMut(usize, usize) -> CollectionStrategy + 'static,
     ) -> Self {
         let num_estimated = batches.iter().map(Vec::len).sum();
@@ -128,7 +128,7 @@ impl ScoreSource for MockScoreSource {
         self.batch_pos = 0;
     }
 
-    fn build_result<'r>(&self, doc_id: t_docId, _score: f64) -> RSIndexResult<'r>
+    fn build_result<'r>(&self, doc_id: DocId, _score: f64) -> RSIndexResult<'r>
     where
         Self: 'r,
     {

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -11,8 +11,8 @@
 //!
 //! [`TopKIterator`]: crate::TopKIterator
 
-use ffi::t_docId;
 use index_result::RSIndexResult;
+use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::RQEIteratorError;
 
@@ -27,12 +27,12 @@ pub trait ScoreBatch {
     /// Advance to the next `(doc_id, score)` pair.
     ///
     /// Returns `None` when the batch is exhausted.
-    fn next(&mut self) -> Option<(t_docId, f64)>;
+    fn next(&mut self) -> Option<(DocId, f64)>;
 
     /// Skip forward to the first pair whose `doc_id >= target`.
     ///
     /// Returns `None` if no such pair exists in this batch.
-    fn skip_to(&mut self, target: t_docId) -> Option<(t_docId, f64)>;
+    fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)>;
 }
 
 /// Decision returned by [`ScoreSource::collection_strategy`] after each batch,
@@ -105,7 +105,7 @@ pub trait ScoreSource {
     /// valid. For `'static` sources, `'r` is unconstrained.
     ///
     /// [`TopKIterator`]: crate::TopKIterator
-    fn build_result<'r>(&self, doc_id: t_docId, score: f64) -> RSIndexResult<'r>
+    fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
     where
         Self: 'r;
 

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -11,6 +11,8 @@
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
+use rqe_core::DocId;
+
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
@@ -40,7 +42,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
 
     fn skip_to(
         &mut self,
-        _doc_id: ffi::t_docId,
+        _doc_id: DocId,
     ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
     {
         unimplemented!()
@@ -59,7 +61,7 @@ impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
         0
     }
 
-    fn last_doc_id(&self) -> ffi::t_docId {
+    fn last_doc_id(&self) -> DocId {
         0
     }
 
@@ -94,7 +96,7 @@ impl ScoreSource for TimingOutSource {
 
     fn rewind(&mut self) {}
 
-    fn build_result<'r>(&self, doc_id: ffi::t_docId, _: f64) -> RSIndexResult<'r>
+    fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
     where
         Self: 'r,
     {
@@ -117,7 +119,7 @@ fn asc(a: f64, b: f64) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)
 }
 
-fn make_child<'a>(ids: Vec<ffi::t_docId>) -> Box<dyn RQEIterator<'a> + 'a> {
+fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
     Box::new(IdList::<true>::new(ids))
 }
 
@@ -391,7 +393,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             self.rewind_count += 1;
         }
 
-        fn build_result<'r>(&self, doc_id: ffi::t_docId, _: f64) -> RSIndexResult<'r>
+        fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
         where
             Self: 'r,
         {

--- a/src/redisearch_rs/ttl_table/Cargo.toml
+++ b/src/redisearch_rs/ttl_table/Cargo.toml
@@ -15,9 +15,9 @@ workspace = true
 ffi.workspace = true
 field.workspace = true
 libc.workspace = true
+rqe_core.workspace = true
 thin_vec.workspace = true
 workspace_hack.workspace = true
-rqe_core.workspace = true
 
 [dev-dependencies]
 ttl_table = { path = ".", features = ["test-utils"] }

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -368,7 +368,7 @@ impl TimeToLiveTable {
     /// 32-bit `field_mask`.
     ///
     /// `ft_id_to_field_index[bit]` translates a bit position in the mask
-    /// into the `t_fieldIndex` recorded in the table; it must contain at
+    /// into the `FieldIndex` recorded in the table; it must contain at
     /// least as many entries as the highest set bit of `field_mask`. The
     /// translation is required to be monotonic, bits scanned low-to-high
     /// must produce non-decreasing field indices.


### PR DESCRIPTION
`t_fieldIndex`, `t_fieldMask` and `t_docId` have been moved from C to the rqe_core crate: https://github.com/RediSearch/RediSearch/pull/9839

Stop using them from ffi and use the new Rust type directly instead.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-alias refactor with no intended behavior change; C ABI still uses generated t_* names at the boundary.
> 
> **Overview**
> Rust code across RediSearch’s `redisearch_rs` tree now treats **`rqe_core`** as the home for core query-engine types instead of pulling them from the **`ffi`** crate.
> 
> **`DocId`**, **`FieldIndex`**, and **`FieldMask`** (plus constants like **`RS_FIELDMASK_ALL`** and **`RS_INVALID_FIELD_INDEX`**) replace **`t_docId`**, **`t_fieldIndex`**, and **`t_fieldMask`** in inverted-index codecs, iterators, FFI entrypoints, numeric range trees, index results, and tests/benches. Many crates gain an **`rqe_core`** dependency in **`Cargo.toml`** / **`Cargo.lock`**.
> 
> The **`ffi`** crate no longer re-exports those aliases; **`ffi/build.rs`** documents that bindgen may still emit **`t_*`** typedefs for C interop while Rust callers should import the canonical names from **`rqe_core`**. C-facing generated headers largely keep **`t_docId`** / **`t_fieldMask`** in signatures; only Rust-side usage and docs shift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05a89c1fd80d6e5da3179e47328886641f07119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->