### PR TITLE
[MOD-12915] FT.HYBRID VSIM: resolve PARAMS placeholders for numeric args (surgical)

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1451,27 +1451,68 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   // Apply the flags that were set during parsing
   vecNode->opts.flags |= pvd->queryNodeFlags;
 
-  if (pvd->isParameter) {
-    // PARAMETER CASE: Set up parameter for evalnode to resolve later
-    QueryToken vecToken = {
-      .type = QT_PARAM_VEC,
-      .s = (vq->type == VECSIM_QT_KNN) ? vq->knn.vector : vq->range.vector,
-      .len = (vq->type == VECSIM_QT_KNN) ? vq->knn.vecLen : vq->range.vecLen,
-      .pos = 0,
-      .numval = 0,
-      .sign = 0
-    };
+  // Count how many deferred params this node needs
+  int numDeferredParams = 0;
+  if (pvd->isParameter) numDeferredParams++;
+  if (pvd->kParamName) numDeferredParams++;
+  if (pvd->radiusParamName) numDeferredParams++;
 
+  if (numDeferredParams > 0) {
     QueryParseCtx q = {0};
-    QueryNode_InitParams(vecNode, 1);
-    switch (vq->type) {
-      case VECSIM_QT_KNN:
-        QueryNode_SetParam(&q, &vecNode->params[0], &vq->knn.vector, &vq->knn.vecLen, &vecToken);
-        break;
-      case VECSIM_QT_RANGE:
-        QueryNode_SetParam(&q, &vecNode->params[0], &vq->range.vector, &vq->range.vecLen, &vecToken);
-        break;
+    QueryNode_InitParams(vecNode, numDeferredParams);
+    int paramIdx = 0;
+
+    if (pvd->isParameter) {
+      // PARAMETER CASE: Set up parameter for evalnode to resolve the vector blob later
+      QueryToken vecToken = {
+        .type = QT_PARAM_VEC,
+        .s = (vq->type == VECSIM_QT_KNN) ? vq->knn.vector : vq->range.vector,
+        .len = (vq->type == VECSIM_QT_KNN) ? vq->knn.vecLen : vq->range.vecLen,
+        .pos = 0,
+        .numval = 0,
+        .sign = 0
+      };
+      switch (vq->type) {
+        case VECSIM_QT_KNN:
+          QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->knn.vector, &vq->knn.vecLen,
+                             &vecToken);
+          break;
+        case VECSIM_QT_RANGE:
+          QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->range.vector, &vq->range.vecLen,
+                             &vecToken);
+          break;
+      }
+      paramIdx++;
     }
+
+    if (pvd->kParamName) {
+      // Deferred K: resolve at query-eval time and write into vq->knn.k
+      QueryToken kToken = {
+        .type = QT_PARAM_SIZE,
+        .s = pvd->kParamName,
+        .len = strlen(pvd->kParamName),
+        .pos = 0,
+        .numval = 0,
+        .sign = 0
+      };
+      QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->knn.k, NULL, &kToken);
+      paramIdx++;
+    }
+
+    if (pvd->radiusParamName) {
+      // Deferred RADIUS: resolve at query-eval time and write into vq->range.radius
+      QueryToken radiusToken = {
+        .type = QT_PARAM_NUMERIC,
+        .s = pvd->radiusParamName,
+        .len = strlen(pvd->radiusParamName),
+        .pos = 0,
+        .numval = 0,
+        .sign = 0
+      };
+      QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->range.radius, NULL, &radiusToken);
+      paramIdx++;
+    }
+
     // Update AST's numParams since we used a local QueryParseCtx
     ast->numParams += q.numParams;
   }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -63,10 +63,21 @@ static VecSimRawParam createVecSimRawParam(const char *name, size_t nameLen, con
   };
 }
 
