### PR TITLE
MOD-16009: use redis `loglevel` as source of truth for rust logging too

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4799,7 +4799,10 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_ERR;
   }
 
-  TracingRedisModule_Init(ctx);
+  RedisModuleString *logLevel = getRedisConfigValue(ctx, "loglevel");
+  RS_ASSERT(logLevel);
+  TracingRedisModule_Init(ctx, RedisModule_StringPtrLen(logLevel, NULL));
+  RedisModule_FreeString(ctx, logLevel);
   RustPanicHook_Init();
 
   setHiredisAllocators();

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -22,6 +22,7 @@
 #include "search_disk.h"
 #include "doc_id_meta.h"
 #include "iterators_ffi.h"
+#include "module_init_ffi.h"
 
 #define JSON_LEN 5 // length of string "json."
 RedisModuleString *global_RenameFromKey = NULL;
@@ -557,6 +558,7 @@ void ShutdownDiskClose(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subev
 
 #define HIDE_USER_DATA_FROM_LOGS "hide-user-data-from-log"
 #define BIGREDIS_MAX_RAM "bigredis-max-ram"
+#define REDIS_LOGLEVEL "loglevel"
 
 bool getHideUserDataFromLogs() {
   return getRedisConfigBool(RSDummyContext, HIDE_USER_DATA_FROM_LOGS, false);
@@ -574,6 +576,15 @@ void onUpdatedHideUserDataFromLogs(RedisModuleCtx *ctx) {
   }
 }
 
+static void onUpdatedLogLevel(RedisModuleCtx *ctx) {
+  RedisModuleString *level = getRedisConfigValue(ctx, REDIS_LOGLEVEL);
+  if (!level) {
+    return;
+  }
+  TracingRedisModule_SetLogLevel(RedisModule_StringPtrLen(level, NULL));
+  RedisModule_FreeString(ctx, level);
+}
+
 void ConfigChangedCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t event, void *data) {
   if (eid.id != REDISMODULE_EVENT_CONFIG ||
       event != REDISMODULE_SUBEVENT_CONFIG_CHANGE) {
@@ -588,6 +599,9 @@ void ConfigChangedCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t e
     if (!strcmp(conf, BIGREDIS_MAX_RAM)) {
       RS_ASSERT(SearchDisk_IsInitialized());
       SearchDisk_UpdateBufferBudget(ctx, (int)RSGlobalConfig.diskBufferPercentage);
+    }
+    if (strcmp(conf, REDIS_LOGLEVEL) == 0) {
+      onUpdatedLogLevel(ctx);
     }
   }
 }

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/src/lib.rs
@@ -7,12 +7,63 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ffi::{CStr, c_char};
 use std::ptr::NonNull;
+use tracing::level_filters::LevelFilter;
+
+/// Parses a redis `loglevel` config value into a `tracing` level.
+///
+/// # Panics
+///
+/// Panics if `level` is not valid UTF-8, or is not one of the redis log levels
+/// `debug`, `verbose`, `notice`, or `warning`.
+///
+/// # Safety
+///
+/// `level` must point to a valid, null-terminated C string.
+unsafe fn parse_level(level: *const c_char) -> LevelFilter {
+    // Safety: the caller guarantees a valid, null-terminated C string.
+    let level = unsafe { CStr::from_ptr(level) };
+    let level = level.to_str().expect("redis loglevel must be valid UTF-8");
+
+    match level {
+        "debug" => LevelFilter::TRACE,
+        "verbose" => LevelFilter::DEBUG,
+        "notice" => LevelFilter::INFO,
+        "warning" => LevelFilter::WARN,
+        "nothing" => LevelFilter::OFF,
+        other => panic!("invalid redis loglevel: {other:?}"),
+    }
+}
 
 /// Initializes a global subscriber that reports Rust `tracing` traces through `redismodule` logging.
+///
+/// `level` is the initial redis `loglevel` config value the filter is set to.
+///
+/// # Safety
+///
+/// `level` must point to a valid, null-terminated C string.
 #[unsafe(no_mangle)]
-pub extern "C" fn TracingRedisModule_Init(ctx: Option<NonNull<ffi::RedisModuleCtx>>) {
-    tracing_redismodule::init(ctx);
+pub unsafe extern "C" fn TracingRedisModule_Init(
+    ctx: Option<NonNull<ffi::RedisModuleCtx>>,
+    level: *const c_char,
+) {
+    // Safety: forwarded to the caller's contract on `level`.
+    let level = unsafe { parse_level(level) };
+    tracing_redismodule::init(ctx, level);
+}
+
+/// Updates the `tracing` log level filter from a redis `loglevel` config value
+/// (one of `debug`, `verbose`, `notice`, `warning`).
+///
+/// # Safety
+///
+/// `level` must point to a valid, null-terminated C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn TracingRedisModule_SetLogLevel(level: *const c_char) {
+    // Safety: forwarded to the caller's contract on `level`.
+    let level = unsafe { parse_level(level) };
+    tracing_redismodule::set_log_level(level);
 }
 
 /// Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).

