### PR TITLE
keep key meta during SST replication in RAM resident keys

### DIFF
--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -160,16 +160,10 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
   }
 
   if (forgetDocIDMetadata) {
-    RedisModule_Log(RSDummyContext, "warning",
-                    "DocIdMeta RDBLoad: forget=1 numEntries=%zu -> SKIP (meta dropped)",
-                    numEntries);
     *meta = 0;
     return DOCID_META_RDB_LOAD_SKIP;
   }
 
-  RedisModule_Log(RSDummyContext, "warning",
-                  "DocIdMeta RDBLoad: forget=0 numEntries=%zu attached=%zu -> ATTACH",
-                  numEntries, dictSize(specIdToDocId));
   *meta = (uint64_t)(specIdToDocId);
   return DOCID_META_RDB_LOAD_ATTACH;
 
@@ -186,14 +180,10 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
 
   if (ForgetDocIdMetadata) {
     // Skip saving during persistence events. We don't want to save this metadata to an RDB/AOF file
-    RedisModule_Log(RSDummyContext, "warning",
-                    "DocIdMeta RDBSave: forget=1 -> SKIP (nothing written)");
     return;
   }
 
   if (*meta == 0) {
-    RedisModule_Log(RSDummyContext, "warning",
-                    "DocIdMeta RDBSave: forget=0 meta=0 -> nothing to save");
     return;
   }
 
@@ -216,9 +206,6 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
   }
 
   // Save entry count. Version is handled by encver in the KeyMeta API.
