### PR TITLE
[MOD-12915] FT.HYBRID VSIM: resolve PARAMS placeholders for numeric args (ArgParser refactor)

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1451,27 +1451,70 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   // Apply the flags that were set during parsing
   vecNode->opts.flags |= pvd->queryNodeFlags;
 
-  if (pvd->isParameter) {
-    // PARAMETER CASE: Set up parameter for evalnode to resolve later
-    QueryToken vecToken = {
-      .type = QT_PARAM_VEC,
-      .s = (vq->type == VECSIM_QT_KNN) ? vq->knn.vector : vq->range.vector,
-      .len = (vq->type == VECSIM_QT_KNN) ? vq->knn.vecLen : vq->range.vecLen,
-      .pos = 0,
-      .numval = 0,
-      .sign = 0
-    };
+  // Determine how many QueryNode params we need:
+  //  - 1 for the vector (always, since isParameter is always true in the hybrid path)
+  //  - +1 if K is a deferred $param (KNN only)
+  //  - +1 if RADIUS is a deferred $param (RANGE only)
+  bool hasKParam = (pvd->kParamName != NULL);
+  bool hasRadiusParam = (pvd->radiusParamName != NULL);
+  size_t numQueryNodeParams = pvd->isParameter ? 1 : 0;
+  if (hasKParam) numQueryNodeParams++;
+  if (hasRadiusParam) numQueryNodeParams++;
 
+  if (numQueryNodeParams > 0) {
     QueryParseCtx q = {0};
-    QueryNode_InitParams(vecNode, 1);
-    switch (vq->type) {
-      case VECSIM_QT_KNN:
-        QueryNode_SetParam(&q, &vecNode->params[0], &vq->knn.vector, &vq->knn.vecLen, &vecToken);
-        break;
-      case VECSIM_QT_RANGE:
-        QueryNode_SetParam(&q, &vecNode->params[0], &vq->range.vector, &vq->range.vecLen, &vecToken);
-        break;
+    QueryNode_InitParams(vecNode, numQueryNodeParams);
+    size_t paramIdx = 0;
+
+    if (pvd->isParameter) {
+      // PARAMETER CASE: Set up parameter for the vector blob
+      QueryToken vecToken = {
+        .type = QT_PARAM_VEC,
+        .s = (vq->type == VECSIM_QT_KNN) ? vq->knn.vector : vq->range.vector,
+        .len = (vq->type == VECSIM_QT_KNN) ? vq->knn.vecLen : vq->range.vecLen,
+        .pos = 0,
+        .numval = 0,
+        .sign = 0
+      };
+      switch (vq->type) {
+        case VECSIM_QT_KNN:
+          QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->knn.vector, &vq->knn.vecLen, &vecToken);
+          break;
+        case VECSIM_QT_RANGE:
+          QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->range.vector, &vq->range.vecLen, &vecToken);
+          break;
+      }
+      paramIdx++;
     }
+
+    if (hasKParam) {
+      // Deferred K: resolve from PARAMS dict as a size_t
+      QueryToken kToken = {
+        .type = QT_PARAM_SIZE,
+        .s = pvd->kParamName,
+        .len = strlen(pvd->kParamName),
+        .pos = 0,
+        .numval = 0,
+        .sign = 1
+      };
+      QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->knn.k, NULL, &kToken);
+      paramIdx++;
+    }
+
+    if (hasRadiusParam) {
+      // Deferred RADIUS: resolve from PARAMS dict as a double
+      QueryToken radiusToken = {
+        .type = QT_PARAM_NUMERIC,
+        .s = pvd->radiusParamName,
+        .len = strlen(pvd->radiusParamName),
+        .pos = 0,
+        .numval = 0,
+        .sign = 1
+      };
+      QueryNode_SetParam(&q, &vecNode->params[paramIdx], &vq->range.radius, NULL, &radiusToken);
+      paramIdx++;
+    }
+
     // Update AST's numParams since we used a local QueryParseCtx
     ast->numParams += q.numParams;
   }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -63,11 +63,135 @@ static VecSimRawParam createVecSimRawParam(const char *name, size_t nameLen, con
   };
 }
 
