### PR TITLE
skip notifications only on replica side

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -82,8 +82,17 @@ do {                                            \
     return REDISMODULE_ERR;                                            \
   }
 
-#define IS_SST_RDB_IN_PROCESS(ctx) (RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_SST_RDB)
-#define IS_SST_RDB_LOADING(ctx) (IS_SST_RDB_IN_PROCESS(ctx) && (RedisModule_GetContextFlags(ctx) & (REDISMODULE_CTX_FLAGS_LOADING | REDISMODULE_CTX_FLAGS_ASYNC_LOADING)))
+static inline bool IS_SST_RDB_IN_PROCESS(RedisModuleCtx *ctx) {
+  return (RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_SST_RDB) != 0;
+}
+
+static inline bool IS_SST_RDB_LOADING(RedisModuleCtx *ctx) {
+  // Fetch the context flags once and test both bits, instead of calling
+  // RedisModule_GetContextFlags() twice.
+  int flags = RedisModule_GetContextFlags(ctx);
+  return (flags & REDISMODULE_CTX_FLAGS_SST_RDB) &&
+         (flags & (REDISMODULE_CTX_FLAGS_LOADING | REDISMODULE_CTX_FLAGS_ASYNC_LOADING));
+}
 
 // Forward declaration of searchReducerCtx
 struct searchReducerCtx;

--- a/src/module.h
+++ b/src/module.h
@@ -83,6 +83,8 @@ do {                                            \
   }
 
 #define IS_SST_RDB_IN_PROCESS(ctx) (RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_SST_RDB)
+#define IS_SST_RDB_LOADING(ctx) (IS_SST_RDB_IN_PROCESS(ctx) && (RedisModule_GetContextFlags(ctx) & (REDISMODULE_CTX_FLAGS_LOADING | REDISMODULE_CTX_FLAGS_ASYNC_LOADING)))
+
 // Forward declaration of searchReducerCtx
 struct searchReducerCtx;
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -113,7 +113,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
     case loaded_cmd:
       // on loaded event the key is stack allocated so to use it to load the
       // document we must copy it
-      if (!IS_SST_RDB_IN_PROCESS(ctx)) {
+      if (!IS_SST_RDB_LOADING(ctx)) {
         key = RedisModule_CreateStringFromString(ctx, key);
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields); //TODO: avoid getDocTypeFromString ?
         RedisModule_FreeString(ctx, key);
@@ -126,7 +126,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
     case hincrby_cmd:
     case hincrbyfloat_cmd:
     case hdel_cmd:
-      if (!IS_SST_RDB_IN_PROCESS(ctx)) {
+      if (!IS_SST_RDB_LOADING(ctx)) {
         Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Hash, hashFields);
       }
       break;


### PR DESCRIPTION
## Describe the changes in the pull request

Only skip notifications during SST-RDB replication only on the replica loading side. On master, from PRE_CHECKPOINT to POST_FORK the engine must keep indexing documents.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when hash/loaded keyspace events update indexes during SST-RDB replication; wrong flag pairing could duplicate or miss indexing on master or replica.
> 
> **Overview**
> During SST-RDB replication, keyspace notifications for **`loaded`** and hash writes (**`hset`**, **`hmset`**, etc.) no longer skip indexing whenever the SST-RDB context flag is set. They skip only when **`IS_SST_RDB_LOADING`** is true—SST-RDB **and** a loading/async-loading context—so the **master** can keep updating indexes through PRE_CHECKPOINT→POST_FORK while the **replica** still avoids duplicate work while loading.
> 
> `IS_SST_RDB_IN_PROCESS` becomes an inline helper (same bit check); **`IS_SST_RDB_LOADING`** is added in `module.h`, reading context flags once. Persistence and RDB loading paths still use `IS_SST_RDB_IN_PROCESS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f5f57a932feaced92bee7290d6ce70eac078827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->