-  RedisModule_Log(RSDummyContext, "warning",
-                  "DocIdMeta RDBSave: forget=0 validEntries=%zu -> writing",
-                  validEntries);
   RedisModule_SaveUnsigned(rdb, validEntries);
 
   if (validEntries == 0) {

--- a/src/doc_id_meta.c
+++ b/src/doc_id_meta.c
@@ -21,17 +21,17 @@
 static RedisModuleKeyMetaClassId docIdKeyMetaClassId;
 
 // When true, RDB save/load callbacks become no-ops.
-// Controlled via DocIdMeta_SetPersistenceInProgress, called from notifications.c
+// Controlled via DocIdMeta_SetForgetDocIdMetadata, called from notifications.c
 // during persistence events (BGSAVE/BGREWRITEAOF) to avoid saving/loading
 // DocIdMeta data while persistence is in progress.
-static bool PersistenceInProgress = false;
+static bool ForgetDocIdMetadata = false;
 
-void DocIdMeta_SetPersistenceInProgress(bool inProgress) {
+void DocIdMeta_SetForgetDocIdMetadata(bool inProgress) {
   const char *message = inProgress ?
                           "DocIdMeta: disabling RDB callbacks during persistence" :
                           "DocIdMeta: re-enabling RDB callbacks after persistence";
   RedisModule_Log(RSDummyContext, "verbose", "%s", message);
-  PersistenceInProgress = inProgress;
+  ForgetDocIdMetadata = inProgress;
 }
 
 // Helper macros for casting between uint64_t and void* for dict keys/values.
@@ -130,14 +130,14 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
 
   // Cache the flag locally to ensure all decisions in this callback observe a
   // consistent value, although it cannot really happen, this gives certainty to static analyzers.
-  const bool persistenceInProgress = PersistenceInProgress;
+  const bool forgetDocIDMetadata = ForgetDocIdMetadata;
 
-  // Even when persistenceInProgress is set we must consume exactly the bytes
+  // Even when forgetDocIDMetadata is set we must consume exactly the bytes
   // that docIdMetaRDBSave wrote: the key-meta framework reads a trailing EOF
   // marker right after this callback returns and expects the stream to be
   // positioned at it. Discarding the parsed entries is fine; skipping the
   // reads would desynchronize the stream and fail the EOF check.
-  dict *specIdToDocId = persistenceInProgress ? NULL : dictCreate(&dictTypeUint64, NULL);
+  dict *specIdToDocId = forgetDocIDMetadata ? NULL : dictCreate(&dictTypeUint64, NULL);
   size_t numEntries;
 
   // Load the number of entries
@@ -149,7 +149,7 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
     uint64_t docId = LoadUnsigned_IOError(rdb, goto cleanup);
 
     // While persistence is in progress, drain the bytes but do not attach.
-    if (persistenceInProgress) continue;
+    if (forgetDocIDMetadata) continue;
 
     // Skip entries belonging to indexes that are no longer in specIdDict_g (O(1) lookup).
     if (!isSpecValid(specId)) {
@@ -159,11 +159,17 @@ static int docIdMetaRDBLoad(RedisModuleIO *rdb, uint64_t *meta, int encver) {
     dictAdd(specIdToDocId, SPECID_TO_KEY(specId), DOCID_TO_VAL(docId));
   }
 
-  if (persistenceInProgress) {
+  if (forgetDocIDMetadata) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "DocIdMeta RDBLoad: forget=1 numEntries=%zu -> SKIP (meta dropped)",
+                    numEntries);
     *meta = 0;
     return DOCID_META_RDB_LOAD_SKIP;
   }
 
+  RedisModule_Log(RSDummyContext, "warning",
+                  "DocIdMeta RDBLoad: forget=0 numEntries=%zu attached=%zu -> ATTACH",
+                  numEntries, dictSize(specIdToDocId));
   *meta = (uint64_t)(specIdToDocId);
   return DOCID_META_RDB_LOAD_ATTACH;
 
@@ -178,12 +184,16 @@ cleanup:
 static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
   REDISMODULE_NOT_USED(value);
 
-  if (PersistenceInProgress) {
+  if (ForgetDocIdMetadata) {
     // Skip saving during persistence events. We don't want to save this metadata to an RDB/AOF file
+    RedisModule_Log(RSDummyContext, "warning",
+                    "DocIdMeta RDBSave: forget=1 -> SKIP (nothing written)");
     return;
   }
 
   if (*meta == 0) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "DocIdMeta RDBSave: forget=0 meta=0 -> nothing to save");
     return;
   }
 
@@ -206,6 +216,9 @@ static void docIdMetaRDBSave(RedisModuleIO *rdb, void *value, uint64_t *meta) {
   }
 
   // Save entry count. Version is handled by encver in the KeyMeta API.
+  RedisModule_Log(RSDummyContext, "warning",
+                  "DocIdMeta RDBSave: forget=0 validEntries=%zu -> writing",
+                  validEntries);
   RedisModule_SaveUnsigned(rdb, validEntries);
 
   if (validEntries == 0) {

--- a/src/doc_id_meta.h
+++ b/src/doc_id_meta.h
@@ -52,7 +52,7 @@ int DocIdMeta_Delete(RedisModuleCtx *ctx, RedisModuleString *keyName, uint64_t s
 
 // Set the persistence-in-progress flag. When true, RDB save/load callbacks
 // become no-ops. Called from notifications.c during persistence events.
-void DocIdMeta_SetPersistenceInProgress(bool inProgress);
+void DocIdMeta_SetForgetDocIdMetadata(bool inProgress);
 
 #ifdef __cplusplus
 }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -694,9 +694,6 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
   REDISMODULE_NOT_USED(data);
   RS_ASSERT(SearchDisk_IsEnabled());
   bool useSst = IS_SST_RDB_IN_PROCESS(ctx);
-  RedisModule_Log(ctx, "warning",
-                  "DocIdMeta PersistenceEvent: subevent=%llu useSst=%d",
-                  (unsigned long long)subevent, (int)useSst);
 
   switch (subevent) {
   case REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START:
@@ -852,9 +849,6 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     // the replica must KEEP the meta it loads (forget = false). For any other
     // load (plain RDB / AOF / legacy RDB-only replication) the index is rebuilt
     // from the keyspace and the stale docIds are meaningless, so we FORGET.
-    RedisModule_Log(ctx, "warning",
-                    "DocIdMeta RDB_LoadingEvent START: subevent=%llu useSst=%d -> forget=%d",
-                    (unsigned long long)subevent, (int)useSst, (int)(!useSst));
     DocIdMeta_SetForgetDocIdMetadata(!useSst);
     Indexes_StartRDBLoadingEvent(ctx);
     workersThreadPool_OnEventStart();

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -693,17 +693,25 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
   REDISMODULE_NOT_USED(eid);
   REDISMODULE_NOT_USED(data);
   RS_ASSERT(SearchDisk_IsEnabled());
+  bool useSst = IS_SST_RDB_IN_PROCESS(ctx);
+  RedisModule_Log(ctx, "warning",
+                  "DocIdMeta PersistenceEvent: subevent=%llu useSst=%d",
+                  (unsigned long long)subevent, (int)useSst);
 
   switch (subevent) {
   case REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START:
   case REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START:
-    RedisModule_Log(ctx, "notice", "Persistence started");
-    DocIdMeta_SetPersistenceInProgress(true);
+    if (!useSst) {
+      RedisModule_Log(ctx, "notice", "Persistence started");
+      DocIdMeta_SetForgetDocIdMetadata(true);
+    }
     break;
   case REDISMODULE_SUBEVENT_PERSISTENCE_ENDED:
   case REDISMODULE_SUBEVENT_PERSISTENCE_FAILED:
-    RedisModule_Log(ctx, "notice", "Persistence ended");
-    DocIdMeta_SetPersistenceInProgress(false);
+    if (!useSst) {
+      RedisModule_Log(ctx, "notice", "Persistence ended");
+      DocIdMeta_SetForgetDocIdMetadata(false);
+    }
     break;
   }
 }
@@ -838,6 +846,16 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
   case REDISMODULE_SUBEVENT_LOADING_RDB_START:
   case REDISMODULE_SUBEVENT_LOADING_AOF_START:
   case REDISMODULE_SUBEVENT_LOADING_REPL_START:
+    // Symmetric counterpart to the save-side decision in PersistenceEvent.
+    // During an SST + RDB sync the master streams RAM-resident keys together
+    // with their DocIdMeta, and the disk state arrives via the SST files, so
+    // the replica must KEEP the meta it loads (forget = false). For any other
+    // load (plain RDB / AOF / legacy RDB-only replication) the index is rebuilt
+    // from the keyspace and the stale docIds are meaningless, so we FORGET.
+    RedisModule_Log(ctx, "warning",
+                    "DocIdMeta RDB_LoadingEvent START: subevent=%llu useSst=%d -> forget=%d",
+                    (unsigned long long)subevent, (int)useSst, (int)(!useSst));
+    DocIdMeta_SetForgetDocIdMetadata(!useSst);
     Indexes_StartRDBLoadingEvent(ctx);
     workersThreadPool_OnEventStart();
     RedisModule_Log(RSDummyContext, "notice", "Loading RDB event started");
@@ -852,6 +870,8 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     RedisModule_Log(RSDummyContext, "notice", "Loading RDB event ended");
     break;
   case REDISMODULE_SUBEVENT_LOADING_ENDED:
+    // Re-enable the DocIdMeta RDB callbacks now that this load is done.
+    DocIdMeta_SetForgetDocIdMetadata(false);
     if (!SearchDisk_IsEnabled()) {
       // This only handles legacy indices that are not available in disk
       Indexes_EndRDBLoadingEvent(ctx);
@@ -872,6 +892,7 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     // aborted, network dropped, validation rejected, etc.) Redis fires LOADING_FAILED. Tear down anything we
     // staged for the round so the next attempt starts from a clean slate.
     // No-op when no specs are staged.
+    DocIdMeta_SetForgetDocIdMetadata(false);
     if (SearchDisk_IsEnabled()) {
       Indexes_AbortSSTReplicationLoading(ctx);
     }

--- a/src/redisearch_rs/redis_mock/src/lib.rs
+++ b/src/redisearch_rs/redis_mock/src/lib.rs
@@ -346,7 +346,7 @@ macro_rules! mock_or_stub_missing_redis_c_symbols {
             DocIdMeta_Set,
             DocIdMeta_Delete,
             DocIdMeta_Init,
-            DocIdMeta_SetPersistenceInProgress,
+            DocIdMeta_SetForgetDocIdMetadata,
         }
     };
 }

--- a/tests/cpptests/test_cpp_doc_id_meta.cpp
+++ b/tests/cpptests/test_cpp_doc_id_meta.cpp
@@ -539,13 +539,13 @@ TEST_F(DocIdMetaTest, TestRdbLoadDuringPersistenceConsumesBytesAndSkips) {
   EXPECT_GT(bytesWritten, 0u);
 
   // Simulate persistence in progress during the load.
-  DocIdMeta_SetPersistenceInProgress(true);
+  DocIdMeta_SetForgetDocIdMetadata(true);
 
   rdbIO->read_pos = 0;
   uint64_t loadedMeta = 0xDEADBEEF; // sentinel; load must overwrite to 0
   int result = RMCK_KeyMetaRdbLoad(getDocIdMetaClassId(), rdbIO, &loadedMeta, 1);
 
-  DocIdMeta_SetPersistenceInProgress(false);
+  DocIdMeta_SetForgetDocIdMetadata(false);
 
   // Return value is SKIP (0): do not attach the meta to the key.
   EXPECT_EQ(result, 0);


### PR DESCRIPTION
## Describe the changes in the pull request

During Replication, do not ignore Key meta during SST+RDB replication so that RAM-resident keys are properly replicated with their metadata.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f085d74be3ef47b918f7856131aa795141f13c3f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->