### PR TITLE
ci: unify make lint with CI lint workflow

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -109,76 +109,10 @@ jobs:
       - name: Cargo deny
         run: cargo install cargo-deny --locked
       - name: Lint
-        id: lint
-        continue-on-error: true
-        run: make lint
-
-      - name: Generated files
-        id: git-diff
-        continue-on-error: true
-        run: |
-          if ! git diff --exit-code; then
-            echo "Uncommitted changes found. Likely causes: stale Rust → C FFI headers under src/redisearch_rs/headers/ (run 'make generate-rust-headers' and commit) or other auto-generated artifacts produced by 'make lint'."
-            exit 1
-          fi
-      - name: License header
-        id: license-header
-        continue-on-error: true
-        run: make license-check
-      - name: Format check
-        id: fmt
-        continue-on-error: true
-        run: make fmt CHECK=1
-      - name: Security advisories
-        id: advisories
-        continue-on-error: true
         env:
           COMPARE_ADVISORIES_TO_BASE: ${{ inputs.compare-advisories-to-base }}
           ADVISORIES_BASE_REF: ${{ inputs.advisories-base-ref }}
-          MANIFEST_PATH: src/redisearch_rs/Cargo.toml
-        run: |
-          ARGS=()
-          if [[ "$COMPARE_ADVISORIES_TO_BASE" == "true" ]]; then
-            ARGS+=(--compare-to-base --base-ref "$ADVISORIES_BASE_REF")
-          fi
-          python3 scripts/cargo_deny_advisory_gate.py \
-            --manifest-path "$MANIFEST_PATH" \
-            "${ARGS[@]}"
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        id: dep-licenses
-        continue-on-error: true
-        with:
-          command: check licenses
-          arguments: --all-features
-          manifest-path: src/redisearch_rs/Cargo.toml
-      - name: Workspace hack check
-        id: workspace_hack
-        working-directory: src/redisearch_rs
-        continue-on-error: true
-        run: |
-          if ! cargo hakari generate --diff || ! cargo hakari manage-deps --dry-run; then
-            echo "Suggested fix:"
-            echo "  Run the following command in 'src/redisearch_rs' to update workspace_hack's Cargo.toml and ensure all workspace crates depend on workspace_hack:"
-            echo "    cargo hakari generate && cargo hakari manage-deps"
-            exit 1
-          fi
+        run: make lint
       - name: Show sccache stats
+        if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
-      - name: Fail if any step failed
-        if: |
-          steps.lint.outcome == 'failure' ||
-          steps.git-diff.outcome == 'failure' ||
-          steps.license-header.outcome == 'failure' ||
-          steps.fmt.outcome == 'failure' ||
-          steps.advisories.outcome == 'failure' ||
-          steps.dep-licenses.outcome == 'failure' ||
-          steps.workspace_hack.outcome == 'failure'
-        run: |
-          echo "Lint: ${{ steps.lint.outcome }}"
-          echo "Generated files: ${{ steps.git-diff.outcome }}"
-          echo "License header: ${{ steps.license-header.outcome }}"
-          echo "Format check: ${{ steps.fmt.outcome }}"
-          echo "Security advisories: ${{ steps.advisories.outcome }}"
-          echo "Dependency licenses: ${{ steps.dep-licenses.outcome }}"
-          echo "Workspace hack check: ${{ steps.workspace_hack.outcome }}"
-          exit 1

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,8 @@ Development:
     WITH_RLTEST=1      Run using RLTest framework
     GDB=1              Invoke using gdb
     CLANG=1            Use lldb instead of gdb (when GDB=1)
-  make lint          Run linters
+  make lint          Run all linters (clippy, docs, fmt, licenses, advisories, hakari)
+    CHECK=1            Check formatting without modifying files
   make fmt           Format source files
     CHECK=1            Check formatting without modifying files
 
@@ -322,11 +323,6 @@ run:
 		fi; \
 	fi
 
