### PR TITLE
[MOD-16081] iterators_ffi: add NewGeometryQueryIterator constructor

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! FFI entry point for the geometry (GEOSHAPE) query iterator.
+
+use std::ptr::NonNull;
+
+use ffi::{QueryIterator, RedisSearchCtx};
+use field::FieldFilterContext;
+use rqe_core::DocId;
+use rqe_iterators::{
+    FieldExpirationChecker, MemTracker, NoTracker,
+    geo_shape::GeoShape,
+    interop::RQEIteratorWrapper,
+    utils::{AnyTimeoutContext, OwnedSlice},
+};
+
+/// Probe the query deadline once every this many candidate documents.
+const TIMEOUT_CHECK_GRANULARITY: u32 = 100;
+
+/// A [`MemTracker`] that adjusts an externally-owned `usize` counter through a
+/// raw pointer — the geometry index's allocation counter, shared from C across
+/// the FFI boundary. Use [`NoTracker`] when there is no counter to track.
+struct ExternalCounter {
+    counter: NonNull<usize>,
+}
+
+impl ExternalCounter {
+    /// Creates a tracker over an externally-owned counter.
+    ///
+    /// # Safety
+    ///
+    /// The pointed-to `usize` must:
+    /// 1. be valid and initialized;
+    /// 2. remain valid for the entire lifetime of the [`GeoShape`] iterator this
+    ///    tracker is given to; and
+    /// 3. only be accessed single-threaded (it is mutated without
+    ///    synchronization, which holds under the index/spec lock).
+    #[inline(always)]
+    const unsafe fn new(counter: NonNull<usize>) -> Self {
+        Self { counter }
+    }
+}
+
+impl MemTracker for ExternalCounter {
+    #[inline(always)]
+    fn add(&self, bytes: usize) {
+        // SAFETY: the safety contract of `ExternalCounter::new` guarantees the
+        // pointer is valid for the iterator's lifetime and accessed
+        // single-threaded.
+        unsafe { *self.counter.as_ptr() += bytes };
+    }
+
+    #[inline(always)]
+    fn sub(&self, bytes: usize) {
+        // SAFETY: see [`ExternalCounter::add`].
+        unsafe { *self.counter.as_ptr() -= bytes };
+    }
+}
+
+/// Creates a new geometry-query iterator over a list of matching document IDs.
+///
+/// `ids` is the set of documents matched by the geometry index, in arbitrary
+/// order; the iterator sorts them on construction and yields them in ascending
+/// order, skipping documents whose queried field has expired and aborting on
+/// query timeout.
+///
+/// Ownership of `ids` is transferred to the iterator, which frees it with
+/// `RedisModule_Free` when dropped. When `allocated` is non-null, the byte size
+/// of the iterator is added to `*allocated` on construction and subtracted on
+/// drop, keeping the geometry index's memory accounting in sync.
+///
+/// # Safety
+///
+/// 1. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
+///    `spec` is a valid [`IndexSpec`](ffi::IndexSpec); both must outlive the
+///    returned iterator.
+/// 2. `filter_ctx` must be a non-null pointer to a valid [`FieldFilterContext`].
+/// 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
+///    `RedisModule_Alloc`. Ownership is transferred to the iterator. When `ids`
+///    is null, `num` must be zero.
+/// 4. `allocated`, when non-null, must point to a valid, initialized `usize`
+///    (it is read-modify-written) that outlives the iterator and is only
+///    accessed single-threaded (it is mutated without synchronization, which
+///    holds under the spec lock).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NewGeometryQueryIterator(
+    sctx: *const RedisSearchCtx,
+    filter_ctx: *const FieldFilterContext,
+    ids: *mut DocId,
+    num: usize,
+    allocated: *mut usize,
+) -> *mut QueryIterator {
+    let sctx_nn = NonNull::new(sctx as *mut RedisSearchCtx).expect("sctx must be non-null");
+    // SAFETY: precondition 1.
+    let sctx_ref = unsafe { sctx_nn.as_ref() };
+
+    let filter_ctx_nn =
+        NonNull::new(filter_ctx as *mut FieldFilterContext).expect("filter_ctx must be non-null");
+    // SAFETY: precondition 2. The fields are `Copy`, so we snapshot them.
+    let fc = unsafe { filter_ctx_nn.as_ref() };
+    let filter = FieldFilterContext {
+        field: fc.field,
+        predicate: fc.predicate,
+    };
+
+    // Geometry queries filter by a single field *index* (never a mask), so the
+    // wide-schema flag is irrelevant; pass empty reader flags.
+    // SAFETY: precondition 1 guarantees `sctx` and `sctx.spec` are valid and outlive the returned iterator.
+    let expiration_checker = unsafe { FieldExpirationChecker::new(sctx_nn, filter, 0) };
+
+    let timeout_ctx = AnyTimeoutContext::from_sctx(sctx_ref, TIMEOUT_CHECK_GRANULARITY);
+
+    let ids_list = if !ids.is_null() {
+        // SAFETY: precondition 3.
+        unsafe { OwnedSlice::from_c(ids, num) }
+    } else {
+        debug_assert_eq!(num, 0, "null id array must have a zero count");
+        OwnedSlice::default()
+    };
+
+    // A null counter means the caller opted out of memory accounting, so use a
+    // no-op tracker; otherwise track through the externally-owned counter.
+    match NonNull::new(allocated) {
+        Some(counter) => {
+            // SAFETY: precondition 4 upholds the counter contract of `ExternalCounter::new`.
+            let mem_tracker = unsafe { ExternalCounter::new(counter) };
+            RQEIteratorWrapper::boxed_new(GeoShape::new(
+                ids_list,
+                timeout_ctx,
+                expiration_checker,
+                mem_tracker,
+            ))
+        }
+        None => RQEIteratorWrapper::boxed_new(GeoShape::new(
+            ids_list,
+            timeout_ctx,
+            expiration_checker,
+            NoTracker,
+        )),
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
@@ -8,6 +8,7 @@
 */
 
 pub mod empty;
+pub mod geo_shape;
 pub mod id_list;
 pub mod intersection;
 pub mod inverted_index;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
@@ -7,8 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-mod timespec;
-
 pub mod empty;
 pub mod id_list;
 pub mod intersection;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -18,7 +18,10 @@ use rqe_iterators::{
     not::Not,
     not_optimized::NotOptimized,
     not_reducer::{NewNotIterator, TIMEOUT_CHECK_GRANULARITY, new_not_iterator},
-    utils::{AnyTimeoutContext, NoTimeout, TimeoutContextBlockedClient, TimeoutContextClock},
+    utils::{
+        AnyTimeoutContext, NoTimeout, TimeoutContextBlockedClient, TimeoutContextClock,
+        duration_from_redis_timespec,
+    },
 };
 
 type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext>;
@@ -187,7 +190,7 @@ unsafe fn build_timeout_context(
             if sctx.time.skipTimeoutChecks {
                 return AnyTimeoutContext::NoTimeout(NoTimeout);
             }
-            match crate::timespec::duration_from_redis_timespec(timeout) {
+            match duration_from_redis_timespec(timeout) {
                 Some(duration) => AnyTimeoutContext::Clock(TimeoutContextClock::new(
                     duration,
                     TIMEOUT_CHECK_GRANULARITY,

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -353,6 +353,35 @@ QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight);
 void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
 
 /**
+ * Creates a new geometry-query iterator over a list of matching document IDs.
+ *
+ * `ids` is the set of documents matched by the geometry index, in arbitrary
+ * order; the iterator sorts them on construction and yields them in ascending
+ * order, skipping documents whose queried field has expired and aborting on
+ * query timeout.
+ *
+ * Ownership of `ids` is transferred to the iterator, which frees it with
+ * `RedisModule_Free` when dropped. When `allocated` is non-null, the byte size
+ * of the iterator is added to `*allocated` on construction and subtracted on
+ * drop, keeping the geometry index's memory accounting in sync.
+ *
+ * # Safety
+ *
+ * 1. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
+ *    `spec` is a valid [`IndexSpec`](ffi::IndexSpec); both must outlive the
+ *    returned iterator.
+ * 2. `filter_ctx` must be a non-null pointer to a valid [`FieldFilterContext`].
+ * 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
+ *    `RedisModule_Alloc`. Ownership is transferred to the iterator. When `ids`
+ *    is null, `num` must be zero.
+ * 4. `allocated`, when non-null, must point to a valid, initialized `usize`
+ *    (it is read-modify-written) that outlives the iterator and is only
+ *    accessed single-threaded (it is mutated without synchronization, which
+ *    holds under the spec lock).
+ */
+QueryIterator *NewGeometryQueryIterator(const RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx, t_docId *ids, size_t num, size_t *allocated);
+
+/**
  *
  * # Safety
  *

--- a/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
@@ -33,7 +33,7 @@
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use rqe_core::DocId;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -120,19 +120,20 @@ where
     /// Creates a new geometry-query iterator.
     ///
     /// `ids` is sorted in place on construction (the geometry index returns
-    /// matches in spatial order). `result` is the reusable result object;
-    /// callers typically pass a virtual result carrying the query weight.
+    /// matches in spatial order).
     ///
     /// The byte size of this iterator is reported to `mem_tracker` immediately
     /// (via [`MemTracker::add`]) and reversed when the iterator is dropped (via
     /// [`MemTracker::sub`]). Pass [`NoTracker`] to opt out of accounting.
     pub fn new(
         ids: impl Into<OwnedSlice<DocId>>,
-        result: RSIndexResult<'index>,
         timeout_ctx: T,
         expiration_checker: E,
         mem_tracker: M,
     ) -> Self {
+        let result = RSIndexResult::build_virt()
+            .field_mask(RS_FIELDMASK_ALL)
+            .build();
         let mut ids = ids.into();
         // The geometry index yields matches in R-tree order; the query engine
         // expects ascending document IDs.

--- a/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
@@ -12,6 +12,7 @@
 mod min_heap;
 mod owned_slice;
 mod timeout;
+mod timespec;
 
 #[doc(inline)]
 pub use self::owned_slice::OwnedSlice;
@@ -19,3 +20,4 @@ pub use min_heap::{DocIdMinHeap, HeapEntry};
 pub use timeout::{
     AnyTimeoutContext, NoTimeout, TimeoutContext, TimeoutContextBlockedClient, TimeoutContextClock,
 };
+pub use timespec::duration_from_redis_timespec;

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -12,9 +12,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ffi::{AREQ, AREQ_CheckTimedOut};
+use ffi::{AREQ, AREQ_CheckTimedOut, RedisSearchCtx};
 
-use crate::RQEIteratorError;
+use crate::{RQEIteratorError, utils::duration_from_redis_timespec};
 
 /// Abstraction over the different ways a query iterator can detect that the
 /// surrounding query has run out of time.
@@ -185,6 +185,26 @@ pub enum AnyTimeoutContext {
     Clock(TimeoutContextClock),
     /// Blocked Client Timeout: relaxed atomic load against the AREQ flag.
     BlockedClient(TimeoutContextBlockedClient),
+}
+
+impl AnyTimeoutContext {
+    /// Builds the timeout context from a search context's time settings.
+    ///
+    /// `skipTimeoutChecks` (or the absence of a deadline) opts out of timeout
+    /// checks entirely, yielding [`NoTimeout`]; otherwise the deadline drives an
+    /// amortized [`TimeoutContextClock`] that probes the clock once every
+    /// `granularity` checks. A search context carries no Blocked Client Timeout
+    /// source, so the [`BlockedClient`](Self::BlockedClient) variant is never
+    /// produced here.
+    pub fn from_sctx(sctx: &RedisSearchCtx, granularity: u32) -> Self {
+        if sctx.time.skipTimeoutChecks {
+            return Self::NoTimeout(NoTimeout);
+        }
+        match duration_from_redis_timespec(sctx.time.timeout) {
+            Some(duration) => Self::Clock(TimeoutContextClock::new(duration, granularity)),
+            None => Self::NoTimeout(NoTimeout),
+        }
+    }
 }
 
 impl TimeoutContext for AnyTimeoutContext {

--- a/src/redisearch_rs/rqe_iterators/src/utils/timespec.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timespec.rs
@@ -11,7 +11,11 @@
 
 use std::time::Duration;
 
-pub(crate) fn duration_from_redis_timespec(deadline: ffi::timespec) -> Option<Duration> {
+/// Converts an absolute Redis deadline into a [`Duration`] from now.
+///
+/// Returns `None` when `deadline` is the Redis sentinel meaning "no timeout",
+/// and `Some(Duration::ZERO)` when the deadline has already passed.
+pub fn duration_from_redis_timespec(deadline: ffi::timespec) -> Option<Duration> {
     // Redis sentinel for no timeout
     // `libc::time_t` is deprecated on musl (musl 1.2 changed it to 64-bit,
     // and the libc crate will follow suit — see libc#1848). Suppress the

--- a/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
@@ -23,13 +23,7 @@ use crate::id_cases;
 /// Builds a `GeoShape` iterator with no timeout, no expiration, and no memory
 /// tracking — the simplest configuration, used by the sorted-id-list tests.
 fn plain(ids: Vec<u64>) -> GeoShape<'static, NoTimeout, NoOpChecker, NoTracker> {
-    GeoShape::new(
-        ids,
-        RSIndexResult::build_virt().build(),
-        NoTimeout,
-        NoOpChecker,
-        NoTracker,
-    )
+    GeoShape::new(ids, NoTimeout, NoOpChecker, NoTracker)
 }
 
 /// A safe [`MemTracker`] backed by a shared cell, letting a test observe the
@@ -253,13 +247,7 @@ fn expired_documents_are_skipped() {
         has_expiration: true,
         expired: vec![2, 4],
     };
-    let mut it = GeoShape::new(
-        vec![1, 2, 3, 4, 5],
-        RSIndexResult::build_virt().build(),
-        NoTimeout,
-        checker,
-        NoTracker,
-    );
+    let mut it = GeoShape::new(vec![1, 2, 3, 4, 5], NoTimeout, checker, NoTracker);
 
     // 2 and 4 are filtered out.
     for expected in [1u64, 3, 5] {
@@ -280,13 +268,7 @@ fn with_expired(
         has_expiration: true,
         expired,
     };
-    GeoShape::new(
-        ids,
-        RSIndexResult::build_virt().build(),
-        NoTimeout,
-        checker,
-        NoTracker,
-    )
+    GeoShape::new(ids, NoTimeout, checker, NoTracker)
 }
 
 #[test]
@@ -396,13 +378,7 @@ fn timeout_aborts_read() {
     // A deadline already in the past with a granularity of 1 makes the very
     // first probe report a timeout.
     let timeout = TimeoutContextClock::new(Duration::from_nanos(1), 1);
-    let mut it = GeoShape::new(
-        vec![1, 2, 3],
-        RSIndexResult::build_virt().build(),
-        timeout,
-        NoOpChecker,
-        NoTracker,
-    );
+    let mut it = GeoShape::new(vec![1, 2, 3], timeout, NoOpChecker, NoTracker);
 
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
 }
@@ -412,13 +388,7 @@ fn memory_tracking_adds_and_subtracts() {
     let tracker = CellTracker::default();
 
     {
-        let it = GeoShape::new(
-            vec![3u64, 1, 2],
-            RSIndexResult::build_virt().build(),
-            NoTimeout,
-            NoOpChecker,
-            tracker.clone(),
-        );
+        let it = GeoShape::new(vec![3u64, 1, 2], NoTimeout, NoOpChecker, tracker.clone());
 
         // The tracker reflects exactly what the iterator reports.
         assert_eq!(tracker.get(), it.mem_usage());


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/9995

Add the C-callable constructor for the Rust GeoShape iterator. It builds the timeout context from the search context's time settings and a FieldExpirationChecker from the search context and field filter, takes ownership of the matched document-id array (freed via RedisModule_Free), and threads through a pointer to the geometry index's allocation counter for memory tracking.

Regenerate the iterators_ffi C header to declare the new symbol.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New FFI on the query execution path with transferred pointer ownership and unsynchronized memory accounting; behavior must match prior C++ timeout/expiration semantics.
> 
> **Overview**
> Adds a C-callable **`NewGeometryQueryIterator`** FFI entry point so geometry (GEOSHAPE) queries can drive the Rust **`GeoShape`** iterator from existing C code.
> 
> The constructor takes matched doc IDs (ownership transferred and freed via **`RedisModule_Free`**), builds query timeout handling from **`RedisSearchCtx`** (clock checks every 100 docs, honoring **`skipTimeoutChecks`**), attaches a **`FieldExpirationChecker`** from the field filter, and optionally updates an external **`allocated`** byte counter through a **`MemTracker`** for geometry-index memory accounting. The iterator is returned as a boxed **`QueryIterator`** via **`RQEIteratorWrapper`**. **`iterators_ffi.h`** is regenerated to declare the new symbol; **`lib.rs`** exports the **`geo_shape`** module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba6202061a4b8dfd1c3c567b76d279721d359bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->