### PR TITLE
Actual DocIDMeta Delete from Update path

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -412,12 +412,14 @@ static void applyDocTable(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   int rc = DocIdMeta_Set(ctx->redisCtx, aCtx->doc->docKey, spec->specId, aCtx->doc->docId);
   RS_LOG_ASSERT_ALWAYS(rc == REDISMODULE_OK, "DocIdMeta_Set failed after a successful disk commit");
 
-  // `oldDocId` comes from the key→docId mapping in Redis and can survive a
-  // prior deindex path that removed the disk row; `oldDocLen` is set by
-  // `SearchDisk_PutDocument` only when a row was actually replaced. Drop stale
-  // VecSim / geometry entries whenever the key meta points at an old doc-id
-  // (no-op safe on unknown ids), but only treat this as a REPLACE for stats
-  // and GC purposes when an on-disk row was really overwritten.
+  // `oldDocId` comes from the key→docId mapping in Redis. The de-index path
+  // (`IndexSpec_DeleteDoc`) now clears that mapping, so in normal operation a
+  // non-zero `oldDocId` means a real on-disk row is being replaced. We still
+  // treat it defensively — the mapping (Redis keyspace) and the disk doc-table
+  // (SpeedB) are separate stores that can diverge on crash — so dropping stale
+  // VecSim / geometry entries is a no-op when the id is unknown. `oldDocLen` is
+  // set by `SearchDisk_PutDocument` only when a row was actually replaced, so
+  // only that case counts as a REPLACE for stats and GC purposes.
   if (aCtx->disk.oldDocId != 0) {
     removeReplacedDocVectorAndGeometry(spec, aCtx->disk.oldDocId);
   }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -414,17 +414,18 @@ static void applyDocTable(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
 
   // `oldDocId` comes from the key→docId mapping in Redis. The de-index path
   // (`IndexSpec_DeleteDoc`) now clears that mapping, so in normal operation a
-  // non-zero `oldDocId` means a real on-disk row is being replaced. We still
-  // treat it defensively — the mapping (Redis keyspace) and the disk doc-table
-  // (SpeedB) are separate stores that can diverge on crash — so dropping stale
-  // VecSim / geometry entries is a no-op when the id is unknown. `oldDocLen` is
-  // set by `SearchDisk_PutDocument` only when a row was actually replaced, so
-  // only that case counts as a REPLACE for stats and GC purposes.
-  if (aCtx->disk.oldDocId != 0) {
-    removeReplacedDocVectorAndGeometry(spec, aCtx->disk.oldDocId);
-  }
-  const bool replaced = aCtx->disk.oldDocLen != 0;
+  // non-zero `oldDocId` means a real on-disk row is being replaced.
+  // `oldDocId` (not `oldDocLen`) is the REPLACE signal for stats and GC: a
+  // vector/tag/numeric-only document has no full-text tokens, so its `docLen`
+  // (== `fwIdx->totalFreq`) is 0. Gating on `oldDocLen != 0` would miss those
+  // replaces and leak `numDocuments` (the new doc's `addNewDocStats` increment
+  // would never be matched by `removeOldDocStats`). This mirrors memory mode,
+  // which gates `removeOldDocStats` on whether an old DMD existed, not on its
+  // length. `oldDocLen` is still the right value to subtract from `totalDocsLen`
+  // (0 for a zero-length old doc is a correct no-op subtraction).
+  const bool replaced = aCtx->disk.oldDocId != 0;
   if (replaced) {
+    removeReplacedDocVectorAndGeometry(spec, aCtx->disk.oldDocId);
     removeOldDocStats(spec, aCtx->disk.oldDocLen);
   }
   addNewDocStats(spec, aCtx->fwIdx->totalFreq);

--- a/src/spec.c
+++ b/src/spec.c
@@ -4184,6 +4184,14 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
       // Failed to delete
       return;
     }
+
+    // Drop the key→docId mapping now that the document is gone from disk. This
+    // keeps DocIdMeta authoritative as an "is this key indexed?" oracle: an
+    // entry exists iff the document is currently indexed in this spec. Without
+    // this, a key that survives in the keyspace but is de-indexed (e.g. an HSET
+    // that makes it stop passing the index FILTER) would keep a stale mapping
+    // pointing at an already-deleted docId.
+    DocIdMeta_Delete(ctx, key, spec->specId);
   } else {
     RSDocumentMetadata *md = DocTable_PopR(&spec->docs, key);
     if (!md) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -568,8 +568,12 @@ StrongRef IndexSpec_ParseC(RedisModuleCtx *ctx, const char *name, const char **a
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);
 
 // Delete a document from the index by its key name.
-// Looks up the docId via DocIdMeta_Get on the key, then removes the document
-// from the DocTable and cleans up associated metadata (DocIdMeta_Delete).
+// In disk mode, looks up the docId via DocIdMeta_Get on the key and removes the
+// document from disk by that id; in memory mode, pops the document metadata from
+// the DocTable. Note it does NOT delete the DocIdMeta key→docId mapping: in disk
+// mode that mapping is left in place and reconciled on the next re-add (see
+// applyDocTable in indexer.c) or cleaned up by the metadata unlink callback when
+// the key itself is deleted.
 // Requires a RedisModuleCtx to access the key's metadata.
 // This function locks the spec for writing.
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);

