### PR TITLE
[MOD-15394] [MOD-16228] coord/rmr: document required MRIteratorConfig fields and guard debug-only include

### DIFF
--- a/src/coord/rmr/cluster.c
+++ b/src/coord/rmr/cluster.c
@@ -12,7 +12,10 @@
 
 #include <stdlib.h>
 #include "rq.h"
+#ifdef ENABLE_ASSERT
+// Only needed for the test-only DebugSendError_Consume() fault injection below.
 #include "debug_commands.h"
+#endif
 
 /* Initialize the MapReduce engine with a node provider */
 MRCluster *MR_NewCluster(MRClusterTopology *initialTopology, size_t conn_pool_size, size_t num_io_threads) {

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -933,6 +933,9 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
 }
 
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, const MRIteratorConfig *config) {
+  // successCB and iterStartCb are required: the per-reply path dereferences
+  // successCB and we unconditionally schedule iterStartCb below.
+  RS_ASSERT(config && config->successCB && config->iterStartCb);
   MRIterator *ret = rm_new(MRIterator);
   // Initial initialization of the iterator.
   // The rest of the initialization is done in the iterator start callback.

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -164,8 +164,10 @@ typedef void (*MRIteratorErrorCallback)(MRIteratorCallbackCtx *ctx);
 typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privateData);
 
 /**
- * Bundles the optional callbacks and private data for MR_IterateWithPrivateData.
- * Only `successCB` is required; every other field may be NULL to opt out of that hook.
+ * Bundles the callbacks and private data for MR_IterateWithPrivateData.
+ * `successCB` and `iterStartCb` are required (MR_IterateWithPrivateData
+ * unconditionally schedules `iterStartCb`); every other field may be NULL to
+ * opt out of that hook.
  *
  * @param successCB              Per-reply callback (required).
  * @param errorCB                No-reply termination callback (optional).
@@ -173,7 +175,7 @@ typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privat
  * @param cbPrivateDataDestructor Frees `cbPrivateData` when the iterator is freed.
  * @param cbPrivateDataInit      Runs once on the IO thread after numShards is known.
  * @param commandModifier        Rewrites the command per-shard before sending.
- * @param iterStartCb            Scheduled on the IO thread to trigger the first send.
+ * @param iterStartCb            Scheduled on the IO thread to trigger the first send (required).
  * @param iterStartCbPrivateData StrongRef demoted and passed to `iterStartCb`.
  */
 typedef struct {


### PR DESCRIPTION
## Describe the changes in the pull request

Follow-up to #9985 (MOD-15394) addressing automated (Copilot) review feedback on the `MRIteratorConfig` API introduced there. No behavior change for users.

1. **Current:** The `MRIteratorConfig` doc states only `successCB` is required and "every other field may be NULL", but `MR_IterateWithPrivateData()` unconditionally schedules `config->iterStartCb` and never validates its inputs — a NULL `iterStartCb` (or `config`/`successCB`) would crash deep inside the IO-runtime schedule. Separately, `cluster.c` included `debug_commands.h` unconditionally even though its only use (`DebugSendError_Consume`) is under `#ifdef ENABLE_ASSERT`.
2. **Change:**
   - Clarify the `MRIteratorConfig` doc: `iterStartCb` is required alongside `successCB`.
   - Add `RS_ASSERT(config && config->successCB && config->iterStartCb)` at the top of `MR_IterateWithPrivateData()` to fail fast on the contract instead of a deep NULL deref.
   - Guard the `debug_commands.h` include in `cluster.c` behind `#ifdef ENABLE_ASSERT` so the production build graph doesn't pull in the debug command header.
3. **Outcome:** The required-field contract is documented and asserted, and non-assert (production) builds no longer depend on `debug_commands.h`. Verified with coordinator builds both with and without `ENABLE_ASSERT=1`.

#### Which additional issues this PR fixes
1. MOD-15394 (follow-up)
2. #9985

#### Main objects this PR modified
1. `src/coord/rmr/rmr.h` — `MRIteratorConfig` doc
2. `src/coord/rmr/rmr.c` — `MR_IterateWithPrivateData` argument assertion
3. `src/coord/rmr/cluster.c` — guard debug-only include

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only change (documentation, a debug-only assertion, and a build-graph include guard); no user-facing behavior change.