### PR TITLE
[MOD-15897] Trie: add StrTrieMap with iterators

### DIFF
--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod iter;
 mod node;
 pub mod opaque;
+pub mod str;
 mod trie;
 mod trie_count;
 mod utils;

--- a/src/redisearch_rs/trie_rs/src/str/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/contains.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{TrieMap, iter, str::iter::iter_::key_to_string};
+
+/// Substring-filtered iterator over a [`StrTrieMap`](crate::str::StrTrieMap),
+/// in lexicographical key order.
+///
+/// Empty `target` yields zero matches (mirrors the C `Trie_IterateContains`
+/// short-circuit). The wrapped `Option` is `None` for the empty-target case.
+///
+/// See [`crate::iter::ContainsIter`] for the underlying traversal.
+pub struct ContainsIter<'tm, 'p, Data: 'tm>(Option<iter::ContainsIter<'tm, 'p, Data>>);
+
+impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
+    pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &'p str) -> Self {
+        if target.is_empty() {
+            return Self(None);
+        }
+        Self(Some(trie.contains_iter(target.as_bytes())))
+    }
+}
+
+impl<'tm, 'p, Data: 'tm> Iterator for ContainsIter<'tm, 'p, Data> {
+    type Item = (String, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.as_mut()?.next().map(|(k, v)| (key_to_string(k), v))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/str/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/iter_.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{
+    TrieMap,
+    iter::{self, filter},
+};
+
+/// Lexicographical-order iterator over a
+/// [`StrTrieMap`](crate::str::StrTrieMap).
+///
+/// See [`crate::iter::Iter`] for the underlying traversal.
+pub struct Iter<'a, Data>(iter::Iter<'a, Data, filter::VisitAll>);
+
+impl<'a, Data> Iter<'a, Data> {
+    pub(crate) fn new(trie: &'a TrieMap<Data>) -> Self {
+        Self(trie.iter())
+    }
+}
+
+impl<'a, Data> Iterator for Iter<'a, Data> {
+    type Item = (String, &'a Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (key_to_string(k), v))
+    }
+}
+
+/// Decode a trie byte key back to a `String`. Keys enter the [`crate::str::StrTrieMap`]
+/// exclusively via `&str` so they are UTF-8 by construction; the validating
+/// `from_utf8` call here is cheap and protects against any future raw-byte
+/// insertion at the lower layer.
+pub(super) fn key_to_string(bytes: Vec<u8>) -> String {
+    String::from_utf8(bytes).expect("StrTrieMap keys are UTF-8 by construction")
+}

--- a/src/redisearch_rs/trie_rs/src/str/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/mod.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Different iterators to traverse a [`StrTrieMap`](crate::str::StrTrieMap).
+
+mod contains;
+mod iter_;
+mod prefixed;
+mod range;
+mod suffixed;
+
+pub use contains::ContainsIter;
+pub use iter_::Iter;
+pub use prefixed::PrefixedIter;
+pub use range::{RangeBoundary, RangeFilter, RangeIter};
+pub use suffixed::SuffixedIter;