-static void addVectorQueryParam(VectorQuery *vq, const char *name, size_t nameLen, const char *value, size_t valueLen) {
+static void addVectorQueryParam(VectorQuery *vq, const char *name, size_t nameLen, const char *value,
+                                size_t valueLen) {
   VecSimRawParam rawParam = createVecSimRawParam(name, nameLen, value, valueLen);
   vq->params.params = array_ensure_append_1(vq->params.params, rawParam);
   bool needResolve = false;
   vq->params.needResolve = array_ensure_append_1(vq->params.needResolve, needResolve);
+}
+
+// Variant that marks the param as needing resolution from PARAMS dict (for $param placeholders).
+// Strips the leading '$' from value before storing.
+static void addVectorQueryParamDeferred(VectorQuery *vq, const char *name, size_t nameLen,
+                                        const char *value, size_t valueLen) {
+  // value is expected to start with '$'; skip it
+  if (valueLen > 0 && value[0] == '$') {
+    value++;
+    valueLen--;
+  }
+  VecSimRawParam rawParam = createVecSimRawParam(name, nameLen, value, valueLen);
+  vq->params.params = array_ensure_append_1(vq->params.params, rawParam);
+  bool needResolve = true;
+  vq->params.needResolve = array_ensure_append_1(vq->params.needResolve, needResolve);
+}
+
+// Context shared by KNN ArgParser callbacks
+typedef struct {
+  VectorQuery *vq;
+  ParsedVectorData *pvd;
+  QueryError *status;
+  bool hasEF;
+  bool hasShardKRatio;
+} KNNCallbackCtx;
+
+// Context shared by RANGE ArgParser callbacks
+typedef struct {
+  VectorQuery *vq;
+  ParsedVectorData *pvd;
+  QueryError *status;
+  bool hasEpsilon;
+} RangeCallbackCtx;
+
+// ArgParser callback for KNN K value
+static void handleKNNK(ArgParser *parser, const void *value, void *user_data) {
+  KNNCallbackCtx *ctx = (KNNCallbackCtx*)user_data;
+  const char *val = *(const char**)value;
+  if (val[0] == '$') {
+    // Deferred: store param name (strip '$')
+    ctx->pvd->kParamName = rm_strdup(val + 1);
+    ctx->pvd->hasExplicitK = true;
+  } else {
+    char *end;
+    long long kValue = strtoll(val, &end, 10);
+    if (*end != '\0' || kValue < 1) {
+      QueryError_SetError(ctx->status, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
+      return;
+    }
+    ctx->vq->knn.k = (size_t)kValue;
+    ctx->pvd->hasExplicitK = true;
+  }
+}
+
+// ArgParser callback for KNN EF_RUNTIME value
+static void handleKNNEFRuntime(ArgParser *parser, const void *value, void *user_data) {
+  KNNCallbackCtx *ctx = (KNNCallbackCtx*)user_data;
+  const char *val = *(const char**)value;
+  size_t valLen = strlen(val);
+  if (ctx->hasEF) {
+    QueryError_SetError(ctx->status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EF_RUNTIME argument");
+    return;
+  }
+  ctx->hasEF = true;
+  if (val[0] == '$') {
+    // Deferred: store as VecSim param with needResolve=true
+    addVectorQueryParamDeferred(ctx->vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), val, valLen);
+  } else {
+    // Validate literal value (must be >= 1)
+    char *end;
+    long long efValue = strtoll(val, &end, 10);
+    if (*end != '\0' || efValue < 1) {
+      QueryError_SetError(ctx->status, QUERY_ERROR_CODE_SYNTAX, "Invalid EF_RUNTIME value");
+      return;
+    }
+    addVectorQueryParam(ctx->vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), val, valLen);
+  }
+}
+
+// ArgParser callback for RANGE RADIUS value
+static void handleRangeRadius(ArgParser *parser, const void *value, void *user_data) {
+  RangeCallbackCtx *ctx = (RangeCallbackCtx*)user_data;
+  const char *val = *(const char**)value;
+  size_t valLen = strlen(val);
+  if (val[0] == '$') {
+    // Deferred: store param name (strip '$')
+    ctx->pvd->radiusParamName = rm_strdup(val + 1);
+  } else {
+    char *end;
+    double radiusValue = strtod(val, &end);
+    if (*end != '\0' || radiusValue < 0.0) {
+      QueryError_SetError(ctx->status, QUERY_ERROR_CODE_SYNTAX, "Invalid RADIUS value");
+      return;
+    }
+    ctx->vq->range.radius = radiusValue;
+  }
+  (void)valLen; // suppress unused warning
+}
+
+// ArgParser callback for RANGE EPSILON value
+static void handleRangeEpsilon(ArgParser *parser, const void *value, void *user_data) {
+  RangeCallbackCtx *ctx = (RangeCallbackCtx*)user_data;
+  const char *val = *(const char**)value;
+  size_t valLen = strlen(val);
+  if (ctx->hasEpsilon) {
+    QueryError_SetError(ctx->status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EPSILON argument");
+    return;
+  }
+  ctx->hasEpsilon = true;
+  if (val[0] == '$') {
+    // Deferred: store as VecSim param with needResolve=true
+    addVectorQueryParamDeferred(ctx->vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), val, valLen);
+  } else {
+    // Validate literal value (must be > 0)
+    char *end;
+    double epsilonValue = strtod(val, &end);
+    if (*end != '\0' || epsilonValue <= 0.0) {
+      QueryError_SetError(ctx->status, QUERY_ERROR_CODE_SYNTAX, "Invalid EPSILON value");
+      return;
+    }
+    addVectorQueryParam(ctx->vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), val, valLen);
+  }
+  (void)valLen; // suppress unused warning
 }
 
 static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
