### PR TITLE
[MOD-15932] trie: rename score-related fields for clarity

### DIFF
--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -283,11 +283,11 @@ Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDi
 
       if (heap_count(pq) == heap_size(pq)) {
         TrieSearchResult *qe = heap_peek(pq);
-        it->minScore = qe->score;
+        it->kthBestScore = qe->score;
       }
 
     } else {
-      if (ent->score > it->minScore) {
+      if (ent->score > it->kthBestScore) {
         pooledEntry = heap_poll(pq);
         rm_free(pooledEntry->str);
         pooledEntry->str = NULL;
@@ -296,10 +296,10 @@ Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDi
         ent->plen = payload.len;
         heap_offerx(pq, ent);
 
-        // get the new minimal score
+        // get the new kth-best score
         TrieSearchResult *qe = heap_peek(pq);
-        if (qe->score > it->minScore) {
-          it->minScore = qe->score;
+        if (qe->score > it->kthBestScore) {
+          it->kthBestScore = qe->score;
         }
 
       } else {

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -794,11 +794,6 @@ TrieIterator *TrieNode_Iterate(TrieNode *n, StepFilter f, StackPopCallback pf, v
   TrieIterator *it = rm_calloc(1, sizeof(TrieIterator));
   it->filter = f;
   it->popCallback = pf;
-  // Sentinel: any real score beats INT_MIN, so the pruning check at
-  // TrieNode_Step accepts every subtree until Trie_Search fills the top-k
-  // heap and starts overwriting kthBestScore with real candidate scores.
-  // DFA-driven iteration never overwrites it, leaving pruning disabled by
-  // design.
   it->kthBestScore = INT_MIN;
   it->ctx = ctx;
   __ti_Push(it, n, 0);

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -794,7 +794,12 @@ TrieIterator *TrieNode_Iterate(TrieNode *n, StepFilter f, StackPopCallback pf, v
   TrieIterator *it = rm_calloc(1, sizeof(TrieIterator));
   it->filter = f;
   it->popCallback = pf;
-  it->kthBestScore = INT_MIN;    // terms from dictionary which are not in term trie get a valid score INT_MIN
+  // Sentinel: any real score beats INT_MIN, so the pruning check at
+  // TrieNode_Step accepts every subtree until Trie_Search fills the top-k
+  // heap and starts overwriting kthBestScore with real candidate scores.
+  // DFA-driven iteration never overwrites it, leaving pruning disabled by
+  // design.
+  it->kthBestScore = INT_MIN;
   it->ctx = ctx;
   __ti_Push(it, n, 0);
 

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -65,7 +65,7 @@ static void __trieNode_sortChildren(TrieNode *n);
 #define updateScore(n, value)                             \
 do {                                                      \
   if (n->sortMode == Trie_Sort_Score) {                   \
-    n->maxChildScore = MAX(n->maxChildScore, value);      \
+    n->subtreeMaxScore = MAX(n->subtreeMaxScore, value);      \
   }                                                       \
 } while(0)
 
@@ -156,7 +156,7 @@ TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *pa
   n->score = score;
   n->sortMode = sortMode;
   n->flags = 0 | (terminal ? TRIENODE_TERMINAL : 0);
-  n->maxChildScore = score;
+  n->subtreeMaxScore = score;
   n->numDocs = numDocs;
   memcpy(n->str, str + offset, sizeof(rune) * (len - offset));
   if (payload != NULL && plen > 0) {
@@ -199,7 +199,7 @@ static TrieNode *__trie_SplitNode(TrieNode *n, t_len offset) {
   // Copy the current node's data and children to a new child node
   TrieNode *newChild = __newTrieNode(n->str, offset, n->len, NULL, 0, n->numChildren, n->score,
                                      TrieNode_IsTerminal(n), n->sortMode, n->numDocs);
-  newChild->maxChildScore = n->maxChildScore;
+  newChild->subtreeMaxScore = n->subtreeMaxScore;
   newChild->flags = n->flags;
   newChild->payload = n->payload;
   n->payload = NULL;
@@ -240,7 +240,7 @@ static TrieNode *__trieNode_MergeWithSingleChild(TrieNode *n, TrieFreeCallback f
   TrieNode *merged = __newTrieNode(
       nstr, 0, n->len + ch->len, NULL, 0, ch->numChildren,
       ch->score, TrieNode_IsTerminal(ch), n->sortMode, ch->numDocs);
-  merged->maxChildScore = ch->maxChildScore;
+  merged->subtreeMaxScore = ch->subtreeMaxScore;
   merged->numChildren = ch->numChildren;
   merged->payload = ch->payload;
   ch->payload = NULL;
@@ -299,7 +299,7 @@ static TrieAddChildResult __trieNode_addChild_lex(
 }
 
 // Score-mode child placement. Children are kept sorted by descending
-// maxChildScore; a recursed update may invalidate that order, so we check the
+// subtreeMaxScore; a recursed update may invalidate that order, so we check the
 // two neighbours and re-sort if needed.
 static TrieAddChildResult __trieNode_addChild_score(
     TrieNode *n, const rune *str, t_len len, t_len offset, RSPayload *payload, float score,
@@ -318,15 +318,15 @@ static TrieAddChildResult __trieNode_addChild_score(
       TrieNode_Children(n)[idx] = child;
       // check if the order was kept and fix as necessary
       if (n->numChildren > 1) {
-        if ((idx > 0 && child->maxChildScore > TrieNode_Children(n)[idx - 1]->maxChildScore) ||
-            (idx < n->numChildren - 2 && child->maxChildScore < TrieNode_Children(n)[idx + 1]->maxChildScore)) {
+        if ((idx > 0 && child->subtreeMaxScore > TrieNode_Children(n)[idx - 1]->subtreeMaxScore) ||
+            (idx < n->numChildren - 2 && child->subtreeMaxScore < TrieNode_Children(n)[idx + 1]->subtreeMaxScore)) {
           __trieNode_sortChildren(n);
         }
       }
       return (TrieAddChildResult){.node = n, .rc = rc};
     }
     // keep the index that fits the score
-    if (child->maxChildScore < score && scoreIdx == REDISEARCH_UNINITIALIZED) {
+    if (child->subtreeMaxScore < score && scoreIdx == REDISEARCH_UNINITIALIZED) {
       scoreIdx = idx;
     }
   }
@@ -518,7 +518,7 @@ static int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
   int rc = 0;
   int i = 0;
   TrieNode **nodes = TrieNode_Children(n);
-  n->maxChildScore = n->score;
+  n->subtreeMaxScore = n->score;
   // free deleted terminal nodes
   while (i < n->numChildren) {
 
@@ -532,7 +532,7 @@ static int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
       while (i < n->numChildren - 1) {
         nodes[i] = nodes[i + 1];
         *nk = *(nk + 1);
-        updateScore(n, nodes[i]->maxChildScore);
+        updateScore(n, nodes[i]->subtreeMaxScore);
         i++;
         nk++;
       }
@@ -548,7 +548,7 @@ static int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
         nodes[i] = __trieNode_MergeWithSingleChild(nodes[i], freecb);
         rc++;
       }
-      updateScore(n, nodes[i]->maxChildScore);
+      updateScore(n, nodes[i]->subtreeMaxScore);
     }
     i++;
   }
@@ -663,9 +663,9 @@ inline static int __trieNode_Cmp_Score(const void *p1, const void *p2) {
   TrieNode *n1 = *(TrieNode **)p1;
   TrieNode *n2 = *(TrieNode **)p2;
 
-  if (n1->maxChildScore < n2->maxChildScore) {
+  if (n1->subtreeMaxScore < n2->subtreeMaxScore) {
     return 1;
-  } else if (n1->maxChildScore > n2->maxChildScore) {
+  } else if (n1->subtreeMaxScore > n2->subtreeMaxScore) {
     return -1;
   }
   return __trieNode_Cmp_Lex(&n1, &n2);
@@ -774,7 +774,7 @@ inline int __ti_step(TrieIterator *it, void *matchCtx) {
       // push the next child
       if (current->childOffset < current->n->numChildren) {
         TrieNode *ch = TrieNode_Children(current->n)[current->childOffset++];
-        if (ch->maxChildScore >= it->minScore || ch->score >= it->minScore) {
+        if (ch->subtreeMaxScore >= it->kthBestScore || ch->score >= it->kthBestScore) {
           __ti_Push(it, ch, 0);
           it->nodesConsumed++;
         } else {
@@ -794,7 +794,7 @@ TrieIterator *TrieNode_Iterate(TrieNode *n, StepFilter f, StackPopCallback pf, v
   TrieIterator *it = rm_calloc(1, sizeof(TrieIterator));
   it->filter = f;
   it->popCallback = pf;
-  it->minScore = INT_MIN;    // terms from dictionary which are not in term trie get a valid score INT_MIN
+  it->kthBestScore = INT_MIN;    // terms from dictionary which are not in term trie get a valid score INT_MIN
   it->ctx = ctx;
   __ti_Push(it, n, 0);
 

--- a/src/trie/trie_node_internal.h
+++ b/src/trie/trie_node_internal.h
@@ -98,6 +98,9 @@ struct TrieIterator {
   stackNode stack[TRIE_INITIAL_STRING_LEN + 1];
   t_len stackOffset;
   StepFilter filter;
+  // kth-best score currently in the top-k heap; rises monotonically as the
+  // heap fills with better candidates. Distinct from the scorer-layer
+  // minScore filter floor (see QueryProcessingCtx::minScore).
   float kthBestScore;
   int nodesConsumed;
   int nodesSkipped;

--- a/src/trie/trie_node_internal.h
+++ b/src/trie/trie_node_internal.h
@@ -54,9 +54,9 @@ struct TrieNode {
   // the node's score. Non termn
   float score;
 
-  // the maximal score of any descendant of this node, used to optimize
-  // traversal
-  float maxChildScore;
+  // max(self.score, max descendant subtreeMaxScore); upper-bound used to
+  // prune branch-and-bound traversal in Trie_Search top-k
+  float subtreeMaxScore;
 
   // the number of documents containing this key
   size_t numDocs;
@@ -98,7 +98,7 @@ struct TrieIterator {
   stackNode stack[TRIE_INITIAL_STRING_LEN + 1];
   t_len stackOffset;
   StepFilter filter;
-  float minScore;
+  float kthBestScore;
   int nodesConsumed;
   int nodesSkipped;
   StackPopCallback popCallback;


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `TrieNode::maxChildScore` and `TrieIterator::minScore` are both misleadingly named. `maxChildScore` reads like "max over direct children" but actually tracks `max(self.score, max descendant score)` — the discrepancy is the only reason the defensive `|| ch->score >= it->minScore` clause exists in the pruning check. `TrieIterator::minScore` reads like a static query-time score floor, but it's a dynamic, monotonically-rising k-th-best score from the top-k heap. It also collides namespace-wise with the *genuinely-static* `minScore` filter floor in `QueryProcessingCtx`.
2. **Change**: Rename `maxChildScore` → `subtreeMaxScore` and `TrieIterator::minScore` → `kthBestScore`. Add an invariant-stating doc-comment on the renamed `subtreeMaxScore`, and a one-line semantics comment on `kthBestScore`. Remove a pre-existing inline note on the `kthBestScore` init line that was provenance about a downstream consumer rather than an invariant. Pure rename + comment changes; no semantic behavior change.
3. **Outcome**: Field names now reflect what the code actually computes. The disambiguation between the trie's dynamic k-th-best threshold and the scorer-layer static `minScore` filter is explicit.

#### Which additional issues this PR fixes
1. MOD-15932

#### Main objects this PR modified
1. `src/trie/trie_node.h` — `TrieNode::subtreeMaxScore`, `TrieIterator::kthBestScore`
2. `src/trie/trie_node.c` — pruning, child placement, optimizer, merge/split
3. `src/trie/trie.c` — `Trie_Search` top-k heap interactions

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier and comment-only changes across trie search/iteration; no logic or API/serialization changes.
> 
> **Overview**
> Renames trie score-related fields so names match what the code computes, with **no runtime behavior change**.
> 
> `TrieNode::maxChildScore` becomes **`subtreeMaxScore`** everywhere (insert/split/merge, score-sorted children, optimizer, iterator pruning). Comments now state it is `max(self.score, max descendant …)` and used for top-k branch-and-bound pruning—not “max over direct children only.”
> 
> `TrieIterator::minScore` becomes **`kthBestScore`** in `Trie_Search` and traversal: the threshold that rises as the top-k heap fills. A short comment distinguishes it from the static query **`minScore`** filter in `QueryProcessingCtx`.
> 
> **`trie.c`**, **`trie_node.c`**, and **`trie_node_internal.h`** are updated consistently; old identifiers are gone from `src/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d162a91a28d9d586bcb2611d288a2d8e6e77aa36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->