### PR TITLE
build: always reconfigure CMake so -D flag changes take effect

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -707,18 +707,16 @@ run_cmake() {
   echo "Configuring CMake..."
   echo "Build directory: $BINDIR"
 
-  # Run CMake with all the flags
-  if [[ "$FORCE" == "1" || ! -f "$BINDIR/Makefile" ]]; then
-    CMAKE_CMD="cmake $ROOT $CMAKE_BASIC_ARGS $CMAKE_ARGS"
-    echo "$CMAKE_CMD"
+  # Always reconfigure so -D changes (BUILD_SEARCH_UNIT_TESTS, DEBUG, COV, SAN, ...)
+  # take effect on subsequent invocations without requiring FORCE.
+  CMAKE_CMD="cmake $ROOT $CMAKE_BASIC_ARGS $CMAKE_ARGS"
+  echo "$CMAKE_CMD"
 
-    # If verbose, dump all CMake variables before and after configuration
-    if [[ "$VERBOSE" == "1" ]]; then
-      echo "Running CMake with verbose output..."
-      RUSTFLAGS="$RUSTFLAGS" $CMAKE_CMD --trace-expand
-    else
-      RUSTFLAGS="$RUSTFLAGS" $CMAKE_CMD
-    fi
+  if [[ "$VERBOSE" == "1" ]]; then
+    echo "Running CMake with verbose output..."
+    RUSTFLAGS="$RUSTFLAGS" $CMAKE_CMD --trace-expand
+  else
+    RUSTFLAGS="$RUSTFLAGS" $CMAKE_CMD
   fi
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `run_cmake` in `build.sh` skips re-running `cmake` whenever `$BINDIR/Makefile` already exists. Toggling any CMake-affecting flag between invocations (e.g. running `./build.sh` and then `./build.sh RUN_TESTS`, which adds `-DBUILD_SEARCH_UNIT_TESTS=ON`) silently keeps the previously-generated Makefile, so the new flag has no effect until the user remembers to pass `FORCE`.
2. **Change**: Drop the `! -f $BINDIR/Makefile` guard. Always invoke `cmake`. CMake's own reconfigure pass is incremental and a no-op when nothing relevant changed; the downstream make incremental compile is unaffected. `FORCE` behavior is unchanged (the `$BINDIR` wipe happens earlier in `run_cmake`).
3. **Outcome**: A subsequent `./build.sh RUN_TESTS` after a plain `./build.sh` now picks up `-DBUILD_SEARCH_UNIT_TESTS=ON`, the `example_extension` target gets generated, `build_test_dependencies` exports `EXT_TEST_PATH`, and `test_default_scorer` / `test_ext` / `test_config` tests that depend on the example extension stop falling back to a hardcoded relative path and failing with `Extension not found at tests/ctests/ext-example/libexample_extension.so`.

#### Which additional issues this PR fixes
None tracked. Mirrors the intent of orphan commit `5e9b10d2a` ("Always reconfigure CMake without needing FORCE") which never landed on master.

#### Main objects this PR modified
1. `build.sh` — `run_cmake`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard change in the build script; no runtime, API, or product code paths affected.
> 
> **Overview**
> **`run_cmake` in `build.sh` now always runs `cmake`**, instead of skipping configuration when `$BINDIR/Makefile` already exists (unless you used `FORCE`).
> 
> That means **later `./build.sh` invocations with different flags**—e.g. plain build then `./build.sh RUN_TESTS` with `-DBUILD_SEARCH_UNIT_TESTS=ON`—**refresh the generated build files** so CMake options like tests, debug, coverage, and sanitizers actually apply. A full clean via **`FORCE` is unchanged** (still removes `$BINDIR` before configure). Incremental **`make` behavior is unchanged** when options are the same; CMake’s reconfigure is cheap when nothing moved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fcd28c5cf7edd447af8660f8e3d02282a4dfb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->