### PR TITLE
[8.6] [MOD-15394] [MOD-16228] Fix FT.HYBRID coordinator hang when a shard command fails to dispatch

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -65,9 +65,13 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // The barrier is freed by MRIterator via shardResponseBarrier_Free destructor
   // shardResponseBarrier_Init is called from iterStartCb when numShards is known from topology
   MRIterator *it = nc->shardResponseBarrier
-                   ? MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, nc->shardResponseBarrier,
-                                               shardResponseBarrier_Free, shardResponseBarrier_Init,
-                                               iterStartCb, NULL)
+                   ? MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
+                       .successCB = netCursorCallback,
+                       .cbPrivateData = nc->shardResponseBarrier,
+                       .cbPrivateDataDestructor = shardResponseBarrier_Free,
+                       .cbPrivateDataInit = shardResponseBarrier_Init,
+                       .iterStartCb = iterStartCb,
+                     })
                    : MR_Iterate(&nc->cmd, netCursorCallback);
 
   if (!it) {

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -190,6 +190,24 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
     MRReply_Free(rep);
 }
 
+// No-reply error callback: bumps responseCount and records a communication
+// error so the wait loop below (which keys completion off responseCount, not
+// iterator depletion) unblocks instead of hanging.
+static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
+    processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
+    RS_ASSERT(cb_ctx);
+
+    pthread_mutex_lock(cb_ctx->mutex);
+    cb_ctx->responseCount++;
+    QueryError error = QueryError_Default();
+    QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
+    // Shared with the MR iterator no-reply path (pre-fanout connection-validation failure).
+    QueryError_SetDetail(&error, CLUSTER_QUERY_ERROR);
+    cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
+    pthread_cond_signal(cb_ctx->completionCond);
+    pthread_mutex_unlock(cb_ctx->mutex);
+}
+
 // Init callback for the private data, so that numShards is set to the actual number of shards in the cluster, and the expected responses.
 static void processCursorMappingInit(void *privateData, MRIterator *it) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
@@ -244,7 +262,13 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // processCursorMappingInit is called from iterStartCb to update ctx->numShards
     // with the actual shard count from the live topology, preventing use-after-free
     // when topology changes during shard migration.
