### PR TITLE
Make SearchEnterpriseIterators return RQEIteratorPrintable

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -198,10 +198,10 @@ pub trait RQEIterator<'index> {
     fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64;
 }
 
-/// Blanket [`RQEIterator`] impl for `Box<I>` where `I` is a concrete iterator type.
+/// [`RQEIterator`] impl for boxed iterators, including type-erased `dyn` variants.
 ///
-/// All core methods delegate to the inner iterator.
-impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
+/// All methods delegate through the vtable to the concrete type's implementation.
+impl<'index, I: RQEIterator<'index> + ?Sized + 'index> RQEIterator<'index> for Box<I> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         (**self).current()
     }
@@ -254,61 +254,13 @@ impl<'index, I: RQEIterator<'index> + 'index> RQEIterator<'index> for Box<I> {
     }
 }
 
-/// [`RQEIterator`] impl for type-erased iterators.
-///
-/// All methods — including profiling — delegate through the vtable to the
-/// concrete type's implementation.
-impl<'index> RQEIterator<'index> for Box<dyn RQEIterator<'index> + 'index> {
-    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        (**self).current()
-    }
+/// Combined trait for iterators that implement both [`RQEIterator`] and
+/// [`ProfilePrint`](profile_print::ProfilePrint).
+pub trait RQEIteratorPrintable<'index>: RQEIterator<'index> + profile_print::ProfilePrint {}
 
-    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        (**self).read()
-    }
-
-    fn skip_to(
-        &mut self,
-        doc_id: DocId,
-    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
-        (**self).skip_to(doc_id)
-    }
-
-    fn revalidate(
-        &mut self,
-        spec: &IndexSpecReadGuard,
-    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate(spec)
-    }
-
-    fn rewind(&mut self) {
-        (**self).rewind()
-    }
-
-    fn num_estimated(&self) -> usize {
-        (**self).num_estimated()
-    }
-
-    fn last_doc_id(&self) -> DocId {
-        (**self).last_doc_id()
-    }
-
-    fn at_eof(&self) -> bool {
-        (**self).at_eof()
-    }
-
-    #[inline(always)]
-    fn type_(&self) -> IteratorType {
-        (**self).type_()
-    }
-
-    fn as_c_iterator(&self) -> Option<&c2rust::CRQEIterator> {
-        (**self).as_c_iterator()
-    }
-
-    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
-        (**self).intersection_sort_weight(prioritize_union_children)
-    }
+impl<'index, T> RQEIteratorPrintable<'index> for T where
+    T: RQEIterator<'index> + profile_print::ProfilePrint
+{
 }
 
 /// Global holder for APIs to get iterators for SearchEnterprise. This allows `rqe_iterators`
@@ -339,7 +291,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
         query_term: Box<RSQueryTerm>,
         field_mask: FieldMask,
         weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>>;
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
 
     /// Iterate over all the terms in the index, skipping offset data for efficiency.
     ///
@@ -353,7 +305,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
         query_term: Box<RSQueryTerm>,
         field_mask: FieldMask,
         weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>>;
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
 
     /// Iterate over all the tags (tokens) in the index at the given field index. Each document in
     /// then iterator will have the given weight.
@@ -363,5 +315,5 @@ pub trait SearchEnterpriseIterators: Send + Sync {
         token: &ffi::RSToken,
         field_index: FieldIndex,
         weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>>;
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
 }

--- a/src/redisearch_rs/rqe_iterators/src/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile_print.rs
@@ -17,6 +17,10 @@ use std::{borrow::Cow, ffi::CStr};
 
 use redis_reply::MapBuilder;
 
+/// Re-exported for crates that implement [`ProfilePrint`] without directly
+/// depending on `redis_reply`.
+pub use redis_reply::MapBuilder as ProfileMapBuilder;
+
 use crate::profile::ProfileCounters;
 
 /// Trait for iterator types that can print their profile.
@@ -115,6 +119,12 @@ impl ProfilePrintCtx<'_> {
             let mut child_ctx = self.child_ctx();
             child.print_profile(&mut child_map, &mut child_ctx);
         }
