### PR TITLE
[8.6-rse] MOD-16154 search-disk-drop-read-cache / search-disk-use-direct-reads

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -99,6 +99,8 @@ configPair_t __configPairs[] = {
   {"_MAX_TRIM_DELAY_MS",               "search-_max-trim-delay-ms"},
   {"_TRIMMING_STATE_CHECK_DELAY_MS",   "search-_trimming-state-check-delay-ms"},
   {"_SIMULATE_IN_FLEX",                "search-_simulate-in-flex"},
+  {"search-disk-drop-read-cache",      "search-disk-drop-read-cache"},
+  {"search-disk-use-direct-reads",     "search-disk-use-direct-reads"},
 };
 
 static const char* FTConfigNameToConfigName(const char *name) {
@@ -215,6 +217,7 @@ static long long get_uint8_numeric_config(const char *name, void *privdata) {
   REDISMODULE_NOT_USED(name);
   return (long long)(*(uint8_t *)privdata);
 }
+
 
 static int set_bool_config(const char *name, int val, void *privdata,
                     RedisModuleString **err) {
@@ -1317,6 +1320,44 @@ static int get_on_oom(const char *name, void *privdata){
   REDISMODULE_NOT_USED(name);
   return *((RSOomPolicy *)privdata);
 }
+// Legacy module-ARGS setter for search-disk-drop-read-cache.
+// Handles yes/no/true/false (case-insensitive).
+// TODO: remove once RLTest can emit `--<config-name> <value>` directly (see RLTest
+// moduleConfigs follow-up); new immutable configs should not need a legacy ARGS entry.
+CONFIG_SETTER(setDiskDropReadCache) {
+  const char *tf;
+  int acrc = AC_GetString(ac, &tf, NULL, 0);
+  CHECK_RETURN_PARSE_ERROR(acrc);
+  if (!strcasecmp(tf, "yes") || !strcasecmp(tf, "true")) {
+    config->diskDropReadCache = true;
+  } else if (!strcasecmp(tf, "no") || !strcasecmp(tf, "false")) {
+    config->diskDropReadCache = false;
+  } else {
+    acrc = AC_ERR_PARSE;
+  }
+  RETURN_STATUS(acrc);
+}
+
+CONFIG_BOOLEAN_GETTER(getDiskDropReadCache, diskDropReadCache, 0)
+
+// Legacy module-ARGS setter for search-disk-use-direct-reads.
+// Handles yes/no/true/false (case-insensitive).
+CONFIG_SETTER(setDiskUseDirectReads) {
+  const char *tf;
+  int acrc = AC_GetString(ac, &tf, NULL, 0);
+  CHECK_RETURN_PARSE_ERROR(acrc);
+  if (!strcasecmp(tf, "yes") || !strcasecmp(tf, "true")) {
+    config->diskUseDirectReads = true;
+  } else if (!strcasecmp(tf, "no") || !strcasecmp(tf, "false")) {
+    config->diskUseDirectReads = false;
+  } else {
+    acrc = AC_ERR_PARSE;
+  }
+  RETURN_STATUS(acrc);
+}
+
+CONFIG_BOOLEAN_GETTER(getDiskUseDirectReads, diskUseDirectReads, 0)
+
 RSConfig RSGlobalConfig = RS_DEFAULT_CONFIG;
 
 static RSConfigVar *findConfigVar(const RSConfigOptions *config, const char *name) {
@@ -1676,6 +1717,16 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Simulate working under Flex conditions. This is used for testing only.",
          .setValue = setDebugSimulateInFlex,
          .getValue = getDebugSimulateInFlex,
+         .flags = RSCONFIGVAR_F_IMMUTABLE},
+        {.name = "search-disk-drop-read-cache",
+         .helpText = "Drop OS read cache after each SpeedB read (yes/no, default no)",
+         .setValue = setDiskDropReadCache,
+         .getValue = getDiskDropReadCache,
+         .flags = RSCONFIGVAR_F_IMMUTABLE},
+        {.name = "search-disk-use-direct-reads",
+         .helpText = "Use O_DIRECT for SpeedB reads (yes/no, default no)",
+         .setValue = setDiskUseDirectReads,
+         .getValue = getDiskUseDirectReads,
          .flags = RSCONFIGVAR_F_IMMUTABLE},
         {.name = NULL}}};
 
@@ -2402,6 +2453,24 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       REDISMODULE_CONFIG_UNPREFIXED, 0,
       100, get_uint8_numeric_config, set_search_disk_buffer_percentage_config, NULL,
       (void *)&(RSGlobalConfig.diskBufferPercentage)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