@@ -151,6 +275,36 @@ static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
   return REDISMODULE_OK;
 }
 
+// SHARD_K_RATIO callback context  (ArgParser callback signature expects ArgParser*, value, user_data)
+typedef struct {
+  ArgsCursor *ac;
+  ParsedVectorData *pvd;
+  QueryError *status;
+  bool hasShardKRatio;
+} ShardKRatioCallbackCtx;
+
+static void handleKNNShardKRatio(ArgParser *parser, const void *value, void *user_data) {
+  ShardKRatioCallbackCtx *ctx = (ShardKRatioCallbackCtx*)user_data;
+  if (ctx->hasShardKRatio) {
+    QueryError_SetError(ctx->status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate SHARD_K_RATIO argument");
+    return;
+  }
+  ctx->hasShardKRatio = true;
+  const char *ratioStr = *(const char**)value;
+  size_t ratioStrLen = strlen(ratioStr);
+  double shardKRatio;
+  if (!validateShardKRatio(ratioStr, &shardKRatio, ctx->status)) {
+    return;
+  }
+  QueryAttribute attr = {
+    .name = SHARD_K_RATIO_ATTR,
+    .namelen = strlen(SHARD_K_RATIO_ATTR),
+    .value = rm_strndup(ratioStr, ratioStrLen),
+    .vallen = ratioStrLen
+  };
+  ctx->pvd->attributes = array_ensure_append_1(ctx->pvd->attributes, attr);
+}
+
 static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd, QueryError *status) {
   // VSIM @vectorfield vector KNN ...
   //                              ^
@@ -160,73 +314,69 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
   }
   // Try to get number of arguments
   unsigned int argumentCount;
-  if (AC_GetUnsigned(ac, &argumentCount, 0) != AC_OK ) {
+  if (AC_GetUnsigned(ac, &argumentCount, 0) != AC_OK) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid argument count: expected an unsigned integer");
     return REDISMODULE_ERR;
   } else if (argumentCount == 0 || argumentCount % 2 != 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count", ": %u (must be a positive even number for key/value pairs)", argumentCount);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count",
+                                  ": %u (must be a positive even number for key/value pairs)", argumentCount);
     return REDISMODULE_ERR;
   }
 
-  bool hasEF = false;
-  bool hasShardKRatio = false;
   RS_ASSERT(pvd->vectorScoreFieldAlias == NULL);
 
