### PR TITLE
[MOD-15540] CI triage: fix empty Slack analysis on live runs; factor log-fetch into shared action

### DIFF
--- a/.github/actions/fetch-failed-run-logs/action.yml
+++ b/.github/actions/fetch-failed-run-logs/action.yml
@@ -1,0 +1,72 @@
+name: Fetch Failed Run Logs
+description: >
+  Download the logs of all failed (or timed-out) jobs in a workflow run and
+  concatenate them into a single file with `##[group]<job_name>` /
+  `##[endgroup]` markers. Works on still-in-progress runs (uses the per-job
+  REST endpoint instead of `gh run view --log-failed`, which refuses while the
+  parent run is live).
+
+inputs:
+  github-token:
+    description: GitHub token with `actions: read` for the target run.
+    required: true
+  run-id:
+    description: Workflow run ID to inspect. Defaults to the current run.
+    required: false
+    default: ${{ github.run_id }}
+  run-attempt:
+    description: Run attempt number. Defaults to the current attempt.
+    required: false
+    default: ${{ github.run_attempt }}
+  output-file:
+    description: Path to write the concatenated logs to.
+    required: false
+    default: failed-logs.txt
+  append:
+    description: >
+      If `true`, append to `output-file` instead of truncating it. Useful when
+      a caller has already prepared part of the log file (e.g. artifact-based
+      test logs) and wants job logs appended.
+    required: false
+    default: 'false'
+  max-bytes:
+    description: >
+      Truncate the final file to its last N bytes. Bounds Codex token spend.
+    required: false
+    default: '204800'
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch failed-job logs
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        RUN_ID: ${{ inputs.run-id }}
+        RUN_ATTEMPT: ${{ inputs.run-attempt }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        APPEND: ${{ inputs.append }}
+        MAX_BYTES: ${{ inputs.max-bytes }}
+      run: |
+        set +e
+        if [ "$APPEND" != "true" ]; then
+          : > "$OUTPUT_FILE"
+        fi
+        # `failure` and `timed_out` both roll up to `failure` in `needs.*.result`,
+        # so triage callers expect both categories of logs.
+        gh api --paginate \
+          "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs" \
+          --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | "\(.id)\t\(.name)"' |
+          while IFS=$'\t' read -r job_id job_name; do
+            [ -z "$job_id" ] && continue
+            printf '##[group]%s\n' "$job_name" >> "$OUTPUT_FILE"
+            gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" >> "$OUTPUT_FILE" 2>&1
+            printf '\n##[endgroup]\n' >> "$OUTPUT_FILE"
+          done
+        if [ "$(wc -c < "$OUTPUT_FILE" 2>/dev/null || echo 0)" -gt "$MAX_BYTES" ]; then
+          tail -c "$MAX_BYTES" "$OUTPUT_FILE" > "${OUTPUT_FILE}.tmp"
+          printf '[truncated to last %s bytes]\n' "$MAX_BYTES" > "$OUTPUT_FILE"
+          cat "${OUTPUT_FILE}.tmp" >> "$OUTPUT_FILE"
+          rm "${OUTPUT_FILE}.tmp"
+        fi
+        exit 0

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -340,35 +340,9 @@ jobs:
       triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
     steps:
       - uses: actions/checkout@v6
-      - name: Fetch failed-job logs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # `gh run view --log-failed` refuses while the run is still in progress
-          # (this triage job is itself part of the run). Fetch per-job logs via the
-          # REST API instead, which works on live runs.
-          set +e
-          : > failed-logs.txt
-          # `timed_out` rolls up to `failure` in `needs.*.result`, so the triage
-          # job also runs for timeouts — include that conclusion in the filter.
-          gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
-            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | "\(.id)\t\(.name)"' \
-            > failed-jobs.tsv
-          while IFS=$'\t' read -r job_id job_name; do
-            [ -z "$job_id" ] && continue
-            printf '##[group]%s\n' "$job_name" >> failed-logs.txt
-            gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" >> failed-logs.txt 2>&1
-            printf '\n##[endgroup]\n' >> failed-logs.txt
-          done < failed-jobs.tsv
-          # Cap at 200KB to bound Codex token spend
-          if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
-            tail -c 204800 failed-logs.txt > failed-logs.txt.tmp
-            printf '[truncated to last 200KB]\n' > failed-logs.txt
-            cat failed-logs.txt.tmp >> failed-logs.txt
-            rm failed-logs.txt.tmp
-          fi
-          exit 0
+      - uses: ./.github/actions/fetch-failed-run-logs
+        with:
+          github-token: ${{ github.token }}
       - name: Run Codex triage
         id: triage
         uses: ./.github/actions/codex-ci-triage

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -349,9 +349,11 @@ jobs:
           # REST API instead, which works on live runs.
           set +e
           : > failed-logs.txt
+          # `timed_out` rolls up to `failure` in `needs.*.result`, so the triage
+          # job also runs for timeouts — include that conclusion in the filter.
           gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
-            --jq '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' \
+            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | "\(.id)\t\(.name)"' \
             > failed-jobs.tsv
           while IFS=$'\t' read -r job_id job_name; do
             [ -z "$job_id" ] && continue

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -344,8 +344,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # `gh run view --log-failed` refuses while the run is still in progress
+          # (this triage job is itself part of the run). Fetch per-job logs via the
+          # REST API instead, which works on live runs.
           set +e
-          gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
+          : > failed-logs.txt
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' \
+            > failed-jobs.tsv
+          while IFS=$'\t' read -r job_id job_name; do
+            [ -z "$job_id" ] && continue
+            printf '##[group]%s\n' "$job_name" >> failed-logs.txt
+            gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" >> failed-logs.txt 2>&1
+            printf '\n##[endgroup]\n' >> failed-logs.txt
+          done < failed-jobs.tsv
           # Cap at 200KB to bound Codex token spend
           if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
             tail -c 204800 failed-logs.txt > failed-logs.txt.tmp

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -22,7 +22,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
-      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
+      actions: read   # fetch-failed-run-logs (triage) reads job logs via the actions REST API
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
@@ -42,7 +42,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
-      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
+      actions: read   # fetch-failed-run-logs (triage) reads job logs via the actions REST API
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -33,20 +33,9 @@ jobs:
       triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
     steps:
       - uses: actions/checkout@v6
-      - name: Fetch failed-job logs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set +e
-          gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed > failed-logs.txt 2>&1
-          # Cap at 200KB to bound Codex token spend
-          if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
-            tail -c 204800 failed-logs.txt > failed-logs.txt.tmp
-            printf '[truncated to last 200KB]\n' > failed-logs.txt
-            cat failed-logs.txt.tmp >> failed-logs.txt
-            rm failed-logs.txt.tmp
-          fi
-          exit 0
+      - uses: ./.github/actions/fetch-failed-run-logs
+        with:
+          github-token: ${{ github.token }}
       - name: Run Codex triage
         id: triage
         uses: ./.github/actions/codex-ci-triage

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -256,17 +256,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Fetch failed-job logs
+      - name: Collect focused test-failure artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set +e
           # Prefer the focused "Failed Test Logs *" artifacts produced by
           # task-test.yml — they contain only logs for tests that actually
           # failed, which is much higher signal than the full job stdout.
-          # Always also include `gh run view --log-failed` so non-pytest
-          # failures (build, sanitizer, Rust, etc.) still have context in
-          # mixed-failure runs.
+          # Job-level logs are appended afterwards (via fetch-failed-run-logs)
+          # so non-pytest failures (build, sanitizer, Rust, etc.) still have
+          # context in mixed-failure runs.
+          set +e
           mkdir -p downloaded-failed-logs
           gh run download "$GITHUB_RUN_ID" \
             --repo "$GITHUB_REPOSITORY" \
@@ -286,22 +286,12 @@ jobs:
           else
             echo "No Failed Test Logs artifacts found."
           fi
-
-          # Also append job-level failed logs to cover non-pytest failures.
-          {
-            printf '\n##[group]gh run view --log-failed\n'
-            gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed 2>&1
-            printf '\n##[endgroup]\n'
-          } >> failed-logs.txt
-
-          # Cap at 200KB to bound Codex token spend
-          if [ "$(wc -c < failed-logs.txt 2>/dev/null || echo 0)" -gt 204800 ]; then
-            tail -c 204800 failed-logs.txt > failed-logs.txt.tmp
-            printf '[truncated to last 200KB]\n' > failed-logs.txt
-            cat failed-logs.txt.tmp >> failed-logs.txt
-            rm failed-logs.txt.tmp
-          fi
           exit 0
+
+      - uses: ./.github/actions/fetch-failed-run-logs
+        with:
+          github-token: ${{ github.token }}
+          append: 'true'
 
       - name: Run Codex triage
         id: ai_triage

--- a/.github/workflows/event-periodic-msmarco-e2e-benchmarks.yml
+++ b/.github/workflows/event-periodic-msmarco-e2e-benchmarks.yml
@@ -8,7 +8,7 @@ jobs:
   run-benchmarks:
     permissions:
       contents: read
-      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
+      actions: read   # fetch-failed-run-logs (triage) reads job logs via the actions REST API
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ needs.check-what-changed.outputs.BENCHMARK_CHANGED == 'true' }}
     permissions:
       contents: read