+      ctx, "search-disk-drop-read-cache", 0,
+      REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.diskDropReadCache)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
+      ctx, "search-disk-use-direct-reads", 0,
+      REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.diskUseDirectReads)
     )
   )
 

--- a/src/config.h
+++ b/src/config.h
@@ -217,6 +217,12 @@ typedef struct {
   bool monitorExpiration;
   // Percentage of available memory to use for disk write buffer (0-100).
   uint8_t diskBufferPercentage;
+  // Controls SpeedB OS page-cache behaviour for disk indexes (MOD-15866).
+  // Both default to false; users opt in via search-disk-drop-read-cache and
+  // search-disk-use-direct-reads at load time.  These are RSE-only knobs and
+  // are intentionally not coupled to any Flex bigredis-driver settings.
+  bool diskDropReadCache;
+  bool diskUseDirectReads;
 } RSConfig;
 
 typedef enum {
@@ -413,6 +419,8 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .simulateInFlex = false,                                                   \
     .monitorExpiration = true,                                                 \
     .diskBufferPercentage = DEFAULT_DISK_BUFFER_PERCENTAGE,                    \
+    .diskDropReadCache = false,                                                \
+    .diskUseDirectReads = false,                                               \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -59,8 +59,9 @@ bool SearchDisk_Initialize(RedisModuleCtx *ctx) {
   RS_ASSERT(disk->basic.setThrottleCallbacks);
   disk->basic.setThrottleCallbacks(VecSim_EnableThrottle, VecSim_DisableThrottle);
 
-  // Pass the disk buffer percentage from config
-  disk_db = disk->basic.open(ctx, (int)RSGlobalConfig.diskBufferPercentage);
+  // Pass the disk buffer percentage and read-cache configs from config
+  disk_db = disk->basic.open(ctx, (int)RSGlobalConfig.diskBufferPercentage,
+                             RSGlobalConfig.diskDropReadCache, RSGlobalConfig.diskUseDirectReads);
   bool disk_initialized = disk_db != NULL;
 
   if (!disk_initialized) {

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -50,9 +50,11 @@ typedef struct BasicDiskAPI {
    * @brief Open the disk storage context
    * @param ctx Redis module context
    * @param buffer_percentage Percentage of available memory to use for write buffer (0-100)
+   * @param dropReadCache When true, hints the OS to evict pages after reading
+   * @param useDirectReads When true, opens files with O_DIRECT to bypass the OS page cache
    * @return Pointer to the disk context, or NULL on error
    */
-  RedisSearchDisk *(*open)(RedisModuleCtx *ctx, int buffer_percentage);
+  RedisSearchDisk *(*open)(RedisModuleCtx *ctx, int buffer_percentage, bool dropReadCache, bool useDirectReads);
   void (*close)(RedisModuleCtx *ctx, RedisSearchDisk *disk);
   /**
    * @brief Open an index spec

--- a/tests/pytests/test_disk_config.py
+++ b/tests/pytests/test_disk_config.py
@@ -1,0 +1,89 @@
+from common import *
+
+"""
+Tests for search-disk-drop-read-cache and search-disk-use-direct-reads module configs.
+
+These configs control SpeedB OS page-cache behaviour for disk indexes:
+  - search-disk-drop-read-cache: whether to drop the OS read cache after each read
+  - search-disk-use-direct-reads: whether to use O_DIRECT for reads
+
+Both are immutable (load-time only) and default to 'no'.  They are RSE-only knobs;
+there is no fallback to any Flex bigredis-driver setting (decision per MOD-15866 review).
+"""
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_defaults():
+    """Both configs default to 'no' when no module arg is provided."""
+    env = Env(noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', 'search-disk-drop-read-cache').equal(
+        ['search-disk-drop-read-cache', 'no'])
+    env.expect('CONFIG', 'GET', 'search-disk-use-direct-reads').equal(
+        ['search-disk-use-direct-reads', 'no'])
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_immutable(env):
+    """Both configs are immutable — runtime CONFIG SET must be rejected."""
+    env.expect('CONFIG', 'SET', 'search-disk-drop-read-cache', 'yes').error()
+    env.expect('CONFIG', 'SET', 'search-disk-use-direct-reads', 'yes').error()
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_startup_drop_read_cache_yes():
+    """search-disk-drop-read-cache=yes set at load time is reflected in CONFIG GET."""
+    env = Env(moduleArgs='search-disk-drop-read-cache yes', noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', 'search-disk-drop-read-cache').equal(
+        ['search-disk-drop-read-cache', 'yes'])
+    env.stop()
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_startup_drop_read_cache_no():
+    """search-disk-drop-read-cache=no set at load time is reflected in CONFIG GET."""
+    env = Env(moduleArgs='search-disk-drop-read-cache no', noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', 'search-disk-drop-read-cache').equal(
+        ['search-disk-drop-read-cache', 'no'])
+    env.stop()
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_startup_use_direct_reads_yes():
+    """search-disk-use-direct-reads=yes set at load time is reflected in CONFIG GET."""
+    env = Env(moduleArgs='search-disk-use-direct-reads yes', noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', 'search-disk-use-direct-reads').equal(
+        ['search-disk-use-direct-reads', 'yes'])
+    env.stop()
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_startup_use_direct_reads_no():
+    """search-disk-use-direct-reads=no set at load time is reflected in CONFIG GET."""
+    env = Env(moduleArgs='search-disk-use-direct-reads no', noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', 'search-disk-use-direct-reads').equal(
+        ['search-disk-use-direct-reads', 'no'])
+    env.stop()
+
+
+@skip(cluster=True, redis_less_than="8.6")
+def test_disk_config_startup_both():
+    """Both configs can be set together at load time."""
+    env = Env(moduleArgs='search-disk-drop-read-cache yes search-disk-use-direct-reads yes',
+              noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect('CONFIG', 'GET', 'search-disk-drop-read-cache').equal(
+        ['search-disk-drop-read-cache', 'yes'])
+    env.expect('CONFIG', 'GET', 'search-disk-use-direct-reads').equal(
+        ['search-disk-use-direct-reads', 'yes'])
+    env.stop()


### PR DESCRIPTION
### Description
Backport of https://github.com/RediSearch/RediSearch/pull/9789 ("MOD-15866 Add disk read-cache and direct-reads module configs") to **8.6-rse**, so the `search-disk-drop-read-cache` and `search-disk-use-direct-reads` immutable bool configs exist in the 8.6 RSE build (needed by Redis Enterprise — they currently only exist on the 99.99/beta line).

Cherry-pick of `3ee4f3e` (squash of #9789) onto `8.6-rse`.

### Deviations from the original PR (8.6-rse adaptations)
The original was based on `master`, which has features not present on `8.6-rse`. To keep this a minimal, correct backport, the conflict resolution **adds only the two disk configs** and intentionally does **not** pull in adjacent master-only code:
- `disk->basic.open()` gains only `dropReadCache` + `useDirectReads` (8.6-rse's signature has no `logObfuscation` param, so it's not introduced here).
- Did **not** add `search-_fallback-to-main-thread-when-block-client-unavailable` (a separate master-only config that appeared in the same hunks).
- Relaxed the test gate from `redis_less_than="8.8"` → `redis_less_than="8.6"` so `test_disk_config.py` actually runs on 8.6 (`REDISMODULE_CONFIG_UNPREFIXED` is supported on 8.6, verified in `redismodule.h`).

### Dependency
This is half of a coupled pair — the RSE-side wiring is backported in RediSearchEnterprise#488 (onto RediSearchEnterprise `8.6`), whose `deps/RediSearch` will point at this branch (then at the `8.6-rse` tip once this merges and syncs to the private fork). The `open()` signature change here must match that backport's Rust implementation.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the disk API `open()` signature and load-time I/O behavior; must stay ABI-aligned with RediSearchEnterprise, but defaults are off and runtime CONFIG SET is blocked.
> 
> **Overview**
> Backports **MOD-15866** disk read-cache knobs to **8.6-rse** with two new **immutable** load-time configs: `search-disk-drop-read-cache` (evict OS pages after SpeedB reads) and `search-disk-use-direct-reads` (`O_DIRECT` reads). Both default to **no** and are wired through `RSGlobalConfig`, Redis `CONFIG` registration, legacy module-args setters (yes/no/true/false), and `RSGlobalConfigOptions` / FT name mapping.
> 
> **`disk->basic.open()`** now takes `dropReadCache` and `useDirectReads` from config at disk init (`search_disk.c` / `search_disk_api.h`), matching the RediSearchEnterprise Rust implementation.
> 
> Adds **`tests/pytests/test_disk_config.py`** (Redis ≥ 8.6): defaults, immutability at runtime, and module-arg startup for each flag and both together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d908b37a2087c369ce1da3bda8deb6d93c9f1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->