### PR TITLE
chore(rust): align Default/new delegation

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs
@@ -15,13 +15,18 @@ pub struct OwnedSlice<T> {
 impl<T> Default for OwnedSlice<T> {
     #[inline(always)]
     fn default() -> Self {
-        Self {
-            kind: SliceKind::Rust(Vec::default()),
-        }
+        Self::new()
     }
 }
 
 impl<T> OwnedSlice<T> {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            kind: SliceKind::Rust(Vec::new()),
+        }
+    }
+
     /// # Safety
     ///
     /// ptr must be non-null and point to `len` initialized elements

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -32,11 +32,7 @@ pub struct TrieMap<Data> {
 
 impl<Data> Default for TrieMap<Data> {
     fn default() -> Self {
-        Self {
-            root: None,
-            n_unique_keys: 0,
-            memory_usage: std::mem::size_of::<Self>(),
-        }
+        Self::new()
     }
 }
 
@@ -48,7 +44,11 @@ impl<Data> TrieMap<Data> {
     /// No allocation is performed on creation.
     /// Memory is allocated only when the first insertion occurs.
     pub fn new() -> Self {
-        Default::default()
+        Self {
+            root: None,
+            n_unique_keys: 0,
+            memory_usage: std::mem::size_of::<Self>(),
+        }
     }
 
     /// Insert a key-value pair into the trie.

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -43,7 +43,7 @@ impl<Data> TrieMap<Data> {
     ///
     /// No allocation is performed on creation.
     /// Memory is allocated only when the first insertion occurs.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             root: None,
             n_unique_keys: 0,


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Two Rust types diverged from the workspace's dominant `Default → new` delegation pattern. `TrieMap<Data>` placed its constructor body in `Default::default()` and made `new()` call `Default::default()` (the reverse direction). `OwnedSlice<T>` inlined its empty-Rust-Vec construction directly in `Default::default()` with no inherent `new()` constructor.
2. **Change**: Move the constructor body in both types into `new()`. `Default::default()` now delegates to `Self::new()`. For `OwnedSlice`, `new()` is `pub const fn` so the empty constructor is usable in const contexts.
3. **Outcome**: Both types now match the dominant pattern used across the rest of the workspace (e.g. `SearchResult`, `RLookup`, `RLookupRow`, `ThinVec`, `Slab`, `Reducer`, `Counter`, `FieldExpirations`, `SlotsTracker`, etc.). No behavior change; the constructed values are identical.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `src/redisearch_rs/trie_rs/src/trie.rs` — `TrieMap<Data>`
2. `src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs` — `OwnedSlice<T>`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical constructor refactor with identical empty values; only adds const `OwnedSlice::new()` without changing runtime paths.
> 
> **Overview**
> Refactors **`OwnedSlice`** and **`TrieMap`** so empty construction lives in **`new()`** and **`Default::default()`** only calls **`Self::new()`**, matching the dominant pattern elsewhere in `redisearch_rs`.
> 
> **`OwnedSlice`** gains a public **`const fn new()`** (empty Rust-backed vec); **`TrieMap::new()`** is now **`const`** with the empty trie fields inlined instead of going through **`Default`**.
> 
> No intended behavior or API surface change beyond **`OwnedSlice::new()`** being callable in const contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454870ced38f4d4a890a834693d620a0cc4d5590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->