### PR TITLE
stopwords: correct StopWordList_Contains doc comment

### DIFF
--- a/src/stopwords.h
+++ b/src/stopwords.h
@@ -32,7 +32,7 @@ typedef struct StopWordList StopWordList;
 struct StopWordList;
 #endif
 
-/* Check if a stopword list contains a term. The term must be already lowercased */
+/* Check if a stopword list contains a term (case-insensitive lookup). */
 int StopWordList_Contains(const struct StopWordList *sl, const char *term, size_t len);
 
 struct StopWordList *DefaultStopWordList();


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The header comment on `StopWordList_Contains` (`src/stopwords.h:35`) claimed callers must pre-lowercase the term.
2. **Change**: Replaced with a comment describing the actual contract — case-insensitive lookup.
3. **Outcome**: Comment matches the implementation, which folds the input internally via `unicode_tolower`. An audit of all five call sites found four rely on the internal fold; only `tokenize.c` pre-folds.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/stopwords.h` — header comment for `StopWordList_Contains`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
