### PR TITLE
[MOD-15897] StrTrieMap - replace Option<Inner> with empty inner iterator

### DIFF
--- a/src/redisearch_rs/trie_rs/src/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/contains.rs
@@ -51,6 +51,18 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
             finder,
         }
     }
+
+    /// Creates a new empty contains iterator, that yields no entries.
+    ///
+    /// The `finder` is initialized to an unused empty needle; the empty
+    /// `stack` causes `advance` to return `None` before consulting it.
+    pub(crate) fn empty() -> Self {
+        Self {
+            stack: vec![],
+            key: vec![],
+            finder: Finder::new(b""),
+        }
+    }
 }
 
 impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {

--- a/src/redisearch_rs/trie_rs/src/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/contains.rs
@@ -53,9 +53,6 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     }
 
     /// Creates a new empty contains iterator, that yields no entries.
-    ///
-    /// The `finder` is initialized to an unused empty needle; the empty
-    /// `stack` causes `advance` to return `None` before consulting it.
     pub(crate) fn empty() -> Self {
         Self {
             stack: vec![],

--- a/src/redisearch_rs/trie_rs/src/str/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/contains.rs
@@ -20,12 +20,11 @@ pub struct ContainsIter<'tm, 'p, Data: 'tm>(iter::ContainsIter<'tm, 'p, Data>);
 
 impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &'p str) -> Self {
-        let inner = if target.is_empty() {
-            iter::ContainsIter::empty()
+        if target.is_empty() {
+            Self(iter::ContainsIter::empty())
         } else {
-            trie.contains_iter(target.as_bytes())
-        };
-        Self(inner)
+            Self(trie.contains_iter(target.as_bytes()))
+        }
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/contains.rs
@@ -13,17 +13,19 @@ use crate::{TrieMap, iter, str::iter::iter_::key_to_string};
 /// in lexicographical key order.
 ///
 /// Empty `target` yields zero matches (mirrors the C `Trie_IterateContains`
-/// short-circuit). The wrapped `Option` is `None` for the empty-target case.
+/// short-circuit) by delegating to an empty inner iterator.
 ///
 /// See [`crate::iter::ContainsIter`] for the underlying traversal.
-pub struct ContainsIter<'tm, 'p, Data: 'tm>(Option<iter::ContainsIter<'tm, 'p, Data>>);
+pub struct ContainsIter<'tm, 'p, Data: 'tm>(iter::ContainsIter<'tm, 'p, Data>);
 
 impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &'p str) -> Self {
-        if target.is_empty() {
-            return Self(None);
-        }
-        Self(Some(trie.contains_iter(target.as_bytes())))
+        let inner = if target.is_empty() {
+            iter::ContainsIter::empty()
+        } else {
+            trie.contains_iter(target.as_bytes())
+        };
+        Self(inner)
     }
 }
 
