### PR TITLE
ci: fall back to uncached build when sccache server fails to start

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -587,11 +587,14 @@ prepare_cmake_arguments() {
     # comes up first, and fall back to a regular uncached build if it does not.
     # --show-stats is idempotent: it spawns the server if needed, connects to
     # an already-running one otherwise, and fails only if it cannot start.
-    if "$SCCACHE" --show-stats >/dev/null 2>&1; then
+    if SCCACHE_PROBE_OUTPUT=$("$SCCACHE" --show-stats 2>&1); then
       CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER_LAUNCHER=$SCCACHE -DCMAKE_CXX_COMPILER_LAUNCHER=$SCCACHE"
       echo "Using sccache for C/C++ compilation caching"
     else
+      # Surface the underlying sccache error (e.g. "Timed out waiting for
+      # server startup") so the cause is visible in CI logs.
       echo "WARNING: sccache server failed to start; building without sccache" >&2
+      echo "$SCCACHE_PROBE_OUTPUT" >&2
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -595,6 +595,10 @@ prepare_cmake_arguments() {
       # server startup") so the cause is visible in CI logs.
       echo "WARNING: sccache server failed to start; building without sccache" >&2
       echo "$SCCACHE_PROBE_OUTPUT" >&2
+      # run_cmake() reuses an existing build directory unless FORCE=1, so a
+      # previously cached CMAKE_*_COMPILER_LAUNCHER would otherwise keep the
+      # broken sccache active on reconfigure. Pass empty values to clear it.
+      CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER_LAUNCHER= -DCMAKE_CXX_COMPILER_LAUNCHER="
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -581,8 +581,18 @@ prepare_cmake_arguments() {
   # Prefer SCCACHE_PATH (set by sccache-action in CI with the full path), otherwise look on PATH.
   SCCACHE="${SCCACHE_PATH:-$(command -v sccache 2>/dev/null || true)}"
   if [[ -n "$SCCACHE" && -x "$SCCACHE" ]]; then
-    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER_LAUNCHER=$SCCACHE -DCMAKE_CXX_COMPILER_LAUNCHER=$SCCACHE"
-    echo "Using sccache for C/C++ compilation caching"
+    # The binary being present is not enough: if the sccache server fails to
+    # start (e.g. the remote S3 cache is unreachable), every compile invocation
+    # errors out and the whole build fails. Probe that the server actually
+    # comes up first, and fall back to a regular uncached build if it does not.
+    # --show-stats is idempotent: it spawns the server if needed, connects to
+    # an already-running one otherwise, and fails only if it cannot start.
+    if "$SCCACHE" --show-stats >/dev/null 2>&1; then
+      CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER_LAUNCHER=$SCCACHE -DCMAKE_CXX_COMPILER_LAUNCHER=$SCCACHE"
+      echo "Using sccache for C/C++ compilation caching"
+    else
+      echo "WARNING: sccache server failed to start; building without sccache" >&2
+    fi
   fi
 
   # Add caching flags to prevent using old configurations


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `build.sh` wires `sccache` in as the C/C++ compiler launcher (`CMAKE_C/CXX_COMPILER_LAUNCHER`) whenever the `sccache` binary is present and executable. It never verifies that the sccache *server* can actually start. When the server fails to come up (e.g. the remote S3 cache is unreachable), every compile invocation errors out and the whole build dies with a cascade of `Error 2` failures across unrelated targets (hiredis, snowball, etc.).
2. **Change:** Before enabling the launcher, probe the server with `sccache --show-stats`. If it starts, use sccache as before; if it fails to start, print a warning and build **without** sccache. `--show-stats` is idempotent — it spawns the server if needed, connects to an already-running one otherwise, and fails only if the server cannot start.
3. **Outcome:** A transient sccache/remote-cache outage now degrades gracefully to a slower, uncached-but-successful build instead of failing the job. Because the fix lives in `build.sh`, it protects local builds as well as CI.

#### Main objects this PR modified
1. `build.sh` — `prepare_cmake_arguments()` sccache setup

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change that improves resilience when sccache is unavailable; no product runtime or API impact.
> 
> **Overview**
> **`build.sh`** no longer enables sccache solely because the binary exists. In `prepare_cmake_arguments()`, it runs **`sccache --show-stats`** first; only if that succeeds does it set **`CMAKE_C_COMPILER_LAUNCHER`** / **`CMAKE_CXX_COMPILER_LAUNCHER`** as before.
> 
> If the server cannot start (e.g. remote cache unreachable), the script logs a **warning** plus the probe output, then **clears** the compiler launcher CMake variables so reconfigures in an existing build dir do not keep a broken sccache wired in. Builds continue **without** cache instead of failing every compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ffa3371d20ed087779a4e2c869a8f356e52e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->