### PR TITLE
[8.6] [MOD-15505] Improve ~23% indexing throughput: unicode_tolower: skip nunicode pipeline on ASCII-only tokens

### DIFF
--- a/.skills/bisect-perf-regression/SKILL.md
+++ b/.skills/bisect-perf-regression/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: bisect-perf-regression
+description: Systematically bisect an end-to-end performance regression between two refs (tags/branches/commits) down to the exact offending commit(s). Use this when CI/customer benchmarks show one version is measurably slower than another and you need to attribute the cost to specific PRs.
+---
+
+# Bisect a performance regression
+
+Pin a perf regression to specific commits using drift-cancelled, repeated, cold benchmarks.
+
+You will need (or need to build) a small harness around the workload of interest.
+The exact shape of the harness does not matter, as long as it satisfies the
+properties described in step 1 below (interleaved labels, cold per-iteration
+state, median + CV reporting).
+
+## Arguments
+
+`$ARGUMENTS` should identify:
+- A **good** ref (older / fast) and a **bad** ref (newer / slow)
+- A reproducible workload and its parameters (workload size, dataset, mode),
+  expressed as whatever the harness consumes (env vars, CLI flags, config file)
+- An expected gap (so you can stop early when a real step is found)
+
+## Instructions
+
+### 1. Reproduce the gap stably before bisecting
+
+Before bisecting anything, prove the two endpoints are reliably distinguishable.
+
+- Use an interleaved harness that restarts the server (or the system under
+  test) per iteration so any cached state is cold each run, drives the workload
+  round-robin across labels
+  (so environmental drift attaches equally to every label), and reports median +
+  CV per label. Sequential "all N runs of label A, then all N runs of label B"
+  attributes any host drift across the wall-clock window entirely to the second
+  label, and is the single largest source of false positives in perf bisection.
+- Pin CPU count (e.g. `--cpus=8` for a Docker harness) and run on a quiet Linux
+  host. Shared/laptop Docker setups (macOS Docker Desktop, Codespaces, noisy CI
+  runners) are generally too jittery for sub-3% deltas.
+- **Pick `N_RUNS` adaptively from observed CV — don't burn 5–8 runs by default.**
+  - Start at `N_RUNS=3` (the minimum that yields a stdev/CV).
+  - After the run, inspect the per-label CV printed by the harness:
+    | observed max CV across labels | action |
+    |-------------------------------|-------|
+    | ≤ 1.5 %                       | 3 runs is enough, accept the medians |
+    | 1.5 – 2.5 %                   | rerun with `N_RUNS=5` for the labels involved in the suspect step |
+    | 2.5 – 4 %                     | rerun with `N_RUNS=8`, and only trust deltas ≥ 2 × max CV |
+    | > 4 %                         | the host is too noisy — fix it before bisecting (see below) |
+  - A claim is "real" when the median gap exceeds `max(3 %, 2 × max CV across the two labels)`.
+- If CV stays > 4 % even at `N_RUNS=8`, increase the per-run workload size, or
+  fix the host (other processes, CPU governor, thermal throttling, neighbour VMs)
+  before continuing — bisection on noisy data attributes regressions to the
+  wrong commit.
+
+### 2. Bracket with version tags first, then commits
+
+Always start with broad strokes and narrow down — never start at the commit level.
+
+1. **Tag ladder** — list the released tags between good and bad and run them all
+   in one interleaved sweep so they share drift. For example, with a project
+   that has tags `v2.10.12 … v2.10.30`, run all of them as labels in a single
+   interleaved sweep at `N_RUNS=3`. Look for the **step** — the adjacent pair
+   with the largest jump. That's your new `[lo, hi]` interval.
+2. **First-parent commit bisect** within `[lo, hi]`. Enumerate evenly-spaced
+   first-parent commits that actually touched code (filter to `src/*`,
+   `deps/*`, or the relevant subtrees — skip pure CI / docs / vendoring
+   commits, since they cannot move performance). Build them, run the
+   interleaved bench `[lo, p1, p2, …, hi]`, and inspect adjacent deltas.
+   Start at `N_RUNS=3` and escalate per the CV table in step 1.
+3. **Iterate** — pick the adjacent pair with the largest delta, recurse on
+   that narrower interval. Stop when `[lo, hi]` is one commit, or when the
+   remaining interval is below the noise floor.
+
+### 3. Watch for compounding / multi-step regressions
+
+A single endpoint number like "+30% slower" can hide several smaller steps that
+may compound through the same code path. Always print the full per-tag /
+per-commit ladder, not just endpoint deltas — a smooth slope versus a single
+cliff have very different fixes.
+
+### 3a. Isolating residuals with the "fix-on-commit" technique
+
+When a known regression dominates the gap and a fix is already in flight,
+**apply that fix on top of every historical commit you benchmark**. This
+neutralises the known cost so the ladder surfaces only the *residual*
+regressions that arrived alongside it. Without this technique, a large dominant
+cost can mask smaller but still real per-commit jumps.
+
+Build the fix-on-commit variants by:
+1. Creating a `fix-on-<sha>` branch off `<sha>`.
+2. Applying the in-flight fix on top.
+3. Building and benching that branch the same way you would a stock commit.
+
+Use a **code injector** (a small script that locates the target function by
+signature regex, balances braces to find its body, and inserts the fix at a
+known anchor) rather than a static `git apply` patch when:
+- the target function's signature changes inside the bracketed range, or
+- surrounding code shifts line numbers across tags (3-line context is too
+  small to disambiguate, and `--ignore-whitespace` won't save you).
+
+Keep the injector **idempotent** (detect its own marker before injecting) so
+reruns are safe across rebuilds.
+
+### 4. Confirm the offender
+
+Once a single commit is suspected:
+
+- Read the diff. The change must plausibly cause the observed cost (e.g. new
+  syscalls per token, new allocations per doc, new Rust↔C boundary calls).
+- Run a **confirmation pair**: `[<commit>^, <commit>]` only. Here it's worth
+  spending more iterations than the bisect ladder used — start at `N_RUNS=5`
+  and escalate to 8 if max CV > 2.5 %. The delta should match the step size
+  found during bisection to within `2 × max CV`.
+- If you can, build a **revert candidate** (`<bad>` with just that commit reverted)
+  and confirm it returns to `<lo>` performance. This guards against picking up an
+  innocent commit that sits next to the real offender via a noisy run.
+
+### 5. Honest reporting
+
+Report only what the data supports:
+- Endpoint medians + CV
+- The bisection ladder with adjacent deltas
+- The candidate commit(s), with PR link, author, and a one-line cause hypothesis
+  grounded in the diff
+- Residual unexplained delta, if any, with the noise floor
+
+Do not round, do not collapse multi-step regressions into a single cause, and do
+not skip the confirmation step.
+
+## Common pitfalls
+
+- **Cold-cache leakage into the first iteration** — the first build in a
+  session is usually slow due to docker layer pulls or compiler-cache warm-up.
+  Pre-build all artifacts before starting the timed benchmark.
+- **Wrong runtime/base image for the branch under test** — each build must run
+  against the runtime version it was compiled against (different minor branches
+  often pin different runtime/host versions). Verify the harness picks the
+  correct base image / runtime per label.
+- **Auto-loaded bundled component** — some base images auto-load a bundled
+  version of the component under test via the entrypoint. Bypass that (e.g.
+  override the entrypoint) so the component you actually want to measure is the
+  only one loaded.
+- **Toolchain / dependency drift across the bisect range** — historical tags may
+  need patches (compiler / library API breakage on newer hosts) or a specific
+  toolchain pin (e.g. a particular nightly). Wrap the per-commit build in a
+  script that detects the tag and applies the required patches / toolchain pin
+  on demand.
+
+## Report Back
+
+End with:
+- The good→bad ladder (medians, CV, adjacent %)
+- The implicated commit(s), short SHA + PR + title
+- The confirmation-pair numbers
+- A diff-grounded hypothesis for *why* the commit costs what it does
+- Residual gap, if any, and what would be needed to attribute it

--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -125,6 +125,35 @@ static char* unicode_tolower(char *encoded, size_t *inout_len) {
 
   size_t in_len = *inout_len;
 
+  // ASCII fast-path: when no byte has the high bit set, every byte is a
+  // single-codepoint ASCII character. Standard ASCII case folding (A-Z -> a-z)
+  // is byte-length preserving and matches what the nunicode pipeline would
+  // produce for codepoints < 0x80, so we can lowercase in place and skip the
+  // multi-pass transform entirely. The scan also stops at an embedded NUL,
+  // because nu_utf8_read treats codepoint 0 as end-of-string and truncates
+  // the output there. Multibyte inputs fall through to the slow path at the
+  // first byte with bit 7 set.
+  {
+    size_t j = 0;
+    while (j < in_len) {
+      unsigned char c = (unsigned char)encoded[j];
+      if (c == 0 || c >= 0x80) break;
+      j++;
+    }
+    if (j == in_len || encoded[j] == 0) {
+      for (size_t k = 0; k < j; k++) {
+        unsigned char c = (unsigned char)encoded[k];
+        if (c >= 'A' && c <= 'Z') {
+          encoded[k] = (char)(c + ('a' - 'A'));
+        }
+      }
+      if (j < in_len && j > 0) {
+        *inout_len = j;
+      }
+      return NULL;
+    }
+  }
+
   uint32_t u_stack_buffer[SSO_MAX_LENGTH];
   uint32_t *u_buffer = u_stack_buffer;
   char *longer_dst = NULL;

--- a/tests/cpptests/micro-benchmarks/CMakeLists.txt
+++ b/tests/cpptests/micro-benchmarks/CMakeLists.txt
@@ -28,3 +28,7 @@ foreach(benchmark_file ${BENCHMARK_ITER_SOURCES})
   add_executable(${benchmark_name} ${benchmark_file} ../index_utils.cpp ../iterator_util.cpp)
   target_link_libraries(${benchmark_name} redisearch redismock benchmark::benchmark)
 endforeach()
+
+# Standalone micro-benchmarks (no iterator/index_utils dependency).
+add_executable(benchmark_unicode_tolower benchmark_unicode_tolower.cpp)
+target_link_libraries(benchmark_unicode_tolower redisearch redismock benchmark::benchmark)

--- a/tests/cpptests/micro-benchmarks/benchmark_unicode_tolower.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_unicode_tolower.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "benchmark/benchmark.h"
+#include "redismock/util.h"
+#include "util/strconv.h"
+#include "rmalloc.h"
+
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+// Token corpora for the unicode_tolower benchmark.
+//
+// MS MARCO and other English document/query workloads feed the tokenizer with
+// short, mixed-case ASCII tokens. We synthesize equivalents here (deterministic
+// PRNG) so the benchmark is self-contained and reproducible:
+//   - ascii:   ~7-byte uppercase/mixed-case ASCII words ([A-Za-z]+)
+//   - cyrillic: ~12-byte Cyrillic words (each codepoint 2 bytes UTF-8)
+//   - mixed:    ASCII tokens with one Latin-1 accented codepoint mid-token
+//
+// The bench measures the per-token cost of unicode_tolower in a tight loop,
+// re-copying the input each iteration since unicode_tolower mutates in place.
+
+namespace {
+
+constexpr size_t kNumTokens = 4096;
+
+std::vector<std::string> MakeAsciiCorpus(uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> len_dist(3, 12);
+  std::uniform_int_distribution<int> case_dist(0, 1);
+  std::uniform_int_distribution<int> letter_dist(0, 25);
+  std::vector<std::string> out;
+  out.reserve(kNumTokens);
+  for (size_t i = 0; i < kNumTokens; ++i) {
+    int n = len_dist(rng);
+    std::string s;
+    s.reserve(n);
+    for (int j = 0; j < n; ++j) {
+      char base = case_dist(rng) ? 'A' : 'a';
+      s.push_back(base + letter_dist(rng));
+    }
+    out.emplace_back(std::move(s));
+  }
+  return out;
+}
+
+std::vector<std::string> MakeCyrillicCorpus(uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> len_dist(3, 12);
+  // Cyrillic uppercase range U+0410..U+042F (32 letters).
+  std::uniform_int_distribution<uint32_t> cp_dist(0x0410, 0x042F);
+  std::vector<std::string> out;
+  out.reserve(kNumTokens);
+  for (size_t i = 0; i < kNumTokens; ++i) {
+    int n = len_dist(rng);
+    std::string s;
+    s.reserve(n * 2);
+    for (int j = 0; j < n; ++j) {
+      uint32_t cp = cp_dist(rng);
+      // Encode 2-byte UTF-8: 110xxxxx 10xxxxxx
+      s.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+      s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    out.emplace_back(std::move(s));
+  }
+  return out;
+}
+
+std::vector<std::string> MakeMixedCorpus(uint32_t seed) {
+  // ASCII token with a single Latin-1 accented codepoint (e.g. U+00C9 É)
+  // inserted at a random position. Models the realistic "mostly-ASCII corpus
+  // with occasional accented word" pattern.
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> len_dist(3, 12);
+  std::uniform_int_distribution<int> case_dist(0, 1);
+  std::uniform_int_distribution<int> letter_dist(0, 25);
+  // U+00C0..U+00DE without U+00D7 (Latin-1 uppercase block).
+  std::uniform_int_distribution<uint32_t> cp_dist(0x00C0, 0x00DE);
+  std::vector<std::string> out;
+  out.reserve(kNumTokens);
+  for (size_t i = 0; i < kNumTokens; ++i) {
+    int n = len_dist(rng);
+    std::string s;
+    s.reserve(n + 2);
+    int accent_pos = std::uniform_int_distribution<int>(0, n - 1)(rng);
+    for (int j = 0; j < n; ++j) {
+      if (j == accent_pos) {
+        uint32_t cp = cp_dist(rng);
+        if (cp == 0x00D7) cp = 0x00C0; // skip multiplication sign
+        s.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+        s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+      } else {
+        char base = case_dist(rng) ? 'A' : 'a';
+        s.push_back(base + letter_dist(rng));
+      }
+    }
+    out.emplace_back(std::move(s));
+  }
+  return out;
+}
+
+enum class Corpus { kAscii, kCyrillic, kMixed };
+
+const std::vector<std::string>& GetCorpus(Corpus c) {
+  static const std::vector<std::string> ascii = MakeAsciiCorpus(0xA5C11A11);
+  static const std::vector<std::string> cyr = MakeCyrillicCorpus(0xC7B1110C);
+  static const std::vector<std::string> mix = MakeMixedCorpus(0x111E4ED1);
+  switch (c) {
+    case Corpus::kAscii: return ascii;
+    case Corpus::kCyrillic: return cyr;
+    case Corpus::kMixed: return mix;
+  }
+  return ascii;
+}
+
+void RunCorpus(benchmark::State& state, Corpus c) {
+  RMCK::init();
+  const auto& tokens = GetCorpus(c);
+  // Compute total bytes processed per iteration for throughput reporting.
+  size_t total_bytes = 0;
+  for (const auto& t : tokens) total_bytes += t.size();
+
+  // Pre-allocate a working buffer large enough for the longest token plus one
+  // (unicode_tolower may write up to the same byte length on its in-place path).
+  size_t max_len = 0;
+  for (const auto& t : tokens) max_len = std::max(max_len, t.size());
+  std::vector<char> buf(max_len + 1);
+
+  for (auto _ : state) {
+    for (const auto& t : tokens) {
+      std::memcpy(buf.data(), t.data(), t.size());
+      size_t len = t.size();
+      char* longer = unicode_tolower(buf.data(), &len);
+      if (longer) {
+        benchmark::DoNotOptimize(longer);
+        rm_free(longer);
+      } else {
+        benchmark::DoNotOptimize(buf.data());
+      }
+    }
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * total_bytes);
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * tokens.size());
+}
+
+void BM_UnicodeToLower_Ascii(benchmark::State& state) { RunCorpus(state, Corpus::kAscii); }
+void BM_UnicodeToLower_Cyrillic(benchmark::State& state) { RunCorpus(state, Corpus::kCyrillic); }
+void BM_UnicodeToLower_Mixed(benchmark::State& state) { RunCorpus(state, Corpus::kMixed); }
+
+}  // namespace
+
+BENCHMARK(BM_UnicodeToLower_Ascii)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_UnicodeToLower_Cyrillic)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_UnicodeToLower_Mixed)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();

