### PR TITLE
ci: allow merge-queue and bot actors past Codex triage gate

### DIFF
--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -48,7 +48,11 @@ runs:
         # Triage runs on post-merge/scheduled events whose actor is a bot
         # (github-merge-queue, github-actions[bot]); allow them past the
         # action's collaborator gate. Sandbox + safety remain read-only.
+        # `allow-bots: true` only covers github-actions[bot] (hardcoded in
+        # codex-action's trusted set); other bot actors must be listed
+        # explicitly via `allow-bot-users`.
         allow-bots: true
+        allow-bot-users: github-merge-queue[bot]
 
     - name: Read triage output
       id: read

--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -45,6 +45,10 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         sandbox: read-only
         safety-strategy: read-only
+        # Triage runs on post-merge/scheduled events whose actor is a bot
+        # (github-merge-queue, github-actions[bot]); allow them past the
+        # action's collaborator gate. Sandbox + safety remain read-only.
+        allow-bots: true
 
     - name: Read triage output
       id: read


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `openai/codex-action@v1` enforces a collaborator / write-access gate on the workflow actor. When a post-merge workflow is launched by the merge queue the actor is `github-merge-queue`, and scheduled workflows run as `github-actions[bot]` — both are bots that fail the gate. The triage step crashes with `Actor '<bot>' is not a collaborator … write access is required` and `ai-triage.txt` is never written, so the downstream Slack notification ships with `"ai_triage": ""`. Observed in https://github.com/RediSearch/RediSearch/actions/runs/26743158666/job/78831913948.
2. **Change:** Set `allow-bots: true` on the action invocation inside the shared `.github/actions/codex-ci-triage` composite, which is the single entry point used by `daily-ci-report`, `benchmark-runner`, `event-periodic-master-validation`, and `event-deploy-snapshots`. Sandbox and safety-strategy stay `read-only`, so the relaxed actor check cannot translate into write access.
3. **Outcome:** Codex triage runs to completion on merge-queue-driven and scheduled workflows, and Slack notifications include the AI triage summary again.

#### Which additional issues this PR fixes
1. n/a

#### Main objects this PR modified
1. `.github/actions/codex-ci-triage/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to GitHub Action inputs; execution remains read-only with no product or API impact.
> 
> **Overview**
> The shared **Codex CI triage** composite action now passes **`allow-bots: true`** and **`allow-bot-users: github-merge-queue[bot]`** into `openai/codex-action@v1`, so scheduled and merge-queue workflows (actors like `github-actions[bot]` and `github-merge-queue`) are no longer blocked by the action’s collaborator gate.
> 
> **Sandbox** and **safety-strategy** stay **read-only**; only who may invoke the step changes. Workflows that consume this action (`daily-ci-report`, `benchmark-runner`, `event-periodic-master-validation`, `event-deploy-snapshots`) should again produce `ai-triage.txt` and populate Slack **`ai_triage`** instead of failing early with an empty triage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda0ce85f3cc0129caed6cb5c29bd343ab5a2565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->