### PR TITLE
Add /compare-bench-c-vs-rust skill for analyzing criterion benchmark sweeps

### DIFF
--- a/.skills/compare-bench-c-vs-rust/SKILL.md
+++ b/.skills/compare-bench-c-vs-rust/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: compare-bench-c-vs-rust
+description: Analyze a criterion benchmark tree to find where a baseline variant beats the others along a chosen pivot parameter, and group the wins into patterns. Defaults to `lang=C` (baseline) vs `lang=Rust` so the C-vs-Rust port comparison is zero-config, but works for any `*_bencher` crate that sweeps a comparison parameter — and re-pivots onto any other parameter to hunt regressions in that dimension.
+---
+
+# Compare Benchmarks along a Pivot Parameter
+
+Find where a **baseline** variant beats the others across a criterion benchmark sweep, and
+isolate the wins into parameter patterns so you know *which* code path to fix — not just
+that a regression exists.
+
+The comparison axis is a **pivot** parameter. By default the pivot is `lang` and the
+baseline is `C`, so with no extra flags this reproduces the original C-vs-Rust port
+comparison (e.g. `ttl_table_bencher`). Override `--pivot`/`--baseline` to compare any other
+parameter — two implementations (`--pivot impl --baseline old`), two algorithms, etc. When
+the pivot has **more than two values**, the baseline is compared against each other value
+in its own block (N-way).
+
+This works for any `*_bencher` crate whose benchmarks encode the pivot as a `k=v` pair in
+the criterion `value_str` (a `BenchmarkGroup` matrix).
+
+## Arguments
+- (optional) a comma-separated list of criterion bench-group folders to analyze
+  (as shown by `ls bin/redisearch_rs/criterion`, e.g.
+  `add_sequential,verify_doc_and_field_doc_default`). When given, only those groups are
+  analyzed and the rest are ignored. When omitted, every group in the tree is analyzed.
+- (optional) path to the criterion output dir. Default: `bin/redisearch_rs/criterion`.
+- (optional) `--pivot <param>` — the comparison axis (default `lang`).
+- (optional) `--baseline <value>` — the pivot value used as the denominator (default `C`).
+
+Arguments provided: `$ARGUMENTS`
+
+Interpret `$ARGUMENTS`: a token that contains commas or matches a folder name under the
+criterion dir is the **group list** → pass it via `--groups`. A path-like token (contains
+`/` and points at a directory) is the **criterion dir** → pass it as the positional arg.
+A `--pivot`/`--baseline` token is passed straight through. Any may be present; with none,
+the default C-vs-Rust comparison runs.
+
+## Prerequisites
+
+Run the benchmark crate first (see `/run-rust-benchmarks`), e.g.:
+```bash
+cargo bench --manifest-path src/redisearch_rs/Cargo.toml -p ttl_table_bencher
+```
+This populates `bin/redisearch_rs/criterion/<group>/<config>/new/{benchmark.json,estimates.json}`.
+**Do not re-run the bench to "see more"** — analyze the saved tree. If the user says
+the bench is still running, the tree is live; note that numbers may shift and offer to
+re-run the analysis once it finishes.
+
+## Instructions
+
+1. Run the analysis script against the criterion dir. Analyze the whole tree (default
+   pivot `lang`, baseline `C` — the C-vs-Rust comparison):
+   ```bash
+   python3 .skills/compare-bench-c-vs-rust/analyze.py bin/redisearch_rs/criterion --json /tmp/bench_pairs.json
+   ```
+   …or restrict to a subset of bench-group folders with `--groups`:
+   ```bash
+   python3 .skills/compare-bench-c-vs-rust/analyze.py bin/redisearch_rs/criterion \
+     --groups add_sequential,verify_doc_and_field_doc_default --json /tmp/bench_pairs.json
+   ```
+   …or compare along a different pivot — any other `value_str` parameter is fair game,
+   including re-pivoting onto a workload parameter to check for a regression in *that*
+   dimension:
+   ```bash
+   python3 .skills/compare-bench-c-vs-rust/analyze.py bin/redisearch_rs/criterion \
+     --pivot impl --baseline old --json /tmp/bench_pairs.json
+   ```
+   It prints: pair count, win/loss split, a ratio-distribution table per group, the
+   top biggest baseline wins, a per-parameter correlation table, and a **worst-regions
+   scan** that ranks the single dimensions and every *pair* of dimensions where the
+   candidate is slowest (flagging interactions). When the pivot has more than two
+   values, each non-baseline value gets its own comparison block (N-way).
+   `--threshold` (default `1.10`) sets what counts as a "meaningful" baseline win;
+   `--top` controls the win list. A `--groups` folder that does not exist is a hard error
+   listing the available groups; an unknown `--pivot`/`--baseline` errors with the
+   parameter names / pivot values actually present.
+
+2. Read the worst-regions scan and the per-parameter correlation table together to
+   locate the pattern. The metric is **ratio = candidate_ns / baseline_ns**, so **>1
+   means the baseline is faster** (the candidate is worse).
+   - The **worst-regions scan** does the dimension-hunting for you: it ranks every
+     single dimension *and every pair of dimensions* by median ratio, so the top rows
+     are literally "where the candidate is worst". You do **not** need to guess which
+     parameters to cross — the scan already crossed all of them.
+   - A 2-D row flagged `✦` is an **interaction**: the corner is worse than either of
+     its two dimensions alone, so the slowdown is born of the *combination* (e.g.
+     `slot_size=large & pop_count=small`). These are the rows a per-dimension view
+     would miss, so call them out specifically.
+   - Use the per-parameter correlation table to spot **noise dimensions**: a parameter
+     whose every value sits near median **1.00x** does not drive the gap — say so and
+     drop it from the narrative.
+   - Discount sub-microsecond `candidate=...ns` rows in the scan as noise-prone, and
+     cross-check the top rows against the "biggest baseline wins" list to confirm a
+     corner is real and not one noisy point. The most actionable wins usually correlate
+     with a single mechanism (e.g. table growth/resize when initial capacity ≪ element
+     count).
+
+3. To make a flagged 2-D region crisp, render its full heatmap with `grid.py`, passing
+   the `--json` dump from step 1 and the group + the two parameters the scan flagged:
+   ```bash
+   python3 .skills/compare-bench-c-vs-rust/grid.py /tmp/bench_pairs.json add/sequential slot_size pop_count
+   ```
+   It prints a heatmap of median ratios (>1 = baseline faster) over the two parameters —
+   the zoom-in on whatever the worst-regions scan surfaced. For an N-way pivot (more than
+   one candidate), add `--candidate <value>` to pick which non-baseline variant to chart;
+   `grid.py` lists the available candidates if you omit it.
+
+4. Report a concise recap:
+   - headline win/loss split and ratio-distribution table,
+   - one section per *pattern* (not per benchmark), each naming the parameter region
+     (single dimension or flagged interaction from the worst-regions scan), the
+     magnitude (e.g. "3–4.5×"), and the likely mechanism,
+   - flag sub-microsecond absolute timings as noise-prone (small `pop_count` rows
+     often are), and flag noise dimensions,
+   - end with the single most actionable hotspot and offer to dig into that code path.
+
+## Method notes (why the script does what it does)
+
+- **Names come from `new/benchmark.json`** (`group_id` + `value_str`), never folder
+  names — criterion truncates directory names and distinct configs can collide.
+- **Timings come from `mean.point_estimate`** in `new/estimates.json`.
+- **Pairing**: parameters are parsed from `value_str` (`/`-separated `k=v`); variants are
+  matched on *all* parameters except the pivot. The `baseline` pivot value is required for
+  a pairing; every other pivot value present becomes a candidate compared against it
+  (so a pivot with N values yields N-1 candidates). Groups can have different parameter
+  sets (e.g. a `mask` sweep adds `mask`/`expired`/`field_filled_at`) — the script keys
+  per group, so don't hard-code a parameter list.
+- Leaves whose `value_str` lacks the pivot parameter (e.g. criterion group-summary dirs,
+  which have none under the default `lang` pivot) are skipped and counted.
+
+## Scripts
+
+- `analyze.py` — pairs variants along the pivot, prints win/loss split, ratio
+  distribution, biggest baseline wins, per-parameter correlation, and a worst-regions
+  scan that ranks every single dimension and every pair of dimensions by median ratio
+  (flagging `✦` interactions worse than either dimension alone), so the worst direction
+  is surfaced automatically rather than guessed (one block per candidate for an N-way
+  pivot). Flags: `--pivot` (default `lang`), `--baseline` (default `C`), `--groups`,
+  `--threshold`, `--top`, `--json`.
+- `grid.py` — two-parameter heatmap of median ratios from the `--json` dump. Sorts
+  parameter values numerically when possible, lexically otherwise (e.g. bitmasks). The
+  group argument accepts either the `group_id` (`add/sequential`) or its folder form
+  (`add_sequential`); pass `--candidate <value>` when the group has more than one
+  candidate (N-way pivot).