+    }
+}
+
+impl<T: ProfilePrint + ?Sized> ProfilePrint for Box<T> {
+    fn print_profile(&self, map: &mut MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
+        (**self).print_profile(map, ctx)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -144,59 +144,6 @@ impl<'index, I: WildcardIterator<'index>> WildcardIterator<'index>
 /// `QueryIterator*` for the `wcii` field.
 impl<'index> WildcardIterator<'index> for crate::c2rust::CRQEIterator {}
 
-impl<'index> RQEIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> {
-    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        (**self).current()
-    }
-
-    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        (**self).read()
-    }
-
-    fn skip_to(
-        &mut self,
-        doc_id: DocId,
-    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
-        (**self).skip_to(doc_id)
-    }
-
-    fn revalidate(
-        &mut self,
-        spec: &IndexSpecReadGuard,
-    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        (**self).revalidate(spec)
-    }
-
-    fn rewind(&mut self) {
-        (**self).rewind()
-    }
-
-    fn num_estimated(&self) -> usize {
-        (**self).num_estimated()
-    }
-
-    fn last_doc_id(&self) -> DocId {
-        (**self).last_doc_id()
-    }
-
-    fn at_eof(&self) -> bool {
-        (**self).at_eof()
-    }
-
-    #[inline(always)]
-    fn type_(&self) -> IteratorType {
-        (**self).type_()
-    }
-
-    fn as_c_iterator(&self) -> Option<&crate::c2rust::CRQEIterator> {
-        (**self).as_c_iterator()
-    }
-
-    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
-        (**self).intersection_sort_weight(prioritize_union_children)
-    }
-}
-
 impl<'index> WildcardIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> {}
 
 /// The result of [`new_wildcard_iterator`], representing the different kinds of

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -16,7 +16,8 @@
 
 use rqe_core::{DocId, FieldIndex};
 use rqe_iterators::{
-    RQEIterator, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators, wildcard::Wildcard,
+    RQEIterator, RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators,
+    wildcard::Wildcard,
 };
 
 /// The `top_id` used by the wildcard returned from
@@ -50,7 +51,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
         _query_term: Box<query_term::RSQueryTerm>,
         _field_mask: inverted_index::FieldMask,
         _weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
         unimplemented!(
             "MockEnterpriseIterators::new_term_on_disk_with_offsets not used in these tests"
         )
@@ -62,7 +63,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
         _query_term: Box<query_term::RSQueryTerm>,
         _field_mask: inverted_index::FieldMask,
         _weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
         unimplemented!(
             "MockEnterpriseIterators::new_term_on_disk_without_offsets not used in these tests"
         )
@@ -74,7 +75,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
         _token: &ffi::RSToken,
         _field_index: FieldIndex,
         _weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
         unimplemented!("MockEnterpriseIterators::new_tag_on_disk not used in these tests")
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request
All three methods on `SearchEnterpriseIterators` now return `Box<dyn RQEIteratorPrintable<'index> + 'index>` instead of `Box<dyn RQEIterator<'index> + 'index>`, so callers can pass the result directly to `RQEIteratorWrapper::boxed_new` which requires `I: RQEIterator + ProfilePrint`.

To support this:
- Add `RQEIteratorPrintable<'index>` supertrait combining `RQEIterator` and `ProfilePrint`, with a blanket impl for all `T` satisfying both.
- Relax the `Box<I>: RQEIterator` blanket impl to `I: ?Sized` so `Box<dyn RQEIteratorPrintable>` is covered without a separate impl; the now-redundant specific `Box<dyn WildcardIterator>: RQEIterator` impl in wildcard.rs is removed.
- Add `impl<T: ProfilePrint + ?Sized> ProfilePrint for Box<T>` and re-export `MapBuilder as ProfileMapBuilder` for implementors that don't depend directly on `redis_reply`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal trait and blanket-impl cleanup in the iterator layer; no auth, persistence, or query-semantics changes beyond typing for PROFILE-capable disk iterators.
> 
> **Overview**
> Enterprise on-disk **term** and **tag** iterator factories now return `Box<dyn RQEIteratorPrintable<'index>>` instead of `Box<dyn RQEIterator<'index>>`, so disk iterators are known to support both query iteration and **PROFILE** tree printing when wrapped for C interop.
> 
> To support that without duplicating delegation code, the crate adds **`RQEIteratorPrintable`** (combines `RQEIterator` + `ProfilePrint`), generalizes **`Box<I>: RQEIterator`** to **`I: ?Sized`**, and drops the separate **`Box<dyn RQEIterator>`** / **`Box<dyn WildcardIterator>: RQEIterator`** impls. **`ProfilePrint`** is implemented for **`Box<T>`** when `T: ?Sized`, and **`MapBuilder`** is re-exported as **`ProfileMapBuilder`** for implementors outside `redis_reply`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c323722a1b018b94755cd4dcf35e5a07b3df56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->