### PR TITLE
[8.8] MOD-15733: Tie-breaking in COLLECT (#9844)

### DIFF
--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -143,10 +143,15 @@ static int Grouper_rpYield(ResultProcessor *base, SearchResult *r) {
   return RS_RESULT_EOF;
 }
 
-static void invokeReducers(Grouper *g, Group *gr, RLookupRow *srcrow) {
+static void invokeReducers(Grouper *g, Group *gr, RLookupRow *srcrow, t_docId docId) {
   size_t nreducers = GROUPER_NREDUCERS(g);
   for (size_t ii = 0; ii < nreducers; ii++) {
-    g->reducers[ii]->Add(g->reducers[ii], gr->accumdata[ii], srcrow);
+    Reducer *r = g->reducers[ii];
+    if (r->AddWithDocId) {
+      r->AddWithDocId(r, gr->accumdata[ii], srcrow, docId);
+    } else {
+      r->Add(r, gr->accumdata[ii], srcrow);
+    }
   }
 }
 
@@ -166,7 +171,7 @@ static void invokeReducers(Grouper *g, Group *gr, RLookupRow *srcrow) {
  * @param rowExpansion the cartesian product size accumulated for the current row
  */
 static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t xlen,
-                         uint64_t hval, RLookupRow *res, size_t rowExpansion) {
+                         uint64_t hval, RLookupRow *res, size_t rowExpansion, t_docId docId) {
   // end of the line - create/add to group
   if (xpos == xlen) {
     Group *group = NULL;
@@ -185,7 +190,7 @@ static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t x
     }
 
     // send the result to the group and its reducers
-    invokeReducers(g, group, res);
+    invokeReducers(g, group, res, docId);
     return RS_RESULT_OK;
   }
 
@@ -194,13 +199,13 @@ static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t x
   // regular value - just move one step -- increment XPOS
   if (!RSValue_IsArray(v)) {
     hval = RSValue_Hash(v, hval);
-    return extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion);
+    return extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion, docId);
   } else if (RSValue_ArrayLen(v) == 0) {
     // Empty array - hash as null
     hval = RSValue_Hash(RSValue_NullStatic(), hval);
     const RSValue *array = xarr[xpos];
     xarr[xpos] = RSValue_NullStatic();
-    int rc = extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion);
+    int rc = extractGroups(g, xarr, xpos + 1, xlen, hval, res, rowExpansion, docId);
     xarr[xpos] = array;
     return rc;
   } else {
@@ -220,7 +225,7 @@ static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t x
       // hash the element, even if it's an array
       uint64_t hh = RSValue_Hash(elem, hval);
       xarr[xpos] = elem;
-      int rc = extractGroups(g, xarr, xpos + 1, xlen, hh, res, rowExpansion);
+      int rc = extractGroups(g, xarr, xpos + 1, xlen, hh, res, rowExpansion, docId);
       if (rc != RS_RESULT_OK) {
         xarr[xpos] = array;
         return rc;
@@ -231,7 +236,7 @@ static int extractGroups(Grouper *g, const RSValue **xarr, size_t xpos, size_t x
   }
 }
 
-static int invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
+static int invokeGroupReducers(Grouper *g, RLookupRow *srcrow, t_docId docId) {
   uint64_t hval = 0;
   size_t nkeys = GROUPER_NSRCKEYS(g);
   const RSValue *groupvals[nkeys];
@@ -244,7 +249,7 @@ static int invokeGroupReducers(Grouper *g, RLookupRow *srcrow) {
     }
     groupvals[ii] = v;
   }
-  return extractGroups(g, groupvals, 0, nkeys, hval, srcrow, 1);
+  return extractGroups(g, groupvals, 0, nkeys, hval, srcrow, 1, docId);
 }
 
 static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
