### PR TITLE
[8.8] test_short_read: skip when RedisJSON is not loaded

### DIFF
--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -599,7 +599,7 @@ def doTest(env: Env, test_name, rdb_name, expected_index, depth=0):
         sendShortReads(env, fullPath, expected_index)
 
 # Dynamically create a test function for each rdb file
-@skip(cluster=True, redis_less_than='6.2.0', macos=True, asan=True, arch='aarch64')
+@skip(cluster=True, redis_less_than='6.2.0', macos=True, asan=True, arch='aarch64', no_json=True)
 def register_tests():
     test_func = lambda test, rdb, idx: lambda env: doTest(env, test, rdb, idx)
     for rdb_name, expected_index in RDBS.items():


### PR DESCRIPTION
Backport of #10039 to `8.8`.

## Describe the changes in the pull request

1. **Current:** `test_short_read.py` unconditionally creates a JSON-backed index (`idxBackup2`) in its `sendShortReads` setup. When the flow tests run without RedisJSON loaded (`REJSON=0`), `japi` is `NULL` and `FT.CREATE ... ON JSON` is rejected with `Invalid rule type: JSON`, failing every short-read variant at setup time instead of skipping.
2. **Change:** Add `no_json=True` to the module's `@skip(...)` decorator so the short-read suite is skipped when RedisJSON is unavailable.
3. **Outcome:** Flow-test runs with rejson disabled cleanly skip these tests; normal CI (rejson enabled) is unaffected.

#### Which additional issues this PR fixes
1. MOD-...
2. #10039

#### Main objects this PR modified
1. `tests/pytests/test_short_read.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skip condition; no production or API behavior changes.
> 
> **Overview**
> Adds **`no_json=True`** to the `@skip(...)` decorator on dynamically registered short-read RDB tests in `test_short_read.py`.
> 
> Those tests call `sendShortReads`, which always creates a JSON index (`idxBackup2`) during setup. Without RedisJSON (`REJSON=0`), `FT.CREATE ... ON JSON` fails at setup instead of skipping. With this flag, the whole suite is skipped when RedisJSON is unavailable, matching other JSON-dependent tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9e93e4835d68b2cdcdf7c5b480234f1ea1eac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->