### PR TITLE
[MOD-14980] Improve ttl_table performance

### DIFF
--- a/src/redisearch_rs/headers/ttl_table_rs.h
+++ b/src/redisearch_rs/headers/ttl_table_rs.h
@@ -37,28 +37,17 @@ typedef struct FieldExpiration {
   t_expirationTimePoint point;
 } FieldExpiration;
 
-#ifndef THINVEC_FIELDEXPIRATION__U32_DEFINED
-#define THINVEC_FIELDEXPIRATION__U32_DEFINED
+#ifndef THINVEC_FIELDEXPIRATION__ALIGNEDU32_DEFINED
+#define THINVEC_FIELDEXPIRATION__ALIGNEDU32_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_FieldExpiration__u32 {
-  struct Header_u32 *ptr;
-} ThinVec_FieldExpiration__u32;
-#endif /* THINVEC_FIELDEXPIRATION__U32_DEFINED */
-
-#ifndef MEDIUMTHINVEC_FIELDEXPIRATION_DEFINED
-#define MEDIUMTHINVEC_FIELDEXPIRATION_DEFINED
-/**
- * A [`ThinVec`] with `u32` capacity, supporting up to ~4 billion elements.
- *
- * This is useful when you want a balance between capacity and header size
- * (8 bytes instead of 16).
- */
-typedef struct ThinVec_FieldExpiration__u32 MediumThinVec_FieldExpiration;
-#endif /* MEDIUMTHINVEC_FIELDEXPIRATION_DEFINED */
+typedef struct ThinVec_FieldExpiration__AlignedU32 {
+  struct Header_AlignedU32 *ptr;
+} ThinVec_FieldExpiration__AlignedU32;
+#endif /* THINVEC_FIELDEXPIRATION__ALIGNEDU32_DEFINED */
 
 /**
  * An ascending-by-`index`, duplicate-free list of [`FieldExpiration`] entries.
  */
-typedef MediumThinVec_FieldExpiration FieldExpirations;
+typedef struct ThinVec_FieldExpiration__AlignedU32 FieldExpirations;

--- a/src/redisearch_rs/thin_vec/src/capacity.rs
+++ b/src/redisearch_rs/thin_vec/src/capacity.rs
@@ -2,11 +2,17 @@ use crate::Header;
 
 /// Private module to seal the [`VecCapacity`] trait.
 mod private {
+    use super::{AlignedU8, AlignedU16, AlignedU32, AlignedU64};
+
     pub trait Sealed {}
     impl Sealed for u8 {}
     impl Sealed for u16 {}
     impl Sealed for u32 {}
     impl Sealed for u64 {}
+    impl Sealed for AlignedU8 {}
+    impl Sealed for AlignedU16 {}
+    impl Sealed for AlignedU32 {}
+    impl Sealed for AlignedU64 {}
 }
 
 /// Trait for types that can be used as the size/capacity type for [`ThinVec`](crate::ThinVec).
@@ -24,6 +30,25 @@ pub trait VecCapacity:
     /// A human-readable name for this type, used in panic messages.
     const TYPE_NAME: &'static str;
 
+    /// The guaranteed alignment of the storage backing [`Self::EMPTY_HEADER`].
+    ///
+    /// One-past-the-end of the empty-header singleton is a validly-aligned data
+    /// pointer for any element type `T` whose alignment does not exceed
+    /// `SINGLETON_ALIGN` (provided no header padding is needed, i.e.
+    /// `header_field_padding::<T, Self>() == 0`). This lets
+    /// [`ThinVec::data_raw`](crate::ThinVec) elide its per-access empty-singleton
+    /// alignment guard for such types (see
+    /// [`data_ptr_guard_elided`](crate::data_ptr_guard_elided)).
+    ///
+    /// The primitive capacity types (`u8`/`u16`/`u32`/`u64`) use their *natural*
+    /// header alignment (`align_of::<Header<Self>>()`), so they are unaligned by
+    /// default. The opt-in [`AlignedU8`]/[`AlignedU16`]/[`AlignedU32`]/[`AlignedU64`]
+    /// newtypes instead over-align the singleton to the full header size
+    /// (`size_of::<Header<Self>>()`), widening the set of `T` for which the guard
+    /// can be elided — useful for e.g. a `u32`-capacity vector of 8-byte-aligned
+    /// records, whose natural header alignment is only 4.
+    const SINGLETON_ALIGN: usize;
+
     /// Reference to a static empty header for this size type.
     const EMPTY_HEADER: &'static Header<Self>;
 
@@ -34,6 +59,10 @@ pub trait VecCapacity:
     fn to_usize(self) -> usize;
 }
 
+// The empty-header singletons for the primitive capacity types use their
+// natural alignment (`align_of::<Header<S>>()`), matching the unaligned-by-default
+// behaviour. The opt-in `AlignedU*` newtypes (defined further down) instead back
+// their singletons with over-aligned wrapper structs.
 static EMPTY_U8: Header<u8> = Header::for_capacity(0);
 static EMPTY_U16: Header<u16> = Header::for_capacity(0);
 static EMPTY_U32: Header<u32> = Header::for_capacity(0);
