### PR TITLE
ci: skip cheadergen in rust micro-benchmarks build

### DIFF
--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -30,6 +30,10 @@ jobs:
           s3-region: ${{ vars.SCCACHE_S3_REGION }}
           s3-key-prefix: ${{ vars.SCCACHE_S3_KEY_PREFIX }}
       - name: Build RediSearch
+        env:
+          # Use committed Rust C headers; cheadergen is not installed on the
+          # benchmark EC2 runner (mirrors flow-micro-benchmarks-runner.yml).
+          REDISEARCH_GENERATE_HEADERS: "0"
         run: make build LTO=1
       - name: Download Latest Baseline Artifact from master
         id: get-artifact

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build RediSearch
         env:
           # Use committed Rust C headers; cheadergen is not installed on the
-          # benchmark EC2 runner (mirrors flow-micro-benchmarks-runner.yml).
+          # benchmark EC2 runner (see redis/redis#15220 for the same pattern).
           REDISEARCH_GENERATE_HEADERS: "0"
         run: make build LTO=1
       - name: Download Latest Baseline Artifact from master


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `Trigger Rust Micro Benchmarks` job in the `Benchmark` workflow fails at CMake configure with `Could not find CHEADERGEN_EXECUTABLE using the following names: cheadergen` (e.g. [run 27105489386](https://github.com/RediSearch/RediSearch/actions/runs/27105489386/job/79993785126)). The benchmark EC2 runner only has the Rust toolchain installed via `.install/install_script.sh`; that script does not source `install_rust_deps.sh`, so the `binstall cheadergen_cli@$CHEADERGEN_VERSION` step never runs.
2. **Change**: Set `REDISEARCH_GENERATE_HEADERS=0` on the `Build RediSearch` step of `flow-rust-micro-benchmarks.yml`. The `src/redisearch_rs/CMakeLists.txt` gate flips to the no-op `cheadergen_generate` stub and the build uses the committed headers under `src/redisearch_rs/headers/`.
3. **Outcome**: Job configures and builds again. Mirrors the same workaround already present in `flow-micro-benchmarks-runner.yml` for the C micro-benchmark flow.

#### Which additional issues this PR fixes

_none_

#### Main objects this PR modified

1. `.github/workflows/flow-rust-micro-benchmarks.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no product code or runtime behavior affected.
> 
> **Overview**
> Fixes the **Rust micro-benchmark** workflow build failing on the EC2 runner when CMake looks for `cheadergen`, which that image does not install.
> 
> The **Build RediSearch** step in `flow-rust-micro-benchmarks.yml` now sets `REDISEARCH_GENERATE_HEADERS: "0"`, so the build uses committed headers under `src/redisearch_rs/headers/` instead of regenerating them. This matches the existing workaround in `flow-micro-benchmarks-runner.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475c943f03fcd07f65cc810747a6281542580e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->