### PR TITLE
[MOD-14868] qast:  Implement the main dispatcher and trivial node evaluators

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1754,10 +1754,17 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "ffi",
+ "index_result",
+ "inverted_index",
  "proptest",
+ "query",
  "query_eval",
+ "query_node_type",
  "redis_mock",
  "redisearch_rs",
+ "rqe_core",
+ "rqe_iterators",
+ "rqe_iterators_test_utils",
  "thiserror",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -121,6 +121,7 @@ inverted_index = { path = "./inverted_index" }
 numeric_range_tree = { path = "./numeric_range_tree" }
 redis_reply = { path = "./redis_reply" }
 qint = { path = "./qint" }
+query = { path = "./c_wrappers/query" }
 query_error = { path = "./query_error" }
 query_eval = { path = "./query_eval" }
 query_flags = { path = "./query_flags" }

--- a/src/redisearch_rs/c_wrappers/query/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/lib.rs
@@ -15,6 +15,11 @@ mod query_node_ref;
 pub use query_eval_ctx::QueryEvalContext;
 pub use query_node_ref::{QueryNode, QueryNodeRef, WildcardMode};
 
+/// Test-only mocks for the query wrapper types, shared with the `query_eval`
+/// crate's evaluation-dispatcher tests.
+#[cfg(feature = "unittest")]
+pub mod mock;
+
 #[cfg(test)]
 mod _test_link {
     extern crate redisearch_rs;

--- a/src/redisearch_rs/c_wrappers/query/src/mock/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Test-only mocks for the query wrapper types.
+//!
+//! These mocks are gated behind the `unittest` feature so they can be shared
+//! across crates: this crate's own integration tests use them, and so does the
+//! `query_eval` crate's evaluation-dispatcher tests.
+
+mod query_eval_ctx;
+mod query_node_ref;
+
+pub use query_eval_ctx::MockQueryEvalCtx;
+pub use query_node_ref::MockQueryNode;

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
@@ -25,6 +25,7 @@ use rqe_iterators::IteratorsConfig;
 /// `rqe_iterators_test_utils::MockContext` for the rationale).
 pub struct MockQueryEvalCtx {
     sctx: *mut ffi::RedisSearchCtx,
+    spec: *mut ffi::IndexSpec,
     opts: *mut ffi::RSSearchOptions,
     status: *mut QueryError,
     metric_requests_inner: *mut rlookup::MetricRequest<'static>,
@@ -40,6 +41,7 @@ impl Drop for MockQueryEvalCtx {
         // exclusively owned by this struct; layouts match those used at
         // allocation time.
         unsafe {
+            dealloc(self.spec.cast(), Layout::new::<ffi::IndexSpec>());
             dealloc(self.sctx.cast(), Layout::new::<ffi::RedisSearchCtx>());
             dealloc(self.opts.cast(), Layout::new::<ffi::RSSearchOptions>());
             drop(Box::from_raw(self.status));
@@ -67,9 +69,14 @@ impl MockQueryEvalCtx {
         // SAFETY: all allocations are zeroed and non-null-checked; pointer
         // fields are immediately initialised to valid, owned allocations.
         unsafe {
+            let spec = alloc_zeroed(Layout::new::<ffi::IndexSpec>()).cast::<ffi::IndexSpec>();
+            assert!(!spec.is_null());
+
             let sctx =
                 alloc_zeroed(Layout::new::<ffi::RedisSearchCtx>()).cast::<ffi::RedisSearchCtx>();
             assert!(!sctx.is_null());
+
+            (*sctx).spec = spec;
 
             let opts =
                 alloc_zeroed(Layout::new::<ffi::RSSearchOptions>()).cast::<ffi::RSSearchOptions>();
@@ -116,6 +123,7 @@ impl MockQueryEvalCtx {
 
             Self {
                 sctx,
+                spec,
                 opts,
                 status,
                 metric_requests_inner,
@@ -141,5 +149,20 @@ impl MockQueryEvalCtx {
 
     pub fn doc_table_ptr(&self) -> *mut ffi::DocTable {
         self.doc_table
+    }
+
+    pub fn set_max_doc_id(&mut self, max_doc_id: rqe_core::DocId) {
+        // SAFETY: `self.doc_table` is a valid, exclusively-owned allocation.
+        unsafe { (*self.doc_table).maxDocId = max_doc_id }
+    }
+
+    /// Set `spec.diskSpec` to a non-null sentinel so that
+    /// `!spec.diskSpec.is_null()` holds (simulating search-on-disk mode).
+    ///
+    /// The pointer is dangling — only use this for code paths that check
+    /// the pointer for null but never dereference it.
+    pub fn enable_disk_mode(&mut self) {
+        // SAFETY: `self.spec` is a valid, exclusively-owned allocation.
+        unsafe { (*self.spec).diskSpec = std::ptr::NonNull::dangling().as_ptr() }
     }
 }

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -18,6 +18,7 @@ use std::{
 
 use inverted_index::NumericFilter;
 use query_node_type::QueryNodeType;
+use rqe_core::DocId;
 
 /// Owns a heap-allocated [`ffi::RSQueryNode`].
 ///
@@ -184,6 +185,33 @@ impl MockQueryNode {
             assert!(!arr.is_null());
             std::ptr::copy_nonoverlapping(children.as_ptr(), arr, children.len());
             (*self.node).children = arr;
+        }
+    }
+
+    /// Set the fields of the IDs-node union variant.
+    ///
+    /// `keys` and `doc_ids` must outlive this `MockQueryNode`.
+    pub fn set_ids(&mut self, keys: *const ffi::sds, doc_ids: *mut DocId, len: usize) {
+        // SAFETY: `self.node` is valid and exclusively owned; the caller
+        // guarantees the node type is Ids so the `fn` variant is active.
+        unsafe {
+            let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
+            let ids = &mut *union_ptr.cast::<ffi::QueryIdFilterNode>();
+            ids.keys = keys;
+            ids.docIds = doc_ids;
+            ids.len = len;
+        }
+    }
+
+    /// Set the `field` pointer of the missing-node union variant.
+    ///
+    /// `field` must outlive this `MockQueryNode`.
+    pub fn set_missing_field(&mut self, field: *const ffi::FieldSpec) {
+        // SAFETY: `self.node` is valid and exclusively owned; the caller
+        // guarantees the node type is Missing so the `miss` variant is active.
+        unsafe {
+            let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
+            (*union_ptr.cast::<ffi::QueryMissingNode>()).field = field.cast_mut();
         }
     }
 }

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -7,10 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-mod mock;
-
-use mock::MockQueryEvalCtx;
-use query::QueryEvalContext;
+use query::{QueryEvalContext, mock::MockQueryEvalCtx};
 use query_flags::QEFlag;
 
 #[test]

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -7,13 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-mod mock;
-
 use std::ops::Bound;
 
 use inverted_index::NumericFilter;
-use mock::MockQueryNode;
-use query::{QueryNode, QueryNodeRef, WildcardMode};
+use query::{QueryNode, QueryNodeRef, WildcardMode, mock::MockQueryNode};
 use query_node_type::QueryNodeType;
 
 #[test]

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -38,7 +38,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "deps/hiredis/sds.h",
-        fns: &["sdscatlen"],
+        fns: &["sdscatlen", "sdsnewlen", "sdsfree"],
         types: &[],
         vars: &[],
     },
@@ -68,7 +68,12 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/doc_table.h",
-        fns: &["DMD_Free", "DocTable_Exists"],
+        fns: &[
+            "DMD_Free",
+            "DocTable_Exists",
+            "DocTable_GetId",
+            "DocTable_Put",
+        ],
         types: &[],
         vars: &[],
     },

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -15,14 +15,22 @@ build_utils.workspace = true
 
 [dependencies]
 ffi.workspace = true
+index_result.workspace = true
+inverted_index.workspace = true
+query.workspace = true
+query_node_type.workspace = true
+rqe_core.workspace = true
+rqe_iterators.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }
+query = { workspace = true, features = ["unittest"] }
 query_eval = { path = ".", features = ["unittest"] }
 redis_mock.workspace = true
 redisearch_rs = { workspace = true, features = ["mock_allocator"] }
+rqe_iterators_test_utils.workspace = true
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Main query evaluation dispatcher.
+//!
+//! Converts a parsed query AST node into an executable iterator tree by
+//! dispatching on the [`QueryNodeType`](query_node_type::QueryNodeType) discriminant.
+
+use std::ptr::NonNull;
+
+use index_result::RSIndexResult;
+use rqe_core::DocId;
+use rqe_iterators::{
+    Empty, RQEIteratorPrintable, id_list::IdListSorted, inverted_index::new_missing_iterator,
+};
+
+use crate::{QueryEvalContext, QueryNode, QueryNodeRef};
+
+/// The return type of [`eval_node`]: a boxed Rust iterator that implements
+/// both [`RQEIterator`](rqe_iterators::RQEIterator) and
+/// [`ProfilePrint`](rqe_iterators::profile_print::ProfilePrint).
+pub type EvalResult<'index> = Box<dyn RQEIteratorPrintable<'index> + 'index>;
+
+/// Evaluate a single query node, producing the corresponding iterator.
+///
+/// Returns `None` when the node produces no results.
+pub fn eval_node<'index>(
+    ctx: &'index mut QueryEvalContext,
+    node: &QueryNodeRef,
+) -> Option<EvalResult<'index>> {
+    match node.as_enum() {
+        QueryNode::Null => Some(eval_null()),
+        QueryNode::Wildcard => Some(eval_wildcard(ctx, node)),
+        QueryNode::Ids { keys, doc_ids } => Some(eval_ids(ctx, keys, doc_ids)),
+        QueryNode::Missing { field } => eval_missing(ctx, field),
+        _ => unimplemented!("eval for {:?} is not yet ported", node.node_type()),
+    }
+}
+
+/// `QN_NULL` — stopword queries produce an empty iterator.
+fn eval_null<'index>() -> EvalResult<'index> {
+    Box::new(Empty)
+}
+
+/// `QN_WILDCARD` — the `*` query that matches every document.
+fn eval_wildcard<'index>(
+    ctx: &'index mut QueryEvalContext,
+    node: &QueryNodeRef,
+) -> EvalResult<'index> {
+    let weight = node.opts().weight;
+    // SAFETY: `new_wildcard_iterator` preconditions map to
+    // `QueryEvalContext::new` invariants as follows:
+    // 1. `query` is a valid `QueryEvalCtx` — invariant (1).
+    // 2. `query.sctx` is a valid, non-null `RedisSearchCtx` — invariant (2).
+    // 3. `query.sctx.spec` is a valid, non-null `IndexSpec` — invariant (2).
+    // 4. `spec.rule`, when non-null, is a valid `SchemaRule` — part of (1),
+    //    a properly initialised `QueryEvalCtx` is built from a valid spec.
+    // 5. `new_wildcard_iterator_optimized` preconditions hold when
+    //    `rule.index_all` is true — the spec's `existingDocs` inverted
+    //    index is initialised during `IndexSpec_Init`.
+    // 6. `query.docTable` is a valid, non-null `DocTable` — invariant (2).
+    // 7. `spec.diskSpec`, when non-null, is a valid
+    //    `RedisSearchDiskIndexSpec` — part of (1).
+    // 8. `SEARCH_ENTERPRISE_ITERATORS` is initialised when `diskSpec` is
+    //    non-null — the enterprise module sets it during `OnLoad`.
+    let it = unsafe { rqe_iterators::wildcard::new_wildcard_iterator(ctx.as_non_null(), weight) };
+    Box::new(it)
+}
+
+/// `QN_IDS` — filter by explicit document key names.
+///
+/// Resolves each key to a document ID, sorts, deduplicates, and creates a
+/// sorted [`IdListSorted`] iterator.
+///
+/// * `keys` — SDS key strings from the query node.  When `doc_ids` is
+///   `None`, each key is looked up in the [`DocTable`](ffi::DocTable) to
+///   obtain its document ID.
+/// * `doc_ids` — when present (search-on-disk mode), contains pre-resolved
+///   document IDs positionally matching `keys`, bypassing the `DocTable`
+///   lookup.
+fn eval_ids<'index>(
+    ctx: &'index mut QueryEvalContext,
+    keys: &[ffi::sds],
+    doc_ids: Option<&[DocId]>,
+) -> EvalResult<'index> {
+    // Pre-resolved `doc_ids` are only produced on the search-on-disk path, so
+    // they must be accompanied by a non-null `spec.diskSpec`. Guard the
+    // invariant.
+    debug_assert!(
+        doc_ids.is_none() || !ctx.spec().diskSpec.is_null(),
+        "pre-resolved doc_ids requires search-on-disk to be enabled"
+    );
+
+    // When pre-resolved, `doc_ids` is consumed directly and must line up
+    // positionally with `keys` (they describe the same id-filter node).
+    debug_assert!(
+        doc_ids.is_none_or(|d| d.len() == keys.len()),
+        "doc_ids and keys must have the same length"
+    );
+
+    let mut ids: Vec<DocId> = match doc_ids {
+        // Search-on-disk: ids are already resolved, just drop the misses.
+        Some(resolved) => resolved.iter().copied().filter(|&did| did != 0).collect(),
+        // In-memory: resolve each key to a doc id through the `DocTable`.
+        None => keys
+            .iter()
+            .filter_map(|&key| {
+                // SAFETY: `key` is a valid SDS string (guaranteed by
+                // `QueryNodeRef`); `sdslen_rust` reads its header.
+                let key_len = unsafe { ffi::sdslen_rust(key) };
+                // SAFETY: `doc_table()` returns a valid `DocTable` reference
+                // (`QueryEvalContext` invariant).
+                let did = unsafe { ffi::DocTable_GetId(ctx.doc_table(), key, key_len) };
+                (did != 0).then_some(did)
+            })
+            .collect(),
+    };
+
+    if !ids.is_empty() {
+        ids.sort_unstable();
+        ids.dedup();
+    }
+
+    Box::new(IdListSorted::with_result(
+        ids,
+        RSIndexResult::build_virt().weight(1.0).build(),
+    ))
+}
+
+/// `QN_MISSING` — matches documents where a field has no indexed value.
+fn eval_missing<'index>(
+    ctx: &'index mut QueryEvalContext,
+    fs: &ffi::FieldSpec,
+) -> Option<EvalResult<'index>> {
+    let spec = ctx.spec();
+
+    // SAFETY: `spec` is valid (`QueryEvalContext::new` invariant 2), and any
+    // queryable spec has its `missingFieldDict` initialised by
+    // `IndexSpec_MakeKeyless`, so the pointer is a valid dict; `fs.fieldName`
+    // is a valid `HiddenString` key, matching the C `Query_EvalMissingNode`.
+    let ii_ptr = unsafe { ffi::RS_dictFetchValue(spec.missingFieldDict, fs.fieldName as *mut _) };
+
+    if ii_ptr.is_null() {
+        // There are no missing values for this field.
+        return None;
+    }
+
+    let ii_ptr: *const inverted_index::opaque::InvertedIndex = ii_ptr.cast();
+    // SAFETY: `ii_ptr` is a valid `InvertedIndex` obtained from the
+    // missing-field dict (non-null checked above).
+    let ii_ref = unsafe { &*ii_ptr };
+
+    // `ctx.sctx()` is a live reference, so the resulting pointer is never null.
+    let sctx_nn = NonNull::from(ctx.sctx());
+
+    // SAFETY: `new_missing_iterator`'s four preconditions hold here:
+    // 1. `sctx` is a valid `RedisSearchCtx` with a non-null, valid `spec` —
+    //    `QueryEvalContext` invariant (2).
+    // 2. `fs.index` is a valid index into `spec.fields`: the query AST node
+    //    references a field of this very spec, so its `FieldSpec::index` is in
+    //    bounds (mirrors the C `Query_EvalMissingNode` using `fs->index`).
+    // 3. `spec.missingFieldDict` is a non-null, valid dict — initialised by
+    //    `IndexSpec_MakeKeyless` for every queryable spec; it is also the dict
+    //    we just fetched `ii_ptr` from above.
+    // 4. `ii_ref` uses `DocIdsOnly`/`RawDocIdsOnly` encoding: the indexer only
+    //    ever stores doc-ids-only inverted indexes in `missingFieldDict`.
+    Some(unsafe { new_missing_iterator(ii_ref, sctx_nn, fs.index) })
+}

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -27,6 +27,17 @@ use crate::{QueryEvalContext, QueryNode, QueryNodeRef};
 /// [`ProfilePrint`](rqe_iterators::profile_print::ProfilePrint).
 pub type EvalResult<'index> = Box<dyn RQEIteratorPrintable<'index> + 'index>;
 
