### PR TITLE
[MOD-16080] rqe_iterators: add GeoShape query iterator

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Iterator over the document IDs returned by a geometry (GEOSHAPE) query.
+//!
+//! A geometry query yields a set of candidate document IDs in spatial (R-tree)
+//! order. This iterator materializes those IDs into a sorted buffer and walks
+//! them in ascending order, the order the rest of the query engine expects.
+//!
+//! On top of the sorted-id-list behavior it provides three extra features:
+//!
+//! * **Field expiration** — skips documents whose queried field has expired,
+//!   using an [`ExpirationChecker`]. Applied on both the [`read`](RQEIterator::read)
+//!   and [`skip_to`](RQEIterator::skip_to) paths, so an expired document never
+//!   leaks even when the iterator is driven via [`skip_to`](RQEIterator::skip_to)
+//!   (e.g. as a non-leading intersection child). The checker is consulted on
+//!   every candidate; it self-gates the no-expiration case (e.g. a missing TTL
+//!   table) cheaply, so no cached flag is kept.
+//! * **Timeout** — aborts a long scan via an amortized [`TimeoutContext`].
+//! * **Memory tracking** — reports the bytes held by the materialized id
+//!   buffer through a [`MemTracker`] (the geometry index's allocation tracker),
+//!   adding on construction and subtracting on drop, so in-flight query
+//!   iterators are reflected in the index's reported memory. Callers that want
+//!   no accounting use [`NoTracker`]. The FFI crates provide their own
+//!   [`MemTracker`] implementation, backed by the index's externally-owned
+//!   counter shared across the C boundary.
+
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
+
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    expiration_checker::ExpirationChecker,
+    profile_print::{ProfilePrint, ProfilePrintCtx},
+    utils::{OwnedSlice, TimeoutContext},
+};
+
+/// Outcome of examining a single candidate document during [`read`](GeoShape::read_single).
+enum SingleRead {
+    /// The candidate is valid and now sits in `result`.
+    Ok,
+    /// The candidate was skipped (expired); keep scanning.
+    NotFound,
+    /// No more candidates.
+    Eof,
+}
+
+/// Sink for a [`GeoShape`] iterator's memory accounting.
+///
+/// The iterator reports the bytes it holds by calling [`add`](MemTracker::add)
+/// once at construction and [`sub`](MemTracker::sub) once on drop, keeping an
+/// external memory counter in sync with its live allocation. Implementations
+/// decide where that accounting goes: [`NoTracker`] discards it, while the FFI
+/// crates provide an implementation that applies it to an externally-owned
+/// `usize` counter shared across the C boundary.
+pub trait MemTracker {
+    /// Records that `bytes` additional bytes are now held.
+    fn add(&self, bytes: usize);
+    /// Records that `bytes` bytes are no longer held.
+    fn sub(&self, bytes: usize);
+}
+
+/// A [`MemTracker`] that records nothing.
+///
+/// Used when no external memory accounting is wanted, e.g. in tests or for
+/// iterators not owned by a memory-tracked index.
+pub struct NoTracker;
+
+impl MemTracker for NoTracker {
+    #[inline(always)]
+    fn add(&self, _bytes: usize) {}
+    #[inline(always)]
+    fn sub(&self, _bytes: usize) {}
+}
+
+/// An iterator over a geometry query's matching document IDs.
+///
+/// # Type parameters
+///
+/// * `'index` — lifetime of the index being queried.
+/// * `T` — the [`TimeoutContext`] used to detect query timeouts.
+/// * `E` — the [`ExpirationChecker`] used to skip expired documents.
+/// * `M` — the [`MemTracker`] kept in sync with the iterator's allocation.
+pub struct GeoShape<'index, T, E, M: MemTracker> {
+    /// The matching document IDs, sorted in ascending order. May contain
+    /// duplicates (the geometry index does not guarantee uniqueness); they are
+    /// yielded as-is.
+    ids: OwnedSlice<DocId>,
+    /// Position of the next document ID to return. `offset == ids.len()` means EOF.
+    offset: usize,
+    /// The last document ID returned by [`read`](Self::read) or
+    /// [`skip_to`](Self::skip_to). Reset to 0 on [`rewind`](Self::rewind).
+    last_doc_id: DocId,
+    /// Reusable result object, avoiding an allocation on every `read`.
+    result: RSIndexResult<'index>,
+    /// Timeout source consulted while scanning.
+    timeout_ctx: T,
+    /// Field-expiration strategy.
+    expiration_checker: E,
+    /// Sink for this iterator's memory accounting (the geometry index's
+    /// allocation tracker). Notified on construction and on drop.
+    mem_tracker: M,
+    /// The number of bytes this iterator reports to `mem_tracker`.
+    /// Added on construction, subtracted on drop.
+    tracked_bytes: usize,
+}
+
+impl<'index, T, E, M> GeoShape<'index, T, E, M>
+where
+    E: ExpirationChecker,
+    M: MemTracker,
+{
+    /// Creates a new geometry-query iterator.
+    ///
+    /// `ids` is sorted in place on construction (the geometry index returns
+    /// matches in spatial order). `result` is the reusable result object;
+    /// callers typically pass a virtual result carrying the query weight.
+    ///
+    /// The byte size of this iterator is reported to `mem_tracker` immediately
+    /// (via [`MemTracker::add`]) and reversed when the iterator is dropped (via
+    /// [`MemTracker::sub`]). Pass [`NoTracker`] to opt out of accounting.
+    pub fn new(
+        ids: impl Into<OwnedSlice<DocId>>,
+        result: RSIndexResult<'index>,
+        timeout_ctx: T,
+        expiration_checker: E,
+        mem_tracker: M,
+    ) -> Self {
+        let mut ids = ids.into();
+        // The geometry index yields matches in R-tree order; the query engine
+        // expects ascending document IDs.
+        ids.sort_unstable();
+
+        let tracked_bytes = Self::mem_bytes(ids.len());
+
+        mem_tracker.add(tracked_bytes);
+
+        Self {
+            ids,
+            offset: 0,
+            last_doc_id: 0,
+            result,
+            timeout_ctx,
+            expiration_checker,
+            mem_tracker,
+            tracked_bytes,
+        }
+    }
+
+    /// The total number of bytes accounted for an iterator holding `len`
+    /// document IDs: the iterator struct itself plus the materialized id buffer.
+    #[inline]
+    const fn mem_bytes(len: usize) -> usize {
+        std::mem::size_of::<Self>() + len * std::mem::size_of::<DocId>()
+    }
+
+    /// Returns the total memory, in bytes, held by this iterator.
+    ///
+    /// This is the same amount added to (and later subtracted from) the
+    /// external memory tracker supplied at construction.
+    #[inline]
+    pub const fn mem_usage(&self) -> usize {
+        self.tracked_bytes
+    }
+
+    /// Whether there are document IDs left to yield.
+    #[inline(always)]
+    fn has_next(&self) -> bool {
+        self.offset < self.ids.len()
+    }
+
+    /// Examine the next candidate document, applying the field-expiration filter.
+    #[inline]
+    fn read_single(&mut self) -> SingleRead {
+        let Some(&doc_id) = self.ids.get(self.offset) else {
+            // No candidate to commit: keep `result` on the last valid doc so an
+            // expired candidate probed on a previous iteration cannot leak via
+            // `current` once the scan settles on EOF.
+            self.result.doc_id = self.last_doc_id;
+            return SingleRead::Eof;
+        };
+        self.offset += 1;
+
+        // `is_expired` reads the candidate out of `result`, so it must be set
+        // before the check.
+        self.result.doc_id = doc_id;
+        if self.expiration_checker.is_expired(&self.result) {
+            // The candidate is expired and must never surface.
+            return SingleRead::NotFound;
+        }
+
+        self.last_doc_id = doc_id;
+        SingleRead::Ok
+    }
+}
+
+impl<'index, T, E, M> RQEIterator<'index> for GeoShape<'index, T, E, M>
+where
+    T: TimeoutContext,
+    E: ExpirationChecker,
+    M: MemTracker,
+{
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        Some(&mut self.result)
+    }
+
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        // The timeout counter is amortized per `read` call: a fresh scan of
+        // candidates is allowed before the next real clock probe.
+        self.timeout_ctx.reset_counter();
+        loop {
+            self.timeout_ctx.check_timeout()?;
+            match self.read_single() {
+                SingleRead::Ok => break,
+                SingleRead::NotFound => continue,
+                SingleRead::Eof => return Ok(None),
+            }
+        }
+        Ok(Some(&mut self.result))
+    }
+
+    fn skip_to(
+        &mut self,
+        doc_id: DocId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        debug_assert!(self.last_doc_id < doc_id, "We're trying to skip backwards!");
+
+        if !self.has_next() {
+            return Ok(None);
+        }
+
+        // `has_next()` is true, so the list is non-empty.
+        let last = *self.ids.last().expect("non-empty list");
+        if doc_id > last {
+            // Past the end: mark EOF without touching `last_doc_id`.
+            self.offset = self.ids.len();
+            return Ok(None);
+        }
+
+        // Binary search for the first ID >= `doc_id` within the unread tail.
+        let tail = &self.ids[self.offset..];
+        let idx = self.offset + tail.partition_point(|&id| id < doc_id);
+        let found = self.ids[idx];
+        self.offset = idx + 1;
+
+        self.result.doc_id = found;
+
+        if self.expiration_checker.is_expired(&self.result) {
+            // The matched entry's field has expired. Fall back to `read`, which
+            // scans from `offset` — the entry right after this expired match —
+            // past any run of expired entries to the next valid one, updating
+            // `result`/`last_doc_id`, so the iterator never settles on an expired
+            // doc. This mirrors the inverted-index iterators' `skip_to` contract.
+            return match self.read()? {
+                // A valid entry beyond `doc_id` was found; the target itself did
+                // not match, so report it as `NotFound`.
+                Some(result) => Ok(Some(SkipToOutcome::NotFound(result))),
+                // No valid entry left: EOF.
+                None => Ok(None),
+            };
+        }
+
+        self.last_doc_id = found;
+
+        if found == doc_id {
+            Ok(Some(SkipToOutcome::Found(&mut self.result)))
+        } else {
+            Ok(Some(SkipToOutcome::NotFound(&mut self.result)))
+        }
+    }
+
+    fn rewind(&mut self) {
+        self.offset = 0;
+        self.last_doc_id = 0;
+        self.result.doc_id = 0;
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        self.ids.len()
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        !self.has_next()
+    }
+
+    fn revalidate(
+        &mut self,
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        // The id buffer is owned, so the iterator's position is never
+        // invalidated by garbage collection; we never move or abort. Field
+        // expiration is re-checked per candidate (the checker self-gates the
+        // no-expiration case), so there is no cached state to refresh here.
+        Ok(RQEValidateStatus::Ok)
+    }
+
+    #[inline(always)]
+    fn type_(&self) -> IteratorType {
+        IteratorType::GeoShape
+    }
+
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
+    }
+}
+
+impl<T, E, M: MemTracker> ProfilePrint for GeoShape<'_, T, E, M> {
+    fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
+        ctx.print_leaf(c"GEO-SHAPE", map);
+    }
+}
+
+impl<T, E, M: MemTracker> Drop for GeoShape<'_, T, E, M> {
+    fn drop(&mut self) {
+        self.mem_tracker.sub(self.tracked_bytes);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -32,6 +32,7 @@ pub mod c2rust;
 pub mod config;
 pub mod empty;
 pub mod expiration_checker;
+pub mod geo_shape;
 pub mod id_list;
 pub mod interop;
 pub mod intersection;
@@ -58,6 +59,7 @@ pub mod wildcard;
 pub use config::IteratorsConfig;
 pub use empty::Empty;
 pub use expiration_checker::{ExpirationChecker, FieldExpirationChecker, NoOpChecker};
+pub use geo_shape::{GeoShape, MemTracker, NoTracker};
 pub use id_list::IdList;
 pub use intersection::{Intersection, NewIntersectionIterator, new_intersection_iterator};
 pub use inverted_index::{

--- a/src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/owned_slice.rs
@@ -64,6 +64,16 @@ impl<T> std::ops::Deref for OwnedSlice<T> {
     }
 }
 
+impl<T> std::ops::DerefMut for OwnedSlice<T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut [T] {
+        match &mut self.kind {
+            SliceKind::C(s) => s,
+            SliceKind::Rust(v) => v,
+        }
+    }
+}
+
 enum SliceKind<T> {
     C(RedisSlice<T>),
     Rust(Vec<T>),
@@ -100,6 +110,17 @@ impl<T> std::ops::Deref for RedisSlice<T> {
     fn deref(&self) -> &[T] {
         // Safety: ptr is not null and we received length via created function
         unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl<T> std::ops::DerefMut for RedisSlice<T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut [T] {
+        // SAFETY: The constructor's safety contract guarantees `self.ptr` is
+        // non-null, well-aligned, and points to `self.len` initialized elements
+        // (so the total size is a valid allocation, hence <= `isize::MAX`).
+        // We hold `&mut self`, so this is the only live reference to the data.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{cell::Cell, rc::Rc, time::Duration};
+
+use index_result::{RSIndexResult, RSResultKind};
+use rqe_iterators::{
+    ExpirationChecker, IteratorType, MemTracker, NoOpChecker, NoTracker, RQEIterator,
+    RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    geo_shape::GeoShape,
+    utils::{NoTimeout, TimeoutContextClock},
+};
+use rstest_reuse::apply;
+
+use crate::id_cases;
+
+/// Builds a `GeoShape` iterator with no timeout, no expiration, and no memory
+/// tracking — the simplest configuration, used by the sorted-id-list tests.
+fn plain(ids: Vec<u64>) -> GeoShape<'static, NoTimeout, NoOpChecker, NoTracker> {
+    GeoShape::new(
+        ids,
+        RSIndexResult::build_virt().build(),
+        NoTimeout,
+        NoOpChecker,
+        NoTracker,
+    )
+}
+
+/// A safe [`MemTracker`] backed by a shared cell, letting a test observe the
+/// add/subtract accounting without any raw pointers.
+#[derive(Clone, Default)]
+struct CellTracker(Rc<Cell<usize>>);
+
+impl CellTracker {
+    fn get(&self) -> usize {
+        self.0.get()
+    }
+}
+
+impl MemTracker for CellTracker {
+    fn add(&self, bytes: usize) {
+        self.0.set(self.0.get() + bytes);
+    }
+
+    fn sub(&self, bytes: usize) {
+        self.0.set(self.0.get() - bytes);
+    }
+}
+
+/// An [`ExpirationChecker`] that reports a fixed set of document IDs as expired.
+struct MockExpiry {
+    has_expiration: bool,
+    expired: Vec<u64>,
+}
+
+impl ExpirationChecker for MockExpiry {
+    fn has_expiration(&self) -> bool {
+        self.has_expiration
+    }
+
+    fn is_expired(&self, result: &RSIndexResult) -> bool {
+        self.expired.contains(&result.doc_id)
+    }
+}
+
+#[test]
+fn type_is_geoshape() {
+    let it = plain(vec![1, 2, 3]);
+    assert_eq!(it.type_(), IteratorType::GeoShape);
+}
+
+#[test]
+fn empty_initialization_works() {
+    let mut it = plain(vec![]);
+
+    let result = it.current().unwrap();
+    assert_eq!(0, result.doc_id);
+    assert_eq!(RSResultKind::Virtual, result.kind());
+
+    assert!(it.at_eof());
+    assert_eq!(it.num_estimated(), 0);
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn unsorted_input_is_sorted_on_construction() {
+    let mut it = plain(vec![5, 3, 1, 4, 2]);
+    for expected in 1..=5u64 {
+        let res = it.read().unwrap().unwrap();
+        assert_eq!(res.doc_id, expected);
+    }
+    assert!(it.at_eof());
+}
+
+#[test]
+fn duplicate_ids_are_yielded_as_is() {
+    // The geometry index does not guarantee unique matches; duplicates must be
+    // sorted alongside everything else and yielded one by one. The shared
+    // `id_cases` fixture is unique, so this behavior is covered here explicitly.
+    let mut it = plain(vec![5, 3, 1, 3]);
+
+    assert_eq!(it.num_estimated(), 4);
+    for expected in [1u64, 3, 3, 5] {
+        let res = it.read().unwrap().unwrap();
+        assert_eq!(res.doc_id, expected);
+    }
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn skip_to_lands_on_first_of_duplicates() {
+    let mut it = plain(vec![1, 3, 3, 5]);
+
+    // Skipping to a duplicated id lands on its first occurrence...
+    let Ok(Some(SkipToOutcome::Found(res))) = it.skip_to(3) else {
+        panic!("expected Found(3)");
+    };
+    assert_eq!(res.doc_id, 3);
+    assert_eq!(it.last_doc_id(), 3);
+
+    // ...and the second copy is still yielded by the next read.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 3);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 5);
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[apply(id_cases)]
+fn read(#[case] case: &[u64]) {
+    let mut it = plain(case.to_vec());
+
+    assert_eq!(it.num_estimated(), case.len());
+    assert!(!it.at_eof());
+
+    for expected_id in case.iter().copied() {
+        assert!(!it.at_eof());
+        let res = it.read().unwrap().unwrap();
+        assert_eq!(res.doc_id, expected_id);
+        assert_eq!(it.last_doc_id(), expected_id);
+
+        let result = it.current().unwrap();
+        assert_eq!(expected_id, result.doc_id);
+        assert_eq!(RSResultKind::Virtual, result.kind());
+    }
+
+    assert!(it.at_eof());
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[apply(id_cases)]
+#[cfg_attr(miri, ignore = "Takes too long with Miri, causing CI to timeout")]
+fn skip_to(#[case] case: &[u64]) {
+    let mut it = plain(case.to_vec());
+
+    // Skip past the last doc id: expect EOF, last_doc_id unchanged.
+    let last = *case.last().unwrap();
+    assert!(matches!(it.skip_to(last + 1), Ok(None)));
+    assert!(it.at_eof());
+    assert_eq!(it.last_doc_id(), 0);
+
+    it.rewind();
+
+    // Walk every value from 1 up to `last`, probing gaps (NotFound) and exact
+    // matches (Found).
+    let mut probe = 1u64;
+    for &id in case {
+        while probe < id {
+            it.rewind();
+            let Ok(Some(SkipToOutcome::NotFound(res))) = it.skip_to(probe) else {
+                panic!("probe {probe} -> Expected NotFound landing on {id}");
+            };
+            assert_eq!(res.doc_id, id);
+            assert_eq!(it.at_eof(), Some(&id) == case.last());
+            assert_eq!(it.last_doc_id(), id);
+            probe += 1;
+        }
+        it.rewind();
+        let Ok(Some(SkipToOutcome::Found(res))) = it.skip_to(probe) else {
+            panic!("probe {probe} -> Expected Found");
+        };
+        assert_eq!(res.doc_id, id);
+        assert_eq!(it.last_doc_id(), id);
+        probe += 1;
+    }
+}
+
+#[test]
+fn skip_to_from_nonzero_offset() {
+    // The `skip_to` test above always rewinds before each probe, so the
+    // binary search only ever runs over the full list. Drive it from a
+    // non-zero offset instead — the path the intersection engine actually
+    // exercises by calling `skip_to`/`read` repeatedly without rewinding.
+    let mut it = plain(vec![1, 3, 5, 7, 9]);
+
+    // First skip lands on 3 and advances the offset past it.
+    let Ok(Some(SkipToOutcome::Found(res))) = it.skip_to(3) else {
+        panic!("expected Found(3)");
+    };
+    assert_eq!(res.doc_id, 3);
+    assert_eq!(it.last_doc_id(), 3);
+
+    // Second skip, without rewinding, must binary-search only the unread tail
+    // [5, 7, 9] and still find 7.
+    let Ok(Some(SkipToOutcome::Found(res))) = it.skip_to(7) else {
+        panic!("expected Found(7) from a non-zero offset");
+    };
+    assert_eq!(res.doc_id, 7);
+    assert_eq!(it.last_doc_id(), 7);
+
+    // The remaining tail is yielded normally.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 9);
+    assert!(matches!(it.read(), Ok(None)));
+
+    // A `read` followed by a `skip_to` that misses must land on the next id in
+    // the tail (NotFound), again searching from a non-zero offset.
+    let mut it = plain(vec![1, 3, 5, 7, 9]);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    let Ok(Some(SkipToOutcome::NotFound(res))) = it.skip_to(6) else {
+        panic!("expected NotFound landing on 7 from a non-zero offset");
+    };
+    assert_eq!(res.doc_id, 7);
+    assert_eq!(it.last_doc_id(), 7);
+}
+
+#[apply(id_cases)]
+fn rewind(#[case] case: &[u64]) {
+    let mut it = plain(case.to_vec());
+
+    for &id in case {
+        let res = it.read().unwrap().unwrap();
+        assert_eq!(res.doc_id, id);
+    }
+    assert!(it.at_eof());
+
+    it.rewind();
+    assert!(!it.at_eof());
+    assert_eq!(it.last_doc_id(), 0);
+
+    let res = it.read().unwrap().unwrap();
+    assert_eq!(res.doc_id, case[0]);
+}
+
+#[test]
+fn expired_documents_are_skipped() {
+    let checker = MockExpiry {
+        has_expiration: true,
+        expired: vec![2, 4],
+    };
+    let mut it = GeoShape::new(
+        vec![1, 2, 3, 4, 5],
+        RSIndexResult::build_virt().build(),
+        NoTimeout,
+        checker,
+        NoTracker,
+    );
+
+    // 2 and 4 are filtered out.
+    for expected in [1u64, 3, 5] {
+        let res = it.read().unwrap().unwrap();
+        assert_eq!(res.doc_id, expected);
+        assert_eq!(it.last_doc_id(), expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+/// Builds a [`GeoShape`] iterator over `ids` with a fixed set of `expired` docs and
+/// expiration gating enabled.
+fn with_expired(
+    ids: Vec<u64>,
+    expired: Vec<u64>,
+) -> GeoShape<'static, NoTimeout, MockExpiry, NoTracker> {
+    let checker = MockExpiry {
+        has_expiration: true,
+        expired,
+    };
+    GeoShape::new(
+        ids,
+        RSIndexResult::build_virt().build(),
+        NoTimeout,
+        checker,
+        NoTracker,
+    )
+}
+
+#[test]
+fn skip_to_onto_expired_target_advances_to_next_valid() {
+    // The geoshape iterator is driven via `skip_to` when it is a non-leading
+    // intersection child. An expired match must not be returned: `skip_to` falls
+    // back to a scan that advances past the expired run [3, 4] to the next valid
+    // doc (5), reported as `NotFound`.
+    let mut it = with_expired(vec![1, 2, 3, 4, 5], vec![3, 4]);
+
+    let Ok(Some(SkipToOutcome::NotFound(res))) = it.skip_to(3) else {
+        panic!("expected NotFound landing on the next valid doc (5)");
+    };
+    assert_eq!(res.doc_id, 5);
+    assert_eq!(it.last_doc_id(), 5);
+
+    // 5 was already consumed by the fallback scan.
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[test]
+fn skip_to_found_when_target_not_expired() {
+    // Expiration is enabled, but the skip target itself is valid: it must still
+    // be reported as `Found`, and only the matched entry is checked.
+    let mut it = with_expired(vec![1, 2, 3, 4, 5], vec![2, 4]);
+
+    let Ok(Some(SkipToOutcome::Found(res))) = it.skip_to(3) else {
+        panic!("expected Found(3)");
+    };
+    assert_eq!(res.doc_id, 3);
+    assert_eq!(it.last_doc_id(), 3);
+}
+
+#[test]
+fn skip_to_onto_expired_run_to_eof() {
+    // The only matches at or beyond the target are expired: the fallback scan
+    // exhausts the list and the iterator reports EOF without settling on an
+    // expired doc.
+    let mut it = with_expired(vec![1, 3, 5], vec![5]);
+
+    assert!(matches!(it.skip_to(5), Ok(None)));
+    assert!(it.at_eof());
+    // `last_doc_id` is untouched: the iterator never settled on a valid match.
+    assert_eq!(it.last_doc_id(), 0);
+    // The expired candidate must not leak through the reusable `current` result
+    // once the scan settles on EOF.
+    assert_ne!(it.current().unwrap().doc_id, 5);
+    assert_eq!(it.current().unwrap().doc_id, 0);
+}
+
+#[test]
+fn read_to_eof_over_expired_tail_does_not_leak() {
+    // The tail [4, 6] is entirely expired, so `read` settles on EOF after the
+    // last valid doc (2). The expired ids probed during the final scan must not
+    // remain visible through `current`.
+    let mut it = with_expired(vec![2, 4, 6], vec![4, 6]);
+
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 2);
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+    // `current` reflects the last valid doc, not the expired tail.
+    assert_eq!(it.current().unwrap().doc_id, 2);
+    assert_eq!(it.last_doc_id(), 2);
+}
+
+#[test]
+fn skip_to_onto_expired_target_does_not_leak_at_eof() {
+    // `skip_to` lands on an expired target whose only successors are also
+    // expired: the fallback scan reaches EOF. `current` must not surface the
+    // expired target (or the expired successors) it probed along the way.
+    let mut it = with_expired(vec![1, 3, 5, 7], vec![5, 7]);
+
+    assert!(matches!(it.skip_to(5), Ok(None)));
+    assert!(it.at_eof());
+    assert_ne!(it.current().unwrap().doc_id, 5);
+    assert_ne!(it.current().unwrap().doc_id, 7);
+    // Nothing valid was ever returned, so `current`/`last_doc_id` stay at 0.
+    assert_eq!(it.current().unwrap().doc_id, 0);
+    assert_eq!(it.last_doc_id(), 0);
+}
+
+#[test]
+fn revalidate_is_a_noop_and_preserves_position() {
+    // The geoshape iterator keeps no cached expiration state: the checker is
+    // consulted on every candidate, so `revalidate` has nothing to refresh. It
+    // must report `Ok` and leave the iterator's position untouched.
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let mut it = plain(vec![1, 2, 3]);
+
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+
+    let status = it
+        .revalidate(&mock_ctx.spec_read())
+        .expect("revalidate failed");
+    assert_eq!(status, RQEValidateStatus::Ok);
+
+    // Position is preserved across revalidate: iteration resumes where it left off.
+    assert_eq!(it.last_doc_id(), 1);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 2);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 3);
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn timeout_aborts_read() {
+    // A deadline already in the past with a granularity of 1 makes the very
+    // first probe report a timeout.
+    let timeout = TimeoutContextClock::new(Duration::from_nanos(1), 1);
+    let mut it = GeoShape::new(
+        vec![1, 2, 3],
+        RSIndexResult::build_virt().build(),
+        timeout,
+        NoOpChecker,
+        NoTracker,
+    );
+
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+}
+
+#[test]
+fn memory_tracking_adds_and_subtracts() {
+    let tracker = CellTracker::default();
+
+    {
+        let it = GeoShape::new(
+            vec![3u64, 1, 2],
+            RSIndexResult::build_virt().build(),
+            NoTimeout,
+            NoOpChecker,
+            tracker.clone(),
+        );
+
+        // The tracker reflects exactly what the iterator reports.
+        assert_eq!(tracker.get(), it.mem_usage());
+        assert!(it.mem_usage() >= 3 * std::mem::size_of::<u64>());
+    }
+
+    // Dropping the iterator restores the counter.
+    assert_eq!(tracker.get(), 0);
+}
+
+#[test]
+fn no_tracker_is_a_noop() {
+    let it = plain(vec![1, 2, 3]);
+    // Three u64s plus the struct overhead.
+    assert!(it.mem_usage() >= 3 * std::mem::size_of::<u64>());
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -36,6 +36,7 @@ mod c2rust;
 mod empty;
 #[cfg(not(miri))]
 mod format_g;
+mod geo_shape;
 mod id_list;
 mod intersection;
 mod inverted_index;


### PR DESCRIPTION
Re-implement the GEOSHAPE query iterator (`src/geometry/query_iterator.cpp`) in the `rqe_iterators` crate.

GeoShape walks a sorted list of matching document IDs like the sorted id-list iterator, plus:
- field-expiration filtering via an `ExpirationChecker`, gated by a cached flag refreshed in revalidate();
- amortized query-timeout checks via a `TimeoutContext`;
- memory-usage tracking: it reports the bytes held by its id buffer to an external counter (the geometry index allocation tracker), adding on construction and subtracting on drop, and exposes mem_usage().


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New query-engine iterator path with subtle skip_to/expiration contracts for intersections; behavior is heavily tested but correctness affects GEOSHAPE query results.
> 
> **Overview**
> Adds a Rust **`GeoShape`** `RQEIterator` in `rqe_iterators`, replacing the C++ geometry query iterator. It takes geometry match doc IDs (R-tree order), **sorts them in place** via new **`OwnedSlice` `DerefMut`**, then walks ascending IDs with full **`read` / `skip_to` / `rewind`** semantics—including duplicates and tail binary search for intersection-driven `skip_to`.
> 
> On top of a sorted id-list it wires **field TTL filtering** (gated flag refreshed in **`revalidate`**), **amortized query timeouts**, and **memory accounting** through a pluggable **`MemTracker`** (`add` on construct, `sub` on drop, **`mem_usage()`**). **`IteratorType::GeoShape`** and profile leaf **`GEO-SHAPE`** are implemented; **`GeoShape`**, **`MemTracker`**, and **`NoTracker`** are re-exported from the crate.
> 
> Integration tests cover sorting, id-list fixtures, expiration edge cases (no leaked expired IDs in **`current`**), timeouts, and memory tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33cd5c3fb77d60c0b997546b2888c13add40d457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->