### PR TITLE
build script - add specific WNO_ERROR flags for homebrew

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,13 +37,19 @@ set(LIBUV_BUILD_TESTS OFF CACHE BOOL "Build libuv tests" FORCE)
 set(LIBUV_BUILD_BENCH OFF CACHE BOOL "Build libuv benchmarks" FORCE)
 set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build shared libuv library" FORCE)
 add_subdirectory(${root}/deps/libuv ${CMAKE_CURRENT_BINARY_DIR}/libuv)
+
+# Homebrew silently removes '-Werror' flags which breaks the regular form of detection.
+# Instead we specifically check for the '-Wno-error' variants here before using them.
+check_c_compiler_flag("-Wno-error=discarded-qualifiers" HAS_WNO_ERROR_DISCARDED_QUALIFIERS)
+check_c_compiler_flag("-Wno-error=incompatible-pointer-types-discards-qualifiers" HAS_WNO_ERROR_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
+
 # libuv has const-correctness issues that trigger warnings-as-errors on newer compilers.
 # gcc 16+: -Werror=discarded-qualifiers; clang 21+: -Werror=incompatible-pointer-types-discards-qualifiers.
-# Mirror the compiler guards from the top-level CMakeLists.txt.
-if(HAS_DISCARDED_QUALIFIERS)
+# Turn off flags set in the top-level CMakeLists.txt.
+if(HAS_WNO_ERROR_DISCARDED_QUALIFIERS)
     target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=discarded-qualifiers>)
 endif()
-if(HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
+if(HAS_WNO_ERROR_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
     target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types-discards-qualifiers>)
 endif()
 


### PR DESCRIPTION
Fix `CMake` compiler flag detection working incorrectly in `Homebrew`, as reported by Daria Guy.

Followed by some cleanup in #10034.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only CMake change for third-party libuv compile flags; no runtime or API impact.
> 
> **Overview**
> Fixes **libuv** warning-as-error overrides on **Homebrew** builds by detecting compiler support for the actual `-Wno-error=…` flags instead of reusing the top-level `-Werror=…` probe results.
> 
> **`src/CMakeLists.txt`** now runs `check_c_compiler_flag` for `-Wno-error=discarded-qualifiers` and `-Wno-error=incompatible-pointer-types-discards-qualifiers`, and only then applies those options to `uv_a`. Homebrew can strip `-Werror` during CMake’s flag tests, which made the old `HAS_DISCARDED_QUALIFIERS` / `HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS` guards unreliable for this workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8f46980411ce14f6fdeba398129d2a929fdc9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->