--- a/src/redisearch_rs/trie_rs/src/str/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/prefixed.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{
+    TrieMap,
+    iter::{self, filter},
+    str::iter::iter_::key_to_string,
+};
+
+/// Prefix-filtered iterator over a [`StrTrieMap`](crate::str::StrTrieMap),
+/// in lexicographical key order.
+///
+/// Empty `prefix` yields zero matches — differs from
+/// [`TrieMap::prefixed_iter`] which yields every entry on `&[]`. The wrapped
+/// `Option` carries the short-circuit: `None` when the prefix was empty.
+///
+/// See [`crate::iter::Iter`] for the underlying traversal.
+pub struct PrefixedIter<'tm, Data: 'tm>(Option<iter::Iter<'tm, Data, filter::VisitAll>>);
+
+impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
+    pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
+        if prefix.is_empty() {
+            return Self(None);
+        }
+        Self(Some(trie.prefixed_iter(prefix.as_bytes())))
+    }
+}
+
+impl<'tm, Data: 'tm> Iterator for PrefixedIter<'tm, Data> {
+    type Item = (String, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.as_mut()?.next().map(|(k, v)| (key_to_string(k), v))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/str/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/range.rs
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{
+    TrieMap,
+    iter::{self, RangeBoundary as InnerBoundary, RangeFilter as InnerFilter},
+    str::iter::iter_::key_to_string,
+};
+
+/// One of the bounds for a [`RangeFilter`].
+///
+/// Mirrors [`crate::iter::RangeBoundary`] but carries a UTF-8 [`str`] value
+/// instead of raw bytes, so the [`StrTrieMap`](crate::str::StrTrieMap) invariant
+/// extends through the range API.
+#[derive(Clone, Copy, Debug)]
+pub struct RangeBoundary<'f> {
+    pub value: &'f str,
+    pub is_included: bool,
+}
+
+impl<'f> RangeBoundary<'f> {
+    /// Create a new range boundary that includes its boundary value.
+    pub const fn included(value: &'f str) -> Self {
+        Self {
+            value,
+            is_included: true,
+        }
+    }
+
+    /// Create a new range boundary that doesn't include its boundary value.
+    pub const fn excluded(value: &'f str) -> Self {
+        Self {
+            value,
+            is_included: false,
+        }
+    }
+}
+
+/// Lower- and upper-bound filter for [`RangeIter`].
+///
+/// A `None` bound disables that side of the range; pairing inclusivity with
+/// the boundary value in [`RangeBoundary`] makes "unbounded but inclusive"
+/// unrepresentable.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RangeFilter<'f> {
+    pub min: Option<RangeBoundary<'f>>,
+    pub max: Option<RangeBoundary<'f>>,
+}
+
+impl RangeFilter<'_> {
+    /// A filter that matches all entries.
+    pub const fn all() -> Self {
+        Self {
+            min: None,
+            max: None,
+        }
+    }
+}
+
+impl<'f> From<RangeBoundary<'f>> for InnerBoundary<'f> {
+    fn from(b: RangeBoundary<'f>) -> Self {
+        Self {
+            value: b.value.as_bytes(),
+            is_included: b.is_included,
+        }
+    }
+}
+
+impl<'f> From<RangeFilter<'f>> for InnerFilter<'f> {
+    fn from(f: RangeFilter<'f>) -> Self {
+        Self {
+            min: f.min.map(InnerBoundary::from),
+            max: f.max.map(InnerBoundary::from),
+        }
+    }
+}
+
+/// Range-filtered iterator over a [`StrTrieMap`](crate::str::StrTrieMap),
+/// in lexicographical key order.
+///
+/// See [`crate::iter::RangeIter`] for the underlying traversal.
+pub struct RangeIter<'tm, 'p, Data: 'tm>(iter::RangeIter<'tm, 'p, Data>);
+
+impl<'tm, 'p, Data: 'tm> RangeIter<'tm, 'p, Data> {
+    pub(crate) fn build_from(trie: &'tm TrieMap<Data>, filter: RangeFilter<'p>) -> Self {
+        Self(trie.range_iter(InnerFilter::from(filter)))
+    }
+}
+
+impl<'tm, 'p, Data: 'tm> Iterator for RangeIter<'tm, 'p, Data> {
+    type Item = (String, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (key_to_string(k), v))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/str/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/suffixed.rs
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{
+    TrieMap,
+    iter::{self, filter},
+    str::iter::iter_::key_to_string,
+};
+
+/// Suffix-filtered iterator over a [`StrTrieMap`](crate::str::StrTrieMap),
+/// in lexicographical key order.
+///
+/// Wrapper-only — [`crate::iter`] has no suffix iterator. Byte `ends_with`
+/// on UTF-8 keys agrees with `&str::ends_with` because UTF-8 is
+/// self-synchronizing: a multibyte sequence cannot be a suffix of another
+/// codepoint. Empty `suffix` yields zero matches.
+///
+/// See [`crate::iter::Iter`] for the underlying traversal.
+pub struct SuffixedIter<'tm, Data: 'tm> {
+    target_bytes: Box<[u8]>,
+    iter: Option<iter::Iter<'tm, Data, filter::VisitAll>>,
+}
+
+impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
+    pub(crate) fn new(trie: &'tm TrieMap<Data>, suffix: &str) -> Self {
+        if suffix.is_empty() {
+            return Self {
+                target_bytes: Box::new([]),
+                iter: None,
+            };
+        }
+        Self {
+            target_bytes: suffix.as_bytes().to_vec().into_boxed_slice(),
+            iter: Some(trie.iter()),
+        }
+    }
+}
+
+impl<'tm, Data: 'tm> Iterator for SuffixedIter<'tm, Data> {
+    type Item = (String, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let iter = self.iter.as_mut()?;
+        loop {
+            let (k, v) = iter.next()?;
+            if k.ends_with(&self.target_bytes) {
+                return Some((key_to_string(k), v));
+            }
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/str/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str/mod.rs
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::fmt;
+
+use crate::TrieMap;
+
+pub mod iter;
+
+/// UTF-8 keyed view over [`TrieMap`].
+///
+/// Keys are stored as their UTF-8 byte representation inside the underlying
+/// [`TrieMap`]; this wrapper enforces the UTF-8 invariant at the API boundary
+/// so callers can work with `&str` and own `String` keys back from iterators.
+///
+/// Method semantics defer to the corresponding [`TrieMap`] method unless
+/// noted otherwise on the wrapper method itself.
+pub struct StrTrieMap<Data> {
+    inner: TrieMap<Data>,
+}
+
+impl<Data> Default for StrTrieMap<Data> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Data> StrTrieMap<Data> {
+    /// Create a new (empty) [`StrTrieMap`]. See [`TrieMap::new`].
+    pub const fn new() -> Self {
+        Self {
+            inner: TrieMap::new(),
+        }
+    }
+
+    /// Insert a `&str`-keyed entry. See [`TrieMap::insert`].
+    pub fn insert(&mut self, key: &str, data: Data) -> Option<Data> {
+        self.inner.insert(key.as_bytes(), data)
+    }
+
+    /// Insert or update a `&str`-keyed entry via a callback.
+    /// See [`TrieMap::insert_with`].
+    pub fn insert_with<F>(&mut self, key: &str, f: F)
+    where
+        F: FnOnce(Option<Data>) -> Data,
+    {
+        self.inner.insert_with(key.as_bytes(), f);
+    }
+
+    /// Remove a `&str`-keyed entry. See [`TrieMap::remove`].
+    pub fn remove(&mut self, key: &str) -> Option<Data> {
+        self.inner.remove(key.as_bytes())
+    }
+
+    /// Get a reference to the value associated with `key`.
+    /// See [`TrieMap::find`].
+    pub fn get(&self, key: &str) -> Option<&Data> {
+        self.inner.find(key.as_bytes())
+    }
+
+    /// Get a mutable reference to the value associated with `key`.
+    /// See [`TrieMap::find_mut`].
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut Data> {
+        self.inner.find_mut(key.as_bytes())
+    }
+
+    /// The number of unique keys stored in this map.
+    /// See [`TrieMap::n_unique_keys`].
+    pub const fn len(&self) -> usize {
+        self.inner.n_unique_keys()
+    }
+
+    /// `true` when no keys are stored.
+    pub const fn is_empty(&self) -> bool {
+        self.inner.n_unique_keys() == 0
+    }
+
+    /// Estimated heap memory currently held by this map. Mirrors the cached
+    /// counter on the underlying [`TrieMap`] — O(1). See [`TrieMap::mem_usage`].
+    pub const fn mem_usage(&self) -> usize {
+        self.inner.mem_usage()
+    }
+
+    /// Iterate over all entries in lexicographical key order. See [`TrieMap::iter`].
+    ///
+    /// Yields `(String, &Data)` — keys are decoded back into owned `String`s
+    /// at the wrapper boundary (the inner trie yields `Vec<u8>`).
+    pub fn iter(&self) -> iter::Iter<'_, Data> {
+        iter::Iter::new(&self.inner)
+    }
+
+    /// Yield every entry whose key starts with `prefix`, in lexicographical
+    /// order. See [`TrieMap::prefixed_iter`].
+    ///
+    /// Byte-prefix matching is codepoint-safe because UTF-8 codepoint
+    /// boundaries align with byte boundaries. Empty `prefix` yields zero
+    /// matches (this differs from the inner method, which would yield all
+    /// entries).
+    pub fn prefixed_iter(&self, prefix: &str) -> iter::PrefixedIter<'_, Data> {
+        iter::PrefixedIter::new(&self.inner, prefix)
+    }
+
+    /// Yield every entry whose key ends with `suffix`. Filters by byte
+    /// `ends_with` — correct because UTF-8 is self-synchronizing (a
+    /// multibyte sequence cannot be a suffix of another codepoint). Empty
+    /// `suffix` yields zero matches.
+    pub fn suffixed_iter(&self, suffix: &str) -> iter::SuffixedIter<'_, Data> {
+        iter::SuffixedIter::new(&self.inner, suffix)
+    }
+
+    /// Yield every entry whose key contains `target` as a substring.
+    /// Empty `target` yields zero matches — without this short-circuit
+    /// memchr semantics would match every term.
+    pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> iter::ContainsIter<'tm, 'p, Data> {
+        iter::ContainsIter::new(&self.inner, target)
+    }
+
+    /// Iterate over entries with keys inside `filter`, in lexicographical
+    /// order. See [`TrieMap::range_iter`].
+    pub fn range_iter<'tm, 'p>(
+        &'tm self,
+        filter: iter::RangeFilter<'p>,
+    ) -> iter::RangeIter<'tm, 'p, Data> {
+        iter::RangeIter::build_from(&self.inner, filter)
+    }
+
+    /// Wildcard iteration over UTF-8 keys with codepoint-aware semantics.
+    ///
+    /// Differs from [`TrieMap::wildcard_iter`], which matches pattern tokens
+    /// against raw bytes — here `?` matches one codepoint, not one byte.
+    pub fn wildcard_iter<'tm>(
+        &'tm self,
+        _pattern: &str,
+    ) -> impl Iterator<Item = (String, &'tm Data)> + 'tm {
+        todo!("UTF-8 wildcard iteration over StrTrieMap not yet implemented");
+        #[expect(unreachable_code)]
+        std::iter::empty()
+    }
+}
+
+impl<Data: fmt::Debug> fmt::Debug for StrTrieMap<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str/empty_short_circuits.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str/empty_short_circuits.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! The wrapper short-circuits three iterators when their input is empty,
+//! diverging from the inner [`TrieMap`](trie_rs::TrieMap) (whose
+//! [`prefixed_iter(&[])`](trie_rs::TrieMap::prefixed_iter) yields every
+//! entry).
+
+use trie_rs::str::StrTrieMap;
+
+fn populated() -> StrTrieMap<i32> {
+    let mut trie = StrTrieMap::new();
+    trie.insert("apple", 1);
+    trie.insert("apricot", 2);
+    trie.insert("banana", 3);
+    trie
+}
+
+#[test]
+fn prefixed_iter_empty_prefix_yields_nothing() {
+    let trie = populated();
+    let hits: Vec<_> = trie.prefixed_iter("").collect();
+    assert!(hits.is_empty());
+}
+
+#[test]
+fn contains_iter_empty_target_yields_nothing() {
+    let trie = populated();
+    let hits: Vec<_> = trie.contains_iter("").collect();
+    assert!(hits.is_empty());
+}
+
+#[test]
+fn suffixed_iter_empty_suffix_yields_nothing() {
+    let trie = populated();
+    let hits: Vec<_> = trie.suffixed_iter("").collect();
+    assert!(hits.is_empty());
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str/mod.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-mod iter;
-mod str;
-mod trie;
+mod empty_short_circuits;
+mod range_iter;
+mod return_value_contracts;
+mod suffixed_iter;
+mod utf8_boundary;

--- a/src/redisearch_rs/trie_rs/tests/integration/str/range_iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str/range_iter.rs
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use trie_rs::str::StrTrieMap;
+use trie_rs::str::iter::{RangeBoundary, RangeFilter};
+
+fn populated() -> StrTrieMap<i32> {
+    let mut trie = StrTrieMap::new();
+    trie.insert("apple", 1);
+    trie.insert("apricot", 2);
+    trie.insert("banana", 3);
+    trie.insert("cherry", 4);
+    trie.insert("date", 5);
+    trie
+}
+
+fn collect(trie: &StrTrieMap<i32>, filter: RangeFilter<'_>) -> Vec<(String, i32)> {
+    trie.range_iter(filter).map(|(k, v)| (k, *v)).collect()
+}
+
+#[test]
+fn range_all_yields_every_entry_in_order() {
+    let trie = populated();
+    let hits = collect(&trie, RangeFilter::all());
+    assert_eq!(
+        hits,
+        vec![
+            ("apple".to_string(), 1),
+            ("apricot".to_string(), 2),
+            ("banana".to_string(), 3),
+            ("cherry".to_string(), 4),
+            ("date".to_string(), 5),
+        ],
+    );
+}
+
+#[test]
+fn range_inclusive_both_ends() {
+    let trie = populated();
+    let hits = collect(
+        &trie,
+        RangeFilter {
+            min: Some(RangeBoundary::included("apricot")),
+            max: Some(RangeBoundary::included("cherry")),
+        },
+    );
+    assert_eq!(
+        hits,
+        vec![
+            ("apricot".to_string(), 2),
+            ("banana".to_string(), 3),
+            ("cherry".to_string(), 4),
+        ],
+    );
+}
+
+#[test]
+fn range_exclusive_both_ends() {
+    let trie = populated();
+    let hits = collect(
+        &trie,
+        RangeFilter {
+            min: Some(RangeBoundary::excluded("apricot")),
+            max: Some(RangeBoundary::excluded("cherry")),
+        },
+    );
+    assert_eq!(hits, vec![("banana".to_string(), 3)]);
+}
+
+#[test]
+fn range_unbounded_min() {
+    let trie = populated();
+    let hits = collect(
+        &trie,
+        RangeFilter {
+            min: None,
+            max: Some(RangeBoundary::included("banana")),
+        },
+    );
+    assert_eq!(
+        hits,
+        vec![
+            ("apple".to_string(), 1),
+            ("apricot".to_string(), 2),
+            ("banana".to_string(), 3),
+        ],
+    );
+}
+
+#[test]
+fn range_unbounded_max() {
+    let trie = populated();
+    let hits = collect(
+        &trie,
+        RangeFilter {
+            min: Some(RangeBoundary::excluded("banana")),
+            max: None,
+        },
+    );
+    assert_eq!(
+        hits,
+        vec![("cherry".to_string(), 4), ("date".to_string(), 5)],
+    );
+}
+
+#[test]
+fn range_multi_byte_utf8_bound() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("cafe", 1);
+    trie.insert("café", 2);
+    trie.insert("cafés", 3);
+    trie.insert("zebra", 4);
+
+    let hits = collect(
+        &trie,
+        RangeFilter {
+            min: Some(RangeBoundary::included("café")),
+            max: Some(RangeBoundary::included("cafés")),
+        },
+    );
+    assert_eq!(
+        hits,
+        vec![("café".to_string(), 2), ("cafés".to_string(), 3)],
+    );
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str/return_value_contracts.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str/return_value_contracts.rs
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use trie_rs::str::StrTrieMap;
+
+#[test]
+fn insert_returns_none_on_new_and_some_on_update() {
+    let mut trie = StrTrieMap::new();
+    assert_eq!(trie.insert("k", 1), None);
+    assert_eq!(trie.insert("k", 2), Some(1));
+    assert_eq!(trie.get("k"), Some(&2));
+    assert_eq!(trie.len(), 1);
+}
+
+#[test]
+fn insert_with_callback_receives_existing_value_on_reinsert() {
+    let mut trie = StrTrieMap::<i32>::new();
+
+    trie.insert_with("k", |prev| {
+        assert!(prev.is_none());
+        10
+    });
+    trie.insert_with("k", |prev| {
+        assert_eq!(prev, Some(10));
+        prev.unwrap() + 5
+    });
+
+    assert_eq!(trie.get("k"), Some(&15));
+    assert_eq!(trie.len(), 1);
+}
+
+#[test]
+fn remove_returns_value_on_hit_and_none_on_miss() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("k", 42);
+
+    assert_eq!(trie.remove("absent"), None);
+    assert_eq!(trie.remove("k"), Some(42));
+    assert_eq!(trie.remove("k"), None);
+    assert!(trie.is_empty());
+}
+
+#[test]
+fn get_mut_mutates_stored_value() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("counter", 0_i32);
+
+    *trie.get_mut("counter").unwrap() += 1;
+    *trie.get_mut("counter").unwrap() += 1;
+
+    assert_eq!(trie.get("counter"), Some(&2));
+    assert!(trie.get_mut("absent").is_none());
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str/suffixed_iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str/suffixed_iter.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use trie_rs::str::StrTrieMap;
+
+#[test]
+fn suffixed_iter_matches_keys_ending_with_target() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("apple", 1);
+    trie.insert("pineapple", 2);
+    trie.insert("banana", 3);
+    trie.insert("application", 4);
+
+    let mut hits: Vec<(String, i32)> = trie.suffixed_iter("apple").map(|(k, v)| (k, *v)).collect();
+    hits.sort();
+    assert_eq!(
+        hits,
+        vec![("apple".to_string(), 1), ("pineapple".to_string(), 2)],
+    );
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/str/utf8_boundary.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str/utf8_boundary.rs
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use trie_rs::str::StrTrieMap;
+
+#[test]
+fn iter_round_trips_multi_byte_utf8_keys() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("ascii", 1);
+    trie.insert("café", 2);
+    trie.insert("東京", 3);
+    trie.insert("🦀", 4);
+    trie.insert("مرحبا", 5);
+    trie.insert("שלום", 6);
+
+    let entries: Vec<(String, i32)> = trie.iter().map(|(k, v)| (k, *v)).collect();
+    let mut sorted = entries.clone();
+    sorted.sort();
+    assert_eq!(entries, sorted, "iter must yield lexicographic byte order");
+    assert_eq!(entries.len(), 6);
+    assert!(entries.contains(&("ascii".to_string(), 1)));
+    assert!(entries.contains(&("café".to_string(), 2)));
+    assert!(entries.contains(&("東京".to_string(), 3)));
+    assert!(entries.contains(&("🦀".to_string(), 4)));
+    assert!(entries.contains(&("مرحبا".to_string(), 5)));
+    assert!(entries.contains(&("שלום".to_string(), 6)));
+}
+
+#[test]
+fn prefixed_iter_matches_on_multi_byte_codepoint_boundary() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("café", 1);
+    trie.insert("cafés", 2);
+    trie.insert("cafe", 3);
+
+    let mut hits: Vec<(String, i32)> = trie.prefixed_iter("café").map(|(k, v)| (k, *v)).collect();
+    hits.sort();
+    assert_eq!(
+        hits,
+        vec![("café".to_string(), 1), ("cafés".to_string(), 2)],
+    );
+}
+
+#[test]
+fn suffixed_iter_matches_on_multi_byte_suffix() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("hello🦀", 1);
+    trie.insert("world🦀", 2);
+    trie.insert("plain", 3);
+
+    let mut hits: Vec<(String, i32)> = trie.suffixed_iter("🦀").map(|(k, v)| (k, *v)).collect();
+    hits.sort();
+    assert_eq!(
+        hits,
+        vec![("hello🦀".to_string(), 1), ("world🦀".to_string(), 2)],
+    );
+}
+
+#[test]
+fn contains_iter_matches_on_multi_byte_target() {
+    let mut trie = StrTrieMap::new();
+    trie.insert("préfecture", 1);
+    trie.insert("café", 2);
+    trie.insert("plain", 3);
+
+    let mut hits: Vec<(String, i32)> = trie.contains_iter("é").map(|(k, v)| (k, *v)).collect();
+    hits.sort();
+    assert_eq!(
+        hits,
+        vec![("café".to_string(), 2), ("préfecture".to_string(), 1)],
+    );
+}
+
+/// `StrTrieMap` matches at the codepoint level, not the grapheme-cluster level.
+/// A ZWJ-joined emoji ("bear + ZWJ + snowflake + VS16") is four scalars and
+/// thirteen UTF-8 bytes; the trie keeps and yields the byte sequence verbatim
+/// but `prefixed_iter` will happily match on any leading prefix of those
+/// bytes — codepoint boundaries respected, cluster boundaries not.
+#[test]
+fn zwj_grapheme_clusters_are_treated_as_codepoint_sequences() {
+    let polar_bear = "\u{1F43B}\u{200D}\u{2744}\u{FE0F}";
+    let bear = "\u{1F43B}";
+    assert_eq!(polar_bear.chars().count(), 4);
+    assert_eq!(polar_bear.len(), 13);
+
+    let mut trie = StrTrieMap::new();
+    trie.insert(polar_bear, 1);
+    trie.insert(bear, 2);
+
+    let round_trip: Vec<(String, i32)> = trie.iter().map(|(k, v)| (k, *v)).collect();
+    assert!(round_trip.contains(&(polar_bear.to_string(), 1)));
+    assert!(round_trip.contains(&(bear.to_string(), 2)));
+
+    let mut hits: Vec<(String, i32)> = trie.prefixed_iter(bear).map(|(k, v)| (k, *v)).collect();
+    hits.sort();
+    assert_eq!(
+        hits,
+        vec![(bear.to_string(), 2), (polar_bear.to_string(), 1)],
+        "prefix matching is codepoint-level: the leading BEAR scalar matches \
+         both the standalone bear and the ZWJ sequence, with no \
+         grapheme-cluster awareness",
+    );
+}


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `trie_rs::TrieMap` is byte-keyed (`&[u8]`). Callers that want a `&str`-keyed API have to hand-encode keys and decode `Vec<u8>` results themselves.
2. Change: Add `trie_rs::str::StrTrieMap<Data>`, a thin UTF-8-keyed newtype over `TrieMap`, and a sibling `str::iter` module wrapping the most-used iterators (`Iter`, `PrefixedIter`, `SuffixedIter`, `ContainsIter`, `RangeIter`). Each wrapper iterator yields `(String, &Data)`; keys are decoded back via a validating `from_utf8` that asserts the UTF-8 invariant the wrapper enforces on input. `SuffixedIter` is wrapper-only — the parent module has no suffix iterator. `wildcard_iter` is declared on the API surface but currently `todo!()`; UTF-8 wildcard semantics will land separately.
3. Outcome: Callers can use `&str` keys directly. The wrapper preserves all `TrieMap` semantics; method-level docs defer to the inner type and only call out wrapper-specific deltas (empty-input short-circuits on `prefixed_iter` / `suffixed_iter` / `contains_iter`, codepoint-aware wildcard semantics, `String` yield contract).