--- a/tests/cpptests/test_cpp_unicode_tolower.cpp
+++ b/tests/cpptests/test_cpp_unicode_tolower.cpp
@@ -145,41 +145,6 @@ TEST_F(UnicodeToLowerTest, testTurkishDottedI) {
   rm_free(dst); // Free the allocated memory for dst
 }
 
-TEST_F(UnicodeToLowerTest, testSupplementaryPlaneBit12) {
-  // Regression test for a libnu b4_utf8 encoder bug where bit 12 of the
-  // codepoint was dropped from byte 1 and leaked into byte 2, producing
-  // invalid UTF-8 for any supplementary-plane codepoint with bit 12 set.
-  //
-  // U+118A0 (WARANG CITI CAPITAL NGAA, F0 91 A2 A0) lowercases to
-  // U+118C0 (WARANG CITI SMALL NGAA,   F0 91 A3 80). Both have codepoint
-  // bit 12 set, so this exercises the previously buggy path.
-  char str[] = "\xF0\x91\xA2\xA0";
-  char *dst = nullptr;
-  size_t newLen = strlen(str);
-
-  dst = unicode_tolower(str, &newLen);
-  ASSERT_EQ(dst, nullptr); // Same byte count, in-place conversion
-  ASSERT_EQ(newLen, 4u);
-  ASSERT_STREQ(str, "\xF0\x91\xA3\x80");
-}
-
-TEST_F(UnicodeToLowerTest, testSupplementaryPlaneNoBit12) {
-  // Companion to testSupplementaryPlaneBit12: a supplementary-plane casing
-  // pair where codepoint bit 12 is clear, to lock in that the encoder fix
-  // did not regress the non-bit-12 path.
-  //
-  // U+10400 (DESERET CAPITAL LONG I, F0 90 90 80) lowercases to
-  // U+10428 (DESERET SMALL LONG I,   F0 90 90 A8).
-  char str[] = "\xF0\x90\x90\x80";
-  char *dst = nullptr;
-  size_t newLen = strlen(str);
-
-  dst = unicode_tolower(str, &newLen);
-  ASSERT_EQ(dst, nullptr);
-  ASSERT_EQ(newLen, 4u);
-  ASSERT_STREQ(str, "\xF0\x90\x90\xA8");
-}
-
 TEST_F(UnicodeToLowerTest, testEmbeddedNulAsciiPrefix) {
   // Embedded NUL terminates the conversion at the NUL position and the ASCII
   // prefix is lowercased in place. Bytes past the NUL are not touched.

--- a/tests/cpptests/test_cpp_unicode_tolower.cpp
+++ b/tests/cpptests/test_cpp_unicode_tolower.cpp
@@ -144,3 +144,105 @@ TEST_F(UnicodeToLowerTest, testTurkishDottedI) {
   ASSERT_STREQ(dst, "i̇stanbul");
   rm_free(dst); // Free the allocated memory for dst
 }
+
+TEST_F(UnicodeToLowerTest, testSupplementaryPlaneBit12) {
+  // Regression test for a libnu b4_utf8 encoder bug where bit 12 of the
+  // codepoint was dropped from byte 1 and leaked into byte 2, producing
+  // invalid UTF-8 for any supplementary-plane codepoint with bit 12 set.
+  //
+  // U+118A0 (WARANG CITI CAPITAL NGAA, F0 91 A2 A0) lowercases to
+  // U+118C0 (WARANG CITI SMALL NGAA,   F0 91 A3 80). Both have codepoint
+  // bit 12 set, so this exercises the previously buggy path.
+  char str[] = "\xF0\x91\xA2\xA0";
+  char *dst = nullptr;
+  size_t newLen = strlen(str);
+
+  dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr); // Same byte count, in-place conversion
+  ASSERT_EQ(newLen, 4u);
+  ASSERT_STREQ(str, "\xF0\x91\xA3\x80");
+}
+
+TEST_F(UnicodeToLowerTest, testSupplementaryPlaneNoBit12) {
+  // Companion to testSupplementaryPlaneBit12: a supplementary-plane casing
+  // pair where codepoint bit 12 is clear, to lock in that the encoder fix
+  // did not regress the non-bit-12 path.
+  //
+  // U+10400 (DESERET CAPITAL LONG I, F0 90 90 80) lowercases to
+  // U+10428 (DESERET SMALL LONG I,   F0 90 90 A8).
+  char str[] = "\xF0\x90\x90\x80";
+  char *dst = nullptr;
+  size_t newLen = strlen(str);
+
+  dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 4u);
+  ASSERT_STREQ(str, "\xF0\x90\x90\xA8");
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulAsciiPrefix) {
+  // Embedded NUL terminates the conversion at the NUL position and the ASCII
+  // prefix is lowercased in place. Bytes past the NUL are not touched.
+  char str[] = {'F', 'O', 'O', '\0', 'B', 'A', 'R'};
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 3u);
+  ASSERT_EQ(str[0], 'f');
+  ASSERT_EQ(str[1], 'o');
+  ASSERT_EQ(str[2], 'o');
+  ASSERT_EQ(str[3], '\0');
+  ASSERT_EQ(str[4], 'B');
+  ASSERT_EQ(str[5], 'A');
+  ASSERT_EQ(str[6], 'R');
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulAtStart) {
+  // NUL at offset 0: no output codepoints, inout_len is left untouched and the
+  // buffer is unchanged.
+  char str[] = {'\0', 'A', 'B', 'C'};
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, sizeof(str));
+  ASSERT_EQ(str[0], '\0');
+  ASSERT_EQ(str[1], 'A');
+  ASSERT_EQ(str[2], 'B');
+  ASSERT_EQ(str[3], 'C');
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulBeforeMultibyte) {
+  // ASCII prefix, NUL, then a multibyte suffix. The NUL terminates the
+  // conversion before the multibyte bytes are ever inspected.
+  char str[] = {'F', 'O', 'O', '\0', '\xC3', '\x89'}; // ..\0É
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 3u);
+  ASSERT_EQ(str[0], 'f');
+  ASSERT_EQ(str[1], 'o');
+  ASSERT_EQ(str[2], 'o');
+  ASSERT_EQ(str[3], '\0');
+  ASSERT_EQ((unsigned char)str[4], 0xC3);
+  ASSERT_EQ((unsigned char)str[5], 0x89);
+}
+
+TEST_F(UnicodeToLowerTest, testEmbeddedNulAfterMultibyte) {
+  // Multibyte prefix, NUL, then an ASCII suffix. This routes through the slow
+  // path (first byte has bit 7 set), and the slow path also truncates at NUL.
+  char str[] = {'\xC3', '\x89', 'A', '\0', 'B', 'C'}; // ÉA\0BC
+  size_t newLen = sizeof(str);
+
+  char *dst = unicode_tolower(str, &newLen);
+  ASSERT_EQ(dst, nullptr);
+  ASSERT_EQ(newLen, 3u);
+  ASSERT_EQ((unsigned char)str[0], 0xC3);
+  ASSERT_EQ((unsigned char)str[1], 0xA9); // é
+  ASSERT_EQ(str[2], 'a');
+  ASSERT_EQ(str[3], '\0');
+  ASSERT_EQ(str[4], 'B');
+  ASSERT_EQ(str[5], 'C');
+}


