### PR TITLE
[MOD-16192] info: obfuscate index name in IndexesInfo lock-acquire warning

### DIFF
--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -34,7 +34,7 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     // Lock for read
     int rc = pthread_rwlock_rdlock(&sp->rwlock);
     if (rc != 0) {
-      RedisModule_Log(RSDummyContext, "warning", "Failed to acquire read lock on index %s: rc=%d (%s). Cannot continue getting Index info", HiddenString_GetUnsafe(sp->specName, NULL), rc, strerror(rc));
+      RedisModule_Log(RSDummyContext, "warning", "Failed to acquire read lock on index %s: rc=%d (%s). Cannot continue getting Index info", IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog), rc, strerror(rc));
       continue;
     }
 


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current:** `IndexesInfo_TotalInfo` (`src/info/indexes_info.c:37`) emits a `warning`-level log on rwlock-acquire failure that formats the index name via `HiddenString_GetUnsafe(sp->specName, NULL)`, which unconditionally returns the real (unobfuscated) name — even when `RSGlobalConfig.hideUserDataFromLog` is enabled.
2. **Change:** Switch the format argument to `IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog)`, matching the scanner (`src/spec.c:2518`, `src/spec.c:2851`) and fork-GC (`src/fork_gc/fork_gc.c:35`) convention.
3. **Outcome:** The warning now respects the user-data hiding config and emits the obfuscated index name when redaction is on. No new includes are needed — `spec.h` already pulls in `config.h`.

#### Which additional issues this PR fixes
1. MOD-16192
2. Relates to MOD-15757 (umbrella for AMR/Azure shard-log redaction; this is one missed site)

#### Main objects this PR modified
1. `src/info/indexes_info.c` — `IndexesInfo_TotalInfo` warning log

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single logging-format change with no behavior change beyond respecting existing redaction config.
> 
> **Overview**
> Fixes a **logging redaction gap** in `IndexesInfo_TotalInfo`: when acquiring a read lock on an index fails, the warning no longer prints the real index name via `HiddenString_GetUnsafe`.
> 
> The log now uses **`IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog)`**, so index names in that message follow the same obfuscation behavior as scanner, fork-GC, and other call sites when user-data hiding is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd610d58f74500657bfd2a6216faf87149939c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->