### PR TITLE
[MOD-16054] suffix: fix wildcard '?' queries on WITHSUFFIXTRIE TEXT degrading to full-trie scan

### DIFF
--- a/src/suffix.c
+++ b/src/suffix.c
@@ -312,9 +312,6 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
     // this branching is heavy
     for (int j = tokenIdx[i]; j < tokenIdx[i] + tokenLen[i]; ++j) {
       if (str[j] == (rune)'?') {
-        // Penalize this candidate, not the running best (`score`): decrementing
-        // `score` underflows from its INT32_MIN seed to INT32_MAX, after which no
-        // token is ever selected and the caller falls back to a full-trie scan.
         --curScore;
       }
     }

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -312,7 +312,10 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
     // this branching is heavy
     for (int j = tokenIdx[i]; j < tokenIdx[i] + tokenLen[i]; ++j) {
       if (str[j] == (rune)'?') {
-        --score;
+        // Penalize this candidate, not the running best (`score`): decrementing
+        // `score` underflows from its INT32_MIN seed to INT32_MAX, after which no
+        // token is ever selected and the caller falls back to a full-trie scan.
+        --curScore;
       }
     }
 

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -23,11 +23,14 @@
 
 class SuffixChooseTokenTest : public ::testing::Test {};
 
-// The chosen token: its ordinal (REDISEARCH_UNINITIALIZED if none) and length,
-// so tests can assert exactly which token the scorer picked.
+// Result of the rune scorer for one pattern, so tests can assert exactly which
+// token it picked.
 struct RuneChoice {
-  int idx;
-  size_t len;
+  // 0-based position of the chosen token among the '*'-split tokens (1st, 2nd,
+  // ...), NOT a character offset into the pattern. REDISEARCH_UNINITIALIZED when
+  // no token qualifies.
+  int tokenOrdinal;
+  size_t len;  // length of the chosen token, in runes
 };
 
 // Run the rune scorer on an ASCII pattern (one byte == one rune here).
@@ -43,7 +46,7 @@ static RuneChoice chooseRune(const char *pattern) {
   return {res, chosenLen};
 }
 
