### PR TITLE
[MOD-16065] Rename blocked-client timeout callbacks to a Callback suffix

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -699,7 +699,7 @@ err:
 
 // Timeout callback for Coordinator AREQ execution
 // Called on the main thread when the blocking client times out (FAIL policy only).
-int DistAggregateTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
 
@@ -744,7 +744,7 @@ static void drainPartialResultsAfterTimeout(AREQ *req) {
 
 // Timeout callback for Coordinator AREQ execution
 // Called on the main thread when the blocking client times out (RETURN-STRICT policy only).
-int DistAggregateTimeoutReturnStrictClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   CoordRequestCtx *CoordReqCtx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (!CoordReqCtx) {
@@ -838,7 +838,7 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // draining the remaining shards and the warning is surfaced via the
   // QEXEC_S_SHARD_TIMED_OUT_WARNING flag. The only RETURN-STRICT path that
   // still produces rc=TIMEDOUT is the coord's own deadline firing, which
-  // routes through DistAggregateTimeoutReturnStrictClient -- not this
+  // routes through DistAggregateTimeoutReturnStrictCallback -- not this
   // callback. Under FAIL, a shard timeout still bails the coord pipeline
   // early; the BG thread stores the resulting error in storedReplyState.err
   // and the early-error branch above replies with it.
@@ -854,7 +854,7 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
 // check at startPipelineCommon handles pipeline-side bails, and pre-pipeline
 // bails are signaled via AREQ_ReplyOrStoreError. The timer waits and branches
 // on `hasStoredResults`.
-int DistCursorReadTimeoutReturnStrictClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   CoordRequestCtx *reqCtx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (!reqCtx) {
     return RedisModule_ReplyWithError(ctx, "Internal error: timeout with no context");

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1152,7 +1152,7 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
 // Timeout callback for Coordinator HybridRequest execution
 // Called on the main thread when the blocking client times out (FAIL policy only).
-int DistHybridTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
 
@@ -1181,7 +1181,7 @@ int DistHybridTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, i
 
 // Timeout callback for Coordinator HybridRequest execution
 // Called on the main thread when the blocking client times out (RETURN-STRICT policy only).
-int DistHybridTimeoutReturnStrictClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
 

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -22,8 +22,8 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                             struct ConcurrentCmdCtx *cmdCtx);
 
-int DistHybridTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int DistHybridTimeoutReturnStrictClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // For testing purposes

--- a/src/gc.c
+++ b/src/gc.c
@@ -181,14 +181,14 @@ void GCContext_ForceBGInvoke(GCContext* gc) {
   GCContext_CommonForceInvoke(gc, NULL);
 }
 
-static void GCContext_UnblockCallback(void* data) {
+static void GCContext_UnblockClient(void* data) {
   RedisModuleBlockedClient *bc = data;
   RedisModule_BlockedClientMeasureTimeEnd(bc);
   RedisModule_UnblockClient(bc, NULL);
 }
 
 void GCContext_WaitForAllOperations(RedisModuleBlockedClient* bc) {
-  redisearch_thpool_add_work(gcThreadpool_g, GCContext_UnblockCallback, bc, THPOOL_PRIORITY_HIGH);
+  redisearch_thpool_add_work(gcThreadpool_g, GCContext_UnblockClient, bc, THPOOL_PRIORITY_HIGH);
 }
 
 void GC_ThreadPoolStart() {

--- a/src/gc.c
+++ b/src/gc.c
@@ -181,14 +181,14 @@ void GCContext_ForceBGInvoke(GCContext* gc) {
   GCContext_CommonForceInvoke(gc, NULL);
 }
 
-static void GCContext_UnblockClient(void* data) {
+static void GCContext_UnblockCallback(void* data) {
   RedisModuleBlockedClient *bc = data;
   RedisModule_BlockedClientMeasureTimeEnd(bc);
   RedisModule_UnblockClient(bc, NULL);
 }
 
 void GCContext_WaitForAllOperations(RedisModuleBlockedClient* bc) {
-  redisearch_thpool_add_work(gcThreadpool_g, GCContext_UnblockClient, bc, THPOOL_PRIORITY_HIGH);
+  redisearch_thpool_add_work(gcThreadpool_g, GCContext_UnblockCallback, bc, THPOOL_PRIORITY_HIGH);
 }
 
 void GC_ThreadPoolStart() {

--- a/src/module.c
+++ b/src/module.c
@@ -4285,7 +4285,7 @@ static void DistSearchCommandHandler(void* pd) {
 // Reply callback for distributed search.
 // Called on the main thread when the client is unblocked.
 // The free_privdata callback (DistSearchFreePrivData) will be called automatically after this to clean up.
-static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+static int DistSearchReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
@@ -4500,7 +4500,7 @@ static RedisModuleBlockedClient* DistSearchBlockClientWithTimeout(RedisModuleCtx
     queryTimeout = 0;
   }
 
-  return RedisModule_BlockClient(ctx, DistSearchUnblockClient, timeoutCallback, freePrivDataCallback, queryTimeout);
+  return RedisModule_BlockClient(ctx, DistSearchReplyCallback, timeoutCallback, freePrivDataCallback, queryTimeout);
 }
 
 int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/module.c
+++ b/src/module.c
@@ -3677,9 +3677,9 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int DistAggregateTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int DistAggregateTimeoutReturnStrictClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int DistCursorReadTimeoutReturnStrictClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Free privdata callback for distributed aggregate and hybrid query
 static void DistCoordReqFreePrivData(RedisModuleCtx *ctx, void *privdata) {
@@ -3790,8 +3790,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   if (policy == TimeoutPolicy_Fail || policy == TimeoutPolicy_ReturnStrict) {
     handlerCtx.bcCtx.reply_callback = DistAggregateReplyCallback;
     handlerCtx.bcCtx.timeout_callback = (policy == TimeoutPolicy_Fail)
-        ? DistAggregateTimeoutFailClient
-        : DistAggregateTimeoutReturnStrictClient;
+        ? DistAggregateTimeoutFailCallback
+        : DistAggregateTimeoutReturnStrictCallback;
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
     CoordRequestCtx_SetUseReplyCallback(reqCtx, true);
   }
@@ -3885,8 +3885,8 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
   if (policy != TimeoutPolicy_Return) {
     handlerCtx.bcCtx.reply_callback = DistHybridReplyCallback;
     handlerCtx.bcCtx.timeout_callback = (policy == TimeoutPolicy_Fail)
-        ? DistHybridTimeoutFailClient
-        : DistHybridTimeoutReturnStrictClient;
+        ? DistHybridTimeoutFailCallback
+        : DistHybridTimeoutReturnStrictCallback;
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
     CoordRequestCtx_SetUseReplyCallback(reqCtx, true);
   }
@@ -3984,9 +3984,9 @@ static inline int CursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
       handlerCtx.bcCtx.timeoutMS = (size_t)capped;
       CoordRequestCtx_SetUseReplyCallback(reqCtx, true);
       if (info.queryTimeoutPolicy == TimeoutPolicy_Fail) {
-        handlerCtx.bcCtx.timeout_callback = DistAggregateTimeoutFailClient;
+        handlerCtx.bcCtx.timeout_callback = DistAggregateTimeoutFailCallback;
       } else {
-        handlerCtx.bcCtx.timeout_callback = DistCursorReadTimeoutReturnStrictClient;
+        handlerCtx.bcCtx.timeout_callback = DistCursorReadTimeoutReturnStrictCallback;
         CoordRequestCtx_SetCursorReadReturnStrict(reqCtx, true);
       }
     }
@@ -4398,7 +4398,7 @@ static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc,
 // Timeout callback for FT.SEARCH in coordinator mode.
 // Called on the main thread when the blocking client times out.
 // For FAIL policy
-static int DistSearchTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+static int DistSearchTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
 
@@ -4425,7 +4425,7 @@ static int DistSearchTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **
 // Timeout callback for FT.SEARCH in coordinator mode.
 // Called on the main thread when the blocking client times out.
 // Used for RETURN-STRICT policy - returns partial results using the blocked client timeout mechanism instead of error
-static int DistSearchTimeoutPartialClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+static int DistSearchTimeoutPartialCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   struct MRCtx *mrctx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (!mrctx) {
@@ -4493,9 +4493,9 @@ static RedisModuleBlockedClient* DistSearchBlockClientWithTimeout(RedisModuleCtx
   BlockedClientFreePrivDataCB freePrivDataCallback = DistSearchFreePrivData;
 
   if (RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail) {
-    timeoutCallback = DistSearchTimeoutFailClient;
+    timeoutCallback = DistSearchTimeoutFailCallback;
   } else if (RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_ReturnStrict) {
-    timeoutCallback = DistSearchTimeoutPartialClient;
+    timeoutCallback = DistSearchTimeoutPartialCallback;
   } else {
     queryTimeout = 0;
   }

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4230,7 +4230,7 @@ class TestCoordinatorTimeout:
         env.assertFalse(t_query.is_alive(), message="Cursor read thread should have finished")
         # Timer replied with the original cid even though the cursor was
         # already freed by the concurrent DEL — this is the documented
-        # behavior of ``DistCursorReadTimeoutReturnStrictClient``.
+        # behavior of ``DistCursorReadTimeoutReturnStrictCallback``.
         _assert_return_strict_cursor_timeout_reply(
             env, result[0], cursor_id, expected_results=0,
             message_prefix='RETURN_STRICT cursor-deleted+timeout pre-pickup')


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current:** The coordinator blocked-client timeout callbacks use a `...Client` suffix (e.g. `DistAggregateTimeoutFailClient`). This was raised as a review nit on PR #9942 — the suffix does not make it clear that these functions are timeout callbacks invoked on the main thread when a blocking client times out.
2. **Change:** Rename the whole family to use a clear `...Callback` suffix, including the forward declarations in `module.c` and the header. Pure rename, no behavior change. Aligns the coordinator names with the existing non-coordinator timeout callbacks (`QueryTimeoutFailCallback`, `HybridQueryTimeoutFailCallback`, …).
3. **Outcome:** Function names now clearly signal that they are timeout callbacks. No functional or serialization changes.

While doing the rename I also caught one timeout callback the ticket missed — `DistSearchTimeoutPartialClient`, the RETURN-STRICT sibling of `DistSearchTimeoutFailClient` — and renamed it for consistency.

#### Renamed functions
- `DistAggregateTimeoutFailClient` → `DistAggregateTimeoutFailCallback`
- `DistAggregateTimeoutReturnStrictClient` → `DistAggregateTimeoutReturnStrictCallback`
- `DistCursorReadTimeoutReturnStrictClient` → `DistCursorReadTimeoutReturnStrictCallback`
- `DistHybridTimeoutFailClient` → `DistHybridTimeoutFailCallback`
- `DistHybridTimeoutReturnStrictClient` → `DistHybridTimeoutReturnStrictCallback`
- `DistSearchTimeoutFailClient` → `DistSearchTimeoutFailCallback`
- `DistSearchTimeoutPartialClient` → `DistSearchTimeoutPartialCallback` (missed by the ticket)

#### Which additional issues this PR fixes
1. MOD-16065

#### Main objects this PR modified
1. `src/coord/dist_aggregate.c`
2. `src/coord/hybrid/dist_hybrid.c`, `src/coord/hybrid/dist_hybrid.h`
3. `src/module.c`
4. `tests/pytests/test_blocked_client_timeout.py` (comment reference)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only refactor (function rename), no user-facing impact.

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=atlassian&utm_medium=jira_issue&utm_campaign=jira)
