### PR TITLE
[MOD-14218] Filter vector range results by max-doc-id snapshot boundary

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1617,6 +1617,10 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
   QueryEvalCtx qectx = {
       .opts = opts,
       .docTable = &sctx->spec->docs,
+      // Capture the snapshot boundary once, under the spec read lock that gates iterator
+      // creation, so every snapshot-bounded iterator built below shares the same maxDocId.
+      .maxDocId = sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(sctx->spec->diskSpec)
+                                       : sctx->spec->docs.maxDocId,
       .sctx = sctx,
       .status = status,
       .metricRequestsP = &qast->metricRequests,

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -21,6 +21,10 @@ typedef struct QueryEvalCtx {
   struct MetricRequest **metricRequestsP;
   uint32_t tokenId;
   DocTable *docTable;
+  // Max doc id captured once at query-snapshot establishment (top of QAST_Iterate), so all
+  // snapshot-bounded iterators share a single boundary that is consistent with the SpeedB
+  // snapshot the disk iterators read from. Disk: SearchDisk_GetMaxDocId; RAM: docs.maxDocId.
+  t_docId maxDocId;
   uint32_t reqFlags;
   IteratorsConfig *config;
   bool notSubtree;

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -260,12 +260,12 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
       bool yields_metric = vq->scoreField != NULL;
       bool sorted_by_id = vq->range.order == BY_ID;
       if (q->sctx->spec->diskSpec) {
-        // On disk indexes the range query reads outside the query snapshot and may return docs
-        // newer than maxDocId. Bound the results to the snapshot, matching the NOT/OPTIONAL
-        // iterators in query.c. RAM indexes need no such bound (no snapshot).
-        t_docId max_doc_id = SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec);
+        // On disk indexes the range query reads the live vector index and may return docs newer
+        // than the query snapshot. Bound the results to q->maxDocId, captured once at query start
+        // (QAST_Iterate) so the bound is consistent with the snapshot-backed sibling iterators -
+        // not re-read here, which would let docs added during the query slip through.
         return createMetricIteratorFromVectorQueryResultsDisk(results, yields_metric, sorted_by_id,
-                                                              max_doc_id);
+                                                              q->maxDocId);
       }
       return createMetricIteratorFromVectorQueryResults(results, yields_metric, sorted_by_id);
     }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -66,7 +66,35 @@ VecSimIndex *openVectorIndex(RedisModuleCtx *ctx, FieldSpec *fieldSpec, bool cre
   return fieldSpec->vectorOpts.vecSimIndex;
 }
 
-QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *reply, const bool yields_metric, const bool sorted_by_id, t_docId max_doc_id) {
+// Wrap the materialized (id, metric) arrays in the matching metric / id-list iterator, taking
+// ownership of the arrays. `num` is the number of valid leading entries (arrays may be
+// over-allocated). Returns NULL and frees the arrays when there are no results to yield.
+static QueryIterator *newMetricOrIdListIterator(t_docId *docIdsList, double *metricList,
+                                                size_t num, const bool yields_metric,
+                                                const bool sorted_by_id) {
+  if (num == 0) {
+    rm_free(docIdsList);
+    if (metricList) {
+      rm_free(metricList);
+    }
+    return NULL;
+  }
+  if (yields_metric) {
+    if (sorted_by_id) {
+      return NewMetricIteratorSortedById(docIdsList, metricList, num, VECTOR_DISTANCE);
+    } else {
+      return NewMetricIteratorSortedByScore(docIdsList, metricList, num, VECTOR_DISTANCE);
+    }
+  } else {
+    if (sorted_by_id) {
+      return NewSortedIdListIterator(docIdsList, num, 1.0);
+    } else {
+      return NewUnsortedIdListIterator(docIdsList, num, 1.0);
+    }
+  }
+}
+
+QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *reply, const bool yields_metric, const bool sorted_by_id) {
   size_t res_num = VecSimQueryReply_Len(reply);
   if (res_num == 0) {
     VecSimQueryReply_Free(reply);
@@ -75,18 +103,42 @@ QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *repl
   t_docId *docIdsList = rm_malloc(sizeof(*docIdsList) * res_num);
   double *metricList = yields_metric ? rm_malloc(sizeof(*metricList) * res_num) : NULL;
 
-  // Collect the results' id and distance and set it in the arrays.
-  // When max_doc_id is non-zero (disk indexes), drop docs newer than the query snapshot so the
-  // range result stays consistent with the snapshot-bounded iterators it may be unioned with.
-  // Compacting in place preserves the relative order, so it is correct for both BY_ID and
-  // BY_SCORE orders and for both the metric and plain id-list output paths.
+  // Collect the results' id and distance into the arrays.
+  VecSimQueryReply_Iterator *iter = VecSimQueryReply_GetIterator(reply);
+  for (size_t i = 0; i < res_num; i++) {
+    VecSimQueryResult *res = VecSimQueryReply_IteratorNext(iter);
+    docIdsList[i] = VecSimQueryResult_GetId(res);
+    if (yields_metric) {
+      metricList[i] = VecSimQueryResult_GetScore(res);
+    }
+  }
+  VecSimQueryReply_IteratorFree(iter);
+  VecSimQueryReply_Free(reply);
+
+  return newMetricOrIdListIterator(docIdsList, metricList, res_num, yields_metric, sorted_by_id);
+}
+
+// Disk variant of createMetricIteratorFromVectorQueryResults. A disk range query reads outside the
+// query snapshot and may return docIds newer than max_doc_id; drop those so the range result stays
+// consistent with the snapshot-bounded iterators it may be unioned with. Compacting in place
+// preserves the relative order, so it is correct for both BY_ID and BY_SCORE orders and for both
+// the metric and plain id-list output paths.
+QueryIterator *createMetricIteratorFromVectorQueryResultsDisk(VecSimQueryReply *reply, const bool yields_metric, const bool sorted_by_id, t_docId max_doc_id) {
+  size_t res_num = VecSimQueryReply_Len(reply);
+  if (res_num == 0) {
+    VecSimQueryReply_Free(reply);
+    return NULL;
+  }
+  t_docId *docIdsList = rm_malloc(sizeof(*docIdsList) * res_num);
+  double *metricList = yields_metric ? rm_malloc(sizeof(*metricList) * res_num) : NULL;
+
   size_t kept = 0;
   VecSimQueryReply_Iterator *iter = VecSimQueryReply_GetIterator(reply);
   for (size_t i = 0; i < res_num; i++) {
     VecSimQueryResult *res = VecSimQueryReply_IteratorNext(iter);
     t_docId id = VecSimQueryResult_GetId(res);
-    if (max_doc_id && id > max_doc_id) {
-      continue;
+    if (id > max_doc_id) {
+      continue;  // newer than the query snapshot
     }
     docIdsList[kept] = id;
     if (yields_metric) {
@@ -97,30 +149,7 @@ QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *repl
   VecSimQueryReply_IteratorFree(iter);
   VecSimQueryReply_Free(reply);
 
-  if (kept == 0) {
-    // Every result was beyond the snapshot boundary.
-    rm_free(docIdsList);
-    if (metricList) {
-      rm_free(metricList);
-    }
-    return NULL;
-  }
-  res_num = kept;  // arrays are slightly over-allocated; the iterator takes ownership as-is.
-
-  // Move ownership on the arrays to the iterator.
-  if (yields_metric) {
-      if (sorted_by_id) {
-          return NewMetricIteratorSortedById(docIdsList, metricList, res_num, VECTOR_DISTANCE);
-      } else {
-          return NewMetricIteratorSortedByScore(docIdsList, metricList, res_num, VECTOR_DISTANCE);
-      }
-  } else {
-      if (sorted_by_id) {
-          return NewSortedIdListIterator(docIdsList, res_num, 1.0);
-      } else {
-          return NewUnsortedIdListIterator(docIdsList, res_num, 1.0);
-      }
-  }
+  return newMetricOrIdListIterator(docIdsList, metricList, kept, yields_metric, sorted_by_id);
 }
 
 static bool VectorQuery_HasParam(const VectorQuery *vq, const char *param_name, size_t param_name_len) {
@@ -230,13 +259,15 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
       }
       bool yields_metric = vq->scoreField != NULL;
       bool sorted_by_id = vq->range.order == BY_ID;
-      // On disk indexes the range query reads outside the query snapshot and may return docs
-      // newer than maxDocId. Bound the results to the snapshot (0 = no filtering for RAM, where
-      // the bound is a guaranteed no-op), matching the NOT/OPTIONAL iterators in query.c.
-      t_docId max_doc_id =
-          q->sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec) : 0;
-      return createMetricIteratorFromVectorQueryResults(results, yields_metric, sorted_by_id,
-                                                        max_doc_id);
+      if (q->sctx->spec->diskSpec) {
+        // On disk indexes the range query reads outside the query snapshot and may return docs
+        // newer than maxDocId. Bound the results to the snapshot, matching the NOT/OPTIONAL
+        // iterators in query.c. RAM indexes need no such bound (no snapshot).
+        t_docId max_doc_id = SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec);
+        return createMetricIteratorFromVectorQueryResultsDisk(results, yields_metric, sorted_by_id,
+                                                              max_doc_id);
+      }
+      return createMetricIteratorFromVectorQueryResults(results, yields_metric, sorted_by_id);
     }
   }
   return NULL;

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -66,7 +66,7 @@ VecSimIndex *openVectorIndex(RedisModuleCtx *ctx, FieldSpec *fieldSpec, bool cre
   return fieldSpec->vectorOpts.vecSimIndex;
 }
 
-QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *reply, const bool yields_metric, const bool sorted_by_id) {
+QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *reply, const bool yields_metric, const bool sorted_by_id, t_docId max_doc_id) {
   size_t res_num = VecSimQueryReply_Len(reply);
   if (res_num == 0) {
     VecSimQueryReply_Free(reply);
@@ -76,16 +76,36 @@ QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *repl
   double *metricList = yields_metric ? rm_malloc(sizeof(*metricList) * res_num) : NULL;
 
   // Collect the results' id and distance and set it in the arrays.
+  // When max_doc_id is non-zero (disk indexes), drop docs newer than the query snapshot so the
+  // range result stays consistent with the snapshot-bounded iterators it may be unioned with.
+  // Compacting in place preserves the relative order, so it is correct for both BY_ID and
+  // BY_SCORE orders and for both the metric and plain id-list output paths.
+  size_t kept = 0;
   VecSimQueryReply_Iterator *iter = VecSimQueryReply_GetIterator(reply);
   for (size_t i = 0; i < res_num; i++) {
     VecSimQueryResult *res = VecSimQueryReply_IteratorNext(iter);
-    docIdsList[i] = VecSimQueryResult_GetId(res);
-    if (yields_metric) {
-      metricList[i] = VecSimQueryResult_GetScore(res);
+    t_docId id = VecSimQueryResult_GetId(res);
+    if (max_doc_id && id > max_doc_id) {
+      continue;
     }
+    docIdsList[kept] = id;
+    if (yields_metric) {
+      metricList[kept] = VecSimQueryResult_GetScore(res);
+    }
+    kept++;
   }
   VecSimQueryReply_IteratorFree(iter);
   VecSimQueryReply_Free(reply);
+
+  if (kept == 0) {
+    // Every result was beyond the snapshot boundary.
+    rm_free(docIdsList);
+    if (metricList) {
+      rm_free(metricList);
+    }
+    return NULL;
+  }
+  res_num = kept;  // arrays are slightly over-allocated; the iterator takes ownership as-is.
 
   // Move ownership on the arrays to the iterator.
   if (yields_metric) {
@@ -210,7 +230,13 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
       }
       bool yields_metric = vq->scoreField != NULL;
       bool sorted_by_id = vq->range.order == BY_ID;
-      return createMetricIteratorFromVectorQueryResults(results, yields_metric, sorted_by_id);
+      // On disk indexes the range query reads outside the query snapshot and may return docs
+      // newer than maxDocId. Bound the results to the snapshot (0 = no filtering for RAM, where
+      // the bound is a guaranteed no-op), matching the NOT/OPTIONAL iterators in query.c.
+      t_docId max_doc_id =
+          q->sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec) : 0;
+      return createMetricIteratorFromVectorQueryResults(results, yields_metric, sorted_by_id,
+                                                        max_doc_id);
     }
   }
   return NULL;

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -192,7 +192,8 @@ extern "C" {
 
 QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *reply,
                                                           bool yields_metric,
-                                                          bool sorted_by_id);
+                                                          bool sorted_by_id,
+                                                          t_docId max_doc_id);
 #ifdef __cplusplus
 }
 #endif

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -192,8 +192,13 @@ extern "C" {
 
 QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *reply,
                                                           bool yields_metric,
-                                                          bool sorted_by_id,
-                                                          t_docId max_doc_id);
+                                                          bool sorted_by_id);
+
+// Disk variant: additionally drops results with docId > max_doc_id (the query snapshot boundary).
+QueryIterator *createMetricIteratorFromVectorQueryResultsDisk(VecSimQueryReply *reply,
+                                                              bool yields_metric,
+                                                              bool sorted_by_id,
+                                                              t_docId max_doc_id);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -826,8 +826,8 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   VecSimQueryReply *results =
       VecSimIndex_RangeQuery(index, range_query.vector, range_query.radius, &queryParams, range_query.order);
 
