### PR TITLE
Use `PrintProfile` from RSE wildcard iterator

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -84,6 +84,15 @@ where
         }
     }
 
+    /// Returns the current query term bytes, if available.
+    ///
+    /// The term is stored in the iterator's result and is set during
+    /// construction. Returns [`None`] if the result is not a term result
+    /// or the term has no string representation.
+    pub fn query_term_bytes(&self) -> Option<&[u8]> {
+        self.result.as_term()?.query_term()?.as_bytes()
+    }
+
     /// Default read implementation, without any additional filtering.
     fn read_default(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         if self.at_eos {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -174,15 +174,6 @@ where
     pub const fn reader(&self) -> &IndexReaderCore<'index, E> {
         &self.it.reader
     }
-
-    /// Returns the current query term bytes, if available.
-    ///
-    /// The term is stored in the iterator's result and is set during
-    /// construction. Returns [`None`] if the result is not a term result
-    /// or the term has no string representation.
-    fn query_term_bytes(&self) -> Option<&[u8]> {
-        self.it.result.as_term()?.query_term()?.as_bytes()
-    }
 }
 
 impl<'index, E, C> RQEIterator<'index> for Tag<'index, E, C>
@@ -260,7 +251,7 @@ where
 {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         map.kv_simple_string(c"Type", c"TAG");
-        if let Some(term_bytes) = self.query_term_bytes() {
+        if let Some(term_bytes) = self.it.query_term_bytes() {
             map.kv_string_buffer(c"Term", term_bytes);
         }
         ctx.print_optional_counters(map);

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -92,15 +92,6 @@ where
         &self.it.reader
     }
 
-    /// Returns the current query term bytes, if available.
-    ///
-    /// The term is stored in the iterator's result and is set during
-    /// construction. Returns [`None`] if the result is not a term result
-    /// or the term has no string representation.
-    fn query_term_bytes(&self) -> Option<&[u8]> {
-        self.it.result.as_term()?.query_term()?.as_bytes()
-    }
-
     /// Check if the iterator should abort revalidation.
     ///
     /// The term's inverted index may have been garbage-collected and
@@ -241,7 +232,7 @@ where
 {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         map.kv_simple_string(c"Type", c"TEXT");
-        if let Some(term_bytes) = self.query_term_bytes() {
+        if let Some(term_bytes) = self.it.query_term_bytes() {
             map.kv_string_buffer(c"Term", term_bytes);
         }
         ctx.print_optional_counters(map);

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -277,7 +277,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
         &self,
         index: &'index mut ffi::RedisSearchDiskIndexSpec,
         weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>>;
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
 
     /// Iterate over all the terms in the index, loading offset data for each document.
     ///

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -18,12 +18,12 @@ use inverted_index::{DocIdsDecoder, opaque};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
-use crate::{IteratorType, RQEIteratorPrintable};
 use crate::{
     Empty, RQEIterator, RQEIteratorError, RQEValidateStatus, SEARCH_ENTERPRISE_ITERATORS,
     SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
+use crate::{IteratorType, RQEIteratorPrintable};
 
 /// An iterator that yields all ids within a given range, from 1 to max id (inclusive) in an index.
 #[derive(Default)]

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -18,7 +18,7 @@ use inverted_index::{DocIdsDecoder, opaque};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
-use crate::IteratorType;
+use crate::{IteratorType, RQEIteratorPrintable};
 use crate::{
     Empty, RQEIterator, RQEIteratorError, RQEValidateStatus, SEARCH_ENTERPRISE_ITERATORS,
     SkipToOutcome,
@@ -482,7 +482,7 @@ pub unsafe fn new_wildcard_iterator<'index>(
 /// allowing disk-based wildcard queries to be used interchangeably with
 /// in-memory ones.
 #[repr(transparent)]
-pub struct DiskWildcardIterator<'index>(Box<dyn RQEIterator<'index> + 'index>);
+pub struct DiskWildcardIterator<'index>(Box<dyn RQEIteratorPrintable<'index> + 'index>);
 
 impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -544,8 +544,7 @@ impl ProfilePrint for Wildcard<'_> {
 
 impl ProfilePrint for DiskWildcardIterator<'_> {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
-        // TODO: delegate to actual implementation once RSE implements the trait.
-        ctx.print_leaf(c"WILDCARD", map);
+        self.0.print_profile(map, ctx)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -390,7 +390,7 @@ pub unsafe fn new_wildcard_iterator_on_disk<'index>(
         .get()
         .expect("SEARCH_ENTERPRISE_ITERATORS not initialized");
     match enterprise_iters_api.new_wildcard_on_disk(disk_spec, weight) {
-        Ok(it) => NewWildcardIterator::Disk(DiskWildcardIterator(it)),
+        Ok(it) => NewWildcardIterator::Disk(it),
         Err(err) => {
             tracing::warn!(
                 "Failed to create a disk wildcard iterator ({err}); falling back to empty iterator."
@@ -481,57 +481,7 @@ pub unsafe fn new_wildcard_iterator<'index>(
 /// [`SEARCH_ENTERPRISE_ITERATORS`] that implements [`WildcardIterator`],
 /// allowing disk-based wildcard queries to be used interchangeably with
 /// in-memory ones.
-#[repr(transparent)]
-pub struct DiskWildcardIterator<'index>(Box<dyn RQEIteratorPrintable<'index> + 'index>);
-
-impl<'index> RQEIterator<'index> for DiskWildcardIterator<'index> {
-    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        self.0.current()
-    }
-
-    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        self.0.read()
-    }
-
-    fn skip_to(
-        &mut self,
-        doc_id: DocId,
-    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
-        self.0.skip_to(doc_id)
-    }
-
-    fn revalidate(
-        &mut self,
-        spec: &IndexSpecReadGuard,
-    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        self.0.revalidate(spec)
-    }
-
-    fn rewind(&mut self) {
-        self.0.rewind()
-    }
-
-    fn num_estimated(&self) -> usize {
-        self.0.num_estimated()
-    }
-
-    fn last_doc_id(&self) -> DocId {
-        self.0.last_doc_id()
-    }
-
-    fn at_eof(&self) -> bool {
-        self.0.at_eof()
-    }
-
-    #[inline(always)]
-    fn type_(&self) -> IteratorType {
-        self.0.type_()
-    }
-
-    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
-        self.0.intersection_sort_weight(prioritize_union_children)
-    }
-}
+pub type DiskWildcardIterator<'index> = Box<dyn RQEIteratorPrintable<'index> + 'index>;
 
 /// [`DiskWildcardIterator`] matches all documents on the disk index.
 impl<'index> WildcardIterator<'index> for DiskWildcardIterator<'index> {}
@@ -539,12 +489,6 @@ impl<'index> WildcardIterator<'index> for DiskWildcardIterator<'index> {}
 impl ProfilePrint for Wildcard<'_> {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         ctx.print_leaf(c"WILDCARD", map);
-    }
-}
-
-impl ProfilePrint for DiskWildcardIterator<'_> {
-    fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
-        self.0.print_profile(map, ctx)
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -16,7 +16,7 @@
 
 use rqe_core::{DocId, FieldIndex};
 use rqe_iterators::{
-    RQEIterator, RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators,
+    RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators,
     wildcard::Wildcard,
 };
 
@@ -41,7 +41,7 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
         &self,
         _index: &'index mut ffi::RedisSearchDiskIndexSpec,
         weight: f64,
-    ) -> Result<Box<dyn RQEIterator<'index> + 'index>, Box<dyn std::error::Error>> {
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
         Ok(Box::new(Wildcard::new(MOCK_DISK_WILDCARD_TOP_ID, weight)))
     }
 


### PR DESCRIPTION
## Describe the changes in the pull request
This makes the RSE return a printable wildcard iterator so that we no longer need to have `PrintProfile` implementation for it.

Then because we now get a printable iterator from RSE, we also no longer need the wrapper at all and can just use a type alias instead.

Finally, for RSE to be able to add extra details to its print profile, it needs access to the term bytes, which this now also exposes to RSE.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of iterator typing and profile delegation for enterprise disk paths; behavior should match except richer disk wildcard profiles when RSE implements them.
> 
> **Overview**
> Disk wildcard iterators from Search Enterprise (RSE) are now required to implement **`ProfilePrint`** via the **`RQEIteratorPrintable`** trait, so profiling uses the enterprise implementation instead of a generic **WILDCARD** stub in open source.
> 
> The **`DiskWildcardIterator`** newtype and its manual **`RQEIterator`** / **`ProfilePrint`** delegations are removed; **`DiskWildcardIterator`** is a type alias for **`Box<dyn RQEIteratorPrintable + 'index>`**, and the disk variant stores that box directly.
> 
> **`query_term_bytes()`** is centralized on **`InvIndIterator`** (public) and reused from **TEXT**/**TAG** profile printing; duplicate helpers on **`Term`** and **`Tag`** are deleted so RSE can read term bytes for richer profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93c1f24f8ea0eb54ecc2da1b767c34241af0d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->