### PR TITLE
ffi: stop forcing a rebuild on every cargo invocation

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -30,13 +30,23 @@ pub fn repository_root() -> Result<std::path::PathBuf, Box<dyn std::error::Error
 }
 
 fn rerun_if_changes(dir: &Path, extensions: &[&str]) -> std::io::Result<()> {
+    // Don't descend into Cargo's target directory. Cargo marks it with a
+    // `CACHEDIR.TAG` file, so detect it that way regardless of where
+    // `CARGO_TARGET_DIR` points (e.g. the CMake build sets it to
+    // `src/redisearch_rs/target`, which sits under the `src` include root
+    // scanned by `ffi/build.rs`). Otherwise the sweep would reach a build
+    // script's own `OUT_DIR` and emit `rerun-if-changed` for the headers that
+    // script just staged there, forcing a rebuild on every invocation.
+    if dir.join("CACHEDIR.TAG").exists() {
+        return Ok(());
+    }
     for entry in read_dir(dir)? {
         let Ok(entry) = entry else {
             continue;
         };
         let path = entry.path();
         if path.is_dir() {
-            return rerun_if_changes(&path, extensions);
+            rerun_if_changes(&path, extensions)?;
         } else if let Some(extension) = path.extension().and_then(|ext| ext.to_str())
             && extensions.contains(&extension)
         {

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -493,7 +493,7 @@ fn main() {
     let includes = [
         src.clone(),
         deps.clone(),
-        permitted_dir,
+        permitted_dir.clone(),
         src.join("inverted_index"),
         deps.join("VectorSimilarity").join("src"),
         src.join("buffer"),
@@ -521,7 +521,13 @@ fn main() {
     }
     for include in &includes {
         bindings = bindings.clang_arg(format!("-I{}", include.display()));
-        let _ = rerun_if_c_changes(include);
+        // Don't watch the staged copies under OUT_DIR: the build script writes
+        // them itself, so their mtimes will always be post-date cargo's fingerprint
+        // reference and would force a rebuild on every invocation. The source
+        // generated headers are already watched above.
+        if include != &permitted_dir {
+            let _ = rerun_if_c_changes(include);
+        }
     }
     // `_GNU_SOURCE` makes `<stdio.h>` declare `asprintf`/`vasprintf`, which
     // `deps/rmalloc/rmalloc.h` uses.


### PR DESCRIPTION
## Describe the changes in the pull request

 `cargo build` / `cargo nextest run` in `redisearch_rs` recompiled the `ffi`
  crate — and everything downstream of it — on *every* invocation, even with no
  source changes.

  ### `ffi: stop forcing a rebuild on every cargo invocation`

  The `ffi` build script stages the permitted generated headers into a
  subdirectory of `OUT_DIR`, then ran its `rerun_if_c_changes` sweep over *every*
  include entry — including that `OUT_DIR` staging dir. It therefore emitted
  `cargo::rerun-if-changed` for files it had just written itself. Since
  `fs::copy` stamps those copies with an mtime that post-dates cargo's
  build-script fingerprint reference, cargo saw a "changed" input on every run,
  re-ran the build script, regenerated `bindings.rs`, and recompiled the crate —
  a self-perpetuating loop.

  **Fix:** skip the `OUT_DIR` staging dir when emitting `rerun-if-changed`. It
  stays on bindgen's `-I` path, and the *source* generated headers are already
  watched, so nothing is lost.

  ### `build_utils: recurse into all subdirectories in rerun_if_changes`

  `rerun_if_changes` `return`ed the recursive call on the first subdirectory it
  hit, bailing out of the loop and skipping every later sibling. As a result most
  nested `.c`/`.h` files under `src/` and `deps/` were never registered as
  `rerun-if-changed` inputs, so real C changes could fail to trigger a rebuild.

  **Fix:** propagate errors with `?` and continue iterating over the rest of the
  directory.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script and dependency-tracking only; no runtime, API, or serialization behavior changes.
> 
> **Overview**
> Fixes **Cargo rebuild loops** in `redisearch_rs` where `ffi` (and downstream crates) recompiled on every `cargo build` / `cargo test` with no source changes.
> 
> In **`ffi/build.rs`**, `rerun_if_c_changes` no longer watches the **staged generated headers under `OUT_DIR`**. Those files are copied by the build script, so their mtimes always look “new” to Cargo and previously re-triggered bindgen every run. **Source** cheadergen headers remain on `rerun-if-changed`.
> 
> In **`build_utils`**, `rerun_if_changes` **skips directories containing `CACHEDIR.TAG`** (e.g. `target` under scanned `src/`) so sweeps do not register build artifacts as inputs. It also **walks all subdirectories** instead of returning after the first child, so nested `.c`/`.h` files actually get `rerun-if-changed` and real C edits trigger rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d5ddd0abf7a7973fa8cb5a15eedf6d3f59aa30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->