### PR TITLE
[MOD-16034] FT.HYBRID: take spec read lock in WORKERS=0 foreground path

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -988,8 +988,15 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
 
     return REDISMODULE_OK;
   } else {
-    // Single-threaded execution path
-    return buildPipelineAndExecute(hybrid_ref, hybridParams, ctx, sctx, status, internal, false);
+    // Single-threaded execution path.
+    // Acquire read lock before building pipeline (matching HREQ_Execute_Callback).
+    // The lock may be released early during pipeline execution (e.g. in
+    // WaitForDepletionToStart); RedisSearchCtx_UnlockSpec safely no-ops in that
+    // case by checking sctx->flags.
+    RedisSearchCtx_LockSpecRead(sctx);
+    int rc = buildPipelineAndExecute(hybrid_ref, hybridParams, ctx, sctx, status, internal, false);
+    RedisSearchCtx_UnlockSpec(sctx);
+    return rc;
   }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `HybridRequest_BuildPipelineAndExecute` acquires the index read lock in its background callback (`HREQ_Execute_Callback` at `src/hybrid/hybrid_exec.c:1214`) but skips it on the single-threaded path taken when `WORKERS=0` (or when the fallback to the main thread fires in single-shard environments). The query then iterates the index without holding the spec read lock, leaving it open to concurrent writers and GC. `FT.AGGREGATE` already takes the lock in both paths (`src/aggregate/aggregate_exec.c:1794`).
2. **Change**: Wrap the foreground `buildPipelineAndExecute` call in `RedisSearchCtx_LockSpecRead` / `RedisSearchCtx_UnlockSpec`, mirroring the background-callback pattern. `RedisSearchCtx_UnlockSpec` already no-ops if the lock was released early during pipeline execution (e.g. by `WaitForDepletionToStart`), so the unlock can be unconditional.
3. **Outcome**: `FT.HYBRID` now holds the spec read lock during single-threaded execution, closing a race with concurrent writers / GC that could surface as use-after-free, torn reads, or incorrect results.

#### Which additional issues this PR fixes
1. MOD-16034

#### Main objects this PR modified
1. `src/hybrid/hybrid_exec.c` — `HybridRequest_BuildPipelineAndExecute` foreground branch

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact (captured in the title): `FT.HYBRID` no longer iterates the index unlocked when `WORKERS=0`, eliminating a window where concurrent writers or GC could corrupt query state.

#### Related

- #8533 (MOD-13110) — added the read lock in the *background* hybrid path.
- #7212 (MOD-12174) — introduced the WORKERS=0 single-thread hybrid path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8988767186398520522eb63c8dc9a1c22c6b1c90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->