### PR DESCRIPTION
Backport of #9882 to branch `8.6`.

## Describe the changes in the pull request

1. **Current:** `unicode_tolower` always runs the full multi-pass nunicode pipeline even for pure ASCII tokens, which dominated indexing cost after multi-byte support was added.
2. **Change:** Cherry-pick of the squash merge from #9882 with two adjustments:
   - Conflict resolution: `test_cpp_unicode_tolower.cpp` ended before the supplementary-plane tests on this branch, so git flagged the newly-appended block as a conflict. Resolved by taking the cherry-pick content.
   - Dropped `testSupplementaryPlaneBit12` and `testSupplementaryPlaneNoBit12`: these tests were added by #9552 ([MOD-8594] libnu b4_utf8 fix) which was intentionally not backported. The underlying encoder bug is still present on this branch, so including those tests would cause deterministic failures.
   - The `.skills/bisect-perf-regression/SKILL.md` file is intentional — it documents the bisection procedure used for MOD-15505 and lives in the `.skills/` directory used by the repo's coding-agent tooling.
3. **Outcome:** ASCII tokens skip the nunicode pipeline entirely, recovering ~23% of per-token case-folding overhead. Non-ASCII tokens fall through to the unchanged slow path.

#### Which additional issues this PR fixes
1. MOD-15505

#### Main objects this PR modified
1. `src/util/strconv.h` — ASCII fast-path in `unicode_tolower`
2. `tests/cpptests/test_cpp_unicode_tolower.cpp` — added embedded-NUL test cases (supplementary-plane tests omitted, pending #9552 backport)
3. `tests/cpptests/micro-benchmarks/benchmark_unicode_tolower.cpp` — new micro-benchmark (new file)
4. `tests/cpptests/micro-benchmarks/CMakeLists.txt` — register the new benchmark target
5. `.skills/bisect-perf-regression/SKILL.md` — bisection skill (intentional, part of original PR)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

[MOD-8594]: https://redislabs.atlassian.net/browse/MOD-8594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