+/// Build the executable iterator tree for a parsed query AST.
+///
+/// The `root` node is evaluated via [`eval_node`]. When evaluation yields no
+/// iterator (`None`), an [`Empty`] iterator is returned.
+pub fn qast_iterate<'index>(
+    ctx: &'index mut QueryEvalContext,
+    root: &QueryNodeRef,
+) -> EvalResult<'index> {
+    eval_node(ctx, root).unwrap_or_else(|| Box::new(Empty))
+}
+
 /// Evaluate a single query node, producing the corresponding iterator.
 ///
 /// Returns `None` when the node produces no results.

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -10,7 +10,13 @@
 //! Query evaluation: traverses a parsed query AST and builds an executable
 //! iterator tree.
 
+pub mod eval;
 pub mod string_utils;
+
+// The query wrapper types live in the `query` crate (`c_wrappers/query`); they
+// are re-exported here so `query_eval` (and its FFI crate) can refer to them
+// through a single module.
+pub use query::{QueryEvalContext, QueryNode, QueryNodeRef};
 
 #[cfg(test)]
 mod _test_link {

--- a/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
@@ -14,6 +14,24 @@ use rqe_iterators::{IteratorType, RQEIterator};
 use query::mock::{MockQueryEvalCtx, MockQueryNode};
 
 // ---------------------------------------------------------------------------
+// QAST_Iterate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn qast_iterate_evaluates_root_node() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+    let mock_node = MockQueryNode::new(QueryNodeType::Null);
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::qast_iterate(&mut ctx, &node);
+
+    assert_eq!(it.type_(), IteratorType::Empty);
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+// ---------------------------------------------------------------------------
 // QN_NULL → Empty
 // ---------------------------------------------------------------------------
 
@@ -253,6 +271,27 @@ mod missing {
             eval::eval_node(&mut ctx, &node).is_none(),
             "no missing values for the field, so eval should return None"
         );
+    }
+
+    #[test]
+    fn qast_iterate_substitutes_empty_for_none() {
+        let _guard = GlobalGuard::default();
+        // Term context: the field has no entry in `missingFieldDict`, so a
+        // QN_MISSING node makes `eval_node` return `None`. `qast_iterate` must
+        // substitute an `Empty` iterator instead of propagating that `None`.
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        let mut mock_node = MockQueryNode::new(QueryNodeType::Missing);
+        mock_node.set_missing_field(context.field_spec());
+        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+        let mut it = eval::qast_iterate(&mut ctx, &node);
+
+        assert_eq!(it.type_(), IteratorType::Empty);
+        assert!(it.at_eof());
+        assert!(matches!(it.read(), Ok(None)));
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use query_eval::{QueryEvalContext, QueryNodeRef, eval};
+use query_node_type::QueryNodeType;
+use rqe_iterators::{IteratorType, RQEIterator};
+
+use query::mock::{MockQueryEvalCtx, MockQueryNode};
+
+// ---------------------------------------------------------------------------
+// QN_NULL → Empty
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eval_null_returns_empty_iterator() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+    let mock_node = MockQueryNode::new(QueryNodeType::Null);
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    assert_eq!(it.type_(), IteratorType::Empty);
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+// ---------------------------------------------------------------------------
+// QN_WILDCARD → Wildcard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eval_wildcard_returns_wildcard_iterator() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(100);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Wildcard);
+    mock_node.opts_mut().weight = 1.0;
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    assert!(!it.at_eof());
+
+    let result = it.read().unwrap().expect("should have a result");
+    assert_eq!(result.doc_id, 1);
+}
+
+#[test]
+fn eval_wildcard_empty_index() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mock_node = MockQueryNode::new(QueryNodeType::Wildcard);
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn eval_wildcard_respects_weight() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(10);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Wildcard);
+    mock_node.opts_mut().weight = 2.5;
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+    let result = it.read().unwrap().expect("should have a result");
+    assert_eq!(result.weight, 2.5);
+}
+
+// ---------------------------------------------------------------------------
+// QN_IDS → IdList
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eval_ids_with_pre_resolved_doc_ids() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.enable_disk_mode();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 3];
+    let mut doc_ids: Vec<u64> = vec![10, 5, 20];
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+    mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    assert_eq!(it.type_(), IteratorType::IdListSorted);
+    assert!(!it.at_eof());
+
+    let r = it.read().unwrap().unwrap();
+    assert_eq!(r.doc_id, 5);
+    let r = it.read().unwrap().unwrap();
+    assert_eq!(r.doc_id, 10);
+    let r = it.read().unwrap().unwrap();
+    assert_eq!(r.doc_id, 20);
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[test]
+fn eval_ids_deduplicates() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.enable_disk_mode();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 4];
+    let mut doc_ids: Vec<u64> = vec![3, 3, 7, 7];
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+    mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    let r = it.read().unwrap().unwrap();
+    assert_eq!(r.doc_id, 3);
+    let r = it.read().unwrap().unwrap();
+    assert_eq!(r.doc_id, 7);
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn eval_ids_filters_zero_doc_ids() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.enable_disk_mode();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 3];
+    let mut doc_ids: Vec<u64> = vec![0, 5, 0];
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+    mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    let r = it.read().unwrap().unwrap();
+    assert_eq!(r.doc_id, 5);
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn eval_ids_all_zero_produces_empty_list() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.enable_disk_mode();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 2];
+    let mut doc_ids: Vec<u64> = vec![0, 0];
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+    mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn eval_ids_empty_keys() {
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+    mock_node.set_ids(std::ptr::null(), std::ptr::null_mut(), 0);
+    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+// ---------------------------------------------------------------------------
+// QN_MISSING → Missing inverted-index iterator
+//
+// These require a real `IndexSpec` with a populated `missingFieldDict`, which
+// the lightweight `MockQueryEvalCtx` cannot provide, so they rely on the
+// full-FFI `TestContext`.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: `TestContext` calls into the C library (e.g. to build
+// the spec and its `missingFieldDict`), and Miri cannot execute foreign
+// (non-Rust) functions.
+#[cfg(not(miri))]
+mod missing {
+    use ffi::IndexFlags_Index_StoreFreqs;
+    use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+    use super::*;
+
+    #[test]
+    fn eval_missing_returns_iterator_over_missing_docs() {
+        let _guard = GlobalGuard::default();
+        // Real spec whose `missingFieldDict` records docs 1, 2 and 3 as
+        // missing a value for the indexed field.
+        let context = TestContext::missing([1u64, 2, 3].into_iter());
+
+        // The `QueryEvalCtx` is backed by the real `sctx`, so `eval_missing`
+        // sees the populated `missingFieldDict`.
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        let mut mock_node = MockQueryNode::new(QueryNodeType::Missing);
+        mock_node.set_missing_field(context.field_spec());
+        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("field has missing values, so should not be None");
+
+        assert_eq!(it.type_(), IteratorType::InvIdxMissing);
+        for expected in [1, 2, 3] {
+            let r = it.read().unwrap().expect("should have a result");
+            assert_eq!(r.doc_id, expected);
+        }
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+    }
+
+    #[test]
+    fn eval_missing_no_values_returns_none() {
+        let _guard = GlobalGuard::default();
+        // Term context: the field exists but has no entry in `missingFieldDict`
+        // (no document is missing a value for it).
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        let mut mock_node = MockQueryNode::new(QueryNodeType::Missing);
+        mock_node.set_missing_field(context.field_spec());
+        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+        assert!(
+            eval::eval_node(&mut ctx, &node).is_none(),
+            "no missing values for the field, so eval should return None"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QN_IDS → IdList, resolving key names through the DocTable
+//
+// The lightweight `MockQueryEvalCtx` has an empty `DocTable`, so the key→docId
+// resolution path (`DocTable_GetId`) is exercised here with the full-FFI
+// `TestContext`, which can register real documents.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: `TestContext` and SDS creation call into the C library,
+// which Miri cannot execute.
+#[cfg(not(miri))]
+mod ids_doctable {
+    use ffi::IndexFlags_Index_StoreFreqs;
+    use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+    use super::*;
+
+    /// Create an SDS string from `s`. The caller owns the result and must free
+    /// it with [`ffi::sdsfree`].
+    fn new_sds(s: &str) -> ffi::sds {
+        // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
+        // into a freshly allocated SDS string.
+        unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
+    }
+
+    #[test]
+    fn eval_ids_resolves_keys_through_doc_table() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        // Register two documents; ids are assigned incrementally from 1.
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // Query for both known keys plus an unknown one, which must resolve to
+        // id 0 and be filtered out. `doc_ids` is NULL, so the DocTable lookup
+        // path is taken.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("ghost"), new_sds("doc_a")];
+
+        let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+        mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+        assert_eq!(it.type_(), IteratorType::IdListSorted);
+        // Results are sorted; the unknown key is dropped.
+        let r = it.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, id_a);
+        let r = it.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, id_b);
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_ids_unknown_keys_produce_empty_list() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // None of these keys exist in the (empty) DocTable.
+        let keys: Vec<ffi::sds> = vec![new_sds("nope"), new_sds("missing")];
+
+        let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
+        mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node).expect("should not be None");
+
+        assert!(it.at_eof());
+        assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+}

--- a/src/redisearch_rs/query_eval/tests/integration/main.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/main.rs
@@ -11,4 +11,5 @@
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 extern crate redisearch_rs;
 
+mod eval;
 mod string_utils;

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -10,6 +10,8 @@
 //! Test context for creating search contexts with proper FFI setup.
 
 use std::{
+    alloc::{Layout, alloc_zeroed, dealloc},
+    cell::OnceCell,
     ffi::CString,
     ptr::{self, NonNull},
     sync::{
@@ -43,6 +45,7 @@ use field::FieldMaskOrIndex;
 use index_result::RSIndexResult;
 use numeric_range_tree::{NumericIndex, NumericRangeTree};
 use query_error::QueryError;
+use rqe_iterators::IteratorsConfig;
 
 /// Wrapper around RedisModuleCtx ensuring its resources are properly cleaned up.
 struct ModuleCtx {
@@ -91,6 +94,12 @@ pub struct TestContext {
     _ctx: ModuleCtx,
     pub sctx: ptr::NonNull<ffi::RedisSearchCtx>,
     pub spec: *mut ffi::IndexSpec,
+
+    /// Lazily-allocated [`QueryEvalCtx`](ffi::QueryEvalCtx) (plus the backing
+    /// structs its pointer fields require), created on the first
+    /// [`qctx`](TestContext::qctx) call and freed on drop. Mirrors
+    /// [`MockContext::qctx`](crate::MockContext::qctx).
+    qctx: OnceCell<QctxAlloc>,
 
     inner: TestContextInner,
 }
@@ -193,6 +202,98 @@ impl TestContext {
         unsafe { index_spec::IndexSpecWriteGuard::from_locked_mut(&mut *self.spec) }
     }
 
+    /// Get a [`QueryEvalCtx`](ffi::QueryEvalCtx) wrapping this context's `sctx`.
+    ///
+    /// The `QueryEvalCtx` is lazily allocated on the first call and freed when
+    /// the [`TestContext`] is dropped. Besides the real `sctx` and `docTable`,
+    /// every pointer field that the `QueryEvalContext::new` safety contract
+    /// requires to be non-null (`opts`, `status`, `metricRequestsP`, `config`)
+    /// is backed by a valid, owned allocation, so the returned context is sound
+    /// to wrap even for evaluation paths that read those fields.
+    pub fn qctx(&self) -> ptr::NonNull<ffi::QueryEvalCtx> {
+        let alloc = self.qctx.get_or_init(|| {
+            // SAFETY: every allocation below is zeroed (a valid bit pattern for
+            // the C POD structs) or initialised from a valid Rust value, and is
+            // non-null-checked. The resulting pointers are owned by the returned
+            // `QctxAlloc` and released in its `Drop`.
+            unsafe {
+                let qctx =
+                    alloc_zeroed(Layout::new::<ffi::QueryEvalCtx>()).cast::<ffi::QueryEvalCtx>();
+                assert!(!qctx.is_null(), "allocation failed");
+
+                // An all-zeros `RSSearchOptions` is a valid (default) value.
+                let opts = alloc_zeroed(Layout::new::<ffi::RSSearchOptions>())
+                    .cast::<ffi::RSSearchOptions>();
+                assert!(!opts.is_null(), "allocation failed");
+
+                let status = Box::into_raw(Box::new(QueryError::default()));
+                // A valid pointer to a (null) `MetricRequest` list head: the
+                // evaluated nodes never append metric requests.
+                let metric_requests_p =
+                    Box::into_raw(Box::new(ptr::null_mut::<std::ffi::c_void>()));
+                let config = Box::into_raw(Box::new(IteratorsConfig::default()));
+
+                // `sctx` and `spec.docs` are real and outlive the
+                // `QueryEvalCtx` (both are dropped after this bundle), so
+                // storing pointers to them here is sound.
+                (*qctx).sctx = self.sctx.as_ptr();
+                (*qctx).docTable = ptr::addr_of_mut!((*self.spec).docs);
+                (*qctx).opts = opts;
+                (*qctx).status = status
+                    .cast::<query_error::opaque::OpaqueQueryError>()
+                    .cast::<ffi::QueryError>();
+                (*qctx).metricRequestsP = metric_requests_p.cast();
+                (*qctx).config = config.cast();
+
+                QctxAlloc {
+                    qctx,
+                    opts,
+                    status,
+                    metric_requests_p,
+                    config,
+                }
+            }
+        });
+        ptr::NonNull::new(alloc.qctx).expect("QueryEvalCtx should not be null")
+    }
+
+    /// Insert a document with the given key into the spec's [`DocTable`](ffi::DocTable)
+    /// and return the document ID assigned to it.
+    ///
+    /// This populates the same `DocTable` that [`qctx`](TestContext::qctx) exposes
+    /// via `docTable`, so that key-to-id resolution (e.g. `DocTable_GetId`) can be
+    /// exercised in tests.
+    pub fn add_document(&self, key: &str) -> DocId {
+        // SAFETY: `self.spec` is a valid, exclusively-owned `IndexSpec`, so
+        // `&spec.docs` is a valid `DocTable`. The key bytes outlive the call,
+        // and a NULL payload tells `DocTable_Put` there is no payload.
+        let dmd = unsafe {
+            ffi::DocTable_Put(
+                std::ptr::addr_of_mut!((*self.spec).docs),
+                key.as_ptr().cast(),
+                key.len(),
+                1.0,
+                0,
+                std::ptr::null(),
+                0,
+                ffi::DocumentType::Hash,
+            )
+        };
+        assert!(!dmd.is_null(), "DocTable_Put returned null");
+        // SAFETY: `DocTable_Put` returns a valid, non-null `RSDocumentMetadata`.
+        let id = unsafe { (*dmd).id };
+
+        // `DocTable_Put` returns the DMD with an extra reference for the caller
+        // on top of the DocTable's own reference. Release it here so the DMD is
+        // freed by `DocTable_Free` during teardown rather than leaking. The
+        // DocTable keeps its own reference, so this never drops the last one;
+        // the document is single-threaded here, so a plain decrement is enough.
+        // SAFETY: `dmd` is the valid, non-null DMD just returned above.
+        unsafe { (*dmd).ref_count -= 1 };
+
+        id
+    }
+
     /// Create a new [`TestContext`] with a numeric inverted index having the given records.
     ///
     /// # Arguments
@@ -242,6 +343,7 @@ impl TestContext {
             _ctx: ctx,
             sctx,
             spec,
+            qctx: OnceCell::new(),
             inner: TestContextInner::Numeric {
                 field_spec: fs,
                 numeric_range_tree: NonNull::from_mut(numeric_range_tree),
@@ -314,6 +416,7 @@ impl TestContext {
             _ctx: ctx,
             sctx,
             spec,
+            qctx: OnceCell::new(),
             inner: TestContextInner::Term {
                 field_spec,
                 inverted_index,
@@ -368,6 +471,7 @@ impl TestContext {
             _ctx: ctx,
             sctx,
             spec,
+            qctx: OnceCell::new(),
             inner: TestContextInner::Wildcard { inverted_index: ii },
         }
     }
@@ -438,6 +542,7 @@ impl TestContext {
             _ctx: ctx,
             sctx,
             spec,
+            qctx: OnceCell::new(),
             inner: TestContextInner::Missing {
                 field_spec,
                 inverted_index: ii,
@@ -516,6 +621,7 @@ impl TestContext {
             _ctx: ctx,
             sctx,
             spec,
+            qctx: OnceCell::new(),
             inner: TestContextInner::Tag {
                 field_spec,
                 tag_index,
@@ -840,11 +946,48 @@ impl TestContext {
     }
 }
 
+/// Owns the lazily-built [`QueryEvalCtx`](ffi::QueryEvalCtx) returned by
+/// [`TestContext::qctx`] together with the auxiliary structs its pointer fields
+/// reference.
+///
+/// The `QueryEvalContext::new` safety contract requires every pointer field of
+/// the `QueryEvalCtx` to be valid and non-null, so the fields that the
+/// [`TestContext`]'s real `sctx`/`spec` don't already provide (`opts`,
+/// `status`, `metricRequestsP`, `config`) get their own backing allocations
+/// here. All of them are released when the bundle is dropped.
+struct QctxAlloc {
+    qctx: *mut ffi::QueryEvalCtx,
+    opts: *mut ffi::RSSearchOptions,
+    status: *mut QueryError,
+    metric_requests_p: *mut *mut std::ffi::c_void,
+    config: *mut IteratorsConfig,
+}
+
+impl Drop for QctxAlloc {
+    fn drop(&mut self) {
+        // SAFETY: each pointer was allocated in `TestContext::qctx` with the
+        // layout used here and is exclusively owned by this bundle. The `sctx`
+        // and `docTable` pointers stored inside `*qctx` are not freed here; they
+        // are owned by the `TestContext`.
+        unsafe {
+            drop(Box::from_raw(self.config));
+            drop(Box::from_raw(self.metric_requests_p));
+            drop(Box::from_raw(self.status));
+            dealloc(self.opts.cast(), Layout::new::<ffi::RSSearchOptions>());
+            dealloc(self.qctx.cast(), Layout::new::<ffi::QueryEvalCtx>());
+        }
+    }
+}
+
 impl Drop for TestContext {
     fn drop(&mut self) {
         // Serialize cleanup to avoid concurrent access to C global state.
         // This matches the lock acquired during creation.
         let _lock = CONTEXT_MUTEX.lock().unwrap();
+
+        // The lazily-allocated `QueryEvalCtx` and its backing structs are freed
+        // by `QctxAlloc`'s `Drop` when the `qctx` `OnceCell` is dropped after
+        // this method returns; that is pure-Rust deallocation needing no lock.
 
         // Note: the wildcard inverted index is freed by IndexSpec_RemoveFromGlobals
         // below, via spec->existingDocs. No explicit free needed here.


### PR DESCRIPTION
## Describe the changes in the pull request

Start porting `QAST_Iterate` and `Query_EvalNode` from `query.c`.

For now only handling the simpler node types: `Null`, `Wildcard`, `Ids` and `Missing`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query execution and unsafe FFI (DocTable, missing-field dict, wildcard iterators); scope is limited to four node types with extensive tests.
> 
> **Overview**
> Ports the core **query AST → iterator** path from C (`QAST_Iterate` / `Query_EvalNode`) into the `query_eval` crate via `qast_iterate` and `eval_node`, which dispatch on node type and return boxed RQE iterators.
> 
> **Implemented evaluators:** `Null` → empty iterator; `Wildcard` → wildcard iterator (with weight); `Ids` → sorted/deduped `IdListSorted` (pre-resolved doc IDs on disk, or `DocTable_GetId` in memory); `Missing` → missing-field inverted-index iterator, or `None` when the field has no missing index. Other node types still `unimplemented!`. `qast_iterate` substitutes `Empty` when evaluation returns `None`.
> 
> **Test infrastructure:** Query evaluation mocks move into `c_wrappers/query` under the `unittest` feature and are shared with `query_eval` integration tests. Mocks gain disk-mode, max doc id, IDs/missing node setup. `TestContext` adds lazy `qctx()` and `add_document()` for full-FFI paths. FFI bindings expose `sdsnewlen`/`sdsfree` and `DocTable_Put`/`DocTable_GetId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43beb4472948e5875037e8b7e8de1445b3bc5f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->