### PR TITLE
build script - refactor compiler error flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,39 +215,44 @@ set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${CMAKE_LD_FLAGS}")
 set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=format")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format")
 
+# Detect available compiler flags for subsequent use. These flags are global and available
+# throughout the build. Some flags below form GCC/Clang equivalence pairs (only one will be
+# available on a given compiler), others stand alone.
+check_c_compiler_flag("-Werror=discarded-qualifiers" HAS_WERROR_DISCARDED_QUALIFIERS)
+check_c_compiler_flag("-Werror=implicit-function-declaration" HAS_WERROR_IMPLICIT_FUNCTION_DECLARATION)
+check_c_compiler_flag("-Werror=incompatible-pointer-types-discards-qualifiers" HAS_WERROR_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
+check_c_compiler_flag("-Werror=jump-misses-init" HAS_WERROR_JUMP_MISSES_INIT)
+check_c_compiler_flag("-Werror=sometimes-uninitialized" HAS_WERROR_SOMETIMES_UNINITIALIZED)
+
+# Homebrew silently removes '-Werror' flags which breaks the regular form of detection.
+# Instead we specifically check for the '-Wno-error' variants here separately.
+check_c_compiler_flag("-Wno-error=discarded-qualifiers" HAS_WNO_ERROR_DISCARDED_QUALIFIERS)
+check_c_compiler_flag("-Wno-error=incompatible-pointer-types-discards-qualifiers" HAS_WNO_ERROR_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
+
 # Promote specific warnings to errors. These use add_compile_options() which
 # propagates to ALL subdirectories, including deps (libuv, VectorSimilarity, etc.).
 # Each flag is compiler-specific (gcc vs clang), so if a dep needs an override
 # (e.g. -Wno-error=X via target_compile_options), guard it with the same
 # compiler check or a $<C_COMPILER_ID:...> generator expression.
 
-# gcc
-check_c_compiler_flag("-Werror=discarded-qualifiers" HAS_DISCARDED_QUALIFIERS)
-if(HAS_DISCARDED_QUALIFIERS)
+# Promote dropped const/volatile qualifier warnings to errors
+if(HAS_WERROR_DISCARDED_QUALIFIERS)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=discarded-qualifiers>)
 endif()
-
-# clang
-check_c_compiler_flag("-Werror=incompatible-pointer-types-discards-qualifiers" HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
-if(HAS_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
+if(HAS_WERROR_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=incompatible-pointer-types-discards-qualifiers>)
 endif()
 
-# Warn when goto jumps over variable initialization
-# gcc: -Werror=jump-misses-init
-check_c_compiler_flag("-Werror=jump-misses-init" HAS_JUMP_MISSES_INIT)
-if(HAS_JUMP_MISSES_INIT)
+# Promote jumps/paths that skip a variable's initialization to errors
+if(HAS_WERROR_JUMP_MISSES_INIT)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=jump-misses-init>)
 endif()
-
-# clang: -Werror=sometimes-uninitialized (equivalent protection)
-check_c_compiler_flag("-Werror=sometimes-uninitialized" HAS_SOMETIMES_UNINITIALIZED)
-if(HAS_SOMETIMES_UNINITIALIZED)
+if(HAS_WERROR_SOMETIMES_UNINITIALIZED)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=sometimes-uninitialized>)
 endif()
 
-check_c_compiler_flag("-Werror=implicit-function-declaration" HAS_IMPLICIT_FUNCTION_DECLARATION)
-if(HAS_IMPLICIT_FUNCTION_DECLARATION)
+# Promote implicit function declarations to errors
+if(HAS_WERROR_IMPLICIT_FUNCTION_DECLARATION)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,13 +38,7 @@ set(LIBUV_BUILD_BENCH OFF CACHE BOOL "Build libuv benchmarks" FORCE)
 set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build shared libuv library" FORCE)
 add_subdirectory(${root}/deps/libuv ${CMAKE_CURRENT_BINARY_DIR}/libuv)
 
-# Homebrew silently removes '-Werror' flags which breaks the regular form of detection.
-# Instead we specifically check for the '-Wno-error' variants here before using them.
-check_c_compiler_flag("-Wno-error=discarded-qualifiers" HAS_WNO_ERROR_DISCARDED_QUALIFIERS)
-check_c_compiler_flag("-Wno-error=incompatible-pointer-types-discards-qualifiers" HAS_WNO_ERROR_INCOMPATIBLE_POINTER_TYPES_DISCARDS_QUALIFIERS)
-
 # libuv has const-correctness issues that trigger warnings-as-errors on newer compilers.
-# gcc 16+: -Werror=discarded-qualifiers; clang 21+: -Werror=incompatible-pointer-types-discards-qualifiers.
 # Turn off flags set in the top-level CMakeLists.txt.
 if(HAS_WNO_ERROR_DISCARDED_QUALIFIERS)
     target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=discarded-qualifiers>)


### PR DESCRIPTION
Follow-up to #10033, cleaning up afterwards. Moving all compiler flag detection to a common place, with common naming.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-configuration refactor only; same flags and libuv overrides, with clearer global detection order.
> 
> **Overview**
> **Centralizes CMake compiler warning flag probing** in the root `CMakeLists.txt` so every `check_c_compiler_flag` runs once up front, with consistent `HAS_WERROR_*` / `HAS_WNO_ERROR_*` variable names, before the global `add_compile_options` that promote those warnings to errors.
> 
> **Removes duplicate detection** from `src/CMakeLists.txt` (including the Homebrew-specific `-Wno-error` checks); `uv_a` still uses the same root-level `HAS_WNO_ERROR_*` variables for its per-target overrides. Comments are tightened to group GCC/Clang pairs without changing which flags are applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f9f779c357c6ee95103d9e3a3aa039801e5763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->