-# Function to extract EXCLUDE_RUST_BENCHING_CRATES_LINKING_C from build.sh
-define get_rust_exclude_crates
-$(shell grep "EXCLUDE_RUST_BENCHING_CRATES_LINKING_C=" build.sh | cut -d'=' -f2 | tr -d '"' | head -n1)
-endef
-
 # Regenerate the Rust → C FFI headers under src/redisearch_rs/headers/.
 #
 # The recipe (cheadergen CLI args + env scrub) lives in
@@ -337,13 +333,8 @@ generate-rust-headers:
 	@echo "Regenerating Rust → C FFI headers via cheadergen..."
 	@$(ROOT)/src/redisearch_rs/regen_headers.sh
 
-lint: generate-rust-headers
-	@echo "Running linters for debug..."
-	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --document-private-items
-	@echo "Running linters for release..."
-	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) --release -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps --document-private-items --release
+lint:
+	@$(ROOT)/scripts/lint.sh
 
 fmt:
 ifeq ($(CHECK),1)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+#
+# Unified lint script. Runs all linting checks, continues past failures,
+# and prints a summary report at the end. Exit code is non-zero if any
+# check failed.
+#
+# Usage:
+#   scripts/lint.sh [options]
+#
+# Options (via environment variables):
+#   CHECK=1                          Check formatting without modifying files (default in CI)
+#   COMPARE_ADVISORIES_TO_BASE=true  Only fail advisories on new findings vs base ref
+#   ADVISORIES_BASE_REF=<ref>        Git ref for advisory comparison
+#
+# CI sets these env vars; local runs use defaults (CHECK=0, no advisory comparison).
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUST_DIR="$ROOT/src/redisearch_rs"
+MANIFEST_PATH="src/redisearch_rs/Cargo.toml"
+
+# Extract exclude crates from build.sh
+EXCLUDE_CRATES=$(grep "EXCLUDE_RUST_BENCHING_CRATES_LINKING_C=" "$ROOT/build.sh" | cut -d'=' -f2 | tr -d '"' | head -n1)
+
+COMPARE_ADVISORIES_TO_BASE="${COMPARE_ADVISORIES_TO_BASE:-false}"
+ADVISORIES_BASE_REF="${ADVISORIES_BASE_REF:-}"
+
+cd "$ROOT"
+
+# Track results: parallel arrays of check names and outcomes
+declare -a CHECK_NAMES=()
+declare -a CHECK_RESULTS=()
+
+run_check() {
+  local name="$1"
+  shift
+  CHECK_NAMES+=("$name")
+  echo ""
+  echo "==== $name ===="
+  if "$@"; then
+    CHECK_RESULTS+=("pass")
+    echo "---- $name: PASSED ----"
+  else
+    CHECK_RESULTS+=("FAIL")
+    echo "---- $name: FAILED ----"
+  fi
+}
+
+# --- Header generation ---
+run_check "Generate Rust headers" "$ROOT/src/redisearch_rs/regen_headers.sh"
+
+# --- Clippy (debug) ---
+run_check "Clippy (debug)" bash -c '
+  cd "'"$RUST_DIR"'" && cargo clippy --workspace '"$EXCLUDE_CRATES"' -- -D warnings
+'
+
+# --- Cargo doc (debug) ---
+run_check "Cargo doc (debug)" bash -c '
+  cd "'"$RUST_DIR"'" && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace '"$EXCLUDE_CRATES"' --no-deps --document-private-items
+'
+
+# --- Clippy (release) ---
+run_check "Clippy (release)" bash -c '
+  cd "'"$RUST_DIR"'" && cargo clippy --workspace '"$EXCLUDE_CRATES"' --release -- -D warnings
+'
+
+# --- Cargo doc (release) ---
+run_check "Cargo doc (release)" bash -c '
+  cd "'"$RUST_DIR"'" && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace '"$EXCLUDE_CRATES"' --no-deps --document-private-items --release
+'
+
+# --- License headers ---
+run_check "License headers" bash -c 'cd "'"$RUST_DIR"'" && cargo license-check'
+
+# --- Format check ---
+run_check "Format (check)" bash -c '
+  cd "'"$RUST_DIR"'" && cargo fmt --check --all
+'
+
+# --- Generated files (git diff) ---
+run_check "Generated files (git diff)" bash -c '
+  if ! git diff --exit-code; then
+    echo "Uncommitted changes found. Likely causes: stale Rust → C FFI headers"
+    echo "under src/redisearch_rs/headers/ (run '\''make generate-rust-headers'\'' and commit)"
+    echo "or other auto-generated artifacts produced by lint."
+    exit 1
+  fi
+'
+
+# --- Security advisories ---
+run_check "Security advisories" bash -c '
+  ARGS=()
+  if [ "'"$COMPARE_ADVISORIES_TO_BASE"'" = "true" ]; then
+    ARGS+=(--compare-to-base --base-ref "'"$ADVISORIES_BASE_REF"'")
+  fi
+  python3 scripts/cargo_deny_advisory_gate.py \
+    --manifest-path "'"$MANIFEST_PATH"'" \
+    "${ARGS[@]}"
+'
+
+# --- Dependency licenses ---
+run_check "Dependency licenses" bash -c '
+  cd "'"$RUST_DIR"'" && cargo deny --all-features check licenses
+'
+
+# --- Workspace hack (hakari) ---
+run_check "Workspace hack (hakari)" bash -c '
+  cd "'"$RUST_DIR"'"
+  if ! cargo hakari generate --diff || ! cargo hakari manage-deps --dry-run; then
+    echo "Suggested fix:"
+    echo "  Run the following in '\''src/redisearch_rs'\'':"
+    echo "    cargo hakari generate && cargo hakari manage-deps"
+    exit 1
+  fi
+'
+
+# --- Summary report ---
+echo ""
+echo "========================================"
+echo "  Lint Summary"
+echo "========================================"
+
+failures=0
+for i in "${!CHECK_NAMES[@]}"; do
+  name="${CHECK_NAMES[$i]}"
+  result="${CHECK_RESULTS[$i]}"
+  if [ "$result" = "FAIL" ]; then
+    printf "  %-35s %s\n" "$name" "FAILED"
+    failures=$((failures + 1))
+  else
+    printf "  %-35s %s\n" "$name" "ok"
+  fi
+done
+
+echo "========================================"
+total=${#CHECK_NAMES[@]}
+passed=$((total - failures))
+echo "  $passed/$total checks passed"
+if [ "$failures" -gt 0 ]; then
+  echo "  $failures FAILED"
+fi
+echo "========================================"
+
+exit $((failures > 0 ? 1 : 0))


### PR DESCRIPTION
Move all CI lint checks (clippy, cargo doc, git diff, license headers, formatting, security advisories, dependency licenses, hakari) into a single scripts/lint.sh runner. The script continues past failures and prints a summary report at the end.

make lint now delegates to this script, and the CI workflow simply calls make lint instead of duplicating each check as separate steps.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Makefile-only refactor with no product runtime or API changes; main risk is lint parity if env wiring (e.g. advisory comparison) diverges from the old workflow.
> 
> **Overview**
> Consolidates Rust/CI linting into **`scripts/lint.sh`**, which runs the former Makefile and workflow checks in one place (header regen, clippy/doc debug+release, license headers, `cargo fmt --check`, clean git tree, advisory gate, `cargo deny` licenses, hakari) and **keeps going after a failure**, then prints a pass/fail summary and exits non-zero if anything failed.
> 
> **`make lint`** now only invokes that script; inline clippy/doc recipes and the Makefile helper for excluded bench crates move into the script (still read from `build.sh`). The **lint workflow** drops per-step `continue-on-error` aggregation and a separate `make fmt CHECK=1` step in favor of a single **`make lint`** with advisory env vars; **sccache stats** run with `if: always()`.
> 
> Help text for **`make lint`** is updated to list the bundled checks; **`make fmt`** / **`license-check`** targets are unchanged for direct use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d5a01c94220bcddaf86f6a32e0047147b12d92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->