-    MRIterator *it = MR_IterateWithPrivateData(cmd, processCursorMappingCallback, ctx, NULL, processCursorMappingInit, iterStartCb, NULL);
+    MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
+        .successCB = processCursorMappingCallback,
+        .errorCB = processCursorMappingErrorCallback,
+        .cbPrivateData = ctx,
+        .cbPrivateDataInit = processCursorMappingInit,
+        .iterStartCb = iterStartCb,
+    });
     if (!it) {
         // Cleanup on error
         QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to communicate with shards");

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -12,7 +12,10 @@
 
 #include <stdlib.h>
 #include "rq.h"
+#ifdef ENABLE_ASSERT
+// Only needed for the test-only DebugSendError_Consume() fault injection below.
 #include "debug_commands.h"
+#endif
 
 /* Initialize the MapReduce engine with a node provider */
 MRCluster *MR_NewCluster(MRClusterTopology *initialTopology, size_t conn_pool_size, size_t num_io_threads) {

--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -12,6 +12,7 @@
 
 #include <stdlib.h>
 #include "rq.h"
+#include "debug_commands.h"
 
 /* Initialize the MapReduce engine with a node provider */
 MRCluster *MR_NewCluster(MRClusterTopology *initialTopology, size_t conn_pool_size, size_t num_io_threads) {
@@ -40,6 +41,12 @@ int MRCluster_SendCommand(IORuntimeCtx *ioRuntime,
                           MRCommand *cmd,
                           redisCallbackFn *fn,
                           void *privdata) {
+#ifdef ENABLE_ASSERT
+  // Test-only: simulate a no-reply dispatch failure.
+  if (DebugSendError_Consume()) {
+    return REDIS_ERR;
+  }
+#endif
   MRConn *conn = MRCluster_GetConn(ioRuntime, cmd);
   if (!conn) return REDIS_ERR;
   return MRConn_SendCommand(conn, cmd, fn, privdata);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -44,8 +44,6 @@
 
 #define CEIL_DIV(a, b) ((a + b - 1) / b)
 
-#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
-
 /* A cluster is a pool of IORuntimes. It is owned by the main thread and accessed in the coordinator threads */
 static MRCluster *cluster_g = NULL;
 
@@ -507,7 +505,8 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
 
 struct MRIteratorCtx {
   MRChannel *chan;
-  MRIteratorCallback cb;
+  MRIteratorCallback successCB;
+  MRIteratorErrorCallback errorCB;  // Optional: callback to execute on error
   short pending;    // Number of shards with more results (not depleted)
   short inProcess;  // Number of currently running commands on shards
   bool timedOut;    // whether the coordinator experienced a timeout
@@ -531,14 +530,22 @@ struct MRIterator {
   size_t len;
 };
 
+// No-reply termination path: invoke the caller's optional errorCB (notify-only)
+// before the iterator's MRIteratorCallback_Done. Without this hook callers that
+// wait on a private counter (e.g. ProcessHybridCursorMappings) would hang.
+static void mrIteratorCallback_Error(MRIteratorCallbackCtx *ctx) {
+  if (ctx->it->ctx.errorCB) {
+    ctx->it->ctx.errorCB(ctx);
+  }
+  MRIteratorCallback_Done(ctx, 1);
+}
+
 static void mrIteratorRedisCB(redisAsyncContext *c, void *r, void *privdata) {
   MRIteratorCallbackCtx *ctx = privdata;
   if (!r) {
-    MRIteratorCallback_Done(ctx, 1);
-    // ctx->numErrored++;
-    // TODO: report error
+    mrIteratorCallback_Error(ctx);
   } else {
-    ctx->it->ctx.cb(ctx, r);
+    ctx->it->ctx.successCB(ctx, r);
   }
 }
 
@@ -646,7 +653,7 @@ void iterStartCb(void *p) {
         it->ctx.privateDataInit(privateData, it);
       }
       MRReply *err = MRReply_CreateError(CLUSTER_QUERY_ERROR, sizeof(CLUSTER_QUERY_ERROR) - 1);
-      it->ctx.cb(&it->cbxs[0], err);
+      it->ctx.successCB(&it->cbxs[0], err);
       rm_free(data);
       return;
     }
@@ -689,7 +696,7 @@ void iterStartCb(void *p) {
   for (size_t i = 0; i < numShards; i++) {
     if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd, mrIteratorRedisCB, &it->cbxs[i]) ==
         REDIS_ERR) {
-      MRIteratorCallback_Done(&it->cbxs[i], 1);
+      mrIteratorCallback_Error(&it->cbxs[i]);
     }
   }
 
@@ -751,7 +758,7 @@ void iterCursorMappingCb(void *p) {
   for (size_t i = 0; i < numShardsWithMapping; i++) {
     if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
                               mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
-      MRIteratorCallback_Done(&it->cbxs[i], 1);
+      mrIteratorCallback_Error(&it->cbxs[i]);
     }
   }
 
@@ -768,7 +775,7 @@ void iterManualNextCb(void *p) {
     if (!it->cbxs[i].cmd.depleted) {
       if (MRCluster_SendCommand(io_runtime_ctx, &it->cbxs[i].cmd,
                                 mrIteratorRedisCB, &it->cbxs[i]) == REDIS_ERR) {
-        MRIteratorCallback_Done(&it->cbxs[i], 1);
+        mrIteratorCallback_Error(&it->cbxs[i]);
       }
     }
   }
@@ -806,13 +813,13 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
 }
 
 MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb) {
-  return MR_IterateWithPrivateData(cmd, cb, NULL, NULL, NULL, iterStartCb, NULL);
+  return MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
+    .successCB = cb,
+    .iterStartCb = iterStartCb,
+  });
 }
 
-MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
-                                      void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, MRIterator *),
-                                      void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData) {
+MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConfig *config) {
   MRIterator *ret = rm_new(MRIterator);
   // Initial initialization of the iterator.
   // The rest of the initialization is done in the iterator start callback.
@@ -825,14 +832,15 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
   *ret = (MRIterator){
     .ctx = {
       .chan = MR_NewChannel(),
-      .cb = cb,
+      .successCB = config->successCB,
+      .errorCB = config->errorCB,
       .pending = 1,
       .inProcess = 1,
       .timedOut = false,
       .itRefCount = 2,
       .ioRuntime = MRCluster_GetIORuntimeCtx(cluster_g, MRCluster_AssignRoundRobinIORuntimeIdx(cluster_g)),
-      .privateDataDestructor = cbPrivateDataDestructor,
-      .privateDataInit = cbPrivateDataInit,
+      .privateDataDestructor = config->cbPrivateDataDestructor,
+      .privateDataInit = config->cbPrivateDataInit,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
     .len = 1,
@@ -841,17 +849,17 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
   *ret->cbxs = (MRIteratorCallbackCtx){
     .cmd = MRCommand_Copy(cmd),
     .it = ret,
-    .privateData = cbPrivateData,
+    .privateData = config->cbPrivateData,
   };
 
   // Create data structure with iterator and private data (on heap)
   IteratorData *data = rm_malloc(sizeof(IteratorData));
   data->it = ret;
   data->privateDataRef = (WeakRef){0};
-  if (iterStartCbPrivateData) {
-    data->privateDataRef = StrongRef_Demote(*iterStartCbPrivateData);
+  if (config->iterStartCbPrivateData) {
+    data->privateDataRef = StrongRef_Demote(*config->iterStartCbPrivateData);
   }
-  IORuntimeCtx_Schedule(ret->ctx.ioRuntime, iterStartCb, data);
+  IORuntimeCtx_Schedule(ret->ctx.ioRuntime, config->iterStartCb, data);
   return ret;
 }
 

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -820,6 +820,9 @@ MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb) {
 }
 
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConfig *config) {
+  // successCB and iterStartCb are required: the per-reply path dereferences
+  // successCB and we unconditionally schedule iterStartCb below.
+  RS_ASSERT(config && config->successCB && config->iterStartCb);
   MRIterator *ret = rm_new(MRIterator);
   // Initial initialization of the iterator.
   // The rest of the initialization is done in the iterator start callback.

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -17,6 +17,13 @@
 #include "util/references.h"
 #include <unistd.h>
 
+typedef struct QueryError QueryError;
+
+// Error detail returned to the client when a query cannot be dispatched to the
+// cluster (pre-fanout connection-validation / send failure). Shared by the MR
+// iterator no-reply path (rmr.c) and the hybrid cursor-mapping error callback;
+// tests assert on this substring, so keep them in sync via this single macro.
+#define CLUSTER_QUERY_ERROR "Could not send query to cluster"
 
 struct MRCtx;
 struct RedisModuleCtx;
@@ -104,7 +111,44 @@ typedef struct MRIteratorCallbackCtx MRIteratorCallbackCtx;
 typedef struct MRIteratorCtx MRIteratorCtx;
 typedef struct MRIterator MRIterator;
 
+/**
+ * Per-reply callback, invoked on the IO thread for every shard reply.
+ * Owns the iterator's completion bookkeeping: it must call
+ * MRIteratorCallback_Done once the shard has no more replies to drive the
+ * iterator toward depletion. Contrast with MRIteratorErrorCallback, which is
+ * notify-only and must not touch the Done state.
+ */
 typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
+
+/**
+ * Invoked on the IO thread when a shard command terminates without a reply
+ * (NULL async reply or synchronous send failure). Notify-only: must not free
+ * the iterator nor call MRIteratorCallback_Done — the MR layer does that next.
+ * Optional; NULL preserves the historical depletion-only behavior.
+ */
+typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
+
+/**
+ * Bundles the optional callbacks and private data for MR_IterateWithPrivateData.
+ * Only `successCB` is required; every other field may be NULL to opt out of that hook.
+ *
+ * @param successCB              Per-reply callback (required).
+ * @param errorCB                No-reply termination callback (optional).
+ * @param cbPrivateData          Private data handed to `successCB` via the callback ctx.
+ * @param cbPrivateDataDestructor Frees `cbPrivateData` when the iterator is freed.
+ * @param cbPrivateDataInit      Runs once on the IO thread after numShards is known.
+ * @param iterStartCb            Scheduled on the IO thread to trigger the first send.
+ * @param iterStartCbPrivateData StrongRef demoted and passed to `iterStartCb`.
+ */
+typedef struct {
+  MRIteratorCallback successCB;
+  MRIteratorErrorCallback errorCB;
+  void *cbPrivateData;
+  void (*cbPrivateDataDestructor)(void *);
+  void (*cbPrivateDataInit)(void *, MRIterator *);
+  void (*iterStartCb)(void *);
+  StrongRef *iterStartCbPrivateData;
+} MRIteratorConfig;
 
 // Trigger all the commands in the iterator to be sent.
 // Returns true if there may be more replies to come, false if we are done.
@@ -122,10 +166,7 @@ MRReply *MRIterator_NextWithTimeout(MRIterator *it, const struct timespec *absti
 
 MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb);
 
-MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
-                                      void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, MRIterator *),
-                                      void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData);
+MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConfig *config);
 
 MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx);
 

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -129,15 +129,17 @@ typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
 typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
 
 /**
- * Bundles the optional callbacks and private data for MR_IterateWithPrivateData.
- * Only `successCB` is required; every other field may be NULL to opt out of that hook.
+ * Bundles the callbacks and private data for MR_IterateWithPrivateData.
+ * `successCB` and `iterStartCb` are required (MR_IterateWithPrivateData
+ * unconditionally schedules `iterStartCb`); every other field may be NULL to
+ * opt out of that hook.
  *
  * @param successCB              Per-reply callback (required).
  * @param errorCB                No-reply termination callback (optional).
  * @param cbPrivateData          Private data handed to `successCB` via the callback ctx.
  * @param cbPrivateDataDestructor Frees `cbPrivateData` when the iterator is freed.
  * @param cbPrivateDataInit      Runs once on the IO thread after numShards is known.
- * @param iterStartCb            Scheduled on the IO thread to trigger the first send.
+ * @param iterStartCb            Scheduled on the IO thread to trigger the first send (required).
  * @param iterStartCbPrivateData StrongRef demoted and passed to `iterStartCb`.
  */
 typedef struct {

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -435,7 +435,11 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     nc->cmd.protocol = 3;
     rm_free(idx_copy);
 
-    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL, NULL, iterCursorMappingCb, &nc->mappings);
+    nc->it = MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
+      .successCB = netCursorCallback,
+      .iterStartCb = iterCursorMappingCb,
+      .iterStartCbPrivateData = &nc->mappings,
+    });
     nc->base.Next = rpnetNext;
 
     return rpnetNext(rp, r);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -34,6 +34,7 @@
 #include "info/info_command.h"
 #include "iterators/inverted_index_iterator.h"
 #include "search_disk.h"
