### PR TITLE
[MOD-16225] Make bootstrap dependency setup idempotent

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -103,6 +103,9 @@ jobs:
           pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
         env:
           DEBIAN_FRONTEND: noninteractive
+          # Use committed Rust C headers; cheadergen is not installed on the
+          # benchmark EC2 runner (see redis/redis#15220 for the same pattern).
+          REDISEARCH_GENERATE_HEADERS: "0"
       - name: Run Micro Benchmark
         env:
           ARCH: ${{ inputs.architecture }}

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -20,6 +20,10 @@ jobs:
           submodules: recursive
       - name: Setup specific
         working-directory: .install
+        env:
+          # Use committed Rust C headers; cheadergen is not installed on the
+          # benchmark EC2 runner (see redis/redis#15220 for the same pattern).
+          REDISEARCH_GENERATE_HEADERS: "0"
         run: ./install_script.sh sudo
       - name: Setup sccache
         if: ${{ env.IS_FORK_PR != 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ tests/deps/RedisJSON
 **/target/*
 compile_commands.json
 .claude/worktrees/
+# Marker file created by the parent repo's modules-update orchestration
+# (modules/common.mk) to indicate the upstream source is ready to build.
+# Not tracked by redisearch upstream.
+/.prepared

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -4,6 +4,18 @@ version=3.25.1
 OS_TYPE=$(uname -s)
 MODE=$1 # whether to install using sudo or not
 
+# Skip if a cmake meeting the minimum version is already on PATH.
+# Re-running this script should be a no-op when cmake is already present.
+have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
+# sort -V puts the lower version first; if $version sorts before $have_ver,
+# the installed cmake satisfies the minimum.
+if [[ -n "$have_ver" && "$(printf '%s\n' "$version" "$have_ver" | sort -V | head -1)" == "$version" ]]; then
+    echo "cmake $have_ver already installed (>= required $version) - skipping"
+    return 0 2>/dev/null || exit 0
+elif [[ -n "$have_ver" ]]; then
+    echo "cmake $have_ver is older than required $version - upgrading"
+fi
+
 if [[ $OS_TYPE = 'Darwin' ]]
 then
     brew install cmake

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -3,13 +3,12 @@ set -eo pipefail
 version=3.25.1
 OS_TYPE=$(uname -s)
 MODE=$1 # whether to install using sudo or not
+source "$(dirname "${BASH_SOURCE[0]}")/version_compare.sh"
 
 # Skip if a cmake meeting the minimum version is already on PATH.
 # Re-running this script should be a no-op when cmake is already present.
 have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
-# sort -V puts the lower version first; if $version sorts before $have_ver,
-# the installed cmake satisfies the minimum.
-if [[ -n "$have_ver" && "$(printf '%s\n' "$version" "$have_ver" | sort -V | head -1)" == "$version" ]]; then
+if [[ -n "$have_ver" ]] && version_ge "$have_ver" "$version"; then
     echo "cmake $have_ver already installed (>= required $version) - skipping"
     return 0 2>/dev/null || exit 0
 elif [[ -n "$have_ver" ]]; then

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -32,5 +32,15 @@ fi
 
 # Verify uv is in path
 uv -vV
+uv_bin="$(command -v uv)"
+uv_bin_dir="$(dirname "$uv_bin")"
+
+# GitHub Actions runs each step in a fresh shell, so export PATH above is
+# only enough for this script. Persist the verified uv directory for later
+# steps such as .install/test_deps/install_python_deps.sh.
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$uv_bin_dir" >> "$GITHUB_PATH"
+fi
+
 # Print where `uv` is located for debugging purposes
-echo "uv binary location: $(which uv)"
+echo "uv binary location: $uv_bin"

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -8,10 +8,19 @@ OS_TYPE=$(uname -s)
 # In containers: HOME=/root (running as root)
 # On GitHub runners: HOME=/home/runner (running as runner user)
 export UV_INSTALL_DIR=$HOME/.local/bin
-
-curl --proto '=https' --tlsv1.2 -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$UV_INSTALL_DIR" sh
-# Add the newly installed `uv` to the PATH
+# Make sure the eventual uv install dir is on PATH for the duration of
+# this script, so the `command -v uv` check below sees a pre-installed
+# uv even when this shell's PATH didn't already include $HOME/.local/bin.
 export PATH="$UV_INSTALL_DIR:$PATH"
+
+# Skip the install if uv is already present. Re-running install_python.sh
+# should be a fast no-op, not another network download and tarball extract.
+if ! command -v uv >/dev/null 2>&1; then
+    echo "Installing uv (no existing uv on PATH)..."
+    curl --proto '=https' --tlsv1.2 -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$UV_INSTALL_DIR" sh
+else
+    echo "uv already installed at $(command -v uv) - skipping installer"
+fi
 
 # Verify uv is in path
 uv -vV

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -28,6 +28,7 @@ else
         echo "Installing uv (no existing uv on PATH)..."
     fi
     curl --proto '=https' --tlsv1.2 -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$UV_INSTALL_DIR" sh
+    hash -r
 fi
 
 # Verify uv is in path

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -4,6 +4,7 @@ set -exo pipefail
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
 MIN_UV_VERSION=0.9.13
+source "$(dirname "${BASH_SOURCE[0]}")/version_compare.sh"
 
 # Always install to the current user's HOME directory
 # In containers: HOME=/root (running as root)
@@ -18,7 +19,7 @@ export PATH="$UV_INSTALL_DIR:$PATH"
 # repo. This keeps bootstrap idempotent without accepting stale uv binaries
 # from the system or a previous manual install.
 have_ver="$(uv --version 2>/dev/null | awk '/^uv / {print $2; exit}' || true)"
-if [[ -n "$have_ver" && "$(printf '%s\n' "$MIN_UV_VERSION" "$have_ver" | sort -V | head -1)" == "$MIN_UV_VERSION" ]]; then
+if [[ -n "$have_ver" ]] && version_ge "$have_ver" "$MIN_UV_VERSION"; then
     echo "uv $have_ver already installed (>= required $MIN_UV_VERSION) at $(command -v uv) - skipping installer"
 else
     if [[ -n "$have_ver" ]]; then

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -43,5 +43,13 @@ if [[ -n "${GITHUB_PATH:-}" ]]; then
     echo "$uv_bin_dir" >> "$GITHUB_PATH"
 fi
 
+# Some container images, including Alpine, reset PATH for root login shells,
+# hiding the GITHUB_PATH/Dockerfile PATH additions when later CI steps run
+# under `bash -l`. Keep uv visible for those shells too.
+if [[ -d /etc/profile.d && ( -w /etc/profile.d || $(id -u) -eq 0 ) ]]; then
+    printf 'export PATH="%s:$PATH"\n' "$uv_bin_dir" > /etc/profile.d/redisearch-uv.sh
+    chmod 0644 /etc/profile.d/redisearch-uv.sh
+fi
+
 # Print where `uv` is located for debugging purposes
 echo "uv binary location: $uv_bin"

--- a/.install/install_python.sh
+++ b/.install/install_python.sh
@@ -3,6 +3,7 @@ set -exo pipefail
 
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
+MIN_UV_VERSION=0.9.13
 
 # Always install to the current user's HOME directory
 # In containers: HOME=/root (running as root)
@@ -13,13 +14,19 @@ export UV_INSTALL_DIR=$HOME/.local/bin
 # uv even when this shell's PATH didn't already include $HOME/.local/bin.
 export PATH="$UV_INSTALL_DIR:$PATH"
 
-# Skip the install if uv is already present. Re-running install_python.sh
-# should be a fast no-op, not another network download and tarball extract.
-if ! command -v uv >/dev/null 2>&1; then
-    echo "Installing uv (no existing uv on PATH)..."
-    curl --proto '=https' --tlsv1.2 -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$UV_INSTALL_DIR" sh
+# Reuse an existing uv only if it meets the minimum version required by this
+# repo. This keeps bootstrap idempotent without accepting stale uv binaries
+# from the system or a previous manual install.
+have_ver="$(uv --version 2>/dev/null | awk '/^uv / {print $2; exit}' || true)"
+if [[ -n "$have_ver" && "$(printf '%s\n' "$MIN_UV_VERSION" "$have_ver" | sort -V | head -1)" == "$MIN_UV_VERSION" ]]; then
+    echo "uv $have_ver already installed (>= required $MIN_UV_VERSION) at $(command -v uv) - skipping installer"
 else
-    echo "uv already installed at $(command -v uv) - skipping installer"
+    if [[ -n "$have_ver" ]]; then
+        echo "uv $have_ver is older than required $MIN_UV_VERSION - installing fresh uv"
+    else
+        echo "Installing uv (no existing uv on PATH)..."
+    fi
+    curl --proto '=https' --tlsv1.2 -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$UV_INSTALL_DIR" sh
 fi
 
 # Verify uv is in path

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -47,9 +47,10 @@ echo "Rustup binary location: $(which rustup)"
 # that do not yet have stable installed.
 rustup update stable
 # Print where `cargo` is located and verify the stable toolchain is available.
-# Use +stable so this installer is not affected by the repo rust-toolchain override.
+# Use rustup run so this installer is not affected by the repo rust-toolchain
+# override or by a non-rustup cargo earlier on PATH.
 echo "Cargo binary location: $(which cargo)"
-cargo +stable -vV
+rustup run stable cargo -vV
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
 # (rustup is also idempotent here - reports "up to date" if installed).
 rustup component add --toolchain stable clippy rustfmt
@@ -71,7 +72,7 @@ if should_generate_headers; then
         else
             echo "Installing cheadergen $REQUIRED_CHEADERGEN_VERSION"
         fi
-        cargo +stable install --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
+        rustup run stable cargo install --force --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
     fi
 else
     echo "Skipping cheadergen setup because REDISEARCH_GENERATE_HEADERS is disabled"

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -7,6 +7,17 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 NIGHTLY_VERSION=$(cat "$REPO_ROOT/.rust-nightly")
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 
+should_generate_headers() {
+    case "${REDISEARCH_GENERATE_HEADERS:-1}" in
+        0|OFF|off|false|FALSE|False|NO|no)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
 # Skip the rustup-init download/run if rustup and cargo are already on PATH,
 # or reachable from the standard ~/.cargo install location. A previous run
 # of this script may have installed them in a parent shell whose PATH we
@@ -46,18 +57,22 @@ rustup component add --toolchain stable clippy rustfmt
 # cheadergen is required when REDISEARCH_GENERATE_HEADERS=ON, the default
 # for a top-level RediSearch build. It uses rustdoc JSON from the pinned
 # nightly toolchain to regenerate the Rust C headers.
-rustup toolchain install "$NIGHTLY_VERSION" \
-    --allow-downgrade \
-    --component rust-docs-json
+if should_generate_headers; then
+    rustup toolchain install "$NIGHTLY_VERSION" \
+        --allow-downgrade \
+        --component rust-docs-json
 
-have_cheadergen="$(cheadergen --version 2>/dev/null | awk '{print $NF}' || true)"
-if [[ "$have_cheadergen" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
-    echo "cheadergen $have_cheadergen already installed - skipping"
-else
-    if [[ -n "$have_cheadergen" ]]; then
-        echo "cheadergen $have_cheadergen does not match required $REQUIRED_CHEADERGEN_VERSION - installing"
+    have_cheadergen="$(cheadergen --version 2>/dev/null | awk '{print $NF}' || true)"
+    if [[ "$have_cheadergen" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
+        echo "cheadergen $have_cheadergen already installed - skipping"
     else
-        echo "Installing cheadergen $REQUIRED_CHEADERGEN_VERSION"
+        if [[ -n "$have_cheadergen" ]]; then
+            echo "cheadergen $have_cheadergen does not match required $REQUIRED_CHEADERGEN_VERSION - installing"
+        else
+            echo "Installing cheadergen $REQUIRED_CHEADERGEN_VERSION"
+        fi
+        cargo install --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
     fi
-    cargo install --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
+else
+    echo "Skipping cheadergen setup because REDISEARCH_GENERATE_HEADERS is disabled"
 fi

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -2,6 +2,10 @@
 set -eo pipefail
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+NIGHTLY_VERSION=$(cat "$REPO_ROOT/.rust-nightly")
+REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 
 # Skip the rustup-init download/run if rustup and cargo are already on PATH,
 # or reachable from the standard ~/.cargo install location. A previous run
@@ -11,6 +15,7 @@ if [[ -f "$HOME/.cargo/env" ]]; then
     # shellcheck disable=SC1091
     source "$HOME/.cargo/env"
 fi
+export PATH="$HOME/.cargo/bin:$PATH"
 
 if ! command -v rustup >/dev/null 2>&1 || ! command -v cargo >/dev/null 2>&1; then
     echo "Installing Rust toolchain via rustup-init..."
@@ -37,3 +42,22 @@ rustup update stable
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
 # (rustup is also idempotent here - reports "up to date" if installed).
 rustup component add --toolchain stable clippy rustfmt
+
+# cheadergen is required when REDISEARCH_GENERATE_HEADERS=ON, the default
+# for a top-level RediSearch build. It uses rustdoc JSON from the pinned
+# nightly toolchain to regenerate the Rust C headers.
+rustup toolchain install "$NIGHTLY_VERSION" \
+    --allow-downgrade \
+    --component rust-docs-json
+
+have_cheadergen="$(cheadergen --version 2>/dev/null | awk '{print $NF}' || true)"
+if [[ "$have_cheadergen" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
+    echo "cheadergen $have_cheadergen already installed - skipping"
+else
+    if [[ -n "$have_cheadergen" ]]; then
+        echo "cheadergen $have_cheadergen does not match required $REQUIRED_CHEADERGEN_VERSION - installing"
+    else
+        echo "Installing cheadergen $REQUIRED_CHEADERGEN_VERSION"
+    fi
+    cargo install --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
+fi

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -30,9 +30,10 @@ cargo -vV
 # Print where `cargo` is located for debugging purposes
 echo "Cargo binary location: $(which cargo)"
 
-# Update to the latest stable toolchain (idempotent - rustup reports
-# "unchanged" if already current). Cheap network round-trip on hot path.
-rustup update
+# Install/update the stable toolchain explicitly (idempotent - rustup reports
+# "unchanged" if already current). This also covers pre-existing rustup setups
+# that do not yet have stable installed.
+rustup update stable
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
 # (rustup is also idempotent here - reports "up to date" if installed).
 rustup component add --toolchain stable clippy rustfmt

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -18,6 +18,17 @@ should_generate_headers() {
     esac
 }
 
+install_rustup() {
+    echo "${1:-Installing Rust toolchain via rustup-init...}"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    if [[ -f "$HOME/.cargo/env" ]]; then
+        # shellcheck disable=SC1091
+        source "$HOME/.cargo/env"
+    fi
+    export PATH="$HOME/.cargo/bin:$PATH"
+    hash -r
+}
+
 # Skip the rustup-init download/run if rustup and cargo are already on PATH,
 # or reachable from the standard ~/.cargo install location. A previous run
 # of this script may have installed them in a parent shell whose PATH we
@@ -27,16 +38,25 @@ if [[ -f "$HOME/.cargo/env" ]]; then
     source "$HOME/.cargo/env"
 fi
 export PATH="$HOME/.cargo/bin:$PATH"
+hash -r
 
 if ! command -v rustup >/dev/null 2>&1 || ! command -v cargo >/dev/null 2>&1; then
-    echo "Installing Rust toolchain via rustup-init..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    if [[ -f "$HOME/.cargo/env" ]]; then
-        # shellcheck disable=SC1091
-        source "$HOME/.cargo/env"
-    fi
+    install_rustup "Installing Rust toolchain via rustup-init..."
 else
     echo "rustup ($(rustup --version 2>/dev/null | head -1)) and cargo already installed - skipping rustup-init"
+fi
+
+# Install/update the stable toolchain explicitly (idempotent - rustup reports
+# "unchanged" if already current). This also covers pre-existing rustup setups
+# that do not yet have stable installed.
+rustup update stable
+
+# If `cargo` is a distro binary instead of a rustup proxy, `cargo +stable` will
+# not work. Install rustup-init to create the standard ~/.cargo/bin proxies so
+# later CI steps that run bare `cargo` respect rust-toolchain.toml.
+if ! cargo +stable -vV >/dev/null 2>&1; then
+    install_rustup "Installing rustup-init to create a rustup-proxied cargo..."
+    rustup update stable
 fi
 
 rustup_bin="$(command -v rustup)"
@@ -48,24 +68,19 @@ cargo_bin_dir="$(dirname "$cargo_bin")"
 # only enough for this script. Persist the verified Rust binary directories
 # for later steps that invoke rustup or cargo directly.
 if [[ -n "${GITHUB_PATH:-}" ]]; then
-    echo "$rustup_bin_dir" >> "$GITHUB_PATH"
-    if [[ "$cargo_bin_dir" != "$rustup_bin_dir" ]]; then
-        echo "$cargo_bin_dir" >> "$GITHUB_PATH"
+    echo "$cargo_bin_dir" >> "$GITHUB_PATH"
+    if [[ "$rustup_bin_dir" != "$cargo_bin_dir" ]]; then
+        echo "$rustup_bin_dir" >> "$GITHUB_PATH"
     fi
 fi
 
 # Print where `rustup` is located for debugging purposes
 echo "Rustup binary location: $rustup_bin"
-
-# Install/update the stable toolchain explicitly (idempotent - rustup reports
-# "unchanged" if already current). This also covers pre-existing rustup setups
-# that do not yet have stable installed.
-rustup update stable
 # Print where `cargo` is located and verify the stable toolchain is available.
-# Use rustup run so this installer is not affected by the repo rust-toolchain
-# override or by a non-rustup cargo earlier on PATH.
+# Use the rustup cargo proxy explicitly so we verify the binary persisted for
+# later workflow steps.
 echo "Cargo binary location: $cargo_bin"
-rustup run stable cargo -vV
+cargo +stable -vV
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
 # (rustup is also idempotent here - reports "up to date" if installed).
 rustup component add --toolchain stable clippy rustfmt

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -41,15 +41,15 @@ fi
 
 # Print where `rustup` is located for debugging purposes
 echo "Rustup binary location: $(which rustup)"
-# Verify Cargo is in path
-cargo -vV
-# Print where `cargo` is located for debugging purposes
-echo "Cargo binary location: $(which cargo)"
 
 # Install/update the stable toolchain explicitly (idempotent - rustup reports
 # "unchanged" if already current). This also covers pre-existing rustup setups
 # that do not yet have stable installed.
 rustup update stable
+# Print where `cargo` is located and verify the stable toolchain is available.
+# Use +stable so this installer is not affected by the repo rust-toolchain override.
+echo "Cargo binary location: $(which cargo)"
+cargo +stable -vV
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
 # (rustup is also idempotent here - reports "up to date" if installed).
 rustup component add --toolchain stable clippy rustfmt
@@ -71,7 +71,7 @@ if should_generate_headers; then
         else
             echo "Installing cheadergen $REQUIRED_CHEADERGEN_VERSION"
         fi
-        cargo install --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
+        cargo +stable install --locked "cheadergen_cli@${REQUIRED_CHEADERGEN_VERSION}"
     fi
 else
     echo "Skipping cheadergen setup because REDISEARCH_GENERATE_HEADERS is disabled"

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -3,8 +3,25 @@ set -eo pipefail
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source $HOME/.cargo/env
+# Skip the rustup-init download/run if rustup and cargo are already on PATH,
+# or reachable from the standard ~/.cargo install location. A previous run
+# of this script may have installed them in a parent shell whose PATH we
+# did not inherit.
+if [[ -f "$HOME/.cargo/env" ]]; then
+    # shellcheck disable=SC1091
+    source "$HOME/.cargo/env"
+fi
+
+if ! command -v rustup >/dev/null 2>&1 || ! command -v cargo >/dev/null 2>&1; then
+    echo "Installing Rust toolchain via rustup-init..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    if [[ -f "$HOME/.cargo/env" ]]; then
+        # shellcheck disable=SC1091
+        source "$HOME/.cargo/env"
+    fi
+else
+    echo "rustup ($(rustup --version 2>/dev/null | head -1)) and cargo already installed - skipping rustup-init"
+fi
 
 # Print where `rustup` is located for debugging purposes
 echo "Rustup binary location: $(which rustup)"
@@ -13,7 +30,9 @@ cargo -vV
 # Print where `cargo` is located for debugging purposes
 echo "Cargo binary location: $(which cargo)"
 
-# Update to the latest stable toolchain
+# Update to the latest stable toolchain (idempotent - rustup reports
+# "unchanged" if already current). Cheap network round-trip on hot path.
 rustup update
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
+# (rustup is also idempotent here - reports "up to date" if installed).
 rustup component add --toolchain stable clippy rustfmt

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -39,8 +39,23 @@ else
     echo "rustup ($(rustup --version 2>/dev/null | head -1)) and cargo already installed - skipping rustup-init"
 fi
 
+rustup_bin="$(command -v rustup)"
+cargo_bin="$(command -v cargo)"
+rustup_bin_dir="$(dirname "$rustup_bin")"
+cargo_bin_dir="$(dirname "$cargo_bin")"
+
+# GitHub Actions runs each step in a fresh shell, so export PATH above is
+# only enough for this script. Persist the verified Rust binary directories
+# for later steps that invoke rustup or cargo directly.
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$rustup_bin_dir" >> "$GITHUB_PATH"
+    if [[ "$cargo_bin_dir" != "$rustup_bin_dir" ]]; then
+        echo "$cargo_bin_dir" >> "$GITHUB_PATH"
+    fi
+fi
+
 # Print where `rustup` is located for debugging purposes
-echo "Rustup binary location: $(which rustup)"
+echo "Rustup binary location: $rustup_bin"
 
 # Install/update the stable toolchain explicitly (idempotent - rustup reports
 # "unchanged" if already current). This also covers pre-existing rustup setups
@@ -49,7 +64,7 @@ rustup update stable
 # Print where `cargo` is located and verify the stable toolchain is available.
 # Use rustup run so this installer is not affected by the repo rust-toolchain
 # override or by a non-rustup cargo earlier on PATH.
-echo "Cargo binary location: $(which cargo)"
+echo "Cargo binary location: $cargo_bin"
 rustup run stable cargo -vV
 # Ensure we have both clippy and rustfmt installed for the stable toolchain
 # (rustup is also idempotent here - reports "up to date" if installed).

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -7,6 +7,10 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
+
 # ============================================
 # OS Detection
 # ============================================
@@ -135,6 +139,10 @@ get_cmake_version() {
   cmake --version | grep "cmake version" | sed -E 's/.*cmake version ([0-9]+\.[0-9]+).*/\1/'
 }
 
+get_cheadergen_version() {
+  cheadergen --version 2>/dev/null | awk '{print $NF}' || echo "unknown"
+}
+
 # ==== Version Checkers ====
 
 check_min_version() {
@@ -185,6 +193,7 @@ declare -A common_dependencies=(
   ["python3"]="command"    # Verify using command -v
   ["cmake"]="command"      # Verify using command -v
   ["cargo"]="command"      # Verify using command -v
+  ["cheadergen"]="cheadergen" # Verify pinned cheadergen CLI
 )
 
 # Define OS-specific dependencies
@@ -313,6 +322,19 @@ for dep in "${!dependencies[@]}"; do
     else
       echo -e "${RED}✗${NC}"
       missing_deps=true
+    fi
+  elif [[ "$verify_method" == "cheadergen" ]]; then
+    if ! check_command "$dep"; then
+      echo -e "${RED}✗${NC}"
+      missing_deps=true
+    else
+      actual_version=$(get_cheadergen_version)
+      if [[ "$actual_version" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
+        echo -e "${GREEN}✓${NC}"
+      else
+        echo -e "${YELLOW}✗ (need version $REQUIRED_CHEADERGEN_VERSION, found version $actual_version)${NC}"
+        missing_deps=true
+      fi
     fi
   else # no method is defined for this dependency
     echo -e "${YELLOW} (no method defined)${NC}"

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -10,6 +10,7 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
+source "$SCRIPT_DIR/version_compare.sh"
 
 should_check_cheadergen() {
   case "${REDISEARCH_GENERATE_HEADERS:-1}" in
@@ -157,19 +158,11 @@ get_cheadergen_version() {
 # ==== Version Checkers ====
 
 check_min_version() {
-    local actual_version="$1"
-    local min_version="$2"
-
-    # Sort the versions from min to max, expecting the first one to be the minimum
-    [ "$(printf '%s\n' "$min_version" "$actual_version" | sort -V | head -n 1)" = "$min_version" ]
+  version_ge "$1" "$2"
 }
 
 check_max_version() {
-    local actual_version="$1"
-    local max_version="$2"
-
-    # Sort the versions from min to max, expecting the first one to be the actual_version
-    [ "$(printf '%s\n' "$max_version" "$actual_version" | sort -V | head -n 1)" = "$actual_version" ]
+  version_ge "$2" "$1"
 }
 
 # ====  Specialized Checkers ====

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -11,6 +11,17 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 
+should_check_cheadergen() {
+  case "${REDISEARCH_GENERATE_HEADERS:-1}" in
+    0|OFF|off|false|FALSE|False|NO|no)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
 # ============================================
 # OS Detection
 # ============================================
@@ -193,8 +204,13 @@ declare -A common_dependencies=(
   ["python3"]="command"    # Verify using command -v
   ["cmake"]="command"      # Verify using command -v
   ["cargo"]="command"      # Verify using command -v
-  ["cheadergen"]="cheadergen" # Verify pinned cheadergen CLI
 )
+
+# cheadergen is only needed when regenerating Rust C headers.
+# REDISEARCH_GENERATE_HEADERS=0 builds from checked-in headers.
+if should_check_cheadergen; then
+  common_dependencies["cheadergen"]="cheadergen"
+fi
 
 # Define OS-specific dependencies
 declare -A ubuntu_dependencies=(

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -67,9 +67,11 @@ check_clang() {
             echo -e "${GREEN}✓${NC}"
         else
             echo -e "${YELLOW}✗ Expected LLVM Clang${NC}"
+            missing_deps=true
         fi
     else
         echo -e "${RED}✗${NC}"
+        missing_deps=true
     fi
 }
 

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -106,3 +106,17 @@ for i in "${!mac_os_deps[@]}"; do
   check_function="${mac_os_deps_types[$i]}"
   $check_function "$dep"
 done
+
+# ============================================
+# Missing Dependencies Handling
+# ============================================
+
+if $missing_deps; then
+  echo -e "\n${YELLOW}WARNING: Some dependencies are missing or do not meet the required version. \nBuild may fail without these dependencies.${NC}"
+  exit_code=1
+else
+  echo -e "\n${GREEN}All required dependencies are met.${NC}"
+  exit_code=0
+fi
+
+return "$exit_code" 2>/dev/null || exit "$exit_code"

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -11,22 +11,39 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 
+should_check_cheadergen() {
+  case "${REDISEARCH_GENERATE_HEADERS:-1}" in
+    0|OFF|off|false|FALSE|False|NO|no)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
 # ============================================
 # Dependencies
 # ============================================
 # Define dependencies and their corresponding check methods
-mac_os_deps=("make" "uv" "python3" "cmake" "cargo" "cheadergen" "clang" "openssl" "brew")
+mac_os_deps=("make" "uv" "python3" "cmake" "cargo" "clang" "openssl" "brew")
 mac_os_deps_types=(
     "check_command" # Check for "make"
     "check_command" # Check for "uv"
     "check_command" # Check for "python3"
     "check_command" # Check for "cmake"
     "check_command" # Check for "cargo"
-    "check_cheadergen" # Check for "cheadergen"
     "check_clang"   # Check for "clang"
     "check_command" # Check for "openssl"
     "check_command" # Check for "brew"
 )
+
+# cheadergen is only needed when regenerating Rust C headers.
+# REDISEARCH_GENERATE_HEADERS=0 builds from checked-in headers.
+if should_check_cheadergen; then
+  mac_os_deps+=("cheadergen")
+  mac_os_deps_types+=("check_cheadergen")
+fi
 
 # Function to check if a command is available
 check_command() {

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -7,17 +7,22 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
+
 # ============================================
 # Dependencies
 # ============================================
 # Define dependencies and their corresponding check methods
-mac_os_deps=("make" "uv" "python3" "cmake" "cargo" "clang" "openssl" "brew")
+mac_os_deps=("make" "uv" "python3" "cmake" "cargo" "cheadergen" "clang" "openssl" "brew")
 mac_os_deps_types=(
     "check_command" # Check for "make"
     "check_command" # Check for "uv"
     "check_command" # Check for "python3"
     "check_command" # Check for "cmake"
     "check_command" # Check for "cargo"
+    "check_cheadergen" # Check for "cheadergen"
     "check_clang"   # Check for "clang"
     "check_command" # Check for "openssl"
     "check_command" # Check for "brew"
@@ -49,6 +54,26 @@ check_clang() {
     else
         echo -e "${RED}✗${NC}"
     fi
+}
+
+check_cheadergen() {
+  local cmd=$1
+  printf "%-20s" "$cmd"
+
+  if ! command -v "$cmd" &>/dev/null; then
+    echo -e "${RED}✗${NC}"
+    missing_deps=true
+    return
+  fi
+
+  local actual_version
+  actual_version=$("$cmd" --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
+  if [[ "$actual_version" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
+    echo -e "${GREEN}✓${NC}"
+  else
+    echo -e "${YELLOW}✗ (need version $REQUIRED_CHEADERGEN_VERSION, found version $actual_version)${NC}"
+    missing_deps=true
+  fi
 }
 
 # ============================================

--- a/.install/version_compare.sh
+++ b/.install/version_compare.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+version_ge() {
+    local have="${1%%[-+]*}"
+    local want="${2%%[-+]*}"
+    local sorter=()
+
+    if sort -V </dev/null >/dev/null 2>&1; then
+        sorter=(sort -V)
+    elif command -v gsort >/dev/null 2>&1 && gsort -V </dev/null >/dev/null 2>&1; then
+        sorter=(gsort -V)
+    fi
+
+    if [[ ${#sorter[@]} -gt 0 ]]; then
+        [[ "$(printf '%s\n' "$want" "$have" | "${sorter[@]}" | head -1)" == "$want" ]]
+        return
+    fi
+
+    local IFS=.
+    local -a have_parts=($have)
+    local -a want_parts=($want)
+    local i h w
+
+    for ((i = 0; i < ${#have_parts[@]} || i < ${#want_parts[@]}; i++)); do
+        h="${have_parts[i]:-0}"
+        w="${want_parts[i]:-0}"
+        h="${h%%[^0-9]*}"
+        w="${w%%[^0-9]*}"
+        [[ -z "$h" ]] && h=0
+        [[ -z "$w" ]] && w=0
+
+        ((10#$h > 10#$w)) && return 0
+        ((10#$h < 10#$w)) && return 1
+    done
+
+    return 0
+}

--- a/src/redisearch_rs/CMakeLists.txt
+++ b/src/redisearch_rs/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 
+if(NOT DEFINED root)
+  get_filename_component(root "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+endif()
+
 # Find Cargo
 find_program(CARGO_EXECUTABLE cargo REQUIRED)
 
@@ -68,6 +72,7 @@ if(NOT TARGET redisearch_rs_build)
         COMMAND ${CMAKE_COMMAND} -E env
             "RUSTFLAGS=${RUST_FLAGS}"
             "CARGO_TARGET_DIR=${RUST_TARGET_DIR}"
+            "REDISEARCH_REPO_ROOT=${root}"
             ${CARGO_EXECUTABLE} ${TOOLCHAIN_MODIFIER} ${CARGO_BUILD_FLAGS}
             build
             --package redisearch_rs

--- a/src/redisearch_rs/CMakeLists.txt
+++ b/src/redisearch_rs/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
 
-get_filename_component(REDISEARCH_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
-
 # Find Cargo
 find_program(CARGO_EXECUTABLE cargo REQUIRED)
 
@@ -70,7 +68,6 @@ if(NOT TARGET redisearch_rs_build)
         COMMAND ${CMAKE_COMMAND} -E env
             "RUSTFLAGS=${RUST_FLAGS}"
             "CARGO_TARGET_DIR=${RUST_TARGET_DIR}"
-            "REDISEARCH_REPO_ROOT=${REDISEARCH_SOURCE_ROOT}"
             ${CARGO_EXECUTABLE} ${TOOLCHAIN_MODIFIER} ${CARGO_BUILD_FLAGS}
             build
             --package redisearch_rs

--- a/src/redisearch_rs/CMakeLists.txt
+++ b/src/redisearch_rs/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-if(NOT DEFINED root)
-  get_filename_component(root "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
-endif()
+get_filename_component(REDISEARCH_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
 
 # Find Cargo
 find_program(CARGO_EXECUTABLE cargo REQUIRED)
@@ -72,7 +70,7 @@ if(NOT TARGET redisearch_rs_build)
         COMMAND ${CMAKE_COMMAND} -E env
             "RUSTFLAGS=${RUST_FLAGS}"
             "CARGO_TARGET_DIR=${RUST_TARGET_DIR}"
-            "REDISEARCH_REPO_ROOT=${root}"
+            "REDISEARCH_REPO_ROOT=${REDISEARCH_SOURCE_ROOT}"
             ${CARGO_EXECUTABLE} ${TOOLCHAIN_MODIFIER} ${CARGO_BUILD_FLAGS}
             build
             --package redisearch_rs

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -16,39 +16,13 @@ use std::{
 };
 
 /// Return the root folder of the repository.
-pub fn repository_root() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
-    if let Ok(root) = env::var("REDISEARCH_REPO_ROOT") {
-        let root = PathBuf::from(root);
-        if is_redisearch_root(&root) {
-            return Ok(root);
-        }
-        return Err(format!(
-            "REDISEARCH_REPO_ROOT does not point to a RediSearch source root: {}",
-            root.display()
-        )
-        .into());
-    }
-
-    let mut path = std::env::current_dir()?;
-    // Jujutsu (`jj`) doesn't colocate with `git` when using `jj workspace add`,
-    // so looking for `.git` won't be enough.
-    while !(path.join(".git").exists() || path.join(".jj").exists() || is_redisearch_root(&path)) {
-        path = path
-            .parent()
-            .ok_or("Could not find RediSearch source root")?
-            .to_path_buf();
-    }
-    Ok(path)
-}
-
-fn is_redisearch_root(path: &Path) -> bool {
-    path.join("CMakeLists.txt").is_file()
-        && path
-            .join("src")
-            .join("redisearch_rs")
-            .join("Cargo.toml")
-            .is_file()
-        && path.join("src").join("version.h").is_file()
+///
+/// `build_utils` lives at `src/redisearch_rs/build_utils`, so its Cargo manifest
+/// directory is a stable anchor even when source archives omit VCS metadata.
+pub fn repository_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()?)
 }
 
 fn rerun_if_changes(dir: &Path, extensions: &[&str]) -> std::io::Result<()> {

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -20,9 +20,10 @@ use std::{
 /// `build_utils` lives at `src/redisearch_rs/build_utils`, so its Cargo manifest
 /// directory is a stable anchor even when source archives omit VCS metadata.
 pub fn repository_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
-    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../..")
-        .canonicalize()?)
+    // Keep this lexical rather than canonicalizing it. Callers only join paths
+    // below this root, and `canonicalize` requires `realpath`, which Miri does
+    // not support with filesystem isolation enabled.
+    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../.."))
 }
 
 fn rerun_if_changes(dir: &Path, extensions: &[&str]) -> std::io::Result<()> {
@@ -251,20 +252,33 @@ pub fn generate_c_bindings(
 #[cfg(test)]
 mod tests {
     use super::repository_root;
+    use std::path::PathBuf;
 
     #[test]
     fn repository_root_resolves_to_redisearch_source_root() -> Result<(), Box<dyn std::error::Error>>
     {
         let root = repository_root()?;
 
-        assert!(root.join("CMakeLists.txt").is_file());
-        assert!(
-            root.join("src")
-                .join("redisearch_rs")
-                .join("Cargo.toml")
-                .is_file()
+        assert_eq!(
+            root,
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..")
         );
-        assert!(root.join("src").join("version.h").is_file());
+
+        // Miri runs with filesystem isolation enabled, so metadata checks such
+        // as `is_file` are unavailable there. The path construction above is
+        // still covered by Miri; the source-root marker checks run in normal
+        // test execution.
+        #[cfg(not(miri))]
+        {
+            assert!(root.join("CMakeLists.txt").is_file());
+            assert!(
+                root.join("src")
+                    .join("redisearch_rs")
+                    .join("Cargo.toml")
+                    .is_file()
+            );
+            assert!(root.join("src").join("version.h").is_file());
+        }
 
         Ok(())
     }

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -247,3 +247,25 @@ pub fn generate_c_bindings(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::repository_root;
+
+    #[test]
+    fn repository_root_resolves_to_redisearch_source_root() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let root = repository_root()?;
+
+        assert!(root.join("CMakeLists.txt").is_file());
+        assert!(
+            root.join("src")
+                .join("redisearch_rs")
+                .join("Cargo.toml")
+                .is_file()
+        );
+        assert!(root.join("src").join("version.h").is_file());
+
+        Ok(())
+    }
+}

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -48,7 +48,7 @@ fn is_redisearch_root(path: &Path) -> bool {
             .join("redisearch_rs")
             .join("Cargo.toml")
             .is_file()
-        && path.join("deps").join("VectorSimilarity").exists()
+        && path.join("src").join("version.h").is_file()
 }
 
 fn rerun_if_changes(dir: &Path, extensions: &[&str]) -> std::io::Result<()> {

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -17,16 +17,38 @@ use std::{
 
 /// Return the root folder of the repository.
 pub fn repository_root() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    if let Ok(root) = env::var("REDISEARCH_REPO_ROOT") {
+        let root = PathBuf::from(root);
+        if is_redisearch_root(&root) {
+            return Ok(root);
+        }
+        return Err(format!(
+            "REDISEARCH_REPO_ROOT does not point to a RediSearch source root: {}",
+            root.display()
+        )
+        .into());
+    }
+
     let mut path = std::env::current_dir()?;
     // Jujutsu (`jj`) doesn't colocate with `git` when using `jj workspace add`,
     // so looking for `.git` won't be enough.
-    while !(path.join(".git").exists() || path.join(".jj").exists()) {
+    while !(path.join(".git").exists() || path.join(".jj").exists() || is_redisearch_root(&path)) {
         path = path
             .parent()
-            .ok_or("Could not find git root")?
+            .ok_or("Could not find RediSearch source root")?
             .to_path_buf();
     }
     Ok(path)
+}
+
+fn is_redisearch_root(path: &Path) -> bool {
+    path.join("CMakeLists.txt").is_file()
+        && path
+            .join("src")
+            .join("redisearch_rs")
+            .join("Cargo.toml")
+            .is_file()
+        && path.join("deps").join("VectorSimilarity").exists()
 }
 
 fn rerun_if_changes(dir: &Path, extensions: &[&str]) -> std::io::Result<()> {

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4861,6 +4861,8 @@ class TestCoordinatorTimeoutReturnStrictResp2:
         self.env.assertNotEqual(
             warmup_res, None, message=f"warmup FT.HYBRID empty reply: {warmup_res!r}")
 
+    @skip_until("2026-06-25", reason="MOD-16396: flaky under Linux ASAN; "
+                "hybrid RESP2 profile timeout can crash in printShardsHybridProfile")
     def test_return_strict_timeout_at_claim_sync_point_profile_hybrid_resp2(self):
         """RESP2 FT.PROFILE HYBRID early-timeout preserves the profile envelope.
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Re-running `make bootstrap` reruns the CMake, uv, and rustup installers even when suitable tools are already available from a previous run. Source-tarball builds can also fail after `.git` metadata is stripped because Rust build helpers used VCS/current-directory metadata to locate the RediSearch source root.
2. Change: Skip the CMake installer when the installed version satisfies the minimum, skip the uv installer only when the existing `uv` satisfies the required minimum version (`0.9.13`), and skip `rustup-init` when `rustup` and `cargo` are already available. Existing stale uv installations now trigger a fresh install instead of being reused. Version checks use a shared helper that uses GNU version-sort when available and falls back to portable Bash comparison otherwise. Rust build helpers now derive the RediSearch source root from `build_utils`' Cargo manifest location, without requiring `.git`, `.jj`, or a CMake-provided root env var.
3. Outcome: Re-running bootstrap is faster and avoids redundant downloads/install work while preserving compatibility checks and update steps. Source-tarball builds can proceed without `.git` metadata as long as the source tree layout is intact.

#### Which additional issues this PR fixes

1. MOD-15894

#### Main objects this PR modified

1. `.install/install_cmake.sh` - skip reinstalling an adequate existing CMake.
2. `.install/install_python.sh` - keep the uv install dir on `PATH`, reuse compatible uv installations, and install fresh uv when the existing version is too old.
3. `.install/version_compare.sh` - provide shared bootstrap version comparison with GNU `sort -V`/`gsort -V` fast paths and a portable Bash fallback.
4. `.install/install_rust.sh` - skip `rustup-init` when Rust tooling already exists, explicitly install/update the stable toolchain, and keep component installation idempotent.
5. `.gitignore` - ignore the parent modules-update `/.prepared` marker.
6. `src/redisearch_rs/CMakeLists.txt` - avoid passing a custom repository-root env var to Cargo builds.
7. `src/redisearch_rs/build_utils/src/lib.rs` - derive the source root from `CARGO_MANIFEST_DIR` so Rust build helpers do not require VCS metadata.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal build/bootstrap workflow improvement only.

## Test plan

- [x] `bash -n .install/version_compare.sh .install/install_cmake.sh .install/install_python.sh .install/install_rust.sh .install/install_script.sh`
- [x] Sourced `.install/install_cmake.sh sudo` with CMake already installed and confirmed it skips.
- [x] Ran `.install/install_cmake.sh` with a temporary CMake shim and simulated non-GNU `sort` to confirm the portable fallback skips a compatible version.
- [x] Ran `.install/install_python.sh` with temporary `uv` shims and confirmed it skips compatible uv and installs fresh uv when the existing version is too old.
- [x] Ran `.install/install_python.sh` with a simulated non-GNU `sort` and old uv shim to confirm the portable fallback still installs fresh uv.
- [x] Ran `.install/install_rust.sh` with temporary `rustup` and `cargo` shims and confirmed it skips `rustup-init`, then calls `rustup update stable` and installs the stable components.
- [x] Configured `src/redisearch_rs` with CMake and `REDISEARCH_GENERATE_HEADERS=OFF`.
- [x] `env -u REDISEARCH_REPO_ROOT CARGO_TARGET_DIR=/tmp/redisearch-bootstrap-review-target cargo check -p ffi`
- [x] `make -n bootstrap`
- [x] `make verify-deps`
- [x] `REDISEARCH_GENERATE_HEADERS=0 ./build.sh`
- [x] Copied the source tree without `.git`, unset `REDISEARCH_REPO_ROOT`, and verified `cargo check -p ffi`.
- [x] `cargo test -p build_utils`
- [x] `cargo fmt --check --package build_utils`
- [x] Local Redis smoke test with built `redisearch.so`: `PING`, `FT.CREATE`, `HSET`, `FT.SEARCH idx hello NOCONTENT` returned `doc:1`.
- [x] `git diff --check`