### PR TITLE
[8.6-rse] CI: Use repository owner in image name for CI container (#10003)

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -54,8 +54,10 @@ jobs:
           SAN: ${{ inputs.san }}
           RUNNER_ENV: ${{ inputs.runner-env }}
           RUN_ID: ${{ github.run_id }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          IMAGE_NAME="ghcr.io/redisearch/redisearch-ci"
+          OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME="ghcr.io/${OWNER_LC}/redisearch-ci"
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
           SAN_SAFE=$(echo "$SAN" | sed 's#[^A-Za-z0-9_.-]#-#g')
           RUNNER_ENV_SAFE=$(echo "$RUNNER_ENV" | sed 's#[^A-Za-z0-9_.-]#-#g')


### PR DESCRIPTION
Backport #10003 to `8.6-rse`
(cherry picked from commit 3ec5a5bb0241795f9db3cf439d9d90b1d8baaf58)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to image naming; no application code, APIs, or serialization. Forks and org repos need GHCR package write permissions under their owner namespace.
> 
> **Overview**
> Updates the **Build Cached Container** reusable workflow so CI images push to a **GHCR namespace owned by the repo** instead of the fixed `ghcr.io/redisearch/redisearch-ci` path.
> 
> The **Set image name** step now reads `github.repository_owner`, lowercases it for GHCR naming rules, and builds `IMAGE_NAME` as `ghcr.io/${OWNER_LC}/redisearch-ci`. Run-specific tags and shared cache refs still use the same suffix pattern; only the registry path prefix changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7ce0834d78de68e30b745d8d97f42f8d40285d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->