### PR TITLE
[MOD-16087] Expose result_processor test harness behind a test-utils feature

### DIFF
--- a/src/redisearch_rs/result_processor/Cargo.toml
+++ b/src/redisearch_rs/result_processor/Cargo.toml
@@ -23,6 +23,9 @@ build_utils.workspace = true
 
 [features]
 unittest = []
+# Exposes `test_utils` (the `Chain` harness) as a public module so downstream crates
+# can drive result processors in pure-Rust tests. See `src/lib.rs`.
+test-utils = []
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -18,8 +18,13 @@
 //! the database indexes.
 
 pub mod counter;
-#[cfg(test)]
-mod test_utils;
+/// Test harness (`Chain`, `from_iter`, `ResultRP`) for driving result processors in pure Rust.
+///
+/// Exposed behind the `test-utils` feature so other crates (e.g. `redisearch_disk`) can build
+/// their own result processors against the real [`Context`]/[`Upstream`] machinery in tests,
+/// since [`Context`] has no public constructor. Always available to this crate's own tests.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 
 use pin_project::pin_project;
 use search_result::SearchResult;

--- a/src/redisearch_rs/result_processor/src/test_utils.rs
+++ b/src/redisearch_rs/result_processor/src/test_utils.rs
@@ -121,7 +121,11 @@ impl Chain {
     /// # Safety
     ///
     /// The caller has to ensure that the given pointer dereferences to a valid result processor.
-    pub unsafe fn push_raw(&mut self, mut result_processor: NonNull<crate::Header>) {
+    // Only this crate's own tests inject a raw (C-style) result processor; downstream `test-utils`
+    // consumers build chains through `append`, so this is `cfg(test)`-only to avoid a dead-code
+    // warning in the feature-only build.
+    #[cfg(test)]
+    pub(crate) unsafe fn push_raw(&mut self, mut result_processor: NonNull<crate::Header>) {
         if let Some(upstream) = self.result_processors.last() {
             unsafe {
                 result_processor.as_mut().upstream = upstream.as_ptr();
@@ -143,7 +147,7 @@ impl Chain {
     /// # Safety
     ///
     /// 1. The caller must treat the returned pointer as pinned
-    pub unsafe fn last_raw(&mut self) -> &mut NonNull<crate::Header> {
+    pub(crate) unsafe fn last_raw(&mut self) -> &mut NonNull<crate::Header> {
         self.result_processors
             .last_mut()
             .expect("empty result processor chain")


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The `test_utils` module in `result_processor` is always compiled into the crate, including `Chain` test helpers and `push_raw`/`last_raw` accessors.
2. Change: Gate the `test_utils` module behind a new `test-utils` Cargo feature. Scope `push_raw` and `last_raw` to `pub(crate)` and guard `push_raw` with `cfg(test)` so the feature-only build stays warning-clean.
3. Outcome: Downstream crates (such as the disk async loader) can declare `result_processor` with `features = ["test-utils"]` in `dev-dependencies` and drive result processors against the real `Context`/`Upstream` machinery in pure-Rust tests. This is needed because `Context` has no public constructor. Follows the same pattern as `ttl_table` and `numeric_range_tree`.

#### Which additional issues this PR fixes
1. MOD-16087

#### Main objects this PR modified
1. `src/redisearch_rs/result_processor/Cargo.toml`
2. `src/redisearch_rs/result_processor/src/lib.rs`
3. `src/redisearch_rs/result_processor/src/test_utils.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only API surface behind an optional feature; production builds unchanged unless the feature is enabled.
> 
> **Overview**
> Adds a **`test-utils`** Cargo feature on `result_processor` so the **`test_utils`** harness (`Chain`, `from_iter`, `ResultRP`) is a **public** module when the feature is enabled (or during this crate’s own tests), matching **`ttl_table`** / **`numeric_range_tree`**.
> 
> Downstream crates can opt in via `dev-dependencies` with `features = ["test-utils"]` to exercise custom result processors against real **`Context`** / **`Upstream`** wiring without a public **`Context`** constructor.
> 
> **`push_raw`** is limited to **`cfg(test)`** and **`pub(crate)`**; **`last_raw`** is **`pub(crate)`** so feature-only builds stay warning-clean while in-crate tests keep raw/C-style injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251fa4f2b8068ab4123decdbbfb3a2afdeb522cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->