### PR TITLE
[MOD-14205] TopK: Vector: c wrapper for vecsim

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3327,6 +3327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vecsim"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "rqe_core",
+ "workspace_hack",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -148,6 +148,7 @@ term_suffix_index = { path = "./term_suffix_index" }
 thin_vec = { path = "./thin_vec" }
 top_k = { path = "./top_k" }
 tracing_assert = { path = "./tracing_assert" }
+vecsim = { path = "./c_wrappers/vecsim" }
 tracing_redismodule = { path = "./tracing_redismodule" }
 trie_rs = { path = "./trie_rs" }
 ttl_table = { path = "./ttl_table" }

--- a/src/redisearch_rs/c_wrappers/vecsim/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/vecsim/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vecsim"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ffi.workspace = true
+rqe_core.workspace = true
+workspace_hack.workspace = true

--- a/src/redisearch_rs/c_wrappers/vecsim/src/batch.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/batch.rs
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`BatchIterator`] — owned wrapper around `VecSimBatchIterator`.
+
+use std::{marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
+
+use ffi::{
+    VecSimBatchIterator, VecSimBatchIterator_Free, VecSimBatchIterator_HasNext,
+    VecSimBatchIterator_Next, VecSimIndex, VecSimQueryParams,
+};
+
+use crate::{QueryError, QueryReply, ReplyOrder};
+
+/// Owned `VecSimBatchIterator`. Freed on [`Drop`].
+///
+/// The lifetime parameters prevent the iterator from outliving the C state it
+/// borrows:
+///
+/// - `'idx`: the VecSim index the iterator was created from. HNSW batch
+///   iterators store a raw index pointer and dereference it on every
+///   [`next`](Self::next) and [`Drop`] call.
+/// - `'params`: the `VecSimQueryParams` borrow passed at construction. The
+///   iterator copies `queryParams->timeoutCtx` and reads that pointer on every
+///   [`next`](Self::next) call; `'params` acts as a conservative lower bound
+///   on the lifetime of the timeout-context object.
+pub struct BatchIterator<'idx, 'params> {
+    /// Owned VecSim batch iterator handle.
+    ///
+    /// # Invariant
+    ///
+    /// Valid (returned by `VecSimBatchIterator_New`) and not yet freed, from
+    /// construction until [`Drop`].
+    inner: NonNull<VecSimBatchIterator>,
+    _idx: PhantomData<&'idx VecSimIndex>,
+    _params: PhantomData<&'params mut VecSimQueryParams>,
+}
+
+impl<'idx, 'params> BatchIterator<'idx, 'params> {
+    /// Wrap a non-null batch iterator obtained from
+    /// `VecSimBatchIterator_New`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must establish the [`inner`](Self::inner) field invariant
+    /// and choose `'idx` and `'params` so that they are bounded by the index
+    /// lifetime and the timeout-context lifetime respectively.
+    ///
+    /// The query blob passed to `VecSimBatchIterator_New` needs no lifetime: it
+    /// is copied into the iterator at construction, so the caller's buffer may
+    /// be dropped before the iterator.
+    pub(crate) const unsafe fn from_raw(ptr: NonNull<VecSimBatchIterator>) -> Self {
+        Self {
+            inner: ptr,
+            _idx: PhantomData,
+            _params: PhantomData,
+        }
+    }
+
+    /// Returns `true` while there are more results to fetch.
+    pub fn has_next(&self) -> bool {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimBatchIterator_HasNext(self.inner.as_ptr()) }
+    }
+
+    /// Fetch the next batch of at most `n` results.
+    ///
+    /// Returns `Ok(None)` if VecSim returned a null reply (depleted iterator
+    /// or out-of-memory) and `Err(QueryError::TimedOut)` if the reply code is
+    /// `VecSim_QueryReply_TimedOut`. The reply is freed by this call in both
+    /// non-`Ok(Some(_))` paths.
+    pub fn next(
+        &mut self,
+        n: NonZeroUsize,
+        order: ReplyOrder,
+    ) -> Result<Option<QueryReply>, QueryError> {
+        // SAFETY: `self.inner` upholds its invariant.
+        let raw = unsafe { VecSimBatchIterator_Next(self.inner.as_ptr(), n.get(), order.as_raw()) };
+        // SAFETY: `raw` is the freshly returned reply pointer from VecSim.
+        unsafe { QueryReply::from_raw_checked(raw, order) }
+    }
+}
+
+impl Drop for BatchIterator<'_, '_> {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimBatchIterator_Free(self.inner.as_ptr()) };
+    }
+}

--- a/src/redisearch_rs/c_wrappers/vecsim/src/batch.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/batch.rs
@@ -23,14 +23,14 @@ use crate::{QueryError, QueryReply, ReplyOrder};
 /// The lifetime parameters prevent the iterator from outliving the C state it
 /// borrows:
 ///
-/// - `'idx`: the VecSim index the iterator was created from. HNSW batch
+/// - `'index`: the VecSim index the iterator was created from. HNSW batch
 ///   iterators store a raw index pointer and dereference it on every
 ///   [`next`](Self::next) and [`Drop`] call.
 /// - `'params`: the `VecSimQueryParams` borrow passed at construction. The
 ///   iterator copies `queryParams->timeoutCtx` and reads that pointer on every
 ///   [`next`](Self::next) call; `'params` acts as a conservative lower bound
 ///   on the lifetime of the timeout-context object.