-  // Run simple range query (max_doc_id = 0 disables the snapshot filter).
-  QueryIterator *vecIt = createMetricIteratorFromVectorQueryResults(results, true, true, 0);
+  // Run simple range query (RAM variant: no snapshot bound).
+  QueryIterator *vecIt = createMetricIteratorFromVectorQueryResults(results, true, true);
   size_t count = 0;
   size_t lowest_id = 25;
   size_t n_expected_res = n - lowest_id + 1;
@@ -895,13 +895,13 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   VecSimIndex_Free(index);
 }
 
-// Verifies the max_doc_id snapshot filter applied while materializing vector
-// range results into a metric/id-list iterator (createMetricIteratorFromVectorQueryResults).
-// On disk indexes the range query may return docIds newer than the query snapshot; those must
-// be dropped so the range result stays consistent with the snapshot-bounded iterators it may be
-// unioned with. This exercises the drop path deterministically, which a flow test cannot: there
-// SearchDisk_GetMaxDocId advances synchronously with docId assignment, so no live docId ever
-// exceeds it.
+// Verifies the max_doc_id snapshot filter applied while materializing vector range results into a
+// metric/id-list iterator (createMetricIteratorFromVectorQueryResultsDisk). On disk indexes the
+// range query may return docIds newer than the query snapshot; those must be dropped so the range
+// result stays consistent with the snapshot-bounded iterators it may be unioned with. This
+// exercises the drop path deterministically, which a flow test cannot: there SearchDisk_GetMaxDocId
+// advances synchronously with docId assignment, so no live docId ever exceeds it. The final case
+// also checks the RAM variant (createMetricIteratorFromVectorQueryResults) leaves results unbounded.
 TEST_F(IndexTest, testMetric_VectorRange_MaxDocIdFilter) {
   size_t n = 100;
   size_t d = 4;
@@ -941,11 +941,11 @@ TEST_F(IndexTest, testMetric_VectorRange_MaxDocIdFilter) {
     return VecSimIndex_RangeQuery(index, query, 0.2, &queryParams, order);
   };
 
-  // BY_ID, cutoff in the middle: only the contiguous head 25..max_doc_id survives, in order.
+  // Disk, BY_ID, cutoff in the middle: only the contiguous head 25..max_doc_id survives, in order.
   {
     const t_docId max_doc_id = 50;
-    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true,
-                                                                   max_doc_id);
+    QueryIterator *it = createMetricIteratorFromVectorQueryResultsDisk(run_range(BY_ID), true, true,
+                                                                       max_doc_id);
     ASSERT_TRUE(it != nullptr);
     size_t count = 0;
     while (it->Read(it) != ITERATOR_EOF) {
@@ -957,12 +957,12 @@ TEST_F(IndexTest, testMetric_VectorRange_MaxDocIdFilter) {
     it->Free(it);
   }
 
-  // BY_SCORE (unsorted by id): order follows distance, but every surviving id must be <= cutoff
-  // and the surviving set must be exactly {25..50}.
+  // Disk, BY_SCORE (unsorted by id): order follows distance, but every surviving id must be <=
+  // cutoff and the surviving set must be exactly {25..50}.
   {
     const t_docId max_doc_id = 50;
-    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_SCORE), true,
-                                                                   false, max_doc_id);
+    QueryIterator *it = createMetricIteratorFromVectorQueryResultsDisk(run_range(BY_SCORE), true,
+                                                                       false, max_doc_id);
     ASSERT_TRUE(it != nullptr);
     std::set<t_docId> seen;
     while (it->Read(it) != ITERATOR_EOF) {
@@ -975,17 +975,17 @@ TEST_F(IndexTest, testMetric_VectorRange_MaxDocIdFilter) {
     it->Free(it);
   }
 
-  // Cutoff below the lowest in-range id: every result is filtered out, so no iterator is created.
+  // Disk, cutoff below the lowest in-range id: every result is filtered out, so no iterator is
+  // created.
   {
-    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true,
-                                                                   /*max_doc_id=*/10);
+    QueryIterator *it = createMetricIteratorFromVectorQueryResultsDisk(run_range(BY_ID), true, true,
+                                                                       /*max_doc_id=*/10);
     ASSERT_TRUE(it == nullptr);
   }
 
-  // max_doc_id == 0 disables filtering entirely (RAM path): all in-range docs are returned.
+  // RAM variant applies no snapshot bound: all in-range docs are returned.
   {
-    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true,
-                                                                   /*max_doc_id=*/0);
+    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true);
     ASSERT_TRUE(it != nullptr);
     size_t count = 0;
     while (it->Read(it) != ITERATOR_EOF) {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include <time.h>
 #include <float.h>
 #include <vector>
+#include <set>
 #include <cstdint>
 #include <random>
 #include <chrono>
@@ -825,8 +826,8 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   VecSimQueryReply *results =
       VecSimIndex_RangeQuery(index, range_query.vector, range_query.radius, &queryParams, range_query.order);
 
-  // Run simple range query.
-  QueryIterator *vecIt = createMetricIteratorFromVectorQueryResults(results, true, true);
+  // Run simple range query (max_doc_id = 0 disables the snapshot filter).
+  QueryIterator *vecIt = createMetricIteratorFromVectorQueryResults(results, true, true, 0);
   size_t count = 0;
   size_t lowest_id = 25;
   size_t n_expected_res = n - lowest_id + 1;
@@ -891,6 +892,109 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   ASSERT_FALSE(vecIt->atEOF);
 
   vecIt->Free(vecIt);
+  VecSimIndex_Free(index);
+}
+
+// Verifies the max_doc_id snapshot filter applied while materializing vector
+// range results into a metric/id-list iterator (createMetricIteratorFromVectorQueryResults).
+// On disk indexes the range query may return docIds newer than the query snapshot; those must
+// be dropped so the range result stays consistent with the snapshot-bounded iterators it may be
+// unioned with. This exercises the drop path deterministically, which a flow test cannot: there
+// SearchDisk_GetMaxDocId advances synchronously with docId assignment, so no live docId ever
+// exceeds it.
+TEST_F(IndexTest, testMetric_VectorRange_MaxDocIdFilter) {
+  size_t n = 100;
+  size_t d = 4;
+  VecSimMetric met = VecSimMetric_Cosine;
+  VecSimType t = VecSimType_FLOAT32;
+
+  VecSimLogCtx logCtx = { .index_field_name = "v" };
+  VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
+                      .algoParams = {.hnswParams = HNSWParams{.type = t,
+                                               .dim = d,
+                                               .metric = met,
+                                               .initialCapacity = n,
+                                               .M = 16,
+                                               .efConstruction = 100}},
+                      .logCtx = &logCtx};
+  VecSimIndex *index = VecSimIndex_New(&params);
+  for (size_t i = 1; i <= n; i++) {
+    float f[d];
+    f[0] = 1.0f;
+    for (size_t j = 1; j < d; j++) {
+      f[j] = (float)i / n;
+    }
+    VecSimIndex_AddVector(index, (const void *)f, (int)i);
+  }
+  ASSERT_EQ(VecSimIndex_IndexSize(index), n);
+
+  float query[] = {(float)n, (float)n, (float)n, (float)n};
+  // Same parameters as testMetric_VectorRange: radius 0.2 admits ids 25..100.
+  const size_t lowest_id = 25;
+  const size_t total_in_range = n - lowest_id + 1;  // 76
+
+  // Fresh range reply per call: createMetricIteratorFromVectorQueryResults takes ownership and
+  // frees it.
+  auto run_range = [&](VecSimQueryReply_Order order) {
+    VecSimQueryParams queryParams = {0};
+    queryParams.hnswRuntimeParams.efRuntime = n;
+    return VecSimIndex_RangeQuery(index, query, 0.2, &queryParams, order);
+  };
+
+  // BY_ID, cutoff in the middle: only the contiguous head 25..max_doc_id survives, in order.
+  {
+    const t_docId max_doc_id = 50;
+    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true,
+                                                                   max_doc_id);
+    ASSERT_TRUE(it != nullptr);
+    size_t count = 0;
+    while (it->Read(it) != ITERATOR_EOF) {
+      ASSERT_EQ(it->current->docId, lowest_id + count);
+      ASSERT_LE(it->current->docId, max_doc_id);
+      count++;
+    }
+    ASSERT_EQ(count, max_doc_id - lowest_id + 1);  // 26
+    it->Free(it);
+  }
+
+  // BY_SCORE (unsorted by id): order follows distance, but every surviving id must be <= cutoff
+  // and the surviving set must be exactly {25..50}.
+  {
+    const t_docId max_doc_id = 50;
+    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_SCORE), true,
+                                                                   false, max_doc_id);
+    ASSERT_TRUE(it != nullptr);
+    std::set<t_docId> seen;
+    while (it->Read(it) != ITERATOR_EOF) {
+      ASSERT_LE(it->current->docId, max_doc_id);
+      seen.insert(it->current->docId);
+    }
+    ASSERT_EQ(seen.size(), max_doc_id - lowest_id + 1);  // 26
+    ASSERT_EQ(*seen.begin(), lowest_id);
+    ASSERT_EQ(*seen.rbegin(), max_doc_id);
+    it->Free(it);
+  }
+
+  // Cutoff below the lowest in-range id: every result is filtered out, so no iterator is created.
+  {
+    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true,
+                                                                   /*max_doc_id=*/10);
+    ASSERT_TRUE(it == nullptr);
+  }
+
+  // max_doc_id == 0 disables filtering entirely (RAM path): all in-range docs are returned.
+  {
+    QueryIterator *it = createMetricIteratorFromVectorQueryResults(run_range(BY_ID), true, true,
+                                                                   /*max_doc_id=*/0);
+    ASSERT_TRUE(it != nullptr);
+    size_t count = 0;
+    while (it->Read(it) != ITERATOR_EOF) {
+      count++;
+    }
+    ASSERT_EQ(count, total_in_range);  // 76
+    it->Free(it);
+  }
+
   VecSimIndex_Free(index);
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** On Redis Flex (disk) indexes, a vector `VECTOR_RANGE` query reads the live tiered vector index, so it can return docIds newer than the query's snapshot. The other query iterators (term/tag/numeric/NOT/OPTIONAL) read from a SpeedB snapshot established at query start and are bounded to that snapshot's `maxDocId`. When a range branch is combined with them via non-intersection (union) logic, it could surface documents the snapshot-bounded branches cannot — an inconsistent result set.
2. **Change:** Bound disk range-query results to the query snapshot. `maxDocId` is captured **once** at query start (`QAST_Iterate`, under the spec read lock that gates iterator creation) and stored on `QueryEvalCtx`; the disk range path drops any `docId > maxDocId` while materializing results. Iterator construction is factored into a shared helper with explicit RAM and disk entry points, so memory-based indexes keep the existing unbounded path. KNN is intentionally untouched: it is always at the root and is either childless or intersected with a snapshot-bounded child, so it is already bounded.
3. **Outcome:** Disk vector range queries no longer return documents newer than the query snapshot, staying consistent with the iterators they may be combined with. RAM indexes are unaffected.

