### PR TITLE
trie - add flow test covering stopwords parser-side case-fold across dialects

### DIFF
--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -444,6 +444,24 @@ def testStopwords(env):
     env.assertEqual(0, r1[0])
     env.assertEqual(1, r2[0])
 
+def testStopwordParserCaseFold(env):
+    # Stopword detection in the query lexer/parser is case-insensitive: a
+    # mixed-case stopword adjacent to a real term must still collapse out
+    # of the query rather than leak through as a literal TERM (which would
+    # then miss the lowercased term trie and yield 0 docs).
+    env.cmd('FT.CREATE', 'idx', 'STOPWORDS', 1, 'the',
+            'SCHEMA', 't', 'TEXT')
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:1', 't', 'The quick brown fox')
+
+    for dialect in (1, 2):
+        for stop in ('the', 'THE', 'The', 'tHe'):
+            env.assertEqual(
+                [1, 'doc:1'],
+                env.cmd('FT.SEARCH', 'idx', f'{stop} quick',
+                        'NOCONTENT', 'DIALECT', dialect),
+                message=f'dialect={dialect} stop={stop!r}')
+
 def testNoStopwords(env):
     # This test taken from Java's test suite
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Stopword case-insensitivity in the query lexer/parser path (v1 and v2) relies on the defensive `unicode_tolower` inside `StopWordList_Contains` — the lexers, unlike the indexing tokenizer, do not pre-fold tokens before the stopword lookup. This behavior had no direct test coverage across dialects.
2. Change: Add `testStopwordParserCaseFold`, asserting that a mixed-case stopword (`the`/`THE`/`The`/`tHe`) adjacent to a real term collapses out of the query in both DIALECT 1 and DIALECT 2, instead of leaking through as a literal TERM that misses the lowercased term trie.
3. Outcome: Coverage only — the test passes against current code. It guards against a future refactor removing the internal case-fold on the assumption that all callers pre-fold; that would silently break only the query-side path while indexing keeps working.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `tests/pytests/test.py` — added `testStopwordParserCaseFold`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
