### PR TITLE
[MOD-15894] Makefile: rename deps target to bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ define HELPTEXT
 RediSearch Build System
 
 Setup:
-  make deps          Install build-time system dependencies.
+  make bootstrap     Install build-time system dependencies.
                      Auto-prefixes `sudo` when not root.
     SUDO=cmd           Override the privilege-escalation command (default: auto)
   make fetch         Download and prepare dependent modules
@@ -224,7 +224,7 @@ help:
 # or to force no prefix.
 SUDO ?= $(shell [ "$$(id -u)" -eq 0 ] || echo sudo)
 
-deps:
+bootstrap:
 	@echo "Installing build dependencies..."
 	@cd $(ROOT)/.install && ./install_script.sh $(SUDO)
 
@@ -469,7 +469,7 @@ test-linkcheck:
 	fi
 	@python3 scripts/test_link_checker.py
 
-.PHONY: help deps fetch build clean test unit-tests rust-tests pytest
+.PHONY: help bootstrap fetch build clean test unit-tests rust-tests pytest
 .PHONY: run lint fmt license-check pack upload-artifacts
 .PHONY: benchmark micro-benchmarks vecsim-bench callgrind parsers verify-deps
 .PHONY: check-links check-links-verbose test-linkcheck


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: RediSearch currently exposes the dependency-install Make target as `make deps`.
2. Change: Rename the target back to `make bootstrap`, and update the help text and `.PHONY` entry accordingly.
3. Outcome: Callers can use the agreed module setup command, `make bootstrap`, while the installer behavior remains unchanged.

#### Which additional issues this PR fixes

1. MOD-15894

#### Main objects this PR modified

1. `Makefile` - rename `deps` to `bootstrap` in the target, help text, and `.PHONY` list.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal build-workflow naming correction with no user-facing runtime behavior impact.

## Test plan

- [x] `make -n bootstrap`
- [x] `make -n bootstrap SUDO=doas`
- [x] `make -n fetch`
- [x] `make -n verify-deps`
- [x] `make help`
- [x] `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only target rename with no change to install scripts or build logic; callers using `make deps` will need to switch to `make bootstrap`.
> 
> **Overview**
> Renames the Makefile setup target from **`make deps`** to **`make bootstrap`** so module setup matches the agreed command name.
> 
> The target recipe is unchanged—it still runs `.install/install_script.sh` with the same `SUDO` behavior. **`make help`** and the **`.PHONY`** list are updated to document and declare `bootstrap` instead of `deps`. Targets like **`verify-deps`** and **`fetch`** are not modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afbd1f766c09c985697b736b816caa702df68308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->