### PR TITLE
agents: genericize personal branch prefix in worktree example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,10 +256,10 @@ on an unrelated branch, or already tied to another open PR, automatically create
 worktree and do the work there. Use the existing checkout only when it is already the right clean
 branch for the task.
 
-Always use `-b` when creating a worktree — git forbids two worktrees on the same branch, so checking out `master` directly will fail when master is already the main checkout:
+Always use `-b` when creating a worktree — git forbids two worktrees on the same branch, so checking out `master` directly will fail when master is already the main checkout. Prefix the branch with your handle (e.g. `alice-`, `bob-`) to avoid collisions on the shared remote:
 
 ```bash
-git worktree add -b memark-<feature> .claude/worktrees/memark-<feature> origin/master
+git worktree add -b <your-handle>-<feature> .claude/worktrees/<your-handle>-<feature> origin/master
 ```
 
 To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules).


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `AGENTS.md` hardcodes one contributor's handle (`memark-<feature>`) as the example worktree/branch name in the "Common Workflows" section.
2. **Change**: Replace the hardcoded handle with the placeholder `<your-handle>-<feature>`, and add a short explanation that the prefix exists to avoid branch-name collisions on the shared remote (with `alice-` / `bob-` as illustrative examples).
3. **Outcome**: Contributor docs no longer prescribe one person's handle; every contributor is steered toward the same convention applied to their own handle.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `AGENTS.md` (worktree example in "Common Workflows")

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime, API, or build impact.
> 
> **Overview**
> Updates the **Common Workflows** worktree instructions so branch and path examples use `<your-handle>-<feature>` instead of a single contributor’s handle.
> 
> The same section now states that the branch prefix should be your handle (e.g. `alice-`, `bob-`) to reduce name collisions on the shared remote. The `-b` worktree guidance is unchanged in intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e914b762860cd065bed040c92609d9ef6ed57e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->