### PR TITLE
rqe_iterators: factor out new_missing_iterator()

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/missing.rs
@@ -7,105 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{fmt::Debug, ptr::NonNull};
+use std::ptr::NonNull;
 
-use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use index_result::RSIndexResult;
-use inverted_index::{IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
-use rqe_core::{DocId, FieldIndex};
-use rqe_iterators::{
-    FieldExpirationChecker, IteratorType, interop::RQEIteratorWrapper, inverted_index::Missing,
-    profile_print,
-};
-
-/// Wrapper around different II missing iterator encoding types to avoid generics in FFI code.
-///
-/// Handles both the standard variable-length encoding ([`DocIdsOnly`]) and the
-/// fixed 4-byte raw encoding ([`RawDocIdsOnly`]).
-pub(super) enum MissingIterator<'index> {
-    Encoded(Missing<'index, DocIdsOnly, FieldExpirationChecker>),
-    Raw(Missing<'index, RawDocIdsOnly, FieldExpirationChecker>),
-}
-
-impl Debug for MissingIterator<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let variant = match self {
-            MissingIterator::Encoded(_) => "Encoded",
-            MissingIterator::Raw(_) => "Raw",
-        };
-        write!(f, "MissingIterator({variant})")
-    }
-}
-
-/// Macro to dispatch RQEIterator methods across all [`MissingIterator`] variants.
-macro_rules! dispatch {
-    ($self:expr, $method:ident $(, $arg:expr)*) => {
-        match $self {
-            MissingIterator::Encoded(m) => m.$method($($arg),*),
-            MissingIterator::Raw(m) => m.$method($($arg),*),
-        }
-    };
-}
-
-impl<'index> rqe_iterators::RQEIterator<'index> for MissingIterator<'index> {
-    #[inline(always)]
-    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        dispatch!(self, current)
-    }
-
-    #[inline(always)]
-    fn read(
-        &mut self,
-    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
-        dispatch!(self, read)
-    }
-
-    #[inline(always)]
-    fn skip_to(
-        &mut self,
-        doc_id: DocId,
-    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
-    {
-        dispatch!(self, skip_to, doc_id)
-    }
-
-    #[inline(always)]
-    fn rewind(&mut self) {
-        dispatch!(self, rewind)
-    }
-
-    #[inline(always)]
-    fn num_estimated(&self) -> usize {
-        dispatch!(self, num_estimated)
-    }
-
-    #[inline(always)]
-    fn last_doc_id(&self) -> DocId {
-        dispatch!(self, last_doc_id)
-    }
-
-    #[inline(always)]
-    fn at_eof(&self) -> bool {
-        dispatch!(self, at_eof)
-    }
-
-    #[inline(always)]
-    fn revalidate(
-        &mut self,
-        spec: &index_spec::IndexSpecReadGuard,
-    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        dispatch!(self, revalidate, spec)
-    }
-
-    #[inline(always)]
-    fn type_(&self) -> IteratorType {
-        IteratorType::InvIdxMissing
-    }
-
-    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
-        1.0
-    }
-}
+use rqe_core::FieldIndex;
+use rqe_iterators::{interop::RQEIteratorWrapper, inverted_index::new_missing_iterator};
 
 /// Creates a new missing-field inverted index iterator.
 ///