@@ -43,6 +72,7 @@ impl VecCapacity for u8 {
     const MAX: Self = u8::MAX;
     const ZERO: Self = 0;
     const TYPE_NAME: &'static str = "8-bit";
+    const SINGLETON_ALIGN: usize = std::mem::align_of::<Header<Self>>();
     const EMPTY_HEADER: &'static Header<Self> = &EMPTY_U8;
 
     #[inline]
@@ -66,6 +96,7 @@ impl VecCapacity for u16 {
     const MAX: Self = u16::MAX;
     const ZERO: Self = 0;
     const TYPE_NAME: &'static str = "16-bit";
+    const SINGLETON_ALIGN: usize = std::mem::align_of::<Header<Self>>();
     const EMPTY_HEADER: &'static Header<Self> = &EMPTY_U16;
 
     #[inline]
@@ -89,6 +120,7 @@ impl VecCapacity for u32 {
     const MAX: Self = u32::MAX;
     const ZERO: Self = 0;
     const TYPE_NAME: &'static str = "32-bit";
+    const SINGLETON_ALIGN: usize = std::mem::align_of::<Header<Self>>();
     const EMPTY_HEADER: &'static Header<Self> = &EMPTY_U32;
 
     #[inline]
@@ -112,6 +144,7 @@ impl VecCapacity for u64 {
     const MAX: Self = u64::MAX;
     const ZERO: Self = 0;
     const TYPE_NAME: &'static str = "64-bit";
+    const SINGLETON_ALIGN: usize = std::mem::align_of::<Header<Self>>();
     const EMPTY_HEADER: &'static Header<Self> = &EMPTY_U64;
 
     #[inline]
@@ -126,5 +159,233 @@ impl VecCapacity for u64 {
         // On 32-bit platforms, this could truncate, but in practice
         // we never store more than usize::MAX elements.
         self as usize
+    }
+}
+
+// Opt-in, over-aligned capacity types.
+//
+// Each is a `#[repr(transparent)]` newtype over the matching primitive, so
+// `Header<AlignedU*>` is byte-identical to `Header<u*>` and switching a vector
+// between them is ABI-compatible. The difference is that their empty-header
+// singleton is backed by an over-aligned wrapper struct (aligned to the full
+// header size, not just the natural header alignment), and `SINGLETON_ALIGN`
+// reports that larger alignment. This lets [`ThinVec::data_raw`](crate::ThinVec)
+// elide its empty-singleton alignment guard for more element types — see
+// [`data_ptr_guard_elided`](crate::data_ptr_guard_elided).
+//
+// The `align` literal on each wrapper must equal `size_of::<Header<S>>()`
+// (`2 * size_of::<S>`); the `aligned_singleton_alignment_matches_header_size`
+// test enforces this.
+
+/// A `u8` capacity type whose empty-header singleton is over-aligned to the full
+/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
+/// for more element types than plain `u8`.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AlignedU8(u8);
+
+/// A `u16` capacity type whose empty-header singleton is over-aligned to the full
+/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
+/// for more element types than plain `u16`.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AlignedU16(u16);
+
+/// A `u32` capacity type whose empty-header singleton is over-aligned to the full
+/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
+/// for more element types than plain `u32` — notably 8-byte-aligned records,
+/// whose natural `u32` header alignment is only 4.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AlignedU32(u32);
+
+/// A `u64` capacity type whose empty-header singleton is over-aligned to the full
+/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
+/// for more element types than plain `u64` (e.g. 16-byte-aligned records).
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AlignedU64(u64);
+
+#[repr(C, align(2))]
+struct AlignedEmptyU8(Header<AlignedU8>);
+#[repr(C, align(4))]
+struct AlignedEmptyU16(Header<AlignedU16>);
+#[repr(C, align(8))]
+struct AlignedEmptyU32(Header<AlignedU32>);
+#[repr(C, align(16))]
+struct AlignedEmptyU64(Header<AlignedU64>);
+
+static EMPTY_ALIGNED_U8: AlignedEmptyU8 = AlignedEmptyU8(Header::for_capacity(AlignedU8(0)));
+static EMPTY_ALIGNED_U16: AlignedEmptyU16 = AlignedEmptyU16(Header::for_capacity(AlignedU16(0)));
+static EMPTY_ALIGNED_U32: AlignedEmptyU32 = AlignedEmptyU32(Header::for_capacity(AlignedU32(0)));
+static EMPTY_ALIGNED_U64: AlignedEmptyU64 = AlignedEmptyU64(Header::for_capacity(AlignedU64(0)));
+
+impl VecCapacity for AlignedU8 {
+    const MAX: Self = AlignedU8(u8::MAX);
+    const ZERO: Self = AlignedU8(0);
+    const TYPE_NAME: &'static str = "8-bit (aligned)";
+    const SINGLETON_ALIGN: usize = std::mem::size_of::<Header<Self>>();
+    const EMPTY_HEADER: &'static Header<Self> = &EMPTY_ALIGNED_U8.0;
+
+    #[inline]
+    fn from_usize(val: usize) -> Self {
+        if val > u8::MAX as usize {
+            panic!(
+                "ThinVec size may not exceed the capacity of an {} sized int",
+                Self::TYPE_NAME
+            );
+        }
+        AlignedU8(val as u8)
+    }
+
+    #[inline]
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl VecCapacity for AlignedU16 {
+    const MAX: Self = AlignedU16(u16::MAX);
+    const ZERO: Self = AlignedU16(0);
+    const TYPE_NAME: &'static str = "16-bit (aligned)";
+    const SINGLETON_ALIGN: usize = std::mem::size_of::<Header<Self>>();
+    const EMPTY_HEADER: &'static Header<Self> = &EMPTY_ALIGNED_U16.0;
+
+    #[inline]
+    fn from_usize(val: usize) -> Self {
+        if val > u16::MAX as usize {
+            panic!(
+                "ThinVec size may not exceed the capacity of a {} sized int",
+                Self::TYPE_NAME
+            );
+        }
+        AlignedU16(val as u16)
+    }
+
+    #[inline]
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl VecCapacity for AlignedU32 {
+    const MAX: Self = AlignedU32(u32::MAX);
+    const ZERO: Self = AlignedU32(0);
+    const TYPE_NAME: &'static str = "32-bit (aligned)";
+    const SINGLETON_ALIGN: usize = std::mem::size_of::<Header<Self>>();
+    const EMPTY_HEADER: &'static Header<Self> = &EMPTY_ALIGNED_U32.0;
+
+    #[inline]
+    fn from_usize(val: usize) -> Self {
+        if val > u32::MAX as usize {
+            panic!(
+                "ThinVec size may not exceed the capacity of a {} sized int",
+                Self::TYPE_NAME
+            );
+        }
+        AlignedU32(val as u32)
+    }
+
+    #[inline]
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl VecCapacity for AlignedU64 {
+    const MAX: Self = AlignedU64(u64::MAX);
+    const ZERO: Self = AlignedU64(0);
+    const TYPE_NAME: &'static str = "64-bit (aligned)";
+    const SINGLETON_ALIGN: usize = std::mem::size_of::<Header<Self>>();
+    const EMPTY_HEADER: &'static Header<Self> = &EMPTY_ALIGNED_U64.0;
+
+    #[inline]
+    fn from_usize(val: usize) -> Self {
+        // On 64-bit platforms, usize::MAX == u64::MAX, so no overflow check needed.
+        // On 32-bit platforms, usize fits in u64.
+        AlignedU64(val as u64)
+    }
+
+    #[inline]
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, size_of};
+
+    /// The runtime address of the empty-header singleton must honour
+    /// `SINGLETON_ALIGN`, so that one-past-the-end (`addr + header_size`) is a
+    /// validly-aligned data pointer for the element types whose guard
+    /// `data_ptr_guard_elided` elides. If this drifts, the guard could be
+    /// wrongly elided, producing a misaligned data pointer. (`align_of_val`
+    /// can't be used here: it reports the *pointee type's* declared alignment,
+    /// erasing any `#[repr(align(N))]` wrapper.)
+    fn check_runtime_alignment<S: VecCapacity>() {
+        let addr = S::EMPTY_HEADER as *const Header<S> as usize;
+        assert!(
+            addr.is_multiple_of(S::SINGLETON_ALIGN),
+            "empty-header singleton for {} is not aligned to SINGLETON_ALIGN ({}) at runtime",
+            S::TYPE_NAME,
+            S::SINGLETON_ALIGN,
+        );
+    }
+
+    /// The primitive capacity types are unaligned by default: their singleton
+    /// uses the *natural* header alignment.
+    fn check_natural<S: VecCapacity>() {
+        assert_eq!(
+            S::SINGLETON_ALIGN,
+            align_of::<Header<S>>(),
+            "SINGLETON_ALIGN ({}) must equal align_of::<Header<{}>>() ({})",
+            S::SINGLETON_ALIGN,
+            S::TYPE_NAME,
+            align_of::<Header<S>>(),
+        );
+        check_runtime_alignment::<S>();
+    }
+
+    /// The opt-in `AlignedU*` types over-align their singleton to the full
+    /// header size.
+    fn check_aligned<S: VecCapacity>() {
+        assert_eq!(
+            S::SINGLETON_ALIGN,
+            size_of::<Header<S>>(),
+            "SINGLETON_ALIGN ({}) must equal size_of::<Header<{}>>() ({})",
+            S::SINGLETON_ALIGN,
+            S::TYPE_NAME,
+            size_of::<Header<S>>(),
+        );
+        check_runtime_alignment::<S>();
+    }
+
+    #[test]
+    fn primitive_singleton_uses_natural_alignment() {
+        check_natural::<u8>();
+        check_natural::<u16>();
+        check_natural::<u32>();
+        check_natural::<u64>();
+    }
+
+    #[test]
+    fn aligned_singleton_alignment_matches_header_size() {
+        check_aligned::<AlignedU8>();
+        check_aligned::<AlignedU16>();
+        check_aligned::<AlignedU32>();
+        check_aligned::<AlignedU64>();
+    }
+
+    /// Pins the opt-in semantics: for an 8-byte-aligned element, plain `u32`
+    /// keeps the empty-singleton guard (natural header alignment is only 4),
+    /// while `AlignedU32` over-aligns the singleton and elides it.
+    #[test]
+    fn aligned_variant_widens_guard_elision() {
+        use crate::data_ptr_guard_elided;
+
+        assert!(!data_ptr_guard_elided::<[u64; 1], u32>());
+        assert!(data_ptr_guard_elided::<[u64; 1], AlignedU32>());
     }
 }

--- a/src/redisearch_rs/thin_vec/src/capacity.rs
+++ b/src/redisearch_rs/thin_vec/src/capacity.rs
@@ -146,9 +146,9 @@ impl VecCapacity for u64 {
 //
 // Each `Header<AlignedU*>` is byte-identical to `Header<u*>`.
 // The `EMPTY_ALIGNED_*` singletons are aligned to the full header size (rather than
-// just the header's natural alignment), so [`ThinVec::data_raw`](crate::ThinVec)
-// elides its empty-singleton alignment guard for more element types — see
-// [`data_ptr_guard_elided`](crate::data_ptr_guard_elided).
+// just the header's natural alignment), reported via [`SINGLETON_ALIGN`](VecCapacity::SINGLETON_ALIGN),
+// so [`ThinVec::data_raw`](crate::ThinVec) elides its empty-singleton alignment
+// guard for more element types.
 
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/redisearch_rs/thin_vec/src/capacity.rs
+++ b/src/redisearch_rs/thin_vec/src/capacity.rs
@@ -30,23 +30,7 @@ pub trait VecCapacity:
     /// A human-readable name for this type, used in panic messages.
     const TYPE_NAME: &'static str;
 
-    /// The guaranteed alignment of the storage backing [`Self::EMPTY_HEADER`].
-    ///
-    /// One-past-the-end of the empty-header singleton is a validly-aligned data
-    /// pointer for any element type `T` whose alignment does not exceed
-    /// `SINGLETON_ALIGN` (provided no header padding is needed, i.e.
-    /// `header_field_padding::<T, Self>() == 0`). This lets
-    /// [`ThinVec::data_raw`](crate::ThinVec) elide its per-access empty-singleton
-    /// alignment guard for such types (see
-    /// [`data_ptr_guard_elided`](crate::data_ptr_guard_elided)).
-    ///
-    /// The primitive capacity types (`u8`/`u16`/`u32`/`u64`) use their *natural*
-    /// header alignment (`align_of::<Header<Self>>()`), so they are unaligned by
-    /// default. The opt-in [`AlignedU8`]/[`AlignedU16`]/[`AlignedU32`]/[`AlignedU64`]
-    /// newtypes instead over-align the singleton to the full header size
-    /// (`size_of::<Header<Self>>()`), widening the set of `T` for which the guard
-    /// can be elided — useful for e.g. a `u32`-capacity vector of 8-byte-aligned
-    /// records, whose natural header alignment is only 4.
+    /// The alignment of the [`Self::EMPTY_HEADER`] singleton's storage.
     const SINGLETON_ALIGN: usize;
 
     /// Reference to a static empty header for this size type.
@@ -59,10 +43,6 @@ pub trait VecCapacity:
     fn to_usize(self) -> usize;
 }
 
-// The empty-header singletons for the primitive capacity types use their
-// natural alignment (`align_of::<Header<S>>()`), matching the unaligned-by-default
-// behaviour. The opt-in `AlignedU*` newtypes (defined further down) instead back
-// their singletons with over-aligned wrapper structs.
 static EMPTY_U8: Header<u8> = Header::for_capacity(0);
 static EMPTY_U16: Header<u16> = Header::for_capacity(0);
 static EMPTY_U32: Header<u32> = Header::for_capacity(0);
@@ -162,46 +142,26 @@ impl VecCapacity for u64 {
     }
 }
 
-// Opt-in, over-aligned capacity types.
+// Aligned capacity types.
 //
-// Each is a `#[repr(transparent)]` newtype over the matching primitive, so
-// `Header<AlignedU*>` is byte-identical to `Header<u*>` and switching a vector
-// between them is ABI-compatible. The difference is that their empty-header
-// singleton is backed by an over-aligned wrapper struct (aligned to the full
-// header size, not just the natural header alignment), and `SINGLETON_ALIGN`
-// reports that larger alignment. This lets [`ThinVec::data_raw`](crate::ThinVec)
-// elide its empty-singleton alignment guard for more element types — see
+// Each `Header<AlignedU*>` is byte-identical to `Header<u*>`.
+// The `EMPTY_ALIGNED_*` singletons are aligned to the full header size (rather than
+// just the header's natural alignment), so [`ThinVec::data_raw`](crate::ThinVec)
+// elides its empty-singleton alignment guard for more element types — see
 // [`data_ptr_guard_elided`](crate::data_ptr_guard_elided).
-//
-// The `align` literal on each wrapper must equal `size_of::<Header<S>>()`
-// (`2 * size_of::<S>`); the `aligned_singleton_alignment_matches_header_size`
-// test enforces this.
 
-/// A `u8` capacity type whose empty-header singleton is over-aligned to the full
-/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
-/// for more element types than plain `u8`.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlignedU8(u8);
 
-/// A `u16` capacity type whose empty-header singleton is over-aligned to the full
-/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
-/// for more element types than plain `u16`.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlignedU16(u16);
 
-/// A `u32` capacity type whose empty-header singleton is over-aligned to the full
-/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
-/// for more element types than plain `u32` — notably 8-byte-aligned records,
-/// whose natural `u32` header alignment is only 4.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlignedU32(u32);
 
-/// A `u64` capacity type whose empty-header singleton is over-aligned to the full
-/// header size, so [`data_ptr_guard_elided`](crate::data_ptr_guard_elided) holds
-/// for more element types than plain `u64` (e.g. 16-byte-aligned records).
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlignedU64(u64);
@@ -309,83 +269,5 @@ impl VecCapacity for AlignedU64 {
     #[inline]
     fn to_usize(self) -> usize {
         self.0 as usize
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::mem::{align_of, size_of};
-
-    /// The runtime address of the empty-header singleton must honour
-    /// `SINGLETON_ALIGN`, so that one-past-the-end (`addr + header_size`) is a
-    /// validly-aligned data pointer for the element types whose guard
-    /// `data_ptr_guard_elided` elides. If this drifts, the guard could be
-    /// wrongly elided, producing a misaligned data pointer. (`align_of_val`
-    /// can't be used here: it reports the *pointee type's* declared alignment,
-    /// erasing any `#[repr(align(N))]` wrapper.)
-    fn check_runtime_alignment<S: VecCapacity>() {
-        let addr = S::EMPTY_HEADER as *const Header<S> as usize;
-        assert!(
-            addr.is_multiple_of(S::SINGLETON_ALIGN),
-            "empty-header singleton for {} is not aligned to SINGLETON_ALIGN ({}) at runtime",
-            S::TYPE_NAME,
-            S::SINGLETON_ALIGN,
-        );
-    }
-
-    /// The primitive capacity types are unaligned by default: their singleton
-    /// uses the *natural* header alignment.
-    fn check_natural<S: VecCapacity>() {
-        assert_eq!(
-            S::SINGLETON_ALIGN,
-            align_of::<Header<S>>(),
-            "SINGLETON_ALIGN ({}) must equal align_of::<Header<{}>>() ({})",
-            S::SINGLETON_ALIGN,
-            S::TYPE_NAME,
-            align_of::<Header<S>>(),
-        );
-        check_runtime_alignment::<S>();
-    }
-
-    /// The opt-in `AlignedU*` types over-align their singleton to the full
-    /// header size.
-    fn check_aligned<S: VecCapacity>() {
-        assert_eq!(
-            S::SINGLETON_ALIGN,
-            size_of::<Header<S>>(),
-            "SINGLETON_ALIGN ({}) must equal size_of::<Header<{}>>() ({})",
-            S::SINGLETON_ALIGN,
-            S::TYPE_NAME,
-            size_of::<Header<S>>(),
-        );
-        check_runtime_alignment::<S>();
-    }
-
-    #[test]
-    fn primitive_singleton_uses_natural_alignment() {
-        check_natural::<u8>();
-        check_natural::<u16>();
-        check_natural::<u32>();
-        check_natural::<u64>();
-    }
-
-    #[test]
-    fn aligned_singleton_alignment_matches_header_size() {
-        check_aligned::<AlignedU8>();
-        check_aligned::<AlignedU16>();
-        check_aligned::<AlignedU32>();
-        check_aligned::<AlignedU64>();
-    }
-
-    /// Pins the opt-in semantics: for an 8-byte-aligned element, plain `u32`
-    /// keeps the empty-singleton guard (natural header alignment is only 4),
-    /// while `AlignedU32` over-aligns the singleton and elides it.
-    #[test]
-    fn aligned_variant_widens_guard_elision() {
-        use crate::data_ptr_guard_elided;
-
-        assert!(!data_ptr_guard_elided::<[u64; 1], u32>());
-        assert!(data_ptr_guard_elided::<[u64; 1], AlignedU32>());
     }
 }

--- a/src/redisearch_rs/thin_vec/src/lib.rs
+++ b/src/redisearch_rs/thin_vec/src/lib.rs
@@ -102,33 +102,22 @@ pub mod layout;
 pub use capacity::{AlignedU8, AlignedU16, AlignedU32, AlignedU64, VecCapacity};
 pub use header::Header;
 
-/// Returns `true` when `ThinVec<T, S>`'s data-pointer computation needs no
-/// runtime empty-singleton alignment guard — i.e. element accesses
-/// ([`as_slice`](ThinVec::as_slice), iteration, indexing, …) compile to a
-/// branch-free offset from the header pointer with no `capacity == 0` check.
+/// Returns `true` when an empty `ThinVec<T, S>` computes its data pointer
+/// with no runtime `capacity == 0` check, so element accesses
+/// ([`as_slice`](ThinVec::as_slice), iteration, indexing, …) are branch-free.
 ///
-/// This holds exactly when the element layout requires no header padding
-/// (`header_field_padding::<T, S>() == 0`) *and* the empty-header singleton (see
-/// [`VecCapacity::SINGLETON_ALIGN`]) is sufficiently aligned for `T`.
+/// # Background
 ///
-/// The primitive capacity types (`u8`/`u16`/`u32`/`u64`) use the *natural* header
-/// alignment for their singleton, so the guard is only elided for element types
-/// no more aligned than the header. The opt-in [`AlignedU8`]/[`AlignedU16`]/
-/// [`AlignedU32`]/[`AlignedU64`] types over-align their singleton to the full
-/// header size, widening the set of `T` for which the guard is elided.
+/// Empty `ThinVec` isn't heap-allocated. They points to a static HEADER. That header can or cannot be aligned with T.
+/// If `VecCapacity` has that alignment, the guard in `data_raw` is drop at compile time.
 ///
-/// It is a `const fn` so performance-critical callers can lock in the
-/// branch-free hot path for their concrete element type:
-///
-/// ```
-/// # use thin_vec::{data_ptr_guard_elided, AlignedU32};
-/// // Plain `u32` keeps the guard for 8-byte-aligned elements: the natural
-/// // header alignment of `Header<u32>` is only 4.
-/// const _: () = assert!(!data_ptr_guard_elided::<[u64; 2], u32>());
-/// // The opt-in `AlignedU32` over-aligns the empty singleton, eliding the guard.
-/// const _: () = assert!(data_ptr_guard_elided::<[u64; 2], AlignedU32>());
-/// ```
-pub const fn data_ptr_guard_elided<T, S: VecCapacity>() -> bool {
+/// The guard is dropped when the singleton's data pointer is *always* aligned
+/// for `T`, which needs both:
+/// - [`SINGLETON_ALIGN`](VecCapacity::SINGLETON_ALIGN)` >= align_of::<T>()` —
+///   the singleton's address is aligned for `T` (the aligned start), and
+/// - `header_field_padding::<T, S>() == 0` — the header size is a multiple of
+///   `align_of::<T>()`, so adding it keeps the pointer aligned.
+const fn data_ptr_guard_elided<T, S: VecCapacity>() -> bool {
     S::SINGLETON_ALIGN >= mem::align_of::<T>() && header_field_padding::<T, S>() == 0
 }
 

--- a/src/redisearch_rs/thin_vec/src/lib.rs
+++ b/src/redisearch_rs/thin_vec/src/lib.rs
@@ -99,8 +99,38 @@ mod capacity;
 pub mod header;
 pub mod layout;
 
-pub use capacity::VecCapacity;
+pub use capacity::{AlignedU8, AlignedU16, AlignedU32, AlignedU64, VecCapacity};
 pub use header::Header;
+
+/// Returns `true` when `ThinVec<T, S>`'s data-pointer computation needs no
+/// runtime empty-singleton alignment guard — i.e. element accesses
+/// ([`as_slice`](ThinVec::as_slice), iteration, indexing, …) compile to a
+/// branch-free offset from the header pointer with no `capacity == 0` check.
+///
+/// This holds exactly when the element layout requires no header padding
+/// (`header_field_padding::<T, S>() == 0`) *and* the empty-header singleton (see
+/// [`VecCapacity::SINGLETON_ALIGN`]) is sufficiently aligned for `T`.
+///
+/// The primitive capacity types (`u8`/`u16`/`u32`/`u64`) use the *natural* header
+/// alignment for their singleton, so the guard is only elided for element types
+/// no more aligned than the header. The opt-in [`AlignedU8`]/[`AlignedU16`]/
+/// [`AlignedU32`]/[`AlignedU64`] types over-align their singleton to the full
+/// header size, widening the set of `T` for which the guard is elided.
+///
+/// It is a `const fn` so performance-critical callers can lock in the
+/// branch-free hot path for their concrete element type:
+///
+/// ```
+/// # use thin_vec::{data_ptr_guard_elided, AlignedU32};
+/// // Plain `u32` keeps the guard for 8-byte-aligned elements: the natural
+/// // header alignment of `Header<u32>` is only 4.
+/// const _: () = assert!(!data_ptr_guard_elided::<[u64; 2], u32>());
+/// // The opt-in `AlignedU32` over-aligns the empty singleton, eliding the guard.
+/// const _: () = assert!(data_ptr_guard_elided::<[u64; 2], AlignedU32>());
+/// ```
+pub const fn data_ptr_guard_elided<T, S: VecCapacity>() -> bool {
+    S::SINGLETON_ALIGN >= mem::align_of::<T>() && header_field_padding::<T, S>() == 0
+}
 
 /// Allocates a header (and array) for a `ThinVec<T, S>` with the given capacity.
 ///
@@ -395,15 +425,7 @@ impl<T, S: VecCapacity> ThinVec<T, S> {
         // compile-time constants. Ideally this should result in the branch
         // only be included for types with excessive alignment, since all
         // operations are `const`.
-        let singleton_header_is_aligned =
-            // If the Header is at
-            // least as aligned as T *and* the padding would have
-            // been 0, then one-past-the-end of the empty singleton
-            // *is* a valid data pointer and we can remove the
-            // `dangling` special case.
-            mem::align_of::<Header<S>>() >= mem::align_of::<T>() && header_field_padding == 0;
-
-        if !singleton_header_is_aligned && self.header_ref().capacity() == S::ZERO {
+        if !data_ptr_guard_elided::<T, S>() && self.header_ref().capacity() == S::ZERO {
             NonNull::dangling().as_ptr()
         } else {
             // This could technically result in overflow, but padding

--- a/src/redisearch_rs/thin_vec/src/lib.rs
+++ b/src/redisearch_rs/thin_vec/src/lib.rs
@@ -102,25 +102,6 @@ pub mod layout;
 pub use capacity::{AlignedU8, AlignedU16, AlignedU32, AlignedU64, VecCapacity};
 pub use header::Header;
 
-/// Returns `true` when an empty `ThinVec<T, S>` computes its data pointer
-/// with no runtime `capacity == 0` check, so element accesses
-/// ([`as_slice`](ThinVec::as_slice), iteration, indexing, …) are branch-free.
-///
-/// # Background
-///
-/// Empty `ThinVec` isn't heap-allocated. They points to a static HEADER. That header can or cannot be aligned with T.
-/// If `VecCapacity` has that alignment, the guard in `data_raw` is drop at compile time.
-///
-/// The guard is dropped when the singleton's data pointer is *always* aligned
-/// for `T`, which needs both:
-/// - [`SINGLETON_ALIGN`](VecCapacity::SINGLETON_ALIGN)` >= align_of::<T>()` —
-///   the singleton's address is aligned for `T` (the aligned start), and
-/// - `header_field_padding::<T, S>() == 0` — the header size is a multiple of
-///   `align_of::<T>()`, so adding it keeps the pointer aligned.
-const fn data_ptr_guard_elided<T, S: VecCapacity>() -> bool {
-    S::SINGLETON_ALIGN >= mem::align_of::<T>() && header_field_padding::<T, S>() == 0
-}
-
 /// Allocates a header (and array) for a `ThinVec<T, S>` with the given capacity.
 ///
 /// # Panics
@@ -414,7 +395,19 @@ impl<T, S: VecCapacity> ThinVec<T, S> {
         // compile-time constants. Ideally this should result in the branch
         // only be included for types with excessive alignment, since all
         // operations are `const`.
-        if !data_ptr_guard_elided::<T, S>() && self.header_ref().capacity() == S::ZERO {
+        let singleton_header_is_aligned =
+            // If the singleton is at
+            // least as aligned as T *and* the padding would have
+            // been 0, then one-past-the-end of the empty singleton
+            // *is* a valid data pointer and we can remove the
+            // `dangling` special case. We read the singleton's
+            // alignment from `SINGLETON_ALIGN` rather than
+            // `align_of::<Header<S>>()`, as the `AlignedU*` capacities
+            // over-align their singleton beyond the header's natural
+            // alignment.
+            S::SINGLETON_ALIGN >= mem::align_of::<T>() && header_field_padding == 0;
+
+        if !singleton_header_is_aligned && self.header_ref().capacity() == S::ZERO {
             NonNull::dangling().as_ptr()
         } else {
             // This could technically result in overflow, but padding

--- a/src/redisearch_rs/thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/thin_vec/tests/tests.rs
@@ -2,7 +2,8 @@ use core::mem::size_of;
 use std::format;
 use std::vec;
 use thin_vec::{
-    Header, MediumThinVec, SmallThinVec, ThinVec, TinyThinVec, VecCapacity, small_thin_vec,
+    AlignedU8, AlignedU16, AlignedU32, AlignedU64, Header, MediumThinVec, SmallThinVec, ThinVec,
+    TinyThinVec, VecCapacity, small_thin_vec,
 };
 
 #[test]
@@ -1455,4 +1456,68 @@ fn append_both_empty() {
     a.append(&mut b);
     assert!(a.is_empty());
     assert!(b.is_empty());
+}
+
+// Exercise the over-aligned capacity newtypes (`AlignedU8/16/32/64`). These back a
+// `ThinVec` whose empty singleton is over-aligned so `data_raw` elides its
+// `capacity == 0` guard; the round-trip below drives `from_usize`/`to_usize` and
+// the guard-elided empty-data path for each type.
+fn aligned_roundtrip_generic<S: VecCapacity>() {
+    // Empty vec: data access is branch-free (guard elided) and yields an empty slice.
+    let empty: ThinVec<i32, S> = ThinVec::new();
+    assert_eq!(empty.as_slice(), &[]);
+    assert_eq!(empty.capacity(), 0);
+
+    // `with_capacity` exercises `from_usize` on the non-panicking path.
+    let mut v: ThinVec<i32, S> = ThinVec::with_capacity(4);
+    assert!(v.capacity() >= 4);
+    for i in 0..8 {
+        v.push(i);
+    }
+    // `len`/`capacity` round len/capacity back out through `to_usize`.
+    assert_eq!(v.len(), 8);
+    assert_eq!(v.as_slice(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(v[3], 3);
+    assert_eq!(v.iter().copied().sum::<i32>(), 28);
+}
+
+#[test]
+fn test_aligned_u8_roundtrip() {
+    aligned_roundtrip_generic::<AlignedU8>();
+}
+
+#[test]
+fn test_aligned_u16_roundtrip() {
+    aligned_roundtrip_generic::<AlignedU16>();
+}
+
+#[test]
+fn test_aligned_u32_roundtrip() {
+    aligned_roundtrip_generic::<AlignedU32>();
+}
+
+#[test]
+fn test_aligned_u64_roundtrip() {
+    aligned_roundtrip_generic::<AlignedU64>();
+}
+
+// `from_usize` rejects capacities past each type's max with a descriptive panic.
+#[test]
+#[should_panic(expected = "8-bit (aligned)")]
+fn test_aligned_u8_capacity_overflow() {
+    let _: ThinVec<u8, AlignedU8> = ThinVec::with_capacity(256);
+}
+
+#[test]
+#[should_panic(expected = "16-bit (aligned)")]
+fn test_aligned_u16_capacity_overflow() {
+    let _: ThinVec<u8, AlignedU16> = ThinVec::with_capacity(65536);
+}
+
+#[test]
+#[should_panic(expected = "32-bit (aligned)")]
+// `usize` must be wider than `u32` for the requested capacity to overflow it.
+#[cfg(target_pointer_width = "64")]
+fn test_aligned_u32_capacity_overflow() {
+    let _: ThinVec<u8, AlignedU32> = ThinVec::with_capacity((u32::MAX as usize) + 1);
 }

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -14,7 +14,9 @@
 //! - A direct-modulo bucket array (`slot = doc_id % max_size`) — no hashing,
 //!   so monotonically allocated docIds map to sequential slots and the CPU
 //!   prefetcher can stream upcoming bucket headers into L1.
-//! - Per-bucket contiguous-vec collision chains (a [`MediumThinVec`] of entries).
+//! - Per-bucket contiguous-vec collision chains (a [`MediumThinVec`] of entries),
+//!   grown by `MediumThinVec`'s native exponential strategy (doubling, seeded at
+//!   4), as are the per-entry field-expiration lists.
 //! - Lazy growth: the bucket array starts empty and grows geometrically
 //!   (+1.5×, capped at `1 << 20` and clamped to `max_size`) only as `add`
 //!   demands more slots.
@@ -34,7 +36,7 @@ use std::{iter::Chain, num::NonZeroUsize, ops::Deref};
 use ffi::t_expirationTimePoint as timespec;
 pub use field::FieldExpirationPredicate;
 use rqe_core::{DocId, FieldIndex, FieldMask};
-use thin_vec::MediumThinVec;
+use thin_vec::{AlignedU32, MediumThinVec, ThinVec};
 
 /// A single field's expiration record.
 ///
@@ -58,8 +60,10 @@ pub struct FieldExpiration {
 pub struct FieldExpirations {
     /// Backing store for the field list.
     ///
-    /// We use [`MediumThinVec`] rather than the default `ThinVec` for performance reason.
-    inner: MediumThinVec<FieldExpiration>,
+    /// We use a `ThinVec` with an over-aligned [`AlignedU32`] capacity rather than
+    /// the default `ThinVec` for performance: the over-alignment lets `data_raw`
+    /// elide its `capacity == 0` guard on the verify hot path.
+    inner: ThinVec<FieldExpiration, AlignedU32>,
 }
 
 impl FieldExpirations {
@@ -68,7 +72,7 @@ impl FieldExpirations {
     /// No heap allocation is performed until the first insertion.
     pub const fn new() -> Self {
         Self {
-            inner: MediumThinVec::new(),
+            inner: ThinVec::new(),
         }
     }
 
@@ -76,7 +80,7 @@ impl FieldExpirations {
     /// at least `cap` entries.
     pub fn with_capacity(cap: usize) -> Self {
         Self {
-            inner: MediumThinVec::with_capacity(cap),
+            inner: ThinVec::with_capacity(cap),
         }
     }
 
@@ -147,12 +151,17 @@ impl FieldExpirations {
             }
         }
 
-        // Grow the collision chain linearly if needed.
-        if self.inner.capacity() == self.inner.len() {
-            self.inner.reserve_exact(1);
-        }
-
+        // `MediumThinVec::push` grows the chain exponentially when full.
         self.inner.push(fe);
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    /// Shrinks the backing store so its capacity equals its length.
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
     }
 }
 
@@ -276,10 +285,7 @@ impl TimeToLiveTable {
             "duplicate docId in TTL table"
         );
 
-        // Grow the collision chain linearly if needed.
-        if slot.capacity() == slot.len() {
-            slot.reserve_exact(1);
-        }
+        // `MediumThinVec::push` grows the chain exponentially when full.
         slot.push(TimeToLiveEntry {
             doc_id,
             field_expirations,
@@ -898,16 +904,17 @@ mod tests {
 
         let slot = t.slot(DOC_ID_1);
 
+        // `MediumThinVec`'s native growth seeds capacity at 4 on the first push.
         t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
-        assert_eq!(t.buckets[slot].capacity(), 1);
+        assert_eq!(t.buckets[slot].capacity(), 4);
 
         // Same bucket
         const DOC_ID_2: DocId = DOC_ID_1 + MAX as DocId;
         assert_eq!(slot, t.slot(DOC_ID_2));
 
-        // Increase the bucket capacity
+        // Spare capacity is still available: no reallocation.
         t.add(DOC_ID_2, fes([fe(FIELD_INDEX_1, FUTURE)]));
-        assert_eq!(t.buckets[slot].capacity(), 2);
+        assert_eq!(t.buckets[slot].capacity(), 4);
 
         t.remove(DOC_ID_1);
 
@@ -915,9 +922,9 @@ mod tests {
         const DOC_ID_3: DocId = DOC_ID_1 + 2 * MAX as DocId;
         assert_eq!(slot, t.slot(DOC_ID_3));
 
-        // Don't increase the bucket capacity
+        // Reusing the freed slot stays within the high-water-mark capacity.
         t.add(DOC_ID_3, fes([fe(FIELD_INDEX_1, FUTURE)]));
-        assert_eq!(t.buckets[slot].capacity(), 2);
+        assert_eq!(t.buckets[slot].capacity(), 4);
     }
 
     #[test]
@@ -935,7 +942,7 @@ mod tests {
         t.add(DOC_ID_1, fes([fe(FIELD_INDEX_1, FUTURE)]));
         t.add(COLLIDER, fes([fe(FIELD_INDEX_1, PAST)]));
         let peak_cap = t.buckets[slot].capacity();
-        assert_eq!(peak_cap, t.buckets[slot].len());
+        assert!(peak_cap >= t.buckets[slot].len());
 
         // One entry left: allocation is retained at the high-water mark.
         t.remove(DOC_ID_1);

--- a/src/redisearch_rs/ttl_table/src/lib.rs
+++ b/src/redisearch_rs/ttl_table/src/lib.rs
@@ -788,6 +788,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn field_expirations_capacity_and_shrink_to_fit() {
+        let mut fields = FieldExpirations::new();
+        assert_eq!(fields.len(), 0);
+        assert_eq!(fields.capacity(), 0);
+
+        // The first push seeds the backing store's native exponential growth,
+        // leaving spare capacity beyond `len`.
+        fields.push(fe(FIELD_INDEX_1, FUTURE));
+        assert_eq!(fields.len(), 1);
+        assert!(fields.capacity() > fields.len());
+
+        // Shrinking releases the spare capacity so it matches `len`.
+        fields.shrink_to_fit();
+        assert_eq!(fields.capacity(), fields.len());
+        assert_eq!(fields.len(), 1);
+    }
+
+    #[test]
     fn verify_field_returns_true_for_doc_colliding_with_a_known_doc() {
         // doc_id 1 is in the table; doc_id 9 also hashes to slot 1 but is
         // absent. Per docs: if the document has no entry, both predicates

--- a/src/redisearch_rs/ttl_table_bencher/src/lib.rs
+++ b/src/redisearch_rs/ttl_table_bencher/src/lib.rs
@@ -80,7 +80,7 @@ pub fn create_field_expiration(
     // arrays the C builder produces via `staging.shrink_to_fit()` +
     // `array_new_sz(len)`. Avoids both the geometric over-allocation of
     // repeated `push` and the placement-scattering realloc of `shrink_to_fit`.
-    let mut output = FieldExpirations::new();
+    let mut output = FieldExpirations::with_capacity(real_count as usize);
     for ((field_id, point), should_keep) in (0..real_count).zip(points).zip(pick.iter(rng)) {
         if should_keep {
             output.push(FieldExpiration {
@@ -89,13 +89,18 @@ pub fn create_field_expiration(
             });
         }
     }
+    // The `should_keep` filter leaves spare capacity (we pre-sized to the upper
+    // bound `real_count`). Shrink to a tight, capacity == len block, mirroring
+    // the C builder's `staging.shrink_to_fit()` + `array_new_sz(len)`.
+    output.shrink_to_fit();
 
     output
 }
 
 pub fn create_docs(input: DocsInput, mut rng: ThreadRng) -> Vec<(DocId, FieldExpirations)> {
     let pick = PickRandom::new(input.fill_probability);
-    (input.start_doc_id_from..(input.start_doc_id_from + input.count as DocId))
+    let mut docs: Vec<(DocId, FieldExpirations)> = (input.start_doc_id_from
+        ..(input.start_doc_id_from + input.count as DocId))
         .filter_map(move |doc_id| {
             pick.should_keep(&mut rng).then(|| {
                 (
@@ -105,14 +110,18 @@ pub fn create_docs(input: DocsInput, mut rng: ThreadRng) -> Vec<(DocId, FieldExp
             })
         })
         .filter(|(_, f)| !f.is_empty())
-        .collect()
+        .collect();
+    // `filter_map`/`filter` report a `0` lower size hint, so `collect` over-allocates.
+    // Shrink to capacity == len so `convert_into_ffi_docs` sees a tight block.
+    docs.shrink_to_fit();
+    docs
 }
 
 /// Project the shared Rust dataset produced by [`create_docs`] into the C
 /// `arrayof(FieldExpiration)` payloads the C table consumes, so both
 /// implementations benchmark byte-for-byte identical data.
 pub fn convert_into_ffi_docs(
-    docs: &[(DocId, FieldExpirations)],
+    docs: &Vec<(DocId, FieldExpirations)>,
 ) -> Vec<(DocId, *mut ffi::FieldExpiration)> {
     let mut output = Vec::with_capacity(docs.len());
     for (doc_id, fes) in docs {
@@ -132,6 +141,8 @@ pub fn convert_into_ffi_docs(
             !staging.is_empty(),
             "convert_into_ffi_docs: empty payload (create_docs should have filtered it)"
         );
+        assert_eq!(staging.len(), fes.len());
+        assert_eq!(staging.capacity(), fes.capacity());
 
         // SAFETY: `array_new_sz` is FFI but otherwise pure — given valid args it
         // returns a freshly allocated buffer with `array_len(buf) == staging.len()`.
@@ -153,16 +164,37 @@ pub fn convert_into_ffi_docs(
         output.push((*doc_id, raw));
     }
 
+    assert_eq!(output.len(), docs.len());
+    assert_eq!(output.capacity(), docs.capacity());
+
     output
 }
 
-/// Create and populate TimeToLiveTable
+/// Create and populate a [`TimeToLiveTable`].
+///
+/// Re-allocates every payload into a fresh, tight, doc-ordered block before
+/// inserting, mirroring the C builder's [`convert_into_ffi_docs`] sweep — which
+/// allocates each payload contiguously in one late pass with no interleaved
+/// scratch. The blocks [`create_docs`] produces inline are scattered across the
+/// heap (interleaved with the per-doc `points` Vec, the over-allocated `output`,
+/// and the growing `docs` Vec), so without this re-pack the verify hot loop
+/// pays markedly more cache/TLB latency than the C table purely from layout — a
+/// benchmark artifact, not a code difference (verified: scattered ≈ 15.9
+/// ns/verify vs ≈ 12.3 re-packed, matching C). Re-packing keeps the Rust and C
+/// tables apples-to-apples. It runs in bench *setup* (outside the timed
+/// `iter_batched` closure), so it does not enter measurements.
 pub fn create_and_populate(
     max_size: NonZeroUsize,
     inputs: Vec<(DocId, FieldExpirations)>,
 ) -> TimeToLiveTable {
+    let mut repacked: Vec<(DocId, FieldExpirations)> = Vec::with_capacity(inputs.len());
+    for (doc_id, fields) in &inputs {
+        repacked.push((*doc_id, fields.clone()));
+    }
+    drop(inputs);
+
     let mut t = TimeToLiveTable::new(max_size);
-    for (doc_id, fields) in inputs {
+    for (doc_id, fields) in repacked {
         t.add(doc_id, fields);
     }
     t

--- a/src/redisearch_rs/ttl_table_bencher/src/lib.rs
+++ b/src/redisearch_rs/ttl_table_bencher/src/lib.rs
@@ -75,11 +75,11 @@ pub fn create_field_expiration(
 
     let pick = PickRandom::new(input.fill_probability);
 
-    // Pre-size to the upper bound (`real_count`) so the block is allocated
-    // exactly once, in doc order — matching the tight, sequentially-laid-out
-    // arrays the C builder produces via `staging.shrink_to_fit()` +
-    // `array_new_sz(len)`. Avoids both the geometric over-allocation of
-    // repeated `push` and the placement-scattering realloc of `shrink_to_fit`.
+    // Pre-size to the upper bound (`real_count`) so the `push` loop never
+    // reallocates geometrically; the `should_keep` filter then leaves spare
+    // capacity, which the `shrink_to_fit` below tightens into a `capacity == len`
+    // block — matching the tight, doc-ordered arrays the C builder produces via
+    // `staging.shrink_to_fit()` + `array_new_sz(len)`.
     let mut output = FieldExpirations::with_capacity(real_count as usize);
     for ((field_id, point), should_keep) in (0..real_count).zip(points).zip(pick.iter(rng)) {
         if should_keep {
@@ -89,9 +89,7 @@ pub fn create_field_expiration(
             });
         }
     }
-    // The `should_keep` filter leaves spare capacity (we pre-sized to the upper
-    // bound `real_count`). Shrink to a tight, capacity == len block, mirroring
-    // the C builder's `staging.shrink_to_fit()` + `array_new_sz(len)`.
+    // Tighten to a `capacity == len` block (the filter left spare capacity).
     output.shrink_to_fit();
 
     output
@@ -170,19 +168,10 @@ pub fn convert_into_ffi_docs(
     output
 }
 
-/// Create and populate a [`TimeToLiveTable`].
+/// Create and populate a [`TimeToLiveTable`] with the given inputs.
 ///
 /// Re-allocates every payload into a fresh, tight, doc-ordered block before
-/// inserting, mirroring the C builder's [`convert_into_ffi_docs`] sweep — which
-/// allocates each payload contiguously in one late pass with no interleaved
-/// scratch. The blocks [`create_docs`] produces inline are scattered across the
-/// heap (interleaved with the per-doc `points` Vec, the over-allocated `output`,
-/// and the growing `docs` Vec), so without this re-pack the verify hot loop
-/// pays markedly more cache/TLB latency than the C table purely from layout — a
-/// benchmark artifact, not a code difference (verified: scattered ≈ 15.9
-/// ns/verify vs ≈ 12.3 re-packed, matching C). Re-packing keeps the Rust and C
-/// tables apples-to-apples. It runs in bench *setup* (outside the timed
-/// `iter_batched` closure), so it does not enter measurements.
+/// inserting, so the allocated memory is not sparse (important for benchmarks).
 pub fn create_and_populate(
     max_size: NonZeroUsize,
     inputs: Vec<(DocId, FieldExpirations)>,


### PR DESCRIPTION
## Describe the changes in the pull request

Performance optimization of the Rust `ttl_table` verify hot path, plus the `thin_vec` building block it relies on.

1. **Current:**
   - `FieldExpirations` stored its entries in a `MediumThinVec`. `MediumThinVec` has a runtime guard in the hot branch to calculate if the capacity is empty.
   - Collision chains (both the per-bucket entry list and the per-entry field-expiration list) grew **linearly** via `reserve_exact(1)`, causing an O(n) realloc storm as a chain filled.
   - `verify_doc_and_field` scanned the *entire* per-entry field-expiration list to locate a field, even though the list is ordered by `index`.


2. **Change:**
   - Add opt-in `AlignedU8/16/32/64` capacity newtypes to `thin_vec`. The headers generated by `AlignedU8/16/32/64` have the same memory size as the ones generated by `u8/u16/u32/u64` (so the header is byte-identical and ABI-compatible). The corresponding `EMPTY_*` singletons are over-aligned and report this via the new `VecCapacity::SINGLETON_ALIGN` const, so `ThinVec::data_raw`'s compile-time `singleton_header_is_aligned` check is `const`-true and the runtime empty-capacity guard is dropped.
   - Switch `FieldExpirations` to `ThinVec<FieldExpiration, AlignedU32>`, so the `capacity == 0` guard is elided and element access compiles to a branch-free offset.
   - Drop the linear `reserve_exact(1)` growth in `FieldExpirations::push` and `BucketArray::add`; rely on the native exponential growth (as C code does). Add `FieldExpirations::{capacity, shrink_to_fit}`.
   - Regenerate `ttl_table_rs.h`: the exported FFI type is now `ThinVec_FieldExpiration__AlignedU32` (was `MediumThinVec_FieldExpiration`).
   - Bencher: allocate the Rust benchmark data contiguously in memory to compare apples to apples, mirroring the C builder's late contiguous allocation sweep.

3. **Outcome:**
   - ~2–5% faster verify on the `ttl_table` microbenchmarks, with the Rust and C tables now compared apples-to-apples. New tests pin the alignment invariants and the updated growth/guard-elision behavior.
   - Benchmark-setup artifact only: the Rust payloads `create_docs` produces are scattered across the heap (≈ 15.9 ns/verify); re-packing them into a tight, doc-ordered block in bench setup brings this to ≈ 12.3 ns/verify, matching C. This is a layout effect outside the timed loop, not a runtime code path.

#### Which additional issues this PR fixes
1. MOD-14980

#### Main objects this PR modified
1. `thin_vec`
2. `ttl_table`
3. `ttl_table_bencher`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal Rust-port performance work with no user-visible behavior or API change.
