### PR TITLE
Framework-neutral spec workflow for external and agent contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,25 @@ The codebase is primarily C, with an ongoing effort to port modules to Rust in `
 
 For human contributor instructions, see `CONTRIBUTING.md`. This file is optimized for coding agents and internal automation workflows.
 
+## Proposing Features and Large Changes
+
+External and automated contributors are welcome to propose new features and improvements — not just fix bugs. Keep the friction proportional to the change:
+
+- **Small changes** (bug fixes, refactors, tests, docs) go straight to a normal PR. See `CONTRIBUTING.md`.
+- **Large changes** — a new `FT.*` command or option, a new field/index type, a behavior or persistence-format change, or a cross-cutting C/Rust refactor — go through a lightweight **spec-driven workflow** so the design is reviewed *before* code is written.
+
+The spec-driven workflow is gated but **framework-neutral**. What is reviewed is a set of artifacts, not any particular tool:
+
+1. **Proposal** — *why* (problem, who is affected) and *what changes* (the user-visible surface). No code.
+2. **Design** — *how*: subsystems touched, data model, edge cases, alternatives considered and rejected.
+3. **Tasks** — an implementation checklist; one item ≈ one reviewable commit or PR.
+4. **Spec delta** — the durable behavior spec for the new or changed surface.
+5. **Tests** — the change is **not done** until new or changed behavior is covered (C unit, Rust, and/or Python end-to-end as appropriate) and the build, lint, and test suites are green.
+
+You may author these artifacts however you like — by hand in Markdown, with [OpenSpec](https://github.com/Fission-AI/OpenSpec) (this repo ships an `openspec/` setup with worked examples), with [GitHub Spec Kit](https://github.com/github/spec-kit), or another spec framework. The artifacts and maintainer review are the contract; the framework is optional.
+
+The **gate is maintainer review at each stage** (proposal → design → implementation), not CI: open a GitHub issue first, get directional agreement, then iterate on the artifacts in a draft PR. See [`docs/CONTRIBUTING-specs.md`](docs/CONTRIBUTING-specs.md) for the full workflow and where artifacts live.
+
 ## Build Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,4 +80,11 @@ Starting with Redis 8, RediSearch is licensed under your choice of: (i) Redis So
 
 ## Code contributions
 
-By contributing code to this Redis module in any form, including sending a pull request via GitHub, a code fragment or patch via private email or public discussion groups, you agree to release your code under the terms of the Redis Software Grant and Contributor License Agreement. Please see the CONTRIBUTING.md file in this source distribution for more information. For security bugs and vulnerabilities, please see SECURITY.md.
+Contributions are welcome — bug fixes, improvements, and new feature proposals alike, from both human and AI-assisted contributors.
+
+- **Getting started, setup, coding standards, and the PR workflow:** see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- **Proposing a feature or other large change** (new commands, new index types, behavior or persistence changes): RediSearch uses a lightweight, framework-neutral spec-driven workflow so the design is reviewed before code is written — see [`docs/CONTRIBUTING-specs.md`](docs/CONTRIBUTING-specs.md).
+- **Coding agents:** repo conventions and the contribution workflow are summarized for automated tooling in [`AGENTS.md`](AGENTS.md).
+- **Security bugs and vulnerabilities:** see [`SECURITY.md`](SECURITY.md).
+
+By contributing code to this Redis module in any form, including sending a pull request via GitHub, a code fragment or patch via private email or public discussion groups, you agree to release your code under the terms of the Redis Software Grant and Contributor License Agreement. Please see the CONTRIBUTING.md file in this source distribution for more information.

--- a/docs/CONTRIBUTING-specs.md
+++ b/docs/CONTRIBUTING-specs.md
@@ -1,0 +1,94 @@
+# Contributing a Spec-Driven Change
+
+For non-trivial changes — new commands, new index types, behavior changes, anything that affects the public API or persistence format — RediSearch uses a lightweight **spec-driven workflow**. Before you write code, you capture the *why*, the *how*, and the *plan* as a small set of review artifacts, so maintainers can agree on the design while it is still cheap to change.
+
+This workflow is **framework-neutral**. What gets reviewed is a set of artifacts (described below), not any particular tool. You can produce them however you like:
+
+- by hand, in plain Markdown — no tooling required;
+- with [OpenSpec](https://github.com/Fission-AI/OpenSpec), which this repo ships a setup for under `openspec/` (see [worked examples](../openspec/changes/));
+- with [GitHub Spec Kit](https://github.com/github/spec-kit) or another spec framework you prefer.
+
+The artifacts and maintainer review are the contract; the tool that generates them is your choice. You do **not** need to install or run any AI tooling to follow this workflow.
+
+If your change is a small bug fix, a refactor, a test, or a docs update, you can ignore this file and use the standard PR flow described in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## When you need a spec
+
+Open an issue first if your change involves any of:
+
+- A new `FT.*` command, or a new option/argument on an existing command.
+- A new field type or index type.
+- A behavior change visible to existing users (different results, different errors, different defaults).
+- A cross-module refactor that touches both C and Rust.
+
+For these, a maintainer will either:
+
+1. Reply on the issue with the design decisions and treat the issue as the spec, **or**
+2. Ask you (or do it themselves) to draft a spec under `openspec/changes/<your-change-name>/`. This is the path described below.
+
+You do not need to draft a spec to open an issue. The issue comes first; the spec is a follow-up only if the change is large enough to warrant one.
+
+## Where specs live
+
+This repository's convention is the OpenSpec directory layout, which any of the tooling options above (or a hand-written change) can target. The shape is what matters, not the tool that produced it:
+
+```
+openspec/
+├── config.yaml                       # OpenSpec config (don't usually need to touch)
+├── specs/                            # Long-lived specs describing current behavior
+└── changes/
+    ├── <your-change-name>/           # In-progress change
+    │   ├── proposal.md               # Why and what (the pitch)
+    │   ├── design.md                 # How (the technical plan)
+    │   ├── tasks.md                  # Checklist of implementation steps
+    │   └── specs/                    # Delta specs that will land in openspec/specs/ on merge
+    └── archive/                      # Completed changes, kept for history
+```
+
+If you use a different framework whose on-disk layout differs, that's fine — note it in your PR so a maintainer can help fold the artifacts into this convention on merge.
+
+For shape and tone, browse any subdirectory under [`openspec/changes/`](../openspec/changes/) or [`openspec/changes/archive/`](../openspec/changes/archive/) — each one contains a worked set of the artifacts described below.
+
+## The four artifacts, in plain English
+
+1. **`proposal.md` — the pitch.** Two sections: **Why** (what problem this solves, who is affected, what costs the status quo has) and **What Changes** (the user-visible surface — new commands, changed defaults, removed behavior). Aim for a page, not a dissertation. No code.
+
+2. **`design.md` — the technical plan.** How you intend to implement it: which subsystems change, what the data model looks like, what edge cases exist, what you considered and rejected. This is where reviewers push back on the *approach* before you write the code.
+
+3. **`tasks.md` — the implementation checklist.** Numbered, checkbox-style. Group by subsystem or by phase, so each top-level item maps to one reviewable unit of work. Granularity should be roughly "one task = one PR or one self-contained commit."
+
+4. **`specs/<capability>/spec.md` — delta specs.** The diff against the long-lived specs in `openspec/specs/`. If your change adds a command, you describe the command here; when the change is merged, this content is folded into `openspec/specs/` and removed from `changes/`. For your first PR, you can ask a maintainer to handle this — it's a mechanical step.
+
+## Suggested flow for outside contributors
+
+1. **Open a GitHub issue** describing the problem and what you'd like to change. Reference any prior issues or community discussion. Wait for a maintainer to agree it's worth a spec-driven change.
+2. **Draft `proposal.md`** in a fork, under `openspec/changes/<change-name>/proposal.md`. Open a draft PR with just that file. This is the cheapest moment to get directional feedback — before you've written code or a detailed design.
+3. **Add `design.md`** to the same draft PR after the proposal is roughly accepted. Iterate on review.
+4. **Add `tasks.md`** once the design is settled. From here, you can start implementing; each task can be its own commit or follow-up PR.
+5. **Implement.** Update the checkboxes in `tasks.md` as you go. The same PR that contains the implementation should also include the delta specs under `changes/<change-name>/specs/`.
+6. **Validate before requesting final review.** A spec-driven change is *done* when all of the following hold. Treat this as a self-check before flipping the PR out of draft, and call it out explicitly in the PR description:
+   - Every checkbox in `tasks.md` is either checked off or moved to a follow-up issue with a link.
+   - The delta specs under `changes/<change-name>/specs/` describe what actually shipped, not what was originally proposed — update them if the implementation diverged.
+   - The new or changed behavior is covered by tests (unit, Rust, and/or Python end-to-end as appropriate). No silent gaps.
+   - The full build, lint, and test suites pass locally (see [`CONTRIBUTING.md`](../CONTRIBUTING.md#testing-requirements)) and CI is green.
+   - Any user-facing surface — commands, error messages, `FT.INFO` output, configuration — is reflected in the docs, and the PR's release-notes checkbox is set correctly.
+   - All review threads from earlier draft rounds are resolved.
+7. **Maintainer archives.** On merge, a maintainer moves the change into `openspec/changes/archive/` and folds the deltas into `openspec/specs/`. You don't need to do this step.
+
+A draft PR per artifact is fine; one PR with all four is also fine. Match the size of the change.
+
+## Naming
+
+Use kebab-case for the change directory and keep it short, action-oriented, and descriptive — the name lives in the archive forever, so favour clarity over cleverness. A verb-noun shape (`add-X`, `fix-Y`, `deprecate-Z`) usually reads well.
+
+## What if I don't follow this exactly?
+
+It's fine. The spec workflow is here to make large changes reviewable, not to add procedural overhead. If you have a working implementation and an issue describing it, a maintainer can help you back-fill the artifacts during review. The goal is shared understanding before merge, not paperwork.
+
+## See also
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — the general contributor guide (setup, coding standards, PR workflow).
+- [`openspec/changes/`](../openspec/changes/) and [`openspec/changes/archive/`](../openspec/changes/archive/) — browse for worked examples.
+- Spec-framework options (all optional — pick one or write the artifacts by hand):
+  - [OpenSpec](https://github.com/Fission-AI/OpenSpec) — the tool this repo's `openspec/` layout matches; its CLI can scaffold the artifacts.
+  - [GitHub Spec Kit](https://github.com/github/spec-kit) — spec-driven development toolkit.

--- a/docs/CONTRIBUTING-specs.md
+++ b/docs/CONTRIBUTING-specs.md
@@ -5,7 +5,7 @@ For non-trivial changes — new commands, new index types, behavior changes, any
 This workflow is **framework-neutral**. What gets reviewed is a set of artifacts (described below), not any particular tool. You can produce them however you like:
 
 - by hand, in plain Markdown — no tooling required;
-- with [OpenSpec](https://github.com/Fission-AI/OpenSpec), which this repo ships a setup for under `openspec/` (see [worked examples](../openspec/changes/));
+- with [OpenSpec](https://github.com/Fission-AI/OpenSpec), which this repo ships a setup for under `openspec/` (see the [worked example](../openspec/changes/example-add-ft-foo/));
 - with [GitHub Spec Kit](https://github.com/github/spec-kit) or another spec framework you prefer.
 
 The artifacts and maintainer review are the contract; the tool that generates them is your choice. You do **not** need to install or run any AI tooling to follow this workflow.
@@ -47,7 +47,7 @@ openspec/
 
 If you use a different framework whose on-disk layout differs, that's fine — note it in your PR so a maintainer can help fold the artifacts into this convention on merge.
 
-For shape and tone, browse any subdirectory under [`openspec/changes/`](../openspec/changes/) or [`openspec/changes/archive/`](../openspec/changes/archive/) — each one contains a worked set of the artifacts described below.
+For shape and tone, see the worked example [`openspec/changes/example-add-ft-foo/`](../openspec/changes/example-add-ft-foo/) — a small, deliberately fictional change carrying a complete set of the artifacts described below. Completed changes are kept under [`openspec/changes/archive/`](../openspec/changes/archive/) (empty until the first change is archived).
 
 ## The four artifacts, in plain English
 
@@ -88,7 +88,7 @@ It's fine. The spec workflow is here to make large changes reviewable, not to ad
 ## See also
 
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — the general contributor guide (setup, coding standards, PR workflow).
-- [`openspec/changes/`](../openspec/changes/) and [`openspec/changes/archive/`](../openspec/changes/archive/) — browse for worked examples.
+- [`openspec/changes/example-add-ft-foo/`](../openspec/changes/example-add-ft-foo/) — a worked example change. Completed changes are archived under [`openspec/changes/archive/`](../openspec/changes/archive/).
 - Spec-framework options (all optional — pick one or write the artifacts by hand):
   - [OpenSpec](https://github.com/Fission-AI/OpenSpec) — the tool this repo's `openspec/` layout matches; its CLI can scaffold the artifacts.
   - [GitHub Spec Kit](https://github.com/github/spec-kit) — spec-driven development toolkit.

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,0 +1,39 @@
+# openspec/
+
+This directory holds the **spec-driven change** artifacts for larger RediSearch
+contributions. It is the on-disk layout described in
+[`../docs/CONTRIBUTING-specs.md`](../docs/CONTRIBUTING-specs.md), which is the
+authoritative human-readable guide — start there.
+
+The workflow is **framework-neutral**: the artifacts below (proposal → design →
+tasks → spec delta → tests) are what gets reviewed. You can produce them by hand
+in Markdown, with [OpenSpec](https://github.com/Fission-AI/OpenSpec) (whose CLI
+this layout matches), with [GitHub Spec Kit](https://github.com/github/spec-kit),
+or any other spec framework. The tool is optional; the artifacts and maintainer
+review are the contract.
+
+## Layout
+
+```
+openspec/
+├── config.yaml                       # Project context + per-artifact rules
+├── specs/                            # Long-lived specs describing current behavior
+└── changes/
+    ├── <change-name>/                # An in-progress change
+    │   ├── proposal.md               # Why + What Changes (the pitch)
+    │   ├── design.md                 # How (the technical plan)
+    │   ├── tasks.md                  # Implementation checklist (incl. tests)
+    │   └── specs/<capability>/spec.md  # Delta specs (fold into ../specs/ on merge)
+    └── archive/                      # Completed changes, kept for history
+```
+
+## Worked example
+
+[`changes/example-add-ft-foo/`](changes/example-add-ft-foo/) is a small,
+**illustrative** change (for a fictional `FT.FOO` command). It is not a real or
+planned RediSearch feature — it exists so you can see the shape of all four
+artifacts. Copy the directory as a starting point for your own change, or create
+the files by hand.
+
+`specs/` and `changes/archive/` start out empty; baseline specs and archived
+changes accumulate over time.

--- a/openspec/changes/archive/.gitkeep
+++ b/openspec/changes/archive/.gitkeep
@@ -1,0 +1,2 @@
+# Completed changes are moved here on merge, kept for history.
+# See ../../README.md and ../../../docs/CONTRIBUTING-specs.md.

--- a/openspec/changes/example-add-ft-foo/.openspec.yaml
+++ b/openspec/changes/example-add-ft-foo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/example-add-ft-foo/design.md
+++ b/openspec/changes/example-add-ft-foo/design.md
@@ -1,0 +1,48 @@
+# Design: FT.FOO (example)
+
+> Illustrative example — `FT.FOO` is fictional. Shows the level of detail a
+> real `design.md` should carry.
+
+## Overview
+
+`FT.FOO <index>` is a thin, read-only command that resolves an index spec and
+formats a one-line summary from data already held in memory. It introduces no
+new data structures and no background work.
+
+## Command dispatch
+
+- Register `FT.FOO` in `src/module.c` alongside the other `FT.*` handlers, as a
+  read-only command (same command flags as `FT.INFO`).
+- The handler resolves the index spec via the existing spec-lookup path used by
+  `FT.INFO` / `FT.SEARCH`. On a miss it returns the standard
+  `Unknown index name (or name is an alias itself)` error so behavior matches
+  the rest of the command surface.
+
+## Producing the summary
+
+- Read the already-maintained counters from the resolved spec:
+  - index name,
+  - number of documents (the same value `FT.INFO` reports as `num_docs`),
+  - number of fields in the schema.
+- Format as a single human-readable bulk string, e.g.
+  `index=<name> docs=<n> fields=<m>`.
+
+## Edge cases
+
+- **Empty index:** `docs=0`, `fields=<schema size>` — not an error.
+- **Alias as argument:** resolves through the alias like other commands.
+- **Cluster mode:** the command runs per-shard like `FT.INFO`; no fan-out/reduce
+  is added in this example.
+
+## Alternatives considered
+
+- **Structured (array) reply** — rejected; `FT.INFO` already covers structured
+  consumption. The value of `FT.FOO` is a terse single line.
+- **Extending `FT.INFO` with a flag** — rejected; a separate command keeps
+  `FT.INFO` parsing untouched and is easier to document.
+
+## Testing strategy
+
+- C unit test for the formatting helper.
+- Python end-to-end tests: summary on a populated index, empty index, unknown
+  index error, and alias resolution.

--- a/openspec/changes/example-add-ft-foo/proposal.md
+++ b/openspec/changes/example-add-ft-foo/proposal.md
@@ -1,0 +1,37 @@
+# Example change: Add FT.FOO
+
+> **This is an illustrative example, not a real or planned RediSearch feature.**
+> It exists to show the shape of a spec-driven change. `FT.FOO` is fictional.
+> Copy this directory as a starting point for your own change, or write the
+> artifacts by hand. See [`../../../docs/CONTRIBUTING-specs.md`](../../../docs/CONTRIBUTING-specs.md).
+
+## Why
+
+Operators occasionally want a one-shot, human-readable health line for an index
+without parsing the full `FT.INFO` reply. Today that requires reading and
+interpreting many `FT.INFO` fields. A tiny convenience command would make quick
+checks and shell scripts simpler.
+
+This is deliberately small: it adds read-only output derived from existing
+state, with no new persistence and no change to indexing behavior — a good size
+for a first contribution.
+
+## What Changes
+
+Add a new read-only command:
+
+```
+FT.FOO <index>
+```
+
+- Returns a single bulk string summarizing the index: its name, number of
+  documents, and number of indexed fields.
+- Errors with `Unknown index name (or name is an alias itself)` if the index
+  does not exist (matching `FT.SEARCH`).
+- No new configuration, no persistence/RDB changes, no API changes to existing
+  commands.
+
+### Non-goals
+
+- No machine-readable / structured output (use `FT.INFO` for that).
+- No cluster-specific aggregation beyond what `FT.INFO` already exposes.

--- a/openspec/changes/example-add-ft-foo/specs/foo-command/spec.md
+++ b/openspec/changes/example-add-ft-foo/specs/foo-command/spec.md
@@ -1,0 +1,31 @@
+# foo-command (example delta)
+
+> Illustrative example — `FT.FOO` is fictional. On merge, the requirements below
+> would be folded into `openspec/specs/foo-command/spec.md`.
+
+## ADDED Requirements
+
+### Requirement: FT.FOO summarizes an index
+The `FT.FOO` command SHALL return a single human-readable summary of an existing
+index, derived from data the index already maintains, without modifying any
+state.
+
+#### Scenario: Summary of a populated index
+- **WHEN** an index `idx` exists with 3 indexed documents and 2 schema fields
+- **AND** the user executes `FT.FOO idx`
+- **THEN** the reply SHALL be a single string reporting the index name, a document count of `3`, and a field count of `2`
+
+#### Scenario: Summary of an empty index
+- **WHEN** an index `idx` exists with a schema but no indexed documents
+- **AND** the user executes `FT.FOO idx`
+- **THEN** the reply SHALL report a document count of `0`
+- **AND** the command SHALL NOT return an error
+
+#### Scenario: Unknown index
+- **WHEN** the user executes `FT.FOO missing` and no index named `missing` exists
+- **THEN** the command SHALL return an error `Unknown index name (or name is an alias itself)`
+
+#### Scenario: Alias argument
+- **WHEN** `alias` is an alias for an existing index `idx`
+- **AND** the user executes `FT.FOO alias`
+- **THEN** the reply SHALL summarize `idx`

--- a/openspec/changes/example-add-ft-foo/tasks.md
+++ b/openspec/changes/example-add-ft-foo/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: FT.FOO (example)
+
+> Illustrative example — `FT.FOO` is fictional. Each top-level task is roughly
+> one reviewable commit or PR. Note the explicit test tasks: a change is not
+> done until new behavior is covered and the suites are green.
+
+## 1. Command registration
+
+- [ ] 1.1 Register `FT.FOO` in `src/module.c` with read-only command flags
+- [ ] 1.2 Wire the handler to the shared index-spec lookup used by `FT.INFO`
+- [ ] 1.3 Return `Unknown index name (or name is an alias itself)` on a miss
+
+## 2. Summary formatting
+
+- [ ] 2.1 Add a helper that formats `index=<name> docs=<n> fields=<m>`
+- [ ] 2.2 Read counts from the resolved spec (reuse `FT.INFO`'s `num_docs`)
+
+## 3. Tests
+
+- [ ] 3.1 C unit test for the formatting helper
+- [ ] 3.2 Python end-to-end test: summary on a populated index
+- [ ] 3.3 Python end-to-end test: empty index (`docs=0`)
+- [ ] 3.4 Python end-to-end test: unknown index returns the standard error
+- [ ] 3.5 Python end-to-end test: alias resolves like other commands
+
+## 4. Docs & spec delta
+
+- [ ] 4.1 Update the delta spec under `specs/foo-command/spec.md` to match what shipped
+- [ ] 4.2 Add user-facing command documentation
+- [ ] 4.3 Confirm the PR's release-notes checkbox reflects the new command

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,22 @@
+schema: spec-driven
+
+# Project context shown to AI tooling when drafting artifacts.
+context: |
+  RediSearch is a Redis module for full-text search, secondary indexing, and
+  vector similarity search. The codebase is primarily C, with an ongoing port
+  to Rust under `src/redisearch_rs/`.
+
+  Commands are prefixed `FT.` (e.g. FT.CREATE, FT.SEARCH, FT.AGGREGATE).
+  Large changes (new commands/options, new field or index types, behavior or
+  persistence-format changes) follow the spec-driven workflow documented in
+  `docs/CONTRIBUTING-specs.md`. The artifacts and maintainer review are the
+  gate; this OpenSpec layout is one convenient way to produce them.
+
+# Per-artifact rules (optional). See docs/CONTRIBUTING-specs.md for guidance.
+rules:
+  proposal:
+    - Keep it to roughly a page; no code.
+    - Two sections only: "## Why" and "## What Changes".
+  tasks:
+    - One top-level task should map to one reviewable commit or PR.
+    - Include explicit tasks for tests (unit, Rust, and/or Python end-to-end).

--- a/openspec/specs/.gitkeep
+++ b/openspec/specs/.gitkeep
@@ -1,0 +1,3 @@
+# Long-lived specs describing current behavior.
+# Baseline specs accumulate here; delta specs from changes fold in on merge.
+# See ../README.md and ../../docs/CONTRIBUTING-specs.md.


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current:** The repository has no contributor-facing guide for proposing larger changes. The agent guide (`AGENTS.md`/`CLAUDE.md`) has no entry point for proposing features, and the README does not route newcomers (human or AI-assisted) to a contribution workflow.
2. **Change:** Make the project ready for external and agentic contributors by:
   - **Adding** `docs/CONTRIBUTING-specs.md` — a lightweight, **framework-neutral** spec-driven workflow for larger changes. The reviewable artifacts (proposal → design → tasks → spec delta → tests) are the contract, and they can be produced by any spec framework or written by hand.
   - Adding a "Proposing Features and Large Changes" section to `AGENTS.md` (and `CLAUDE.md` via symlink) describing the gated, test-validated workflow.
   - Expanding the README "Code contributions" section to route to `CONTRIBUTING.md`, the new spec workflow, `AGENTS.md`, and `SECURITY.md`.
3. **Outcome:** A contributor or coding agent can understand the repo, propose a feature, and follow a gate that is easy for small changes and reviewed-by-maintainers for large ones — without being locked to a single spec framework. The gate stays maintainer-review-based (CI-soft).

#### Which additional issues this PR fixes
1. MOD-... <!-- internal Jira ticket; leave blank if none -->
2. Follow-up to #9725 (community contribution readiness)

#### Main objects this PR modified
1. `docs/CONTRIBUTING-specs.md` — **new** framework-neutral spec-driven contribution guide
2. `AGENTS.md` (and `CLAUDE.md`, which is a symlink to it) — added "Proposing Features and Large Changes"
3. `README.md` — expanded "Code contributions" with routing links

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Documentation-only change (contributor guidance); no user-facing product behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example spec artifacts only; no product code, API, or persistence changes.
> 
> **Overview**
> Introduces a **framework-neutral, spec-driven path** for large contributions (new `FT.*` surface, index types, behavior/persistence changes) so design is reviewed before implementation. **`docs/CONTRIBUTING-specs.md`** is the main guide: when to spec, artifact layout under `openspec/`, issue → draft PR → proposal/design/tasks/delta specs → tests, with maintainer review as the gate (not a hard CI gate).
> 
> **`AGENTS.md`** gains *Proposing Features and Large Changes* (small PRs vs spec workflow, five artifacts including tests). **`README.md`** *Code contributions* now routes to `CONTRIBUTING.md`, the spec guide, `AGENTS.md`, and `SECURITY.md`.
> 
> Adds **`openspec/`** scaffolding: `config.yaml`, `README.md`, placeholder `specs/` and `changes/archive/`, and a fictional **`example-add-ft-foo`** change (proposal, design, tasks, delta spec) as a copyable template. No runtime or `FT.*` behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416007da528e0277ab8b945feb72bb1af34de41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->