### PR TITLE
[MOD-15394] [MOD-16228] Fix FT.HYBRID coordinator hang when a shard command fails to dispatch

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -179,7 +179,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // aggregateIteratorContext_Free
   // Use aggregateNetCursorCallback to properly extract ShardResponseBarrier
   // from AggregateIteratorContext
-  MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, aggregateNetCursorCallback, iterCtx,
+  MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, aggregateNetCursorCallback, NULL, iterCtx,
                                               aggregateIteratorContext_Free,
                                               aggregateIteratorContext_Init,
                                               cmdModifier, iterStartCb, NULL);

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -179,10 +179,14 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // aggregateIteratorContext_Free
   // Use aggregateNetCursorCallback to properly extract ShardResponseBarrier
   // from AggregateIteratorContext
-  MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, aggregateNetCursorCallback, NULL, iterCtx,
-                                              aggregateIteratorContext_Free,
-                                              aggregateIteratorContext_Init,
-                                              cmdModifier, iterStartCb, NULL);
+  MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
+    .cb = aggregateNetCursorCallback,
+    .cbPrivateData = iterCtx,
+    .cbPrivateDataDestructor = aggregateIteratorContext_Free,
+    .cbPrivateDataInit = aggregateIteratorContext_Init,
+    .commandModifier = cmdModifier,
+    .iterStartCb = iterStartCb,
+  });
 
   if (!it) {
     // Iterator never started, so no callbacks are running and the iterator did

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -180,7 +180,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // Use aggregateNetCursorCallback to properly extract ShardResponseBarrier
   // from AggregateIteratorContext
   MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
-    .cb = aggregateNetCursorCallback,
+    .successCB = aggregateNetCursorCallback,
     .cbPrivateData = iterCtx,
     .cbPrivateDataDestructor = aggregateIteratorContext_Free,
     .cbPrivateDataInit = aggregateIteratorContext_Init,

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -310,7 +310,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // with the actual shard count from the live topology, preventing use-after-free
     // when topology changes during shard migration.
     MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
-        .cb = processCursorMappingCallback,
+        .successCB = processCursorMappingCallback,
         .errorCB = processCursorMappingErrorCallback,
         .cbPrivateData = ctx,
         .cbPrivateDataInit = processCursorMappingInit,

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -213,6 +213,35 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
     MRReply_Free(rep);
 }
 
+// Error callback: invoked by the MR layer when a shard command terminates without
+// delivering a reply (connection dropped / NULL reply, or a synchronous send
+// failure). Unlike FT.SEARCH/FT.AGGREGATE — which track completion via iterator
+// depletion — ProcessHybridCursorMappings waits on a private responseCount, which
+// only processCursorMappingCallback ever increments. Without notifying here, the
+// failing shard would never be counted and the coordinator would block on
+// completionCond forever (the hang in MOD-15394); and even if it unblocked, it
+// would silently return partial cursor mappings. Record a communication error and
+// bump responseCount so the wait loop completes and surfaces the failure.
+//
+// Mirrors the locked section of processCursorMappingCallback. Per the
+// MRIteratorErrorCallback contract, this only notifies — the MR layer calls
+// MRIteratorCallback_Done after this returns.
+static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
+    processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
+    RS_ASSERT(cb_ctx);
+
+    pthread_mutex_lock(cb_ctx->mutex);
+    cb_ctx->responseCount++;
+    QueryError error = QueryError_Default();
+    QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
+    // Matches CLUSTER_QUERY_ERROR in rmr.c, so a post-validation connection drop is
+    // reported identically to the pre-fanout connection-validation failure.
+    QueryError_SetDetail(&error, "Could not send query to cluster");
+    cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
+    pthread_cond_signal(cb_ctx->completionCond);
+    pthread_mutex_unlock(cb_ctx->mutex);
+}
+
 // Init callback for the private data, so that numShards is set to the actual number of shards in the cluster, and the expected responses.
 static void processCursorMappingInit(void *privateData, const MRIterator *it) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
@@ -292,6 +321,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // with the actual shard count from the live topology, preventing use-after-free
     // when topology changes during shard migration.
     MRIterator *it = MR_IterateWithPrivateData(cmd, processCursorMappingCallback,
+                                               processCursorMappingErrorCallback,
                                                ctx, NULL, processCursorMappingInit,
                                                cmdModifier, iterStartCb, NULL);
     if (!it) {

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -224,8 +224,8 @@ static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     cb_ctx->responseCount++;
     QueryError error = QueryError_Default();
     QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
-    // Matches CLUSTER_QUERY_ERROR in rmr.c (pre-fanout connection-validation failure).
-    QueryError_SetDetail(&error, "Could not send query to cluster");
+    // Shared with the MR iterator no-reply path (pre-fanout connection-validation failure).
+    QueryError_SetDetail(&error, CLUSTER_QUERY_ERROR);
     cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
     pthread_cond_signal(cb_ctx->completionCond);
     pthread_mutex_unlock(cb_ctx->mutex);

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -213,19 +213,9 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
     MRReply_Free(rep);
 }
 
-// Error callback: invoked by the MR layer when a shard command terminates without
-// delivering a reply (connection dropped / NULL reply, or a synchronous send
-// failure). Unlike FT.SEARCH/FT.AGGREGATE — which track completion via iterator
-// depletion — ProcessHybridCursorMappings waits on a private responseCount, which
-// only processCursorMappingCallback ever increments. Without notifying here, the
-// failing shard would never be counted and the coordinator would block on
-// completionCond forever (the hang in MOD-15394); and even if it unblocked, it
-// would silently return partial cursor mappings. Record a communication error and
-// bump responseCount so the wait loop completes and surfaces the failure.
-//
-// Mirrors the locked section of processCursorMappingCallback. Per the
-// MRIteratorErrorCallback contract, this only notifies — the MR layer calls
-// MRIteratorCallback_Done after this returns.
+// No-reply error callback: bumps responseCount and records a communication
+// error so the wait loop below (which keys completion off responseCount, not
+// iterator depletion) unblocks instead of hanging (MOD-15394).
 static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
     RS_ASSERT(cb_ctx);
@@ -234,8 +224,7 @@ static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     cb_ctx->responseCount++;
     QueryError error = QueryError_Default();
     QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
-    // Matches CLUSTER_QUERY_ERROR in rmr.c, so a post-validation connection drop is
-    // reported identically to the pre-fanout connection-validation failure.
+    // Matches CLUSTER_QUERY_ERROR in rmr.c (pre-fanout connection-validation failure).
     QueryError_SetDetail(&error, "Could not send query to cluster");
     cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
     pthread_cond_signal(cb_ctx->completionCond);

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -309,10 +309,14 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // processCursorMappingInit is called from iterStartCb to update ctx->numShards
     // with the actual shard count from the live topology, preventing use-after-free
     // when topology changes during shard migration.
