### PR TITLE
ci: route github-merge-queue past codex triage gate via allow-users

### DIFF
--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -44,10 +44,12 @@ runs:
         # (github-merge-queue, github-actions[bot]); allow them past the
         # action's collaborator gate. Sandbox + safety remain read-only.
         # `allow-bots: true` only covers github-actions[bot] (hardcoded in
-        # codex-action's trusted set); other bot actors must be listed
-        # explicitly via `allow-bot-users`.
+        # codex-action's trusted set). `github-merge-queue` is exposed
+        # without the `[bot]` suffix in `github.actor`, so the action's
+        # `isBotActor` check (endsWith "[bot]") rejects it and never
+        # consults `allow-bot-users`; pass it via `allow-users` instead.
         allow-bots: true
-        allow-bot-users: github-merge-queue[bot]
+        allow-users: github-merge-queue
 
     - name: Read triage output
       id: read


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `notify-cie-failure` job in the periodic master validation workflow fails before Codex runs. The `openai/codex-action@v1` collaborator gate rejects the merge-queue actor:

   ```
   Checking write access for actor 'github-merge-queue' on RediSearch/RediSearch
   GET /repos/RediSearch/RediSearch/collaborators/github-merge-queue/permission - 404
   Actor 'github-merge-queue' is not permitted to run this action
   ```

   We tried to handle this with `allow-bot-users: github-merge-queue[bot]`, but the action's bot branch is gated on `isBotActor(actor)` which requires the actor string to end with `[bot]`. For merge-queue pushes `github.actor` is the bare `github-merge-queue`, so the bot branch is skipped entirely and the action falls through to the collaborator check.

   Reference: [codex-action `checkActorPermissions.ts`](https://github.com/openai/codex-action/blob/v1/src/checkActorPermissions.ts).

2. **Change:** Move the override to `allow-users: github-merge-queue`. The plain-user allow-list does a case-insensitive exact match without the `[bot]` suffix requirement, so it lets the merge-queue actor through. Sandbox + safety remain `read-only`. Updated the comment to explain the suffix gotcha so it doesn't get reverted to `allow-bot-users` again.

3. **Outcome:** Post-merge selected-platform validation failures will produce Codex triage output again instead of an empty `ai_triage` block in the Slack notification.

Example of the failure this fixes: https://github.com/RediSearch/RediSearch/actions/runs/26982790400/job/79637439290

#### Which additional issues this PR fixes
- None

#### Main objects this PR modified
1. `.github/actions/codex-ci-triage/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission wiring for a known bot actor; no application code, APIs, or runtime behavior changes.
> 
> **Overview**
> Fixes **Codex CI triage** failing on merge-queue–driven runs because `openai/codex-action` treated `github-merge-queue` as a normal user and hit the collaborator permission check (404).
> 
> The composite action **`.github/actions/codex-ci-triage`** now allows that actor via **`allow-users: github-merge-queue`** instead of **`allow-bot-users: github-merge-queue[bot]`**, since `github.actor` for merge queue does not end with `[bot]` and never matched the bot allow path. Comments were updated to document the suffix behavior so this is not reverted. **Read-only sandbox/safety settings are unchanged.**
> 
> Post-merge / periodic failure workflows that call this action (e.g. master validation Slack notifications) should populate **`ai_triage`** again instead of skipping Codex at the permission gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626181affee9b9c3ce8a3c3287ec9a04e06aeb42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->