+#include <limits.h>
 
 DebugCTX globalDebugCtx = {0};
 
@@ -174,6 +175,24 @@ void SyncPoint_Wait(const char *name) {
     usleep(1000);  // Spin-wait with 1ms sleep (matches existing pattern)
   }
   atomic_fetch_sub(&sp->waiting, 1);  // Decrement waiting counter
+}
+
+// Shard dispatch fault injection (test-only, see DebugSendError_* in header).
+// Set from the main thread via FT.DEBUG SEND_ERROR, consumed from the IO threads.
+static _Atomic int g_debugSendErrorCount = 0;
+
+void DebugSendError_Arm(int count) {
+  atomic_store(&g_debugSendErrorCount, count);
+}
+
+bool DebugSendError_Consume(void) {
+  int cur = atomic_load(&g_debugSendErrorCount);
+  while (cur > 0) {
+    if (atomic_compare_exchange_weak(&g_debugSendErrorCount, &cur, cur - 1)) {
+      return true;
+    }
+  }
+  return false;
 }
 #endif
 
@@ -2253,6 +2272,24 @@ DEBUG_COMMAND(syncPoint) {
   }
   return RedisModule_ReplyWithError(ctx, "Unknown SYNC_POINT subcommand. Valid: ARM, SIGNAL, IS_WAITING, IS_ARMED, CLEAR");
 }
