### PR TITLE
[8.6-rse] [MOD-16019] Notify VecSim on doc replacement in disk indexing path

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -152,7 +152,8 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
       if (spec->flags & Index_HasVecSim) {
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-            VecSimIndex *vecsim = openVectorIndex(ctx, &spec->fields[i], DONT_CREATE_INDEX);
+            // ctx is NULL because we don't create the index here
+            VecSimIndex *vecsim = openVectorIndex(NULL, &spec->fields[i], DONT_CREATE_INDEX);
             if(!vecsim)
               continue;
             VecSimIndex_DeleteVector(vecsim, dmd->id);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -229,8 +229,8 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
         updated = docId != 0; // If docId is 0, the document was not added
       }
 
-      // Vector indexes are in-process and not managed by the disk layer, so
-      // they must be updated explicitly when a document is replaced.
+      // Vector indexes are cleaned explicitly and not managed by the disk layer or GC,
+      // so they must be updated explicitly when a document is replaced.
       if (oldDocId != 0 && (spec->flags & Index_HasVecSim)) {
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -152,8 +152,7 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
       if (spec->flags & Index_HasVecSim) {
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-            // ctx is NULL because we don't create the index here
-            VecSimIndex *vecsim = openVectorIndex(NULL, &spec->fields[i], DONT_CREATE_INDEX);
+            VecSimIndex *vecsim = openVectorIndex(ctx, &spec->fields[i], DONT_CREATE_INDEX);
             if(!vecsim)
               continue;
             VecSimIndex_DeleteVector(vecsim, dmd->id);
@@ -227,6 +226,18 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
         RS_ASSERT(spec->stats.scoring.totalDocsLen >= oldLen);
         spec->stats.scoring.totalDocsLen -= oldLen;
         updated = docId != 0; // If docId is 0, the document was not added
+      }
+
+      // Vector indexes are in-process and not managed by the disk layer, so
+      // they must be updated explicitly when a document is replaced.
+      if (oldDocId != 0 && (spec->flags & Index_HasVecSim)) {
+        for (int i = 0; i < spec->numFields; ++i) {
+          if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
+            VecSimIndex *vecsim = openVectorIndex(ctx->redisCtx, &spec->fields[i], DONT_CREATE_INDEX);
+            if (!vecsim) continue;
+            VecSimIndex_DeleteVector(vecsim, oldDocId);
+          }
+        }
       }
 
       if (!failure) {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: When a document is replaced on the on-disk index path (`SearchDisk_IsEnabled()` branch of `doAssignIds`), the old vector is left behind in the in-process VecSim index. KNN queries then return stale results because the previous embedding for the doc id is still searchable.
2. **Change**: After `SearchDisk_PutDocument` returns (success or failure) for a key that already had a prior `docId`, walk the schema's vector fields and call `VecSimIndex_DeleteVector(vecsim, oldDocId)` for each. The cleanup is guarded by `oldDocId != 0` (a previous doc-id was actually mapped) and the `Index_HasVecSim` short-circuit.
3. **Outcome**: Updating a document via `HSET` on the disk path now correctly replaces the previous vector instead of accumulating a stale copy. `FT.INFO num_docs` and the HNSW backend `INDEX_SIZE` stay in sync with the actual document count, and KNN queries return only the latest vector for a given key.

`SearchDisk_PutDocument` already removes the previous document from the doc table and disk inverted indexes; it does not (and cannot) reach into VecSim, which lives entirely in this process. The RAM path already performs equivalent cleanup — this PR brings the disk path in line.

Geometry fields are intentionally not handled: GEOSHAPE is not supported on disk in 8.6.

### Testing

No OSS test is added because the on-disk path is gated on `SearchDisk_IsEnabled()`, which returns true only when `bigredis-enabled yes` is configured — that requires the SpeedB-backed disk runtime which lives in RediSearchEnterprise. `_SIMULATE_IN_FLEX` only flips `SearchDisk_IsEnabledForValidation()` and does not exercise the actual disk write path in `doAssignIds`.

Coverage for this fix lives in the Enterprise flow test `test_update_vector_for_same_doc_yields_one_vector` added in [RediSearchEnterprise#442](https://github.com/redislabsdev/RediSearchEnterprise/pull/442). That test fails on the current code and is expected to pass once this PR lands and is consumed by an Enterprise build.

#### Which additional issues this PR fixes
1. MOD-16019

#### Main objects this PR modified
1. `src/indexer.c` — `doAssignIds` (disk branch): new VecSim cleanup block keyed on `oldDocId` for replaced documents.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User-impacting bug fix: vector updates on the disk indexing path no longer leave stale vectors in the in-memory VecSim index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets indexing correctness for vector KNN on the disk path; scope is narrow (one guarded block in doAssignIds) but wrong cleanup would affect search results.
> 
> **Overview**
> On the **on-disk indexing path** in `doAssignIds`, replacing a document now **removes the previous embedding** from in-process VecSim indexes for each vector field, using the prior `oldDocId` when `Index_HasVecSim` is set.
> 
> `SearchDisk_PutDocument` already updates disk inverted structures but **does not touch VecSim**, so stale vectors could remain searchable on KNN until this explicit `VecSimIndex_DeleteVector` loop—bringing disk behavior in line with the RAM path in `makeDocumentId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbcbdbf467fd476c3556f3ed782e268e1e863f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->