### PR TITLE
[MOD-15113] Keep FT.HYBRID GROUPBY cap unscaled on coordinator

### DIFF
--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -73,7 +73,6 @@ typedef struct Grouper {
   // array of reducers
   Reducer **reducers;
 
-  // GROUPBY materialization limit.
   GroupByLimits groupByLimits;
 
   // Used for maintaining state when yielding groups

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -622,9 +622,6 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     if (rc != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
-    hybridParams.aggregationParams.groupByLimits =
-        GroupByLimits_ForCoordinator(RSGlobalConfig.maxAggregateGroups, numShards);
-
     // Set skip timeout
     HybridRequest_SetSkipTimeoutChecks(hreq, !shouldCheckInPipelineTimeoutCoord(hreq));
 

--- a/tests/pytests/test_hybrid_groupby.py
+++ b/tests/pytests/test_hybrid_groupby.py
@@ -113,7 +113,7 @@ def test_hybrid_groupby_total_group_limit():
         .contains('2')
 
 @skip(cluster=False)
-def test_hybrid_groupby_coordinator_group_limit_uses_shard_count():
+def test_hybrid_groupby_coordinator_group_limit():
     env = Env(shardsCount=3, protocol=3, moduleArgs='MAX_AGGREGATE_GROUPS 2')
 
     env.expect('FT.CREATE', 'idx',
@@ -131,17 +131,15 @@ def test_hybrid_groupby_coordinator_group_limit_uses_shard_count():
                              'embedding', vector)
 
     query_vector = np.array([0.0, 0.0], dtype=np.float32).tobytes()
-    res = env.cmd('FT.HYBRID', 'idx',
-                  'SEARCH', 'nomatch',
-                  'VSIM', '@embedding', '$BLOB',
-                      'RANGE', '2', 'RADIUS', '16',
-                  'GROUPBY', '1', '@__key',
-                      'REDUCE', 'COUNT', '0', 'AS', 'count',
-                  'PARAMS', '2', 'BLOB', query_vector)
-
-    env.assertEqual(len(res['results']), 3)
-    for row in res['results']:
-        env.assertEqual(row['count'], '1')
+    env.expect('FT.HYBRID', 'idx',
+               'SEARCH', 'nomatch',
+               'VSIM', '@embedding', '$BLOB',
+                   'RANGE', '2', 'RADIUS', '16',
+               'GROUPBY', '1', '@__key',
+                   'REDUCE', 'COUNT', '0', 'AS', 'count',
+               'PARAMS', '2', 'BLOB', query_vector).error() \
+        .contains('MAX_AGGREGATE_GROUPS') \
+        .contains('2')
 
 def test_hybrid_groupby_small():
     """Test hybrid search with small result set (3 docs) + groupby"""


### PR DESCRIPTION
## Describe the changes in the pull request

Current: #9830 made coordinator GROUPBY limits shard-scaled for distributed aggregate and also applied that scaling to FT.HYBRID tail GROUPBY.
Change: Keep FT.HYBRID tail GROUPBY on the parser-provided `MAX_AGGREGATE_GROUPS` cap in coordinator mode, and update the cluster hybrid test to expect the same cap as standalone. Distributed FT.AGGREGATE still uses shard-scaled coordinator limits.
Outcome: FT.HYBRID no longer allows `MAX_AGGREGATE_GROUPS * shardCount` groups on the coordinator for a GROUPBY that is not distributed.

#### Which additional issues this PR fixes
1. MOD-15113
2. Follow-up to #9830

#### Main objects this PR modified
1. FT.HYBRID coordinator pipeline setup
2. Hybrid GROUPBY tests
3. GROUPBY result processor field comments

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