-  for (int i=0; i<argumentCount; i+=2) {
-    if (AC_IsAtEnd(ac)) {
-      setExpectedArgumentsError(status, argumentCount, i);
-      return REDISMODULE_ERR;
-    }
-
-    if (AC_AdvanceIfMatch(ac, "K")) {
-      if (pvd->hasExplicitK) { // codespell:ignore
-        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate K argument");
-        return REDISMODULE_ERR;
-      }
-      if (CheckEnd(ac, "K", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      long long kValue;
-      if (AC_GetLongLong(ac, &kValue, AC_F_GE1) != AC_OK) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
-        return REDISMODULE_ERR;
-      }
-      vq->knn.k = (size_t)kValue;
-      pvd->hasExplicitK = true;
-
-    } else if (AC_AdvanceIfMatch(ac, "EF_RUNTIME")) {
-      if (hasEF) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EF_RUNTIME argument");
-        return REDISMODULE_ERR;
-      }
-      if (CheckEnd(ac, "EF_RUNTIME", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      long long efValue;
-      if (AC_GetLongLong(ac, &efValue, AC_F_GE1 | AC_F_NOADVANCE) != AC_OK) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EF_RUNTIME value");
-        return REDISMODULE_ERR;
-      }
-      const char *value;
-      size_t valueLen;
-      value = AC_GetStringNC(ac, &valueLen);
-      // Add directly to VectorQuery params
-      addVectorQueryParam(vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), value, valueLen);
-      hasEF = true;
-
-    } else if (AC_AdvanceIfMatch(ac, "SHARD_K_RATIO")) {
-      if (hasShardKRatio) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate SHARD_K_RATIO argument");
-        return REDISMODULE_ERR;
-      }
-      if (parseShardKRatioClause(ac, pvd, status) != REDISMODULE_OK) {
-        return REDISMODULE_ERR;
-      }
-      hasShardKRatio = true;
-
-    } else {
-      const char *current;
-      AC_GetString(ac, &current, NULL, AC_F_NOADVANCE);
-      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_ARG_UNRECOGNIZED, "Unknown argument", " `%s` in KNN", current);
-      return REDISMODULE_ERR;
-    }
+  // Slice exactly argumentCount tokens into a sub-cursor so ArgParser sees only KNN args
+  ArgsCursor knnCursor = {0};
+  int sliceRes = AC_GetSlice(ac, &knnCursor, argumentCount);
+  if (sliceRes == AC_ERR_NOARG) {
+    setExpectedArgumentsError(status, argumentCount, (int)AC_NumRemaining(ac));
+    return REDISMODULE_ERR;
+  } else if (sliceRes != AC_OK) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Bad arguments", " in KNN: %s",
+                                  AC_Strerror(sliceRes));
+    return REDISMODULE_ERR;
   }
+
+  // Set up ArgParser for KNN key/value pairs
+  KNNCallbackCtx knnCtx = {.vq = vq, .pvd = pvd, .status = status, .hasEF = false, .hasShardKRatio = false};
+  ShardKRatioCallbackCtx shardCtx = {.ac = ac, .pvd = pvd, .status = status, .hasShardKRatio = false};
+
+  const char *kStr = NULL;
+  const char *efRuntimeStr = NULL;
+  const char *shardKRatioStr = NULL;
+
+  ArgParser *parser = ArgParser_New(&knnCursor, "KNN");
+  if (!parser) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to create argument parser for KNN");
+    return REDISMODULE_ERR;
+  }
+
+  ArgParser_AddStringV(parser, "K", "Number of nearest neighbors",
+                       &kStr, ARG_OPT_OPTIONAL,
+                       ARG_OPT_CALLBACK, handleKNNK, &knnCtx,
+                       ARG_OPT_END);
+  ArgParser_AddStringV(parser, "EF_RUNTIME", "Exploration factor at query time",
+                       &efRuntimeStr, ARG_OPT_OPTIONAL,
+                       ARG_OPT_CALLBACK, handleKNNEFRuntime, &knnCtx,
+                       ARG_OPT_END);
+  ArgParser_AddStringV(parser, "SHARD_K_RATIO", "Shard window ratio",
+                       &shardKRatioStr, ARG_OPT_OPTIONAL,
+                       ARG_OPT_CALLBACK, handleKNNShardKRatio, &shardCtx,
+                       ARG_OPT_END);
+
+  ArgParseResult result = ArgParser_Parse(parser);
+  if (!result.success) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, ArgParser_GetErrorString(parser));
+    ArgParser_Free(parser);
+    return REDISMODULE_ERR;
+  }
+  ArgParser_Free(parser);
+
+  // Propagate any error set by callbacks
+  if (QueryError_HasError(status)) {
+    return REDISMODULE_ERR;
+  }
+
   if (!pvd->hasExplicitK) { // codespell:ignore
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing required argument K");
     return REDISMODULE_ERR;
@@ -243,63 +393,64 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
   }
   // Try to get number of arguments
   unsigned int argumentCount;
-  if (AC_GetUnsigned(ac, &argumentCount, 0) != AC_OK ) {
+  if (AC_GetUnsigned(ac, &argumentCount, 0) != AC_OK) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid argument count: expected an unsigned integer");
     return REDISMODULE_ERR;
   } else if (argumentCount == 0 || argumentCount % 2 != 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count", ": %u (must be a positive even number for key/value pairs)", argumentCount);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count",
+                                  ": %u (must be a positive even number for key/value pairs)", argumentCount);
     return REDISMODULE_ERR;
   }
 
