### PR TITLE
[MOD-14738] Expose helpers from `build_utils`

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -78,7 +78,7 @@ pub fn bind_foreign_c_symbols() {
 }
 
 /// Require all symbols to be resolved at link time.
-fn force_link_time_symbol_resolution() {
+pub fn force_link_time_symbol_resolution() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string());
     if target_os == "macos" {
         println!("cargo::rustc-link-arg=-Wl,-undefined,error");

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -71,9 +71,10 @@ pub fn rerun_if_c_changes(dir: &Path) -> std::io::Result<()> {
 /// all C code and dependencies together. The combined library is created by CMake
 /// during the build process.
 pub fn bind_foreign_c_symbols() {
+    let bin_root = bin_root();
     force_link_time_symbol_resolution();
-    link_redisearch_all().unwrap_or_else(|e| panic!("{e}"));
-    link_mkl(&bin_root().join("_deps/svs-src/lib"));
+    link_redisearch_all(&bin_root).unwrap_or_else(|e| panic!("{e}"));
+    link_mkl(&bin_root.join("_deps/svs-src/lib"));
     link_c_plusplus();
 }
 
@@ -134,8 +135,7 @@ fn bin_root() -> PathBuf {
 /// Callers that need soft-fail behaviour (e.g. lint-only runs where the
 /// library has not been built) can inspect the returned `Err` and emit a
 /// `cargo::warning` instead of panicking.
-pub fn link_redisearch_all() -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let bin_root = bin_root();
+pub fn link_redisearch_all(bin_root: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let lib_dir = bin_root.join("src");
     let lib = lib_dir.join("libredisearch_all.a");
     if std::fs::exists(&lib).unwrap_or(false) {

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -73,7 +73,7 @@ pub fn rerun_if_c_changes(dir: &Path) -> std::io::Result<()> {
 pub fn bind_foreign_c_symbols() {
     force_link_time_symbol_resolution();
     link_redisearch_all().unwrap_or_else(|e| panic!("{e}"));
-    link_mkl();
+    link_mkl(&bin_root().join("_deps/svs-src/lib"));
     link_c_plusplus();
 }
 
@@ -153,8 +153,11 @@ pub fn link_redisearch_all() -> Result<PathBuf, Box<dyn std::error::Error>> {
 /// MKL is excluded from `libredisearch_all.a` because its ~42K object files
 /// overflow the `u16` archive member index in rustc's `ar_archive_writer`.
 /// Like `redisearch_all`, we link with `-bundle` to avoid rlib bloat.
-fn link_mkl() {
-    let svs_lib_dir = bin_root().join("_deps/svs-src/lib");
+///
+/// `svs_lib_dir` is the directory that contains `libmkl_static_library.a`.
+/// Its location varies across build configurations, so callers are responsible
+/// for supplying the correct path.
+pub fn link_mkl(svs_lib_dir: &Path) {
     let mkl = svs_lib_dir.join("libmkl_static_library.a");
     if std::fs::exists(&mkl).unwrap_or(false) {
         println!("cargo::rerun-if-changed={}", mkl.display());

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -72,7 +72,7 @@ pub fn rerun_if_c_changes(dir: &Path) -> std::io::Result<()> {
 /// during the build process.
 pub fn bind_foreign_c_symbols() {
     force_link_time_symbol_resolution();
-    link_redisearch_all();
+    link_redisearch_all().unwrap_or_else(|e| panic!("{e}"));
     link_mkl();
     link_c_plusplus();
 }
@@ -116,7 +116,8 @@ fn bin_root() -> PathBuf {
     }
 }
 
-/// Link `libredisearch_all.a` using the `-bundle` modifier.
+/// Link `libredisearch_all.a` using the `-bundle` modifier, returning an error if the
+/// library is not found.
 ///
 /// The `-bundle` modifier prevents the (very large) C archive from being
 /// embedded into every Rust rlib in the dependency tree. Instead, the linker
@@ -129,7 +130,11 @@ fn bin_root() -> PathBuf {
 ///    errors in unrelated workspace members.
 /// 2. Archive member counts exceeding `u16::MAX` in rustc's
 ///    `ar_archive_writer` when MKL or other large archives are involved.
-fn link_redisearch_all() {
+///
+/// Callers that need soft-fail behaviour (e.g. lint-only runs where the
+/// library has not been built) can inspect the returned `Err` and emit a
+/// `cargo::warning` instead of panicking.
+pub fn link_redisearch_all() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let bin_root = bin_root();
     let lib_dir = bin_root.join("src");
     let lib = lib_dir.join("libredisearch_all.a");
@@ -137,8 +142,9 @@ fn link_redisearch_all() {
         println!("cargo::rustc-link-lib=static:-bundle=redisearch_all");
         println!("cargo::rerun-if-changed={}", lib.display());
         println!("cargo::rustc-link-search=native={}", lib_dir.display());
+        Ok(lib)
     } else {
-        panic!("Static library not found: {}", lib.display());
+        Err(format!("Static library not found: {}", lib.display()).into())
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request
This allows RSE to reuse more of `build_utils` rather than duplicating this code in it's own `build.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script/linking API only; no runtime or product behavior change beyond how missing static libs are handled by callers.
> 
> **Overview**
> **Public build helpers** in `build_utils` so other crates (e.g. RSE) can share the same link logic instead of copying `build.rs`.
> 
> `force_link_time_symbol_resolution`, `link_redisearch_all`, and `link_mkl` are now **`pub`**. `link_redisearch_all` takes an explicit **`bin_root`** and returns **`Result`** (missing `libredisearch_all.a` is an error callers can warn on instead of panic). `link_mkl` takes an explicit **`svs_lib_dir`** instead of deriving it internally. `bind_foreign_c_symbols` wires these together and still **panics** on a missing combined archive for the default “full bind” path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2385cc02db3b621a0cd6f3a8f1454939edd3040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->