### PR TITLE
docs: add --no-track to worktree command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,10 +256,10 @@ on an unrelated branch, or already tied to another open PR, automatically create
 worktree and do the work there. Use the existing checkout only when it is already the right clean
 branch for the task.
 
-Always use `-b` when creating a worktree — git forbids two worktrees on the same branch, so checking out `master` directly will fail when master is already the main checkout. Prefix the branch with your handle (e.g. `alice-`, `bob-`) to avoid collisions on the shared remote:
+Always use `-b` when creating a worktree — git forbids two worktrees on the same branch, so checking out `master` directly will fail when master is already the main checkout. Prefix the branch with your handle (e.g. `alice-`, `bob-`) to avoid collisions on the shared remote. Pass `--no-track` so the new branch does not inherit `origin/master` as its upstream — otherwise a later `git push --force` without an explicit target can try to force-push the feature branch onto master:
 
 ```bash
-git worktree add -b <your-handle>-<feature> .claude/worktrees/<your-handle>-<feature> origin/master
+git worktree add --no-track -b <your-handle>-<feature> .claude/worktrees/<your-handle>-<feature> origin/master
 ```
 
 To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules).


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The documented worktree command (`git worktree add -b <branch> ... origin/master`) leaves the new branch with `origin/master` set as its upstream, because git's default `branch.autoSetupMerge=true` wires up tracking from the start-point.
2. **Change**: Add `--no-track` to the command and a sentence explaining why.
3. **Outcome**: New branches created by following this doc no longer carry `origin/master` as upstream, so a later `git push --force` without an explicit target cannot accidentally force-push the feature branch onto master.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `AGENTS.md` (and `CLAUDE.md` symlink) — worktree-creation snippet

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime or API impact.
> 
> **Overview**
> Updates the agent workflow docs so the recommended **feature worktree** command uses `git worktree add --no-track` alongside `-b` and a handle-prefixed branch name.
> 
> The new note explains that without `--no-track`, Git can set **`origin/master`** as the new branch’s upstream (via default merge tracking from the start-point), which makes a later bare **`git push --force`** dangerous because it may target master instead of the feature branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386fc7f95e0fbbbd8c5a399ed819d7a116966649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->