-      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
+      actions: read   # fetch-failed-run-logs (triage) reads job logs via the actions REST API
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -10,7 +10,7 @@ jobs:
   run-benchmarks:
     permissions:
       contents: read
-      actions: read   # benchmark-runner.yml triage step calls `gh run view --log-failed`
+      actions: read   # fetch-failed-run-logs (triage) reads job logs via the actions REST API
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Three workflows ([benchmark-runner.yml](.github/workflows/benchmark-runner.yml), [event-deploy-snapshots.yml](.github/workflows/event-deploy-snapshots.yml), [event-periodic-master-validation.yml](.github/workflows/event-periodic-master-validation.yml)) each had near-duplicate shell to collect failed-job logs for Codex triage. All three relied on `gh run view --log-failed`, which **refuses to return logs while the parent run is still in progress** — but every triage job runs *inside* its own run, so `failed-logs.txt` ended up containing only the 81-byte `run NNN is still in progress; logs will be available when it is complete` sentinel. Codex (correctly) responded `needs-more-evidence`, and the Slack `notify-failure` jobs shipped messages with an empty `ai_triage` field. Example: [run 26773477904](https://github.com/RediSearch/RediSearch/actions/runs/26773477904/job/78920610360) — `benchmark-search-oss-standalone-aarch64 (1/3)` failed, Slack analysis came through empty.
2. **Change:**
   - New composite action [.github/actions/fetch-failed-run-logs/action.yml](.github/actions/fetch-failed-run-logs/action.yml). It uses the per-job REST endpoint (`/actions/runs/{id}/attempts/{n}/jobs` → `/actions/jobs/{id}/logs`), which works on live runs because it queries only individual jobs that have already terminated (the ones our `needs:` already gates on). Each job's logs are wrapped in `##[group]<name>` / `##[endgroup]` markers — matching what [.github/codex/prompts/benchmark-triage.md](.github/codex/prompts/benchmark-triage.md) already documents. Selects jobs whose `conclusion` is `failure` **or** `timed_out` (the latter rolls up to `failure` in `needs.*.result`, so triage runs but would otherwise have no logs to fetch). 200KB cap retained. Supports `append: true` for callers that pre-populate the log file (used by `event-periodic-master-validation.yml`).
   - Replace the inline shell in all three workflows with a single `uses:` call.
   - Update stale "calls `gh run view --log-failed`" comments in 5 wrapper workflows (`benchmark-trigger`, `event-periodic-msmarco-e2e-benchmarks`, `event-push-to-integ`, `event-weekly`) that justify the `actions: read` permission.
3. **Outcome:** Slack notifications get real Codex analysis instead of empty `ai_triage` fields. The triage log-fetching logic now lives in one place; future workflows can opt in with three lines of YAML.

#### Which additional issues this PR fixes
1. MOD-15540

#### Main objects this PR modified
1. `.github/actions/fetch-failed-run-logs/action.yml` *(new)* — composite action.
2. `.github/workflows/benchmark-runner.yml` — `triage-benchmark-failures` job's fetch step.
3. `.github/workflows/event-deploy-snapshots.yml` — `triage-failure` job's fetch step.
4. `.github/workflows/event-periodic-master-validation.yml` — `notify-cie-failure` job's fetch step (keeps the focused-artifact prep step, uses `append: 'true'`).
5. Permission comments in five wrapper workflows.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-visible behavior. Supersedes the closed #9958 (branch rename closed it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)