### PR TITLE
ci: cover both bare and [bot] merge-queue actors in codex triage

### DIFF
--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -44,10 +44,12 @@ runs:
         # (github-merge-queue, github-actions[bot]); allow them past the
         # action's collaborator gate. Sandbox + safety remain read-only.
         # `allow-bots: true` only covers github-actions[bot] (hardcoded in
-        # codex-action's trusted set); other bot actors must be listed
-        # explicitly via `allow-bot-users`.
+        # codex-action's trusted set). `github-merge-queue` is exposed
+        # without the `[bot]` suffix in `github.actor`, so the action's
+        # `isBotActor` check (endsWith "[bot]") rejects it and never
+        # consults `allow-bot-users`; pass it via `allow-users` instead.
         allow-bots: true
-        allow-bot-users: github-merge-queue[bot]
+        allow-users: github-merge-queue
 
     - name: Read triage output
       id: read

--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -44,12 +44,16 @@ runs:
         # (github-merge-queue, github-actions[bot]); allow them past the
         # action's collaborator gate. Sandbox + safety remain read-only.
         # `allow-bots: true` only covers github-actions[bot] (hardcoded in
-        # codex-action's trusted set). `github-merge-queue` is exposed
-        # without the `[bot]` suffix in `github.actor`, so the action's
-        # `isBotActor` check (endsWith "[bot]") rejects it and never
-        # consults `allow-bot-users`; pass it via `allow-users` instead.
+        # codex-action's trusted set). For merge-queue, `github.actor`
+        # differs by event: `push` runs see `github-merge-queue[bot]`,
+        # but `schedule` runs see the bare `github-merge-queue`. The
+        # action's `isBotActor` check (endsWith "[bot]") rejects the
+        # bare form and never consults `allow-bot-users`, so we list
+        # the bare form under `allow-users` and the suffixed form under
+        # `allow-bot-users`.
         allow-bots: true
         allow-users: github-merge-queue
+        allow-bot-users: github-merge-queue[bot]
 
     - name: Read triage output
       id: read


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `notify-cie-failure` job in the periodic master validation workflow fails before Codex runs. The `openai/codex-action@v1` collaborator gate rejects the merge-queue actor — but in two different ways depending on the event:

   - **Schedule** (e.g. [run 26982790400](https://github.com/RediSearch/RediSearch/actions/runs/26982790400/job/79637439290) from 2026-06-04): `GITHUB_ACTOR=github-merge-queue` (bare), collaborator API returns `404`.
   - **Push** from the merge queue (e.g. [run 26577364183](https://github.com/RediSearch/RediSearch/actions/runs/26577364183) from 2026-05-28): `GITHUB_ACTOR=github-merge-queue[bot]`, collaborator API returns `permission: 'none'`.

   The previous configuration set only `allow-bot-users: github-merge-queue[bot]`. The action's bot branch is gated on `isBotActor(actor)` which requires the actor string to end with `[bot]`, so for the bare schedule form the bot branch is skipped entirely and the action falls through to the collaborator check. The suffixed push form would match `allow-bot-users` in principle, but the run from 2026-05-28 shows it never actually succeeded for push-event triage either (the override hadn't been wired yet at that time).

   Reference: [codex-action `checkActorPermissions.ts`](https://github.com/openai/codex-action/blob/v1/src/checkActorPermissions.ts).

2. **Change:** Cover both actor forms by listing each under the matching allow-list:

   ```yaml
   allow-bots: true
   allow-users: github-merge-queue          # schedule events (bare)
   allow-bot-users: github-merge-queue[bot] # push events from merge queue
   ```

   Sandbox + safety remain `read-only`. The inline comment now documents the per-event split so the override is not collapsed back to a single field.

3. **Outcome:** Post-merge selected-platform validation failures will produce Codex triage output again — for both push- and schedule-triggered failures — instead of an empty `ai_triage` block in the Slack notification.

#### Which additional issues this PR fixes
- None

#### Main objects this PR modified
1. `.github/actions/codex-ci-triage/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)