### PR TITLE
[8.6] CI: match redisearch-community prefix in Set Version Artifacts

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -210,6 +210,11 @@ jobs:
 
           bucket = "redismodules"
           oss_dir = "redisearch-oss"
+          # Artifacts uploaded to the OSS directory use the "redisearch-community"
+          # file prefix (see sbin/upload-artifacts), which differs from the S3
+          # directory name. Example name:
+          #   redisearch-community.macos-sequoia-aarch64.8.6.20260601.131332.03edbf8.zip
+          oss_file_prefix = "redisearch-community"
 
           expected_sha = os.environ["EXPECTED_SHA"]
           expected_short_sha = expected_sha[:7]
@@ -232,8 +237,12 @@ jobs:
                       if suffix_pattern.search(obj["Key"]):
                           yield obj["Key"]
 
-          def list_snapshots_by_branch(dir):
-              return list_files_by_branch(f"{dir}/snapshots/{dir}")
+          # The S3 directory name and the artifact file prefix can differ
+          # (e.g. the "redisearch-oss" dir holds "redisearch-community.*" files),
+          # so allow the file prefix to be specified independently.
+          def list_snapshots_by_branch(dir, file_prefix=None):
+              file_prefix = file_prefix or dir
+              return list_files_by_branch(f"{dir}/snapshots/{file_prefix}")
 
           # Return the git sha from the module.json file in the zip file (build sha)
           def extract_sha(key):
@@ -259,7 +268,7 @@ jobs:
 
           ############################### Main Script ###############################
 
-          files = list(list_snapshots_by_branch(oss_dir))
+          files = list(list_snapshots_by_branch(oss_dir, oss_file_prefix))
 
           group_print(f"{os.environ['SOURCE']} Build Candidates", files)
           if not files:


### PR DESCRIPTION
OSS snapshot artifacts are uploaded into the redisearch-oss/ S3 directory with the "redisearch-community" file prefix (see sbin/upload-artifacts), e.g. redisearch-community.macos-sequoia-aarch64.8.6.20260601.131332.03edbf8.zip.

The "Set Version Artifacts" step assumed the file prefix equals the S3 directory name (redisearch-oss/snapshots/redisearch-oss), so it listed zero candidates and failed with "No candidates found".

Decouple the file prefix from the directory name and list the OSS snapshots using the "redisearch-community" prefix.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to S3 listing logic for releases; no runtime product or security surface.
> 
> **Overview**
> Fixes the release workflow **Set Version Artifacts** step so it can find OSS snapshot zips in S3.
> 
> Artifacts live under `redisearch-oss/snapshots/` but are named with the **`redisearch-community`** prefix (per `sbin/upload-artifacts`), not `redisearch-oss`. Listing used the directory name as the object prefix, found no keys, and failed with **No candidates found**.
> 
> The script now passes **`redisearch-community`** when listing snapshots via an optional `file_prefix` on `list_snapshots_by_branch`, keeping the S3 path and filename prefix separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5d97d063e5f26ed918fb676344dd92cc13215da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->