### PR TITLE
remove legacy QAST_ValidationFlags type

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1788,9 +1788,9 @@ static int validateQueryNotDisk(const char *queryTypeName,
 }
 
 static int QueryNode_CheckIsValid(QueryNode *n, IndexSpec *spec, RSSearchOptions *opts,
-  QueryError *status, QAST_ValidationFlags validationFlags) {
+  QueryError *status, QASTValidationFlagsSet validationFlags) {
   // Check if this is the main vector node in a hybrid vector subquery
-  QAST_ValidationFlags effectiveFlags = validationFlags;
+  QASTValidationFlagsSet effectiveFlags = validationFlags;
   if ((n->opts.flags & QueryNode_HybridVectorSubqueryNode) && (n->type == QN_VECTOR)) {
     // This is the main vector node in hybrid vector subquery - allow it despite restrictions
     effectiveFlags &= ~(QAST_NO_WEIGHT | QAST_NO_VECTOR);

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -251,9 +251,6 @@ after_includes = """
 #define QAST_NO_WEIGHT       QASTValidationFlags_NoWeight
 #define QAST_NO_VECTOR       QASTValidationFlags_NoVector
 
-/* Backward-compatible typedef for C code that uses the old enum name. */
-typedef uint32_t QAST_ValidationFlags;
-
 /* Backward-compatible aliases for C code that uses the old PHONETIC_* macros. */
 #define PHONETIC_DEFAULT  PhoneticMode_Default
 #define PHONETIC_ENABLED  PhoneticMode_Enabled

--- a/src/redisearch_rs/headers/query_node_type.h
+++ b/src/redisearch_rs/headers/query_node_type.h
@@ -43,9 +43,6 @@
 #define QAST_NO_WEIGHT       QASTValidationFlags_NoWeight
 #define QAST_NO_VECTOR       QASTValidationFlags_NoVector
 
-/* Backward-compatible typedef for C code that uses the old enum name. */
-typedef uint32_t QAST_ValidationFlags;
-
 /* Backward-compatible aliases for C code that uses the old PHONETIC_* macros. */
 #define PHONETIC_DEFAULT  PhoneticMode_Default
 #define PHONETIC_ENABLED  PhoneticMode_Enabled

--- a/tests/cpptests/query_test_utils.h
+++ b/tests/cpptests/query_test_utils.h
@@ -73,7 +73,7 @@ class QASTCXX : public QueryAST {
    * Check if a query string is valid with the specified validation flags
    * This is a generic validation method that can be used with any validation flags
    */
-  bool isValidQuery(const char *s, QAST_ValidationFlags validationFlags) {
+  bool isValidQuery(const char *s, QASTValidationFlagsSet validationFlags) {
     // Parse the query using version 2 parser
     if (!parse(s, 2)) {
       return false;

--- a/tests/cpptests/test_cpp_query_validation.cpp
+++ b/tests/cpptests/test_cpp_query_validation.cpp
@@ -17,8 +17,8 @@
 
 class QueryValidationTest : public ::testing::Test {};
 
-QAST_ValidationFlags hybridVectorFilterValidationFlags = (QAST_ValidationFlags)(QAST_NO_VECTOR | QAST_NO_WEIGHT);
-QAST_ValidationFlags hybridSearchValidationFlags = QAST_NO_VECTOR;
+QASTValidationFlagsSet hybridVectorFilterValidationFlags = (QASTValidationFlagsSet)(QAST_NO_VECTOR | QAST_NO_WEIGHT);
+QASTValidationFlagsSet hybridSearchValidationFlags = QAST_NO_VECTOR;
 
 bool isValidAsHybridVectorFilter(const char *qt, RedisSearchCtx &ctx) {
   QASTCXX ast;
@@ -35,7 +35,7 @@ bool isValidAsHybridSearch(const char *qt, RedisSearchCtx &ctx) {
 }
 
 bool isInvalidHybridSearch(const char *qt, RedisSearchCtx &ctx,
-  QAST_ValidationFlags validationFlags, QueryErrorCode error) {
+  QASTValidationFlagsSet validationFlags, QueryErrorCode error) {
   QASTCXX ast;
   ast.setContext(&ctx);
   ast.isValidQuery(qt, validationFlags);


### PR DESCRIPTION
Let's use the proper name generated from Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type rename only; validation behavior and QAST_NO_* macros are unchanged.
> 
> **Overview**
> Removes the legacy C typedef **`QAST_ValidationFlags`** (`uint32_t`) from cheadergen output and switches C/C++ call sites to the Rust-generated **`QASTValidationFlagsSet`** for query AST validation flags.
> 
> **`QueryNode_CheckIsValid`** in `query.c`, **`QASTCXX::isValidQuery`** in `query_test_utils.h`, and hybrid validation tests in `test_cpp_query_validation.cpp` now take **`QASTValidationFlagsSet`** instead of the old typedef. **`QAST_NO_WEIGHT`** / **`QAST_NO_VECTOR`** macros are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b3c047cee024699848c317d5d096fffc57a55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->