### PR TITLE
Remove "-nan" test

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/format_g.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/format_g.rs
@@ -66,14 +66,6 @@ fn non_finite() {
 }
 
 #[test]
-fn negative_nan() {
-    let neg_nan = f64::from_bits(0xFFF8000000000000u64);
-    assert!(neg_nan.is_nan());
-    assert!(neg_nan.is_sign_negative());
-    assert_eq!(format_g(neg_nan), c_format_g(neg_nan));
-}
-
-#[test]
 fn negative() {
     assert_eq!(format_g(-1.0), "-1");
     assert_eq!(format_g(-0.00001), "-1e-05");


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `negative_nan` test in `rqe_iterators/tests/integration/format_g.rs` (added in #9417) asserts that our Rust `format_g` reimplementation produces the same string as C's `snprintf("%g", ...)` for a negative NaN bit pattern (`0xFFF8000000000000`). This assertion is platform-dependent and fails on macOS (reproduced on macOS 26 / M3 Max and other Macs): the C library and Rust disagree on whether to emit `-nan` or `nan`.
2. **Change:** Remove the `negative_nan` test.
3. **Outcome:** The test suite is no longer platform-dependent and passes consistently across Linux and macOS.

   #### Rationale

The sign bit of a NaN carries no meaningful semantics: per IEEE 754, every bit pattern with all exponent bits set and a non-zero mantissa is a NaN, regardless of the sign bit.

More importantly, `format_g` is not expected to be called with NaN inputs in the profile-printing path it serves; NaN handling was only added for feature parity with the C implementation, and we do not rely on the negative-NaN formatting behavior.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or API impact.
> 
> **Overview**
> Removes the **`negative_nan`** integration test from `format_g.rs` that compared Rust **`format_g`** output to C **`snprintf("%g")`** for a negative-NaN bit pattern. That check was **platform-dependent** (Linux vs macOS disagree on `-nan` vs `nan`) and caused CI failures without reflecting real profile-print usage.
> 
> Other **`format_g`** coverage (finite values, plain NaN/inf, and the **`matches_c`** proptest) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6249128989d1e00ee89fe4e39bd7a262b1da1e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->