+
+/**
+ * FT.DEBUG SEND_ERROR <count>
+ * Arm the next <count> MRCluster_SendCommand dispatches to return REDIS_ERR,
+ * simulating a no-reply shard failure.
+ */
+DEBUG_COMMAND(sendError) {
+  if (!debugCommandsEnabled(ctx)) return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  if (argc != 3) return RedisModule_WrongArity(ctx);
+  long long count;
+  if (RedisModule_StringToLongLong(argv[2], &count) != REDISMODULE_OK || count < 0 ||
+      count > INT_MAX) {
+    return RedisModule_ReplyWithError(ctx,
+        "SEND_ERROR count must be a non-negative integer no greater than INT_MAX");
+  }
+  DebugSendError_Arm((int)count);
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
 #endif
 
 /**
@@ -2519,6 +2556,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
 // Add new assert-only commands to this array instead of hard-coding #ifdef blocks
 static DebugCommandType assertOnlyCommands[] = {
     {"SYNC_POINT", syncPoint},
+    {"SEND_ERROR", sendError},
     {NULL, NULL}};
 #endif
 

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -89,6 +89,14 @@ void SyncPoint_ClearAll(void);
 // If the named point is armed, blocks until signaled
 void SyncPoint_Wait(const char *name);
 
+// Shard dispatch fault injection (test-only, ENABLE_ASSERT builds): arm the next
+// `count` MRCluster_SendCommand calls to return REDIS_ERR, so DebugSendError_Consume
+// returns true that many times. Exercises the no-reply error path.
+void DebugSendError_Arm(int count);
+// Consume one armed failure; returns true if the caller should treat the send as
+// failed. Thread-safe.
+bool DebugSendError_Consume(void);
+
 #endif  // ENABLE_ASSERT
 
 // Yield counter functions

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -78,9 +78,10 @@ class TestDebugCommands(object):
         ]
         coord_help_list = ['SHARD_CONNECTION_STATES', 'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY']
         help_list.extend(coord_help_list)
-        # SYNC_POINT is only available in ENABLE_ASSERT builds
+        # SYNC_POINT and SEND_ERROR are only available in ENABLE_ASSERT builds
         if isEnableAssertEnabled(self.env):
             help_list.append('SYNC_POINT')
+            help_list.append('SEND_ERROR')
 
         self.env.expect(debug_cmd(), 'help').equal(help_list)
 

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -2,26 +2,29 @@ from common import *
 import threading
 
 
-@skip(cluster=False)
-@require_enable_assert
-def test_dist_hybrid_index_drop_after_sctx_allocation(env):
-    """MOD-14135: SearchCtx must be freed when index is dropped between
-    sctx allocation and IndexSpecRef_Promote in RSExecDistHybrid.
-    Leak detection relies on valgrind/sanitizers in CI."""
+def _setup_hybrid_index(env, dim=2):
+    """Create the standard hybrid index used by these tests and return
+    (conn, query_vec, doc_vec)."""
     set_workers(env, 1)
-
-    dim = 2
     conn = getConnectionByEnv(env)
-
     env.expect(
         'FT.CREATE', 'idx', 'SCHEMA',
         'name', 'TEXT',
         'embedding', 'VECTOR', 'FLAT', '6',
         'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2'
     ).ok()
-
     query_vec = np.array([0.0] * dim, dtype=np.float32).tobytes()
     doc_vec = np.array([1.0] * dim, dtype=np.float32).tobytes()
+    return conn, query_vec, doc_vec
+
+
+@skip(cluster=False)
+@require_enable_assert
+def test_dist_hybrid_index_drop_after_sctx_allocation(env):
+    """MOD-14135: SearchCtx must be freed when index is dropped between
+    sctx allocation and IndexSpecRef_Promote in RSExecDistHybrid.
+    Leak detection relies on valgrind/sanitizers in CI."""
+    conn, query_vec, doc_vec = _setup_hybrid_index(env)
     conn.execute_command('HSET', 'doc1', 'name', 'hello', 'embedding', doc_vec)
 
     sync_point = 'BeforeDistHybridPromote'
@@ -64,3 +67,45 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
     error_msg = str(error_holder[0])
     env.assertEqual(error_msg, 'The index was dropped before the query could be executed',
                    message=f'Expected error: `The index was dropped before the query could be executed`, got: {error_msg}')
+
+
+@skip(cluster=False)
+@require_enable_assert
+def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
+    """A no-reply shard dispatch failure must surface as an error
+    rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
+    FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
+    conn, query_vec, doc_vec = _setup_hybrid_index(env)
+    for i in range(10):
+        conn.execute_command('HSET', f'doc{i}', 'name', 'hello', 'embedding', doc_vec)
+
+    # Arm the coordinator to fail the next shard dispatch (the FT.HYBRID fan-out).
+    env.cmd(debug_cmd(), 'SEND_ERROR', '1')
+
+    error_holder = []
+    result_holder = []
+    def run_hybrid_query(c, errors, results):
+        try:
+            results.append(c.execute_command(
+                'FT.HYBRID', 'idx',
+                'SEARCH', '*',
+                'VSIM', '@embedding', '$BLOB',
+                'PARAMS', '2', 'BLOB', query_vec
+            ))
+        except Exception as e:
+            errors.append(e)
+
+    query_conn = env.getConnection()
+    query_thread = threading.Thread(
+        target=run_hybrid_query,
+        args=(query_conn, error_holder, result_holder),
+        daemon=True
+    )
+    query_thread.start()
+    query_thread.join(timeout=15)
+
+    env.assertFalse(query_thread.is_alive(),
+                    message='FT.HYBRID hung after a shard dispatch failure')
+    env.assertEqual(len(error_holder), 1,
+                    message=f'Expected a communication error, got results: {result_holder}')
+    env.assertContains('Could not send query to cluster', str(error_holder[0]))


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9985 to the `8.6` branch.

1. **Current**: `ProcessHybridCursorMappings` waits on a private `responseCount` that only the success callback increments. A shard command that terminates without delivering a reply (a NULL async reply after a connection drop/error post pre-fanout validation, or a synchronous send failure) bypassed that bookkeeping, so the coordinator blocked on `completionCond` forever and the `FT.HYBRID` client hung.
2. **Change**: Add an optional `MRIteratorErrorCallback` to the MR iterator that routes every no-reply termination through it before the iterator's own `MRIteratorCallback_Done`. The hybrid path registers an error callback that counts the shard and records a "Could not send query to cluster" error. `errorCB` defaults to NULL, leaving `FT.SEARCH`/`FT.AGGREGATE` (which key completion off iterator depletion) unchanged.
3. **Outcome**: `FT.HYBRID` returns an error instead of hanging when a shard command fails to dispatch.

#### Which additional issues this PR fixes
1. MOD-15394
2. #9985

#### Main objects this PR modified
1. `src/coord/rmr/rmr.{c,h}` — new `MRIteratorErrorCallback` / `MRIteratorConfig`
2. `src/coord/hybrid/hybrid_cursor_mappings.c` — no-reply error callback
3. `src/debug_commands.{c,h}` — `FT.DEBUG SEND_ERROR` fault injection (ENABLE_ASSERT only)
4. `tests/pytests/test_hybrid_dist.py`, `tests/pytests/test_debug_commands.py`, `tests/pytests/common.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes a coordinator hang in `FT.HYBRID` when a shard command fails to dispatch.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author