-  bool hasRadius = false;
-  bool hasEpsilon = false;
   RS_ASSERT(pvd->vectorScoreFieldAlias == NULL);
 
-  for (int i=0; i<argumentCount; i+=2) {
-    if (AC_IsAtEnd(ac)) {
-      setExpectedArgumentsError(status, argumentCount, i);
-      return REDISMODULE_ERR;
-    }
-
-    if (AC_AdvanceIfMatch(ac, "RADIUS")) {
-      if (hasRadius) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate RADIUS argument");
-        return REDISMODULE_ERR;
-      }
-      if (CheckEnd(ac, "RADIUS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      double radiusValue;
-      if (AC_GetDouble(ac, &radiusValue, AC_F_GE0) != AC_OK) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid RADIUS value");
-        return REDISMODULE_ERR;
-      }
-      vq->range.radius = radiusValue;
-      hasRadius = true;
-
-    } else if (AC_AdvanceIfMatch(ac, "EPSILON")) {
-      if (hasEpsilon) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EPSILON argument");
-        return REDISMODULE_ERR;
-      }
-      if (CheckEnd(ac, "EPSILON", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      double epsilonValue;
-      if (AC_GetDouble(ac, &epsilonValue, AC_F_GE0 | AC_F_NOADVANCE) != AC_OK || epsilonValue == 0.0) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EPSILON value");
-        return REDISMODULE_ERR;
-      }
-      const char *value;
-      size_t valueLen;
-      value = AC_GetStringNC(ac, &valueLen);
-      // Add directly to VectorQuery params
-      addVectorQueryParam(vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), value, valueLen);
-      hasEpsilon = true;
-
-    } else {
-      const char *current;
-      AC_GetString(ac, &current, NULL, AC_F_NOADVANCE);
-      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_ARG_UNRECOGNIZED, "Unknown argument", " `%s` in RANGE", current);
-      return REDISMODULE_ERR;
-    }
+  // Slice exactly argumentCount tokens into a sub-cursor so ArgParser sees only RANGE args
+  ArgsCursor rangeCursor = {0};
+  int sliceRes = AC_GetSlice(ac, &rangeCursor, argumentCount);
+  if (sliceRes == AC_ERR_NOARG) {
+    setExpectedArgumentsError(status, argumentCount, (int)AC_NumRemaining(ac));
+    return REDISMODULE_ERR;
+  } else if (sliceRes != AC_OK) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Bad arguments", " in RANGE: %s",
+                                  AC_Strerror(sliceRes));
+    return REDISMODULE_ERR;
   }
+
+  RangeCallbackCtx rangeCtx = {.vq = vq, .pvd = pvd, .status = status, .hasEpsilon = false};
+
+  const char *radiusStr = NULL;
+  const char *epsilonStr = NULL;
+
+  ArgParser *parser = ArgParser_New(&rangeCursor, "RANGE");
+  if (!parser) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to create argument parser for RANGE");
+    return REDISMODULE_ERR;
+  }
+
+  ArgParser_AddStringV(parser, "RADIUS", "Search radius",
+                       &radiusStr, ARG_OPT_OPTIONAL,
+                       ARG_OPT_CALLBACK, handleRangeRadius, &rangeCtx,
+                       ARG_OPT_END);
+  ArgParser_AddStringV(parser, "EPSILON", "Exploration epsilon",
+                       &epsilonStr, ARG_OPT_OPTIONAL,
+                       ARG_OPT_CALLBACK, handleRangeEpsilon, &rangeCtx,
+                       ARG_OPT_END);
+
+  ArgParseResult result = ArgParser_Parse(parser);
+  if (!result.success) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, ArgParser_GetErrorString(parser));
+    ArgParser_Free(parser);
+    return REDISMODULE_ERR;
+  }
+  ArgParser_Free(parser);
+
+  // Propagate any error set by callbacks
+  if (QueryError_HasError(status)) {
+    return REDISMODULE_ERR;
+  }
+
+  // RADIUS is required (either literal or deferred via $param)
+  bool hasRadius = (radiusStr != NULL) || (pvd->radiusParamName != NULL);
   if (!hasRadius) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing required argument RADIUS");
     return REDISMODULE_ERR;

