### PR TITLE
MOD-15724: Set error upon failure to create disk iterator

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
@@ -178,8 +178,9 @@ where
             // SAFETY: Caller guarantees `spec.diskSpec` is valid, non-null and
             // remains valid for `'index` (5).
             let disk_spec = unsafe { &mut *spec.diskSpec };
-            // SAFETY: Caller guarantees all preconditions of `new_wildcard_iterator_on_disk` hold (5).
-            unsafe { new_wildcard_iterator_on_disk(disk_spec, weight) }
+            // SAFETY: Caller guarantees all preconditions of `new_wildcard_iterator_on_disk` hold (5);
+            // `query.status` is the query's error accumulator.
+            unsafe { new_wildcard_iterator_on_disk(disk_spec, weight, query_ref.status) }
         } else {
             // SAFETY: Caller guarantees `query.sctx` is a valid, non-null pointer (2)
             // and all preconditions of `new_wildcard_iterator_optimized` hold (5).

--- a/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
@@ -101,8 +101,8 @@ where
                     // SAFETY: We checked `disk_index_available` (i.e. `!spec.diskSpec.is_null()`)
                     // above, and (6) guarantees the pointer is valid for `'index`.
                     let disk_spec = unsafe { &mut *spec.diskSpec };
-                    // SAFETY: (6).
-                    unsafe { new_wildcard_iterator_on_disk(disk_spec, weight) }
+                    // SAFETY: (6). `query.status` is the query's error accumulator.
+                    unsafe { new_wildcard_iterator_on_disk(disk_spec, weight, query_ref.status) }
                 } else {
                     // SAFETY: (2) guarantees `sctx` is valid; (7) covers all remaining
                     // preconditions of `new_wildcard_iterator_optimized`.

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -372,17 +372,22 @@ pub unsafe fn new_wildcard_iterator_optimized<'index>(
 /// [`new_wildcard_on_disk`](crate::SearchEnterpriseIterators::new_wildcard_on_disk)
 /// and wraps the resulting iterator in a [`DiskWildcardIterator`].
 ///
-/// If the enterprise iterator cannot be created, this function logs a warning
-/// and falls back to an empty iterator.
+/// If the enterprise iterator cannot be created, this function records a
+/// [`DiskCreation`](query_error::QueryErrorCode::DiskCreation) error on `status`
+/// (when non-null) so the query fails instead of silently returning no results,
+/// and returns an empty iterator as a placeholder.
 ///
 /// # Safety
 ///
 /// 1. `disk_spec` must reference a valid [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec)
 ///    that remains valid for `'index`.
 /// 2. [`SEARCH_ENTERPRISE_ITERATORS`] must be initialized before calling this function.
+/// 3. `status`, when non-null, must point to a valid [`QueryError`](ffi::QueryError)
+///    to which we have exclusive access for the duration of the call.
 pub unsafe fn new_wildcard_iterator_on_disk<'index>(
     disk_spec: &'index mut ffi::RedisSearchDiskIndexSpec,
     weight: f64,
+    status: *mut ffi::QueryError,
 ) -> NewWildcardIterator<'index> {
     // SAFETY: Caller guarantees `SEARCH_ENTERPRISE_ITERATORS` is
     // initialized when `spec.diskSpec` is non-null (8).
@@ -392,9 +397,20 @@ pub unsafe fn new_wildcard_iterator_on_disk<'index>(
     match enterprise_iters_api.new_wildcard_on_disk(disk_spec, weight) {
         Ok(it) => NewWildcardIterator::Disk(it),
         Err(err) => {
-            tracing::warn!(
-                "Failed to create a disk wildcard iterator ({err}); falling back to empty iterator."
-            );
+            tracing::warn!("Failed to create a disk wildcard iterator ({err});");
+            // SAFETY: Caller guarantees `status`, when non-null, points to a
+            // valid `QueryError` we have exclusive access to (3). `ffi::QueryError`
+            // is the opaque representation of `query_error::QueryError`.
+            if let Some(status) = unsafe {
+                query_error::QueryError::from_opaque_mut_ptr(
+                    status.cast::<query_error::opaque::OpaqueQueryError>(),
+                )
+            } {
+                status.set_error(
+                    query_error::QueryErrorCode::DiskCreation,
+                    "Failed to create wildcard iterator on disk index",
+                );
+            }
             NewWildcardIterator::Empty(Empty)
         }
     }
@@ -449,8 +465,9 @@ pub unsafe fn new_wildcard_iterator<'index>(
         // `'index` (7).
         let disk_spec = unsafe { &mut *spec.diskSpec };
         // SAFETY: Caller guarantees all preconditions of
-        // `new_wildcard_iterator_on_disk` hold (7, 8).
-        return unsafe { new_wildcard_iterator_on_disk(disk_spec, weight) };
+        // `new_wildcard_iterator_on_disk` hold (7, 8); `query.status` is the
+        // query's error accumulator.
+        return unsafe { new_wildcard_iterator_on_disk(disk_spec, weight, query.status) };
     }
 
     let index_all = NonNull::new(spec.rule)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Upon failing to create a disk iterator, we return an empty iterator, always, masking away the failure.
2. Change: Return an error upon failing to create a disk iterator.
3. Outcome: Upon failing to create a disk iterator, an appropriate error is returned. To be extended with a more fine-grained error as a follow-up.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query failure semantics for disk-backed wildcard/NOT/OPTIONAL paths: queries that previously returned zero hits may now error, which is correct but can affect production behavior on disk index issues.
> 
> **Overview**
> When enterprise disk wildcard iterator creation fails, the query no longer **silently behaves like an empty index**. `new_wildcard_iterator_on_disk` now takes the query’s `status` pointer and, on failure, records **`QueryErrorCode::DiskCreation`** (`SEARCH_DISK_CREATION`) while still returning an empty iterator as a structural placeholder.
> 
> **NOT** and **OPTIONAL** optimized disk paths, plus the general `new_wildcard_iterator` disk branch, were updated to pass **`query.status`** through to that helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b66447d7772c89a6c2eec232fce78f35ad0b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->