### PR TITLE
[MOD-15868] skip test_cluster_set_errors pending fix

### DIFF
--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4397,7 +4397,9 @@ def test_cluster_set_myself_excluded(env: Env):
     ]
     env.expect('SEARCH.CLUSTERINFO').equal(expected)
 
-@skip(cluster=False) # this test is only relevant on cluster
+# TODO(MOD-15868): re-enable once https://redislabs.atlassian.net/browse/MOD-15868 is resolved
+@skip()
+#@skip(cluster=False) # this test is only relevant on cluster
 def test_cluster_set_errors(env: Env):
 
     # Check general values parsing


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `test_cluster_set_errors` in `tests/pytests/test.py` is decorated with `@skip(cluster=False)` and runs on cluster environments, but currently fails pending the work tracked in [MOD-15868](https://redislabs.atlassian.net/browse/MOD-15868) (use the new module API topology parser in `SEARCH.CLUSTERREFRESH`).
2. **Change**: Replace the decorator with the legacy unconditional `@skip()` marker and add a `TODO(MOD-15868)` comment. The prior `@skip(cluster=False)` line is preserved as a commented-out breadcrumb to make restoration mechanical once the ticket is resolved.
3. **Outcome**: The test is unconditionally skipped on all environments until MOD-15868 lands; no other tests are affected. A reminder comment has been posted on MOD-15868 so the test is re-enabled when the ticket closes.

#### Which additional issues this PR fixes
1. MOD-15868 (tracked, not fixed by this PR)

#### Main objects this PR modified
1. `tests/pytests/test.py` — `test_cluster_set_errors`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-15868]: https://redislabs.atlassian.net/browse/MOD-15868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