-static int chooseTokenRune(const char *pattern) { return chooseRune(pattern).idx; }
+static int chooseTokenRune(const char *pattern) { return chooseRune(pattern).tokenOrdinal; }
 
 static int chooseTokenChar(const char *pattern) {
   size_t n = strlen(pattern);
@@ -55,42 +58,67 @@ static int chooseTokenChar(const char *pattern) {
 // token from being chosen. Before the fix the rune scorer returned
 // REDISEARCH_UNINITIALIZED here, forcing a full-trie brute-force fallback.
 TEST_F(SuffixChooseTokenTest, questionMarkInFirstTokenStillSelects) {
-  // Each case asserts the chosen token's ordinal and length, making it explicit
-  // which '?'-bearing token survives (token shapes shown in comments).
+  // Each case asserts the chosen token's ordinal (which token in the split) and
+  // length, making it explicit which '?'-bearing token survives.
   // Single token "?abcd" (len 5), '?' leading.
-  EXPECT_EQ(chooseRune("?abcd").idx, 0);
+  EXPECT_EQ(chooseRune("?abcd").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("?abcd").len, 5u);
   // Single token "ab?cd" (len 5), '?' in the middle.
-  EXPECT_EQ(chooseRune("ab?cd").idx, 0);
+  EXPECT_EQ(chooseRune("ab?cd").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("ab?cd").len, 5u);
   // Single token "abc?" (len 4), '?' trailing.
-  EXPECT_EQ(chooseRune("abc?").idx, 0);
+  EXPECT_EQ(chooseRune("abc?").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("abc?").len, 4u);
   // Single token "a??cd" (len 5): each '?' must penalize only this candidate,
   // not the running best, so the token is still selectable.
-  EXPECT_EQ(chooseRune("a??cd").idx, 0);
+  EXPECT_EQ(chooseRune("a??cd").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("a??cd").len, 5u);
   // Degenerate token "??" (len 2, == MIN_SUFFIX) is a weak but valid filter and
   // must be chosen over a full-trie fallback.
-  EXPECT_EQ(chooseRune("??").idx, 0);
+  EXPECT_EQ(chooseRune("??").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("??").len, 2u);
-  // "a?c"*"defg": clean token "defg" (idx 1, len 4) beats the '?'-bearing first.
-  EXPECT_EQ(chooseRune("a?c*defg").idx, 1);
+  // "a?c"*"defg": the clean 2nd token "defg" (ordinal 1, len 4) beats the
+  // '?'-bearing 1st.
+  EXPECT_EQ(chooseRune("a?c*defg").tokenOrdinal, 1);
   EXPECT_EQ(chooseRune("a?c*defg").len, 4u);
-  // "a?b"*"c?d": both tokens carry a '?'; the later "c?d" (idx 1, len 3) wins by
-  // avoiding the trailing-'*' penalty the first token pays.
-  EXPECT_EQ(chooseRune("a?b*c?d").idx, 1);
+  // "a?b"*"c?d": both tokens carry a '?'; the 2nd token "c?d" (ordinal 1, len 3)
+  // wins by avoiding the trailing-'*' penalty the 1st token pays.
+  EXPECT_EQ(chooseRune("a?b*c?d").tokenOrdinal, 1);
   EXPECT_EQ(chooseRune("a?b*c?d").len, 3u);
-  // "abcde?fghij"*"xy": the long first token (idx 0, len 11) keeps winning
-  // despite its '?' and trailing '*', over the short clean later token.
-  EXPECT_EQ(chooseRune("abcde?fghij*xy").idx, 0);
+  // "abcde?fghij"*"xy": the long 1st token (ordinal 0, len 11) keeps winning
+  // despite its '?' and trailing '*', over the short clean 2nd token.
+  EXPECT_EQ(chooseRune("abcde?fghij*xy").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("abcde?fghij*xy").len, 11u);
 }
 
-// The rune scorer must agree with the char scorer on the chosen token index.
+// Tokenization splits the pattern on runs of '*': consecutive '*' collapse, and
+// leading/trailing '*' are dropped. The scorer returns the chosen token's
+// ordinal in that split, which is unrelated to its character offset.
+TEST_F(SuffixChooseTokenTest, multipleStarsSelectByTokenOrdinal) {
+  // Consecutive and leading/trailing '*' collapse to a single token "abcd".
+  EXPECT_EQ(chooseRune("**abcd**").tokenOrdinal, 0);
+  EXPECT_EQ(chooseRune("**abcd**").len, 4u);
+  // "ab"**"cd": a double '*' still yields just two tokens; the clean trailing
+  // "cd" (2nd token, ordinal 1) wins.
+  EXPECT_EQ(chooseRune("ab**cd").tokenOrdinal, 1);
+  EXPECT_EQ(chooseRune("ab**cd").len, 2u);
+  // "ab"*"cd"*"ef": three tokens; the last (3rd token, ordinal 2) avoids the
+  // trailing-'*' penalty and wins.
+  EXPECT_EQ(chooseRune("ab*cd*ef").tokenOrdinal, 2);
+  EXPECT_EQ(chooseRune("ab*cd*ef").len, 2u);
+  // Sub-MIN_SUFFIX tokens are skipped for scoring but still counted in the
+  // ordinal: "a"/"b"/"cd"/"ef"/"ghij" -> the chosen "ghij" is the 5th token
+  // (ordinal 4), even though its character offset is 10. Confirms the result is
+  // the split ordinal, not an offset.
+  EXPECT_EQ(chooseRune("a*b*cd*ef*ghij").tokenOrdinal, 4);
+  EXPECT_EQ(chooseRune("a*b*cd*ef*ghij").len, 4u);
+}
+
+// The rune scorer must agree with the char scorer on the chosen token ordinal.
 TEST_F(SuffixChooseTokenTest, runeAgreesWithChar) {
   const char *patterns[] = {
       "?abcd", "ab?cd", "a?c*defg", "abc*defg", "ab*cd*efgh", "*magicneedl?*",
+      "**abcd**", "ab**cd", "ab*cd*ef", "a*b*cd*ef*ghij",
   };
   for (const char *p : patterns) {
     EXPECT_EQ(chooseTokenRune(p), chooseTokenChar(p)) << "pattern: " << p;

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -23,17 +23,27 @@
 
 class SuffixChooseTokenTest : public ::testing::Test {};
 
+// The chosen token: its ordinal (REDISEARCH_UNINITIALIZED if none) and length,
+// so tests can assert exactly which token the scorer picked.
+struct RuneChoice {
+  int idx;
+  size_t len;
+};
+
 // Run the rune scorer on an ASCII pattern (one byte == one rune here).
-static int chooseTokenRune(const char *pattern) {
+static RuneChoice chooseRune(const char *pattern) {
   size_t n = strlen(pattern);
   runeBuf buf;
   size_t rlen;
   rune *runes = runeBufFill(pattern, n, &buf, &rlen);
   std::vector<size_t> idx(rlen + 1), len(rlen + 1);
   int res = Suffix_ChooseToken_rune(runes, rlen, idx.data(), len.data());
+  size_t chosenLen = res == REDISEARCH_UNINITIALIZED ? 0 : len[res];
   runeBufFree(&buf);
-  return res;
+  return {res, chosenLen};
 }
+
+static int chooseTokenRune(const char *pattern) { return chooseRune(pattern).idx; }
 
 static int chooseTokenChar(const char *pattern) {
   size_t n = strlen(pattern);
@@ -45,26 +55,36 @@ static int chooseTokenChar(const char *pattern) {
 // token from being chosen. Before the fix the rune scorer returned
 // REDISEARCH_UNINITIALIZED here, forcing a full-trie brute-force fallback.
 TEST_F(SuffixChooseTokenTest, questionMarkInFirstTokenStillSelects) {
-  // Single token, '?' as its leading character.
-  EXPECT_EQ(chooseTokenRune("?abcd"), 0);
-  // Single token, '?' in the middle.
-  EXPECT_EQ(chooseTokenRune("ab?cd"), 0);
-  // Single token, '?' as its trailing character.
-  EXPECT_EQ(chooseTokenRune("abc?"), 0);
-  // Several '?' in the token: each must penalize only this candidate, not the
-  // running best, so the token is still selectable.
-  EXPECT_EQ(chooseTokenRune("a??cd"), 0);
-  // Degenerate token of only '?' (still >= MIN_SUFFIX) is a weak but valid
-  // filter and must be chosen over a full-trie fallback.
-  EXPECT_EQ(chooseTokenRune("??"), 0);
-  // First token carries the '?', a clean selective token follows: token 1 wins.
-  EXPECT_EQ(chooseTokenRune("a?c*defg"), 1);
-  // Both tokens carry a '?'; the later one wins by avoiding the trailing-'*'
-  // penalty the first token pays.
-  EXPECT_EQ(chooseTokenRune("a?b*c?d"), 1);
-  // A long first token keeps winning despite its '?' and trailing '*', over a
-  // short clean later token.
-  EXPECT_EQ(chooseTokenRune("abcde?fghij*xy"), 0);
+  // Each case asserts the chosen token's ordinal and length, making it explicit
+  // which '?'-bearing token survives (token shapes shown in comments).
+  // Single token "?abcd" (len 5), '?' leading.
+  EXPECT_EQ(chooseRune("?abcd").idx, 0);
+  EXPECT_EQ(chooseRune("?abcd").len, 5u);
+  // Single token "ab?cd" (len 5), '?' in the middle.
+  EXPECT_EQ(chooseRune("ab?cd").idx, 0);
+  EXPECT_EQ(chooseRune("ab?cd").len, 5u);
+  // Single token "abc?" (len 4), '?' trailing.
+  EXPECT_EQ(chooseRune("abc?").idx, 0);
+  EXPECT_EQ(chooseRune("abc?").len, 4u);
+  // Single token "a??cd" (len 5): each '?' must penalize only this candidate,
+  // not the running best, so the token is still selectable.
+  EXPECT_EQ(chooseRune("a??cd").idx, 0);
+  EXPECT_EQ(chooseRune("a??cd").len, 5u);
+  // Degenerate token "??" (len 2, == MIN_SUFFIX) is a weak but valid filter and
+  // must be chosen over a full-trie fallback.
+  EXPECT_EQ(chooseRune("??").idx, 0);
+  EXPECT_EQ(chooseRune("??").len, 2u);
+  // "a?c"*"defg": clean token "defg" (idx 1, len 4) beats the '?'-bearing first.
+  EXPECT_EQ(chooseRune("a?c*defg").idx, 1);
+  EXPECT_EQ(chooseRune("a?c*defg").len, 4u);
+  // "a?b"*"c?d": both tokens carry a '?'; the later "c?d" (idx 1, len 3) wins by
+  // avoiding the trailing-'*' penalty the first token pays.
+  EXPECT_EQ(chooseRune("a?b*c?d").idx, 1);
+  EXPECT_EQ(chooseRune("a?b*c?d").len, 3u);
+  // "abcde?fghij"*"xy": the long first token (idx 0, len 11) keeps winning
+  // despite its '?' and trailing '*', over the short clean later token.
+  EXPECT_EQ(chooseRune("abcde?fghij*xy").idx, 0);
+  EXPECT_EQ(chooseRune("abcde?fghij*xy").len, 11u);
 }
 
 // The rune scorer must agree with the char scorer on the chosen token index.

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -111,6 +111,8 @@ TEST_F(SuffixChooseTokenTest, multipleStarsSelectByTokenOrdinal) {
   // the split ordinal, not an offset.
   EXPECT_EQ(chooseRune("a*b*cd*ef*ghij").tokenOrdinal, 4);
   EXPECT_EQ(chooseRune("a*b*cd*ef*ghij").len, 4u);
+  EXPECT_EQ(chooseRune("ab*cd*longestmiddle*ef").tokenOrdinal, 2);
+  EXPECT_EQ(chooseRune("ab*cd*longestmiddle*ef").len, 13u);
 }
 
 // The rune scorer must agree with the char scorer on the chosen token ordinal.
@@ -137,4 +139,11 @@ TEST_F(SuffixChooseTokenTest, noQualifyingTokenIsUninitialized) {
   EXPECT_EQ(chooseTokenRune("?"), REDISEARCH_UNINITIALIZED);      // single '?'
   EXPECT_EQ(chooseTokenRune("*?*"), REDISEARCH_UNINITIALIZED);    // token "?" len 1
   EXPECT_EQ(chooseTokenRune("a*?*b"), REDISEARCH_UNINITIALIZED);  // "a","?","b" all len 1
+}
+
+TEST_F(SuffixChooseTokenTest, multiByteCharsScoredByRune) {
+  EXPECT_EQ(chooseRune("αβγ*δεζη").tokenOrdinal, 1);
+  EXPECT_EQ(chooseRune("αβγ*δεζη").len, 4u);
+  EXPECT_EQ(chooseRune("αβγδε").tokenOrdinal, 0);
+  EXPECT_EQ(chooseRune("αβγδε").len, 5u);
 }

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -125,8 +125,6 @@ TEST_F(SuffixChooseTokenTest, runeAgreesWithChar) {
 
 // Tokens shorter than MIN_SUFFIX are not usable; with no qualifying token the
 // scorer reports UNINITIALIZED so the caller falls back to a brute-force scan.
-// This is the *correct* UNINITIALIZED outcome, distinct from the fixed bug that
-// returned UNINITIALIZED for valid '?'-bearing tokens.
 TEST_F(SuffixChooseTokenTest, noQualifyingTokenIsUninitialized) {
   EXPECT_EQ(chooseTokenRune(""), REDISEARCH_UNINITIALIZED);       // no tokens
   EXPECT_EQ(chooseTokenRune("*"), REDISEARCH_UNINITIALIZED);      // only '*'

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -17,9 +17,7 @@
 
 // Suffix_ChooseToken (char) and Suffix_ChooseToken_rune (rune) pick the literal
 // token of a wildcard "contains" pattern used to narrow the suffix-trie scan.
-// The two must agree on which token they choose; the rune variant once
-// decremented the shared `score` accumulator on every '?', underflowing it from
-// INT32_MIN to INT32_MAX so that no token was ever selected.
+// The two must agree on which token they choose.
 
 class SuffixChooseTokenTest : public ::testing::Test {};
 
@@ -55,7 +53,7 @@ static int chooseTokenChar(const char *pattern) {
 }
 
 // A '?' in the first qualifying (len >= MIN_SUFFIX) token must not prevent a
-// token from being chosen. Before the fix the rune scorer returned
+// token from being chosen. Before the fix (MOD-16054) the rune scorer returned
 // REDISEARCH_UNINITIALIZED here, forcing a full-trie brute-force fallback.
 TEST_F(SuffixChooseTokenTest, questionMarkInFirstTokenStillSelects) {
   // Each case asserts the chosen token's ordinal (which token in the split) and

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "gtest/gtest.h"
+#include "suffix.h"
+#include "trie/rune_util.h"
+#include "redisearch.h"
+
+#include <string>
+#include <vector>
+
+// Suffix_ChooseToken (char) and Suffix_ChooseToken_rune (rune) pick the literal
+// token of a wildcard "contains" pattern used to narrow the suffix-trie scan.
+// The two must agree on which token they choose; the rune variant once
+// decremented the shared `score` accumulator on every '?', underflowing it from
+// INT32_MIN to INT32_MAX so that no token was ever selected.
+
+class SuffixChooseTokenTest : public ::testing::Test {};
+
+// Run the rune scorer on an ASCII pattern (one byte == one rune here).
+static int chooseTokenRune(const char *pattern) {
+  size_t n = strlen(pattern);
+  runeBuf buf;
+  size_t rlen;
+  rune *runes = runeBufFill(pattern, n, &buf, &rlen);
+  std::vector<size_t> idx(rlen + 1), len(rlen + 1);
+  int res = Suffix_ChooseToken_rune(runes, rlen, idx.data(), len.data());
+  runeBufFree(&buf);
+  return res;
+}
+
+static int chooseTokenChar(const char *pattern) {
+  size_t n = strlen(pattern);
+  std::vector<size_t> idx(n + 1), len(n + 1);
+  return Suffix_ChooseToken(pattern, n, idx.data(), len.data());
+}
+
+// A '?' in the first qualifying (len >= MIN_SUFFIX) token must not prevent a
+// token from being chosen. Before the fix the rune scorer returned
+// REDISEARCH_UNINITIALIZED here, forcing a full-trie brute-force fallback.
+TEST_F(SuffixChooseTokenTest, questionMarkInFirstTokenStillSelects) {
+  // Single token, '?' as its leading character.
+  EXPECT_EQ(chooseTokenRune("?abcd"), 0);
+  // Single token, '?' in the middle.
+  EXPECT_EQ(chooseTokenRune("ab?cd"), 0);
+  // First token carries the '?', a clean selective token follows: token 1 wins.
+  EXPECT_EQ(chooseTokenRune("a?c*defg"), 1);
+}
+
+// The rune scorer must agree with the char scorer on the chosen token index.
+TEST_F(SuffixChooseTokenTest, runeAgreesWithChar) {
+  const char *patterns[] = {
+      "?abcd", "ab?cd", "a?c*defg", "abc*defg", "ab*cd*efgh", "*magicneedl?*",
+  };
+  for (const char *p : patterns) {
+    EXPECT_EQ(chooseTokenRune(p), chooseTokenChar(p)) << "pattern: " << p;
+  }
+}
+
+// Tokens shorter than MIN_SUFFIX are not usable; with no qualifying token the
+// scorer reports UNINITIALIZED so the caller falls back to a brute-force scan.
+TEST_F(SuffixChooseTokenTest, noQualifyingTokenIsUninitialized) {
+  EXPECT_EQ(chooseTokenRune("a*b*c"), REDISEARCH_UNINITIALIZED);
+}

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -127,6 +127,17 @@ TEST_F(SuffixChooseTokenTest, runeAgreesWithChar) {
 
 // Tokens shorter than MIN_SUFFIX are not usable; with no qualifying token the
 // scorer reports UNINITIALIZED so the caller falls back to a brute-force scan.
+// This is the *correct* UNINITIALIZED outcome, distinct from the fixed bug that
+// returned UNINITIALIZED for valid '?'-bearing tokens.
 TEST_F(SuffixChooseTokenTest, noQualifyingTokenIsUninitialized) {
-  EXPECT_EQ(chooseTokenRune("a*b*c"), REDISEARCH_UNINITIALIZED);
+  EXPECT_EQ(chooseTokenRune(""), REDISEARCH_UNINITIALIZED);       // no tokens
+  EXPECT_EQ(chooseTokenRune("*"), REDISEARCH_UNINITIALIZED);      // only '*'
+  EXPECT_EQ(chooseTokenRune("**"), REDISEARCH_UNINITIALIZED);     // only '*'
+  EXPECT_EQ(chooseTokenRune("a"), REDISEARCH_UNINITIALIZED);      // single short token
+  EXPECT_EQ(chooseTokenRune("a*b*c"), REDISEARCH_UNINITIALIZED);  // all tokens len 1
+  // A '?' below MIN_SUFFIX is still too short to be a usable filter: it must be
+  // skipped, not force a selection.
+  EXPECT_EQ(chooseTokenRune("?"), REDISEARCH_UNINITIALIZED);      // single '?'
+  EXPECT_EQ(chooseTokenRune("*?*"), REDISEARCH_UNINITIALIZED);    // token "?" len 1
+  EXPECT_EQ(chooseTokenRune("a*?*b"), REDISEARCH_UNINITIALIZED);  // "a","?","b" all len 1
 }

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -49,8 +49,22 @@ TEST_F(SuffixChooseTokenTest, questionMarkInFirstTokenStillSelects) {
   EXPECT_EQ(chooseTokenRune("?abcd"), 0);
   // Single token, '?' in the middle.
   EXPECT_EQ(chooseTokenRune("ab?cd"), 0);
+  // Single token, '?' as its trailing character.
+  EXPECT_EQ(chooseTokenRune("abc?"), 0);
+  // Several '?' in the token: each must penalize only this candidate, not the
+  // running best, so the token is still selectable.
+  EXPECT_EQ(chooseTokenRune("a??cd"), 0);
+  // Degenerate token of only '?' (still >= MIN_SUFFIX) is a weak but valid
+  // filter and must be chosen over a full-trie fallback.
+  EXPECT_EQ(chooseTokenRune("??"), 0);
   // First token carries the '?', a clean selective token follows: token 1 wins.
   EXPECT_EQ(chooseTokenRune("a?c*defg"), 1);
+  // Both tokens carry a '?'; the later one wins by avoiding the trailing-'*'
+  // penalty the first token pays.
+  EXPECT_EQ(chooseTokenRune("a?b*c?d"), 1);
+  // A long first token keeps winning despite its '?' and trailing '*', over a
+  // short clean later token.
+  EXPECT_EQ(chooseTokenRune("abcde?fghij*xy"), 0);
 }
 
 // The rune scorer must agree with the char scorer on the chosen token index.

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -13,6 +13,7 @@
 #include "redisearch.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 // Suffix_ChooseToken (char) and Suffix_ChooseToken_rune (rune) pick the literal
@@ -32,11 +33,11 @@ struct RuneChoice {
 };
 
 // Run the rune scorer on an ASCII pattern (one byte == one rune here).
-static RuneChoice chooseRune(const char *pattern) {
-  size_t n = strlen(pattern);
+static RuneChoice chooseRune(std::string_view pattern) {
+  size_t n = pattern.size();
   runeBuf buf;
   size_t rlen;
-  rune *runes = runeBufFill(pattern, n, &buf, &rlen);
+  rune *runes = runeBufFill(pattern.data(), n, &buf, &rlen);
   std::vector<size_t> idx(rlen + 1), len(rlen + 1);
   int res = Suffix_ChooseToken_rune(runes, rlen, idx.data(), len.data());
   size_t chosenLen = res == REDISEARCH_UNINITIALIZED ? 0 : len[res];
@@ -44,12 +45,12 @@ static RuneChoice chooseRune(const char *pattern) {
   return {res, chosenLen};
 }
 
-static int chooseTokenRune(const char *pattern) { return chooseRune(pattern).tokenOrdinal; }
+static int chooseTokenRune(std::string_view pattern) { return chooseRune(pattern).tokenOrdinal; }
 
-static int chooseTokenChar(const char *pattern) {
-  size_t n = strlen(pattern);
+static int chooseTokenChar(std::string_view pattern) {
+  size_t n = pattern.size();
   std::vector<size_t> idx(n + 1), len(n + 1);
-  return Suffix_ChooseToken(pattern, n, idx.data(), len.data());
+  return Suffix_ChooseToken(pattern.data(), n, idx.data(), len.data());
 }
 
 // A '?' in the first qualifying (len >= MIN_SUFFIX) token must not prevent a


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** For a wildcard "contains" query on a `WITHSUFFIXTRIE` TEXT field, `Suffix_ChooseToken_rune` picks the most-selective literal token to narrow the suffix-trie scan. Its `?`-penalty loop decremented the shared running-best accumulator `score` (seeded to `INT32_MIN`) instead of the candidate's `curScore`. When the first qualifying (`len >= MIN_SUFFIX`) token contains a `?`, `score` underflows from `INT32_MIN` to `INT32_MAX` (signed-overflow UB), after which no token can satisfy `curScore >= score`, so the scorer returns `REDISEARCH_UNINITIALIZED`.
2. **Change:** Penalize the candidate (`--curScore`) rather than the running best (`--score`), matching the char twin `Suffix_ChooseToken`.
3. **Outcome:** Wildcard patterns whose first qualifying token contains `?` once fell back to a full brute-force walk of the entire term trie (`query.c` `fallbackBruteForce`), silently defeating the `WITHSUFFIXTRIE` optimization. With the fix they use the suffix trie again. **Results were always correct** (the brute-force path re-validates every candidate with a full wildcard match), so this is a performance fix only — a local micro-benchmark on a 100k-term trie showed the affected query going from ~78× slower back to parity.

#### Exactly which queries were affected

Trigger condition: a wildcard `w'…'` query on a **`WITHSUFFIXTRIE` TEXT** field where, after splitting the pattern on `*`, the **first token of length ≥ 2 (`MIN_SUFFIX`) contains a `?`**. A `?` only in a *later* token does not trigger it (no underflow), and **TAG** fields are unaffected (their path uses the non-buggy `Suffix_ChooseToken`).

| Query | First ≥2-len token | Before this fix |
|---|---|---|
| `w'?abc'` | `?abc` | ❌ full brute-force trie scan |
| `w'a?c'` | `a?c` | ❌ full brute-force trie scan |
| `w'*serv?r*'` | `serv?r` | ❌ full brute-force trie scan |
| `w'he??o*world'` | `he??o` | ❌ full brute-force trie scan |
| `w'*abc*'` | `abc` | ✅ suffix trie (no `?`) |
| `w'abc*d?ef'` | `abc` | ✅ suffix trie (`?` is in a later token) |
| `@t:{w'serv?r'}` (TAG) | `serv?r` | ✅ suffix trie (char scorer, never buggy) |

<details>
<summary>Reproduction (pre-fix: <code>w'*magicneedl?*'</code> ≈ 78× slower than <code>w'*magicneedle*'</code>, same 3 results)</summary>

```python
import time, redis

r = redis.Redis()
r.execute_command("FT.CREATE", "idx", "SCHEMA", "t", "TEXT", "WITHSUFFIXTRIE")

# Big, varied trie so a full brute-force walk is expensive.
p = r.pipeline(transaction=False)
for i in range(100_000):
    p.execute_command("HSET", f"d{i}", "t", f"commonword{i:08d}")
    if i % 5000 == 0:
        p.execute()
p.execute()
# A few docs carrying the rare needle substring.
for i in range(3):
    r.execute_command("HSET", f"n{i}", "t", f"magicneedle{i}")

def best_ms(q):                       # min over 5 runs; both queries match the same 3 docs
    r.execute_command("FT.SEARCH", "idx", q, "LIMIT", 0, 0, "DIALECT", 2)  # warmup
    times = []
    for _ in range(5):
        s = time.perf_counter()
        r.execute_command("FT.SEARCH", "idx", q, "LIMIT", 0, 0, "DIALECT", 2)
        times.append(time.perf_counter() - s)
    return min(times) * 1e3

good = best_ms("w'*magicneedle*'")    # token "magicneedle" -> suffix trie
bug  = best_ms("w'*magicneedl?*'")    # token "magicneedl?" -> brute-force whole trie (pre-fix)
print(f"good {good:.2f} ms | bug {bug:.2f} ms | {bug/good:.0f}x")
```

Measured on a 100k-term trie (single machine, illustrative):

| Query | Path (pre-fix) | Time |
|---|---|---|
| `w'*magicneedle*'` | suffix trie | **0.08 ms** |
| `w'*magicneedl?*'` | full brute-force trie scan | **6.45 ms** (~78×) |

After the fix both use the suffix trie and run at parity.

</details>

#### Which additional issues this PR fixes

1. MOD-16054

#### Main objects this PR modified

1. `Suffix_ChooseToken_rune` in `src/suffix.c`
2. New regression suite `tests/cpptests/test_cpp_suffix.cpp`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: restores the `WITHSUFFIXTRIE` fast path for wildcard "contains" queries containing `?`, which previously degraded to a full-trie scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line scoring fix in query optimization only; brute-force fallback already returned correct results, and new unit tests lock behavior.
> 
> **Overview**
> Fixes a one-line bug in **`Suffix_ChooseToken_rune`** (`src/suffix.c`): wildcard `?` penalties now decrement the candidate **`curScore`** instead of the shared best **`score`**, aligning with **`Suffix_ChooseToken`**.
> 
> That mistake could leave **`score`** corrupted when the first qualifying token contained `?`, so the rune scorer returned **`REDISEARCH_UNINITIALIZED`** and **`WITHSUFFIXTRIE` TEXT** wildcard “contains” queries fell back to a full trie scan instead of the suffix-trie fast path. **Correctness was unchanged**; this restores performance for patterns like `w'*magicneedl?*'`.
> 
> Adds **`tests/cpptests/test_cpp_suffix.cpp`** with GTest coverage for `?` in early tokens, multi-`*` token choice, rune vs char agreement, no qualifying token, and multi-byte runes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1b8c46c2f92c6fb8017f8fd962c4f34e3142b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