-pub struct BatchIterator<'idx, 'params> {
+pub struct BatchIterator<'index, 'params> {
     /// Owned VecSim batch iterator handle.
     ///
     /// # Invariant
@@ -38,19 +38,20 @@ pub struct BatchIterator<'idx, 'params> {
     /// Valid (returned by `VecSimBatchIterator_New`) and not yet freed, from
     /// construction until [`Drop`].
     inner: NonNull<VecSimBatchIterator>,
-    _idx: PhantomData<&'idx VecSimIndex>,
+    _idx: PhantomData<&'index VecSimIndex>,
     _params: PhantomData<&'params mut VecSimQueryParams>,
 }
 
-impl<'idx, 'params> BatchIterator<'idx, 'params> {
+impl<'index, 'params> BatchIterator<'index, 'params> {
     /// Wrap a non-null batch iterator obtained from
     /// `VecSimBatchIterator_New`.
     ///
     /// # Safety
     ///
-    /// The caller must establish the [`inner`](Self::inner) field invariant
-    /// and choose `'idx` and `'params` so that they are bounded by the index
-    /// lifetime and the timeout-context lifetime respectively.
+    /// The caller must:
+    /// 1. establish the [`inner`](Self::inner) field invariant;
+    /// 2. choose `'index` so it is bounded by the index lifetime;
+    /// 3. choose `'params` so it is bounded by the timeout-context lifetime.
     ///
     /// The query blob passed to `VecSimBatchIterator_New` needs no lifetime: it
     /// is copied into the iterator at construction, so the caller's buffer may

--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -136,7 +136,8 @@ impl<'index> IndexRef<'index> {
     /// # Safety
     ///
     /// The caller must establish the [`inner`](Self::inner) field invariant
-    /// for the chosen `'index` lifetime.
+    /// for the chosen `'index` lifetime: `ptr` must point to a valid VecSim
+    /// index that is not freed for the entire `'index` lifetime.
     pub const unsafe fn from_raw(ptr: NonNull<VecSimIndex>) -> Self {
         Self {
             inner: ptr,
@@ -223,24 +224,19 @@ impl<'index> IndexRef<'index> {
         Some(unsafe { BatchIterator::from_raw(ptr) })
     }
 
-    /// Acquire the shared locks for RAM adhoc distance lookups against
+    /// Acquire VecSim's shared read locks for ad-hoc distance lookups against
     /// `query_vector`, returning a [`SharedLockGuard`].
     ///
-    /// RAM/tiered indexes only; disk indexes must use
-    /// [`adhoc_bf_ctx`](Self::adhoc_bf_ctx) instead.
+    /// VecSim only takes real locks for tiered indexes; on any other index the
+    /// underlying `VecSimTieredIndex_AcquireSharedLocks` is a no-op.
     ///
     /// The query is normalized for cosine indexes (see [`prepare_query`]), so
     /// the caller passes a plain query just like for
     /// [`top_k_query`](Self::top_k_query).
-    pub fn acquire_ram_shared_locks(
+    pub fn acquire_shared_locks(
         &self,
         query_vector: &QueryVector<'index>,
     ) -> SharedLockGuard<'index> {
-        debug_assert!(
-            // SAFETY: `self.inner` upholds its invariant.
-            !unsafe { VecSimIndex_BasicInfo(self.inner.as_ptr()) }.isDisk,
-            "acquire_ram_shared_locks called on a disk index; use adhoc_bf_ctx instead"
-        );
         let query = prepare_query(self.inner, query_vector.as_bytes());
         // SAFETY: `self.inner` upholds its invariant.
         unsafe { VecSimTieredIndex_AcquireSharedLocks(self.inner.as_ptr()) };
@@ -251,10 +247,10 @@ impl<'index> IndexRef<'index> {
     }
 
     /// Create an [`AdhocBfCtx`] that preprocesses `query_vector` once for
-    /// repeated disk-index distance lookups.
+    /// repeated ad-hoc distance lookups.
     ///
-    /// Returns `None` when VecSim does not support adhoc-BF for this index
-    /// type (e.g. RAM indexes).
+    /// Returns `None` when the index type does not implement ad-hoc BF, i.e.
+    /// VecSim's `newAdhocBfCtx` returns null.
     pub fn adhoc_bf_ctx(&self, query_vector: &QueryVector<'index>) -> Option<AdhocBfCtx<'index>> {
         // SAFETY:
         // 1. `self.inner` upholds its invariant.
@@ -275,7 +271,7 @@ impl<'index> IndexRef<'index> {
 }
 
 /// RAII guard holding the tiered-index shared locks acquired by
-/// [`IndexRef::acquire_ram_shared_locks`], bound to the query vector it was
+/// [`IndexRef::acquire_shared_locks`], bound to the query vector it was
 /// acquired for.
 ///
 /// While the guard exists, [`get_distance_from`](Self::get_distance_from) is
@@ -298,7 +294,7 @@ impl SharedLockGuard<'_> {
         // 2. The tiered-index shared locks are held for the lifetime of
         //    `self`, satisfying the `_Unsafe` precondition.
         // 3. `self.query` was sized and (for cosine) normalized to match the
-        //    index in `acquire_ram_shared_locks`.
+        //    index in `acquire_shared_locks`.
         let distance = unsafe {
             VecSimIndex_GetDistanceFrom_Unsafe(
                 self.index.inner.as_ptr(),
@@ -313,7 +309,7 @@ impl SharedLockGuard<'_> {
 impl Drop for SharedLockGuard<'_> {
     fn drop(&mut self) {
         // SAFETY: `self.index.inner` upholds its invariant; the locks were
-        // acquired in `IndexRef::acquire_ram_shared_locks`.
+        // acquired in `IndexRef::acquire_shared_locks`.
         unsafe { VecSimTieredIndex_ReleaseSharedLocks(self.index.inner.as_ptr()) };
     }
 }

--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -119,7 +119,7 @@ fn prepare_query(ptr: NonNull<VecSimIndex>, query_vector: &[u8]) -> Vec<u8> {
     // The normalized blob is at least as large as the input; the extra tail (if
     // any) is the appended norm slot, left zeroed for `VecSim_Normalize` to fill.
     debug_assert!(blob_len >= query_vector.len());
-    let mut blob = vec![0u8; blob_len.max(query_vector.len())];
+    let mut blob = vec![0u8; blob_len];
     blob[..query_vector.len()].copy_from_slice(query_vector);
     // SAFETY:
     // 1. `blob` is `blob_len` bytes, the size VecSim requires for a normalized

--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -1,0 +1,459 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`IndexRef`] — non-owning borrow of a `VecSimIndex` — plus the two
+//! adhoc-BF helpers it can produce: [`SharedLockGuard`] for RAM indexes and
+//! [`AdhocBfCtx`] for disk indexes.
+
+use std::{ffi::c_void, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
+
+use crate::{BatchIterator, QueryError, QueryReply, ReplyOrder};
+use ffi::{
+    VecSim_Normalize, VecSimAdhocBfCtx, VecSimIndex, VecSimIndex_AdhocBfCtx_Free,
+    VecSimIndex_AdhocBfCtx_GetDistanceFrom, VecSimIndex_AdhocBfCtx_GetExactDistances,
+    VecSimIndex_AdhocBfCtx_New, VecSimIndex_BasicInfo, VecSimIndex_GetDistanceFrom_Unsafe,
+    VecSimIndex_IndexSize, VecSimIndex_PreferAdHocSearch, VecSimIndex_TopKQuery,
+    VecSimMetric_VecSimMetric_Cosine, VecSimParams_GetQueryBlobSize, VecSimQueryParams,
+    VecSimTieredIndex_AcquireSharedLocks, VecSimTieredIndex_ReleaseSharedLocks,
+    VecSimType_VecSimType_BFLOAT16, VecSimType_VecSimType_FLOAT16, VecSimType_VecSimType_FLOAT32,
+    VecSimType_VecSimType_FLOAT64, VecSimType_VecSimType_INT8, VecSimType_VecSimType_INT32,
+    VecSimType_VecSimType_INT64, VecSimType_VecSimType_UINT8,
+};
+use rqe_core::DocId;
+
+/// A non-owning reference to a `VecSimIndex`.
+///
+/// The C side owns the index and must keep it live for at least `'idx`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct IndexRef<'idx> {
+    /// Borrowed VecSim index pointer.
+    ///
+    /// # Invariant
+    ///
+    /// Valid and not freed for the entire `'idx` lifetime.
+    inner: NonNull<VecSimIndex>,
+    _marker: PhantomData<&'idx VecSimIndex>,
+}
+
+/// A query blob whose length matches the index it was built for: exactly
+/// `dim × bytes-per-element` bytes (`dim` and the per-element size both come
+/// from the index's immutable metadata).
+///
+/// The length match is a type invariant: every safe method taking a
+/// `QueryVector` (e.g. [`IndexRef::top_k_query`], [`IndexRef::batch_iterator`])
+/// hands the blob to VecSim, which reads exactly that many bytes, and none of
+/// them re-validate. Constructing the value is therefore the sole checkpoint,
+/// and [`QueryVector::new`] is `unsafe` for that reason.
+///
+/// Note: `'idx` brands the blob with the index *lifetime*, not its *identity*.
+/// A `QueryVector` built for one index is accepted by any other index of the
+/// same layout, so the caller must use it with the intended index.
+pub struct QueryVector<'idx> {
+    /// Query blob, laid out as the index expects.
+    blob: Vec<u8>,
+    _marker: PhantomData<&'idx VecSimIndex>,
+}
+
+impl<'idx> QueryVector<'idx> {
+    /// Wrap `blob` as a query vector for `index`.
+    ///
+    /// # Safety
+    ///
+    /// `blob` must have the length required by [`QueryVector`] for `index`, laid
+    /// out as the index expects (e.g. `f32`s for a float32 index). A shorter
+    /// blob is read out of bounds by VecSim in every safe query method that
+    /// consumes the returned value. A `debug_assert!` checks the length in debug
+    /// builds only; release builds trust this precondition.
+    pub unsafe fn new(index: IndexRef<'idx>, blob: Vec<u8>) -> Self {
+        debug_assert_eq!(
+            blob.len(),
+            expected_blob_len(index.inner),
+            "query_vector length does not match the index's expected blob size"
+        );
+        Self {
+            blob,
+            _marker: PhantomData,
+        }
+    }
+
+    /// The query blob, laid out as the index expects.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.blob
+    }
+}
+
+/// Returns the byte length every [`QueryVector`] must have for `ptr`.
+///
+/// Multiplies the index's immutable `dim` by its per-element size. Intended for
+/// `debug_assert!` checks only; not for use on hot paths in release builds.
+fn expected_blob_len(ptr: NonNull<VecSimIndex>) -> usize {
+    // SAFETY: `ptr` is a valid VecSimIndex for at least as long as the caller's borrow.
+    let info = unsafe { VecSimIndex_BasicInfo(ptr.as_ptr()) };
+    let bytes_per_elem: usize = match info.type_ {
+        t if t == VecSimType_VecSimType_FLOAT32 => 4,
+        t if t == VecSimType_VecSimType_FLOAT64 => 8,
+        t if t == VecSimType_VecSimType_BFLOAT16 => 2,
+        t if t == VecSimType_VecSimType_FLOAT16 => 2,
+        t if t == VecSimType_VecSimType_INT8 => 1,
+        t if t == VecSimType_VecSimType_UINT8 => 1,
+        t if t == VecSimType_VecSimType_INT32 => 4,
+        t if t == VecSimType_VecSimType_INT64 => 8,
+        _ => panic!("unknown VecSimType: {}", info.type_),
+    };
+    info.dim * bytes_per_elem
+}
+
+/// Prepare a query vector for direct distance lookups against this index.
+///
+/// Unlike a top-k or batch query, a direct distance lookup applies no
+/// preprocessing to the query: it compares the bytes as given. Cosine indexes
+/// assume both vectors are normalized, so an un-normalized query would produce
+/// wrong distances. We therefore normalize the query once, up front, and reuse
+/// the result for every per-document lookup.
+///
+/// For non-cosine metrics the query is returned unchanged. For cosine the
+/// result may be slightly larger than the input, because normalization can
+/// append bookkeeping (e.g. the precomputed norm) that the index expects.
+fn prepare_query(ptr: NonNull<VecSimIndex>, query_vector: &[u8]) -> Vec<u8> {
+    // SAFETY: `ptr` is a valid VecSimIndex for at least as long as the caller's borrow.
+    let info = unsafe { VecSimIndex_BasicInfo(ptr.as_ptr()) };
+    if info.metric != VecSimMetric_VecSimMetric_Cosine {
+        return query_vector.to_vec();
+    }
+
+    // SAFETY: reads only immutable index metadata.
+    let blob_len = unsafe { VecSimParams_GetQueryBlobSize(info.type_, info.dim, info.metric) };
+    // The normalized blob is at least as large as the input; the extra tail (if
+    // any) is the appended norm slot, left zeroed for `VecSim_Normalize` to fill.
+    debug_assert!(blob_len >= query_vector.len());
+    let mut blob = vec![0u8; blob_len.max(query_vector.len())];
+    blob[..query_vector.len()].copy_from_slice(query_vector);
+    // SAFETY:
+    // - `blob` is `blob_len` bytes, the size VecSim requires for a normalized
+    //   query of this `dim`/`type`, so the in-place normalization (and any
+    //   appended norm) stays in bounds.
+    // - `info.dim` and `info.type_` come from this index's own metadata.
+    unsafe { VecSim_Normalize(blob.as_mut_ptr().cast::<c_void>(), info.dim, info.type_) };
+    blob
+}
+
+impl<'idx> IndexRef<'idx> {
+    /// Create an `IndexRef` from a non-null pointer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must establish the [`inner`](Self::inner) field invariant
+    /// for the chosen `'idx` lifetime.
+    pub const unsafe fn from_raw(ptr: NonNull<VecSimIndex>) -> Self {
+        Self {
+            inner: ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Number of vectors currently in the index.
+    pub fn size(&self) -> usize {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimIndex_IndexSize(self.inner.as_ptr()) }
+    }
+
+    /// VecSim heuristic: should adhoc-BF be preferred over batch iteration
+    /// for the given filter-subset size and `k`?
+    pub fn prefer_adhoc(&self, subset_size: usize, k: usize, initial_check: bool) -> bool {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimIndex_PreferAdHocSearch(self.inner.as_ptr(), subset_size, k, initial_check) }
+    }
+
+    /// Run a single-shot top-`k` query.
+    ///
+    /// `params` is mutated by VecSim (e.g. it reads/writes `timeoutCtx`). See
+    /// [`QueryReply::from_raw_checked`] for the timeout/null handling contract.
+    pub fn top_k_query(
+        &self,
+        query_vector: &QueryVector<'idx>,
+        k: NonZeroUsize,
+        params: &mut VecSimQueryParams,
+        order: ReplyOrder,
+    ) -> Result<Option<QueryReply>, QueryError> {
+        // SAFETY:
+        // - `self.inner` upholds its invariant.
+        // - `query_vector`'s blob is sized to the index by the `QueryVector`
+        //   invariant, so the pointer is valid for the bytes VecSim reads.
+        // - `params` is exclusively borrowed for this call.
+        let raw = unsafe {
+            VecSimIndex_TopKQuery(
+                self.inner.as_ptr(),
+                query_vector.as_bytes().as_ptr().cast::<c_void>(),
+                k.get(),
+                params,
+                order.as_raw(),
+            )
+        };
+        // SAFETY: `raw` is the freshly returned reply pointer from VecSim.
+        unsafe { QueryReply::from_raw_checked(raw, order) }
+    }
+
+    /// Create a batch iterator scoped to `query_vector` and `params`.
+    ///
+    /// Returns `None` if VecSim returns a null iterator pointer.
+    ///
+    /// The returned [`BatchIterator`] is bounded by both `'idx` (the index
+    /// must remain valid) and `'params` (the `timeoutCtx` referenced inside
+    /// `params` must remain valid for the full lifetime of the iterator).
+    pub fn batch_iterator<'params>(
+        &self,
+        query_vector: &QueryVector<'idx>,
+        params: &'params mut VecSimQueryParams,
+    ) -> Option<BatchIterator<'idx, 'params>> {
+        // SAFETY: same argument as `top_k_query`.
+        let raw = unsafe {
+            ffi::VecSimBatchIterator_New(
+                self.inner.as_ptr(),
+                query_vector.as_bytes().as_ptr().cast::<c_void>(),
+                params,
+            )
+        };
+        let ptr = NonNull::new(raw)?;
+        // SAFETY:
+        // - `ptr` is non-null and freshly returned by `VecSimBatchIterator_New`,
+        //   so the `BatchIterator::inner` invariant holds.
+        // - `'idx` is the index lifetime from `IndexRef<'idx>`; the HNSW batch
+        //   iterator stores the raw index pointer and uses it on every Next call.
+        // - `'params` is bounded by the exclusive borrow of `params`; the iterator
+        //   copies `params.timeoutCtx` at construction and reads it on every Next
+        //   call, so the timeout-context referent must outlive the iterator.
+        // - `query_vector` needs no lifetime tracking: VecSimBatchIterator_New
+        //   force-copies the blob (see `BatchIterator::from_raw` safety docs).
+        Some(unsafe { BatchIterator::from_raw(ptr) })
+    }
+
+    /// Like [`batch_iterator`](Self::batch_iterator), but takes the query
+    /// params as a raw pointer so the caller chooses `'params` instead of
+    /// borrowing the params storage.
+    ///
+    /// This is the escape hatch for owners that store the returned iterator
+    /// alongside the `VecSimQueryParams` it was built from: a safe
+    /// `&'params mut` borrow would tie `'params` to that owner's own fields,
+    /// which Rust cannot express. Here the caller picks `'params` and takes on
+    /// the obligation below.
+    ///
+    /// # Safety
+    ///
+    /// - `params` must point to a valid `VecSimQueryParams` for this call.
+    /// - The `timeoutCtx` referenced by `*params` must remain valid for the
+    ///   whole of `'params`, since the iterator copies it and reads it on every
+    ///   [`BatchIterator::next`] call.
+    pub unsafe fn batch_iterator_unchecked<'params>(
+        &self,
+        query_vector: &QueryVector<'idx>,
+        params: *mut VecSimQueryParams,
+    ) -> Option<BatchIterator<'idx, 'params>> {
+        // SAFETY:
+        // - `self.inner` upholds its invariant.
+        // - `query_vector`'s blob is sized to the index by the `QueryVector`
+        //   invariant, so the pointer is valid for the bytes VecSim reads.
+        // - `params` is a valid pointer for this call per the caller's obligation.
+        let raw = unsafe {
+            ffi::VecSimBatchIterator_New(
+                self.inner.as_ptr(),
+                query_vector.as_bytes().as_ptr().cast::<c_void>(),
+                params,
+            )
+        };
+        let ptr = NonNull::new(raw)?;
+        // SAFETY:
+        // - `ptr` is non-null and freshly returned by `VecSimBatchIterator_New`,
+        //   so the `BatchIterator::inner` invariant holds.
+        // - `'idx` is the index lifetime from `IndexRef<'idx>`; the HNSW batch
+        //   iterator stores the raw index pointer and uses it on every Next call.
+        // - `'params` is chosen by the caller, who guarantees the `timeoutCtx`
+        //   referent outlives it.
+        // - `query_vector` needs no lifetime tracking: VecSimBatchIterator_New
+        //   force-copies the blob (see `BatchIterator::from_raw` safety docs).
+        Some(unsafe { BatchIterator::from_raw(ptr) })
+    }
+
+    /// Acquire the tiered-index shared locks required for unsafe RAM adhoc
+    /// distance lookups against `query_vector`. The returned guard releases the
+    /// locks on drop.
+    ///
+    /// RAM/tiered indexes only: the guard's lookups use the RAM-only distance
+    /// path. Disk indexes must use [`adhoc_bf_ctx`](Self::adhoc_bf_ctx) instead,
+    /// which preprocesses the query and registers the marker disk lookups need.
+    ///
+    /// `query_vector` is normalized once here for cosine indexes (see
+    /// [`prepare_query`]) and the prepared blob is reused by every
+    /// [`get_distance_from`](SharedLockGuard::get_distance_from) call, so the
+    /// caller passes a plain (un-normalized) query just like for
+    /// [`top_k_query`](Self::top_k_query).
+    ///
+    /// The guard's lifetime is the index's `'idx`, not the borrow of `self`,
+    /// so it can be stored alongside the [`IndexRef`].
+    pub fn acquire_ram_shared_locks(
+        &self,
+        query_vector: &QueryVector<'idx>,
+    ) -> SharedLockGuard<'idx> {
+        debug_assert!(
+            // SAFETY: `self.inner` upholds its invariant.
+            !unsafe { VecSimIndex_BasicInfo(self.inner.as_ptr()) }.isDisk,
+            "acquire_ram_shared_locks called on a disk index; use adhoc_bf_ctx instead"
+        );
+        let query = prepare_query(self.inner, query_vector.as_bytes());
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimTieredIndex_AcquireSharedLocks(self.inner.as_ptr()) };
+        SharedLockGuard {
+            index: *self,
+            query,
+        }
+    }
+
+    /// Create a disk-index adhoc-BF context that preprocesses `query_vector`
+    /// once for repeated distance lookups.
+    ///
+    /// Returns `None` when VecSim does not support adhoc-BF for this index
+    /// type (e.g. RAM indexes) and yields a null context.
+    ///
+    /// The context's lifetime is the index's `'idx`, not the borrow of `self`,
+    /// so it can be stored alongside the [`IndexRef`]. For disk indexes the
+    /// context keeps performing label distance lookups against the backing
+    /// index, so it must not outlive it.
+    pub fn adhoc_bf_ctx(&self, query_vector: &QueryVector<'idx>) -> Option<AdhocBfCtx<'idx>> {
+        // SAFETY: same argument as `top_k_query`.
+        let raw = unsafe {
+            VecSimIndex_AdhocBfCtx_New(
+                self.inner.as_ptr(),
+                query_vector.as_bytes().as_ptr().cast::<c_void>(),
+            )
+        };
+        let ptr = NonNull::new(raw)?;
+        // SAFETY: `ptr` is non-null and freshly returned by
+        // `VecSimIndex_AdhocBfCtx_New`, so the `AdhocBfCtx::inner` invariant
+        // holds.
+        Some(unsafe { AdhocBfCtx::from_raw(ptr) })
+    }
+}
+
+/// RAII guard holding the tiered-index shared locks acquired by
+/// [`IndexRef::acquire_ram_shared_locks`], bound to the query vector it was
+/// acquired for.
+///
+/// While the guard exists, [`get_distance_from`](Self::get_distance_from) is
+/// safe to call; the locks are released when the guard is dropped.
+#[must_use = "the shared locks are released when the guard is dropped"]
+pub struct SharedLockGuard<'idx> {
+    index: IndexRef<'idx>,
+    /// Query blob, normalized once for cosine indexes at construction, reused
+    /// by every [`get_distance_from`](Self::get_distance_from) call.
+    query: Vec<u8>,
+}
+
+impl SharedLockGuard<'_> {
+    /// Look up the distance from the indexed vector with label `doc_id` to the
+    /// query vector this guard was acquired for. Returns `None` if VecSim
+    /// returns `NaN` (label not found).
+    pub fn get_distance_from(&self, doc_id: DocId) -> Option<f64> {
+        // SAFETY:
+        // - `self.index.inner` upholds its invariant.
+        // - The tiered-index shared locks are held for the lifetime of
+        //   `self`, satisfying the `_Unsafe` precondition.
+        // - `self.query` was sized and (for cosine) normalized to match the
+        //   index in `acquire_ram_shared_locks`.
+        let distance = unsafe {
+            VecSimIndex_GetDistanceFrom_Unsafe(
+                self.index.inner.as_ptr(),
+                doc_id as usize,
+                self.query.as_ptr().cast::<c_void>(),
+            )
+        };
+        (!distance.is_nan()).then_some(distance)
+    }
+}
+
+impl Drop for SharedLockGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: `self.index.inner` upholds its invariant; the locks were
+        // acquired in `IndexRef::acquire_ram_shared_locks`.
+        unsafe { VecSimTieredIndex_ReleaseSharedLocks(self.index.inner.as_ptr()) };
+    }
+}
+
+/// Owned disk-index adhoc-BF context, borrowing the index it was created from
+/// for `'idx`. Freed on [`Drop`].
+pub struct AdhocBfCtx<'idx> {
+    /// Owned VecSim adhoc-BF context handle.
+    ///
+    /// # Invariant
+    ///
+    /// Valid (returned by `VecSimIndex_AdhocBfCtx_New`) and not yet freed,
+    /// from construction until [`Drop`].
+    inner: NonNull<VecSimAdhocBfCtx>,
+    /// Ties the context to the `'idx` lifetime of the index it was created
+    /// from: disk contexts perform label distance lookups against that index
+    /// on every [`get_distance_from`](Self::get_distance_from) call, so the
+    /// index must outlive the context.
+    _marker: PhantomData<&'idx VecSimIndex>,
+}
+
+impl<'idx> AdhocBfCtx<'idx> {
+    /// # Safety
+    ///
+    /// The caller must establish the [`inner`](Self::inner) field invariant,
+    /// and the index `ptr` was created from must stay valid for the chosen
+    /// `'idx` lifetime.
+    const unsafe fn from_raw(ptr: NonNull<VecSimAdhocBfCtx>) -> Self {
+        Self {
+            inner: ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Look up the distance from `doc_id` to the preprocessed query vector.
+    /// Returns `None` if VecSim returns `NaN` (label not found).
+    pub fn get_distance_from(&self, doc_id: DocId) -> Option<f64> {
+        // SAFETY: `self.inner` upholds its invariant.
+        let distance =
+            unsafe { VecSimIndex_AdhocBfCtx_GetDistanceFrom(self.inner.as_ptr(), doc_id as usize) };
+        (!distance.is_nan()).then_some(distance)
+    }
+
+    /// Fetch exact FP32 distances for a batch of `labels`, writing one distance
+    /// per label into `distances_out`. For disk indexes this reads the full-
+    /// precision vectors from disk, recomputing distances that the adhoc scan
+    /// approximated from SQ8-quantized data. Entries whose label is not found
+    /// are written as `NaN`.
+    ///
+    /// `labels` and `distances_out` must have the same length; the slice
+    /// lengths bound the C call, so it never reads or writes past either.
+    pub fn get_exact_distances(&self, labels: &[usize], distances_out: &mut [f64]) {
+        debug_assert_eq!(
+            labels.len(),
+            distances_out.len(),
+            "labels and distances_out must have equal length"
+        );
+        // SAFETY: `self.inner` upholds its invariant. `labels` and
+        // `distances_out` are valid for `count` reads/writes respectively, and
+        // `count` is their (equal) length, so the C call stays in bounds.
+        unsafe {
+            VecSimIndex_AdhocBfCtx_GetExactDistances(
+                self.inner.as_ptr(),
+                labels.as_ptr(),
+                distances_out.as_mut_ptr(),
+                labels.len(),
+            );
+        }
+    }
+}
+
+impl Drop for AdhocBfCtx<'_> {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimIndex_AdhocBfCtx_Free(self.inner.as_ptr()) };
+    }
+}

--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -11,7 +11,7 @@
 //! adhoc-BF helpers it can produce: [`SharedLockGuard`] for RAM indexes and
 //! [`AdhocBfCtx`] for disk indexes.
 
-use std::{ffi::c_void, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
+use std::{ffi::c_void, marker::PhantomData, ptr::NonNull};
 
 use crate::{BatchIterator, QueryError, QueryReply, ReplyOrder};
 use ffi::{
@@ -165,7 +165,7 @@ impl<'index> IndexRef<'index> {
     pub fn top_k_query(
         &self,
         query_vector: &QueryVector<'index>,
-        k: NonZeroUsize,
+        k: usize,
         params: &mut VecSimQueryParams,
         order: ReplyOrder,
     ) -> Result<Option<QueryReply>, QueryError> {
@@ -178,7 +178,7 @@ impl<'index> IndexRef<'index> {
             VecSimIndex_TopKQuery(
                 self.inner.as_ptr(),
                 query_vector.as_bytes().as_ptr().cast::<c_void>(),
-                k.get(),
+                k,
                 params,
                 order.as_raw(),
             )

--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -151,6 +151,12 @@ impl<'index> IndexRef<'index> {
         unsafe { VecSimIndex_IndexSize(self.inner.as_ptr()) }
     }
 
+    /// Whether VecSim stores this index's vectors on disk.
+    pub fn is_disk(&self) -> bool {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimIndex_BasicInfo(self.inner.as_ptr()) }.isDisk
+    }
+
     /// VecSim heuristic: should adhoc-BF be preferred over batch iteration
     /// for the given filter-subset size and `k`?
     pub fn prefer_adhoc(&self, subset_size: usize, k: usize, initial_check: bool) -> bool {

--- a/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/index.rs
@@ -29,49 +29,42 @@ use rqe_core::DocId;
 
 /// A non-owning reference to a `VecSimIndex`.
 ///
-/// The C side owns the index and must keep it live for at least `'idx`.
+/// The C side owns the index and must keep it live for at least `'index`.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct IndexRef<'idx> {
+pub struct IndexRef<'index> {
     /// Borrowed VecSim index pointer.
     ///
     /// # Invariant
     ///
-    /// Valid and not freed for the entire `'idx` lifetime.
+    /// Valid and not freed for the entire `'index` lifetime.
     inner: NonNull<VecSimIndex>,
-    _marker: PhantomData<&'idx VecSimIndex>,
+    _marker: PhantomData<&'index VecSimIndex>,
 }
 
 /// A query blob whose length matches the index it was built for: exactly
-/// `dim × bytes-per-element` bytes (`dim` and the per-element size both come
-/// from the index's immutable metadata).
+/// `dim × bytes-per-element` bytes, both taken from the index's immutable
+/// metadata.
 ///
-/// The length match is a type invariant: every safe method taking a
-/// `QueryVector` (e.g. [`IndexRef::top_k_query`], [`IndexRef::batch_iterator`])
-/// hands the blob to VecSim, which reads exactly that many bytes, and none of
-/// them re-validate. Constructing the value is therefore the sole checkpoint,
-/// and [`QueryVector::new`] is `unsafe` for that reason.
+/// The length match is a type invariant that safe query methods rely on
+/// without re-validating, so [`QueryVector::new`] is `unsafe`.
 ///
-/// Note: `'idx` brands the blob with the index *lifetime*, not its *identity*.
-/// A `QueryVector` built for one index is accepted by any other index of the
-/// same layout, so the caller must use it with the intended index.
-pub struct QueryVector<'idx> {
+/// `'index` ties the blob to the index *lifetime*, not its *identity*: it does
+/// not prevent using the blob with a different index of the same lifetime.
+pub struct QueryVector<'index> {
     /// Query blob, laid out as the index expects.
     blob: Vec<u8>,
-    _marker: PhantomData<&'idx VecSimIndex>,
+    _marker: PhantomData<&'index VecSimIndex>,
 }
 
-impl<'idx> QueryVector<'idx> {
+impl<'index> QueryVector<'index> {
     /// Wrap `blob` as a query vector for `index`.
     ///
     /// # Safety
     ///
     /// `blob` must have the length required by [`QueryVector`] for `index`, laid
-    /// out as the index expects (e.g. `f32`s for a float32 index). A shorter
-    /// blob is read out of bounds by VecSim in every safe query method that
-    /// consumes the returned value. A `debug_assert!` checks the length in debug
-    /// builds only; release builds trust this precondition.
-    pub unsafe fn new(index: IndexRef<'idx>, blob: Vec<u8>) -> Self {
+    /// out as the index expects (e.g. `f32`s for a 32-bit-float index).
+    pub unsafe fn new(index: IndexRef<'index>, blob: Vec<u8>) -> Self {
         debug_assert_eq!(
             blob.len(),
             expected_blob_len(index.inner),
@@ -110,17 +103,10 @@ fn expected_blob_len(ptr: NonNull<VecSimIndex>) -> usize {
     info.dim * bytes_per_elem
 }
 
-/// Prepare a query vector for direct distance lookups against this index.
+/// Returns a query blob ready for direct distance lookups against this index.
 ///
-/// Unlike a top-k or batch query, a direct distance lookup applies no
-/// preprocessing to the query: it compares the bytes as given. Cosine indexes
-/// assume both vectors are normalized, so an un-normalized query would produce
-/// wrong distances. We therefore normalize the query once, up front, and reuse
-/// the result for every per-document lookup.
-///
-/// For non-cosine metrics the query is returned unchanged. For cosine the
-/// result may be slightly larger than the input, because normalization can
-/// append bookkeeping (e.g. the precomputed norm) that the index expects.
+/// Cosine indexes require normalized queries, so cosine inputs are normalized
+/// (see [`VecSim_Normalize`]); all other metrics are returned unchanged.
 fn prepare_query(ptr: NonNull<VecSimIndex>, query_vector: &[u8]) -> Vec<u8> {
     // SAFETY: `ptr` is a valid VecSimIndex for at least as long as the caller's borrow.
     let info = unsafe { VecSimIndex_BasicInfo(ptr.as_ptr()) };
@@ -136,21 +122,21 @@ fn prepare_query(ptr: NonNull<VecSimIndex>, query_vector: &[u8]) -> Vec<u8> {
     let mut blob = vec![0u8; blob_len.max(query_vector.len())];
     blob[..query_vector.len()].copy_from_slice(query_vector);
     // SAFETY:
-    // - `blob` is `blob_len` bytes, the size VecSim requires for a normalized
-    //   query of this `dim`/`type`, so the in-place normalization (and any
-    //   appended norm) stays in bounds.
-    // - `info.dim` and `info.type_` come from this index's own metadata.
+    // 1. `blob` is `blob_len` bytes, the size VecSim requires for a normalized
+    //    query of this `dim`/`type`, so the in-place normalization (and any
+    //    appended norm) stays in bounds.
+    // 2. `info.dim` and `info.type_` come from this index's own metadata.
     unsafe { VecSim_Normalize(blob.as_mut_ptr().cast::<c_void>(), info.dim, info.type_) };
     blob
 }
 
-impl<'idx> IndexRef<'idx> {
+impl<'index> IndexRef<'index> {
     /// Create an `IndexRef` from a non-null pointer.
     ///
     /// # Safety
     ///
     /// The caller must establish the [`inner`](Self::inner) field invariant
-    /// for the chosen `'idx` lifetime.
+    /// for the chosen `'index` lifetime.
     pub const unsafe fn from_raw(ptr: NonNull<VecSimIndex>) -> Self {
         Self {
             inner: ptr,
@@ -177,16 +163,16 @@ impl<'idx> IndexRef<'idx> {
     /// [`QueryReply::from_raw_checked`] for the timeout/null handling contract.
     pub fn top_k_query(
         &self,
-        query_vector: &QueryVector<'idx>,
+        query_vector: &QueryVector<'index>,
         k: NonZeroUsize,
         params: &mut VecSimQueryParams,
         order: ReplyOrder,
     ) -> Result<Option<QueryReply>, QueryError> {
         // SAFETY:
-        // - `self.inner` upholds its invariant.
-        // - `query_vector`'s blob is sized to the index by the `QueryVector`
-        //   invariant, so the pointer is valid for the bytes VecSim reads.
-        // - `params` is exclusively borrowed for this call.
+        // 1. `self.inner` upholds its invariant.
+        // 2. `query_vector`'s blob is sized to the index by the `QueryVector`
+        //    invariant, so the pointer is valid for the bytes VecSim reads.
+        // 3. `params` is exclusively borrowed for this call.
         let raw = unsafe {
             VecSimIndex_TopKQuery(
                 self.inner.as_ptr(),
@@ -200,49 +186,9 @@ impl<'idx> IndexRef<'idx> {
         unsafe { QueryReply::from_raw_checked(raw, order) }
     }
 
-    /// Create a batch iterator scoped to `query_vector` and `params`.
-    ///
-    /// Returns `None` if VecSim returns a null iterator pointer.
-    ///
-    /// The returned [`BatchIterator`] is bounded by both `'idx` (the index
-    /// must remain valid) and `'params` (the `timeoutCtx` referenced inside
-    /// `params` must remain valid for the full lifetime of the iterator).
-    pub fn batch_iterator<'params>(
-        &self,
-        query_vector: &QueryVector<'idx>,
-        params: &'params mut VecSimQueryParams,
-    ) -> Option<BatchIterator<'idx, 'params>> {
-        // SAFETY: same argument as `top_k_query`.
-        let raw = unsafe {
-            ffi::VecSimBatchIterator_New(
-                self.inner.as_ptr(),
-                query_vector.as_bytes().as_ptr().cast::<c_void>(),
-                params,
-            )
-        };
-        let ptr = NonNull::new(raw)?;
-        // SAFETY:
-        // - `ptr` is non-null and freshly returned by `VecSimBatchIterator_New`,
-        //   so the `BatchIterator::inner` invariant holds.
-        // - `'idx` is the index lifetime from `IndexRef<'idx>`; the HNSW batch
-        //   iterator stores the raw index pointer and uses it on every Next call.
-        // - `'params` is bounded by the exclusive borrow of `params`; the iterator
-        //   copies `params.timeoutCtx` at construction and reads it on every Next
-        //   call, so the timeout-context referent must outlive the iterator.
-        // - `query_vector` needs no lifetime tracking: VecSimBatchIterator_New
-        //   force-copies the blob (see `BatchIterator::from_raw` safety docs).
-        Some(unsafe { BatchIterator::from_raw(ptr) })
-    }
-
-    /// Like [`batch_iterator`](Self::batch_iterator), but takes the query
-    /// params as a raw pointer so the caller chooses `'params` instead of
-    /// borrowing the params storage.
-    ///
-    /// This is the escape hatch for owners that store the returned iterator
-    /// alongside the `VecSimQueryParams` it was built from: a safe
-    /// `&'params mut` borrow would tie `'params` to that owner's own fields,
-    /// which Rust cannot express. Here the caller picks `'params` and takes on
-    /// the obligation below.
+    /// Create a batch iterator, taking `params` as a raw pointer so the caller
+    /// picks `'params`. Use this to store the iterator alongside the
+    /// `VecSimQueryParams` it was built from.
     ///
     /// # Safety
     ///
@@ -252,14 +198,14 @@ impl<'idx> IndexRef<'idx> {
     ///   [`BatchIterator::next`] call.
     pub unsafe fn batch_iterator_unchecked<'params>(
         &self,
-        query_vector: &QueryVector<'idx>,
+        query_vector: &QueryVector<'index>,
         params: *mut VecSimQueryParams,
-    ) -> Option<BatchIterator<'idx, 'params>> {
+    ) -> Option<BatchIterator<'index, 'params>> {
         // SAFETY:
-        // - `self.inner` upholds its invariant.
-        // - `query_vector`'s blob is sized to the index by the `QueryVector`
-        //   invariant, so the pointer is valid for the bytes VecSim reads.
-        // - `params` is a valid pointer for this call per the caller's obligation.
+        // 1. `self.inner` upholds its invariant.
+        // 2. `query_vector`'s blob is sized to the index by the `QueryVector`
+        //    invariant, so the pointer is valid for the bytes VecSim reads.
+        // 3. `params` is a valid pointer for this call per the caller's obligation.
         let raw = unsafe {
             ffi::VecSimBatchIterator_New(
                 self.inner.as_ptr(),
@@ -268,38 +214,28 @@ impl<'idx> IndexRef<'idx> {
             )
         };
         let ptr = NonNull::new(raw)?;
-        // SAFETY:
-        // - `ptr` is non-null and freshly returned by `VecSimBatchIterator_New`,
-        //   so the `BatchIterator::inner` invariant holds.
-        // - `'idx` is the index lifetime from `IndexRef<'idx>`; the HNSW batch
-        //   iterator stores the raw index pointer and uses it on every Next call.
-        // - `'params` is chosen by the caller, who guarantees the `timeoutCtx`
-        //   referent outlives it.
-        // - `query_vector` needs no lifetime tracking: VecSimBatchIterator_New
-        //   force-copies the blob (see `BatchIterator::from_raw` safety docs).
+        // SAFETY: satisfies `BatchIterator::from_raw`:
+        // 1. `inner` invariant: `ptr` is non-null and freshly returned by
+        //    `VecSimBatchIterator_New`.
+        // 2. `'index` is bounded by the index lifetime.
+        // 3. `'params` is caller-chosen; the caller guarantees the `timeoutCtx`
+        //    referent outlives it.
         Some(unsafe { BatchIterator::from_raw(ptr) })
     }
 
-    /// Acquire the tiered-index shared locks required for unsafe RAM adhoc
-    /// distance lookups against `query_vector`. The returned guard releases the
-    /// locks on drop.
+    /// Acquire the shared locks for RAM adhoc distance lookups against
+    /// `query_vector`, returning a [`SharedLockGuard`].
     ///
-    /// RAM/tiered indexes only: the guard's lookups use the RAM-only distance
-    /// path. Disk indexes must use [`adhoc_bf_ctx`](Self::adhoc_bf_ctx) instead,
-    /// which preprocesses the query and registers the marker disk lookups need.
+    /// RAM/tiered indexes only; disk indexes must use
+    /// [`adhoc_bf_ctx`](Self::adhoc_bf_ctx) instead.
     ///
-    /// `query_vector` is normalized once here for cosine indexes (see
-    /// [`prepare_query`]) and the prepared blob is reused by every
-    /// [`get_distance_from`](SharedLockGuard::get_distance_from) call, so the
-    /// caller passes a plain (un-normalized) query just like for
+    /// The query is normalized for cosine indexes (see [`prepare_query`]), so
+    /// the caller passes a plain query just like for
     /// [`top_k_query`](Self::top_k_query).
-    ///
-    /// The guard's lifetime is the index's `'idx`, not the borrow of `self`,
-    /// so it can be stored alongside the [`IndexRef`].
     pub fn acquire_ram_shared_locks(
         &self,
-        query_vector: &QueryVector<'idx>,
-    ) -> SharedLockGuard<'idx> {
+        query_vector: &QueryVector<'index>,
+    ) -> SharedLockGuard<'index> {
         debug_assert!(
             // SAFETY: `self.inner` upholds its invariant.
             !unsafe { VecSimIndex_BasicInfo(self.inner.as_ptr()) }.isDisk,
@@ -314,18 +250,16 @@ impl<'idx> IndexRef<'idx> {
         }
     }
 
-    /// Create a disk-index adhoc-BF context that preprocesses `query_vector`
-    /// once for repeated distance lookups.
+    /// Create an [`AdhocBfCtx`] that preprocesses `query_vector` once for
+    /// repeated disk-index distance lookups.
     ///
     /// Returns `None` when VecSim does not support adhoc-BF for this index
-    /// type (e.g. RAM indexes) and yields a null context.
-    ///
-    /// The context's lifetime is the index's `'idx`, not the borrow of `self`,
-    /// so it can be stored alongside the [`IndexRef`]. For disk indexes the
-    /// context keeps performing label distance lookups against the backing
-    /// index, so it must not outlive it.
-    pub fn adhoc_bf_ctx(&self, query_vector: &QueryVector<'idx>) -> Option<AdhocBfCtx<'idx>> {
-        // SAFETY: same argument as `top_k_query`.
+    /// type (e.g. RAM indexes).
+    pub fn adhoc_bf_ctx(&self, query_vector: &QueryVector<'index>) -> Option<AdhocBfCtx<'index>> {
+        // SAFETY:
+        // 1. `self.inner` upholds its invariant.
+        // 2. `query_vector`'s blob is sized to the index by the `QueryVector`
+        //    invariant, so the pointer is valid for the bytes VecSim reads.
         let raw = unsafe {
             VecSimIndex_AdhocBfCtx_New(
                 self.inner.as_ptr(),
@@ -347,8 +281,8 @@ impl<'idx> IndexRef<'idx> {
 /// While the guard exists, [`get_distance_from`](Self::get_distance_from) is
 /// safe to call; the locks are released when the guard is dropped.
 #[must_use = "the shared locks are released when the guard is dropped"]
-pub struct SharedLockGuard<'idx> {
-    index: IndexRef<'idx>,
+pub struct SharedLockGuard<'index> {
+    index: IndexRef<'index>,
     /// Query blob, normalized once for cosine indexes at construction, reused
     /// by every [`get_distance_from`](Self::get_distance_from) call.
     query: Vec<u8>,
@@ -360,11 +294,11 @@ impl SharedLockGuard<'_> {
     /// returns `NaN` (label not found).
     pub fn get_distance_from(&self, doc_id: DocId) -> Option<f64> {
         // SAFETY:
-        // - `self.index.inner` upholds its invariant.
-        // - The tiered-index shared locks are held for the lifetime of
-        //   `self`, satisfying the `_Unsafe` precondition.
-        // - `self.query` was sized and (for cosine) normalized to match the
-        //   index in `acquire_ram_shared_locks`.
+        // 1. `self.index.inner` upholds its invariant.
+        // 2. The tiered-index shared locks are held for the lifetime of
+        //    `self`, satisfying the `_Unsafe` precondition.
+        // 3. `self.query` was sized and (for cosine) normalized to match the
+        //    index in `acquire_ram_shared_locks`.
         let distance = unsafe {
             VecSimIndex_GetDistanceFrom_Unsafe(
                 self.index.inner.as_ptr(),
@@ -385,8 +319,8 @@ impl Drop for SharedLockGuard<'_> {
 }
 
 /// Owned disk-index adhoc-BF context, borrowing the index it was created from
-/// for `'idx`. Freed on [`Drop`].
-pub struct AdhocBfCtx<'idx> {
+/// for `'index`. Freed on [`Drop`].
+pub struct AdhocBfCtx<'index> {
     /// Owned VecSim adhoc-BF context handle.
     ///
     /// # Invariant
@@ -394,19 +328,20 @@ pub struct AdhocBfCtx<'idx> {
     /// Valid (returned by `VecSimIndex_AdhocBfCtx_New`) and not yet freed,
     /// from construction until [`Drop`].
     inner: NonNull<VecSimAdhocBfCtx>,
-    /// Ties the context to the `'idx` lifetime of the index it was created
+    /// Ties the context to the `'index` lifetime of the index it was created
     /// from: disk contexts perform label distance lookups against that index
     /// on every [`get_distance_from`](Self::get_distance_from) call, so the
     /// index must outlive the context.
-    _marker: PhantomData<&'idx VecSimIndex>,
+    _marker: PhantomData<&'index VecSimIndex>,
 }
 
-impl<'idx> AdhocBfCtx<'idx> {
+impl<'index> AdhocBfCtx<'index> {
     /// # Safety
     ///
-    /// The caller must establish the [`inner`](Self::inner) field invariant,
-    /// and the index `ptr` was created from must stay valid for the chosen
-    /// `'idx` lifetime.
+    /// The caller must:
+    /// 1. establish the [`inner`](Self::inner) field invariant;
+    /// 2. ensure the index `ptr` was created from stays valid for the chosen
+    ///    `'index` lifetime.
     const unsafe fn from_raw(ptr: NonNull<VecSimAdhocBfCtx>) -> Self {
         Self {
             inner: ptr,

--- a/src/redisearch_rs/c_wrappers/vecsim/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/lib.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Safe wrappers around the `VecSim*` C API exposed by `deps/VectorSimilarity`.
+//!
+//! The wrappers cover the surface needed by the top-K hybrid query source:
+//! single-shot top-K queries, batch iteration, and the two adhoc-BF execution
+//! paths (RAM with tiered-index shared locks, disk with a preprocessed
+//! `VecSimAdhocBfCtx`). Each owned VecSim handle becomes a Rust struct that
+//! frees the handle in `Drop`, and the lock ordering between a
+//! `VecSimQueryReply` and its iterator is encoded in [`ReplyResults`].
+//!
+//! The non-owning [`IndexRef`] is the entry point; everything else is
+//! produced from it.
+
+mod batch;
+mod index;
+mod params;
+mod reply;
+
+pub use batch::BatchIterator;
+pub use index::{AdhocBfCtx, IndexRef, QueryVector, SharedLockGuard};
+pub use params::{QueryError, ReplyOrder};
+pub use reply::{QueryReply, ReplyResults};

--- a/src/redisearch_rs/c_wrappers/vecsim/src/params.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/params.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Plain enums mirroring the VecSim C constants.
+
+use ffi::{VecSimQueryReply_Order, VecSimQueryReply_Order_BY_ID, VecSimQueryReply_Order_BY_SCORE};
+
+/// Sort order for results returned by a VecSim query.
+///
+/// Only `ByScore` and `ById` are accepted by the public VecSim C API
+/// (`VecSimIndex_TopKQuery`, `VecSimBatchIterator_Next`). The `BY_SCORE_THEN_ID`
+/// constant exists in `VecSimQueryReply_Order` but is reserved for internal
+/// use inside VecSim's tiered algorithms and is rejected by both entry points
+/// with an assertion failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplyOrder {
+    ByScore,
+    ById,
+}
+
+impl ReplyOrder {
+    pub(crate) const fn as_raw(self) -> VecSimQueryReply_Order {
+        match self {
+            ReplyOrder::ByScore => VecSimQueryReply_Order_BY_SCORE,
+            ReplyOrder::ById => VecSimQueryReply_Order_BY_ID,
+        }
+    }
+}
+
+/// Errors produced by VecSim query calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryError {
+    /// VecSim reported `VecSim_QueryReply_TimedOut` via the query reply code.
+    TimedOut,
+}

--- a/src/redisearch_rs/c_wrappers/vecsim/src/reply.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/reply.rs
@@ -7,8 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! [`QueryReply`] (owned reply) and [`ReplyResults`] (iterator that keeps the
-//! reply alive).
+//! Iteration over a VecSim query's results, freed automatically when done.
 
 use std::ptr::NonNull;
 
@@ -32,7 +31,7 @@ pub struct QueryReply {
     /// `VecSimBatchIterator_Next`) and not yet freed, from construction until
     /// [`Drop`].
     inner: NonNull<VecSimQueryReply>,
-    /// Order the reply's results are sorted in, as requested when the query
+    /// The Order the reply's results are sorted in, as requested when the query
     /// was issued. VecSim does not expose this on the reply, so we record the
     /// caller-supplied order to keep order-sensitive consumers (e.g.
     /// [`ReplyResults::skip_to`]) correct.
@@ -64,8 +63,9 @@ impl QueryReply {
     ///
     /// # Safety
     ///
-    /// `raw` must be a freshly returned pointer from a VecSim query call
-    /// (or null). If non-null, ownership is consumed by this call.
+    /// `raw` must be a pointer returned by a VecSim query call that has not yet
+    /// been consumed or freed (or null). If non-null, ownership is transferred
+    /// to this call.
     pub(crate) unsafe fn from_raw_checked(
         raw: *mut VecSimQueryReply,
         order: ReplyOrder,
@@ -73,8 +73,8 @@ impl QueryReply {
         let Some(reply) = NonNull::new(raw) else {
             return Ok(None);
         };
-        // SAFETY: `reply` is non-null and freshly returned by VecSim, so the
-        // `QueryReply::inner` invariant is upheld.
+        // SAFETY: `reply` is non-null and returned by VecSim without being
+        // consumed yet, so the `QueryReply::inner` invariant is upheld.
         let reply = unsafe { Self::from_raw(reply, order) };
         // SAFETY: `reply.inner` upholds its invariant.
         let code = unsafe { VecSimQueryReply_GetCode(reply.inner.as_ptr()) };
@@ -90,10 +90,9 @@ impl QueryReply {
         // SAFETY: `self.inner` upholds its invariant.
         let iter = unsafe { VecSimQueryReply_GetIterator(self.inner.as_ptr()) };
         let iter = NonNull::new(iter)?;
-        let order = self.order;
         Some(ReplyResults {
             iter,
-            order,
+            order: self.order,
             reply: self,
         })
     }
@@ -152,12 +151,7 @@ impl ReplyResults {
             ReplyOrder::ById,
             "skip_to requires an id-ordered reply; ByScore replies are not monotonic in doc id"
         );
-        loop {
-            let (id, score) = self.next()?;
-            if id >= target {
-                return Some((id, score));
-            }
-        }
+        self.find(|&(id, _)| id >= target)
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/vecsim/src/reply.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/reply.rs
@@ -56,8 +56,8 @@ impl QueryReply {
     /// Convert a raw reply pointer into a [`Result`], translating the VecSim
     /// reply code into [`QueryError::TimedOut`] when applicable.
     ///
-    /// Frees the reply on the error and `Ok(None)` paths so the caller never
-    /// has to worry about leaks.
+    /// The caller never has to free: a null `raw` yields `Ok(None)`, and a
+    /// timed-out reply is freed before returning [`QueryError::TimedOut`].
     ///
     /// `order` must be the sort order requested from the VecSim query call that
     /// produced `raw`.
@@ -86,10 +86,6 @@ impl QueryReply {
     }
 
     /// Consume the reply and produce an iterator over its results.
-    ///
-    /// Returns `None` if VecSim does not provide an iterator for this reply
-    /// (i.e. `VecSimQueryReply_GetIterator` returned null), in which case the
-    /// reply itself is freed.
     pub fn into_results(self) -> Option<ReplyResults> {
         // SAFETY: `self.inner` upholds its invariant.
         let iter = unsafe { VecSimQueryReply_GetIterator(self.inner.as_ptr()) };
@@ -113,8 +109,7 @@ impl Drop for QueryReply {
 /// Iterator over the results of a [`QueryReply`].
 ///
 /// Holds the owning [`QueryReply`] so the reply lives at least as long as the
-/// iterator. On drop the VecSim iterator handle is freed first, then the
-/// reply (via `QueryReply::Drop`) — the order required by VecSim.
+/// iterator.
 pub struct ReplyResults {
     /// Owned VecSim reply iterator handle.
     ///
@@ -150,12 +145,7 @@ impl ReplyResults {
     ///
     /// # Precondition
     ///
-    /// Only valid on [`ReplyOrder::ById`] replies. The linear scan discards
-    /// every result until it sees an id `>= target`, which assumes ids arrive
-    /// in increasing order. On a [`ReplyOrder::ByScore`] reply ids are
-    /// unordered, so this would silently skip valid results with smaller ids;
-    /// callers must check [`order`](Self::order) first. Debug builds assert
-    /// the precondition.
+    /// Only valid on [`ReplyOrder::ById`] replies.
     pub fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)> {
         debug_assert_eq!(
             self.order,

--- a/src/redisearch_rs/c_wrappers/vecsim/src/reply.rs
+++ b/src/redisearch_rs/c_wrappers/vecsim/src/reply.rs
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`QueryReply`] (owned reply) and [`ReplyResults`] (iterator that keeps the
+//! reply alive).
+
+use std::ptr::NonNull;
+
+use ffi::{
+    VecSimQueryReply, VecSimQueryReply_Code_VecSim_QueryReply_TimedOut, VecSimQueryReply_Free,
+    VecSimQueryReply_GetCode, VecSimQueryReply_GetIterator, VecSimQueryReply_Iterator,
+    VecSimQueryReply_IteratorFree, VecSimQueryReply_IteratorNext, VecSimQueryResult_GetId,
+    VecSimQueryResult_GetScore,
+};
+use rqe_core::DocId;
+
+use crate::{QueryError, ReplyOrder};
+
+/// Owned `VecSimQueryReply`. Freed on [`Drop`].
+pub struct QueryReply {
+    /// Owned VecSim reply handle.
+    ///
+    /// # Invariant
+    ///
+    /// Valid (returned by `VecSimIndex_TopKQuery` or
+    /// `VecSimBatchIterator_Next`) and not yet freed, from construction until
+    /// [`Drop`].
+    inner: NonNull<VecSimQueryReply>,
+    /// Order the reply's results are sorted in, as requested when the query
+    /// was issued. VecSim does not expose this on the reply, so we record the
+    /// caller-supplied order to keep order-sensitive consumers (e.g.
+    /// [`ReplyResults::skip_to`]) correct.
+    order: ReplyOrder,
+}
+
+impl QueryReply {
+    /// Wrap a non-null reply pointer obtained from VecSim.
+    ///
+    /// `order` must be the sort order that was passed to the VecSim query call
+    /// that produced `ptr`, so the reply can correctly answer order-sensitive
+    /// queries later.
+    ///
+    /// # Safety
+    ///
+    /// The caller must establish the [`inner`](Self::inner) field invariant.
+    pub(crate) const unsafe fn from_raw(ptr: NonNull<VecSimQueryReply>, order: ReplyOrder) -> Self {
+        Self { inner: ptr, order }
+    }
+
+    /// Convert a raw reply pointer into a [`Result`], translating the VecSim
+    /// reply code into [`QueryError::TimedOut`] when applicable.
+    ///
+    /// Frees the reply on the error and `Ok(None)` paths so the caller never
+    /// has to worry about leaks.
+    ///
+    /// `order` must be the sort order requested from the VecSim query call that
+    /// produced `raw`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a freshly returned pointer from a VecSim query call
+    /// (or null). If non-null, ownership is consumed by this call.
+    pub(crate) unsafe fn from_raw_checked(
+        raw: *mut VecSimQueryReply,
+        order: ReplyOrder,
+    ) -> Result<Option<Self>, QueryError> {
+        let Some(reply) = NonNull::new(raw) else {
+            return Ok(None);
+        };
+        // SAFETY: `reply` is non-null and freshly returned by VecSim, so the
+        // `QueryReply::inner` invariant is upheld.
+        let reply = unsafe { Self::from_raw(reply, order) };
+        // SAFETY: `reply.inner` upholds its invariant.
+        let code = unsafe { VecSimQueryReply_GetCode(reply.inner.as_ptr()) };
+        if code == VecSimQueryReply_Code_VecSim_QueryReply_TimedOut {
+            drop(reply);
+            return Err(QueryError::TimedOut);
+        }
+        Ok(Some(reply))
+    }
+
+    /// Consume the reply and produce an iterator over its results.
+    ///
+    /// Returns `None` if VecSim does not provide an iterator for this reply
+    /// (i.e. `VecSimQueryReply_GetIterator` returned null), in which case the
+    /// reply itself is freed.
+    pub fn into_results(self) -> Option<ReplyResults> {
+        // SAFETY: `self.inner` upholds its invariant.
+        let iter = unsafe { VecSimQueryReply_GetIterator(self.inner.as_ptr()) };
+        let iter = NonNull::new(iter)?;
+        let order = self.order;
+        Some(ReplyResults {
+            iter,
+            order,
+            reply: self,
+        })
+    }
+}
+
+impl Drop for QueryReply {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` upholds its invariant.
+        unsafe { VecSimQueryReply_Free(self.inner.as_ptr()) };
+    }
+}
+
+/// Iterator over the results of a [`QueryReply`].
+///
+/// Holds the owning [`QueryReply`] so the reply lives at least as long as the
+/// iterator. On drop the VecSim iterator handle is freed first, then the
+/// reply (via `QueryReply::Drop`) — the order required by VecSim.
+pub struct ReplyResults {
+    /// Owned VecSim reply iterator handle.
+    ///
+    /// # Invariants
+    ///
+    /// - Valid (returned by `VecSimQueryReply_GetIterator` on
+    ///   [`reply`](Self::reply)) and not yet freed, from construction until
+    ///   [`Drop`].
+    /// - Declared *before* [`reply`](Self::reply): Rust drops fields in
+    ///   declaration order, so the iterator handle is freed first — the order
+    ///   required by VecSim.
+    iter: NonNull<VecSimQueryReply_Iterator>,
+    /// Sort order of the results, propagated from the originating
+    /// [`QueryReply`]. Read by [`skip_to`](Self::skip_to) to enforce its
+    /// id-ordered precondition.
+    order: ReplyOrder,
+    /// Owning [`QueryReply`] that backs [`iter`](Self::iter); kept alive for
+    /// the lifetime of `self`.
+    #[expect(dead_code, reason = "held for Drop ordering: freed after `iter`")]
+    reply: QueryReply,
+}
+
+impl ReplyResults {
+    /// Sort order the underlying results are returned in.
+    pub const fn order(&self) -> ReplyOrder {
+        self.order
+    }
+
+    /// Advance to the first result whose doc id is `>= target`.
+    ///
+    /// Performs a linear scan: VecSim reply iterators have no random-access
+    /// API.
+    ///
+    /// # Precondition
+    ///
+    /// Only valid on [`ReplyOrder::ById`] replies. The linear scan discards
+    /// every result until it sees an id `>= target`, which assumes ids arrive
+    /// in increasing order. On a [`ReplyOrder::ByScore`] reply ids are
+    /// unordered, so this would silently skip valid results with smaller ids;
+    /// callers must check [`order`](Self::order) first. Debug builds assert
+    /// the precondition.
+    pub fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)> {
+        debug_assert_eq!(
+            self.order,
+            ReplyOrder::ById,
+            "skip_to requires an id-ordered reply; ByScore replies are not monotonic in doc id"
+        );
+        loop {
+            let (id, score) = self.next()?;
+            if id >= target {
+                return Some((id, score));
+            }
+        }
+    }
+}
+
+impl Iterator for ReplyResults {
+    type Item = (DocId, f64);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: `self.iter` upholds its invariant.
+        let result = unsafe { VecSimQueryReply_IteratorNext(self.iter.as_ptr()) };
+        if result.is_null() {
+            return None;
+        }
+        // SAFETY: `result` is non-null and owned by `self.reply`, which
+        // outlives this borrow.
+        let id = unsafe { VecSimQueryResult_GetId(result) } as DocId;
+        // SAFETY: as above.
+        let score = unsafe { VecSimQueryResult_GetScore(result) };
+        Some((id, score))
+    }
+}
+
+impl Drop for ReplyResults {
+    fn drop(&mut self) {
+        // SAFETY: `self.iter` upholds its invariant; `self.reply` is freed
+        // immediately after, by `QueryReply::Drop` (fields drop in
+        // declaration order).
+        unsafe { VecSimQueryReply_IteratorFree(self.iter.as_ptr()) };
+    }
+}

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -28,12 +28,60 @@ struct HeaderAllowlist {
 /// Bindgen inputs. Each entry both feeds clang and constrains which symbols
 /// bindgen emits. Sorted alphabetically by `path` for easy scanning.
 const HEADERS: &[HeaderAllowlist] = &[
+    // `c_wrappers/vecsim`: query replies and their iterators.
+    HeaderAllowlist {
+        path: "deps/VectorSimilarity/src/VecSim/query_results.h",
+        fns: &[
+            "VecSimBatchIterator_Free",
+            "VecSimBatchIterator_HasNext",
+            "VecSimBatchIterator_Next",
+            "VecSimQueryReply_Free",
+            "VecSimQueryReply_GetCode",
+            "VecSimQueryReply_GetIterator",
+            "VecSimQueryReply_IteratorFree",
+            "VecSimQueryReply_IteratorNext",
+            "VecSimQueryResult_GetId",
+            "VecSimQueryResult_GetScore",
+        ],
+        types: &[
+            "VecSimQueryReply",
+            "VecSimQueryReply_Code",
+            "VecSimQueryReply_Iterator",
+            "VecSimQueryReply_Order",
+        ],
+        vars: &[],
+    },
+    // `c_wrappers/vecsim`: index handle + adhoc-BF / batch-iterator entry points.
+    HeaderAllowlist {
+        path: "deps/VectorSimilarity/src/VecSim/vec_sim.h",
+        fns: &[
+            "VecSimBatchIterator_New",
+            "VecSimIndex_AddVector",
+            "VecSimIndex_AdhocBfCtx_Free",
+            "VecSimIndex_AdhocBfCtx_GetDistanceFrom",
+            "VecSimIndex_AdhocBfCtx_GetExactDistances",
+            "VecSimIndex_AdhocBfCtx_New",
+            "VecSimIndex_BasicInfo",
+            "VecSimIndex_Free",
+            "VecSimIndex_GetDistanceFrom_Unsafe",
+            "VecSimIndex_IndexSize",
+            "VecSimIndex_New",
+            "VecSimIndex_PreferAdHocSearch",
+            "VecSimIndex_TopKQuery",
+            "VecSimParams_GetQueryBlobSize",
+            "VecSimTieredIndex_AcquireSharedLocks",
+            "VecSimTieredIndex_ReleaseSharedLocks",
+            "VecSim_Normalize",
+        ],
+        types: &["VecSimBatchIterator", "VecSimIndex"],
+        vars: &[],
+    },
     // RSE: `ThrottleCB` and `VecSimParamsDisk` are consumed by the disk
     // vector-index API exposed through `src/search_disk_api.h`.
     HeaderAllowlist {
         path: "deps/VectorSimilarity/src/VecSim/vec_sim_common.h",
         fns: &[],
-        types: &["ThrottleCB", "VecSimParamsDisk"],
+        types: &["ThrottleCB", "VecSimIndexBasicInfo", "VecSimParamsDisk"],
         vars: &[],
     },
     HeaderAllowlist {


### PR DESCRIPTION
- Built on top of #9447
- C wrappers needed for future work on https://github.com/RediSearch/RediSearch/pull/9590

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches query timeout, cursor, and distributed hybrid reply paths plus broad CI/build changes; regressions could affect production query behavior and release pipelines.
> 
> **Overview**
> This PR bundles a wide set of changes across CI, build tooling, query execution, and contributor docs.
> 
> **CI and automation:** Adds a reusable `fetch-failed-run-logs` action (per-job REST logs, truncation, optional append) and wires it into benchmark, snapshot, and post-merge triage flows instead of `gh run view --log-failed`. **Codex CI triage** now reads `codex-action`’s `final-message` output (read-only sandbox can’t write triage files) and fixes merge-queue bot allowlisting. **`retry-command`** can expose an optional `GITHUB_TOKEN` for authenticated installs; benchmark and artifact builds use it for test deps. CI images are published under `ghcr.io/<owner>/redisearch-ci` (lowercased owner). Rust micro-benchmark builds set `REDISEARCH_GENERATE_HEADERS=0` on runners without cheadergen; **cheadergen** is bumped to **0.2.4**.
> 
> **Build:** `make deps` is renamed **`make bootstrap`**; **sccache** is only enabled after a successful server probe, with launcher cleared on failure; **CMake** reconfigures on every `build.sh` run; coverage **lcov** ignores mismatch errors; Boost download retries with a 60s timeout.
> 
> **Query behavior:** Introduces **`search-_max-foreground-timeout-limit`** and **`RSConfig_CapQueryTimeoutToForegroundLimit`** when workers are 0, with a RESP3 **MaxTimeoutCapped** warning. **RETURN_STRICT** cursor reads get shard/standalone blocked-client timeout handling (claim/sync, cursor id preserved on timeout). Coordinator **hybrid** execution is refactored: cursor setup, depleter scheduling on the coord pool, tail merger on a separate worker, pinned timeout policy on `CoordRequestCtx`, and a **RETURN_STRICT** coord timeout callback. **GROUP BY** reducers can use **`AddWithDocId`**; disk indexes force-disable aggregate **OPTIMIZE**. Misc: concurrent command ctx can keep the blocked client; MR iterator uses a config struct and cursor-mapping error callback.
> 
> **Docs / process:** Spec-driven contribution workflow (`docs/CONTRIBUTING-specs.md`, `openspec/` example), **AGENTS.md** updates, and hardened agent **skills** (prompt-injection guardrails, perf-bisect skill).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0250938777fe2b0eb75e116a1823040685733cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->