#### Which additional issues this PR fixes
1. MOD-14218

#### Main objects this PR modified
1. `src/vector_index.{c,h}` — split range materialization into RAM (`createMetricIteratorFromVectorQueryResults`) and disk (`…Disk`, drops `docId > max_doc_id`) entry points sharing a `newMetricOrIdListIterator` helper; range path filters against the query-start bound.
2. `src/query.c` / `src/query_ctx.h` — capture `maxDocId` once in `QAST_Iterate` into `QueryEvalCtx.maxDocId`.
3. `tests/cpptests/test_cpp_index.cpp` — `testMetric_VectorRange_MaxDocIdFilter` covering BY_ID, BY_SCORE, all-filtered (→ empty), and the RAM unbounded path.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Disk-based vector range queries are a not-yet-GA feature still under active development, so this internal consistency fix has no released behavior to note against.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disk vector RANGE result sets and query snapshot semantics; scoped to range + disk path with unit tests, but affects correctness of combined queries on Flex indexes.
> 
> **Overview**
> Fixes **disk index vector RANGE** queries returning doc IDs newer than the query snapshot, which could disagree with snapshot-bounded siblings (e.g. in unions/intersections).
> 
> **`QueryEvalCtx`** now carries **`maxDocId`**, set once in **`QAST_Iterate`** (disk: `SearchDisk_GetMaxDocId`, RAM: `docs.maxDocId`) so the boundary is fixed for the whole evaluation—not re-read later.
> 
> For **RANGE** on disk, results are materialized via **`createMetricIteratorFromVectorQueryResultsDisk`**, which drops entries with `docId > maxDocId` while preserving order (BY_ID / BY_SCORE, metric and plain id-list paths). Iterator construction is factored through **`newMetricOrIdListIterator`**. **KNN** and RAM indexes keep the existing unbounded path.
> 
> Adds **`testMetric_VectorRange_MaxDocIdFilter`** to exercise the filter deterministically (BY_ID, BY_SCORE, all filtered, RAM unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d6d5850f22dd532c228350c0a4707eb7bb8693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