--- a/src/spec.h
+++ b/src/spec.h
@@ -568,12 +568,10 @@ StrongRef IndexSpec_ParseC(RedisModuleCtx *ctx, const char *name, const char **a
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);
 
 // Delete a document from the index by its key name.
-// In disk mode, looks up the docId via DocIdMeta_Get on the key and removes the
-// document from disk by that id; in memory mode, pops the document metadata from
-// the DocTable. Note it does NOT delete the DocIdMeta key→docId mapping: in disk
-// mode that mapping is left in place and reconciled on the next re-add (see
-// applyDocTable in indexer.c) or cleaned up by the metadata unlink callback when
-// the key itself is deleted.
+// In disk mode, looks up the docId via DocIdMeta_Get on the key, removes the
+// document from disk by that id, and deletes the DocIdMeta key→docId mapping so
+// it stays authoritative (an entry exists iff the doc is indexed). In memory
+// mode, pops the document metadata from the DocTable.
 // Requires a RedisModuleCtx to access the key's metadata.
 // This function locks the spec for writing.
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);


### PR DESCRIPTION
## Describe the changes in the pull request

### What this PR actually does

> [!WARNING]
> The auto-generated summary above is stale — it was produced for an earlier commit that only touched comments and states "`DocIdMeta` key→docId mappings are **not** removed on delete." This PR now does the **opposite**: it *deletes* the mapping. Please read the diff over the bot summary.

**Functional change (`src/spec.c`):** in the disk branch of `IndexSpec_DeleteDoc_Unsafe`, after a successful `SearchDisk_DeleteDocumentById`, we now call `DocIdMeta_Delete(ctx, key, spec->specId)`.

Previously the delete path removed the on-disk row but left the `specId → docId` mapping attached to the Redis key. A key that stays in the keyspace while being de-indexed — e.g. an `HSET` that makes the document stop passing the index `FILTER` — kept a stale mapping pointing at an already-deleted docId. The stale entry was tolerated (every consumer was defensive: the unlink callback's `SearchDisk_DeleteDocumentById`-returns-false early-return avoided a double stats decrement, and re-add overwrote it), but it meant `DocIdMeta` could not be trusted as a source of truth.

This change enforces the invariant: **a `DocIdMeta` entry for `(key, specId)` exists iff the document is currently indexed in that spec.** That makes `DocIdMeta` an authoritative "is this key indexed / what's its docId" oracle for its consumers (debug commands, aggregate).

**Comment updates:**
- `src/spec.h` — the `IndexSpec_DeleteDoc` doc-comment previously claimed it cleaned up `DocIdMeta` (which was false at the time); now accurate for both disk and memory paths.
- `src/indexer.c` — `applyDocTable`'s comment reworded: a non-zero `oldDocId` now normally means a real on-disk row is being replaced. The defensive handling stays, reframed around the real reason it's still needed — `DocIdMeta` (Redis keyspace) and the disk doc-table (SpeedB) are separate stores that can diverge on crash.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disk de-index and document-replace accounting paths; incorrect behavior could skew index stats or leave stale key metadata, but the change aligns metadata with on-disk state and mirrors memory-mode REPLACE semantics.
> 
> **Overview**
> **Disk de-index** now removes the Redis **DocIdMeta** key→docId entry after a successful on-disk delete, so a mapping exists only while the document is actually indexed (fixes stale mappings when keys stay in the keyspace but fail the index filter).
> 
> **Disk re-add / replace** in `applyDocTable` treats a non-zero **`oldDocId`** (not **`oldDocLen`**) as REPLACE for scoring stats, GC, and VecSim/geometry cleanup—so vector/tag/numeric-only docs with zero text length no longer leak **`numDocuments`**.
> 
> Comments in **`spec.h`** and **`indexer.c`** were updated to match this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b68964e5f737f88f576a24c95442db412e66b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->