#### Which additional issues this PR fixes
1. MOD-15897

#### Main objects this PR modified
1. `src/redisearch_rs/trie_rs/src/str/mod.rs` — `StrTrieMap` newtype + `Debug` impl
2. `src/redisearch_rs/trie_rs/src/str/iter/` — wrapper iterators (`Iter`, `PrefixedIter`, `SuffixedIter`, `ContainsIter`, `RangeIter`)
3. `src/redisearch_rs/trie_rs/tests/integration/str/` — wrapper-specific integration tests: empty-input short-circuit invariants, return-value contracts for `insert` / `insert_with` / `remove` / `get` / `get_mut`, and multi-byte UTF-8 round-trip + prefix/suffix/contains on codepoint boundaries

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive library API in trie_rs with no changes to existing TrieMap behavior; wildcard_iter panics if called until implemented.
> 
> **Overview**
> Adds **`trie_rs::str::StrTrieMap`**, a UTF-8-keyed newtype over byte-keyed `TrieMap`, so callers use `&str` for insert/get/remove and get **`String`** keys back from iterators instead of hand-encoding/decoding `Vec<u8>`.
> 
> The **`str::iter`** layer wraps full scan, prefix, contains, range, and a new **suffix** iterator (not on the inner trie); all yield `(String, &Data)`. Wrapper-specific behavior: **empty** prefix/suffix/contains inputs yield **no** matches (unlike inner `prefixed_iter` on empty bytes, which returns everything). **`range_iter`** uses `&str` bounds. **`wildcard_iter`** is on the API but **`todo!()`** until codepoint-aware wildcards land.
> 
> Integration tests cover empty-input short-circuits, CRUD return contracts, range bounds (including multi-byte UTF-8), and UTF-8 prefix/suffix/contains semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17a46049b40cedcb236c95af10db9f3fad2aeaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->