### PR TITLE
[MOD-16140] Add add_record microbench (baseline for lock-free II)

### DIFF
--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -20,6 +20,10 @@ harness = false
 name = "garbage_collection"
 harness = false
 
+[[bench]]
+name = "add_record"
+harness = false
+
 [dependencies]
 buffer.workspace = true
 criterion.workspace = true

--- a/src/redisearch_rs/inverted_index_bencher/benches/add_record.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/add_record.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Focused bench for `InvertedIndex::add_record` — the indexing write path.
+//!
+//! Existing `encoding_decoding` benches call codec functions (e.g.
+//! `DocIdsOnly::encode`) directly into a `Cursor<Vec<u8>>`, never constructing
+//! an `InvertedIndex`. The `garbage_collection` bench builds an index in setup
+//! but doesn't measure the build. So neither captures the per-record cost
+//! introduced by the `ArcSwap<State>` write path. This bench fills that gap.
+
+use std::time::Duration;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::IndexFlags_Index_DocIdsOnly;
+use index_result::RSIndexResult;
+use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly, numeric::Numeric};
+
+const RECORD_COUNTS: [u64; 3] = [1_000, 10_000, 100_000];
+
+fn bench_add_record(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_record");
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(800));
+
+    for n in RECORD_COUNTS {
+        group.bench_function(BenchmarkId::new("DocIdsOnly", n), |b| {
+            b.iter_batched(
+                || InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+                |mut ii| {
+                    for doc_id in 0..n {
+                        let record = RSIndexResult::build_term().doc_id(doc_id).build();
+                        ii.add_record(&record).unwrap();
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("Numeric", n), |b| {
+            b.iter_batched(
+                || InvertedIndex::<Numeric>::new(IndexFlags_Index_DocIdsOnly),
+                |mut ii| {
+                    for doc_id in 0..n {
+                        let record = RSIndexResult::build_numeric(doc_id as f64 / 10.0)
+                            .doc_id(doc_id)
+                            .build();
+                        ii.add_record(&record).unwrap();
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_add_record);
+criterion_main!(benches);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `inverted_index` crate ships a `encoding_decoding` Criterion bench that covers all encoder/decoder codecs but no top-of-the-pipeline write benchmark.
2. **Change:** Adds an `add_record` Criterion bench that measures the full `InvertedIndex::add_record` path through the framework — block lifecycle, encoder dispatch, and bookkeeping — for `DocIdsOnly` and `Numeric` (the two cheapest encoders, so framework overhead dominates).
3. **Outcome:** Provides a stable baseline for the upcoming lock-free read work ([MOD-16139](https://redislabs.atlassian.net/browse/MOD-16139)). Subsequent PRs in the epic change the backing storage and need a regression signal independent of codec cost.

#### Which additional issues this PR fixes
1. MOD-16140

#### Main objects this PR modified
1. `src/redisearch_rs/inverted_index/benches/add_record.rs` (new)
2. `src/redisearch_rs/inverted_index/Cargo.toml` (register bench)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Stack:
- **PR 1 (this) → `master`**
- PR 2 → PR 1: [MOD-16141] RepairContext
- PR 3 → PR 2: [MOD-16142] HRTB on GC repair closure
- PR 4 → PR 3: [MOD-16143] InvertedIndexSnapshot API
- PR 5 → PR 4: [MOD-16144] Three-region storage + lock-free reads

Tracking epic: [MOD-16139](https://redislabs.atlassian.net/browse/MOD-16139)

[MOD-16139]: https://redislabs.atlassian.net/browse/MOD-16139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-16141]: https://redislabs.atlassian.net/browse/MOD-16141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only change in the bencher crate; no production indexing logic or APIs are modified.
> 
> **Overview**
> Adds a new Criterion benchmark **`add_record`** under `inverted_index_bencher` so the full **`InvertedIndex::add_record`** write path can be measured end-to-end (block lifecycle, encoder dispatch, framework bookkeeping), not just isolated codec encode/decode or GC setup.
> 
> The bench uses **`iter_batched`** to create a fresh index per iteration, then inserts **1k / 10k / 100k** monotonic doc IDs for **`DocIdsOnly`** and **`Numeric`** encoders. That is intended as a regression baseline before lock-free inverted-index read work, where per-record framework cost (e.g. **`ArcSwap<State>`**) matters more than codec micro-optimizations.
> 
> **`Cargo.toml`** registers the new `[[bench]]` target with `harness = false`, matching the existing Criterion benches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c99a478fa77ebaf7bd59b8ad676ee241121e264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->