-static void addVectorQueryParam(VectorQuery *vq, const char *name, size_t nameLen, const char *value, size_t valueLen) {
+static void addVectorQueryParam(VectorQuery *vq, const char *name, size_t nameLen, const char *value,
+                                size_t valueLen) {
   VecSimRawParam rawParam = createVecSimRawParam(name, nameLen, value, valueLen);
   vq->params.params = array_ensure_append_1(vq->params.params, rawParam);
   bool needResolve = false;
+  vq->params.needResolve = array_ensure_append_1(vq->params.needResolve, needResolve);
+}
+
+// Like addVectorQueryParam but marks the entry as needing $param resolution.
+// The value must be a param name (without '$').
+static void addVectorQueryParamDeferred(VectorQuery *vq, const char *name, size_t nameLen,
+                                        const char *paramName, size_t paramNameLen) {
+  VecSimRawParam rawParam = createVecSimRawParam(name, nameLen, paramName, paramNameLen);
+  vq->params.params = array_ensure_append_1(vq->params.params, rawParam);
+  bool needResolve = true;
   vq->params.needResolve = array_ensure_append_1(vq->params.needResolve, needResolve);
 }
 
@@ -184,12 +195,23 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "K", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      long long kValue;
-      if (AC_GetLongLong(ac, &kValue, AC_F_GE1) != AC_OK) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
-        return REDISMODULE_ERR;
+      const char *kStr;
+      size_t kStrLen;
+      AC_GetString(ac, &kStr, &kStrLen, AC_F_NOADVANCE);
+      if (kStr[0] == '$') {
+        // PARAMETER CASE: defer resolution; skip the '$' prefix
+        kStr++;
+        kStrLen--;
+        pvd->kParamName = rm_strndup(kStr, kStrLen);
+        AC_Advance(ac);
+      } else {
+        long long kValue;
+        if (AC_GetLongLong(ac, &kValue, AC_F_GE1) != AC_OK) {
+          QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
+          return REDISMODULE_ERR;
+        }
+        vq->knn.k = (size_t)kValue;
       }
-      vq->knn.k = (size_t)kValue;
       pvd->hasExplicitK = true;
 
     } else if (AC_AdvanceIfMatch(ac, "EF_RUNTIME")) {
@@ -198,16 +220,24 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "EF_RUNTIME", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      long long efValue;
-      if (AC_GetLongLong(ac, &efValue, AC_F_GE1 | AC_F_NOADVANCE) != AC_OK) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EF_RUNTIME value");
-        return REDISMODULE_ERR;
-      }
       const char *value;
       size_t valueLen;
-      value = AC_GetStringNC(ac, &valueLen);
-      // Add directly to VectorQuery params
-      addVectorQueryParam(vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), value, valueLen);
+      AC_GetString(ac, &value, &valueLen, AC_F_NOADVANCE);
+      if (value[0] == '$') {
+        // PARAMETER CASE: defer resolution; skip the '$' prefix
+        AC_Advance(ac);
+        addVectorQueryParamDeferred(vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), value + 1,
+                                    valueLen - 1);
+      } else {
+        long long efValue;
+        if (AC_GetLongLong(ac, &efValue, AC_F_GE1 | AC_F_NOADVANCE) != AC_OK) {
+          QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EF_RUNTIME value");
+          return REDISMODULE_ERR;
+        }
+        value = AC_GetStringNC(ac, &valueLen);
+        // Add directly to VectorQuery params
+        addVectorQueryParam(vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), value, valueLen);
+      }
       hasEF = true;
 
     } else if (AC_AdvanceIfMatch(ac, "SHARD_K_RATIO")) {
@@ -267,12 +297,23 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "RADIUS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      double radiusValue;
-      if (AC_GetDouble(ac, &radiusValue, AC_F_GE0) != AC_OK) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid RADIUS value");
-        return REDISMODULE_ERR;
+      const char *radiusStr;
+      size_t radiusStrLen;
+      AC_GetString(ac, &radiusStr, &radiusStrLen, AC_F_NOADVANCE);
+      if (radiusStr[0] == '$') {
+        // PARAMETER CASE: defer resolution; skip the '$' prefix
+        radiusStr++;
+        radiusStrLen--;
+        pvd->radiusParamName = rm_strndup(radiusStr, radiusStrLen);
+        AC_Advance(ac);
+      } else {
+        double radiusValue;
+        if (AC_GetDouble(ac, &radiusValue, AC_F_GE0) != AC_OK) {
+          QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid RADIUS value");
+          return REDISMODULE_ERR;
+        }
+        vq->range.radius = radiusValue;
       }
-      vq->range.radius = radiusValue;
       hasRadius = true;
 
     } else if (AC_AdvanceIfMatch(ac, "EPSILON")) {
@@ -281,16 +322,25 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "EPSILON", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      double epsilonValue;
-      if (AC_GetDouble(ac, &epsilonValue, AC_F_GE0 | AC_F_NOADVANCE) != AC_OK || epsilonValue == 0.0) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EPSILON value");
-        return REDISMODULE_ERR;
-      }
       const char *value;
       size_t valueLen;