-    MRIterator *it = MR_IterateWithPrivateData(cmd, processCursorMappingCallback,
-                                               processCursorMappingErrorCallback,
-                                               ctx, NULL, processCursorMappingInit,
-                                               cmdModifier, iterStartCb, NULL);
+    MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
+        .cb = processCursorMappingCallback,
+        .errorCB = processCursorMappingErrorCallback,
+        .cbPrivateData = ctx,
+        .cbPrivateDataInit = processCursorMappingInit,
+        .commandModifier = cmdModifier,
+        .iterStartCb = iterStartCb,
+    });
     if (!it) {
         // Cleanup on error
         QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to communicate with shards");

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -215,7 +215,7 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
 
 // No-reply error callback: bumps responseCount and records a communication
 // error so the wait loop below (which keys completion off responseCount, not
-// iterator depletion) unblocks instead of hanging (MOD-15394).
+// iterator depletion) unblocks instead of hanging.
 static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
     RS_ASSERT(cb_ctx);

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -42,7 +42,7 @@ int MRCluster_SendCommand(IORuntimeCtx *ioRuntime,
                           redisCallbackFn *fn,
                           void *privdata) {
 #ifdef ENABLE_ASSERT
-  // Test-only: simulate a no-reply dispatch failure (MOD-15394).
+  // Test-only: simulate a no-reply dispatch failure.
   if (DebugSendError_Consume()) {
     return REDIS_ERR;
   }

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -12,6 +12,7 @@
 
 #include <stdlib.h>
 #include "rq.h"
+#include "debug_commands.h"  // DebugSendError_Consume (ENABLE_ASSERT fault injection)
 
 /* Initialize the MapReduce engine with a node provider */
 MRCluster *MR_NewCluster(MRClusterTopology *initialTopology, size_t conn_pool_size, size_t num_io_threads) {
@@ -40,6 +41,13 @@ int MRCluster_SendCommand(IORuntimeCtx *ioRuntime,
                           MRCommand *cmd,
                           redisCallbackFn *fn,
                           void *privdata) {
+#ifdef ENABLE_ASSERT
+  // Test-only: simulate a shard connection that drops/errors after pre-fanout
+  // validation, so the dispatch fails without a reply ever arriving (MOD-15394).
+  if (DebugSendError_Consume()) {
+    return REDIS_ERR;
+  }
+#endif
   MRConn *conn = MRCluster_GetConn(ioRuntime, cmd);
   if (!conn) return REDIS_ERR;
   return MRConn_SendCommand(conn, cmd, fn, privdata);

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -12,7 +12,7 @@
 
 #include <stdlib.h>
 #include "rq.h"
-#include "debug_commands.h"  // DebugSendError_Consume
+#include "debug_commands.h"
 
 /* Initialize the MapReduce engine with a node provider */
 MRCluster *MR_NewCluster(MRClusterTopology *initialTopology, size_t conn_pool_size, size_t num_io_threads) {

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -12,7 +12,7 @@
 
 #include <stdlib.h>
 #include "rq.h"
-#include "debug_commands.h"  // DebugSendError_Consume (ENABLE_ASSERT fault injection)
+#include "debug_commands.h"  // DebugSendError_Consume
 
 /* Initialize the MapReduce engine with a node provider */
 MRCluster *MR_NewCluster(MRClusterTopology *initialTopology, size_t conn_pool_size, size_t num_io_threads) {
@@ -42,8 +42,7 @@ int MRCluster_SendCommand(IORuntimeCtx *ioRuntime,
                           redisCallbackFn *fn,
                           void *privdata) {
 #ifdef ENABLE_ASSERT
-  // Test-only: simulate a shard connection that drops/errors after pre-fanout
-  // validation, so the dispatch fails without a reply ever arriving (MOD-15394).
+  // Test-only: simulate a no-reply dispatch failure (MOD-15394).
   if (DebugSendError_Consume()) {
     return REDIS_ERR;
   }

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -615,6 +615,7 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
 struct MRIteratorCtx {
   MRChannel *chan;
   MRIteratorCallback cb;
+  MRIteratorErrorCallback errorCB;  // Optional: notify caller's completion tracking on a no-reply error
   short pending;    // Number of shards with more results (not depleted)
   short inProcess;  // Number of currently running commands on shards
   bool timedOut;    // whether the coordinator experienced a timeout
@@ -639,12 +640,28 @@ struct MRIterator {
   size_t len;
 };
 
+// Terminate a shard command that produced no reply for the success callback
+// (a NULL async reply because the connection dropped/errored, or a synchronous
+// send failure). First notify the caller's own completion tracking via the
+// optional errorCB, then perform the iterator's bookkeeping. errorCB must only
+// notify; it must not free the iterator nor call MRIteratorCallback_Done (this
+// function owns that). When errorCB is NULL the behavior is exactly the historical
+// one: a plain MRIteratorCallback_Done.
+//
+// Callers that key completion off a private counter (e.g. ProcessHybridCursorMappings)
+// register an errorCB; otherwise the shard's failure would never be counted and the
+// caller would wait on its completion condition forever (see MOD-15394).
+static void mrIteratorCallback_Error(MRIteratorCallbackCtx *ctx) {
+  if (ctx->it->ctx.errorCB) {
+    ctx->it->ctx.errorCB(ctx);
+  }
+  MRIteratorCallback_Done(ctx, 1);
+}
+
 static void mrIteratorRedisCB(redisAsyncContext *c, void *r, void *privdata) {
   MRIteratorCallbackCtx *ctx = privdata;
   if (!r) {
-    MRIteratorCallback_Done(ctx, 1);
-    // ctx->numErrored++;
-    // TODO: report error
+    mrIteratorCallback_Error(ctx);
   } else {
     ctx->it->ctx.cb(ctx, r);
   }
@@ -802,7 +819,7 @@ void iterStartCb(void *p) {
   for (size_t i = 0; i < numShards; i++) {
     if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd, mrIteratorRedisCB, &it->cbxs[i]) ==
         REDIS_ERR) {
-      MRIteratorCallback_Done(&it->cbxs[i], 1);
+      mrIteratorCallback_Error(&it->cbxs[i]);
     }
   }
 
@@ -871,7 +888,7 @@ void iterCursorMappingCb(void *p) {
   for (size_t i = 0; i < numShardsWithMapping; i++) {
     if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
                               mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
-      MRIteratorCallback_Done(&it->cbxs[i], 1);
+      mrIteratorCallback_Error(&it->cbxs[i]);
     }
   }
 
@@ -888,7 +905,7 @@ void iterManualNextCb(void *p) {
     if (!it->cbxs[i].cmd.depleted) {
       if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
                                 mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
-        MRIteratorCallback_Done(&it->cbxs[i], 1);
+        mrIteratorCallback_Error(&it->cbxs[i]);
       }
     }
   }
@@ -925,7 +942,8 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   return channelSize > 0;
 }
 
-MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
+MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb,
+                                      MRIteratorErrorCallback errorCB, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
                                       void (*cbPrivateDataInit)(void *, const MRIterator *),
                                       MRCommandModifier commandModifier,
@@ -943,6 +961,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
     .ctx = {
       .chan = MR_NewChannel(),
       .cb = cb,
+      .errorCB = errorCB,
       .pending = 1,
       .inProcess = 1,
       .timedOut = false,

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -47,7 +47,7 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
-#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
+// CLUSTER_QUERY_ERROR is defined in rmr.h and shared with the hybrid error path.
 
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -47,8 +47,7 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
-// Declared extern in rmr.h; shared with the hybrid cursor-mapping error path.
-const char CLUSTER_QUERY_ERROR[] = "Could not send query to cluster";
+// CLUSTER_QUERY_ERROR is defined in rmr.h and shared with the hybrid error path.
 
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -615,7 +615,7 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
 struct MRIteratorCtx {
   MRChannel *chan;
   MRIteratorCallback cb;
-  MRIteratorErrorCallback errorCB;  // Optional: notify caller's completion tracking on a no-reply error
+  MRIteratorErrorCallback errorCB;  // Optional: notify caller on no-reply termination
   short pending;    // Number of shards with more results (not depleted)
   short inProcess;  // Number of currently running commands on shards
   bool timedOut;    // whether the coordinator experienced a timeout
@@ -640,17 +640,10 @@ struct MRIterator {
   size_t len;
 };
 
-// Terminate a shard command that produced no reply for the success callback
-// (a NULL async reply because the connection dropped/errored, or a synchronous
-// send failure). First notify the caller's own completion tracking via the
-// optional errorCB, then perform the iterator's bookkeeping. errorCB must only
-// notify; it must not free the iterator nor call MRIteratorCallback_Done (this
-// function owns that). When errorCB is NULL the behavior is exactly the historical
-// one: a plain MRIteratorCallback_Done.
-//
-// Callers that key completion off a private counter (e.g. ProcessHybridCursorMappings)
-// register an errorCB; otherwise the shard's failure would never be counted and the
-// caller would wait on its completion condition forever (see MOD-15394).
+// No-reply termination path: invoke the caller's optional errorCB (notify-only)
+// before the iterator's MRIteratorCallback_Done. Without this hook callers that
+// wait on a private counter (e.g. ProcessHybridCursorMappings) would hang
+// (MOD-15394).
 static void mrIteratorCallback_Error(MRIteratorCallbackCtx *ctx) {
   if (ctx->it->ctx.errorCB) {
     ctx->it->ctx.errorCB(ctx);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -47,7 +47,8 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
-// CLUSTER_QUERY_ERROR is defined in rmr.h and shared with the hybrid error path.
+// Declared extern in rmr.h; shared with the hybrid cursor-mapping error path.
+const char CLUSTER_QUERY_ERROR[] = "Could not send query to cluster";
 
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;
@@ -642,8 +643,7 @@ struct MRIterator {
 
 // No-reply termination path: invoke the caller's optional errorCB (notify-only)
 // before the iterator's MRIteratorCallback_Done. Without this hook callers that
-// wait on a private counter (e.g. ProcessHybridCursorMappings) would hang
-// (MOD-15394).
+// wait on a private counter (e.g. ProcessHybridCursorMappings) would hang.
 static void mrIteratorCallback_Error(MRIteratorCallbackCtx *ctx) {
   if (ctx->it->ctx.errorCB) {
     ctx->it->ctx.errorCB(ctx);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -47,8 +47,6 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
-// CLUSTER_QUERY_ERROR is defined in rmr.h and shared with the hybrid error path.
-
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;
 
@@ -614,8 +612,8 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
 
 struct MRIteratorCtx {
   MRChannel *chan;
-  MRIteratorCallback cb;
-  MRIteratorErrorCallback errorCB;  // Optional: notify caller on no-reply termination
+  MRIteratorCallback successCB;
+  MRIteratorErrorCallback errorCB;  // Optional: callback to execute on error
   short pending;    // Number of shards with more results (not depleted)
   short inProcess;  // Number of currently running commands on shards
   bool timedOut;    // whether the coordinator experienced a timeout
@@ -655,7 +653,7 @@ static void mrIteratorRedisCB(redisAsyncContext *c, void *r, void *privdata) {
   if (!r) {
     mrIteratorCallback_Error(ctx);
   } else {
-    ctx->it->ctx.cb(ctx, r);
+    ctx->it->ctx.successCB(ctx, r);
   }
 }
 
@@ -763,7 +761,7 @@ void iterStartCb(void *p) {
         it->ctx.privateDataInit(privateData, it);
       }
       MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
-      it->ctx.cb(&it->cbxs[0], err);
+      it->ctx.successCB(&it->cbxs[0], err);
       rm_free(data);
       return;
     }
@@ -947,7 +945,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConf
   *ret = (MRIterator){
     .ctx = {
       .chan = MR_NewChannel(),
-      .cb = config->cb,
+      .successCB = config->successCB,
       .errorCB = config->errorCB,
       .pending = 1,
       .inProcess = 1,

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -935,12 +935,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   return channelSize > 0;
 }
 
-MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb,
-                                      MRIteratorErrorCallback errorCB, void *cbPrivateData,
-                                      void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, const MRIterator *),
-                                      MRCommandModifier commandModifier,
-                                      void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData) {
+MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConfig *config) {
   MRIterator *ret = rm_new(MRIterator);
   // Initial initialization of the iterator.
   // The rest of the initialization is done in the iterator start callback.
@@ -953,16 +948,16 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
   *ret = (MRIterator){
     .ctx = {
       .chan = MR_NewChannel(),
-      .cb = cb,
-      .errorCB = errorCB,
+      .cb = config->cb,
+      .errorCB = config->errorCB,
       .pending = 1,
       .inProcess = 1,
       .timedOut = false,
       .itRefCount = 2,
       .ioRuntime = MRCluster_GetIORuntimeCtx(cluster_g, MRCluster_AssignRoundRobinIORuntimeIdx(cluster_g)),
-      .privateDataDestructor = cbPrivateDataDestructor,
-      .privateDataInit = cbPrivateDataInit,
-      .commandModifier = commandModifier,
+      .privateDataDestructor = config->cbPrivateDataDestructor,
+      .privateDataInit = config->cbPrivateDataInit,
+      .commandModifier = config->commandModifier,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
     .len = 1,
@@ -971,17 +966,17 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
   *ret->cbxs = (MRIteratorCallbackCtx){
     .cmd = MRCommand_Copy(cmd),
     .it = ret,
-    .privateData = cbPrivateData,
+    .privateData = config->cbPrivateData,
   };
 
   // Create data structure with iterator and private data (on heap)
   IteratorData *data = rm_malloc(sizeof(IteratorData));
   data->it = ret;
   data->privateDataRef = (WeakRef){0};
-  if (iterStartCbPrivateData) {
-    data->privateDataRef = StrongRef_Demote(*iterStartCbPrivateData);
+  if (config->iterStartCbPrivateData) {
+    data->privateDataRef = StrongRef_Demote(*config->iterStartCbPrivateData);
   }
-  IORuntimeCtx_Schedule(ret->ctx.ioRuntime, iterStartCb, data);
+  IORuntimeCtx_Schedule(ret->ctx.ioRuntime, config->iterStartCb, data);
   return ret;
 }
 

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -29,10 +29,10 @@ extern "C" {
 typedef struct QueryError QueryError;
 
 // Error detail returned to the client when a query cannot be dispatched to the
-// cluster (pre-fanout connection-validation / send failure). Shared by the MR
-// iterator no-reply path (rmr.c) and the hybrid cursor-mapping error callback;
-// tests assert on this substring, so keep them in sync via this single macro.
-#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
+// cluster (pre-fanout connection-validation / send failure). Defined in rmr.c
+// and shared by the MR iterator no-reply path and the hybrid cursor-mapping
+// error callback; tests assert on this substring, so keep it the single source.
+extern const char CLUSTER_QUERY_ERROR[];
 
 struct MRCtx;
 struct RedisModuleCtx;
@@ -140,7 +140,7 @@ typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
  * Invoked on the IO thread when a shard command terminates without a reply
  * (NULL async reply or synchronous send failure). Notify-only: must not free
  * the iterator nor call MRIteratorCallback_Done — the MR layer does that next.
- * Optional; NULL preserves the historical depletion-only behavior (MOD-15394).
+ * Optional; NULL preserves the historical depletion-only behavior.
  */
 typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
 
@@ -161,7 +161,7 @@ typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privat
  * Only `cb` is required; every other field may be NULL to opt out of that hook.
  *
  * @param cb                     Per-reply callback (required).
- * @param errorCB                No-reply termination callback (optional, MOD-15394).
+ * @param errorCB                No-reply termination callback (optional).
  * @param cbPrivateData          Private data handed to `cb` via the callback ctx.
  * @param cbPrivateDataDestructor Frees `cbPrivateData` when the iterator is freed.
  * @param cbPrivateDataInit      Runs once on the IO thread after numShards is known.

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -156,6 +156,30 @@ typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
  */
 typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privateData);
 
+/**
+ * Bundles the optional callbacks and private data for MR_IterateWithPrivateData.
+ * Only `cb` is required; every other field may be NULL to opt out of that hook.
+ *
+ * @param cb                     Per-reply callback (required).
+ * @param errorCB                No-reply termination callback (optional, MOD-15394).
+ * @param cbPrivateData          Private data handed to `cb` via the callback ctx.
+ * @param cbPrivateDataDestructor Frees `cbPrivateData` when the iterator is freed.
+ * @param cbPrivateDataInit      Runs once on the IO thread after numShards is known.
+ * @param commandModifier        Rewrites the command per-shard before sending.
+ * @param iterStartCb            Scheduled on the IO thread to trigger the first send.
+ * @param iterStartCbPrivateData StrongRef demoted and passed to `iterStartCb`.
+ */
+typedef struct {
+  MRIteratorCallback cb;
+  MRIteratorErrorCallback errorCB;
+  void *cbPrivateData;
+  void (*cbPrivateDataDestructor)(void *);
+  void (*cbPrivateDataInit)(void *, const MRIterator *);
+  MRCommandModifier commandModifier;
+  void (*iterStartCb)(void *);
+  StrongRef *iterStartCbPrivateData;
+} MRIteratorConfig;
+
 // Trigger all the commands in the iterator to be sent.
 // Returns true if there may be more replies to come, false if we are done.
 bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold);
@@ -173,12 +197,7 @@ MRReply *MRIterator_NextWithTimeout(MRIterator *it, const struct timespec *absti
  * invoke MRChannel_WakeAbort directly (e.g. from a timeout callback on another thread). */
 struct MRChannel *MRIterator_GetChannel(MRIterator *it);
 
-MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb,
-                                      MRIteratorErrorCallback errorCB, void *cbPrivateData,
-                                      void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, const MRIterator *),
-                                      MRCommandModifier commandModifier,
-                                      void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData);
+MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConfig *config);
 
 MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx);
 

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -28,6 +28,11 @@ extern "C" {
 
 typedef struct QueryError QueryError;
 
+// Error detail returned to the client when a query cannot be dispatched to the
+// cluster (pre-fanout connection-validation / send failure). Shared by the MR
+// iterator no-reply path (rmr.c) and the hybrid cursor-mapping error callback;
+// tests assert on this substring, so keep them in sync via this single macro.
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
 
 struct MRCtx;
 struct RedisModuleCtx;

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -132,6 +132,21 @@ typedef struct MRIterator MRIterator;
 typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
 
 /**
+ * Callback invoked when a shard command terminates WITHOUT delivering a reply to
+ * the success callback (`MRIteratorCallback`): i.e. a NULL async reply (the shard
+ * connection dropped or errored) or a synchronous send failure. It runs on the IO
+ * thread and is only responsible for notifying the caller's own completion
+ * bookkeeping (e.g. a hand-rolled response counter). It must NOT free the iterator
+ * and must NOT call MRIteratorCallback_Done — the MR layer performs the iterator's
+ * own accounting immediately after this returns.
+ *
+ * When NULL, the MR layer simply performs MRIteratorCallback_Done, preserving the
+ * historical behavior for callers that key completion off iterator depletion
+ * rather than a private counter.
+ */
+typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
+
+/**
  * Callback type for modifying commands before they are sent to shards.
  * Called from iterStartCb on the IO thread after numShards is known but before
  * commands are sent.
@@ -160,7 +175,8 @@ MRReply *MRIterator_NextWithTimeout(MRIterator *it, const struct timespec *absti
  * invoke MRChannel_WakeAbort directly (e.g. from a timeout callback on another thread). */
 struct MRChannel *MRIterator_GetChannel(MRIterator *it);
 
-MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
+MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb,
+                                      MRIteratorErrorCallback errorCB, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
                                       void (*cbPrivateDataInit)(void *, const MRIterator *),
                                       MRCommandModifier commandModifier,

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -29,10 +29,10 @@ extern "C" {
 typedef struct QueryError QueryError;
 
 // Error detail returned to the client when a query cannot be dispatched to the
-// cluster (pre-fanout connection-validation / send failure). Defined in rmr.c
-// and shared by the MR iterator no-reply path and the hybrid cursor-mapping
-// error callback; tests assert on this substring, so keep it the single source.
-extern const char CLUSTER_QUERY_ERROR[];
+// cluster (pre-fanout connection-validation / send failure). Shared by the MR
+// iterator no-reply path (rmr.c) and the hybrid cursor-mapping error callback;
+// tests assert on this substring, so keep them in sync via this single macro.
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
 
 struct MRCtx;
 struct RedisModuleCtx;

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -134,6 +134,13 @@ typedef struct MRIteratorCallbackCtx MRIteratorCallbackCtx;
 typedef struct MRIteratorCtx MRIteratorCtx;
 typedef struct MRIterator MRIterator;
 
+/**
+ * Per-reply callback, invoked on the IO thread for every shard reply.
+ * Owns the iterator's completion bookkeeping: it must call
+ * MRIteratorCallback_Done once the shard has no more replies to drive the
+ * iterator toward depletion. Contrast with MRIteratorErrorCallback, which is
+ * notify-only and must not touch the Done state.
+ */
 typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
 
 /**
@@ -158,11 +165,11 @@ typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privat
 
 /**
  * Bundles the optional callbacks and private data for MR_IterateWithPrivateData.
- * Only `cb` is required; every other field may be NULL to opt out of that hook.
+ * Only `successCB` is required; every other field may be NULL to opt out of that hook.
  *
- * @param cb                     Per-reply callback (required).
+ * @param successCB              Per-reply callback (required).
  * @param errorCB                No-reply termination callback (optional).
- * @param cbPrivateData          Private data handed to `cb` via the callback ctx.
+ * @param cbPrivateData          Private data handed to `successCB` via the callback ctx.
  * @param cbPrivateDataDestructor Frees `cbPrivateData` when the iterator is freed.
  * @param cbPrivateDataInit      Runs once on the IO thread after numShards is known.
  * @param commandModifier        Rewrites the command per-shard before sending.
@@ -170,7 +177,7 @@ typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privat
  * @param iterStartCbPrivateData StrongRef demoted and passed to `iterStartCb`.
  */
 typedef struct {
-  MRIteratorCallback cb;
+  MRIteratorCallback successCB;
   MRIteratorErrorCallback errorCB;
   void *cbPrivateData;
   void (*cbPrivateDataDestructor)(void *);

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -132,17 +132,10 @@ typedef struct MRIterator MRIterator;
 typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
 
 /**
- * Callback invoked when a shard command terminates WITHOUT delivering a reply to
- * the success callback (`MRIteratorCallback`): i.e. a NULL async reply (the shard
- * connection dropped or errored) or a synchronous send failure. It runs on the IO
- * thread and is only responsible for notifying the caller's own completion
- * bookkeeping (e.g. a hand-rolled response counter). It must NOT free the iterator
- * and must NOT call MRIteratorCallback_Done — the MR layer performs the iterator's
- * own accounting immediately after this returns.
- *
- * When NULL, the MR layer simply performs MRIteratorCallback_Done, preserving the
- * historical behavior for callers that key completion off iterator depletion
- * rather than a private counter.
+ * Invoked on the IO thread when a shard command terminates without a reply
+ * (NULL async reply or synchronous send failure). Notify-only: must not free
+ * the iterator nor call MRIteratorCallback_Done — the MR layer does that next.
+ * Optional; NULL preserves the historical depletion-only behavior (MOD-15394).
  */
 typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
 

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -402,7 +402,7 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     rm_free(idx_copy);
 
     nc->it = MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
-      .cb = netCursorCallback,
+      .successCB = netCursorCallback,
       .iterStartCb = iterCursorMappingCb,
       .iterStartCbPrivateData = &nc->mappings,
     });

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -401,7 +401,7 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     nc->cmd.protocol = 3;
     rm_free(idx_copy);
 
-    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL,
+    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL, NULL,
                                        NULL, NULL, iterCursorMappingCb,
                                        &nc->mappings);
 

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -401,9 +401,11 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     nc->cmd.protocol = 3;
     rm_free(idx_copy);
 
-    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL, NULL,
-                                       NULL, NULL, iterCursorMappingCb,
-                                       &nc->mappings);
+    nc->it = MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
+      .cb = netCursorCallback,
+      .iterStartCb = iterCursorMappingCb,
+      .iterStartCbPrivateData = &nc->mappings,
+    });
 
     // Register the iterator's channel so the main-thread timeout callback can wake a
     // blocked reader after flipping AREQ's `timedOut` flag. Paired with

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -306,6 +306,29 @@ void SyncPoint_WaitUntil(const char *name, SyncPointStopFn stop_fn, void *arg) {
   atomic_fetch_sub(&sp->waiting, 1);
 }
 
+// ============================================================================
+// Shard dispatch fault injection (test-only, see DebugSendError_* in header)
+// ============================================================================
+
+// Number of upcoming MRCluster_SendCommand dispatches to fail. Set from the main
+// thread via FT.DEBUG SEND_ERROR, consumed from the IO threads.
+static _Atomic int g_debugSendErrorCount = 0;
+
+void DebugSendError_Arm(int count) {
+  atomic_store(&g_debugSendErrorCount, count);
+}
+
+bool DebugSendError_Consume(void) {
+  int cur = atomic_load(&g_debugSendErrorCount);
+  while (cur > 0) {
+    if (atomic_compare_exchange_weak(&g_debugSendErrorCount, &cur, cur - 1)) {
+      return true;  // caller treats this dispatch as failed
+    }
+    // cur was reloaded by the failed CAS; retry
+  }
+  return false;
+}
+
 static _Atomic uint32_t g_pendingSpecWriters = 0;
 
 void PendingSpecWriters_Incr(void) {
@@ -2823,6 +2846,26 @@ DEBUG_COMMAND(syncPoint) {
 }
 
 /**
+ * FT.DEBUG SEND_ERROR <count>
+ *
+ * Arm the coordinator to fail the next <count> shard command dispatches
+ * (MRCluster_SendCommand returns REDIS_ERR), simulating a shard connection that
+ * drops or errors after pre-fanout validation. Used to deterministically exercise
+ * the no-reply error path without killing a shard process (see MOD-15394).
+ */
+DEBUG_COMMAND(sendError) {
+  if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  // argv[0] = FT.DEBUG, argv[1] = SEND_ERROR, argv[2] = count
+  if (argc != 3) return RedisModule_WrongArity(ctx);
+  long long count;
+  if (RedisModule_StringToLongLong(argv[2], &count) != REDISMODULE_OK || count < 0) {
+    return RedisModule_ReplyWithError(ctx, "SEND_ERROR count must be a non-negative integer");
+  }
+  DebugSendError_Arm((int)count);
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/**
  * FT.DEBUG BG_PENDING_REPLIES
  * Returns the `pending` shard counter of the currently active coordinator
  * MRIterator (the number of shards that have not yet delivered their final
@@ -3251,6 +3294,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
 static DebugCommandType assertOnlyCommands[] = {
     {"SYNC_POINT", syncPoint},
     {"BG_PENDING_REPLIES", bgPendingReplies},
+    {"SEND_ERROR", sendError},
     {NULL, NULL}};
 #endif
 

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -306,12 +306,8 @@ void SyncPoint_WaitUntil(const char *name, SyncPointStopFn stop_fn, void *arg) {
   atomic_fetch_sub(&sp->waiting, 1);
 }
 
-// ============================================================================
-// Shard dispatch fault injection (test-only, see DebugSendError_* in header)
-// ============================================================================
-
-// Number of upcoming MRCluster_SendCommand dispatches to fail. Set from the main
-// thread via FT.DEBUG SEND_ERROR, consumed from the IO threads.
+// Shard dispatch fault injection (test-only, see DebugSendError_* in header).
+// Set from the main thread via FT.DEBUG SEND_ERROR, consumed from the IO threads.
 static _Atomic int g_debugSendErrorCount = 0;
 
 void DebugSendError_Arm(int count) {
@@ -322,9 +318,8 @@ bool DebugSendError_Consume(void) {
   int cur = atomic_load(&g_debugSendErrorCount);
   while (cur > 0) {
     if (atomic_compare_exchange_weak(&g_debugSendErrorCount, &cur, cur - 1)) {
-      return true;  // caller treats this dispatch as failed
+      return true;
     }
-    // cur was reloaded by the failed CAS; retry
   }
   return false;
 }
@@ -2847,15 +2842,11 @@ DEBUG_COMMAND(syncPoint) {
 
 /**
  * FT.DEBUG SEND_ERROR <count>
- *
- * Arm the coordinator to fail the next <count> shard command dispatches
- * (MRCluster_SendCommand returns REDIS_ERR), simulating a shard connection that
- * drops or errors after pre-fanout validation. Used to deterministically exercise
- * the no-reply error path without killing a shard process (see MOD-15394).
+ * Arm the next <count> MRCluster_SendCommand dispatches to return REDIS_ERR,
+ * simulating a no-reply shard failure (MOD-15394).
  */
 DEBUG_COMMAND(sendError) {
   if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
-  // argv[0] = FT.DEBUG, argv[1] = SEND_ERROR, argv[2] = count
   if (argc != 3) return RedisModule_WrongArity(ctx);
   long long count;
   if (RedisModule_StringToLongLong(argv[2], &count) != REDISMODULE_OK || count < 0) {

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2844,7 +2844,7 @@ DEBUG_COMMAND(syncPoint) {
 /**
  * FT.DEBUG SEND_ERROR <count>
  * Arm the next <count> MRCluster_SendCommand dispatches to return REDIS_ERR,
- * simulating a no-reply shard failure (MOD-15394).
+ * simulating a no-reply shard failure.
  */
 DEBUG_COMMAND(sendError) {
   if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -43,6 +43,7 @@
 #include "query_error_ffi.h"
 #include "doc_id_meta.h"
 #include "coord/rmr/rmr.h"
+#include <limits.h>
 
 DebugCTX globalDebugCtx = {0};
 
@@ -2849,8 +2850,10 @@ DEBUG_COMMAND(sendError) {
   if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
   if (argc != 3) return RedisModule_WrongArity(ctx);
   long long count;
-  if (RedisModule_StringToLongLong(argv[2], &count) != REDISMODULE_OK || count < 0) {
-    return RedisModule_ReplyWithError(ctx, "SEND_ERROR count must be a non-negative integer");
+  if (RedisModule_StringToLongLong(argv[2], &count) != REDISMODULE_OK || count < 0 ||
+      count > INT_MAX) {
+    return RedisModule_ReplyWithError(ctx,
+        "SEND_ERROR count must be a non-negative integer no greater than INT_MAX");
   }
   DebugSendError_Arm((int)count);
   return RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -176,7 +176,7 @@ void SyncPoint_WaitUntil(const char *name, SyncPointStopFn stop_fn, void *arg);
 
 // Shard dispatch fault injection (test-only, ENABLE_ASSERT builds): arm the next
 // `count` MRCluster_SendCommand calls to return REDIS_ERR, so DebugSendError_Consume
-// returns true that many times. Exercises the no-reply error path (MOD-15394).
+// returns true that many times. Exercises the no-reply error path.
 void DebugSendError_Arm(int count);
 // Consume one armed failure; returns true if the caller should treat the send as
 // failed. Thread-safe.

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -174,6 +174,19 @@ typedef bool (*SyncPointStopFn)(void *arg);
 // true. Lets workers release early when a timeout fires on the main thread.
 void SyncPoint_WaitUntil(const char *name, SyncPointStopFn stop_fn, void *arg);
 
+// ============================================================================
+// Shard dispatch fault injection (test-only)
+// ============================================================================
+// Arm the coordinator to fail the next `count` shard command dispatches:
+// DebugSendError_Consume() returns true that many times, so MRCluster_SendCommand
+// returns REDIS_ERR, simulating a shard connection that drops/errors after
+// pre-fanout validation. Used to exercise the no-reply error path (MOD-15394).
+// Only consumed in ENABLE_ASSERT builds.
+void DebugSendError_Arm(int count);
+// Consume one armed dispatch failure. Returns true if the caller should treat the
+// send as failed. Thread-safe.
+bool DebugSendError_Consume(void);
+
 // Process-wide counter of threads parked in `RedisSearchCtx_LockSpecWrite`
 // waiting on a spec rwlock. Bumped before `pthread_rwlock_wrlock` and
 // decremented once the write lock has been acquired. Used by tests (sync-point

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -174,17 +174,12 @@ typedef bool (*SyncPointStopFn)(void *arg);
 // true. Lets workers release early when a timeout fires on the main thread.
 void SyncPoint_WaitUntil(const char *name, SyncPointStopFn stop_fn, void *arg);
 
-// ============================================================================
-// Shard dispatch fault injection (test-only)
-// ============================================================================
-// Arm the coordinator to fail the next `count` shard command dispatches:
-// DebugSendError_Consume() returns true that many times, so MRCluster_SendCommand
-// returns REDIS_ERR, simulating a shard connection that drops/errors after
-// pre-fanout validation. Used to exercise the no-reply error path (MOD-15394).
-// Only consumed in ENABLE_ASSERT builds.
+// Shard dispatch fault injection (test-only, ENABLE_ASSERT builds): arm the next
+// `count` MRCluster_SendCommand calls to return REDIS_ERR, so DebugSendError_Consume
+// returns true that many times. Exercises the no-reply error path (MOD-15394).
 void DebugSendError_Arm(int count);
-// Consume one armed dispatch failure. Returns true if the caller should treat the
-// send as failed. Thread-safe.
+// Consume one armed failure; returns true if the caller should treat the send as
+// failed. Thread-safe.
 bool DebugSendError_Consume(void);
 
 // Process-wide counter of threads parked in `RedisSearchCtx_LockSpecWrite`

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -86,10 +86,11 @@ class TestDebugCommands(object):
         ]
         coord_help_list = ['SHARD_CONNECTION_STATES', 'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY']
         help_list.extend(coord_help_list)
-        # SYNC_POINT and BG_PENDING_REPLIES are only available in ENABLE_ASSERT builds
+        # SYNC_POINT, BG_PENDING_REPLIES and SEND_ERROR are only available in ENABLE_ASSERT builds
         if isEnableAssertEnabled(self.env):
             help_list.append('SYNC_POINT')
             help_list.append('BG_PENDING_REPLIES')
+            help_list.append('SEND_ERROR')
 
         self.env.expect(debug_cmd(), 'help').equal(help_list)
 

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -2,26 +2,29 @@ from common import *
 import threading
 
 
-@skip(cluster=False)
-@require_enable_assert
-def test_dist_hybrid_index_drop_after_sctx_allocation(env):
-    """MOD-14135: SearchCtx must be freed when index is dropped between
-    sctx allocation and IndexSpecRef_Promote in RSExecDistHybrid.
-    Leak detection relies on valgrind/sanitizers in CI."""
+def _setup_hybrid_index(env, dim=2):
+    """Create the standard hybrid index used by these tests and return
+    (conn, query_vec, doc_vec)."""
     set_workers(env, 1)
-
-    dim = 2
     conn = getConnectionByEnv(env)
-
     env.expect(
         'FT.CREATE', 'idx', 'SCHEMA',
         'name', 'TEXT',
         'embedding', 'VECTOR', 'FLAT', '6',
         'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2'
     ).ok()
-
     query_vec = np.array([0.0] * dim, dtype=np.float32).tobytes()
     doc_vec = np.array([1.0] * dim, dtype=np.float32).tobytes()
+    return conn, query_vec, doc_vec
+
+
+@skip(cluster=False)
+@require_enable_assert
+def test_dist_hybrid_index_drop_after_sctx_allocation(env):
+    """MOD-14135: SearchCtx must be freed when index is dropped between
+    sctx allocation and IndexSpecRef_Promote in RSExecDistHybrid.
+    Leak detection relies on valgrind/sanitizers in CI."""
+    conn, query_vec, doc_vec = _setup_hybrid_index(env)
     conn.execute_command('HSET', 'doc1', 'name', 'hello', 'embedding', doc_vec)
 
     sync_point = 'BeforeDistHybridPromote'
@@ -72,19 +75,7 @@ def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     """MOD-15394: a no-reply shard dispatch failure must surface as an error
     rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
     FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
-    set_workers(env, 1)
-
-    dim = 2
-    conn = getConnectionByEnv(env)
-    env.expect(
-        'FT.CREATE', 'idx', 'SCHEMA',
-        'name', 'TEXT',
-        'embedding', 'VECTOR', 'FLAT', '6',
-        'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2'
-    ).ok()
-
-    query_vec = np.array([0.0] * dim, dtype=np.float32).tobytes()
-    doc_vec = np.array([1.0] * dim, dtype=np.float32).tobytes()
+    conn, query_vec, doc_vec = _setup_hybrid_index(env)
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 'name', 'hello', 'embedding', doc_vec)
 

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -72,7 +72,7 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
 @skip(cluster=False)
 @require_enable_assert
 def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
-    """MOD-15394: a no-reply shard dispatch failure must surface as an error
+    """A no-reply shard dispatch failure must surface as an error
     rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
     FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
     conn, query_vec, doc_vec = _setup_hybrid_index(env)
@@ -105,7 +105,7 @@ def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     query_thread.join(timeout=15)
 
     env.assertFalse(query_thread.is_alive(),
-                    message='FT.HYBRID hung after a shard dispatch failure (MOD-15394)')
+                    message='FT.HYBRID hung after a shard dispatch failure')
     env.assertEqual(len(error_holder), 1,
                     message=f'Expected a communication error, got results: {result_holder}')
     env.assertContains('Could not send query to cluster', str(error_holder[0]))

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -64,3 +64,66 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
     error_msg = str(error_holder[0])
     env.assertTrue(error_msg.startswith('SEARCH_INDEX_DROPPED_BG'),
                    message=f'Expected error to start with SEARCH_INDEX_DROPPED_BG, got: {error_msg}')
+
+
+@skip(cluster=False)
+@require_enable_assert
+def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
+    """MOD-15394: a shard command that fails to dispatch (connection dropped or
+    errored after pre-fanout validation) must not hang the coordinator.
+
+    ProcessHybridCursorMappings waits on a private responseCount that only the
+    success callback increments. Before the fix the failed shard was never
+    counted, so the coordinator blocked on completionCond forever (the FT.HYBRID
+    client would hang). The fix routes the no-reply error path through an error
+    callback that counts the shard and records a communication error, so the
+    command returns an error instead of hanging.
+
+    FT.DEBUG SEND_ERROR makes the next MRCluster_SendCommand return REDIS_ERR,
+    which deterministically reproduces the failure without killing a shard."""
+    set_workers(env, 1)
+
+    dim = 2
+    conn = getConnectionByEnv(env)
+    env.expect(
+        'FT.CREATE', 'idx', 'SCHEMA',
+        'name', 'TEXT',
+        'embedding', 'VECTOR', 'FLAT', '6',
+        'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2'
+    ).ok()
+
+    query_vec = np.array([0.0] * dim, dtype=np.float32).tobytes()
+    doc_vec = np.array([1.0] * dim, dtype=np.float32).tobytes()
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 'name', 'hello', 'embedding', doc_vec)
+
+    # Arm the coordinator to fail the next shard dispatch (the FT.HYBRID fan-out).
+    env.cmd(debug_cmd(), 'SEND_ERROR', '1')
+
+    error_holder = []
+    result_holder = []
+    def run_hybrid_query(c, errors, results):
+        try:
+            results.append(c.execute_command(
+                'FT.HYBRID', 'idx',
+                'SEARCH', '*',
+                'VSIM', '@embedding', '$BLOB',
+                'PARAMS', '2', 'BLOB', query_vec
+            ))
+        except Exception as e:
+            errors.append(e)
+
+    query_conn = env.getConnection()
+    query_thread = threading.Thread(
+        target=run_hybrid_query,
+        args=(query_conn, error_holder, result_holder),
+        daemon=True
+    )
+    query_thread.start()
+    query_thread.join(timeout=15)
+
+    env.assertFalse(query_thread.is_alive(),
+                    message='FT.HYBRID hung after a shard dispatch failure (MOD-15394)')
+    env.assertEqual(len(error_holder), 1,
+                    message=f'Expected a communication error, got results: {result_holder}')
+    env.assertContains('Could not send query to cluster', str(error_holder[0]))

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -69,18 +69,9 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
 @skip(cluster=False)
 @require_enable_assert
 def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
-    """MOD-15394: a shard command that fails to dispatch (connection dropped or
-    errored after pre-fanout validation) must not hang the coordinator.
-
-    ProcessHybridCursorMappings waits on a private responseCount that only the
-    success callback increments. Before the fix the failed shard was never
-    counted, so the coordinator blocked on completionCond forever (the FT.HYBRID
-    client would hang). The fix routes the no-reply error path through an error
-    callback that counts the shard and records a communication error, so the
-    command returns an error instead of hanging.
-
-    FT.DEBUG SEND_ERROR makes the next MRCluster_SendCommand return REDIS_ERR,
-    which deterministically reproduces the failure without killing a shard."""
+    """MOD-15394: a no-reply shard dispatch failure must surface as an error
+    rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
+    FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
     set_workers(env, 1)
 
     dim = 2


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** In a cluster, `FT.HYBRID` opens per-shard cursors via `ProcessHybridCursorMappings`, which blocks on a private `responseCount`/`completionCond` that **only the success callback increments**. When a shard command terminates without delivering a reply — a NULL async reply (the shard connection drops/errors after pre-fanout validation) or a synchronous send failure — that path went straight to `MRIteratorCallback_Done` and never touched the hybrid bookkeeping. The failed shard was never counted, so the coordinator waited on `completionCond` forever and the `FT.HYBRID` client hung indefinitely (MOD-15394).
2. **Change:** Added an optional `MRIteratorErrorCallback` to the MR iterator. The new `mrIteratorCallback_Error` helper routes every no-reply termination (`mrIteratorRedisCB` r==NULL, and the `iterStartCb`/`iterCursorMappingCb`/`iterManualNextCb` send-failure sites) through it before doing the iterator's own `MRIteratorCallback_Done`. The hybrid path registers an error callback that counts the shard and records a `Could not send query to cluster` error.
3. **Outcome:** `FT.HYBRID` now returns an error instead of hanging when a shard command fails to dispatch. `errorCB` defaults to `NULL`, so `FT.SEARCH`/`FT.AGGREGATE` (which key completion off iterator depletion, not a private counter) are byte-for-byte unchanged.

**Testing:** added an `ENABLE_ASSERT`-only `FT.DEBUG SEND_ERROR <count>` fault-injection toggle (mirrors the existing SyncPoint infra) that makes `MRCluster_SendCommand` return `REDIS_ERR`, plus a cluster test `test_dist_hybrid_shard_dispatch_failure_does_not_hang` that deterministically reproduces the failure without killing a shard process. Verified RED (without the fix the test detects the hang) → GREEN (with the fix it returns the error in ~3s); full `test_hybrid_dist.py` passes.

> **Scope note:** MOD-15394's bug report also contains a fatal `SIGSEGV` (signal 11, accessing `0x8`) in the `search-uv` thread at `mrIteratorRedisCB`'s success branch (`ctx->it->ctx.cb(...)` with `ctx->it == NULL`), which looks like a **separate** use-after-free. This PR fixes the **hang** only; the crash needs its own investigation (addr2line against the 8.4.4 debuginfo) and is intentionally out of scope here.

#### Which additional issues this PR fixes
1. MOD-15394

#### Main objects this PR modified
1. `MRIteratorCtx` / `MR_IterateWithPrivateData` — new `errorCB` field + parameter (`src/coord/rmr/rmr.{c,h}`)
2. `mrIteratorCallback_Error` — shared no-reply termination helper (`src/coord/rmr/rmr.c`)
3. `processCursorMappingErrorCallback` — hybrid error callback (`src/coord/hybrid/hybrid_cursor_mappings.c`)
4. `MRCluster_SendCommand` + `FT.DEBUG SEND_ERROR` — test-only fault injection (`src/coord/rmr/cluster.c`, `src/debug_commands.{c,h}`)
5. Callers pass `NULL` errorCB (`src/coord/rpnet.c`, `src/coord/dist_aggregate.c`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes a coordinator hang where a clustered `FT.HYBRID` could block indefinitely if a shard connection dropped or a command failed to dispatch; it now returns an error instead.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator IO-thread iterator completion and hybrid synchronization; incorrect error-hook behavior could affect cluster query hangs or error surfacing, though other commands opt out via NULL errorCB.
> 
> **Overview**
> Fixes a **clustered `FT.HYBRID` hang** when a shard command ends without a reply (NULL async response or synchronous `MRCluster_SendCommand` failure). `ProcessHybridCursorMappings` waited on `responseCount`/`completionCond`, but only the success path incremented the counter—no-reply failures went straight to `MRIteratorCallback_Done` and never woke the coordinator.
> 
> The MR iterator gains an optional **`MRIteratorErrorCallback`** and **`MRIteratorConfig`** (replacing the long `MR_IterateWithPrivateData` argument list). **`mrIteratorCallback_Error`** runs the optional error hook, then `MRIteratorCallback_Done`. Hybrid registers **`processCursorMappingErrorCallback`**, which bumps `responseCount`, records **`CLUSTER_QUERY_ERROR`**, and signals completion. **`FT.SEARCH` / `FT.AGGREGATE`** callers leave `errorCB` unset so behavior stays iterator-depletion-driven.
> 
> **`CLUSTER_QUERY_ERROR`** moves to `rmr.h` as a shared macro. **Test-only** `FT.DEBUG SEND_ERROR <count>` (ENABLE_ASSERT) forces the next N sends to fail; **`test_dist_hybrid_shard_dispatch_failure_does_not_hang`** asserts the query errors instead of blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b5c6dd20705939dea80ce57b96bcf3930f3aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->