--- a/.skills/compare-bench-c-vs-rust/analyze.py
+++ b/.skills/compare-bench-c-vs-rust/analyze.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Pair criterion benchmark variants along a pivot parameter and report where the
+baseline variant beats the others.
+
+Reads a criterion output tree (default: bin/redisearch_rs/criterion/) and compares the
+variants of a single *pivot* parameter. By default the pivot is `lang` and the baseline
+is `C`, so this reproduces the original C-vs-Rust workflow with zero extra flags. Pass
+`--pivot`/`--baseline` to compare any other parameter (e.g. `--pivot impl --baseline old`).
+
+Benchmarks are paired by their remaining parameters (everything in `value_str` except the
+pivot). For each pairing, the baseline value is the denominator and every other pivot value
+is a *candidate*: the reported ratio is candidate_ns / baseline_ns (>1 means the baseline is
+faster). When the pivot has more than two values, each non-baseline value gets its own
+comparison block (N-way).
+
+Names come from each `new/benchmark.json` (`group_id`, `value_str`); folder names are
+ignored because criterion truncates them and distinct configs can collide. Timings come
+from `mean.point_estimate` in each `new/estimates.json`.
+
+Usage:
+    python3 analyze.py [CRITERION_DIR] [--pivot lang] [--baseline C]
+                       [--groups g1,g2,...] [--threshold 1.10] [--json OUT.json]
+
+`--groups` is a comma-separated list of top-level bench-group folders (as shown by
+`ls CRITERION_DIR`, e.g. `add_sequential,verify_doc_and_field_doc_default`). Only those
+folders are analyzed; the rest are ignored. A requested folder that does not exist is a
+hard error listing the available groups.
+"""
+import argparse
+import glob
+import json
+import os
+import statistics
+from collections import defaultdict
+from itertools import combinations
+
+
+def group_folder(criterion_dir, benchmark_json):
+    """Top-level bench-group folder a leaf lives under (the first `*` in the glob)."""
+    return os.path.relpath(benchmark_json, criterion_dir).split(os.sep)[0]
+
+
+def load_pairs(criterion_dir, pivot, baseline, groups=None):
+    """Return (pairs, skipped_no_pivot, skipped_no_baseline).
+
+    Each pair: dict of the non-pivot params plus `candidate`, `baseline`, `baseline_ns`,
+    `candidate_ns`, `ratio` (candidate_ns / baseline_ns; >1 means the baseline is faster).
+
+    Benchmarks are paired on every `value_str` param except `pivot`. Within a pairing the
+    `baseline` pivot value is the denominator and every other pivot value emits one row.
+
+    If `groups` is a set of top-level folder names, only those folders are analyzed; a
+    requested folder absent from the tree is a hard error listing what is available.
+    """
+    rows = []
+    no_pivot = 0
+    all_param_names = set()
+    pivot_values = set()
+    pattern = os.path.join(criterion_dir, "*", "*", "new", "benchmark.json")
+    leaves = glob.glob(pattern)
+
+    if groups:
+        available = {group_folder(criterion_dir, bj) for bj in leaves}
+        missing = [g for g in groups if g not in available]
+        if missing:
+            raise SystemExit(
+                f"Bench group(s) not found: {', '.join(sorted(missing))}\n"
+                f"Available groups under {criterion_dir!r}: "
+                f"{', '.join(sorted(available)) or '(none)'}")
+
+    for bj in leaves:
+        if groups and group_folder(criterion_dir, bj) not in groups:
+            continue
+        est = os.path.join(os.path.dirname(bj), "estimates.json")
+        if not os.path.exists(est):
+            continue
+        b = json.load(open(bj))
+        e = json.load(open(est))
+        params = dict(p.split("=", 1) for p in b["value_str"].split("/") if "=" in p)
+        all_param_names.update(params)
+        if pivot not in params:
+            no_pivot += 1  # group-summary folder or a leaf that lacks the pivot param
+            continue
+        pivot_values.add(params[pivot])
+        rows.append((b["group_id"], params, e["mean"]["point_estimate"]))
+
+    if not rows:
+        raise SystemExit(
+            f"No benchmark leaf carries a {pivot!r} parameter"
+            + (f" in groups {sorted(groups)}" if groups else "") + ".\n"
+            f"Parameters seen: {', '.join(sorted(all_param_names)) or '(none)'}\n"
+            f"Pass --pivot with one of those (the pivot is the comparison axis).")
+
+    by = defaultdict(dict)
+    for group, params, mean in rows:
+        key = (group, tuple(sorted((k, v) for k, v in params.items() if k != pivot)))
+        by[key][params[pivot]] = mean
+
+    pairs = []
+    no_baseline = 0
+    for (group, kp), d in by.items():
+        if baseline not in d:
+            no_baseline += 1
+            continue
+        base_ns = d[baseline]
+        for pv, mean in d.items():
+            if pv == baseline:
+                continue
+            row = {"group": group, **dict(kp)}
+            row["candidate"] = pv
+            row["baseline"] = baseline
+            row["baseline_ns"] = base_ns
+            row["candidate_ns"] = mean
+            row["ratio"] = mean / base_ns
+            pairs.append(row)
+
+    if not pairs:
+        raise SystemExit(
+            f"Pivot {pivot!r} has values {sorted(pivot_values)} but none could be paired "
+            f"against baseline {baseline!r}.\n"
+            f"Pass --baseline with one of: {', '.join(sorted(pivot_values))}.")
+
+    return pairs, no_pivot, no_baseline
+
+
+# Bookkeeping keys that are never benchmark parameters.
+META_KEYS = {"group", "candidate", "baseline", "baseline_ns", "candidate_ns", "ratio"}
+
+
+def param_names(pairs, group):
+    names = []
+    for p in pairs:
+        if p["group"] != group:
+            continue
+        for k in p:
+            if k not in META_KEYS and k not in names:
+                names.append(k)
+    return names
+
+
+def dist(ratios, baseline, candidate):
+    b = {f"{candidate} faster (<0.95)": 0, "~tie (0.95-1.05)": 0, f"{baseline} win 5-10%": 0,
+         f"{baseline} win 10-25%": 0, f"{baseline} win 25-50%": 0, f"{baseline} win >50%": 0}
+    keys = list(b)
+    for r in ratios:
+        if r < 0.95: b[keys[0]] += 1
+        elif r < 1.05: b[keys[1]] += 1
+        elif r < 1.10: b[keys[2]] += 1
+        elif r < 1.25: b[keys[3]] += 1
+        elif r < 1.50: b[keys[4]] += 1
+        else: b[keys[5]] += 1
+    return b
+
+
+def sortkey(values):
+    """Numeric sort if all values parse as float, else lexical."""
+    try:
+        [float(v) for v in values]
+        return lambda x: float(x)
+    except ValueError:
+        return str
+
+
+def worst_regions(pairs, baseline, candidate, top):
+    """Rank the parameter regions where the candidate is slowest, 1-D and 2-D.
+
+    This is the "which direction is worst" answer: instead of leaving the agent to
+    guess which dimensions to cross, it scans *every* single dimension and *every*
+    pair of dimensions automatically and ranks them by median ratio (candidate_ns /
+    baseline_ns; >1 means the baseline is faster, i.e. the candidate is worse).
+
+    The 2-D block flags **interactions** with `✦` — corners whose median ratio
+    exceeds, by a clear margin, the worse of the two single-dimension medians that
+    make them up. An interaction is a slowdown born of the *combination* of two
+    parameter values, which a per-dimension (marginal) view averages away and
+    misses. Absolute candidate ns is shown so sub-microsecond, noise-prone regions
+    are easy to discount.
+    """
+    groups = sorted({p["group"] for p in pairs})
+
+    # 1-D marginals: (group, param, value) -> [(ratio, candidate_ns), ...]
+    one = defaultdict(list)
+    for p in pairs:
+        for k in param_names(pairs, p["group"]):
+            if k in p:
+                one[(p["group"], k, p[k])].append((p["ratio"], p["candidate_ns"]))
+    med1 = {k: statistics.median([r for r, _ in v]) for k, v in one.items()}
+
+    print(f"\n=== worst regions: single dimension "
+          f"(top {top} by median ratio; >1 = {baseline} faster) ===")
+    for key in sorted(one, key=lambda k: -med1[k])[:top]:
+        g, k, v = key
+        ns = statistics.median([n for _, n in one[key]])
+        print(f"   {med1[key]:5.2f}x  {candidate.lower()}={ns:12.0f}ns  "
+              f"{g}  {k}={v}  n={len(one[key])}")
+
+    # 2-D corners: every pair of dimensions, per group.
+    two = defaultdict(list)  # (group, pa, va, pb, vb) -> [(ratio, candidate_ns), ...]
+    for g in groups:
+        names = param_names(pairs, g)
+        ps = [p for p in pairs if p["group"] == g]
+        for a, b in combinations(names, 2):
+            for p in ps:
+                if a in p and b in p:
+                    two[(g, a, p[a], b, p[b])].append((p["ratio"], p["candidate_ns"]))
+    if not two:
+        return  # groups have <2 non-pivot params; nothing to cross
+
+    med2 = {k: statistics.median([r for r, _ in v]) for k, v in two.items()}
+    print(f"\n=== worst regions: dimension pairs "
+          f"(top {top} by median ratio; ✦ = interaction, worse than either dim alone) ===")
+    for key in sorted(two, key=lambda k: -med2[k])[:top]:
+        g, a, va, b, vb = key
+        m, ma, mb = med2[key], med1[(g, a, va)], med1[(g, b, vb)]
+        ns = statistics.median([n for _, n in two[key]])
+        flag = "  ✦" if m > max(ma, mb) * 1.10 else ""
+        print(f"   {m:5.2f}x  {candidate.lower()}={ns:12.0f}ns  {g}  "
+              f"{a}={va} & {b}={vb}  (alone: {a}={ma:.2f}x {b}={mb:.2f}x)  "
+              f"n={len(two[key])}{flag}")
+
+
+def print_blocks(pairs, baseline, candidate, threshold, top):
+    """Distribution, biggest wins, and per-parameter correlation for one candidate."""
+    groups = sorted({p["group"] for p in pairs})
+    cwins = [p for p in pairs if p["ratio"] > 1.0]
+    pct = 100 * len(cwins) / len(pairs)
+    print(f"{baseline} faster: {len(cwins)} ({pct:.0f}%)  |  "
+          f"{candidate} faster-or-tied: {len(pairs)-len(cwins)}")
+
+    print(f"\n=== ratio distribution ({candidate.lower()}/{baseline.lower()}; "
+          f">1 = {baseline} faster) ===")
+    overall = dist([p["ratio"] for p in pairs], baseline, candidate)
+    print(f"{'OVERALL':>40} | " + " ".join(f"{k}={v}" for k, v in overall.items()))
+    for g in groups:
+        rs = [p["ratio"] for p in pairs if p["group"] == g]
+        print(f"{g:>40} | " + " ".join(f"{k}={v}" for k, v in dist(rs, baseline, candidate).items()))
+
+    print(f"\n=== top {top} biggest {baseline} wins ===")
+    bl, cl = baseline.lower(), candidate.lower()
+    for p in sorted(pairs, key=lambda x: -x["ratio"])[:top]:
+        extra = " ".join(f"{k}={p[k]}" for k in param_names(pairs, p["group"]))
+        print(f"   {p['ratio']:5.2f}x  {bl}={p['baseline_ns']:12.0f} "
+              f"{cl}={p['candidate_ns']:12.0f}  {p['group']}  {extra}")
+
+    print(f"\n=== per-parameter correlation (median ratio, % meaningful {baseline}-wins) ===")
+    for g in groups:
+        ps = [p for p in pairs if p["group"] == g]
+        print(f"\n{g}  (n={len(ps)})")
+        for param in param_names(pairs, g):
+            d = defaultdict(list)
+            for p in ps:
+                d[p[param]].append(p["ratio"])
+            if len(d) < 2:
+                continue  # constant param, no signal
+            print(f"  by {param}:")
+            for v in sorted(d, key=sortkey(d.keys())):
+                rsv = d[v]
+                cwin = 100 * sum(1 for r in rsv if r >= threshold) / len(rsv)
+                print(f"     {param}={v:>14}: median={statistics.median(rsv):5.2f}x  "
+                      f"{baseline}-wins(>={threshold})={cwin:3.0f}%  n={len(rsv)}")
+
+    worst_regions(pairs, baseline, candidate, top)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("criterion_dir", nargs="?",
+                    default="bin/redisearch_rs/criterion")
+    ap.add_argument("--pivot", default="lang",
+                    help="the value_str parameter that is the comparison axis "
+                         "(default: lang)")
+    ap.add_argument("--baseline", default="C",
+                    help="the pivot value used as the denominator; every other pivot "
+                         "value is compared against it (default: C)")
+    ap.add_argument("--groups",
+                    help="comma-separated top-level bench-group folders to analyze "
+                         "(e.g. add_sequential,verify_doc_and_field_doc_default); "
+                         "other folders are ignored")
+    ap.add_argument("--threshold", type=float, default=1.10,
+                    help="ratio at/above which a baseline win counts as 'meaningful'")
+    ap.add_argument("--json", help="dump the raw pairs to this path")
+    ap.add_argument("--top", type=int, default=15,
+                    help="how many biggest baseline wins to list")
+    args = ap.parse_args()
+
+    groups = {g.strip() for g in args.groups.split(",") if g.strip()} if args.groups else None
+    pairs, no_pivot, no_baseline = load_pairs(
+        args.criterion_dir, args.pivot, args.baseline, groups)
+    if args.json:
+        json.dump(pairs, open(args.json, "w"))
+
+    candidates = sorted({p["candidate"] for p in pairs}, key=sortkey({p["candidate"] for p in pairs}))
+    skip_note = f"skipped {no_pivot} leaves without {args.pivot!r}"
+    if no_baseline:
+        skip_note += f", {no_baseline} pairings lacking a {args.baseline!r} sample"
+    print(f"Pairs: {len(pairs)}  (pivot={args.pivot!r} baseline={args.baseline!r}; {skip_note})")
+
+    if len(candidates) == 1:
+        print_blocks(pairs, args.baseline, candidates[0], args.threshold, args.top)
+    else:
+        print(f"Candidates vs baseline {args.baseline!r}: {', '.join(candidates)}")
+        for cand in candidates:
+            cps = [p for p in pairs if p["candidate"] == cand]
+            print(f"\n########## candidate = {cand}  (vs baseline {args.baseline}) ##########")
+            print_blocks(cps, args.baseline, cand, args.threshold, args.top)
+
+    print("\nHint: parameters whose every value sits near median 1.00x are noise "
+          f"dimensions for the {args.baseline}-vs-candidate gap; the ones that swing the "
+          "median locate the win. Re-run with a different --pivot to check other dimensions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/compare-bench-c-vs-rust/grid.py
+++ b/.skills/compare-bench-c-vs-rust/grid.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Two-parameter heatmap of median baseline-vs-candidate ratios for one benchmark group.
+
+Reads the raw pairs dumped by `analyze.py --json` and prints a grid of median ratios
+(candidate_ns / baseline_ns; >1 means the baseline is faster) over two chosen parameters.
+
+When the group was analyzed with a pivot that has more than two values, it contains
+several candidates; pass `--candidate` to pick which one to chart.
+
+Usage:
+    python3 grid.py PAIRS.json GROUP ROW_PARAM COL_PARAM [--candidate VALUE]
+Example:
+    python3 analyze.py --json /tmp/bench_pairs.json
+    python3 grid.py /tmp/bench_pairs.json add/sequential slot_size pop_count
+"""
+import argparse
+import json
+import statistics
+from collections import defaultdict
+
+META_KEYS = {"group", "candidate", "baseline", "baseline_ns", "candidate_ns", "ratio"}
+
+
+def sortkey(values):
+    """Numeric sort if all values parse as float, else lexical."""
+    try:
+        [float(v) for v in values]
+        return float
+    except ValueError:
+        return str
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pairs_json", help="output of `analyze.py --json`")
+    ap.add_argument("group", help="benchmark group, either group_id (add/sequential) "
+                                  "or its folder form (add_sequential)")
+    ap.add_argument("row_param")
+    ap.add_argument("col_param")
+    ap.add_argument("--candidate",
+                    help="which non-baseline pivot value to chart (required only when the "
+                         "group has more than one candidate)")
+    args = ap.parse_args()
+
+    # Accept either the group_id (`add/sequential`) stored in the dump or the folder
+    # form (`add_sequential`) the user sees via `ls` and passes to `analyze.py --groups`.
+    all_pairs = json.load(open(args.pairs_json))
+    pairs = [p for p in all_pairs
+             if args.group in (p["group"], p["group"].replace("/", "_"))]
+    if not pairs:
+        groups = sorted({p["group"] for p in all_pairs})
+        raise SystemExit(f"No pairs for group {args.group!r} in {args.pairs_json!r}. "
+                         f"Available: {', '.join(groups) or '(none)'}")
+
+    candidates = sorted({p["candidate"] for p in pairs}, key=sortkey({p["candidate"] for p in pairs}))
+    if args.candidate:
+        if args.candidate not in candidates:
+            raise SystemExit(f"Candidate {args.candidate!r} not in group {args.group!r}. "
+                             f"Available: {', '.join(candidates)}")
+        candidate = args.candidate
+    elif len(candidates) == 1:
+        candidate = candidates[0]
+    else:
+        raise SystemExit(f"Group {args.group!r} has multiple candidates: "
+                         f"{', '.join(candidates)}. Pass --candidate to pick one.")
+    pairs = [p for p in pairs if p["candidate"] == candidate]
+    baseline = pairs[0]["baseline"]
+
+    for param in (args.row_param, args.col_param):
+        if param not in pairs[0]:
+            raise SystemExit(f"Parameter {param!r} not found. Available: "
+                             f"{sorted(k for k in pairs[0] if k not in META_KEYS)}")
+
+    rows = sorted({p[args.row_param] for p in pairs}, key=sortkey({p[args.row_param] for p in pairs}))
+    cols = sorted({p[args.col_param] for p in pairs}, key=sortkey({p[args.col_param] for p in pairs}))
+    d = defaultdict(list)
+    for p in pairs:
+        d[(p[args.row_param], p[args.col_param])].append(p["ratio"])
+
+    label = f"{args.row_param} \\ {args.col_param}"
+    print(f"{args.group} — median ratio {candidate.lower()}/{baseline.lower()}  "
+          f"(>1 = {baseline} faster)")
+    print(f"{label:>18}|" + "".join(f"{c:>12}" for c in cols))
+    for r in rows:
+        cells = "".join(
+            f"{statistics.median(d[(r, c)]):>12.2f}" if d.get((r, c)) else f"{'-':>12}"
+            for c in cols)
+        print(f"{r:>18}|" + cells)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Describe the changes in the pull request
Adds a coding-agent skill, `/compare-bench-c-vs-rust`, that analyzes a [criterion](https://github.com/bheisler/criterion.rs) benchmark tree and reports where one implementation variant beats another, grouping the wins into parameter patterns — so you learn *which* code path regressed, not just *that* a regression exists.

### Motivation

When porting a C module to Rust (e.g. `ttl_table`), the `*_bencher` crates sweep a large parameter matrix and emit a deep `criterion/` tree. Eyeballing that output to find where the Rust port still trails C is tedious and easy to get wrong: a single noisy sub-microsecond point looks like a regression, and the real hotspot is usually confined to one corner of the parameter space. This skill automates the pairing, ranking, and correlation.

### What it does

The comparison axis is a configurable **pivot** parameter:

- **Zero-config C-vs-Rust**: defaults to `--pivot lang --baseline C`, so it directly compares `lang=C` vs `lang=Rust` variants of any `*_bencher` crate (e.g. `ttl_table_bencher`).
- **Any pivot**: override `--pivot`/`--baseline` to compare any `value_str` parameter — two implementations, two algorithms, or *re-pivot onto a workload parameter* to check whether a regression lives in that dimension.
- **N-way**: when a pivot has more than two values, the baseline is compared against each other value in its own block.

### What's included

- `SKILL.md` — the skill instructions and method notes.
- `analyze.py` — pairs variants along the pivot and prints the win/loss split, a ratio-distribution table, the biggest baseline wins, and a per-parameter correlation table that locates the hotspot. Flags: `--pivot`, `--baseline`, `--groups`, `--threshold`, `--top`, `--json`.
- `grid.py` — a two-parameter heatmap of median ratios from the `--json` dump (`--candidate` selects the variant for an N-way pivot).

### Scope

Internal tooling only — no product/runtime code, build, or test changes; nothing user-facing.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