-      value = AC_GetStringNC(ac, &valueLen);
-      // Add directly to VectorQuery params
-      addVectorQueryParam(vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), value, valueLen);
+      AC_GetString(ac, &value, &valueLen, AC_F_NOADVANCE);
+      if (value[0] == '$') {
+        // PARAMETER CASE: defer resolution; skip the '$' prefix
+        AC_Advance(ac);
+        addVectorQueryParamDeferred(vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), value + 1,
+                                    valueLen - 1);
+      } else {
+        double epsilonValue;
+        if (AC_GetDouble(ac, &epsilonValue, AC_F_GE0 | AC_F_NOADVANCE) != AC_OK ||
+            epsilonValue == 0.0) {
+          QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EPSILON value");
+          return REDISMODULE_ERR;
+        }
+        value = AC_GetStringNC(ac, &valueLen);
+        // Add directly to VectorQuery params
+        addVectorQueryParam(vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), value, valueLen);
+      }
       hasEpsilon = true;
 
     } else {

--- a/src/hybrid/vector_query_utils.c
+++ b/src/hybrid/vector_query_utils.c
@@ -28,5 +28,13 @@ void ParsedVectorData_Free(ParsedVectorData *pvd) {
     rm_free(pvd->vectorScoreFieldAlias);
   }
 
+  if (pvd->kParamName) {
+    rm_free(pvd->kParamName);
+  }
+
+  if (pvd->radiusParamName) {
+    rm_free(pvd->radiusParamName);
+  }
+
   rm_free(pvd);
 }

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -31,6 +31,9 @@ typedef struct {
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set
   uint32_t queryNodeFlags;     // QueryNode flags to be applied when creating the vector node
   bool skipFilterIntegration;  // true to make vector node root without filter wrapping (RANGE without explicit FILTER)
+  // Deferred $param names for numeric VSIM args (OWNED, NULL when arg is a literal)
+  char *kParamName;            // param name (without '$') for KNN K when supplied as $param
+  char *radiusParamName;       // param name (without '$') for RANGE RADIUS when supplied as $param
 } ParsedVectorData;
 
 void ParsedVectorData_Free(ParsedVectorData *pvd);

--- a/src/query.c
+++ b/src/query.c
@@ -2252,13 +2252,23 @@ static int QueryVectorNode_ApplyAttribute(VectorQuery *vq, QueryAttribute *attr,
              STR_EQCASE(attr->name, attr->namelen, VECSIM_RERANK)) {
     // Move ownership on the value string, so it won't get freed when releasing the QueryAttribute.
     // The name string was not copied by the parser (unlike the value) - so we copy and save it.
+    // If the value starts with '$' it is a PARAMS placeholder: strip the '$' and mark for
+    // deferred resolution so VectorQuery_ParamResolve can substitute the real value later.
+    bool resolve_required = false;
+    const char *val = attr->value;
+    size_t valLen = attr->vallen;
+    if (val && valLen > 1 && val[0] == '$') {
+      val++;
+      valLen--;
+      resolve_required = true;
+      attr->value = rm_strndup(val, valLen);  // take ownership of the stripped copy
+    }
     VecSimRawParam param = (VecSimRawParam){ .name = rm_strndup(attr->name, attr->namelen),
                                             .nameLen = attr->namelen,
                                             .value = attr->value,
-                                            .valLen = attr->vallen };
+                                            .valLen = valLen };
     attr->value = NULL;
     vq->params.params = array_ensure_append_1(vq->params.params, param);
-    bool resolve_required = false;  // at this point, we have the actual value in hand, not the query param.
     vq->params.needResolve = array_ensure_append_1(vq->params.needResolve, resolve_required);
     return 1;
   }

--- a/tests/pytests/test_hybrid_vector.py
+++ b/tests/pytests/test_hybrid_vector.py
@@ -154,6 +154,75 @@ def test_hybrid_vector_range_with_filter():
 
         env.flush()
 
+def test_hybrid_vector_params_numeric_args():
+    """Regression test for MOD-12915: numeric VSIM args must accept $param
+    placeholders via PARAMS, not just literal values. Before the fix these were
+    validated as numbers during parsing (e.g. "Invalid K value") before PARAMS
+    substitution, so a $param was rejected.
+
+    Approach A (surgical) covers K and RADIUS (deferred via ParsedVectorData) and
+    EF_RUNTIME and EPSILON (deferred via the VectorQuery needResolve mechanism).
+    BATCH_SIZE goes through parseFilterClause/ArgParser and is NOT addressed by
+    this surgical pass — it is intentionally out of scope here (see the PR body).
+    """
+    env = Env()
+    blob = np.array([1.2, 0.2]).astype(np.float32).tobytes()
+
+    # --- FLAT index: K (KNN) and RADIUS (RANGE) ---
+    setup_basic_index(env)
+
+    # K via $param: with K=1 the KNN side keeps only the single nearest vector.
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'KNN', '2', 'K', '$k',
+        'PARAMS', '4', 'BLOB', blob, 'k', '1')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+    env.assertEqual(set(results.keys()), {"doc:2"})
+
+    # RADIUS via $param: command must parse and return a well-formed response
+    # (the bug was a parse-time rejection of the $param value).
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'RANGE', '2', 'RADIUS', '$r',
+        'PARAMS', '4', 'BLOB', blob, 'r', '1')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+
+    env.flush()
+
+    # --- HNSW index: EF_RUNTIME (KNN) and EPSILON (RANGE) are HNSW-only args ---
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'description', 'TEXT',
+               'embedding', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32',
+               'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+    conn = env.getClusterConnectionIfNeeded()
+    for doc_id, doc_data in test_data.items():
+        conn.execute_command('HSET', doc_id, 'description', doc_data['description'],
+                              'embedding', doc_data['embedding'])
+
+    # EF_RUNTIME via $param
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'KNN', '4', 'K', '1', 'EF_RUNTIME', '$ef',
+        'PARAMS', '4', 'BLOB', blob, 'ef', '10')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+
+    # EPSILON via $param
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'RANGE', '4', 'RADIUS', '1', 'EPSILON', '$e',
+        'PARAMS', '4', 'BLOB', blob, 'e', '0.5')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+
+    env.flush()
+
+
 def test_hybrid_vector_invalid_filter_with_weight():
     """Test that hybrid vector filter fails when it contains weight attribute"""
     env = Env()


### PR DESCRIPTION
## Describe the changes in the pull request

**Decision rationale — Approach A (surgical).** This is the smallest, lowest-blast-radius fix for MOD-12915: it defers `$param` values exactly where the eager numeric validation lived, mirroring the vector argument's existing deferred-resolution pattern, without restructuring the parser. Tradeoff: it does **not** future-proof — each numeric arg keeps its own branch, and it does not move VSIM parsing toward the codebase's `ArgParser` direction. Sibling approaches **B (ArgParser refactor)** and **C (shared param-resolver helper)** will be produced in a separate fork run for side-by-side comparison (no sibling PR links yet — this is the linear plumbing run).

1. **Current:** `FT.HYBRID`'s `VSIM` section validates numeric args (`KNN K`/`EF_RUNTIME`, `RANGE RADIUS`/`EPSILON`) as literal numbers during parsing — *before* `PARAMS` substitution — so a `$param` placeholder is rejected, e.g. `FT.HYBRID idx SEARCH * VSIM @v $vec KNN 2 K $k PARAMS 4 vector ... k 5` → `Invalid K value`.
2. **Change:** Defer `$param` numeric values like the vector arg already is. `K`/`RADIUS` store the param name in `ParsedVectorData` and bind a deferred query param (`QT_PARAM_SIZE`/`QT_PARAM_NUMERIC`) resolved at query-eval time; `EF_RUNTIME`/`EPSILON` are appended to the `VectorQuery` params with `needResolve=true`. Literal values keep their existing eager validation.
3. **Outcome:** All four params resolve via `PARAMS` on a single instance. New regression test covers them on FLAT (K, RADIUS) and HNSW (EF_RUNTIME, EPSILON). Full `test_hybrid_vector.py` is green (7/7).

#### Which additional issues this PR fixes
1. MOD-12915

#### Main objects this PR modified
1. `src/hybrid/parse_hybrid.c` — defer `$param` for K/RADIUS/EF_RUNTIME/EPSILON instead of eager numeric validation
2. `src/aggregate/aggregate_request.c` — generalize vector-node deferred-param setup to also bind deferred K/RADIUS
3. `src/hybrid/vector_query_utils.{c,h}` — `ParsedVectorData` gains `kParamName`/`radiusParamName` (owned; freed on cleanup)
4. `src/query.c` — strip `$` and mark deferred for vector attribute params
5. `tests/pytests/test_hybrid_vector.py` — regression test `test_hybrid_vector_params_numeric_args`

#### Known scope limitation
`BATCH_SIZE` (the `FILTER`/`ArgParser` path in `parseFilterClause`) is **not** addressed by this surgical change. It is a natural fit for the ArgParser approach (sibling B) and is left as a follow-up.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: `FT.HYBRID` `VSIM` now accepts `PARAMS` placeholders for the numeric arguments `KNN K` / `EF_RUNTIME` and `RANGE RADIUS` / `EPSILON`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
