### PR TITLE
[MOD-16167] geometry: apply field-expiration check in QueryIterator::skip_to

### DIFF
--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -36,6 +36,7 @@ auto CPPQueryIterator::base() noexcept -> QueryIterator * {
 
 IteratorStatus CPPQueryIterator::read_single() noexcept {
   if (!has_next()) {
+    base_.atEOF = true;
     return ITERATOR_EOF;
   }
   t_docId docId = iter_[index_++];
@@ -74,14 +75,33 @@ IteratorStatus CPPQueryIterator::skip_to(t_docId docId) {
   const auto it = std::ranges::lower_bound(std::ranges::next(std::ranges::begin(iter_), index_),
                                            std::ranges::end(iter_), docId);
   index_ = std::ranges::distance(std::ranges::begin(iter_), it + 1);
+
+  const t_docId found = *it;
+  if (check_field_expiration_
+      && !DocTable_CheckFieldExpirationPredicate(&sctx_->spec->docs, found,
+                                                 filterCtx_.field.index,
+                                                 filterCtx_.predicate, &sctx_->time.current)) {
+    // The matched entry's field has expired. Fall back to read(), which loops
+    // past expired entries to the next valid one (updating current/lastDocId,
+    // and setting atEOF on EOF), so the iterator never settles on an expired
+    // doc. read() resumes from index_, i.e. the entry right after this expired
+    // match.
+    const IteratorStatus rc = read();
+    if (rc == ITERATOR_OK) {
+      // A valid entry beyond docId was found; the target itself did not match.
+      return ITERATOR_NOTFOUND;
+    }
+    return rc;
+  }
+
   if (!has_next()) {
     base_.atEOF = true;
   }
 
-  base_.current->docId = *it;
-  base_.lastDocId = *it;
+  base_.current->docId = found;
+  base_.lastDocId = found;
 
-  if (*it == docId) {
+  if (found == docId) {
     return ITERATOR_OK;
   }
   return ITERATOR_NOTFOUND;

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -776,6 +776,44 @@ def testFastPathGeoshapeFieldExpiration(env):
     env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3).equal([1, 'doc:2'])
 
 
+# Regression for the GEOSHAPE query iterator: read_single() applies the
+# field-expiration predicate (DocTable_CheckFieldExpirationPredicate),
+# but skip_to() historically did not.
+# A bare `@geom:[within ...]` query only ever drives the iterator via Read, so
+# the gap is invisible there. To reach skip_to(), the geoshape must be the
+# NON-leading child of an intersection: an intersection sorts children by
+# estimated result count and leads with the smallest via Read, driving the rest
+# via SkipTo. Here `@txt:hello` matches only 2 docs while the geoshape matches
+# all 12, so the text term leads and the geoshape is skipped to each candidate.
+# doc:1's geom field is expired, so it must be filtered out. Before the fix
+# skip_to() skipped the expiration check and doc:1 leaked into the results.
+@skip(cluster=True, redis_less_than='8.0')
+def testGeoshapeFieldExpirationSkipToPath(env):
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'geom', 'GEOSHAPE', 'FLAT').ok()
+    env.cmd(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx', 'fields')
+
+    shape = 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))'
+    # doc:1 and doc:2 carry the 'hello' term (2 estimated results) so the text
+    # term leads the intersection; doc:1's geom field is the one that expires.
+    conn.execute_command('HSET', 'doc:1', 'txt', 'hello', 'geom', shape)
+    conn.execute_command('HSET', 'doc:2', 'txt', 'hello', 'geom', shape)
+    # Filler docs inflate the geoshape iterator's estimate well above the text
+    # term so the geoshape is the non-leading child driven via SkipTo.
+    for i in range(3, 13):
+        conn.execute_command('HSET', f'doc:{i}', 'txt', 'world', 'geom', shape)
+    conn.execute_command('HPEXPIRE', 'doc:1', '1', 'FIELDS', '1', 'geom')
+    # https://www.kernel.org/doc/html/latest/core-api/timekeeping.html (CLOCK_REALTIME_COARSE may be off by 10ms)
+    time.sleep(0.015)
+
+    query = 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))'
+    # The text term 'hello' leads and drives the geoshape via SkipTo. doc:1's
+    # geom field is expired, so only doc:2 must survive the intersection.
+    env.expect('FT.SEARCH', 'idx', '@txt:hello @geom:[within $poly]',
+               'PARAMS', 2, 'poly', query, 'NOCONTENT').equal([1, 'doc:2'])
+
+
 @skip(cluster=True, redis_less_than='8.0')
 def testHashFieldExpirationWithNonMatchingIndexes(env):
     # Cover Indexes_UpdateMatchingHashFieldExpiration (src/spec.c) when several


### PR DESCRIPTION
The `GEOSHAPE` query iterator's `read_single()` filtered out documents whose indexed field had expired (via `DocTable_CheckFieldExpirationPredicate`), but `skip_to()` did not. When the geoshape iterator is the non-leading child of an intersection it is driven via `SkipTo` rather than Read, so expired documents leaked into query results.

Apply the same expiration predicate in `skip_to()`: on an expired match, fall back to read() to advance past any run of expired entries to the next valid one, returning `NOTFOUND` (or `EOF/TIMEOUT`) so the iterator never settles on an expired doc, matching the inverted-index iterator's SkipTo contract.

Add `testGeoshapeFieldExpirationSkipToPath`, which drives the geoshape via `SkipTo` by intersecting it with a more selective text term.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query iterator semantics for intersected GEOSHAPE + field TTL searches; scope is localized to geometry skip_to/read paths with a targeted regression test.
> 
> **Overview**
> Fixes a bug where **GEOSHAPE** queries could return documents whose indexed geometry field had already expired when the geoshape iterator was advanced via **`SkipTo`** (e.g. as the non-leading child in an intersection), because **`CPPQueryIterator::skip_to`** did not run the same **`DocTable_CheckFieldExpirationPredicate`** check as **`read_single`**.
> 
> **`skip_to`** now applies that predicate on the located doc; if it is expired, it delegates to **`read()`** to skip past expired entries and never leaves the iterator positioned on an invalid doc, returning **`NOTFOUND`** when a later valid doc exists past the skip target (aligned with inverted-index **`SkipTo`** behavior). **`read_single`** also sets **`atEOF`** when there is no next entry.
> 
> Adds **`testGeoshapeFieldExpirationSkipToPath`**, which intersects a selective text term with a broad geoshape query so the geoshape child is driven by **`SkipTo`** and expired **`doc:1`** must not appear in results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c4e6508004849b78f815919147ad5e53dda164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->