@@ -254,7 +259,7 @@ static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
   int rc;
 
   while ((rc = base->upstream->Next(base->upstream, res)) == RS_RESULT_OK) {
-    rc = invokeGroupReducers(g, SearchResult_GetRowDataMut(res));
+    rc = invokeGroupReducers(g, SearchResult_GetRowDataMut(res), SearchResult_GetDocId(res));
     SearchResult_Clear(res);
     if (rc != RS_RESULT_OK) {
       break;

--- a/src/aggregate/reducer.h
+++ b/src/aggregate/reducer.h
@@ -74,6 +74,13 @@ typedef struct Reducer {
   int (*Add)(struct Reducer *parent, void *instance, const RLookupRow *srcrow);
 
   /**
+   * Optional Add variant for reducers that need the upstream document id as
+   * out-of-band metadata. Reducers that do not set this callback use Add().
+   */
+  int (*AddWithDocId)(struct Reducer *parent, void *instance, const RLookupRow *srcrow,
+                      t_docId docId);
+
+  /**
    * Called when Add() has been invoked for the last time. This is used to
    * populate the result of the reduce function.
    */

--- a/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
+++ b/src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn CollectReducer_CreateRemote(
 
     cr.reducer_mut()
         .set_new_instance(collectRemoteNewInstance)
-        .set_add(collectRemoteAdd)
+        .set_add_with_doc_id(collectRemoteAddWithDocId)
         .set_finalize(collectRemoteFinalize)
         .set_free_instance(collectRemoteFreeInstance)
         .set_free(collectRemoteFree);
@@ -116,8 +116,8 @@ pub unsafe extern "C" fn collectRemoteFreeInstance(_r: *mut ffi::Reducer, ctx: *
     unsafe { ptr::drop_in_place(ctx.cast::<RemoteCollectCtx>()) }
 }
 
-/// Processes the provided [`ffi::RLookupRow`] with the shard collect reducer
-/// instance.
+/// Processes the provided [`ffi::RLookupRow`] and document id with the shard
+/// collect reducer instance.
 ///
 /// # Safety
 ///
@@ -127,10 +127,11 @@ pub unsafe extern "C" fn collectRemoteFreeInstance(_r: *mut ffi::Reducer, ctx: *
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn collectRemoteAdd(
+pub unsafe extern "C" fn collectRemoteAddWithDocId(
     r: *mut ffi::Reducer,
     ctx: *mut c_void,
     srcrow: *const ffi::RLookupRow,
+    doc_id: ffi::t_docId,
 ) -> c_int {
     // SAFETY: ensured by caller (1.)
     let r = unsafe { r.cast::<RemoteCollectReducer>().as_ref().unwrap() };
@@ -139,7 +140,7 @@ pub unsafe extern "C" fn collectRemoteAdd(
     // SAFETY: ensured by caller (3.)
     let srcrow = unsafe { srcrow.cast::<RLookupRow>().as_ref().unwrap() };
 
-    collect.add(r, srcrow);
+    collect.add(r, srcrow, doc_id);
 
     1 // C reducer->Add convention: always returns 1
 }

--- a/src/redisearch_rs/headers/reducers_rs.h
+++ b/src/redisearch_rs/headers/reducers_rs.h
@@ -149,8 +149,8 @@ void *collectRemoteNewInstance(Reducer *r);
 void collectRemoteFreeInstance(Reducer *_r, void *ctx);
 
 /**
- * Processes the provided [`ffi::RLookupRow`] with the shard collect reducer
- * instance.
+ * Processes the provided [`ffi::RLookupRow`] and document id with the shard
+ * collect reducer instance.
  *
  * # Safety
  *
@@ -160,7 +160,7 @@ void collectRemoteFreeInstance(Reducer *_r, void *ctx);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int collectRemoteAdd(Reducer *r, void *ctx, const RLookupRow *srcrow);
+int collectRemoteAddWithDocId(Reducer *r, void *ctx, const RLookupRow *srcrow, t_docId doc_id);
 
 /**
  * Finalizes the shard collect reducer instance result into an `RSValue`.

--- a/src/redisearch_rs/reducers/src/collect/heap.rs
+++ b/src/redisearch_rs/reducers/src/collect/heap.rs
@@ -11,7 +11,7 @@
 //! top-K path.
 //!
 //! Wraps an `Ord`-driven [`MinMaxHeap`][min_max_heap::MinMaxHeap] over
-//! [`HeapEntry<T>`], where the comparator only reads the [`EntryKey`] half. The
+//! [`HeapEntry<D, T>`], where the comparator only reads the [`EntryKey`] half. The
 //! split lets the heap defer payload projection until a candidate's survival is
 //! confirmed.
 //!
@@ -32,35 +32,37 @@ use value::comparison::cmp_fields;
 ///
 /// Bit `i` of `sort_asc_map` (LSB-first) selects ASC for the `i`-th key
 /// (set) or DESC (clear), matching `SORTASCMAP_GETASC` / `cmp_fields`.
-pub struct EntryKey {
+pub struct EntryKey<D: Ord> {
     sort_vals: Box<[Option<SharedValue>]>,
     sort_asc_map: u64,
+    doc_id: D,
 }
 
-impl EntryKey {
-    pub const fn new(sort_vals: Box<[Option<SharedValue>]>, sort_asc_map: u64) -> Self {
+impl<D: Ord> EntryKey<D> {
+    pub const fn new(sort_vals: Box<[Option<SharedValue>]>, sort_asc_map: u64, doc_id: D) -> Self {
         Self {
             sort_vals,
             sort_asc_map,
+            doc_id,
         }
     }
 }
 
-impl PartialEq for EntryKey {
+impl<D: Ord> PartialEq for EntryKey<D> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
-impl Eq for EntryKey {}
+impl<D: Ord> Eq for EntryKey<D> {}
 
-impl PartialOrd for EntryKey {
+impl<D: Ord> PartialOrd for EntryKey<D> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for EntryKey {
+impl<D: Ord> Ord for EntryKey<D> {
     fn cmp(&self, other: &Self) -> Ordering {
         debug_assert_eq!(
             self.sort_vals.len(),
@@ -76,7 +78,11 @@ impl Ord for EntryKey {
         // `Ordering::Greater` for the "better" side, matching the
         // "best = max" convention in `SearchResult_CmpByFields` and the
         // C `RPSorter`'s `mmh_pop_max` consumer.
+        //
+        // On a tie, break by doc id. Reversing the comparison makes a
+        // smaller doc id "stronger" (greater), so the heap prefers it.
         cmp_fields(pairs, self.sort_asc_map, None)
+            .then_with(|| self.doc_id.cmp(&other.doc_id).reverse())
     }
 }
 
@@ -85,17 +91,17 @@ impl Ord for EntryKey {
 /// `T` is the per-row payload the consumer (`Storage::Heap`) yields at
 /// finalize. Comparing only reads `key`, so the choice of `T` does not
 /// affect ranking.
-pub struct HeapEntry<T> {
-    key: EntryKey,
+pub struct HeapEntry<D: Ord, T> {
+    key: EntryKey<D>,
     projected: T,
 }
 
-impl<T> HeapEntry<T> {
-    pub const fn new(key: EntryKey, projected: T) -> Self {
+impl<D: Ord, T> HeapEntry<D, T> {
+    pub const fn new(key: EntryKey<D>, projected: T) -> Self {
         Self { key, projected }
     }
 
-    pub const fn key(&self) -> &EntryKey {
+    pub const fn key(&self) -> &EntryKey<D> {
         &self.key
     }
 
@@ -109,21 +115,21 @@ impl<T> HeapEntry<T> {
     }
 }
 
-impl<T> PartialEq for HeapEntry<T> {
+impl<D: Ord, T> PartialEq for HeapEntry<D, T> {
     fn eq(&self, other: &Self) -> bool {
         self.key == other.key
     }
 }
 
-impl<T> Eq for HeapEntry<T> {}
+impl<D: Ord, T> Eq for HeapEntry<D, T> {}
 
-impl<T> PartialOrd for HeapEntry<T> {
+impl<D: Ord, T> PartialOrd for HeapEntry<D, T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T> Ord for HeapEntry<T> {
+impl<D: Ord, T> Ord for HeapEntry<D, T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.key.cmp(&other.key)
     }

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -170,7 +170,7 @@ const _: () = assert!(
 /// [`SharedValue`] refcounts.
 pub struct LocalCollectCtx {
     lookup: RLookup<'static>,
-    storage: Storage,
+    storage: Storage<()>,
 }
 
 impl<'a> LocalCollectReducer<'a> {
@@ -240,6 +240,7 @@ impl LocalCollectCtx {
             }
             self.storage.insert_entry(
                 || snapshot_sort_keys(&r.sort_key_names, item),
+                (),
                 || prepare_row(&mut self.lookup, r.requested.as_deref(), item),
             );
         }

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -61,7 +61,7 @@ const _: () = assert!(
 /// called to release the stored [`RLookupRow`]s and decrement
 /// [`SharedValue`] refcounts.
 pub struct RemoteCollectCtx {
-    storage: Storage,
+    storage: Storage<ffi::t_docId>,
 }
 
 impl<'a> RemoteCollectReducer<'a> {
@@ -179,7 +179,12 @@ impl RemoteCollectCtx {
     /// The array path ignores the snapshot closure entirely. The heap path
     /// uses the snapshot to drive comparisons, dropping doomed candidates
     /// without paying the row-projection cost.
-    pub fn add(&mut self, r: &RemoteCollectReducer<'_>, row: &RLookupRow<'_>) {
+    pub fn add(
+        &mut self,
+        r: &RemoteCollectReducer<'_>,
+        row: &RLookupRow<'_>,
+        doc_id: ffi::t_docId,
+    ) {
         let sort_vals = || -> Box<[Option<SharedValue>]> {
             r.sort_keys
                 .iter()
@@ -209,7 +214,7 @@ impl RemoteCollectCtx {
             }
             dst
         };
-        self.storage.insert_entry(sort_vals, project);
+        self.storage.insert_entry(sort_vals, doc_id, project);
     }
 
     /// Serialize the buffered rows into an array of maps. Keys absent from a

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -17,6 +17,8 @@
 //!   primitive defined in [`super::heap`] and draining best→worst.
 //!   Suitable when a ranked top-K is needed.
 
+use std::marker::PhantomData;
+
 use itertools::Either;
 use min_max_heap::MinMaxHeap;
 use rlookup::RLookupRow;
@@ -34,21 +36,22 @@ pub const DEFAULT_LIMIT: u64 = 10;
 /// number of rows we will retain.
 const INITIAL_CAPACITY_CAP: usize = 16_384;
 
-pub enum Storage {
+pub enum Storage<D: Ord> {
     Array {
         buf: Vec<RLookupRow<'static>>,
         offset: usize,
         count: usize,
+        _marker: PhantomData<D>,
     },
     Heap {
-        heap: MinMaxHeap<HeapEntry<RLookupRow<'static>>>,
+        heap: MinMaxHeap<HeapEntry<D, RLookupRow<'static>>>,
         sort_asc_map: u64,
         offset: usize,
         count: usize,
     },
 }
 
-impl Storage {
+impl<D: Ord> Storage<D> {
     /// Resolve `(offset, count)` and pre-size the buffer/heap.
     pub fn new(sortby: bool, limit: Option<(u64, u64)>, sort_asc_map: u64) -> Self {
         let (offset, count) = match (sortby, limit) {
@@ -72,6 +75,7 @@ impl Storage {
                 buf: Vec::with_capacity(initial_capacity),
                 offset,
                 count,
+                _marker: PhantomData,
             }
         }
     }
@@ -86,7 +90,12 @@ impl Storage {
     ///   the current worst).
     ///
     /// Returns `true` if the entry was buffered, `false` if it was dropped.
-    pub fn insert_entry<S, P>(&mut self, sort_vals: S, project: P) -> bool
+    ///
+    /// `doc_id` is only consulted on the heap path, where it acts as a
+    /// deterministic tie-breaker when sort keys compare equal. Callers
+    /// that don't need tie-breaking instantiate `Storage<()>` and pass
+    /// `()` here — `()`'s `Ord` impl makes the fallback a no-op.
+    pub fn insert_entry<S, P>(&mut self, sort_vals: S, doc_id: D, project: P) -> bool
     where
         S: FnOnce() -> Box<[Option<SharedValue>]>,
         P: FnOnce() -> RLookupRow<'static>,
@@ -110,15 +119,16 @@ impl Storage {
                 count,
             } => {
                 let max_size = offset.saturating_add(*count);
+                let make_key = |sort_vals: S| EntryKey::new(sort_vals(), *sort_asc_map, doc_id);
                 if max_size == 0 {
                     return false;
                 }
                 if heap.len() < max_size {
-                    let key = EntryKey::new(sort_vals(), *sort_asc_map);
+                    let key = make_key(sort_vals);
                     heap.push(HeapEntry::new(key, project()));
                     true
                 } else {
-                    let cand_key = EntryKey::new(sort_vals(), *sort_asc_map);
+                    let cand_key = make_key(sort_vals);
                     // `peek_min` returns the worst surviving candidate
                     // under the "best = max" convention (see `heap`).
                     // The unwrap is sound: `cap > 0` implies the heap is
@@ -156,6 +166,7 @@ impl Storage {
                 buf: Vec::new(),
                 offset: 0,
                 count: 0,
+                _marker: PhantomData,
             },
         );
         match taken {

--- a/src/redisearch_rs/reducers/src/reducer.rs
+++ b/src/redisearch_rs/reducers/src/reducer.rs
@@ -27,6 +27,7 @@ impl Reducer {
             reducerId: 0,
             NewInstance: None,
             Add: None,
+            AddWithDocId: None,
             Finalize: None,
             FreeInstance: None,
             Free: None,
@@ -70,6 +71,20 @@ impl Reducer {
         f: unsafe extern "C" fn(*mut ffi::Reducer, *mut c_void, *const ffi::RLookupRow) -> i32,
     ) -> &mut Self {
         self.0.Add = Some(f);
+        self
+    }
+
+    /// Set `AddWithDocId` function pointer.
+    pub fn set_add_with_doc_id(
+        &mut self,
+        f: unsafe extern "C" fn(
+            *mut ffi::Reducer,
+            *mut c_void,
+            *const ffi::RLookupRow,
+            ffi::t_docId,
+        ) -> i32,
+    ) -> &mut Self {
+        self.0.AddWithDocId = Some(f);
         self
     }
 

--- a/src/redisearch_rs/reducers/tests/collect/helpers.rs
+++ b/src/redisearch_rs/reducers/tests/collect/helpers.rs
@@ -112,7 +112,7 @@ pub(super) fn run_collect(
     let mut ctx = RemoteCollectCtx::new(&r);
     for (projected, sort_vals) in rows {
         let row = make_row(&field_keys, &sort_keys, &projected, &sort_vals);
-        ctx.add(&r, &row);
+        ctx.add(&r, &row, 0);
     }
     ctx.finalize(&r)
 }

--- a/src/redisearch_rs/reducers/tests/collect/limit.rs
+++ b/src/redisearch_rs/reducers/tests/collect/limit.rs
@@ -125,7 +125,7 @@ fn remote_internal_mode_does_not_apply_limit_offset_locally() {
                 &[SharedValue::new_num(i as f64)],
                 &[SharedValue::new_num(i as f64)],
             );
-            ctx.add(&r, &row);
+            ctx.add(&r, &row, 0);
         }
         let out = ctx.finalize(&r);
         extract_num_field(&out, b"v")

--- a/src/redisearch_rs/reducers/tests/collect/remote.rs
+++ b/src/redisearch_rs/reducers/tests/collect/remote.rs
@@ -22,7 +22,7 @@ fn remote_external_collect_emits_only_requested_fields() {
     let mut ctx = RemoteCollectCtx::new(&reducer);
     let row = fixture.row("apple", 10.0);
 
-    ctx.add(&reducer, &row);
+    ctx.add(&reducer, &row, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 1);
@@ -42,7 +42,7 @@ fn remote_internal_collect_includes_sort_fields_for_coordinator_merge() {
     let mut ctx = RemoteCollectCtx::new(&reducer);
     let row = fixture.row("apple", 10.0);
 
-    ctx.add(&reducer, &row);
+    ctx.add(&reducer, &row, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 1);
@@ -73,7 +73,7 @@ fn remote_finalize_dedupes_overlapping_field_and_sort_key() {
     let mut ctx = RemoteCollectCtx::new(&reducer);
     let row = fixture.row("apple", 10.0);
 
-    ctx.add(&reducer, &row);
+    ctx.add(&reducer, &row, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 1);
@@ -91,13 +91,57 @@ fn remote_finalize_dedupes_overlapping_field_and_sort_key() {
 }
 
 #[test]
+fn remote_collect_uses_raw_doc_id_to_break_equal_sortby_values() {
+    // Models the C-side flow: the grouper passes doc ids out-of-band to the
+    // remote COLLECT reducer, and the heap comparator uses them only after all
+    // user sort keys compare equal.
+    let fixture = RemoteCollectFixture::new();
+    let reducer = RemoteCollectReducer::new(
+        Box::new([&fixture.name_key]),
+        None,
+        Box::new([&fixture.sweetness_key]),
+        0b1,
+        Some((0, 2)),
+        false,
+    );
+    let mut ctx = RemoteCollectCtx::new(&reducer);
+
+    let larger_doc_id: ffi::t_docId = (1_u64 << 53) + 1;
+    let smaller_doc_id: ffi::t_docId = 1_u64 << 53;
+
+    let larger = fixture.row("larger-docid", 10.0);
+    let smaller = fixture.row("smaller-docid", 10.0);
+
+    // Insert worse-first so a broken comparator would surface as wrong order.
+    ctx.add(&reducer, &larger, larger_doc_id);
+    ctx.add(&reducer, &smaller, smaller_doc_id);
+
+    let output = ctx.finalize(&reducer);
+    let rows = array_entries(&output);
+    assert_eq!(rows.len(), 2);
+    let names: Vec<&[u8]> = rows
+        .iter()
+        .map(|r| {
+            map_entries(r)
+                .get(b"name")
+                .and_then(|v| v.as_str_bytes())
+                .expect("row must carry a `name` field")
+        })
+        .collect();
+    assert_eq!(
+        names,
+        [b"smaller-docid".as_slice(), b"larger-docid".as_slice()]
+    );
+}
+
+#[test]
 fn remote_finalize_hoists_name_allocations() {
     let fixture = RemoteCollectFixture::new();
     let reducer = fixture.reducer(false);
     let mut ctx = RemoteCollectCtx::new(&reducer);
 
-    ctx.add(&reducer, &fixture.row("apple", 10.0));
-    ctx.add(&reducer, &fixture.row("banana", 20.0));
+    ctx.add(&reducer, &fixture.row("apple", 10.0), 0);
+    ctx.add(&reducer, &fixture.row("banana", 20.0), 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 2);
@@ -134,8 +178,8 @@ fn remote_external_omits_keys_missing_on_row() {
     let mut row_b = RLookupRow::new();
     row_b.write_key(&fixture.name_key, string_value("lemon"));
 
-    ctx.add(&reducer, &row_a);
-    ctx.add(&reducer, &row_b);
+    ctx.add(&reducer, &row_a, 0);
+    ctx.add(&reducer, &row_b, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 2);
@@ -176,7 +220,7 @@ fn remote_load_all_emits_all_lookup_keys_present_on_row() {
     );
     let mut ctx = RemoteCollectCtx::new(&reducer);
 
-    ctx.add(&reducer, &row);
+    ctx.add(&reducer, &row, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 1);
@@ -222,8 +266,8 @@ fn remote_load_all_omits_keys_missing_on_row() {
     );
     let mut ctx = RemoteCollectCtx::new(&reducer);
 
-    ctx.add(&reducer, &row_a);
-    ctx.add(&reducer, &row_b);
+    ctx.add(&reducer, &row_a, 0);
+    ctx.add(&reducer, &row_b, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 2);
@@ -266,7 +310,7 @@ fn remote_load_all_skips_hidden_keys_even_when_row_has_value() {
     );
     let mut ctx = RemoteCollectCtx::new(&reducer);
 
-    ctx.add(&reducer, &row);
+    ctx.add(&reducer, &row, 0);
     let output = ctx.finalize(&reducer);
     let rows = array_entries(&output);
     assert_eq!(rows.len(), 1);

--- a/src/redisearch_rs/reducers/tests/collect/sortby.rs
+++ b/src/redisearch_rs/reducers/tests/collect/sortby.rs
@@ -106,7 +106,7 @@ fn remote_sortby_mixed_directions() {
         row.write_key(&v, SharedValue::new_num(*vv));
         row.write_key(&s0, SharedValue::new_num(*s0v));
         row.write_key(&s1, SharedValue::new_num(*s1v));
-        ctx.add(&r, &row);
+        ctx.add(&r, &row, 0);
     }
     let out = ctx.finalize(&r);
     // Expected best→worst: (s0=0,s1=1), (s0=1,s1=9), (s0=1,s1=5).
@@ -133,7 +133,7 @@ fn remote_sortby_internal_emits_sort_snapshot() {
             &[SharedValue::new_num(n * 10.0)],
             &[SharedValue::new_num(n)],
         );
-        ctx.add(&r, &row);
+        ctx.add(&r, &row, 0);
     }
     let out = ctx.finalize(&r);
     let rows = array_entries(&out);

--- a/src/redisearch_rs/reducers/tests/heap.rs
+++ b/src/redisearch_rs/reducers/tests/heap.rs
@@ -21,7 +21,7 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 /// Builds an [`EntryKey`] from `f64`s — `f64::NAN` projects to `None` so tests
 /// can exercise the missing-worst policy.
-fn key(vals: &[f64], asc: u64) -> EntryKey {
+fn key(vals: &[f64], asc: u64) -> EntryKey<()> {
     let snapshot: Box<[Option<SharedValue>]> = vals
         .iter()
         .map(|v| {
@@ -32,7 +32,7 @@ fn key(vals: &[f64], asc: u64) -> EntryKey {
             }
         })
         .collect();
-    EntryKey::new(snapshot, asc)
+    EntryKey::new(snapshot, asc, ())
 }
 
 /// Bit `i` ASC.
@@ -131,9 +131,9 @@ fn heap_entry_into_projected_returns_payload() {
 
 #[test]
 fn min_max_heap_top_k_under_asc() {
-    let mut heap: MinMaxHeap<HeapEntry<u64>> = MinMaxHeap::with_capacity(3);
+    let mut heap: MinMaxHeap<HeapEntry<(), u64>> = MinMaxHeap::with_capacity(3);
     // ASC bit 0 set → smaller is better. Top-3 of {5,1,4,2,3} = {1,2,3}.
-    let push = |heap: &mut MinMaxHeap<HeapEntry<u64>>, v: f64| {
+    let push = |heap: &mut MinMaxHeap<HeapEntry<(), u64>>, v: f64| {
         heap.push(HeapEntry::new(key(&[v], asc(0)), v as u64));
     };
     push(&mut heap, 5.0);
@@ -161,4 +161,23 @@ fn min_max_heap_top_k_under_asc() {
     // Sorted drain best→worst = ASC top-K = 1,2,3.
     let drained: Vec<u64> = heap.drain_desc().map(HeapEntry::into_projected).collect();
     assert_eq!(drained, vec![1, 2, 3]);
+}
+
+#[test]
+fn entry_key_compares_doc_id_only_after_sort_values_tie() {
+    let primary = Some(SharedValue::new_num(1.0));
+    let a = EntryKey::new(Box::new([primary.clone()]), asc(0), 10u64);
+    let b = EntryKey::new(Box::new([primary]), asc(0), 20u64);
+    // Sort values tie -> smaller doc id is "better".
+    assert_eq!(a.cmp(&b), Ordering::Greater);
+    assert_eq!(b.cmp(&a), Ordering::Less);
+}
+
+#[test]
+fn entry_key_sort_values_take_precedence_over_doc_id() {
+    let a = EntryKey::new(Box::new([Some(SharedValue::new_num(1.0))]), asc(0), 20u64);
+    let b = EntryKey::new(Box::new([Some(SharedValue::new_num(2.0))]), asc(0), 10u64);
+    // Sort value wins first; doc id is only a tie-breaker.
+    assert_eq!(a.cmp(&b), Ordering::Greater);
+    assert_eq!(b.cmp(&a), Ordering::Less);
 }

--- a/src/redisearch_rs/reducers/tests/storage.rs
+++ b/src/redisearch_rs/reducers/tests/storage.rs
@@ -60,7 +60,7 @@ fn insert_entry_array_caps_at_cap_in_insertion_order() {
     let key = make_key();
     let mut s = Storage::new(false, Some((0, 3)), 0);
     for i in 0..5 {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(true).collect();
     assert_eq!(drained.len(), 3);
@@ -73,7 +73,7 @@ fn insert_entry_array_drops_excess_without_calling_project() {
     let mut counter = 0;
     let mut s = Storage::new(false, Some((0, 2)), 0);
     for v in [1.0_f64, 2.0, 3.0, 4.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     assert_eq!(
         counter, 2,
@@ -86,7 +86,7 @@ fn insert_entry_heap_keeps_top_k_under_asc() {
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), || row(&key, i));
+        s.insert_entry(|| sort_vals(i), (), || row(&key, i));
     }
     let drained: Vec<_> = s.drain(true).collect();
     // ASC: smallest is best; heap drains best→worst.
@@ -98,7 +98,7 @@ fn insert_entry_heap_keeps_top_k_under_desc() {
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_DESC);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), || row(&key, i));
+        s.insert_entry(|| sort_vals(i), (), || row(&key, i));
     }
     let drained: Vec<_> = s.drain(true).collect();
     // DESC: largest is best; heap drains best→worst.
@@ -112,12 +112,12 @@ fn insert_entry_heap_skips_project_for_doomed_candidates() {
     let mut s = Storage::new(true, Some((0, 2)), SORT_ASC);
     // Fill with the two best candidates first.
     for v in [0.0_f64, 1.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     // Each subsequent candidate is worse than the worst survivor (1.0)
     // under ASC, so `project` must not run.
     for v in [2.0_f64, 3.0, 4.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     assert_eq!(
         counter, 2,
@@ -133,7 +133,7 @@ fn insert_entry_heap_invokes_project_on_eviction() {
     // Each insert is strictly better than the current worst, so every
     // candidate must be projected.
     for v in [5.0_f64, 3.0, 1.0] {
-        s.insert_entry(|| sort_vals(v), counting_project(&mut counter, &key, v));
+        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     assert_eq!(counter, 3);
 }
@@ -143,7 +143,7 @@ fn drain_array_applies_skip_take() {
     let key = make_key();
     let mut s = Storage::new(false, Some((1, 2)), 0);
     for i in 0..5 {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(true).collect();
     assert_eq!(drained_nums(&key, &drained), vec![1.0, 2.0]);
@@ -154,7 +154,7 @@ fn drain_without_limit_ignores_stored_limit() {
     let key = make_key();
     let mut s = Storage::new(false, Some((1, 2)), 0);
     for i in 0..3 {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(false).collect();
     assert_eq!(drained_nums(&key, &drained), vec![0.0, 1.0, 2.0]);
@@ -165,7 +165,7 @@ fn drain_heap_applies_skip_take_after_best_first_order() {
     let key = make_key();
     let mut s = Storage::new(true, Some((1, 2)), SORT_ASC);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), || row(&key, i));
+        s.insert_entry(|| sort_vals(i), (), || row(&key, i));
     }
     // Top-3 under ASC = [0, 1, 2] best→worst; offset 1, count 2 → [1, 2].
     let drained: Vec<_> = s.drain(true).collect();
@@ -177,7 +177,7 @@ fn insert_entry_heap_uses_default_limit_when_no_explicit_limit() {
     let key = make_key();
     let mut s = Storage::new(true, None, SORT_ASC);
     for i in 0..(DEFAULT_LIMIT as usize + 5) {
-        s.insert_entry(|| sort_vals(i as f64), || row(&key, i as f64));
+        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
     }
     let drained: Vec<_> = s.drain(true).collect();
     assert_eq!(drained.len(), DEFAULT_LIMIT as usize);

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1751,3 +1751,258 @@ def test_collect_followed_by_apply_and_filter():
     env.assertEqual(attrs['color_upper'], 'RED')
     env.assertEqual(int(attrs['cnt']), 2)
     env.assertEqual(attrs['names'], [{'name': 'apple'}, {'name': 'strawberry'}])
+
+
+# ---------------------------------------------------------------------------
+# Tie-breaking on COLLECT + SORTBY.
+# ---------------------------------------------------------------------------
+def _insert_tied_docs(env, names=('a', 'b', 'c', 'd', 'e')):
+    """Insert docs that fully tie on the SORTBY key (color='black',
+    sweetness=1), so order is determined solely by the doc_id tie-break.
+    Returns the list of names in insertion order."""
+    conn = getConnectionByEnv(env)
+    names = list(names)
+    for i, name in enumerate(names):
+        conn.execute_command('HSET', f'doc:{i}', 'name', name,
+                             'color', 'black', 'sweetness', '1')
+    return names
+
+
+@skip(cluster=True)
+def test_collect_sortby_tiebreak_stable_under_asc():
+    """Single shard, ASC SORTBY. All rows tie on the sort key, so the order
+    must come entirely from the doc_id tie-breaker — smaller doc_id wins
+    under ASC, matching FT.AGGREGATE SORTBY."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+    names_in_insert_order = _insert_tied_docs(env)
+
+    cmd = (
+        'FT.AGGREGATE', 'idx', '@color:{black}',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'ASC',
+            'AS', 'names')
+
+    res1 = env.cmd(*cmd)
+    res2 = env.cmd(*cmd)
+    env.assertEqual(res1, res2, message='order must be stable across runs')
+
+    attrs = res1['results'][0]['extra_attributes']
+    # ASC + ties → smaller doc_id wins → insertion order preserved.
+    env.assertEqual([r['name'] for r in attrs['names']], names_in_insert_order)
+
+
+@skip(cluster=True)
+def test_collect_sortby_tiebreak_stable_under_desc():
+    """Single shard, DESC SORTBY. When all rows tie on the user sort key,
+    the implicit doc-id tie-breaker (always ASC) decides ordering — so even
+    a DESC user direction yields rows in insertion (smaller-docid-first)
+    order."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+    names_in_insert_order = _insert_tied_docs(env)
+
+    cmd = (
+        'FT.AGGREGATE', 'idx', '@color:{black}',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'DESC',
+            'AS', 'names')
+
+    res1 = env.cmd(*cmd)
+    res2 = env.cmd(*cmd)
+    env.assertEqual(res1, res2, message='order must be stable across runs')
+
+    attrs = res1['results'][0]['extra_attributes']
+    # Ties → ASC doc-id tie-break → insertion order.
+    env.assertEqual([r['name'] for r in attrs['names']], names_in_insert_order)
+
+
+@skip(cluster=False)
+def test_collect_cluster_sortby_tiebreak_result_complete():
+    """Multi-shard. Shard payloads arriving on the coordinator carry no
+    document id, so the tie-break collapses on coord — matching
+    FT.AGGREGATE SORTBY's coord semantics: order depends on shard
+    arrival sequence and is not guaranteed stable across runs. This
+    test therefore only verifies completeness of the result set."""
+    env = Env(shardsCount=3, protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+    conn = getConnectionByEnv(env)
+    # Spread documents across shards via hash tags; all share the same
+    # sweetness so the SORTBY key fully ties.
+    for i in range(9):
+        conn.execute_command('HSET', f'doc:{i}{{shard:{i % 3}}}',
+                             'name', f'n{i}', 'color', 'black', 'sweetness', '1')
+
+    cmd = (
+        'FT.AGGREGATE', 'idx', '@color:{black}',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'ASC',
+            'AS', 'names')
+    res = env.cmd(*cmd)
+    attrs = res['results'][0]['extra_attributes']
+    names = sorted(r['name'] for r in attrs['names'])
+    env.assertEqual(names, [f'n{i}' for i in range(9)])
+
+
+@skip(cluster=True)
+def test_collect_sortby_tiebreak_two_collects_same_groupby():
+    """Two sibling COLLECT … SORTBY reducers in the same GROUPBY must both
+    receive the doc_id tie-break — not only the first one."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+    # Both SORTBY keys fully tie, so the only thing that can order the
+    # rows is the doc_id tie-break.
+    names_in_insert_order = _insert_tied_docs(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '@color:{black}',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'ASC',
+            'AS', 'first_names',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'ASC',
+            'AS', 'second_names')
+
+    attrs = res['results'][0]['extra_attributes']
+    first  = [r['name'] for r in attrs['first_names']]
+    second = [r['name'] for r in attrs['second_names']]
+
+    # Under ASC with all sort-values tied, both must collapse to
+    # insertion (doc_id) order.
+    env.assertEqual(first, names_in_insert_order)
+    env.assertEqual(second, names_in_insert_order,
+                    message="second COLLECT lost its doc_id tie-break "
+                            "(RLookup_GetKey_Write returned NULL on a "
+                            "duplicate `__docid` registration)")
+
+
+@skip(cluster=True)
+def test_collect_sortby_tiebreak_two_collects_same_groupby_asc_desc():
+    """Two sibling COLLECT … SORTBY reducers over the same fully-tied input.
+
+    The implicit shard-side doc_id tie-breaker is always ASC (lower doc_id
+    wins) regardless of the user's primary sort direction, so when every
+    user sort value ties, both ASC and DESC variants land on the exact same
+    row order — they do NOT reverse each other."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+    conn = getConnectionByEnv(env)
+    # All docs share color='black' and sweetness=1 — the user SORTBY key
+    # fully ties, so the implicit ASC doc-id tie-break drives ordering.
+    _insert_tied_docs(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '@color:{black}',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'ASC',
+            'AS', 'asc_names',
+            'REDUCE', 'COLLECT', '7',
+                'FIELDS', '1', '@name',
+                'SORTBY', '2', '@sweetness', 'DESC',
+            'AS', 'desc_names')
+
+    attrs = res['results'][0]['extra_attributes']
+    asc_names = [r['name'] for r in attrs['asc_names']]
+    desc_names = [r['name'] for r in attrs['desc_names']]
+
+    env.assertEqual(asc_names, desc_names)
+
+
+# ---------------------------------------------------------------------------
+# Chained GROUPBY with COLLECT SORTBY in the outer reducer
+# ---------------------------------------------------------------------------
+def test_chained_groupby_outer_collect_sortby():
+    """Chained GROUPBY with COLLECT SORTBY in the outer reducer"""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_hash(env)
+
+    # Inner GROUPBY aggregates per-price (multiple groups since prices repeat),
+    # producing synthetic rows with no underlying docId. Outer GROUPBY COLLECTs
+    # them sorted by the aggregated count.
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@price',
+            'REDUCE', 'COUNT', '0', 'AS', 'n',
+        'GROUPBY', '0',
+            'REDUCE', 'COLLECT', '8',
+                'FIELDS', '2', '@price', '@n',
+                'SORTBY', '2', '@n', 'DESC',
+            'AS', 'rows')
+
+    env.assertEqual(len(res['results']), 1)
+    rows = res['results'][0]['extra_attributes']['rows']
+    # 12 docs, prices 10 and 15 each appear twice, others once -> 10 groups.
+    env.assertEqual(len(rows), 10)
+    counts = [int(r['n']) for r in rows]
+    env.assertEqual(counts, sorted(counts, reverse=True))
+
+
+def test_chained_groupby_outer_collect_sortby_limit():
+    """Chained GROUPBY with COLLECT SORTBY in the outer reducer but with a LIMIT
+    on the outer COLLECT, forcing the bounded top-K heap path on synthetic rows."""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@price',
+            'REDUCE', 'COUNT', '0', 'AS', 'n',
+        'GROUPBY', '0',
+            'REDUCE', 'COLLECT', '11',
+                'FIELDS', '2', '@price', '@n',
+                'SORTBY', '2', '@n', 'DESC',
+                'LIMIT', '0', '3',
+            'AS', 'rows')
+
+    env.assertEqual(len(res['results']), 1)
+    rows = res['results'][0]['extra_attributes']['rows']
+    env.assertEqual(len(rows), 3)
+    counts = [int(r['n']) for r in rows]
+    env.assertEqual(counts, sorted(counts, reverse=True))
+
+
+
+def test_chained_groupby_outer_collect_sortby_partial_ties():
+    """Outer SORTBY has both non-tied and tied groups"""
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_hash(env)
+
+    # Inner GROUPBY by @price: prices 10 and 15 each have 2 docs, the rest 1.
+    # Counts -> {2, 2, 1, 1, 1, 1, 1, 1, 1, 1}. LIMIT 0 4 forces the heap to
+    # cover both sides of the tie between the two n=2 winners and two of the
+    # eight n=1 candidates.
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@price',
+            'REDUCE', 'COUNT', '0', 'AS', 'n',
+        'GROUPBY', '0',
+            'REDUCE', 'COLLECT', '11',
+                'FIELDS', '2', '@price', '@n',
+                'SORTBY', '2', '@n', 'DESC',
+                'LIMIT', '0', '4',
+            'AS', 'rows')
+
+    env.assertEqual(len(res['results']), 1)
+    rows = res['results'][0]['extra_attributes']['rows']
+    env.assertEqual(len(rows), 4)
+    counts = [int(r['n']) for r in rows]
+    env.assertEqual(counts, [2, 2, 1, 1])


### PR DESCRIPTION
Backport #9844 to 8.8
(cherry picked from commit 7dbc8f5657a5e5e9780007f79b11d985633fe6ac)

Conflicts solved:
- Since [[8.8] [MOD-15113] Limit aggregate GROUPBY groups](https://github.com/RediSearch/RediSearch/pull/9884)  has not been merged, `invokeGroupReducers()` is still returning `void`

## Description

1. Current: `COLLECT ... SORTBY` could produce unstable ordering when multiple collected rows had equal sort-key values, because the reducer did not have access to the upstream document id for deterministic tie-breaking.
2. Change: Thread the upstream docId through the grouper reducer callback path and use it as an out-of-band tie-breaker in the remote COLLECT heap comparator. 
The shared heap/storage code now uses a generic tie-break key: remote collection instantiates it with `t_docId`, while the coordinator/local merge path instantiates it with `()` because shard payloads do not carry doc ids.
3. Outcome: Single-shard `COLLECT ... SORTBY` now has deterministic tie ordering that matches aggregate SORTBY behavior, including multiple sibling COLLECT reducers in the same GROUPBY.


#### Which additional issues this PR fixes
1. MOD-15733

#### Main objects this PR modified
1. `src/aggregate/group_by.c`
2. `src/aggregate/reducer.h`
3. `src/redisearch_rs/reducers/src/collect/*`
4. `src/redisearch_rs/c_entrypoint/reducers_ffi/src/collect/remote.rs`
5. `tests/pytests/test_groupby_collect.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes



[MOD-15113]: https://redislabs.atlassian.net/browse/MOD-15113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GROUPBY→reducer callback contract and COLLECT SORTBY ordering semantics across C/Rust FFI; behavior is intentional but affects aggregation results when sort keys tie.
> 
> **Overview**
> Fixes **unstable ordering** when `COLLECT … SORTBY` rows tie on all user sort keys by threading the upstream **document id** from the GROUPBY grouper into reducers that opt in.
> 
> The C grouper now passes `SearchResult_GetDocId` through `invokeReducers` / `extractGroups`, and `Reducer` gains an optional **`AddWithDocId`** callback (existing reducers keep using `Add`). Shard-side remote COLLECT wires **`collectRemoteAddWithDocId`** instead of `collectRemoteAdd`.
> 
> COLLECT heap ranking uses a generic tie-break key: **`EntryKey` / `Storage<D>`** take `doc_id` on the heap path only (smaller id wins after `cmp_fields` ties). Remote collect uses **`Storage<t_docId>`**; local/coordinator merge uses **`Storage<()>`** because shard payloads do not carry doc ids.
> 
> Rust/unit tests cover doc-id tie-breaking and comparator precedence; Python flow tests cover single-shard stability, cluster completeness, sibling COLLECT reducers, and chained GROUPBY with outer COLLECT SORTBY.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a434338cfd99b2c5f4085f88974a70fada6eb7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->