### PR TITLE
[MOD-16185] Trie: add TermSuffixIndex

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
 name = "trie_rs"
 version = "0.0.1"
 dependencies = [
+ "ffi",
  "fs-err",
  "insta",
  "lending-iterator",

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -299,6 +299,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/suffix.h",
+        fns: &[],
+        types: &[],
+        vars: &["MIN_SUFFIX"],
+    },
+    HeaderAllowlist {
         path: "src/tag_index.h",
         fns: &["TagIndex_Ensure", "TagIndex_OpenIndex"],
         types: &[],

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 test_utils = []
 
 [dependencies]
+ffi.workspace = true
 lending-iterator.workspace = true
 libc.workspace = true
 memchr.workspace = true

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -15,6 +15,7 @@ pub mod iter;
 mod node;
 pub mod opaque;
 pub mod str;
+pub mod term_suffix_index;
 mod trie;
 mod trie_count;
 mod utils;

--- a/src/redisearch_rs/trie_rs/src/term_suffix_index/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/term_suffix_index/mod.rs
@@ -107,10 +107,20 @@ impl TermSuffixIndex {
             .map(|(_, (byte_idx, _))| &term[byte_idx..])
     }
 
-    /// Yield every indexed term containing `needle`. Empty `needle`
-    /// yields nothing. Order unspecified. A term may be yielded more
-    /// than once; dedupe by [`Rc::as_ptr`] if needed.
+    /// Yield every indexed term containing `needle`, in unspecified
+    /// order. Empty `needle` yields nothing. A term may be yielded
+    /// more than once; dedupe by [`Rc::as_ptr`] if needed.
+    ///
+    /// Non-empty `needle` must span at least [`MIN_SUFFIX`] codepoints.
+    /// Shorter needles silently yield a subset of matching terms,
+    /// since suffixes below the threshold aren't indexed; debug
+    /// builds assert this. Production callers filter upstream via
+    /// the query engine's `minTermPrefix` gate.
     pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
+        debug_assert!(
+            needle.is_empty() || needle.chars().count() >= MIN_SUFFIX,
+            "needle must span at least {MIN_SUFFIX} codepoints; caller must filter shorter needles (production gate: minTermPrefix)",
+        );
         (!needle.is_empty())
             .then_some(needle)
             .into_iter()
@@ -122,7 +132,17 @@ impl TermSuffixIndex {
     /// order. Empty `needle` yields nothing.
     ///
     /// Each matching term is yielded exactly once.
+    ///
+    /// Non-empty `needle` must span at least [`MIN_SUFFIX`] codepoints.
+    /// Shorter needles silently yield a subset of matching terms,
+    /// since suffixes below the threshold aren't indexed; debug
+    /// builds assert this. Production callers filter upstream via
+    /// the query engine's `minTermPrefix` gate.
     pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
+        debug_assert!(
+            needle.is_empty() || needle.chars().count() >= MIN_SUFFIX,
+            "needle must span at least {MIN_SUFFIX} codepoints; caller must filter shorter needles (production gate: minTermPrefix)",
+        );
         (!needle.is_empty())
             .then_some(needle)
             .into_iter()

--- a/src/redisearch_rs/trie_rs/src/term_suffix_index/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/term_suffix_index/mod.rs
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A string set supporting substring and ends-with queries against
+//! its members.
+//!
+//! Powers RediSearch's `WITHSUFFIXTRIE` field option, where each
+//! member is a word-level term harvested from an indexed text field
+//! by the tokenizer. The structure itself is content-agnostic — any
+//! `&str` will do.
+//!
+//! # Why a suffix trie answers substring queries
+//!
+//! Every substring of a string is a prefix of *some* suffix of that
+//! string. So indexing all suffixes and then prefix-searching the
+//! trie for the needle surfaces every member containing it.
+//! [`TermSuffixIndex::iter_contains`] is the prefix lookup;
+//! [`TermSuffixIndex::iter_suffix`] is the exact lookup.
+//!
+//! Suffixes shorter than [`MIN_SUFFIX`] codepoints aren't indexed —
+//! trades index size for a minimum supported needle length.
+
+mod term_refs;
+
+use std::rc::Rc;
+
+use crate::str::StrTrieMap;
+use term_refs::{Outcome, TermRefs};
+
+const MIN_SUFFIX: usize = ffi::MIN_SUFFIX as usize;
+
+pub struct TermSuffixIndex {
+    inner: StrTrieMap<TermRefs>,
+}
+
+impl Default for TermSuffixIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TermSuffixIndex {
+    pub const fn new() -> Self {
+        Self {
+            inner: StrTrieMap::new(),
+        }
+    }
+
+    pub fn mem_usage(&self) -> usize {
+        todo!("FT.INFO memory accounting for the suffix index")
+    }
+
+    pub fn add(&mut self, term: &str) {
+        if term.is_empty() {
+            return;
+        }
+
+        if self.inner.get(term).is_some_and(TermRefs::has_full_term) {
+            return;
+        }
+
+        let owner = Rc::from(term);
+        self.inner.insert_with(term, |existing| {
+            TermRefs::upsert_full_term(existing, Rc::clone(&owner))
+        });
+
+        for suffix in Self::suffixes_of(term) {
+            self.inner.insert_with(suffix, |existing| {
+                TermRefs::upsert_longer_term(existing, Rc::clone(&owner))
+            });
+        }
+    }
+
+    pub fn remove(&mut self, term: &str) {
+        if term.is_empty() {
+            return;
+        }
+
+        if let Some(data) = self.inner.get_mut(term)
+            && data.has_full_term()
+            && data.clear_full_term() == Outcome::Drained
+        {
+            self.inner.remove(term);
+        }
+
+        for suffix in Self::suffixes_of(term) {
+            if let Some(data) = self.inner.get_mut(suffix)
+                && data.remove_longer_term(term) == Outcome::Drained
+            {
+                self.inner.remove(suffix);
+            }
+        }
+    }
+
+    fn suffixes_of(term: &str) -> impl Iterator<Item = &str> {
+        let total_chars = term.chars().count();
+        term.char_indices()
+            .enumerate()
+            .skip(1)
+            .take_while(move |(char_idx, _)| total_chars - char_idx >= MIN_SUFFIX)
+            .map(|(_, (byte_idx, _))| &term[byte_idx..])
+    }
+
+    /// Yield every indexed term containing `needle`. Empty `needle`
+    /// yields nothing. Order unspecified. A term may be yielded more
+    /// than once; dedupe by [`Rc::as_ptr`] if needed.
+    pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
+        (!needle.is_empty())
+            .then_some(needle)
+            .into_iter()
+            .flat_map(|n| self.inner.prefixed_iter(n))
+            .flat_map(|(_key, data)| data.terms().cloned())
+    }
+
+    /// Yield every indexed term that ends with `needle`, in unspecified
+    /// order. Empty `needle` yields nothing.
+    ///
+    /// Each matching term is yielded exactly once.
+    pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
+        (!needle.is_empty())
+            .then_some(needle)
+            .into_iter()
+            .flat_map(|n| self.inner.get(n))
+            .flat_map(|data| data.terms().cloned())
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/term_suffix_index/term_refs.rs
+++ b/src/redisearch_rs/trie_rs/src/term_suffix_index/term_refs.rs
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Per-entry payload for [`TermSuffixIndex`](super::TermSuffixIndex).
+//!
+//! A trie key `K` can play two independent roles at the same time:
+//!
+//! - `K` may itself be an indexed member of the set.
+//! - `K` may be a proper suffix of one or more longer members.
+//!
+//! Both, either, or neither role may hold at any moment. Tracking
+//! them in separate fields (`full_term` and `longer_terms`) lets
+//! [`add`](super::TermSuffixIndex::add) and
+//! [`remove`](super::TermSuffixIndex::remove) distinguish updating
+//! an indexed member from updating back-reference bookkeeping for
+//! a longer source.
+
+use std::rc::Rc;
+
+/// `Rc<str>` shares one heap allocation across all of a term's
+/// trie entries — one full-term entry plus up to
+/// `N - `[`MIN_SUFFIX`](super::MIN_SUFFIX) proper-suffix entries —
+/// keeping per-term memory `O(N)` instead of `O(N²)`. Bytes drop
+/// with the last reference.
+pub(super) struct TermRefs {
+    full_term: Option<Rc<str>>,
+    longer_terms: Vec<Rc<str>>,
+}
+
+impl TermRefs {
+    pub(super) fn upsert_full_term(slot: Option<Self>, term: Rc<str>) -> Self {
+        match slot {
+            Some(mut data) => {
+                debug_assert!(
+                    data.full_term.is_none(),
+                    "upsert_full_term on full-term entry"
+                );
+                data.full_term = Some(term);
+                data
+            }
+            None => Self {
+                full_term: Some(term),
+                longer_terms: Vec::new(),
+            },
+        }
+    }
+
+    pub(super) fn upsert_longer_term(slot: Option<Self>, term: Rc<str>) -> Self {
+        match slot {
+            Some(mut data) => {
+                data.longer_terms.push(term);
+                data
+            }
+            None => Self {
+                full_term: None,
+                longer_terms: vec![term],
+            },
+        }
+    }
+
+    pub(super) const fn has_full_term(&self) -> bool {
+        self.full_term.is_some()
+    }
+
+    pub(super) fn clear_full_term(&mut self) -> Outcome {
+        debug_assert!(
+            self.full_term.is_some(),
+            "clear_full_term on suffix-only entry"
+        );
+        self.full_term = None;
+        self.outcome()
+    }
+
+    pub(super) fn remove_longer_term(&mut self, term: &str) -> Outcome {
+        if let Some(pos) = self.longer_terms.iter().position(|t| t.as_ref() == term) {
+            self.longer_terms.swap_remove(pos);
+        }
+        self.outcome()
+    }
+
+    const fn outcome(&self) -> Outcome {
+        if self.is_empty() {
+            Outcome::Drained
+        } else {
+            Outcome::Retained
+        }
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.full_term.is_none() && self.longer_terms.is_empty()
+    }
+
+    pub(super) fn terms(&self) -> impl Iterator<Item = &Rc<str>> {
+        self.full_term.iter().chain(self.longer_terms.iter())
+    }
+}
+
+/// Whether a mutating operation on `TermRefs` left the entry empty.
+#[derive(Debug, PartialEq, Eq)]
+#[must_use = "evict the entry from the trie on Outcome::Drained"]
+pub(super) enum Outcome {
+    Drained,
+    Retained,
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/main.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/main.rs
@@ -9,4 +9,5 @@
 
 mod iter;
 mod str;
+mod term_suffix_index;
 mod trie;

--- a/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
@@ -200,7 +200,7 @@ fn iter_suffix_yields_one_hit_per_matching_term() {
 
 // --- Proptest fuzz
 
-#[cfg(not(miri))] // these proptests are too slow to run under miri
+#[cfg_attr(miri, ignore = "These proptests are too slow to run under miri")]
 mod fuzz {
     use super::*;
 

--- a/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
@@ -198,7 +198,7 @@ fn iter_suffix_yields_one_hit_per_matching_term() {
 
 // --- Proptest fuzz
 
-#[cfg_attr(miri, ignore = "These proptests are too slow to run under miri")]
+#[cfg(not(miri))]
 mod fuzz {
     use proptest::prelude::*;
 

--- a/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
@@ -11,8 +11,6 @@
 
 use std::{collections::HashSet, rc::Rc};
 
-#[cfg(not(miri))]
-use proptest::prelude::*;
 use trie_rs::term_suffix_index::TermSuffixIndex;
 
 fn build_index(corpus: &[String]) -> TermSuffixIndex {
@@ -202,6 +200,8 @@ fn iter_suffix_yields_one_hit_per_matching_term() {
 
 #[cfg_attr(miri, ignore = "These proptests are too slow to run under miri")]
 mod fuzz {
+    use proptest::prelude::*;
+
     use super::*;
 
     /// Kept small so fuzz cases land in a regime where suffix collisions are common.

--- a/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Property tests for [`TermSuffixIndex`].
+
+use std::{collections::HashSet, rc::Rc};
+
+#[cfg(not(miri))]
+use proptest::prelude::*;
+use trie_rs::term_suffix_index::TermSuffixIndex;
+
+fn build_index(corpus: &[String]) -> TermSuffixIndex {
+    let mut sut = TermSuffixIndex::new();
+    for t in corpus {
+        sut.add(t);
+    }
+    sut
+}
+
+fn collect_set<I: Iterator<Item = Rc<str>>>(it: I) -> HashSet<String> {
+    it.map(|r| r.as_ref().to_string()).collect()
+}
+
+// --- Focused, hand-rolled cases ----------------------------------------
+
+#[test]
+fn iter_suffix_yields_terms_ending_with_needle() {
+    let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+    let expected = ["cat", "concat", "scat"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+
+    let actual = collect_set(sut.iter_suffix("cat"));
+
+    assert_eq!(actual, expected, "iter_suffix('cat')");
+}
+
+#[test]
+fn iter_contains_yields_terms_containing_needle() {
+    let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+    let expected = corpus.iter().cloned().collect::<HashSet<_>>();
+
+    let actual = collect_set(sut.iter_contains("cat"));
+
+    assert_eq!(actual, expected, "iter_contains('cat')");
+}
+
+#[test]
+fn empty_needle_yields_no_matches() {
+    let corpus = ["cat", "dog"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    let actual_suffix = sut.iter_suffix("").count();
+    let actual_contains = sut.iter_contains("").count();
+
+    assert_eq!(actual_suffix, 0);
+    assert_eq!(actual_contains, 0);
+}
+
+#[test]
+fn add_then_remove_clears_the_index() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("banana");
+    sut.add("anaconda");
+
+    sut.remove("banana");
+    sut.remove("anaconda");
+
+    for needle in [
+        "banana", "anana", "nana", "ana", "na", "anaconda", "naconda", "aconda", "conda", "onda",
+        "nda", "da", "an",
+    ] {
+        assert_eq!(sut.iter_contains(needle).count(), 0, "needle={needle}");
+        assert_eq!(sut.iter_suffix(needle).count(), 0, "needle={needle}");
+    }
+}
+
+#[test]
+fn add_same_term_twice_is_noop() {
+    let mut sut = TermSuffixIndex::new();
+
+    sut.add("apple");
+    sut.add("apple");
+    let actual = sut.iter_contains("apple").collect::<Vec<_>>();
+
+    assert_eq!(actual.len(), 1, "apple inserted twice yields one hit");
+    assert_eq!(actual[0].as_ref(), "apple");
+}
+
+#[test]
+fn add_promotes_existing_suffix_only_node_to_full_term() {
+    // "longer" leaves "ger" as a suffix-only node; inserting "ger"
+    // must promote it.
+    let mut sut = TermSuffixIndex::new();
+    sut.add("longer");
+    sut.add("ger");
+
+    let actual = collect_set(sut.iter_suffix("ger"));
+
+    let expected = HashSet::from(["longer".to_string(), "ger".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn min_suffix_boundary_two_chars_no_proper_suffix() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("ab");
+
+    let actual_exact = collect_set(sut.iter_suffix("ab"));
+    let actual_single_char = sut.iter_suffix("b").count();
+
+    let expected_exact = HashSet::from(["ab".to_string()]);
+    assert_eq!(actual_exact, expected_exact);
+    assert_eq!(actual_single_char, 0);
+}
+
+#[test]
+fn multibyte_utf8_min_suffix_is_codepoint_aware() {
+    // Codepoint-aware suffix slicing: "café" has 4 codepoints, so the
+    // length-2 suffix "fé" is indexed but length-1 "é" is not. A
+    // byte-stride port would either panic (`&term[3..]` splits the
+    // first byte of "é") or insert a malformed key — neither should
+    // happen here.
+    let mut sut = TermSuffixIndex::new();
+    for t in ["café", "naïve", "日本語", "🦀rust"] {
+        sut.add(t);
+    }
+
+    assert!(collect_set(sut.iter_suffix("fé")).contains("café"));
+    // "é" is a one-codepoint suffix; below MIN_SUFFIX → no entry.
+    assert_eq!(sut.iter_suffix("é").count(), 0);
+    // "本語" is a two-codepoint suffix of "日本語" — should be present.
+    assert!(collect_set(sut.iter_suffix("本語")).contains("日本語"));
+
+    for t in ["café", "naïve", "日本語", "🦀rust"] {
+        sut.remove(t);
+    }
+
+    assert_eq!(sut.iter_contains("café").count(), 0);
+    assert_eq!(sut.iter_contains("本語").count(), 0);
+    assert_eq!(sut.iter_contains("rust").count(), 0);
+}
+
+#[test]
+fn remove_unknown_term_is_noop() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("present");
+
+    sut.remove("absent");
+
+    assert!(collect_set(sut.iter_suffix("present")).contains("present"));
+}
+
+#[test]
+fn remove_suffix_only_entry_is_noop() {
+    // "ger" was never `add`ed, but it exists in the trie as a
+    // back-reference key for "longer". Remove must no-op gracefully.
+    let mut sut = TermSuffixIndex::new();
+    sut.add("longer");
+
+    sut.remove("ger");
+
+    assert!(collect_set(sut.iter_suffix("ger")).contains("longer"));
+}
+
+#[test]
+fn iter_suffix_yields_one_hit_per_matching_term() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("abc");
+    sut.add("xabc");
+
+    let actual = sut
+        .iter_suffix("abc")
+        .map(|r| r.as_ref().to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(actual.len(), 2, "each match yielded exactly once");
+    let actual_set = actual.into_iter().collect::<HashSet<_>>();
+    let expected = HashSet::from(["abc".to_string(), "xabc".to_string()]);
+    assert_eq!(actual_set, expected);
+}
+
+// --- Proptest fuzz
+
+#[cfg(not(miri))] // these proptests are too slow to run under miri
+mod fuzz {
+    use super::*;
+
+    /// Kept small so fuzz cases land in a regime where suffix collisions are common.
+    fn term_strategy() -> impl Strategy<Value = String> {
+        "[a-z]{1,8}"
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 2_000, .. ProptestConfig::default() })]
+
+        #[test]
+        fn iter_contains_matches_substring_oracle(
+            corpus in proptest::collection::vec(term_strategy(), 1..=20),
+            needle in "[a-z]{2,4}",
+        ) {
+            let sut = build_index(&corpus);
+            let expected = corpus
+                .iter()
+                .filter(|t| t.contains(&needle))
+                .cloned()
+                .collect::<HashSet<_>>();
+
+            let actual = collect_set(sut.iter_contains(&needle));
+
+            prop_assert_eq!(actual, expected, "needle={:?} corpus={:?}", needle, corpus);
+        }
+
+        #[test]
+        fn iter_suffix_matches_ends_with_oracle(
+            corpus in proptest::collection::vec(term_strategy(), 1..=20),
+            needle in "[a-z]{2,4}",
+        ) {
+            let sut = build_index(&corpus);
+            let expected = corpus
+                .iter()
+                .filter(|t| t.ends_with(&needle))
+                .cloned()
+                .collect::<HashSet<_>>();
+
+            let actual = collect_set(sut.iter_suffix(&needle));
+
+            prop_assert_eq!(actual, expected, "needle={:?} corpus={:?}", needle, corpus);
+        }
+
+        #[test]
+        fn removing_all_added_terms_clears_the_index(
+            corpus in proptest::collection::vec(term_strategy(), 1..=10),
+        ) {
+            let mut sut = TermSuffixIndex::new();
+            for t in &corpus {
+                sut.add(t);
+            }
+
+            // Remove in reverse insertion order — exercises the
+            // suffix-promotion path inside the index more often than
+            // forward removal.
+            for t in corpus.iter().rev() {
+                sut.remove(t);
+            }
+
+            // Every needle of length up to 4 yields zero hits.
+            for sample in ["a", "ab", "abc", "abcd"] {
+                prop_assert_eq!(sut.iter_contains(sample).count(), 0,
+                    "stale entries for needle={:?} corpus={:?}", sample, corpus);
+                prop_assert_eq!(sut.iter_suffix(sample).count(), 0,
+                    "stale entries for needle={:?} corpus={:?}", sample, corpus);
+            }
+        }
+
+        #[test]
+        fn mixed_add_remove_matches_hashset_oracle(
+            ops in proptest::collection::vec(
+                (any::<bool>(), "[a-z]{1,6}"),
+                1..=30,
+            ),
+            needle in "[a-z]{2,3}",
+        ) {
+            let mut sut = TermSuffixIndex::new();
+            let mut alive = HashSet::new();
+
+            // Apply add/remove stream, mirroring into a HashSet oracle.
+            for (is_add, t) in &ops {
+                if *is_add {
+                    if alive.insert(t.clone()) {
+                        sut.add(t);
+                    }
+                } else if alive.remove(t) {
+                    sut.remove(t);
+                }
+            }
+            let actual_contains = collect_set(sut.iter_contains(&needle));
+            let actual_suffix = collect_set(sut.iter_suffix(&needle));
+
+            let expected_contains =
+                alive.iter().filter(|t| t.contains(&needle)).cloned().collect();
+            prop_assert_eq!(actual_contains, expected_contains,
+                "iter_contains needle={:?}", needle);
+            let expected_suffix =
+                alive.iter().filter(|t| t.ends_with(&needle)).cloned().collect();
+            prop_assert_eq!(actual_suffix, expected_suffix,
+                "iter_suffix needle={:?}", needle);
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/term_suffix_index.rs
@@ -123,11 +123,9 @@ fn min_suffix_boundary_two_chars_no_proper_suffix() {
     sut.add("ab");
 
     let actual_exact = collect_set(sut.iter_suffix("ab"));
-    let actual_single_char = sut.iter_suffix("b").count();
 
     let expected_exact = HashSet::from(["ab".to_string()]);
     assert_eq!(actual_exact, expected_exact);
-    assert_eq!(actual_single_char, 0);
 }
 
 #[test]
@@ -143,8 +141,6 @@ fn multibyte_utf8_min_suffix_is_codepoint_aware() {
     }
 
     assert!(collect_set(sut.iter_suffix("fé")).contains("café"));
-    // "é" is a one-codepoint suffix; below MIN_SUFFIX → no entry.
-    assert_eq!(sut.iter_suffix("é").count(), 0);
     // "本語" is a two-codepoint suffix of "日本語" — should be present.
     assert!(collect_set(sut.iter_suffix("本語")).contains("日本語"));
 
@@ -263,7 +259,7 @@ mod fuzz {
             }
 
             // Every needle of length up to 4 yields zero hits.
-            for sample in ["a", "ab", "abc", "abcd"] {
+            for sample in ["ab", "abc", "abcd"] {
                 prop_assert_eq!(sut.iter_contains(sample).count(), 0,
                     "stale entries for needle={:?} corpus={:?}", sample, corpus);
                 prop_assert_eq!(sut.iter_suffix(sample).count(), 0,


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: WITHSUFFIXTRIE substring queries (`FT.SEARCH idx '@field:*foo*'`)
   are backed by `src/suffix.c` — a rune-based `Trie` wrapper that indexes every
   suffix of every term so substring search reduces to a prefix lookup. No Rust
   equivalent exists yet, blocking the `src/trie/` port from removing
   `src/suffix.c` as a consumer.

2. **Change**: Adds `trie_rs::term_suffix_index::TermSuffixIndex` — a pure-Rust
   substring/ends-with index keyed off `StrTrieMap` (added in #9947). Each
   trie entry tracks the term itself (when the key matches an indexed member)
   plus `Rc<str>` back-references to all longer terms that have this key as a
   proper suffix. `Rc<str>` sharing keeps per-term memory O(N) instead of O(N²)
   across the up to `N - MIN_SUFFIX` trie entries the term produces.

   The payload type (`TermRefs`) returns an `Outcome` enum from mutators
   signalling whether the entry was left empty — making the post-mutation
   eviction step explicit at every call site instead of hidden inside the
   data type.

3. **Outcome**: Standalone Rust crate, fully tested. Not yet wired up — `sp->suffix`
   and `idx->suffix` still use the C implementations. A follow-up will build the
   FFI surface and route the tag-index path through this crate.

#### Which additional issues this PR fixes
1. MOD-16185

#### Main objects this PR modified
1. `src/redisearch_rs/trie_rs/src/term_suffix_index/` (new module)
2. `src/redisearch_rs/ffi/build.rs` (allowlist `MIN_SUFFIX` from `src/suffix.h`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Stacked on #9947 — base will auto-rebase to master once that lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New standalone `trie_rs` module with no production wiring; behavior is heavily tested but will matter for search correctness once it replaces `suffix.c`.
> 
> **Overview**
> Adds **`trie_rs::term_suffix_index::TermSuffixIndex`**, a pure-Rust suffix-trie index for substring (`iter_contains`) and ends-with (`iter_suffix`) lookups over indexed terms—the intended replacement for `src/suffix.c` behind `WITHSUFFIXTRIE`.
> 
> The index is built on **`StrTrieMap`** with per-key **`TermRefs`** payloads (full-term vs longer-term back-references) and shared **`Rc<str>`** storage so add/remove can evict empty trie nodes via an explicit **`Outcome`**. Suffix insertion respects C’s **`MIN_SUFFIX`** (exposed through **`ffi`** / `suffix.h` allowlist); shorter suffixes are skipped with UTF-8 codepoint-aware slicing.
> 
> **`mem_usage`** is stubbed (`todo!`). Production **`sp->suffix` / `idx->suffix`** are unchanged—this PR is library + integration/proptest coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c86cafcc23369b12a3335c4a239776735d09f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->