### PR TITLE
test_short_read: skip when RedisJSON is not loaded

### DIFF
--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -599,7 +599,7 @@ def doTest(env: Env, test_name, rdb_name, expected_index, depth=0):
         sendShortReads(env, fullPath, expected_index)
 
 # Dynamically create a test function for each rdb file
-@skip(cluster=True, redis_less_than='6.2.0', macos=True, asan=True, arch='aarch64')
+@skip(cluster=True, redis_less_than='6.2.0', macos=True, asan=True, arch='aarch64', no_json=True)
 def register_tests():
     test_func = lambda test, rdb, idx: lambda env: doTest(env, test, rdb, idx)
     for rdb_name, expected_index in RDBS.items():


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `test_short_read.py` unconditionally creates a JSON-backed index (`idxBackup2`, via `add_index(env, False, ...)`) in its `sendShortReads` backup/restore setup, regardless of whether the RDB under test is hash- or JSON-based. When the flow tests run without RedisJSON loaded (`REJSON=0`), `japi` is `NULL` and `FT.CREATE ... ON JSON` is rejected by `DocumentType_Parse` with `Invalid rule type: JSON` ([src/rules.c:43-47](https://github.com/RediSearch/RediSearch/blob/master/src/rules.c#L43-L47)). This fails **every** short-read variant at setup time (the cascade then surfaces as `Index not found: idxBackup2`) instead of the suite being skipped.

2. **Change:** Add `no_json=True` to the module's `@skip(...)` decorator, so the entire short-read suite is skipped when RedisJSON is unavailable — matching how other JSON-dependent tests guard themselves (`skip(no_json=...)` keys off the `REJSON` env var).

3. **Outcome:** Running the flow tests with rejson disabled (e.g. a manual `flow-test.yml` dispatch / platform build that omits the `rejson` option) cleanly skips the short-read tests instead of failing. Normal CI (nightly, periodic, merge-to-queue, PR) enables `rejson` and is unaffected — the tests continue to run there.

Discovered in a manual "Build on Platforms" run that dispatched the flow tests without `rejson`.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. `tests/pytests/test_short_read.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skip condition; no production or API behavior changes.
> 
> **Overview**
> Adds **`no_json=True`** to the `@skip` decorator on `register_tests()` in `test_short_read.py`, so the dynamically registered short-read RDB tests are **skipped when RedisJSON is not loaded** (`REJSON=0`), consistent with other JSON-dependent suites.
> 
> Without this guard, setup still runs `add_index(..., False, 'idxBackup2', ...)` (`FT.CREATE ... ON JSON`) and fails before the short-read scenarios run when ReJSON is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64de7d0b07c8784d4098684c595a9d258761afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->