### PR TITLE
[8.6] CI: Use repository owner in image name for CI container (#10003)

### DIFF
--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -54,8 +54,10 @@ jobs:
           SAN: ${{ inputs.san }}
           RUNNER_ENV: ${{ inputs.runner-env }}
           RUN_ID: ${{ github.run_id }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          IMAGE_NAME="ghcr.io/redisearch/redisearch-ci"
+          OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME="ghcr.io/${OWNER_LC}/redisearch-ci"
           CONTAINER_SAFE=$(echo "$CONTAINER" | sed 's#[^A-Za-z0-9_.-]#-#g')
           SAN_SAFE=$(echo "$SAN" | sed 's#[^A-Za-z0-9_.-]#-#g')
           RUNNER_ENV_SAFE=$(echo "$RUNNER_ENV" | sed 's#[^A-Za-z0-9_.-]#-#g')


### PR DESCRIPTION
Backport #10003  to `8.6`
(cherry picked from commit 3ec5a5bb0241795f9db3cf439d9d90b1d8baaf58)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to image naming; no application, API, or runtime behavior is affected.
> 
> **Overview**
> CI cached container images are no longer pushed to a fixed `ghcr.io/redisearch/redisearch-ci` namespace. The **Set image name** step now derives the GHCR repository from `github.repository_owner` (lowercased), so tags and cache refs use `ghcr.io/<owner>/redisearch-ci` for the repo that runs the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d008c04256ac5f90d165738a9892a78ba93b4739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->