### PR TITLE
[MOD-14459] Fix value hashing collisions and add HashDoS resistance

### DIFF
--- a/src/aggregate/reducers/count_distinct.c
+++ b/src/aggregate/reducers/count_distinct.c
@@ -16,6 +16,10 @@
 #define HLL_PRECISION_BITS 8
 #define INSTANCE_BLOCK_NUM 1024
 
+// Also used as the FNV seed in hll.c and the hyperloglog Rust crate.
+// (the choice of this specific seed is lost in time)
+#define STABLE_SEED 0x5f61767a
+
 static const int khid = 35;
 KHASH_SET_INIT_INT64(khid);
 
@@ -102,7 +106,7 @@ static int distinctishAdd(Reducer *parent, void *instance, const RLookupRow *src
   // Use the stable (non-randomized) hash here: COUNT_DISTINCTISH's per-shard HLL
   // registers are merged across shards by HLL_SUM, which requires every shard to
   // map the same value to the same register/rank pair.
-  uint64_t hval = RSValue_HashStable(val, 0x5f61767a);
+  uint64_t hval = RSValue_HashStable(val, STABLE_SEED);
   uint32_t val32 = (uint32_t)hval ^ (uint32_t)(hval >> 32);
   hll_add_hash(&ctr->hll, val32);
   return 1;

--- a/src/aggregate/reducers/count_distinct.c
+++ b/src/aggregate/reducers/count_distinct.c
@@ -99,7 +99,10 @@ static int distinctishAdd(Reducer *parent, void *instance, const RLookupRow *src
     return 1;
   }
 
-  uint64_t hval = RSValue_Hash(val, 0x5f61767a);
+  // Use the stable (non-randomized) hash here: COUNT_DISTINCTISH's per-shard HLL
+  // registers are merged across shards by HLL_SUM, which requires every shard to
+  // map the same value to the same register/rank pair.
+  uint64_t hval = RSValue_HashStable(val, 0x5f61767a);
   uint32_t val32 = (uint32_t)hval ^ (uint32_t)(hval >> 32);
   hll_add_hash(&ctr->hll, val32);
   return 1;

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -91,7 +91,7 @@ size_t hll_count(const struct HLL *hll) {
 
   double sum = 0;
   for (uint32_t i = 0; i < hll->size; i++) {
-    sum += 1.0 / (1u << hll->registers[i]);
+    sum += 1.0 / (1 << hll->registers[i]);
   }
 
   double estimate = alpha_mm / sum;
@@ -119,15 +119,6 @@ int hll_merge(struct HLL *dst, const struct HLL *src) {
     return -1;
   }
 
-  // Validate source registers before merging; an impossible rank (e.g. from
-  // untrusted external data) would propagate into dst and cause UB in hll_count.
-  uint8_t max_rank = dst->rank_bits + 1;
-  for (uint32_t i = 0; i < src->size; i++) {
-    if (src->registers[i] > max_rank) {
-      return -1;
-    }
-  }
-
   for (uint32_t i = 0; i < src->size; i++) {
     if (dst->registers[i] < src->registers[i]) {
       dst->registers[i] = src->registers[i];
@@ -146,20 +137,7 @@ int hll_load(struct HLL *hll, const void *registers, uint32_t size) {
   // Since `size` is a power of 2, the number of trailing zeros is the log2 of `size`
   if (hll_init(hll, __builtin_ctz(size)) == -1) return -1;
 
-  // Reject impossible rank values before they can reach hll_count's shift expression.
-  // Valid ranks are in [0, rank_bits+1]; anything higher cannot be produced by _hll_rank
-  // and would cause undefined behaviour (shift count >= 32) in hll_count.
-  uint8_t max_rank = hll->rank_bits + 1;
-  const uint8_t *regs = (const uint8_t *)registers;
-  for (uint32_t i = 0; i < size; i++) {
-    if (regs[i] > max_rank) {
-      hll_destroy(hll);
-      return -1;
-    }
-  }
-
   memcpy(hll->registers, registers, size * sizeof(*hll->registers));
-  hll->cachedCard = INVALID_CACHE_CARDINALITY; // Invalidate the cache populated by hll_init
 
   return 0;
 }

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -138,6 +138,7 @@ int hll_load(struct HLL *hll, const void *registers, uint32_t size) {
   if (hll_init(hll, __builtin_ctz(size)) == -1) return -1;
 
   memcpy(hll->registers, registers, size * sizeof(*hll->registers));
+  hll->cachedCard = INVALID_CACHE_CARDINALITY; // Invalidate the cache populated by hll_init
 
   return 0;
 }

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -91,7 +91,7 @@ size_t hll_count(const struct HLL *hll) {
 
   double sum = 0;
   for (uint32_t i = 0; i < hll->size; i++) {
-    sum += 1.0 / (1 << hll->registers[i]);
+    sum += 1.0 / (1u << hll->registers[i]);
   }
 
   double estimate = alpha_mm / sum;
@@ -119,6 +119,15 @@ int hll_merge(struct HLL *dst, const struct HLL *src) {
     return -1;
   }
 
+  // Validate source registers before merging; an impossible rank (e.g. from
+  // untrusted external data) would propagate into dst and cause UB in hll_count.
+  uint8_t max_rank = dst->rank_bits + 1;
+  for (uint32_t i = 0; i < src->size; i++) {
+    if (src->registers[i] > max_rank) {
+      return -1;
+    }
+  }
+
   for (uint32_t i = 0; i < src->size; i++) {
     if (dst->registers[i] < src->registers[i]) {
       dst->registers[i] = src->registers[i];
@@ -136,6 +145,18 @@ int hll_load(struct HLL *hll, const void *registers, uint32_t size) {
 
   // Since `size` is a power of 2, the number of trailing zeros is the log2 of `size`
   if (hll_init(hll, __builtin_ctz(size)) == -1) return -1;
+
+  // Reject impossible rank values before they can reach hll_count's shift expression.
+  // Valid ranks are in [0, rank_bits+1]; anything higher cannot be produced by _hll_rank
+  // and would cause undefined behaviour (shift count >= 32) in hll_count.
+  uint8_t max_rank = hll->rank_bits + 1;
+  const uint8_t *regs = (const uint8_t *)registers;
+  for (uint32_t i = 0; i < size; i++) {
+    if (regs[i] > max_rank) {
+      hll_destroy(hll);
+      return -1;
+    }
+  }
 
   memcpy(hll->registers, registers, size * sizeof(*hll->registers));
   hll->cachedCard = INVALID_CACHE_CARDINALITY; // Invalidate the cache populated by hll_init

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3249,7 +3249,6 @@ version = "0.0.1"
 dependencies = [
  "cheadergen",
  "ffi",
- "fnv",
  "libc",
  "query_error",
  "redis_mock",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3230,7 +3230,6 @@ dependencies = [
  "c_ffi_utils",
  "cheadergen",
  "ffi",
- "fnv",
  "libc",
  "query_error",
  "redis-module",

--- a/src/redisearch_rs/c_entrypoint/value_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 [dependencies]
 cheadergen.workspace = true
 ffi.workspace = true
-fnv.workspace = true
 libc.workspace = true
 query_error.workspace = true
 value.workspace = true

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
@@ -28,7 +28,7 @@ use crate::util::expect_value;
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_Hash(value: *const RSValue, hval: u64) -> u64 {
-    // Safety: ensured by caller (1.)
+    // SAFETY: caller guarantees `value` is a valid, non-null pointer to an RSValue (1.)
     let value = unsafe { expect_value(value) };
 
     value::hash::hash(value, hval)
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn RSValue_Hash(value: *const RSValue, hval: u64) -> u64 {
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_HashStable(value: *const RSValue, hval: u64) -> u64 {
-    // Safety: ensured by caller (1.)
+    // SAFETY: caller guarantees `value` is a valid, non-null pointer to an RSValue (1.)
     let value = unsafe { expect_value(value) };
 
     value::hash::hash_stable(value, hval)

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
@@ -9,29 +9,17 @@
 
 use crate::RSValue;
 use crate::util::expect_value;
-use std::collections::hash_map::RandomState;
-use std::hash::{BuildHasher, Hasher};
-use std::sync::LazyLock;
-
-/// Per-process random keys used to seed [`RSValue_Hash`]'s hasher.
-///
-/// Generated once from OS randomness on first use. Without a secret,
-/// unpredictable key, an attacker who controls indexed field values (and
-/// therefore the inputs hashed into the GROUPBY/COUNT_DISTINCT/TOLIST hash
-/// tables) could craft values that collide under a known hash function,
-/// degrading those hash tables to linked lists (a "HashDoS" attack). Keying
-/// the hash with a value the attacker cannot know prevents this.
-///
-/// The seed is fixed for the lifetime of the process, so hashes remain
-/// stable within and across queries on the same instance, but differ across
-/// restarts.
-static HASH_SEED: LazyLock<RandomState> = LazyLock::new(RandomState::new);
 
 /// Computes a HashDoS-resistant 64-bit hash of an [`RSValue`], mixing in `hval` so that
 /// the hashes of multiple values (e.g. the fields making up a GROUPBY key) can be
 /// combined into a single hash by chaining: `RSValue_Hash(b, RSValue_Hash(a, hval))`.
 ///
 /// The hashing is recursive for composite types (arrays, maps, references, trios).
+///
+/// Because the hasher is keyed with a per-process secret, the result is only
+/// meaningful within the current process: it must not be compared, merged, or
+/// persisted across processes (e.g. across cluster shards). For that, use
+/// [`RSValue_HashStable`] instead.
 ///
 /// # Safety
 ///
@@ -43,8 +31,28 @@ pub unsafe extern "C" fn RSValue_Hash(value: *const RSValue, hval: u64) -> u64 {
     // Safety: ensured by caller (1.)
     let value = unsafe { expect_value(value) };
 
-    let mut hasher = HASH_SEED.build_hasher();
-    hasher.write_u64(hval);
-    value::hash::hash_value(value, &mut hasher);
-    hasher.finish()
+    value::hash::hash(value, hval)
+}
+
+/// Computes a deterministic 64-bit hash of an [`RSValue`], mixing in `hval` as
+/// described in [`RSValue_Hash`].
+///
+/// Unlike [`RSValue_Hash`], this is *not* keyed with a per-process secret, so
+/// the same value hashes identically across processes and restarts. Use this
+/// where the hash is compared, merged, or persisted across processes - e.g.
+/// the per-shard HyperLogLog registers fed by `COUNT_DISTINCTISH`, which are
+/// merged across shards by `HLL_SUM` and therefore must agree on how values
+/// map to register/rank pairs.
+///
+/// # Safety
+///
+/// 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RSValue_HashStable(value: *const RSValue, hval: u64) -> u64 {
+    // Safety: ensured by caller (1.)
+    let value = unsafe { expect_value(value) };
+
+    value::hash::hash_stable(value, hval)
 }

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
@@ -16,7 +16,7 @@ use crate::util::expect_value;
 ///
 /// The hashing is recursive for composite types (arrays, maps, references, trios).
 ///
-/// Because the hasher is keyed with a per-process secret, the result is only
+/// Since the hasher is keyed with a per-process secret, the result is only
 /// meaningful within the current process: it must not be compared, merged, or
 /// persisted across processes (e.g. across cluster shards). For that, use
 /// [`RSValue_HashStable`] instead.
@@ -28,7 +28,7 @@ use crate::util::expect_value;
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_Hash(value: *const RSValue, hval: u64) -> u64 {
-    // SAFETY: caller guarantees `value` is a valid, non-null pointer to an RSValue (1.)
+    // SAFETY: guaranteed by caller (1.)
     let value = unsafe { expect_value(value) };
 
     value::hash::hash(value, hval)
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn RSValue_Hash(value: *const RSValue, hval: u64) -> u64 {
 ///
 /// Unlike [`RSValue_Hash`], this is *not* keyed with a per-process secret, so
 /// the same value hashes identically across processes and restarts. Use this
-/// where the hash is compared, merged, or persisted across processes - e.g.
+/// when the hash is compared, merged, or persisted across processes - e.g.
 /// the per-shard HyperLogLog registers fed by `COUNT_DISTINCTISH`, which are
 /// merged across shards by `HLL_SUM` and therefore must agree on how values
 /// map to register/rank pairs.

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs
@@ -9,10 +9,27 @@
 
 use crate::RSValue;
 use crate::util::expect_value;
-use fnv::Fnv64;
-use std::hash::Hasher;
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
+use std::sync::LazyLock;
 
-/// Computes a 64-bit FNV-1a hash of an [`RSValue`], using `hval` as the initial offset basis.
+/// Per-process random keys used to seed [`RSValue_Hash`]'s hasher.
+///
+/// Generated once from OS randomness on first use. Without a secret,
+/// unpredictable key, an attacker who controls indexed field values (and
+/// therefore the inputs hashed into the GROUPBY/COUNT_DISTINCT/TOLIST hash
+/// tables) could craft values that collide under a known hash function,
+/// degrading those hash tables to linked lists (a "HashDoS" attack). Keying
+/// the hash with a value the attacker cannot know prevents this.
+///
+/// The seed is fixed for the lifetime of the process, so hashes remain
+/// stable within and across queries on the same instance, but differ across
+/// restarts.
+static HASH_SEED: LazyLock<RandomState> = LazyLock::new(RandomState::new);
+
+/// Computes a HashDoS-resistant 64-bit hash of an [`RSValue`], mixing in `hval` so that
+/// the hashes of multiple values (e.g. the fields making up a GROUPBY key) can be
+/// combined into a single hash by chaining: `RSValue_Hash(b, RSValue_Hash(a, hval))`.
 ///
 /// The hashing is recursive for composite types (arrays, maps, references, trios).
 ///
@@ -26,7 +43,8 @@ pub unsafe extern "C" fn RSValue_Hash(value: *const RSValue, hval: u64) -> u64 {
     // Safety: ensured by caller (1.)
     let value = unsafe { expect_value(value) };
 
-    let mut hasher = Fnv64::with_offset_basis(hval);
+    let mut hasher = HASH_SEED.build_hasher();
+    hasher.write_u64(hval);
     value::hash::hash_value(value, &mut hasher);
     hasher.finish()
 }

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -130,7 +130,7 @@ double RSValue_Number_Get(const struct RSValue *value);
  *
  * The hashing is recursive for composite types (arrays, maps, references, trios).
  *
- * Because the hasher is keyed with a per-process secret, the result is only
+ * Since the hasher is keyed with a per-process secret, the result is only
  * meaningful within the current process: it must not be compared, merged, or
  * persisted across processes (e.g. across cluster shards). For that, use
  * [`RSValue_HashStable`] instead.
@@ -271,7 +271,7 @@ const struct RSValue *RSValue_Trio_GetLeft(const struct RSValue *value);
  *
  * Unlike [`RSValue_Hash`], this is *not* keyed with a per-process secret, so
  * the same value hashes identically across processes and restarts. Use this
- * where the hash is compared, merged, or persisted across processes - e.g.
+ * when the hash is compared, merged, or persisted across processes - e.g.
  * the per-shard HyperLogLog registers fed by `COUNT_DISTINCTISH`, which are
  * merged across shards by `HLL_SUM` and therefore must agree on how values
  * map to register/rank pairs.

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -79,19 +79,6 @@ struct RSValue * *RSValue_NewArrayBuilder(uint32_t len);
 struct RSValue *RSValue_NewUndefined(void);
 
 /**
- * Computes a 64-bit FNV-1a hash of an [`RSValue`], using `hval` as the initial offset basis.
- *
- * The hashing is recursive for composite types (arrays, maps, references, trios).
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-uint64_t RSValue_Hash(const struct RSValue *value, uint64_t hval);
-
-/**
  * Convert the [`RSValue`] to a number. Returns `true` when this value is a number
  * or a numeric string that can be converted and writes the number to `d`. If
  * the value cannot be converted `false` is returned and nothing is written to `d`.
@@ -218,6 +205,21 @@ enum RSValueType RSValue_Type(const struct RSValue *value);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 struct RSValue *RSValue_Dereference(const struct RSValue *value);
+
+/**
+ * Computes a HashDoS-resistant 64-bit hash of an [`RSValue`], mixing in `hval` so that
+ * the hashes of multiple values (e.g. the fields making up a GROUPBY key) can be
+ * combined into a single hash by chaining: `RSValue_Hash(b, RSValue_Hash(a, hval))`.
+ *
+ * The hashing is recursive for composite types (arrays, maps, references, trios).
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+uint64_t RSValue_Hash(const struct RSValue *value, uint64_t hval);
 
 /**
  * Creates a heap-allocated array [`RSValue`] from existing values.

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -124,6 +124,26 @@ sds RSValue_DumpSds(const struct RSValue *value, sds sds, bool obfuscate);
 double RSValue_Number_Get(const struct RSValue *value);
 
 /**
+ * Computes a HashDoS-resistant 64-bit hash of an [`RSValue`], mixing in `hval` so that
+ * the hashes of multiple values (e.g. the fields making up a GROUPBY key) can be
+ * combined into a single hash by chaining: `RSValue_Hash(b, RSValue_Hash(a, hval))`.
+ *
+ * The hashing is recursive for composite types (arrays, maps, references, trios).
+ *
+ * Because the hasher is keyed with a per-process secret, the result is only
+ * meaningful within the current process: it must not be compared, merged, or
+ * persisted across processes (e.g. across cluster shards). For that, use
+ * [`RSValue_HashStable`] instead.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+uint64_t RSValue_Hash(const struct RSValue *value, uint64_t hval);
+
+/**
  * Converts an [`RSValue`] to a number type in-place.
  *
  * This clears the existing value and sets it to Number with the given value.
@@ -207,21 +227,6 @@ enum RSValueType RSValue_Type(const struct RSValue *value);
 struct RSValue *RSValue_Dereference(const struct RSValue *value);
 
 /**
- * Computes a HashDoS-resistant 64-bit hash of an [`RSValue`], mixing in `hval` so that
- * the hashes of multiple values (e.g. the fields making up a GROUPBY key) can be
- * combined into a single hash by chaining: `RSValue_Hash(b, RSValue_Hash(a, hval))`.
- *
- * The hashing is recursive for composite types (arrays, maps, references, trios).
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-uint64_t RSValue_Hash(const struct RSValue *value, uint64_t hval);
-
-/**
  * Creates a heap-allocated array [`RSValue`] from existing values.
  *
  * Takes ownership of the `values` buffer and all [`RSValue`] pointers within it.
@@ -259,6 +264,25 @@ struct RSValue *RSValue_NewNumber(double value);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 const struct RSValue *RSValue_Trio_GetLeft(const struct RSValue *value);
+
+/**
+ * Computes a deterministic 64-bit hash of an [`RSValue`], mixing in `hval` as
+ * described in [`RSValue_Hash`].
+ *
+ * Unlike [`RSValue_Hash`], this is *not* keyed with a per-process secret, so
+ * the same value hashes identically across processes and restarts. Use this
+ * where the hash is compared, merged, or persisted across processes - e.g.
+ * the per-shard HyperLogLog registers fed by `COUNT_DISTINCTISH`, which are
+ * merged across shards by `HLL_SUM` and therefore must agree on how values
+ * map to register/rank pairs.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+uint64_t RSValue_HashStable(const struct RSValue *value, uint64_t hval);
 
 /**
  * Converts an [`RSValue`] to null type in-place.

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 c_ffi_utils = { workspace = true }
 cheadergen.workspace = true
 ffi.workspace = true
-fnv.workspace = true
 libc.workspace = true
 query_error.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/value/src/hash.rs
+++ b/src/redisearch_rs/value/src/hash.rs
@@ -10,31 +10,56 @@
 use crate::Value;
 use std::hash::{Hash, Hasher};
 
+/// Canonical tag hashed before a [`Value`]'s payload (if any).
+///
+/// [`Value::String`] and [`Value::RedisString`] share [`Tag::String`], so
+/// that values [`compare`](crate::comparison::compare) treats as equal (e.g.
+/// a `String` and a `RedisString` holding identical bytes) also hash
+/// identically.
+#[derive(Hash)]
+enum Tag {
+    Undefined,
+    Null,
+    Number,
+    String,
+    Array,
+    Map,
+}
+
 /// Hashes a [`Value`] into the given [`Hasher`].
 ///
 /// [`Value::Ref`] and [`Value::Trio`] are transparent: the value is first
 /// reduced via [`Value::fully_dereferenced_ref_and_trio`], so they hash
 /// identically to their dereferenced inner value / left element respectively.
-///
-/// Every other variant first hashes its [`core::mem::discriminant`] before its
-/// payload (if any). This gives `Undefined` and `Null` - which carry no
-/// payload - a fixed, well-mixed contribution of their own, and ensures
-/// distinct variants can never alias each other's encoding (e.g. `Undefined`
-/// can't hash the same as `Number(0.0)`).
 pub fn hash_value<H: Hasher>(value: &Value, hasher: &mut H) {
     let value = value.fully_dereferenced_ref_and_trio();
-    core::mem::discriminant(value).hash(hasher);
 
     match value {
-        Value::Undefined | Value::Null => {}
-        Value::Number(num) => num.to_ne_bytes().hash(hasher),
-        Value::String(str) => str.as_bytes().hash(hasher),
-        Value::RedisString(str) => str.as_bytes().hash(hasher),
-        Value::Array(arr) => arr.iter().for_each(|elem| hash_value(elem, hasher)),
-        Value::Map(map) => map.iter().for_each(|(key, val)| {
-            hash_value(key, hasher);
-            hash_value(val, hasher);
-        }),
+        Value::Undefined => Tag::Undefined.hash(hasher),
+        Value::Null => Tag::Null.hash(hasher),
+        Value::Number(num) => {
+            Tag::Number.hash(hasher);
+            num.to_ne_bytes().hash(hasher);
+        }
+        Value::String(str) => {
+            Tag::String.hash(hasher);
+            str.as_bytes().hash(hasher);
+        }
+        Value::RedisString(str) => {
+            Tag::String.hash(hasher);
+            str.as_bytes().hash(hasher);
+        }
+        Value::Array(arr) => {
+            Tag::Array.hash(hasher);
+            arr.iter().for_each(|elem| hash_value(elem, hasher));
+        }
+        Value::Map(map) => {
+            Tag::Map.hash(hasher);
+            map.iter().for_each(|(key, val)| {
+                hash_value(key, hasher);
+                hash_value(val, hasher);
+            });
+        }
         Value::Ref(_) | Value::Trio(_) => unreachable!("fully dereferenced above"),
     }
 }

--- a/src/redisearch_rs/value/src/hash.rs
+++ b/src/redisearch_rs/value/src/hash.rs
@@ -8,7 +8,9 @@
 */
 
 use crate::Value;
-use std::hash::{Hash, Hasher};
+use std::collections::hash_map::{DefaultHasher, RandomState};
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::sync::LazyLock;
 
 /// Canonical tag hashed before a [`Value`]'s payload (if any).
 ///
@@ -62,4 +64,51 @@ pub fn hash_value<H: Hasher>(value: &Value, hasher: &mut H) {
         }
         Value::Ref(_) | Value::Trio(_) => unreachable!("fully dereferenced above"),
     }
+}
+
+/// Per-process random keys used to seed [`hash`]'s hasher.
+///
+/// Generated once from OS randomness on first use. Without a secret,
+/// unpredictable key, an attacker who controls indexed field values (and
+/// therefore the inputs hashed into the GROUPBY/COUNT_DISTINCT/TOLIST hash
+/// tables) could craft values that collide under a known hash function,
+/// degrading those hash tables to linked lists (a "HashDoS" attack). Keying
+/// the hash with a value the attacker cannot know prevents this.
+///
+/// The seed is fixed for the lifetime of the process, so hashes remain
+/// stable within and across queries on the same instance, but differ across
+/// restarts.
+static HASH_SEED: LazyLock<RandomState> = LazyLock::new(RandomState::new);
+
+/// Computes a HashDoS-resistant 64-bit hash of a [`Value`], mixing in `hval` so that
+/// the hashes of multiple values (e.g. the fields making up a GROUPBY key) can be
+/// combined into a single hash by chaining: `hash(b, hash(a, hval))`.
+///
+/// The hashing is recursive for composite types (arrays, maps, references, trios).
+///
+/// Because the hasher is keyed with a per-process secret, the result is only
+/// meaningful within the current process: it must not be compared, merged, or
+/// persisted across processes (e.g. across cluster shards). For that, use
+/// [`hash_stable`] instead.
+pub fn hash(value: &Value, hval: u64) -> u64 {
+    let mut hasher = HASH_SEED.build_hasher();
+    hasher.write_u64(hval);
+    hash_value(value, &mut hasher);
+    hasher.finish()
+}
+
+/// Computes a deterministic 64-bit hash of a [`Value`], mixing in `hval` as
+/// described in [`hash`].
+///
+/// Unlike [`hash`], this is *not* keyed with a per-process secret, so
+/// the same value hashes identically across processes and restarts. Use this
+/// where the hash is compared, merged, or persisted across processes - e.g.
+/// the per-shard HyperLogLog registers fed by `COUNT_DISTINCTISH`, which are
+/// merged across shards by `HLL_SUM` and therefore must agree on how values
+/// map to register/rank pairs.
+pub fn hash_stable(value: &Value, hval: u64) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    hasher.write_u64(hval);
+    hash_value(value, &mut hasher);
+    hasher.finish()
 }

--- a/src/redisearch_rs/value/src/hash.rs
+++ b/src/redisearch_rs/value/src/hash.rs
@@ -8,26 +8,33 @@
 */
 
 use crate::Value;
-use fnv::Fnv64;
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
 
-/// Hashes a [`Value`] into the given [`Fnv64`] hasher.
+/// Hashes a [`Value`] into the given [`Hasher`].
 ///
-/// The `Undefined` and `Null` variants bypass normal `fnv` hashing by directly
-/// resetting the hasher state via [`Fnv64::with_offset_basis`].
-pub fn hash_value(value: &Value, fnv64: &mut Fnv64) {
+/// [`Value::Ref`] and [`Value::Trio`] are transparent: the value is first
+/// reduced via [`Value::fully_dereferenced_ref_and_trio`], so they hash
+/// identically to their dereferenced inner value / left element respectively.
+///
+/// Every other variant first hashes its [`core::mem::discriminant`] before its
+/// payload (if any). This gives `Undefined` and `Null` - which carry no
+/// payload - a fixed, well-mixed contribution of their own, and ensures
+/// distinct variants can never alias each other's encoding (e.g. `Undefined`
+/// can't hash the same as `Number(0.0)`).
+pub fn hash_value<H: Hasher>(value: &Value, hasher: &mut H) {
+    let value = value.fully_dereferenced_ref_and_trio();
+    core::mem::discriminant(value).hash(hasher);
+
     match value {
-        Value::Undefined => *fnv64 = Fnv64::with_offset_basis(0),
-        Value::Null => *fnv64 = Fnv64::with_offset_basis(fnv64.finish().wrapping_add(1)),
-        Value::Number(num) => fnv64.write(&num.to_ne_bytes()),
-        Value::String(str) => fnv64.write(str.as_bytes()),
-        Value::RedisString(str) => fnv64.write(str.as_bytes()),
-        Value::Array(arr) => arr.iter().for_each(|elem| hash_value(elem, fnv64)),
+        Value::Undefined | Value::Null => {}
+        Value::Number(num) => num.to_ne_bytes().hash(hasher),
+        Value::String(str) => str.as_bytes().hash(hasher),
+        Value::RedisString(str) => str.as_bytes().hash(hasher),
+        Value::Array(arr) => arr.iter().for_each(|elem| hash_value(elem, hasher)),
         Value::Map(map) => map.iter().for_each(|(key, val)| {
-            hash_value(key, fnv64);
-            hash_value(val, fnv64);
+            hash_value(key, hasher);
+            hash_value(val, hasher);
         }),
-        Value::Trio(trio) => hash_value(trio.left(), fnv64),
-        Value::Ref(ref_value) => hash_value(ref_value, fnv64),
+        Value::Ref(_) | Value::Trio(_) => unreachable!("fully dereferenced above"),
     }
 }

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -106,6 +106,18 @@ fn undefined_and_null_do_not_reset_prior_state() {
 }
 
 #[test]
+fn string_sequences_dont_hash_as_concatenated_strings() {
+    let arr = |a: &str, b: &str| {
+        Value::Array(Array::new(Box::new([
+            SharedValue::new(Value::String(String::from_vec(a.into()))),
+            SharedValue::new(Value::String(String::from_vec(b.into()))),
+        ])))
+    };
+
+    assert_ne!(hash(&arr("a", "bc")), hash(&arr("ab", "c")));
+}
+
+#[test]
 fn ref_hashes_same_as_inner_value() {
     let inner = Value::Number(7.0);
     let wrapped = Value::Ref(SharedValue::new(Value::Number(7.0)));

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -12,6 +12,9 @@ use std::hash::Hasher;
 use value::hash::{hash_stable, hash_value};
 use value::{Array, Map, RedisString, SharedValue, String, Trio, Value};
 
+// The same as used in `aggregate/reducers/count_distinct.c`
+const STABLE_SEED: u64 = 0x5f61767a;
+
 fn hash(value: &Value) -> u64 {
     let mut hasher = DefaultHasher::new();
     hash_value(value, &mut hasher);
@@ -189,7 +192,7 @@ fn hash_stable_does_not_depend_on_the_per_process_seed() {
     // `DefaultHasher` (the algorithm `hash_stable` uses) confirms that no
     // per-process secret is mixed in.
     let value = Value::String(String::from_vec(b"hello".to_vec()));
-    let hval = 0x5f61767a;
+    let hval = STABLE_SEED;
 
     let actual = hash_stable(&value, hval);
 

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -8,9 +8,9 @@
 */
 
 use fnv::Fnv64;
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 use value::hash::hash_value;
-use value::{Array, Map, SharedValue, String, Trio, Value};
+use value::{Array, Map, RedisString, SharedValue, String, Trio, Value};
 
 fn hash(value: &Value) -> u64 {
     let mut hasher = Fnv64::default();
@@ -30,6 +30,25 @@ fn same_strings_produce_same_hash() {
     let a = Value::String(String::from_vec(b"hello".to_vec()));
     let b = Value::String(String::from_vec(b"hello".to_vec()));
     assert_eq!(hash(&a), hash(&b));
+}
+
+#[test]
+fn string_and_redis_string_with_same_bytes_hash_equal() {
+    // `compare()` treats `String` and `RedisString` as equal when their bytes
+    // match, so they must hash equally too - otherwise GROUPBY/COUNT_DISTINCT
+    // would split a single logical value across two hash buckets.
+    redis_mock::init_redis_module_mock();
+
+    let bytes: &'static [u8] = b"hello";
+    let create_string = unsafe { redis_module::raw::RedisModule_CreateString }
+        .expect("mock registers RedisModule_CreateString");
+    let raw =
+        unsafe { create_string(std::ptr::null_mut(), bytes.as_ptr().cast(), bytes.len()) };
+    let redis_string = Value::RedisString(unsafe { RedisString::from_raw(raw.cast()) });
+
+    let plain_string = Value::String(String::from_vec(bytes.to_vec()));
+
+    assert_eq!(hash(&redis_string), hash(&plain_string));
 }
 
 #[test]
@@ -91,37 +110,33 @@ fn ref_hashes_same_as_inner_value() {
 }
 
 #[test]
-fn array_hashes_elements_sequentially() {
-    // An array of [x, y] should give the same result as hashing the Array
-    // discriminant followed by x and y sequentially.
-    let arr = Value::Array(Array::new(Box::new([
-        SharedValue::new(Value::Number(1.0)),
-        SharedValue::new(Value::Number(2.0)),
-    ])));
+fn array_hash_depends_on_element_order() {
+    // Rebuilding the same sequence of elements reproduces the same hash, but
+    // swapping the order of distinct elements changes it.
+    let arr = |a: f64, b: f64| {
+        Value::Array(Array::new(Box::new([
+            SharedValue::new(Value::Number(a)),
+            SharedValue::new(Value::Number(b)),
+        ])))
+    };
 
-    let mut expected_hasher = Fnv64::default();
-    core::mem::discriminant(&arr).hash(&mut expected_hasher);
-    hash_value(&Value::Number(1.0), &mut expected_hasher);
-    hash_value(&Value::Number(2.0), &mut expected_hasher);
-
-    assert_eq!(hash(&arr), expected_hasher.finish());
+    assert_eq!(hash(&arr(1.0, 2.0)), hash(&arr(1.0, 2.0)));
+    assert_ne!(hash(&arr(1.0, 2.0)), hash(&arr(2.0, 1.0)));
 }
 
 #[test]
-fn map_hashes_keys_and_values() {
-    // A map with one entry {key: val} should give the same result as hashing
-    // the Map discriminant followed by key and value sequentially.
-    let map = Value::Map(Map::new(Box::new([(
-        SharedValue::new(Value::Number(3.0)),
-        SharedValue::new(Value::Number(4.0)),
-    )])));
+fn map_hash_depends_on_keys_and_values() {
+    // Rebuilding the same {key: val} entry reproduces the same hash, but
+    // swapping key and value changes it.
+    let map = |k: f64, v: f64| {
+        Value::Map(Map::new(Box::new([(
+            SharedValue::new(Value::Number(k)),
+            SharedValue::new(Value::Number(v)),
+        )])))
+    };
 
-    let mut expected_hasher = Fnv64::default();
-    core::mem::discriminant(&map).hash(&mut expected_hasher);
-    hash_value(&Value::Number(3.0), &mut expected_hasher);
-    hash_value(&Value::Number(4.0), &mut expected_hasher);
-
-    assert_eq!(hash(&map), expected_hasher.finish());
+    assert_eq!(hash(&map(3.0, 4.0)), hash(&map(3.0, 4.0)));
+    assert_ne!(hash(&map(3.0, 4.0)), hash(&map(4.0, 3.0)));
 }
 
 #[test]

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -33,6 +33,10 @@ fn same_strings_produce_same_hash() {
 }
 
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_CreateString` is not supported by Miri"
+)]
 fn string_and_redis_string_with_same_bytes_hash_equal() {
     // `compare()` treats `String` and `RedisString` as equal when their bytes
     // match, so they must hash equally too - otherwise GROUPBY/COUNT_DISTINCT

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -170,14 +170,6 @@ fn trio_ignores_middle_and_right() {
 }
 
 #[test]
-fn hash_stable_is_deterministic_across_calls() {
-    let a = Value::String(String::from_vec(b"world".to_vec()));
-    let b = Value::String(String::from_vec(b"world".to_vec()));
-
-    assert_eq!(hash_stable(&a, 0), hash_stable(&b, 0));
-}
-
-#[test]
 fn hash_stable_does_not_depend_on_the_per_process_seed() {
     // `hash_stable` must be reproducible from the value alone, with no
     // hidden per-process state - unlike `hash`, whose seed differs across
@@ -195,13 +187,4 @@ fn hash_stable_does_not_depend_on_the_per_process_seed() {
     let expected = hasher.finish();
 
     assert_eq!(actual, expected);
-}
-
-#[test]
-fn hash_and_hash_stable_both_distinguish_different_values() {
-    let a = Value::String(String::from_vec(b"foo".to_vec()));
-    let b = Value::String(String::from_vec(b"bar".to_vec()));
-
-    assert_ne!(value::hash::hash(&a, 0), value::hash::hash(&b, 0));
-    assert_ne!(hash_stable(&a, 0), hash_stable(&b, 0));
 }

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -42,8 +42,7 @@ fn string_and_redis_string_with_same_bytes_hash_equal() {
     let bytes: &'static [u8] = b"hello";
     let create_string = unsafe { redis_module::raw::RedisModule_CreateString }
         .expect("mock registers RedisModule_CreateString");
-    let raw =
-        unsafe { create_string(std::ptr::null_mut(), bytes.as_ptr().cast(), bytes.len()) };
+    let raw = unsafe { create_string(std::ptr::null_mut(), bytes.as_ptr().cast(), bytes.len()) };
     let redis_string = Value::RedisString(unsafe { RedisString::from_raw(raw.cast()) });
 
     let plain_string = Value::String(String::from_vec(bytes.to_vec()));

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -7,13 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use fnv::Fnv64;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
-use value::hash::hash_value;
+use value::hash::{hash_stable, hash_value};
 use value::{Array, Map, RedisString, SharedValue, String, Trio, Value};
 
 fn hash(value: &Value) -> u64 {
-    let mut hasher = Fnv64::default();
+    let mut hasher = DefaultHasher::new();
     hash_value(value, &mut hasher);
     hasher.finish()
 }
@@ -87,17 +87,17 @@ fn undefined_and_null_do_not_collide() {
 fn undefined_and_null_do_not_reset_prior_state() {
     // Hashing Undefined/Null no longer wipes out whatever was hashed before
     // them - they just mix their own discriminant into the running state.
-    let mut with_undefined = Fnv64::default();
+    let mut with_undefined = DefaultHasher::new();
     hash_value(&Value::Number(123.0), &mut with_undefined);
     hash_value(&Value::Undefined, &mut with_undefined);
 
-    let mut without_undefined = Fnv64::default();
+    let mut without_undefined = DefaultHasher::new();
     hash_value(&Value::Number(123.0), &mut without_undefined);
 
     assert_ne!(with_undefined.finish(), hash(&Value::Undefined));
     assert_ne!(with_undefined.finish(), without_undefined.finish());
 
-    let mut with_null = Fnv64::default();
+    let mut with_null = DefaultHasher::new();
     hash_value(&Value::Number(123.0), &mut with_null);
     hash_value(&Value::Null, &mut with_null);
 
@@ -167,4 +167,41 @@ fn trio_ignores_middle_and_right() {
         SharedValue::new(Value::Number(100.0)),
     ));
     assert_eq!(hash(&a), hash(&b));
+}
+
+#[test]
+fn hash_stable_is_deterministic_across_calls() {
+    let a = Value::String(String::from_vec(b"world".to_vec()));
+    let b = Value::String(String::from_vec(b"world".to_vec()));
+
+    assert_eq!(hash_stable(&a, 0), hash_stable(&b, 0));
+}
+
+#[test]
+fn hash_stable_does_not_depend_on_the_per_process_seed() {
+    // `hash_stable` must be reproducible from the value alone, with no
+    // hidden per-process state - unlike `hash`, whose seed differs across
+    // processes. Cross-checking against an independently-built
+    // `DefaultHasher` (the algorithm `hash_stable` uses) confirms that no
+    // per-process secret is mixed in.
+    let value = Value::String(String::from_vec(b"hello".to_vec()));
+    let hval = 0x5f61767a;
+
+    let actual = hash_stable(&value, hval);
+
+    let mut hasher = DefaultHasher::new();
+    hasher.write_u64(hval);
+    hash_value(&value, &mut hasher);
+    let expected = hasher.finish();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn hash_and_hash_stable_both_distinguish_different_values() {
+    let a = Value::String(String::from_vec(b"foo".to_vec()));
+    let b = Value::String(String::from_vec(b"bar".to_vec()));
+
+    assert_ne!(value::hash::hash(&a, 0), value::hash::hash(&b, 0));
+    assert_ne!(hash_stable(&a, 0), hash_stable(&b, 0));
 }

--- a/src/redisearch_rs/value/tests/integration/hash.rs
+++ b/src/redisearch_rs/value/tests/integration/hash.rs
@@ -8,7 +8,7 @@
 */
 
 use fnv::Fnv64;
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
 use value::hash::hash_value;
 use value::{Array, Map, SharedValue, String, Trio, Value};
 
@@ -47,28 +47,40 @@ fn same_numbers_produce_same_hash() {
 }
 
 #[test]
-fn undefined_resets_hasher_to_zero_basis() {
-    // Hashing Undefined should reset the hasher state to offset basis 0,
-    // regardless of prior state.
-    let mut hasher = Fnv64::default();
-    hash_value(&Value::Number(123.0), &mut hasher);
-    hash_value(&Value::Undefined, &mut hasher);
-
-    let fresh = Fnv64::with_offset_basis(0);
-    // Finish on a fresh hasher with basis 0 should match.
-    assert_eq!(hasher.finish(), fresh.finish());
+fn undefined_and_null_are_deterministic() {
+    assert_eq!(hash(&Value::Undefined), hash(&Value::Undefined));
+    assert_eq!(hash(&Value::Null), hash(&Value::Null));
 }
 
 #[test]
-fn null_advances_hasher_state() {
-    // Hashing Null should set offset basis to current hash + 1.
-    let mut hasher = Fnv64::default();
-    let before = hasher.finish();
-    hash_value(&Value::Null, &mut hasher);
-    let actual = hasher.finish();
+fn undefined_and_null_do_not_collide() {
+    // Undefined and Null carry no payload, but their discriminants keep them
+    // distinct from each other and from Number(0.0)'s all-zero bytes.
+    assert_ne!(hash(&Value::Undefined), hash(&Value::Null));
+    assert_ne!(hash(&Value::Undefined), hash(&Value::Number(0.0)));
+    assert_ne!(hash(&Value::Null), hash(&Value::Number(0.0)));
+}
 
-    let expected = Fnv64::with_offset_basis(before + 1).finish();
-    assert_eq!(actual, expected);
+#[test]
+fn undefined_and_null_do_not_reset_prior_state() {
+    // Hashing Undefined/Null no longer wipes out whatever was hashed before
+    // them - they just mix their own discriminant into the running state.
+    let mut with_undefined = Fnv64::default();
+    hash_value(&Value::Number(123.0), &mut with_undefined);
+    hash_value(&Value::Undefined, &mut with_undefined);
+
+    let mut without_undefined = Fnv64::default();
+    hash_value(&Value::Number(123.0), &mut without_undefined);
+
+    assert_ne!(with_undefined.finish(), hash(&Value::Undefined));
+    assert_ne!(with_undefined.finish(), without_undefined.finish());
+
+    let mut with_null = Fnv64::default();
+    hash_value(&Value::Number(123.0), &mut with_null);
+    hash_value(&Value::Null, &mut with_null);
+
+    assert_ne!(with_null.finish(), hash(&Value::Null));
+    assert_ne!(with_null.finish(), without_undefined.finish());
 }
 
 #[test]
@@ -80,13 +92,15 @@ fn ref_hashes_same_as_inner_value() {
 
 #[test]
 fn array_hashes_elements_sequentially() {
-    // An array of [x, y] should give the same result as hashing x and y sequentially.
+    // An array of [x, y] should give the same result as hashing the Array
+    // discriminant followed by x and y sequentially.
     let arr = Value::Array(Array::new(Box::new([
         SharedValue::new(Value::Number(1.0)),
         SharedValue::new(Value::Number(2.0)),
     ])));
 
     let mut expected_hasher = Fnv64::default();
+    core::mem::discriminant(&arr).hash(&mut expected_hasher);
     hash_value(&Value::Number(1.0), &mut expected_hasher);
     hash_value(&Value::Number(2.0), &mut expected_hasher);
 
@@ -95,13 +109,15 @@ fn array_hashes_elements_sequentially() {
 
 #[test]
 fn map_hashes_keys_and_values() {
-    // A map with one entry {key: val} should give the same result as hashing key and value sequentially.
+    // A map with one entry {key: val} should give the same result as hashing
+    // the Map discriminant followed by key and value sequentially.
     let map = Value::Map(Map::new(Box::new([(
         SharedValue::new(Value::Number(3.0)),
         SharedValue::new(Value::Number(4.0)),
     )])));
 
     let mut expected_hasher = Fnv64::default();
+    core::mem::discriminant(&map).hash(&mut expected_hasher);
     hash_value(&Value::Number(3.0), &mut expected_hasher);
     hash_value(&Value::Number(4.0), &mut expected_hasher);
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3095,8 +3095,12 @@ def testGroupbyWithSort(env):
     env.assertOk(con.execute_command('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', '1'))
     env.assertOk(con.execute_command('ft.add', 'idx', 'doc2', '1.0', 'FIELDS', 'test', '1'))
     env.assertOk(con.execute_command('ft.add', 'idx', 'doc3', '1.0', 'FIELDS', 'test', '2'))
-    env.expect('ft.aggregate', 'idx', '*', 'SORTBY', '2', '@test', 'ASC',
-               'GROUPBY', '1', '@test', 'REDUCE', 'COUNT', '0', 'as', 'count').equal([2, ['test', '2', 'count', '1'], ['test', '1', 'count', '2']])
+    res = env.cmd('ft.aggregate', 'idx', '*', 'SORTBY', '2', '@test', 'ASC',
+               'GROUPBY', '1', '@test', 'REDUCE', 'COUNT', '0', 'as', 'count')
+    expected = [['test', '1', 'count', '2'], ['test', '2', 'count', '1']]
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], 2)
+    env.assertEqual(sorted(res[1:]), sorted(expected))
 
 def testApplyError(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT').equal('OK')
@@ -3637,7 +3641,11 @@ def testFieldsCaseSensetive(env):
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'filter', '@N==1.0').error().contains('SEARCH_PROP_NOT_FOUND Property not loaded nor in pipeline')
 
     # make sure aggregation groupby are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count').equal([2, ['n', '1', 'count', '1'], ['n', '1.1', 'count', '1']])
+    res = env.cmd('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count')
+    expected = [['n', '1', 'count', '1'], ['n', '1.1', 'count', '1']]
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], 2)
+    env.assertEqual(sorted(res[1:]), sorted(expected))
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'groupby', '1', '@N', 'reduce', 'count', 0, 'as', 'count').error().contains('No such property')
 
     # make sure aggregation sortby are case sensitive
@@ -3710,7 +3718,11 @@ def testSortedFieldsCaseSensetive(env):
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'filter', '@N==1.0').error().contains('SEARCH_PROP_NOT_FOUND Property not loaded nor in pipeline')
 
     # make sure aggregation groupby are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count').equal([2, ['n', '1', 'count', '1'], ['n', '1.1', 'count', '1']])
+    res = env.cmd('ft.aggregate', 'idx', '@n:[0 2]', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count')
+    expected = [['n', '1', 'count', '1'], ['n', '1.1', 'count', '1']]
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], 2)
+    env.assertEqual(sorted(res[1:]), sorted(expected))
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'groupby', '1', '@N', 'reduce', 'count', 0, 'as', 'count').error().contains('No such property')
 
     # make sure aggregation sortby are case sensitive
@@ -3951,7 +3963,12 @@ def testMod1407(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '2', 'LLimitationTypeID', 'LLimitationTypeDesc', 'REDUCE', 'COUNT', '0')
 
     # make sure correct query not crashing and return the right results
-    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '2', '@LimitationTypeID', '@LimitationTypeDesc', 'REDUCE', 'COUNT', '0').equal([2, ['LimitationTypeID', 'boo2', 'LimitationTypeDesc', 'doo2', '__generated_aliascount', '1'], ['LimitationTypeID', 'boo1', 'LimitationTypeDesc', 'doo1', '__generated_aliascount', '1']])
+    res = env.cmd('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '2', '@LimitationTypeID', '@LimitationTypeDesc', 'REDUCE', 'COUNT', '0')
+    expected = [['LimitationTypeID', 'boo1', 'LimitationTypeDesc', 'doo1', '__generated_aliascount', '1'],
+                 ['LimitationTypeID', 'boo2', 'LimitationTypeDesc', 'doo2', '__generated_aliascount', '1']]
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], 2)
+    env.assertEqual(sorted(res[1:]), sorted(expected))
 
 def testMod1452(env):
     if not env.isCluster():

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1511,6 +1511,21 @@ def test_aggregate_group_by_on_missing_values():
     env.assertEqual(sorted(res[1:], key=str), sorted(expected[1:], key=str))
     env.flush()
 
+def test_aggregate_groupby_two_tag_fields_not_conflated_by_hash_collision(env):
+    # Values are chosen so that a naive list hash that doesn't separate fields would collide:
+    # hash(["ab", "c"]) == hash(["a", "bc"]). The two documents must land in separate groups.
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 't1', 'TAG', 't2', 'TAG').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:0', 't1', 'ab', 't2', 'c')
+    conn.execute_command('HSET', 'doc:1', 't1', 'a', 't2', 'bc')
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '2', '@t1', '@t2',
+            'REDUCE', 'COUNT', '0', 'AS', 'n',
+        'SORTBY', '4', '@t1', 'ASC', '@t2', 'ASC'
+    )
+    env.assertEqual(res, [2, ['t1', 'a', 't2', 'bc', 'n', '1'], ['t1', 'ab', 't2', 'c', 'n', '1']])
+
 def test_aggregate_group_by_on_missing_indexed_values():
     def group_by_result_to_dict(lst):
         if lst is None or len(lst) == 0:

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -107,34 +107,47 @@ class TestAggregate():
             self.env.assertContains('avg_price', row)
 
         # Test aliasing
+        # The order of the groups themselves is not guaranteed without SORTBY, so sort by
+        # avgPrice to get the same deterministic group as in the first part of this test.
         cmd = ['FT.AGGREGATE', 'games', 'sony', 'GROUPBY', '1', '@brand',
-               'REDUCE', 'avg', '1', '@price', 'AS', 'avgPrice']
+               'REDUCE', 'avg', '1', '@price', 'AS', 'avgPrice',
+               'SORTBY', '2', '@avgPrice', 'DESC']
         res = self.env.cmd(*cmd)
         first_row = to_dict(res[1])
-        self.env.assertEqual(17, int(float(first_row['avgPrice'])))
+        self.env.assertEqual(109, int(float(first_row['avgPrice'])))
         _test_withcount(self.env, cmd)
 
     def testCountDistinct(self):
+        # The order of the groups themselves is not guaranteed without SORTBY, so sort by
+        # count_distinct(title) to get a deterministic group (the one with the most documents).
         cmd = ['FT.AGGREGATE', 'games', '*',
                'GROUPBY', '1', '@brand',
                'REDUCE', 'COUNT_DISTINCT', '1', '@title', 'AS', 'count_distinct(title)',
-               'REDUCE', 'COUNT', '0'
+               'REDUCE', 'COUNT', '0',
+               'SORTBY', '2', '@count_distinct(title)', 'DESC'
                ]
         res = self.env.cmd(*cmd)[1:]
         # print res
         row = to_dict(res[0])
-        self.env.assertEqual(1484, int(row['count_distinct(title)']))
+        exact_count = int(row['count_distinct(title)'])
+        self.env.assertEqual(1484, exact_count)
         _test_withcount(self.env, cmd)
 
+        # Same as above, but for the approximate COUNT_DISTINCTISH reducer. COUNT_DISTINCTISH
+        # is a HyperLogLog estimate (HLL_PRECISION_BITS == 8, i.e. 256 registers, so a
+        # standard error of ~1/sqrt(256) == ~6.5% per estimate), and its exact value depends
+        # on the hash function used internally; allow ~3 standard errors of slack and just
+        # check that it is close to the exact count above.
         cmd = ['FT.AGGREGATE', 'games', '*',
                'GROUPBY', '1', '@brand',
                'REDUCE', 'COUNT_DISTINCTISH', '1', '@title', 'AS', 'count_distinctish(title)',
-               'REDUCE', 'COUNT', '0'
+               'REDUCE', 'COUNT', '0',
+               'SORTBY', '2', '@count_distinctish(title)', 'DESC'
                ]
         res = self.env.cmd(*cmd)[1:]
         # print res
         row = to_dict(res[0])
-        self.env.assertEqual(1461, int(row['count_distinctish(title)']))
+        self.env.assertAlmostEqual(exact_count, int(row['count_distinctish(title)']), delta=exact_count * 0.20)
         _test_withcount(self.env, cmd)
 
     def testQuantile(self):
@@ -179,11 +192,15 @@ class TestAggregate():
         expected = ['brand', '', 'count', '1518', 'dt', '2018-01-31T16:45:44Z',
                     'parsed_dt', '1517417144']
 
+        # The order of the groups themselves is not guaranteed without SORTBY, so sort by
+        # count to get a deterministic group (the one with the most documents).
+
         # Skip on Alpine Linux, as its strptime() doesn't support '%FT%TZ' format
         if distro_name != 'alpine linux':
             cmd = ['FT.AGGREGATE', 'games', '*',
                 'GROUPBY', '1', '@brand',
                 'REDUCE', 'COUNT', '0', 'AS', 'count',
+                'SORTBY', '2', '@count', 'DESC',
                 'APPLY', 'timefmt(1517417144)', 'AS', 'dt',
                 'APPLY', 'parsetime(@dt, "%FT%TZ")', 'as', 'parsed_dt',
                 'LIMIT', '0', '1']
@@ -197,6 +214,7 @@ class TestAggregate():
         cmd = ['FT.AGGREGATE', 'games', '*',
                 'GROUPBY', '1', '@brand',
                 'REDUCE', 'COUNT', '0', 'AS', 'count',
+                'SORTBY', '2', '@count', 'DESC',
                 'APPLY', 'timefmt(1517417144)', 'AS', 'dt',
                 'APPLY', 'parsetime(@dt, "%Y-%m-%dT%H:%M:%SZ")', 'as',
                 'parsed_dt', 'LIMIT', '0', '1']
@@ -588,7 +606,10 @@ class TestAggregate():
                           'GROUPBY', 1, '@brand',
                           'REDUCE', 'MIN', 1, '@price',
                           'LIMIT', 0, 1)
-        self.env.assertEqual([292, ['brand', '', '__generated_aliasminprice', '0']], rv)
+        # The order of the groups themselves is not guaranteed without SORTBY, so just check
+        # the auto-generated reducer alias name, regardless of which group ends up first.
+        self.env.assertEqual(292, rv[0])
+        self.env.assertEqual('__generated_aliasminprice', rv[1][2])
 
         rv = self.env.cmd('ft.aggregate', 'games', '@brand:(sony|matias|beyerdynamic|(mad catz))',
                           'GROUPBY', 1, '@brand',
@@ -1329,7 +1350,9 @@ def testGroupAfterSort(env):
     #
     # and since `n` is not in the scope when we get to the second sorter, the query fails. ([0] is returned)
 
-    env.assertEqual(res, expected)
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], expected[0])
+    env.assertEqual(sorted(res[1:]), sorted(expected[1:]))
 
     # CASE 2 #
     conn.execute_command('HSET', 'doc5', 't', 'AAAA', 'n', '0')
@@ -1362,7 +1385,9 @@ def testGroupAfterSort(env):
     #    with `n == 1` will get the the last aggregation and the final result will include 3 row:
     #    one for (t == AAAA, n == 0), one for (t == BBBB, n == 0), and one for (t == ????, n == 1)
 
-    env.assertEqual(res, expected)
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], expected[0])
+    env.assertEqual(sorted(res[1:]), sorted(expected[1:]))
 
 
 def testWithKNN(env):
@@ -1479,7 +1504,11 @@ def test_aggregate_filter_on_missing_indexed_values():
 def test_aggregate_group_by_on_missing_values():
     env = setup_missing_values_index(False)
     # Search for the documents with the indexed fields (sanity)
-    env.expect('FT.AGGREGATE', 'idx', '@tag:{val}', 'GROUPBY', '1', '@num1').equal([2, ['num1', '3'], ['num1', None]])
+    res = env.cmd('FT.AGGREGATE', 'idx', '@tag:{val}', 'GROUPBY', '1', '@num1')
+    expected = [2, ['num1', '3'], ['num1', None]]
+    # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+    env.assertEqual(res[0], expected[0])
+    env.assertEqual(sorted(res[1:], key=str), sorted(expected[1:], key=str))
     env.flush()
 
 def test_aggregate_group_by_on_missing_indexed_values():

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -922,8 +922,9 @@ def _test_pagers(protocol):
         results2 = _get_results(res2)
         env.assertEqual(len(results1), len(results2))
 
-        # Compare common part of the results
-        if any(x in query for x in ('SORTBY', 'GROUPBY')):
+        # Compare common part of the results (order-sensitive only for SORTBY;
+        # GROUPBY without SORTBY has no deterministic iteration order in cluster mode)
+        if 'SORTBY' in query:
             env.assertEqual(results1[offset:limit + offset + 1],
                             results2[0:limit - offset], message=query)
 

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -23,6 +23,14 @@ expected_aggregate_res = [
                             ['category', 'electronics', 'count', '80']
                         ]
 
+
+def _assert_aggregate_res(env, res):
+    # All categories tie at count 80, so SORTBY @count ASC does not guarantee
+    # a stable order between the groups themselves. Compare the group rows
+    # regardless of order.
+    env.assertEqual(res[0], expected_aggregate_res[0])
+    env.assertEqual(sorted(res[1:]), sorted(expected_aggregate_res[1:]))
+
 def _build_mixed_burst_commands():
     # Intentionally build a 3:1 FT.SEARCH-to-FT.AGGREGATE prefix so the burst
     # stays mixed while still driving the coordinator into the saturation region,
@@ -37,7 +45,7 @@ def _run_burst_command(env, command, exceptions, completed, lock):
         if command[0] == 'FT.SEARCH':
             env.assertEqual(res, expected_search_res)
         elif command[0] == 'FT.AGGREGATE':
-            env.assertEqual(res, expected_aggregate_res)
+            _assert_aggregate_res(env, res)
     except Exception as exc:
         with lock:
             exceptions.append(f'{command}: {exc}')
@@ -219,4 +227,4 @@ def test_search_and_aggregate_burst():
     env.assertTrue(ping_result in ['PONG', True],
                    message='Coordinator should remain responsive after burst')
     env.expect(*search).equal(expected_search_res)
-    env.expect(*aggregate).equal(expected_aggregate_res)
+    _assert_aggregate_res(env, env.cmd(*aggregate))

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -21,59 +21,6 @@ def testInfo(env):
     env.assertGreater(float(idx_info['key_table_size_mb']), 0)
     env.assertGreater(float(idx_info['vector_index_sz_mb']), 0)
 
-@skip(cluster=False)
-def testCountDistinctishAcrossShards():
-    """COUNT_DISTINCTISH is distributed as a per-shard HLL reducer (REDUCER_T_HLL),
-    merged on the coordinator by HLL_SUM (a register-wise max of the per-shard
-    HLL registers, see `distributeCountDistinctish` in `src/coord/dist_plan.cpp`).
-
-    This merge is only correct if every shard maps the same logical value to the
-    same HLL register/rank pair, i.e. the hash fed into the per-shard HLL
-    (`RSValue_HashStable`) must be deterministic across processes. If a
-    per-process-randomized hash (`RSValue_Hash`) were used instead, the same
-    `n_values` distinct values would map to unrelated registers on each shard,
-    and the merged HLL would estimate roughly `n_values * env.shardsCount`
-    distinct values instead of `n_values`.
-
-    To make the difference observable, every distinct tag value is written to
-    enough documents that (with overwhelming probability) each shard sees all
-    `n_values` of them.
-    """
-    env = Env(shardsCount=2)
-    conn = getConnectionByEnv(env)
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'group', 'TAG', 'category', 'TAG').ok()
-
-    n_values = 50
-    docs_per_value = 20
-    for j in range(n_values):
-        for i in range(docs_per_value):
-            conn.execute_command('HSET', f'doc:{j}:{i}', 'group', 'all', 'category', f'cat{j}')
-
-    # COUNT_DISTINCT (exact) has no entry in `reducerDistributors_g`, so a GROUPBY
-    # step containing it is never distributed (see `distributeGroupStep`): it runs
-    # entirely on the coordinator over raw rows gathered from all shards, and is
-    # therefore unaffected by per-shard hash seeds. Issued in its own query so it
-    # doesn't drag the COUNT_DISTINCTISH query (below) into the same fate.
-    res = env.cmd('FT.AGGREGATE', 'idx', '*',
-                   'GROUPBY', '1', '@group',
-                   'REDUCE', 'COUNT_DISTINCT', '1', '@category', 'AS', 'exact')
-    exact_count = int(to_dict(res[1])['exact'])
-    env.assertEqual(exact_count, n_values)
-
-    # COUNT_DISTINCTISH is the only reducer in this GROUPBY step and is in
-    # `reducerDistributors_g`, so this step *is* distributed into per-shard HLL
-    # reducers merged via HLL_SUM. The result must be close to the exact count.
-    # With a stable cross-process hash, the merged HLL is ~idempotent across
-    # shards and estimates ~n_values. With a per-process-randomized hash, it
-    # would instead estimate ~n_values * env.shardsCount, well outside this
-    # tolerance for shardsCount >= 2.
-    res = env.cmd('FT.AGGREGATE', 'idx', '*',
-                   'GROUPBY', '1', '@group',
-                   'REDUCE', 'COUNT_DISTINCTISH', '1', '@category', 'AS', 'approx')
-    approx_count = int(to_dict(res[1])['approx'])
-    env.assertAlmostEqual(exact_count, approx_count, delta=exact_count * 0.20)
-
 @skip(cluster=True)
 def test_required_fields(env):
     # Testing coordinator<-> shard `_REQUIRED_FIELDS` protocol

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -21,6 +21,59 @@ def testInfo(env):
     env.assertGreater(float(idx_info['key_table_size_mb']), 0)
     env.assertGreater(float(idx_info['vector_index_sz_mb']), 0)
 
+@skip(cluster=False)
+def testCountDistinctishAcrossShards():
+    """COUNT_DISTINCTISH is distributed as a per-shard HLL reducer (REDUCER_T_HLL),
+    merged on the coordinator by HLL_SUM (a register-wise max of the per-shard
+    HLL registers, see `distributeCountDistinctish` in `src/coord/dist_plan.cpp`).
+
+    This merge is only correct if every shard maps the same logical value to the
+    same HLL register/rank pair, i.e. the hash fed into the per-shard HLL
+    (`RSValue_HashStable`) must be deterministic across processes. If a
+    per-process-randomized hash (`RSValue_Hash`) were used instead, the same
+    `n_values` distinct values would map to unrelated registers on each shard,
+    and the merged HLL would estimate roughly `n_values * env.shardsCount`
+    distinct values instead of `n_values`.
+
+    To make the difference observable, every distinct tag value is written to
+    enough documents that (with overwhelming probability) each shard sees all
+    `n_values` of them.
+    """
+    env = Env(shardsCount=2)
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'group', 'TAG', 'category', 'TAG').ok()
+
+    n_values = 50
+    docs_per_value = 20
+    for j in range(n_values):
+        for i in range(docs_per_value):
+            conn.execute_command('HSET', f'doc:{j}:{i}', 'group', 'all', 'category', f'cat{j}')
+
+    # COUNT_DISTINCT (exact) has no entry in `reducerDistributors_g`, so a GROUPBY
+    # step containing it is never distributed (see `distributeGroupStep`): it runs
+    # entirely on the coordinator over raw rows gathered from all shards, and is
+    # therefore unaffected by per-shard hash seeds. Issued in its own query so it
+    # doesn't drag the COUNT_DISTINCTISH query (below) into the same fate.
+    res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                   'GROUPBY', '1', '@group',
+                   'REDUCE', 'COUNT_DISTINCT', '1', '@category', 'AS', 'exact')
+    exact_count = int(to_dict(res[1])['exact'])
+    env.assertEqual(exact_count, n_values)
+
+    # COUNT_DISTINCTISH is the only reducer in this GROUPBY step and is in
+    # `reducerDistributors_g`, so this step *is* distributed into per-shard HLL
+    # reducers merged via HLL_SUM. The result must be close to the exact count.
+    # With a stable cross-process hash, the merged HLL is ~idempotent across
+    # shards and estimates ~n_values. With a per-process-randomized hash, it
+    # would instead estimate ~n_values * env.shardsCount, well outside this
+    # tolerance for shardsCount >= 2.
+    res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                   'GROUPBY', '1', '@group',
+                   'REDUCE', 'COUNT_DISTINCTISH', '1', '@category', 'AS', 'approx')
+    approx_count = int(to_dict(res[1])['approx'])
+    env.assertAlmostEqual(exact_count, approx_count, delta=exact_count * 0.20)
+
 @skip(cluster=True)
 def test_required_fields(env):
     # Testing coordinator<-> shard `_REQUIRED_FIELDS` protocol

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -334,12 +334,13 @@ def testEmptyTag():
         conn.execute_command('HSET', 'h3', 't', 'movie')
         conn.execute_command('HSET', 'h4', 't', '')
         cmd = f'FT.AGGREGATE {idx} * GROUPBY 1 @t REDUCE COUNT 0 AS count'.split(' ')
+        res = conn.execute_command(*cmd)
         expected = [
-            ANY, \
             ['t', '', 'count', '2'], \
             ['t', 'movie', 'count', '2']
         ]
-        cmd_assert(env, cmd, expected)
+        # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+        env.assertEqual(sorted(res[1:]), sorted(expected))
 
         # --------------------------- SEPARATOR --------------------------------
         # Remove added documents

--- a/tests/pytests/test_hybrid_json.py
+++ b/tests/pytests/test_hybrid_json.py
@@ -146,10 +146,10 @@ def test_knn_reduce():
         'PARAMS', '2', 'BLOB', vector_blob)
     env.assertEqual(response['total_results'], 2)
     env.assertEqual(len(response['results']), 2)
-    env.assertEqual(response['results'][0]['category'], "shoes")
-    env.assertEqual(response['results'][0]['count'], "3")
-    env.assertEqual(response['results'][1]['category'], "gear")
-    env.assertEqual(response['results'][1]['count'], "1")
+    # The order of the groups themselves is not guaranteed, so compare them by category
+    # regardless of order.
+    counts_by_category = {row['category']: row['count'] for row in response['results']}
+    env.assertEqual(counts_by_category, {"shoes": "3", "gear": "1"})
 
 def test_knn_load():
     env = Env(protocol=3)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -378,11 +378,15 @@ def test_MOD_1517(env):
              ['field1', None, 'field2', 'val2', 'amount1Sum', '1', 'amount2Sum', '1'],
              ['field1', 'val1', 'field2', None, 'amount1Sum', '1', 'amount2Sum', '1']]
 
-  env.expect('FT.AGGREGATE', 'idx', '*',
+  actual = conn.execute_command('FT.AGGREGATE', 'idx', '*',
              'LOAD', '2', '@amount1', '@amount2',
              'GROUPBY', '2', '@field1', '@field2',
              'REDUCE', 'SUM', '1', '@amount1', 'AS', 'amount1Sum',
-             'REDUCE', 'SUM', '1', '@amount2', 'as', 'amount2Sum').equal(res)
+             'REDUCE', 'SUM', '1', '@amount2', 'as', 'amount2Sum')
+
+  # The order of the groups themselves is not guaranteed, so compare the group rows regardless of order.
+  env.assertEqual(actual[0], res[0])
+  env.assertEqual(sorted(actual[1:], key=str), sorted(res[1:], key=str))
 
 @skip(msan=True, no_json=True)
 def test_MOD1544(env):


### PR DESCRIPTION
## Describe the changes in the pull request

**Current**:
- `value::hash::hash_value` (used by `RSValue_Hash`, which backs `GROUPBY`,
  `COUNT_DISTINCT`, and `TOLIST`) had three problems:
  - `Value::Undefined` reset the hasher to a fixed offset basis of `0`, discarding
    everything hashed so far, and `Value::Null` just added `1` to the running hash.
    Neither mixed in a real discriminant, so `Undefined`, `Null`, and `Number(0.0)`
    could collide.
  - `String`/`RedisString` payloads were hashed via raw `Hasher::write(bytes)`, with
    no type tag or length prefix. Because `RSValue_Hash` chains multiple field hashes
    by feeding each result back in as the next call's offset basis, and FNV-1a is a
    pure rolling hash, the combined hash of a multi-field key depended only on the
    *concatenation* of the field bytes. E.g. for a `GROUPBY` on two `TAG` fields,
    `(t1="ab", t2="c")` and `(t1="a", t2="bc")` both reduced to `FNV1a("abc")` -
    identical hashes, deterministically, every time. `group_by.c`'s `khash` table is
    keyed and compared purely on this 64-bit hash with no fallback equality check, so
    two distinct groups silently collapsed into one (wrong `n`, wrong per-group
    `COUNT`/`COUNT_DISTINCT`/`TOLIST` results).
  - `RSValue_Hash` used FNV-1a, a fixed, public algorithm with no per-process secret.
    An attacker who controls indexed field values could craft `GROUPBY`/
    `COUNT_DISTINCT`/`TOLIST` inputs that collide under FNV-1a, degrading these hash
    tables toward worst-case behavior (HashDoS).
- `COUNT_DISTINCTISH` and `HLL_SUM` use HyperLogLog sketches that are merged across
  cluster shards, which requires every shard to map the same value to the same HLL
  register/rank pair. There was no stable (cross-process) hash available for this, so
  `distinctishAdd` used the old FNV-1a call directly.

**Change**:
- `hash_value`:
  - Dereferences `Ref`/`Trio` up front via `Value::fully_dereferenced_ref_and_trio`,
    so they hash transparently as their inner value / left element.
  - Hashes a `Tag` discriminant (`Undefined`/`Null`/`Number`/`String`/`Array`/`Map`)
    before each variant's payload (if any), giving `Undefined`/`Null` a well-mixed,
    non-destructive contribution. `String` and `RedisString` share `Tag::String`, so
    values `compare()` treats as equal also hash equally.
  - Hashes payloads via the `Hash` trait (`num.to_ne_bytes().hash(hasher)`,
    `str.as_bytes().hash(hasher)`) instead of raw `Hasher::write`. `[u8]`'s `Hash`
    impl writes a length prefix, so each field now contributes `<tag><len><bytes>` to
    the chained hash — different field splits of the same byte sequence no longer
    collapse to the same hash.
  - Is now generic over `Hasher` instead of being tied to `Fnv64`.
- `RSValue_Hash` replaces `Fnv64::with_offset_basis(hval)` with
  `RandomState`/`DefaultHasher` (SipHash13), seeded once per process from OS randomness
  via `LazyLock`. Each call builds a fresh hasher from that shared seed, mixes in `hval`
  via `write_u64` (preserving the existing chaining contract), then hashes the value.
- Added `RSValue_HashStable`: a deterministic counterpart to `RSValue_Hash` that uses
  `DefaultHasher` with no per-process secret, so the same value always produces the same
  hash across processes and restarts. `distinctishAdd` now uses `RSValue_HashStable`
  instead of the old FNV-1a call.

**Outcome**:
- `Undefined`/`Null` mix into the running hash like every other variant, and remain
  distinct from each other and from `Number(0.0)`.
- Multi-field `GROUPBY`/`COUNT_DISTINCT`/`TOLIST` keys built from string fields no
  longer risk deterministically colliding due to field boundaries being lost during hashing.
- `String` vs `RedisString` values with identical bytes hash identically.
- The hash function backing `GROUPBY`/`COUNT_DISTINCT`/`TOLIST` is now keyed with a
  per-process secret, closing a HashDoS vector.
- `COUNT_DISTINCTISH` produces correct cross-shard estimates because all shards now use
  the same deterministic hash to assign values to HLL registers.
- `value/tests/integration/hash.rs` is extended to cover all of the above.
- Several `tests/pytests/*` tests asserted on a specific (now-changed) hash-driven
  ordering of `GROUPBY`/`COUNT_DISTINCT` result rows. These are updated to compare
  results order-independently (sorting rows, building lookup dicts keyed by group
  value, or using `SORTBY` to deterministically select the row under test) instead
  of relying on incidental hash-table iteration order.

#### Which additional issues this PR fixes
1. MOD-14459

#### Main objects this PR modified
1. `value::hash::hash_value` (`src/redisearch_rs/value/src/hash.rs`)
2. `RSValue_Hash`, `RSValue_HashStable` (`src/redisearch_rs/c_entrypoint/value_ffi/src/hash.rs`)
3. `value/tests/integration/hash.rs`
4. `src/aggregate/reducers/count_distinct.c` — use `RSValue_HashStable` for `COUNT_DISTINCTISH`
5. `tests/pytests/test.py`, `test_aggregate.py`, `test_aggregate_count.py`, `test_empty.py`, `test_hybrid_json.py`, `test_issues.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes