### PR TITLE
MOD-15930 Bump ramp-packer to 2.5.18

### DIFF
--- a/.install/build_package_requirements.txt
+++ b/.install/build_package_requirements.txt
@@ -1,4 +1,4 @@
 addict
 toml
 jinja2
-ramp-packer==2.5.17
+ramp-packer==2.5.18


### PR DESCRIPTION
## Summary

Bump the packaging dependency to `ramp-packer==2.5.18`.

## Context

RAMP 2.5.18 resolves module OS metadata from `/etc/devcontainer` when available before falling back to `/etc/os-release`/`distro` detection. This keeps generated `module.json` OS metadata aligned with devcontainer-based build platforms.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin with no application code changes; impact is limited to packaging/OS metadata detection behavior in the build toolchain.
> 
> **Overview**
> Pins **`ramp-packer`** from **2.5.17** to **2.5.18** in `.install/build_package_requirements.txt`.
> 
> That release prefers **`/etc/devcontainer`** for module OS metadata when present, then falls back to **`/etc/os-release`** / **`distro`**—so **`module.json`** OS fields match devcontainer-based builds more reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde696e9b4614f6f3ec0adb235bf7d55360b7db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->