--- a/src/hybrid/vector_query_utils.c
+++ b/src/hybrid/vector_query_utils.c
@@ -28,5 +28,13 @@ void ParsedVectorData_Free(ParsedVectorData *pvd) {
     rm_free(pvd->vectorScoreFieldAlias);
   }
 
+  if (pvd->kParamName) {
+    rm_free(pvd->kParamName);
+  }
+
+  if (pvd->radiusParamName) {
+    rm_free(pvd->radiusParamName);
+  }
+
   rm_free(pvd);
 }

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -31,6 +31,9 @@ typedef struct {
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set
   uint32_t queryNodeFlags;     // QueryNode flags to be applied when creating the vector node
   bool skipFilterIntegration;  // true to make vector node root without filter wrapping (RANGE without explicit FILTER)
+  // Deferred-param names for numeric args supplied as $param placeholders (OWNED, NULL if literal)
+  char *kParamName;            // param name for KNN K when given as $param
+  char *radiusParamName;       // param name for RANGE RADIUS when given as $param
 } ParsedVectorData;
 
 void ParsedVectorData_Free(ParsedVectorData *pvd);

--- a/src/query.c
+++ b/src/query.c
@@ -2252,13 +2252,25 @@ static int QueryVectorNode_ApplyAttribute(VectorQuery *vq, QueryAttribute *attr,
              STR_EQCASE(attr->name, attr->namelen, VECSIM_RERANK)) {
     // Move ownership on the value string, so it won't get freed when releasing the QueryAttribute.
     // The name string was not copied by the parser (unlike the value) - so we copy and save it.
+    // If the value starts with '$', it is a PARAMS placeholder that must be resolved at query time.
+    bool resolve_required = (attr->vallen > 0 && attr->value[0] == '$');
+    const char *paramValue = attr->value;
+    size_t paramValueLen = attr->vallen;
+    if (resolve_required) {
+      // Strip the leading '$' so VectorQuery_ParamResolve can look up the param name.
+      paramValue++;
+      paramValueLen--;
+    }
     VecSimRawParam param = (VecSimRawParam){ .name = rm_strndup(attr->name, attr->namelen),
                                             .nameLen = attr->namelen,
-                                            .value = attr->value,
-                                            .valLen = attr->vallen };
-    attr->value = NULL;
+                                            .value = resolve_required ? rm_strndup(paramValue, paramValueLen)
+                                                                       : attr->value,
+                                            .valLen = paramValueLen };
+    if (!resolve_required) {
+      // Ownership transferred: prevent double-free on attribute teardown
+      attr->value = NULL;
+    }
     vq->params.params = array_ensure_append_1(vq->params.params, param);
-    bool resolve_required = false;  // at this point, we have the actual value in hand, not the query param.
     vq->params.needResolve = array_ensure_append_1(vq->params.needResolve, resolve_required);
     return 1;
   }