@@ -140,56 +45,15 @@ pub unsafe extern "C" fn NewInvIndIterator_MissingQuery(
     debug_assert!(!idx.is_null(), "idx must not be null");
     debug_assert!(!sctx.is_null(), "sctx must not be null");
 
-    // Cast to the FFI wrapper enum which handles type dispatch
     let idx_ffi: *const inverted_index_ffi::InvertedIndex = idx.cast();
-    // SAFETY: 1. guarantees idx is valid and non-null
+    // SAFETY: 1. guarantees idx is valid and non-null.
     let ii_ref = unsafe { &*idx_ffi };
 
-    // SAFETY: 3. guarantees sctx is valid and non-null
+    // SAFETY: 3. guarantees sctx is valid and non-null.
     let sctx_nn = unsafe { NonNull::new_unchecked(sctx as *mut _) };
 
-    // Build the expiration checker for the Missing predicate
-    let filter_ctx = FieldFilterContext {
-        field: FieldMaskOrIndex::Index(field_index),
-        predicate: FieldExpirationPredicate::Missing,
-    };
-
-    // Create the appropriate missing iterator variant based on encoding type.
-    let iterator = match ii_ref {
-        inverted_index_ffi::InvertedIndex::DocIdsOnly(ii) => {
-            let reader = ii.reader();
-            // SAFETY: 3.-6. guarantee validity for the iterator's lifetime.
-            let checker =
-                unsafe { FieldExpirationChecker::new(sctx_nn, filter_ctx, reader.flags()) };
-            // SAFETY: 3.-6. guarantee validity for the iterator's lifetime.
-            MissingIterator::Encoded(unsafe { Missing::new(reader, sctx_nn, field_index, checker) })
-        }
-        inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
-            let reader = ii.reader();
-            // SAFETY: 3.-6. guarantee validity for the iterator's lifetime.
-            let checker =
-                unsafe { FieldExpirationChecker::new(sctx_nn, filter_ctx, reader.flags()) };
-            // SAFETY: 3.-6. guarantee validity for the iterator's lifetime.
-            MissingIterator::Raw(unsafe { Missing::new(reader, sctx_nn, field_index, checker) })
-        }
-        _ => panic!(
-            "Missing iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",
-            std::mem::discriminant(ii_ref)
-        ),
-    };
-
-    RQEIteratorWrapper::boxed_new(iterator)
-}
-
-impl profile_print::ProfilePrint for MissingIterator<'_> {
-    fn print_profile(
-        &self,
-        map: &mut redis_reply::MapBuilder<'_>,
-        ctx: &mut profile_print::ProfilePrintCtx<'_>,
-    ) {
-        match self {
-            MissingIterator::Encoded(m) => m.print_profile(map, ctx),
-            MissingIterator::Raw(m) => m.print_profile(map, ctx),
-        }
-    }
+    // SAFETY: 3.-6. guarantee sctx, spec, field_index, and
+    // missingFieldDict validity.
+    let it = unsafe { new_missing_iterator(ii_ref, sctx_nn, field_index) };
+    RQEIteratorWrapper::boxed_new(it)
 }

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -221,6 +221,34 @@ void Hybrid_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, str
 QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, const struct IteratorsConfig *config);
 
 /**
+ * Creates a new missing-field inverted index iterator.
+ *
+ * # Parameters
+ *
+ * * `idx` - Pointer to the missing-field inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+ * * `sctx` - Pointer to the Redis search context.
+ * * `field_index` - The index of the field in `spec.fields` whose missing documents are tracked.
+ *
+ * # Returns
+ *
+ * A pointer to a `QueryIterator` that can be used from C code.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *
+ * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ *    mechanism detects when the index has been replaced via `spec.missingFieldDict`
+ *    lookup.
+ * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ * 5. `field_index` must be a valid index into `sctx.spec.fields`.
+ * 6. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
+ */
+QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex field_index);
+
+/**
  * Creates a new iterator over a list of unsorted document IDs.
  *
  * # Safety
@@ -371,34 +399,6 @@ void GeoShape_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, s
  * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
  */
 void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
