### PR TITLE
command_info: sync committed file with generator output

### DIFF
--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -3477,3 +3477,4 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
+


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `src/command_info/command_info.c` is regenerated by `srcutil/gen_command_info.py` (wired through `src/CMakeLists.txt` as a custom command whose declared inputs are `commands.json` and the script itself). The generator emits a trailing blank line after the last function definition (`SetFtHybridInfo`), but the committed file ends with a single newline.
2. Change: Add the one trailing newline byte to the committed file so it matches the generator's output exactly.
3. Outcome: Builds that invalidate the custom-command rule (e.g. by editing `commands.json` or the generator) no longer leave the working tree dirty by one byte. `git diff` is clean after a regen.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `src/command_info/command_info.c` (single trailing newline)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only sync on a generated file; no runtime or API behavior change.
> 
> **Overview**
> Aligns the committed **`command_info.c`** output with **`gen_command_info.py`** by adding a **trailing blank line** after the last `SetFtHybridInfo` function. No command metadata, arity, or logic changes.
> 
> This removes the one-byte mismatch that left **`git diff`** dirty after CMake regenerates the file from **`commands.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8a2fb611e598191dc5fd791dcc03870dd932c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->