@@ -31,6 +33,6 @@ impl<'tm, 'p, Data: 'tm> Iterator for ContainsIter<'tm, 'p, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.as_mut()?.next().map(|(k, v)| (key_to_string(k), v))
+        self.0.next().map(|(k, v)| (key_to_string(k), v))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/prefixed.rs
@@ -25,12 +25,11 @@ pub struct PrefixedIter<'tm, Data: 'tm>(iter::Iter<'tm, Data, filter::VisitAll>)
 
 impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
-        let inner = if prefix.is_empty() {
-            iter::Iter::empty()
+        if prefix.is_empty() {
+            Self(iter::Iter::empty())
         } else {
-            trie.prefixed_iter(prefix.as_bytes())
-        };
-        Self(inner)
+            Self(trie.prefixed_iter(prefix.as_bytes()))
+        }
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/prefixed.rs
@@ -17,18 +17,20 @@ use crate::{
 /// in lexicographical key order.
 ///
 /// Empty `prefix` yields zero matches — differs from
-/// [`TrieMap::prefixed_iter`] which yields every entry on `&[]`. The wrapped
-/// `Option` carries the short-circuit: `None` when the prefix was empty.
+/// [`TrieMap::prefixed_iter`] which yields every entry on `&[]`. The
+/// short-circuit is encoded by delegating to an empty inner iterator.
 ///
 /// See [`crate::iter::Iter`] for the underlying traversal.
-pub struct PrefixedIter<'tm, Data: 'tm>(Option<iter::Iter<'tm, Data, filter::VisitAll>>);
+pub struct PrefixedIter<'tm, Data: 'tm>(iter::Iter<'tm, Data, filter::VisitAll>);
 
 impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
-        if prefix.is_empty() {
-            return Self(None);
-        }
-        Self(Some(trie.prefixed_iter(prefix.as_bytes())))
+        let inner = if prefix.is_empty() {
+            iter::Iter::empty()
+        } else {
+            trie.prefixed_iter(prefix.as_bytes())
+        };
+        Self(inner)
     }
 }
 
@@ -36,6 +38,6 @@ impl<'tm, Data: 'tm> Iterator for PrefixedIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.as_mut()?.next().map(|(k, v)| (key_to_string(k), v))
+        self.0.next().map(|(k, v)| (key_to_string(k), v))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str/iter/suffixed.rs
@@ -19,12 +19,13 @@ use crate::{
 /// Wrapper-only — [`crate::iter`] has no suffix iterator. Byte `ends_with`
 /// on UTF-8 keys agrees with `&str::ends_with` because UTF-8 is
 /// self-synchronizing: a multibyte sequence cannot be a suffix of another
-/// codepoint. Empty `suffix` yields zero matches.
+/// codepoint. Empty `suffix` yields zero matches by delegating to an empty
+/// inner iterator.
 ///
 /// See [`crate::iter::Iter`] for the underlying traversal.
 pub struct SuffixedIter<'tm, Data: 'tm> {
     target_bytes: Box<[u8]>,
-    iter: Option<iter::Iter<'tm, Data, filter::VisitAll>>,
+    iter: iter::Iter<'tm, Data, filter::VisitAll>,
 }
 
 impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
@@ -32,12 +33,12 @@ impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
         if suffix.is_empty() {
             return Self {
                 target_bytes: Box::new([]),
-                iter: None,
+                iter: iter::Iter::empty(),
             };
         }
         Self {
             target_bytes: suffix.as_bytes().to_vec().into_boxed_slice(),
-            iter: Some(trie.iter()),
+            iter: trie.iter(),
         }
     }
 }
@@ -46,9 +47,8 @@ impl<'tm, Data: 'tm> Iterator for SuffixedIter<'tm, Data> {
     type Item = (String, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let iter = self.iter.as_mut()?;
         loop {
-            let (k, v) = iter.next()?;
+            let (k, v) = self.iter.next()?;
             if k.ends_with(&self.target_bytes) {
                 return Some((key_to_string(k), v));
             }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The str-layer `ContainsIter`, `PrefixedIter` and `SuffixedIter` each wrap their inner trie iterator in `Option<T>` and use `None` as the empty-input short-circuit (empty target/prefix/suffix → zero matches). Every `next()` call pays an `self.0.as_mut()?` branch on a discriminant that is decided once at construction time.
2. **Change:** Add a no-arg `ContainsIter::empty()` constructor in the inner crate, symmetric to the existing `Iter::empty()`. Refactor the three str-layer wrappers to hold their inner iterator directly; route the empty-input short-circuit through the relevant `*::empty()` constructor at build time. The new `ContainsIter::empty()` takes no target argument — the empty stack short-circuits `advance()` before the finder is consulted, so the `finder` field is filled with an unused `Finder::new(b"")` (valid by `memchr::memmem::Finder`'s covariance in its needle lifetime).
3. **Outcome:** All five str-layer iterator wrappers (`Iter`, `RangeIter`, `PrefixedIter`, `SuffixedIter`, `ContainsIter`) now share an identical pure-newtype shape: one-line `next()` delegation, no per-call discriminant check. No behavior change — the empty-input contract is preserved by `Iter::empty()` / `ContainsIter::empty()`.

#### Which additional issues this PR fixes
None.

#### Main objects this PR modified
1. `trie_rs::iter::ContainsIter` — added `pub(crate) fn empty()` constructor
2. `trie_rs::str::iter::ContainsIter`, `PrefixedIter`, `SuffixedIter` — dropped `Option<Inner>` wrapper

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal iterator wiring only; empty-input semantics are unchanged and there is no public API change.
> 
> **Overview**
> Refactors the string-layer **contains**, **prefix**, and **suffix** trie iterators so they always hold a concrete inner iterator instead of `Option<Inner>`. Empty target/prefix/suffix still yields no items, but that case is decided at construction via `ContainsIter::empty()` (new) or the existing `Iter::empty()`, not via `None` on every `next()`.
> 
> Adds **`ContainsIter::empty()`** in the byte-level iterator (empty stack, unused empty `Finder`), matching the pattern used by `Iter::empty()`. Str wrappers now delegate with a straight `self.0.next()` (or `self.iter.next()` for suffix), aligning all five str iterator newtypes on the same shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66b966ff2ccf5529a43704af651f3c79a80dc60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->