-
-/**
- * Creates a new missing-field inverted index iterator.
- *
- * # Parameters
- *
- * * `idx` - Pointer to the missing-field inverted index (DocIdsOnly or RawDocIdsOnly encoded).
- * * `sctx` - Pointer to the Redis search context.
- * * `field_index` - The index of the field in `spec.fields` whose missing documents are tracked.
- *
- * # Returns
- *
- * A pointer to a `QueryIterator` that can be used from C code.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- *
- * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
- *    mechanism detects when the index has been replaced via `spec.missingFieldDict`
- *    lookup.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- * 5. `field_index` must be a valid index into `sctx.spec.fields`.
- * 6. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
- */
-QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex field_index);
 
 /**
  * Get a mutable reference to the [`RLookupKey`] stored inside this metric iterator.

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -18,9 +18,12 @@ use index_spec::IndexSpecReadGuard;
 use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
 use rqe_core::{DocId, FieldIndex, RS_FIELDMASK_ALL};
 
+use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
+use inverted_index::IndexReader;
+
 use crate::{
-    ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
-    SkipToOutcome,
+    ExpirationChecker, FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError,
+    RQEIteratorPrintable, RQEValidateStatus, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
@@ -33,7 +36,7 @@ use super::InvIndIterator;
 /// documents is maintained per-field in the index spec's `missingFieldDict`.
 ///
 /// This iterator supports per-field expiration checks via
-/// [`FieldExpirationChecker`](crate::FieldExpirationChecker) using the
+/// [`FieldExpirationChecker`] using the
 /// [`Missing`](field::FieldExpirationPredicate::Missing) predicate.
 ///
 /// # Type Parameters
@@ -255,5 +258,52 @@ where
         }
         ctx.print_optional_counters(map);
         map.kv_long_long(c"Estimated number of matches", self.num_estimated() as i64);
+    }
+}
+
+/// Create a missing-field iterator from an opaque [`InvertedIndex`](inverted_index::opaque::InvertedIndex),
+/// dispatching on the encoding type.
+///
+/// # Safety
+///
+/// 1. `sctx` must point to a valid [`RedisSearchCtx`] whose `spec` is
+///    non-null and valid.
+/// 2. `field_index` must be a valid index into `sctx.spec.fields`.
+/// 3. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
+/// 4. The opaque inverted index must use either
+///    [`DocIdsOnly`](inverted_index::doc_ids_only::DocIdsOnly) or
+///    [`RawDocIdsOnly`](inverted_index::raw_doc_ids_only::RawDocIdsOnly)
+///    encoding.
+pub unsafe fn new_missing_iterator<'index>(
+    ii: &'index inverted_index::opaque::InvertedIndex,
+    sctx: NonNull<RedisSearchCtx>,
+    field_index: FieldIndex,
+) -> Box<dyn RQEIteratorPrintable<'index> + 'index> {
+    let filter_ctx = FieldFilterContext {
+        field: FieldMaskOrIndex::Index(field_index),
+        predicate: FieldExpirationPredicate::Missing,
+    };
+
+    match ii {
+        inverted_index::opaque::InvertedIndex::DocIdsOnly(ii) => {
+            let reader = ii.reader();
+            // SAFETY: caller guarantees sctx and spec validity (1-3).
+            let checker = unsafe { FieldExpirationChecker::new(sctx, filter_ctx, reader.flags()) };
+            // SAFETY: caller guarantees sctx, spec, field_index, and
+            // missingFieldDict validity (1-3).
+            Box::new(unsafe { Missing::new(reader, sctx, field_index, checker) })
+        }
+        inverted_index::opaque::InvertedIndex::RawDocIdsOnly(ii) => {
+            let reader = ii.reader();
+            // SAFETY: caller guarantees sctx and spec validity (1-3).
+            let checker = unsafe { FieldExpirationChecker::new(sctx, filter_ctx, reader.flags()) };
+            // SAFETY: caller guarantees sctx, spec, field_index, and
+            // missingFieldDict validity (1-3).
+            Box::new(unsafe { Missing::new(reader, sctx, field_index, checker) })
+        }
+        _ => panic!(
+            "Missing iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",
+            std::mem::discriminant(ii)
+        ),
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -22,7 +22,7 @@ pub use geo::{
     GeoRangeError, InvalidGeoInput, build_geo_numeric_filters, extract_geo_unit_factor,
     new_geo_range_iterator,
 };
-pub use missing::Missing;
+pub use missing::{Missing, new_missing_iterator};
 pub use numeric::{Numeric, NumericIteratorVariant, open_numeric_or_geo_index};
 pub use tag::Tag;
 pub use term::Term;


### PR DESCRIPTION
The QAST eval code will need the exact same code.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no intended query semantics change; same safety preconditions and encoding dispatch, only call-site consolidation.
> 
> **Overview**
> Moves **missing-field inverted index** iterator construction from the C FFI entrypoint into shared **`new_missing_iterator()`** in `rqe_iterators`, so the same logic can be reused (e.g. from QAST evaluation) without duplicating encoding dispatch.
> 
> The FFI **`NewInvIndIterator_MissingQuery`** is now a thin wrapper: cast pointers, call **`new_missing_iterator`**, and box via **`RQEIteratorWrapper`**. The local **`MissingIterator`** enum, **`dispatch!` macro**, and manual **`RQEIterator` / `ProfilePrint`** impls are removed in favor of a single **`Box<dyn RQEIteratorPrintable>`** returned from the library helper (still branching on **`DocIdsOnly`** vs **`RawDocIdsOnly`** with **`FieldExpirationChecker`** and **`Missing`**).
> 
> The public C API and safety documentation for **`NewInvIndIterator_MissingQuery`** are unchanged; **`iterators_ffi.h`** only relocates that declaration within the generated header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8a7127e313874f2f985c8643481e029ba4798c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->