--- a/src/redisearch_rs/headers/module_init_ffi.h
+++ b/src/redisearch_rs/headers/module_init_ffi.h
@@ -15,8 +15,24 @@ extern "C" {
 
 /**
  * Initializes a global subscriber that reports Rust `tracing` traces through `redismodule` logging.
+ *
+ * `level` is the initial redis `loglevel` config value the filter is set to.
+ *
+ * # Safety
+ *
+ * `level` must point to a valid, null-terminated C string.
  */
-void TracingRedisModule_Init(RedisModuleCtx *ctx);
+void TracingRedisModule_Init(RedisModuleCtx *ctx, const char *level);
+
+/**
+ * Updates the `tracing` log level filter from a redis `loglevel` config value
+ * (one of `debug`, `verbose`, `notice`, `warning`).
+ *
+ * # Safety
+ *
+ * `level` must point to a valid, null-terminated C string.
+ */
+void TracingRedisModule_SetLogLevel(const char *level);
 
 /**
  * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).

--- a/src/redisearch_rs/tracing_redismodule/src/lib.rs
+++ b/src/redisearch_rs/tracing_redismodule/src/lib.rs
@@ -11,32 +11,13 @@
 //!
 //! # Configuring Logging Output
 //!
-//! Logging output can be configured by setting the `RUST_LOG` environment variable to a _filter_.
-//! A filter consists of one or more comma-separated directives which match on `Span`s and `Event`s.
-//! Each directive may have a corresponding maximum verbosity [`level`] which enables (e.g., _selects for_)
-//! spans and events that match. Like `log`, `tracing` considers less exclusive levels (like `trace` or `info`)
-//! to be more verbose than more exclusive levels (like `error` or `warn`).
+//! The maximum verbosity is set by the redis server `loglevel` config option. Its values map
+//! onto `tracing` [`level`]s as follows:
 //!
-//! At a high level, the syntax for directives consists of several parts:
-//!
-//! ```text
-//! target[span{field=value}]=level
-//! ```
-//!
-//! - `target` matches the event or span's target. In general, this is the module path and/or crate name.
-//!   Examples of targets `h2`, `tokio::net`, or `tide::server`. For more information on targets,
-//!   please refer to [`Metadata`]'s documentation.
-//! - `span` matches on the span's name. If a `span` directive is provided alongside a `target`,
-//!   the `span` directive will match on spans _within_ the `target`.
-//! - `field` matches on fields within spans. Field names can also be supplied without a `value`
-//!   and will match on any `Span` or `Event` that has a field with that name.
-//!   For example: `[span{field=\"value\"}]=debug`, `[{field}]=trace`.
-//! - `value` matches on the value of a span's field. If a value is a numeric literal or a bool,
-//!   it will match _only_ on that value. Otherwise, this filter matches the
-//!   [`std::fmt::Debug`] output from the value.
-//! - `level` sets a maximum verbosity level accepted by this directive.
-//!
-//! For details see the [`tracing_subscriber`] documentation.
+//! - `debug` => [`Level::TRACE`]
+//! - `verbose` => [`Level::DEBUG`]
+//! - `notice` => [`Level::INFO`]
+//! - `warning` => [`Level::WARN`] (and [`Level::ERROR`])
 //!
 //! ## Output Styling
 //!
@@ -49,8 +30,6 @@
 //! - `never` will never print style characters.
 //!
 //! [`level`]: tracing_core::Level
-//! [`Metadata`]: tracing_core::Metadata
-//! [`tracing_subscriber`]: https://docs.rs/tracing-subscriber/0.3.20/tracing_subscriber/filter/struct.EnvFilter.html#directives
 
 use std::cell::RefCell;
 use std::env::{self, VarError};
@@ -58,17 +37,26 @@ use std::error::Error;
 use std::ffi::{CStr, c_char};
 use std::io::IsTerminal;
 use std::ptr::NonNull;
+use std::sync::OnceLock;
 use std::{io, ptr};
 use tracing::Level;
 use tracing_core::LevelFilter;
-use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{Registry, reload};
 
 const LOGLEVEL_DEBUG: &CStr = c"debug";
 const LOGLEVEL_VERBOSE: &CStr = c"verbose";
 const LOGLEVEL_NOTICE: &CStr = c"notice";
 const LOGLEVEL_WARNING: &CStr = c"warning";
+
+/// Handle to the reloadable level filter, installed by [`try_init`].
+///
+/// Used by [`set_log_level`] to update the active filter when the redis
+/// `loglevel` config changes.
+static FILTER_RELOAD: OnceLock<reload::Handle<LevelFilter, Registry>> = OnceLock::new();
 
 type LogFunc = unsafe extern "C" fn(
     ctx: *mut ffi::RedisModuleCtx,
@@ -78,12 +66,16 @@ type LogFunc = unsafe extern "C" fn(
 );
 
 /// Initializes a global subscriber that reports traces through `redismodule` logging.
-pub fn init(ctx: Option<NonNull<ffi::RedisModuleCtx>>) {
-    try_init(ctx).expect("Unable to install global tracing subscriber")
+///
+/// `level` is the initial maximum verbosity the filter is set to.
+pub fn init(ctx: Option<NonNull<ffi::RedisModuleCtx>>, filter: LevelFilter) {
+    try_init(ctx, filter).expect("Unable to install global tracing subscriber")
 }
 
 /// Initializes a global subscriber that reports traces through `redismodule`
 ///  logging if one is not already set.
+///
+/// `level` is the initial maximum verbosity the filter is set to.
 ///
 /// # Errors
 ///
@@ -91,18 +83,16 @@ pub fn init(ctx: Option<NonNull<ffi::RedisModuleCtx>>) {
 /// a global subscriber was already installed by another call to `try_init`.
 pub fn try_init(
     ctx: Option<NonNull<ffi::RedisModuleCtx>>,
+    filter: LevelFilter,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let env_filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
-        .from_env_lossy();
+    let (filter, reload_handle) = reload::Layer::new(filter);
 
-    tracing_subscriber::fmt()
+    let fmt = tracing_subscriber::fmt::Layer::default()
         .with_file(true)
         .with_line_number(true)
         .with_thread_names(true)
         .with_thread_ids(true)
         .with_span_events(FmtSpan::FULL)
-        .with_env_filter(env_filter)
         .with_ansi(should_print_colors())
         .without_time() // redis already prints timestamps
         .with_writer(MakeRedisModuleWriter {
@@ -117,12 +107,27 @@ pub fn try_init(
             }),
             // Safety: This static will not be written to after it has been initialized
             log: unsafe { ffi::RedisModule_Log.unwrap() },
-        })
+        });
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt)
         .try_init()?;
+
+    let _ = FILTER_RELOAD.set(reload_handle);
 
     tracing::debug!("Tracing Subscriber Initialized!");
 
     Ok(())
+}
+
+/// Updates the active maximum verbosity of the log filter.
+///
+/// Has no effect if the subscriber is not installed yet.
+pub fn set_log_level(filter: LevelFilter) {
+    if let Some(reload_handle) = FILTER_RELOAD.get() {
+        let _ = reload_handle.reload(filter);
+    }
 }
 
 fn should_print_colors() -> bool {
@@ -166,11 +171,7 @@ impl<'a> MakeWriter<'a> for MakeRedisModuleWriter {
     type Writer = RedisModuleWriter;
 
     fn make_writer(&'a self) -> Self::Writer {
-        RedisModuleWriter {
-            ctx: self.ctx,
-            level: LOGLEVEL_NOTICE,
-            log: self.log,
-        }
+        unreachable!("must always be configured with a log level");
     }
 
     fn make_writer_for(&'a self, meta: &tracing::Metadata<'_>) -> Self::Writer {

--- a/tests/pytests/test_tracing.py
+++ b/tests/pytests/test_tracing.py
@@ -1,80 +1,58 @@
-from RLTest import Env
-
 from common import *
 from includes import *
+from RLTest import Env
+from RLTest.env import Defaults
+
+INIT_MESSAGE = "Tracing Subscriber Initialized!"
 
 
-# Assert that by default "init message" is hidden
-def test_default_level(env):
+def _log_has_init_message(env):
     logDir = env.cmd("config", "get", "dir")[1]
     logFileName = env.cmd("CONFIG", "GET", "logfile")[1]
     logFilePath = os.path.join(logDir, logFileName)
-    matchCount = _grep_file_count(logFilePath, "Tracing Subscriber Initialized!")
-    env.assertEqual(
-        matchCount, 0, message="tracing subscriber message present for default level"
-    )
-
-
-# Assert that we can set the `RUST_LOG` env var to enable the "init message"s level
-def test_trace_level():
-    with EnvContextManager(RUST_LOG="trace"):
-        env = Env()
-        logDir = env.cmd("config", "get", "dir")[1]
-        logFileName = env.cmd("CONFIG", "GET", "logfile")[1]
-        logFilePath = os.path.join(logDir, logFileName)
-        matchCount = _grep_file_count(logFilePath, "Tracing Subscriber Initialized!")
-        env.assertEqual(matchCount, 1, message="missing tracing subscriber message")
-
-
-# Assert that we can disable log message sources (in this case the subscriber itseflf)
-def test_ignore_crate():
-    with EnvContextManager(RUST_LOG="trace,tracing_redismodule=off"):
-        env = Env()
-        logDir = env.cmd("config", "get", "dir")[1]
-        logFileName = env.cmd("CONFIG", "GET", "logfile")[1]
-        logFilePath = os.path.join(logDir, logFileName)
-        matchCount = _grep_file_count(logFilePath, "Tracing Subscriber Initialized!")
-        env.assertEqual(
-            matchCount,
-            0,
-            message="tracing subscriber message even though source was disabled",
-        )
-
-
-class EnvContextManager:
-    def __init__(self, **kwargs):
-        self.env_vars = kwargs
-
-    def __enter__(self):
-        self.old_env = dict(os.environ)
-        os.environ.update(self.env_vars)
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        os.environ.clear()
-        os.environ.update(self.old_env)
-
-
-def _grep_file_count(filename, pattern):
-    """
-    Grep a file for a given pattern using python.
-
-    Args:
-        filename (str): The path to the file to grep.
-        pattern (str): The pattern to search for.
-
-    Returns:
-        int: The number of lines that match the pattern.
-    """
     try:
-        with open(filename, "r") as f:
-            count = 0
-            for line in f:
-                if pattern in line:
-                    count += 1
-            return count
+        with open(logFilePath) as f:
+            return any(INIT_MESSAGE in line for line in f)
     except FileNotFoundError:
-        print(f"Error: File not found: {filename}")
-        return 0
-    except Exception as e:
-        print(f"Error: {e}")
-        return 0
+        return False
+
+
+# creates an RLTest Env configured with the given loglevel.
+def _env_with_loglevel(level):
+    Defaults.loglevel = level
+    logDir = os.path.join(Defaults.logdir, f"test_tracing_loglevel_{level}")
+    # force a brand-new env bc RLTests default env comparison doesn't include the loglevel
+    # also force logs into prefixed logdirs so they don't trample on one another
+    return Env(freshEnv=True, logDir=logDir)
+
+
+# The redis `loglevel` is read at module load and drives the tracing filter.
+# The init message is a DEBUG-level log, so it should only show for "debug" or "verbose"
+@skip(cluster=True)
+def test_initial_level_filtering():
+    saved_loglevel = Defaults.loglevel
+    try:
+        env = _env_with_loglevel("debug")
+        env.assertTrue(_log_has_init_message(env), message="debug")
+        env.stop()
+
+        env = _env_with_loglevel("verbose")
+        env.assertTrue(_log_has_init_message(env), message="verbose")
+        env.stop()
+
+        env = _env_with_loglevel("notice")
+        env.assertFalse(_log_has_init_message(env), message="notice")
+        env.stop()
+
+        env = _env_with_loglevel("warning")
+        env.assertFalse(_log_has_init_message(env), message="warning")
+        env.stop()
+    finally:
+        Defaults.loglevel = saved_loglevel
+
+
+# Each accepted `loglevel` must reload the filter without crashing the module.
+def test_loglevel_reload(env):
+    for level in ("debug", "verbose", "notice", "warning"):
+        env.expect("CONFIG", "SET", "loglevel", level).ok()
+    env.assertTrue(env.cmd("PING"))


### PR DESCRIPTION
We previously configured the rust log level separately from the C log level. This change brings Rust in-line by reading & subscribing to the redis `loglevel` config value

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging verbosity only; no changes to search, auth, or data paths beyond how Rust traces are filtered and emitted.
> 
> **Overview**
> Rust **`tracing`** output now follows the Redis server **`loglevel`** instead of **`RUST_LOG`**.
> 
> On load, **`RedisModule_OnLoad`** reads **`loglevel`** and passes it into **`TracingRedisModule_Init`**. **`ConfigChangedCallback`** in **`notifications.c`** reacts to **`CONFIG SET loglevel`** and calls **`TracingRedisModule_SetLogLevel`**, which maps Redis levels (`debug`, `verbose`, `notice`, `warning`, `nothing`) to **`tracing`** filters via a reloadable layer in **`tracing_redismodule`**. Tests were updated to assert filtering at startup and after live config changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a40a498c4d557aec7c01c296d097b8290a2c648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->