### PR TITLE
[8.4] [MOD-15996] Fix uint32 underflow in suffix loop bound (fork-GC crash on empty TAG)

### DIFF
--- a/src/suffix.c
+++ b/src/suffix.c
@@ -405,7 +405,7 @@ void addSuffixTrieMap(TrieMap *trie, const char *str, uint32_t len) {
 
   // Save string copy to all suffixes of it
   // If it exists, move to the next field
-  for (int j = 1; j < len - MIN_SUFFIX + 1; ++j) {
+  for (uint32_t j = 1; j + MIN_SUFFIX <= len; ++j) {
     data = TrieMap_Find(trie, copyStr + j, len - j);
 
     if (data == TRIEMAP_NOTFOUND) {
@@ -422,7 +422,7 @@ void deleteSuffixTrieMap(TrieMap *trie, const char *str, uint32_t len) {
   char *oldTerm = NULL;
 
   // iterate all matching terms and remove word
-  for (int j = 0; j < len - MIN_SUFFIX + 1; ++j) {
+  for (uint32_t j = 0; j + MIN_SUFFIX <= len; ++j) {
     suffixData *data = TrieMap_Find(trie, str + j, len - j);
     RS_LOG_ASSERT(data != TRIEMAP_NOTFOUND, "all suffixes must exist");
     if (j == 0) {

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -511,3 +511,17 @@ def test_gc_oom_replica_relaxed():
     bytes_collected = int(gc_dict['bytes_collected'])
     env.assertGreater(bytes_collected, 0,
         message="GC should run on replica even when maxmemory is exceeded")
+
+
+# Regression for [MOD-15940](https://redislabs.atlassian.net/browse/MOD-15940)
+@skip(cluster=True)
+def testForkGCEmptyTagSuffixTrie_emptyValue_MOD_15996():
+    env = Env(moduleArgs='FORK_GC_CLEAN_THRESHOLD 0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               't', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
+    waitForIndex(env, 'idx')
+    env.cmd('HSET', 'doc1', 't', '')
+    env.expect('DEL', 'doc1').equal(1)
+    forceInvokeGC(env, 'idx')
+    env.expect('PING').equal(True)
+


### PR DESCRIPTION
# Description
Backport of #9916 to `8.4`.


## Describe the changes in the pull request

1. **Current**: A `TAG INDEXEMPTY WITHSUFFIXTRIE` field crashes the server in the fork-GC thread when the last document holding an empty (`""`) tag value is deleted. The root cause in `src/suffix.c` is a `uint32` underflow at the suffix-loop bound: `for (int j = 0; j < len - MIN_SUFFIX + 1; ++j)`. For `len = 0`, `len - MIN_SUFFIX + 1` evaluates as `uint32_t` and underflows to `UINT32_MAX`. On the next iteration `len - j` underflows again and is truncated to `uint16_t = 65535` when passed to `TrieMap_Find`, producing an OOB read.

   This bug has been latent since [#4475](https://github.com/RediSearch/RediSearch/pull/4475) (which introduced `INDEXEMPTY` for TAGs and made `len = 0` reachable from a sanctioned customer path).

2. **Change** (`src/suffix.c`): switch the loop bound in `addSuffixTrieMap` and `deleteSuffixTrieMap` to the underflow-safe `j + MIN_SUFFIX <= len` form already used by the rune-trie siblings. For `len ≥ MIN_SUFFIX` it is mathematically identical to the previous bound; for `len < MIN_SUFFIX` it cleanly evaluates to `false` instead of underflowing.

3. **Outcome**: the four-command repro (`FT.CREATE ... INDEXEMPTY WITHSUFFIXTRIE` → `HSET d t ""` → `DEL d` → `FT.DEBUG GC_FORCEINVOKE`) no longer crashes. At `len = 0` the loop simply does not execute.

### Tests

`tests/pytests/test_gc.py::testForkGCEmptyTagSuffixTrie_emptyValue_MOD_15996` — exercises the canonical four-command repro. Pre-fix this crashes the server in the fork-GC thread; post-fix the final `PING` returns.

### Backport notes

- Clean cherry-pick of `src/suffix.c` (file matches master at the changed hunks).
- `tests/pytests/test_gc.py` had a trivial conflict because `testForceGCBypassesThreshold` (an unrelated master-only test) is not present on `8.4`. Resolved by appending only the new MOD-15996 regression test to the existing end-of-file; no other lines touched.

#### Which additional issues this PR fixes
1. MOD-15996
2. MOD-15940 (production incident driving this fix)

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted loop-bound fix in suffix TrieMap maintenance with a focused regression test; no auth or broad API changes.
> 
> **Overview**
> Fixes a **fork-GC server crash** when the last document with an **empty TAG value** is removed from an index that uses **`INDEXEMPTY`** and **`WITHSUFFIXTRIE`**.
> 
> In `addSuffixTrieMap` and `deleteSuffixTrieMap`, the suffix iteration bound is changed from `j < len - MIN_SUFFIX + 1` (which **underflows** for `len < MIN_SUFFIX`, e.g. `len == 0`) to **`j + MIN_SUFFIX <= len`**, with `j` as `uint32_t`. For normal lengths the behavior matches the old bound; for short or zero-length strings the loops **do not run**, avoiding bogus `TrieMap_Find` lengths and out-of-bounds reads during GC cleanup.
> 
> Adds **`testForkGCEmptyTagSuffixTrie_emptyValue_MOD_15996`**: create index, index `""`, delete doc, force GC, assert **`PING`** still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c32e01469f2044c5a3094d7ee9952aa384de71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->