### PR TITLE
[MOD-16153] spec: handle FieldSpec_RdbLoad failure in legacy RDB loader

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3831,7 +3831,10 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   for (int i = 0; i < sp->numFields; i++) {
     FieldSpec *fs = sp->fields + i;
     initializeFieldSpec(fs, i);
-    FieldSpec_RdbLoad(rdb, fs, spec_ref, encver, false);
+    if (FieldSpec_RdbLoad(rdb, fs, spec_ref, encver, false) != REDISMODULE_OK) {
+      StrongRef_Release(spec_ref);
+      return NULL;
+    }
     if (FieldSpec_IsSortable(fs)) {
       sp->numSortableFields++;
     }


### PR DESCRIPTION
IndexSpec_LegacyRdbLoad called FieldSpec_RdbLoad but ignored its return value. After commit 4b5a561 added interior-NUL rejection to FieldSpec_RdbLoad, that function can now return REDISMODULE_ERR before assigning f->fieldName (leaving it NULL). The legacy loader then fell through to IndexSpec_BuildSpecCache, which unconditionally calls HiddenString_Duplicate(fs->fieldName) and dereferences the NULL pointer, crashing the process during RDB/RESTORE load of a legacy index (encver 8-16) carrying a field name with an embedded NUL byte.

Check the return value and abort cleanly, mirroring the modern IndexSpec_RdbLoad path and the other early-return cleanup sites in this function.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded early-return on an existing error path during legacy RDB/RESTORE load; aligns with the modern loader and avoids a NULL dereference crash.
> 
> **Overview**
> **Fixes a crash when loading legacy index RDB data (encver 8–16) that contains field names with embedded NUL bytes.**
> 
> `IndexSpec_LegacyRdbLoad` now checks `FieldSpec_RdbLoad`'s return value and aborts with `StrongRef_Release` + `NULL`, matching `IndexSpec_RdbLoad` and other failure paths in the same function. Previously a failed load could leave `fieldName` unset and still call `IndexSpec_BuildSpecCache`, which dereferences NULL via `HiddenString_Duplicate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097c018be97bd9f349cc55a9e5031b4de666f76e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->