### PR TITLE
[MOD-15540] benchmark triage: fetch failed-job logs via REST API

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -344,8 +344,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # `gh run view --log-failed` refuses while the run is still in progress
+          # (this triage job is itself part of the run). Fetch per-job logs via the
+          # REST API instead, which works on live runs.
           set +e
-          gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
+          : > failed-logs.txt
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' \
+            > failed-jobs.tsv
+          while IFS=$'\t' read -r job_id job_name; do
+            [ -z "$job_id" ] && continue
+            printf '##[group]%s\n' "$job_name" >> failed-logs.txt
+            gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" >> failed-logs.txt 2>&1
+            printf '\n##[endgroup]\n' >> failed-logs.txt
+          done < failed-jobs.tsv
           # Cap at 200KB to bound Codex token spend
           if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
             tail -c 204800 failed-logs.txt > failed-logs.txt.tmp


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The benchmark-runner `triage-benchmark-failures` job calls `gh run view --log-failed` to collect failed-job logs as Codex's input. That command refuses to return logs while the parent workflow run is still in progress — but the triage job runs *inside* that same run, so the file ends up containing only the 81-byte `run NNN is still in progress; logs will be available when it is complete` message. Codex (correctly) outputs `needs-more-evidence`, and the downstream Slack `notify-failure` step ships an empty `ai_triage` field. Example: [run 26773477904](https://github.com/RediSearch/RediSearch/actions/runs/26773477904/job/78920610360) failed and the Slack message had no analysis.
2. **Change:** Replace `gh run view --log-failed` with a per-job REST fetch:
   - `gh api --paginate /actions/runs/{id}/attempts/{n}/jobs` to list jobs in the current attempt.
   - `--jq '.jobs[] | select(.conclusion == "failure")'` to keep only failed jobs (the still-running triage job has `conclusion=null`, so it's excluded).
   - For each failed job, write `##[group]<job_name>`, fetch `/actions/jobs/{id}/logs`, write `##[endgroup]`.
   The 200KB cap is preserved.
3. **Outcome:** Codex sees the real failure logs even though the run is still in progress, so the Slack notification's AI analysis is populated. As a bonus, `failed-logs.txt` now actually matches the `##[group]<job_name>` / `##[endgroup]` structure that `.github/codex/prompts/benchmark-triage.md` documents.

#### Which additional issues this PR fixes
1. MOD-15540

#### Main objects this PR modified
1. `.github/workflows/benchmark-runner.yml` — `triage-benchmark-failures` job's "Fetch failed-job logs" step.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how logs are collected for triage; no product code, APIs, or serialization.
> 
> **Overview**
> Fixes benchmark failure triage so Codex gets real failed-job logs while the workflow run is still in progress.
> 
> The **Fetch failed-job logs** step in `triage-benchmark-failures` no longer uses `gh run view --log-failed` (which only returns a “run still in progress” stub when triage runs inside the same run). It now lists jobs for the current run attempt via the Actions REST API, keeps only jobs with `conclusion == "failure"`, and appends each job’s logs under `##[group]<job_name>` / `##[endgroup]`—matching what `benchmark-triage.md` expects. The existing **200KB** cap on `failed-logs.txt` is unchanged.
> 
> Slack `notify-failure` should receive populated `ai_triage` instead of empty analysis when benchmarks fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5258e3e27a5681de2af1384bfe668ea47b7e075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->