--- a/tests/pytests/test_hybrid_vector.py
+++ b/tests/pytests/test_hybrid_vector.py
@@ -163,6 +163,69 @@ def test_hybrid_vector_invalid_filter_with_weight():
     env.expect('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', '$BLOB',\
                 'KNN', '2', 'K', '2', 'FILTER', '@description:blue => {$weight: 2.0}', 'PARAMS', "2", "BLOB", b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e").error().contains('Weight attributes are not allowed in FT.HYBRID VSIM FILTER')
 
+def test_hybrid_vector_params_numeric_args():
+    """Regression test for MOD-12915: VSIM numeric args (K, RADIUS, EF_RUNTIME, EPSILON)
+    must resolve $param placeholders from PARAMS before numeric validation.
+    Prior to the fix, passing e.g. K $k would fail with 'Invalid K value'."""
+    blob = np.array([1.2, 0.2]).astype(np.float32).tobytes()
+
+    # --- KNN K via $param (FLAT index) ---
+    env = Env()
+    setup_basic_index(env)
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'KNN', '2', 'K', '$k',
+        'PARAMS', '4', 'BLOB', blob, 'k', '1')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+    # K=1 → nearest doc is doc:2 (distance ~0.05)
+    env.assertTrue('doc:2' in results)
+
+    # --- RANGE RADIUS via $param (FLAT index) ---
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'RANGE', '2', 'RADIUS', '$r',
+        'PARAMS', '4', 'BLOB', blob, 'r', '1.0')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+    # radius=1.0 from query vector (1.2,0.2): doc:2 (dist≈0.04), doc:4 (dist≈0.64) are within 1
+    env.assertTrue(len(results) >= 1)
+    env.flush()
+
+    # --- EF_RUNTIME and EPSILON via $param (HNSW index, required for those params) ---
+    conn = env.getClusterConnectionIfNeeded()
+    env.expect(
+        'FT.CREATE', 'hnsw_idx',
+        'SCHEMA', 'description', 'TEXT', 'embedding', 'VECTOR', 'HNSW', '6',
+        'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2'
+    ).ok()
+    for doc_id, doc_data in test_data.items():
+        conn.execute_command(
+            'HSET', doc_id,
+            'description', doc_data['description'],
+            'embedding', doc_data['embedding'])
+
+    # EF_RUNTIME via $param
+    response = env.cmd(
+        'FT.HYBRID', 'hnsw_idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'KNN', '4', 'K', '2', 'EF_RUNTIME', '$ef',
+        'PARAMS', '4', 'BLOB', blob, 'ef', '100')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+
+    # EPSILON via $param (RANGE query on HNSW)
+    response = env.cmd(
+        'FT.HYBRID', 'hnsw_idx',
+        'SEARCH', 'green',
+        'VSIM', '@embedding', '$BLOB', 'RANGE', '4', 'RADIUS', '1.0', 'EPSILON', '$eps',
+        'PARAMS', '4', 'BLOB', blob, 'eps', '0.01')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
+
+
 def test_hybrid_vector_invalid_filter_with_vector():
     """Test that hybrid vector filter fails when it contains vector operations"""
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Passing a `$param` placeholder for a numeric argument to `FT.HYBRID VSIM` (e.g., `K $k`, `RADIUS $r`, `EF_RUNTIME $ef`, `EPSILON $eps`) fails at parse time with an error like "Invalid K value" because the literal string `"$k"` fails numeric validation before the PARAMS dict is consulted.

2. **Change:** Rewrite VSIM numeric-arg parsing onto `ArgParser` (the same approach used by `parseFilterClause`). For each of the five numeric args — KNN K, EF_RUNTIME, RANGE RADIUS, EPSILON, and FILTER BATCH_SIZE — the parser now detects the `$` prefix, stores the param name for deferred resolution, and skips immediate numeric validation. Resolution happens at query-execution time via the existing `QueryNode` param-resolution mechanism. `query.c`'s VecSim attribute path is also extended to handle `$param` values for BATCH_SIZE and other pass-through attributes.

3. **Outcome:** Users can now parametrize all five VSIM numeric args via `PARAMS`, e.g.:
   ```
   FT.HYBRID idx SEARCH green VSIM @vec $BLOB KNN 4 K $k EF_RUNTIME $ef PARAMS 6 BLOB <blob> k 5 ef 100
   ```
   The fix is backward-compatible: literal numeric values continue to work exactly as before.

#### Which additional issues this PR fixes
1. MOD-12915

#### Main objects this PR modified
1. `src/hybrid/parse_hybrid.c` — KNN/RANGE arg parsing refactored onto ArgParser with deferred-param support
2. `src/aggregate/aggregate_request.c` — `applyVectorQuery` extended to create `QueryNode` params for K and RADIUS
3. `src/hybrid/vector_query_utils.h/.c` — `ParsedVectorData` gains `kParamName` / `radiusParamName` fields
4. `src/query.c` — VecSim attribute handler recognises `$param` values and sets `needResolve=true`
5. `tests/pytests/test_hybrid_vector.py` — regression test `test_hybrid_vector_params_numeric_args`

---

**Approach B — ArgParser refactor rationale:**
This is the more invasive of the two sibling approaches. The surgical patch (approach A, PR #10037) changes as few lines as possible while fixing the bug. Approach B rewrites the parsing loops onto the existing `ArgParser` infrastructure, which is the stated codebase direction and gives uniform handling of all five params, consistent duplicate-detection, and better extensibility. The tradeoff is a larger diff and more regression surface. Approach C (a shared helper extracted from A and B) is also being produced.

**Sibling PR (approach A — surgical):** https://github.com/RediSearch/RediSearch/pull/10037

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

**User impact:** `FT.HYBRID VSIM` now correctly resolves `$param` placeholders for numeric arguments (K, RADIUS, EF_RUNTIME, EPSILON, BATCH_SIZE) supplied via `PARAMS`. Previously these were rejected with a parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)