### PR TITLE
CI: Use repository owner in image name for CI container

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -54,9 +54,11 @@ jobs:
           SAN: ${{ inputs.san }}
           RUNNER_ENV: ${{ inputs.runner-env }}
           RUN_ID: ${{ github.run_id }}
+          OWNER: ${{ github.repository_owner }}
           IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
-          IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/redisearch-ci"
+          OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME="ghcr.io/${OWNER_LC}/redisearch-ci"
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
           SAN_SAFE=$(echo "$SAN" | sed 's#[^A-Za-z0-9_.-]#-#g')
           RUNNER_ENV_SAFE=$(echo "$RUNNER_ENV" | sed 's#[^A-Za-z0-9_.-]#-#g')

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -56,7 +56,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
-          IMAGE_NAME="ghcr.io/redisearch/redisearch-ci"
+          IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/redisearch-ci"
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
           SAN_SAFE=$(echo "$SAN" | sed 's#[^A-Za-z0-9_.-]#-#g')
           RUNNER_ENV_SAFE=$(echo "$RUNNER_ENV" | sed 's#[^A-Za-z0-9_.-]#-#g')


### PR DESCRIPTION
## Description
Use the repository owner (lowercase) when composing the GHCR image name

#### Main objects this PR modified
1. `.github/workflows/task-build-cached-container.yml`


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where CI images are pushed and cached in GHCR; workflows that still expect the old `ghcr.io/redisearch/...` path could miss images until callers are aligned.
> 
> **Overview**
> CI cached container builds now publish to **GHCR under the current repository owner** instead of a fixed `redisearch` namespace.
> 
> The **Set image name** step in `task-build-cached-container.yml` adds `github.repository_owner`, lowercases it for the registry path, and sets `IMAGE_NAME` to `ghcr.io/<owner>/redisearch-ci`. Image tags and cache refs still use the same suffix pattern; only the registry namespace changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbbbebcc60311380d429e6cbbe357f94354dfcb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->