### PR TITLE
ci: skip redis-server build on skip-tests jobs

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -346,6 +346,7 @@ jobs:
           echo "LD=$CLANG_BIN" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-$CLANG_VERSION/bin/llvm-symbolizer" >> $GITHUB_ENV
       - name: Build Redis (cached)
+        if: ${{ !inputs.skip-tests }}
         uses: ./.github/actions/build-redis
         with:
           ref: ${{ inputs.redis-ref }}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** In `task-test.yml`, the `Build Redis (cached)` step always runs, regardless of whether the job will actually exercise `redis-server`. The merge-queue `build-unique-oses` matrix (macos-26, alpine:3.23, intel) uses `options: skip-tests,fail-fast` — it builds the module to verify cross-platform compilation but never runs tests against Redis.
2. **Change:** Gate the `Build Redis (cached)` step on `!inputs.skip-tests`.
3. **Outcome:** Build-only matrix entries (notably the three merge-queue platforms above) skip the cache restore / Redis build entirely. On cache hit this saves the restore + PATH setup (~tens of seconds per platform); on cache miss it avoids a multi-minute Redis build that would never be used.

#### Which additional issues this PR fixes
_None_

#### Main objects this PR modified
1. `.github/workflows/task-test.yml` — add `if: \${{ !inputs.skip-tests }}` to the `Build Redis (cached)` step.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; test jobs that run tests still build Redis unchanged.
> 
> **Overview**
> Skips the **Build Redis (cached)** step in the shared `task-test` workflow when `skip-tests` is set, so build-only jobs no longer restore or compile `redis-server`.
> 
> That aligns Redis setup with jobs that only compile the module (e.g. merge-queue **build-unique-oses** on macOS, Alpine, and Intel with `options: skip-tests,fail-fast`), cutting unused cache work and avoiding long Redis builds on cache miss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5a97d4c95d765e514fe63d18943c8af2d4a2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->