### PR TITLE
[MOD-12438] FT.HYBRID: stable RRF result order across cluster shards

### DIFF
--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -101,6 +101,8 @@ typedef struct {
   uint64_t sortAscMap;            // Mapping of ascending/descending. Bitwise
   bool isLimited;                 // Flag if `LIMIT` keyword was used.
   bool runLocal;                  // Indicator that this step should run only local (not in shards)
+  const char *scoreTieBreakField; // If set, sort-by-score breaks ties by this field, not the doc
+                                  // id (see setupCoordinatorArrangeSteps).
   uint64_t offset;                // Seek results. If 0, then no paging is applied
   uint64_t limit;                 // Number of rows to output
 } PLN_ArrangeStep;

--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -101,8 +101,7 @@ typedef struct {
   uint64_t sortAscMap;            // Mapping of ascending/descending. Bitwise
   bool isLimited;                 // Flag if `LIMIT` keyword was used.
   bool runLocal;                  // Indicator that this step should run only local (not in shards)
-  const char *scoreTieBreakField; // If set, sort-by-score breaks ties by this field, not the doc
-                                  // id (see setupCoordinatorArrangeSteps).
+  const char *scoreTieBreakField; // If set, sort-by-score breaks ties by this field, not the doc id
   uint64_t offset;                // Seek results. If 0, then no paging is applied
   uint64_t limit;                 // Number of rows to output
 } PLN_ArrangeStep;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -415,9 +415,8 @@ static void setupCoordinatorArrangeSteps(AREQ *searchRequest, AREQ *vectorReques
   const size_t window =
       isRRF ? hybridParams->scoringCtx->rrfCtx.window : hybridParams->scoringCtx->linearCtx.window;
 
-  // RRF scores a doc from its rank within a branch, so per-branch ties ordered differently across
-  // shards yield different RRF scores. Break ties by `__key` (stable across shards, unlike doc id).
-  // Only reached on the multi-shard path, so standalone keeps the cheaper doc-id tiebreak.
+  // RRF scores a doc by its rank, so tied branch scores become distinct RRF scores by position.
+  // Use a cross-shard-stable tiebreaker (`__key`) on the coordinator; a single shard uses doc id.
   const char *scoreTieBreakField = isRRF ? UNDERSCORE_KEY : NULL;
 
   // TODO: would be better to look for a vector node (recursive search on the ast) and decide according to its query type (knn/range)

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -415,8 +415,8 @@ static void setupCoordinatorArrangeSteps(AREQ *searchRequest, AREQ *vectorReques
   const size_t window =
       isRRF ? hybridParams->scoringCtx->rrfCtx.window : hybridParams->scoringCtx->linearCtx.window;
 
-  // RRF scores a doc by its rank, so tied branch scores become distinct RRF scores by position.
-  // Use a cross-shard-stable tiebreaker (`__key`) on the coordinator; a single shard uses doc id.
+  // RRF scores a doc by its rank, so tied branch scores need a tiebreaker; otherwise their order
+  // follows non-deterministic shard arrival order. Break ties by `__key` (multi-shard path only).
   const char *scoreTieBreakField = isRRF ? UNDERSCORE_KEY : NULL;
 
   // TODO: would be better to look for a vector node (recursive search on the ast) and decide according to its query type (knn/range)

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -27,6 +27,7 @@
 #include "debug_commands.h"
 #include "result_processor.h"
 #include "concurrent_ctx.h"
+#include "document.h"
 #include "info/info_redis/threads/current_thread.h"
 #include "aggregate/reply_empty.h"
 
@@ -410,7 +411,14 @@ static void HybridRequest_buildDistRPChain(AREQ *r, MRCommand *xcmd,
 }
 
 static void setupCoordinatorArrangeSteps(AREQ *searchRequest, AREQ *vectorRequest, HybridPipelineParams *hybridParams) {
-  const size_t window = hybridParams->scoringCtx->scoringType == HYBRID_SCORING_RRF ? hybridParams->scoringCtx->rrfCtx.window : hybridParams->scoringCtx->linearCtx.window;
+  const bool isRRF = hybridParams->scoringCtx->scoringType == HYBRID_SCORING_RRF;
+  const size_t window =
+      isRRF ? hybridParams->scoringCtx->rrfCtx.window : hybridParams->scoringCtx->linearCtx.window;
+
+  // RRF scores a doc from its rank within a branch, so per-branch ties ordered differently across
+  // shards yield different RRF scores. Break ties by `__key` (stable across shards, unlike doc id).
+  // Only reached on the multi-shard path, so standalone keeps the cheaper doc-id tiebreak.
+  const char *scoreTieBreakField = isRRF ? UNDERSCORE_KEY : NULL;
 
   // TODO: would be better to look for a vector node (recursive search on the ast) and decide according to its query type (knn/range)
   const bool isKNN = vectorRequest->ast.root->type == QN_VECTOR;
@@ -418,8 +426,10 @@ static void setupCoordinatorArrangeSteps(AREQ *searchRequest, AREQ *vectorReques
 
   PLN_ArrangeStep *searchArrangeStep = AGPLN_GetOrCreateArrangeStep(AREQ_AGGPlan(searchRequest));
   searchArrangeStep->limit = window;
+  searchArrangeStep->scoreTieBreakField = scoreTieBreakField;
 
   PLN_ArrangeStep *vectorArrangeStep = AGPLN_GetOrCreateArrangeStep(AREQ_AGGPlan(vectorRequest));
+  vectorArrangeStep->scoreTieBreakField = scoreTieBreakField;
   if (isKNN) {
     // Vector subquery is a KNN query
     // Heapsize should be min(window, KNN K)

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -240,7 +240,7 @@ static ResultProcessor *getArrangeRP(Pipeline *pipeline, const AggregationPipeli
               HasScorer(&params->common)) {
       // No sort? then it must be sort by score, which is the default.
       // In optimize mode, add sorter for queries with a scorer.
-      // Resolve the score-tie-break field if one was requested (see setupCoordinatorArrangeSteps).
+      // Resolve the score-tie-break field if one was requested.
       const RLookupKey *scoreTieBreakKey = NULL;
       if (astp->scoreTieBreakField) {
         RLookup *lk = AGPLN_GetLookup(&pipeline->ap, stp, AGPLN_GETLOOKUP_PREV);

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -240,7 +240,13 @@ static ResultProcessor *getArrangeRP(Pipeline *pipeline, const AggregationPipeli
               HasScorer(&params->common)) {
       // No sort? then it must be sort by score, which is the default.
       // In optimize mode, add sorter for queries with a scorer.
-      rp = RPSorter_NewByScore(maxResults);
+      // Resolve the score-tie-break field if one was requested (see setupCoordinatorArrangeSteps).
+      const RLookupKey *scoreTieBreakKey = NULL;
+      if (astp->scoreTieBreakField) {
+        RLookup *lk = AGPLN_GetLookup(&pipeline->ap, stp, AGPLN_GETLOOKUP_PREV);
+        scoreTieBreakKey = RLookup_GetKey_Read(lk, astp->scoreTieBreakField, RLOOKUP_F_HIDDEN);
+      }
+      rp = RPSorter_NewByScore(maxResults, scoreTieBreakKey);
       up = pushRP(&pipeline->qctx, rp, up);
     }
   }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -623,7 +623,7 @@ typedef struct {
     uint64_t ascendMap;
   } fieldcmp;
 
-  // When set, score ties are broken by this key's value instead of the doc id. NULL by default.
+  // When set, score ties are broken by this key's value instead of the doc id.
   const RLookupKey *scoreTieBreakKey;
 
   // Whether a timeout warning needs to be propagated down the downstream
@@ -743,9 +743,8 @@ static inline int cmpByScore(const void *e1, const void *e2, const void *udata) 
   } else if (SearchResult_GetScore(h1) > SearchResult_GetScore(h2)) {
     return 1;
   }
-  // Score tie: with a tie-break key, defer to the by-fields comparator over that single key so the
-  // missing-value and doc-id sub-tiebreaks match sort-by-field. ascendMap=1 gives ascending key
-  // order and a lower-doc-id-first fallback, matching the no-key path below.
+  // Tie-break via the by-fields comparator over the key (ascendMap=1 -> ascending key,
+  // lower-doc-id-first, matching the no-key path below).
   if (self->scoreTieBreakKey) {
     QueryError *qerr = (self->base.parent) ? self->base.parent->err : NULL;
     return SearchResult_CmpByFields(&self->scoreTieBreakKey, 1, h1, h2, /*ascendMap=*/1, qerr);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -623,6 +623,9 @@ typedef struct {
     uint64_t ascendMap;
   } fieldcmp;
 
+  // When set, score ties are broken by this key's value instead of the doc id. NULL by default.
+  const RLookupKey *scoreTieBreakKey;
+
   // Whether a timeout warning needs to be propagated down the downstream
   bool timedOut;
 } RPSorter;
@@ -732,12 +735,20 @@ static int rpsortNext_Accum(ResultProcessor *rp, SearchResult *r) {
 
 /* Compare results for the heap by score */
 static inline int cmpByScore(const void *e1, const void *e2, const void *udata) {
+  const RPSorter *self = udata;
   const SearchResult *h1 = e1, *h2 = e2;
 
   if (SearchResult_GetScore(h1) < SearchResult_GetScore(h2)) {
     return -1;
   } else if (SearchResult_GetScore(h1) > SearchResult_GetScore(h2)) {
     return 1;
+  }
+  // Score tie: with a tie-break key, defer to the by-fields comparator over that single key so the
+  // missing-value and doc-id sub-tiebreaks match sort-by-field. ascendMap=1 gives ascending key
+  // order and a lower-doc-id-first fallback, matching the no-key path below.
+  if (self->scoreTieBreakKey) {
+    QueryError *qerr = (self->base.parent) ? self->base.parent->err : NULL;
+    return SearchResult_CmpByFields(&self->scoreTieBreakKey, 1, h1, h2, /*ascendMap=*/1, qerr);
   }
   return SearchResult_GetDocId(h1) > SearchResult_GetDocId(h2) ? -1 : 1;
 }
@@ -786,8 +797,10 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   return &ret->base;
 }
 
-ResultProcessor *RPSorter_NewByScore(size_t maxresults) {
-  return RPSorter_NewByFields(maxresults, NULL, 0, 0);
+ResultProcessor *RPSorter_NewByScore(size_t maxresults, const RLookupKey *scoreTieBreakKey) {
+  ResultProcessor *rp = RPSorter_NewByFields(maxresults, NULL, 0, 0);
+  ((RPSorter *)rp)->scoreTieBreakKey = scoreTieBreakKey;
+  return rp;
 }
 
 /*******************************************************************************************************************

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -169,7 +169,12 @@ ResultProcessor *RPMetricsLoader_New();
  */
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys, uint64_t ascendingMap);
 
-ResultProcessor *RPSorter_NewByScore(size_t maxresults);
+/**
+ * Creates a sorter result processor that sorts by score.
+ * @param scoreTieBreakKey if non-NULL, score ties break by this key's value, not the doc id.
+ *   Used on the coordinator for hybrid RRF where doc ids are not comparable across shards.
+ */
+ResultProcessor *RPSorter_NewByScore(size_t maxresults, const RLookupKey *scoreTieBreakKey);
 
 ResultProcessor *RPPager_New(size_t offset, size_t limit);
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -172,7 +172,6 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
 /**
  * Creates a sorter result processor that sorts by score.
  * @param scoreTieBreakKey if non-NULL, score ties break by this key's value, not the doc id.
- *   Used on the coordinator for hybrid RRF where doc ids are not comparable across shards.
  */
 ResultProcessor *RPSorter_NewByScore(size_t maxresults, const RLookupKey *scoreTieBreakKey);
 

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -109,3 +109,55 @@ def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     env.assertEqual(len(error_holder), 1,
                     message=f'Expected a communication error, got results: {result_holder}')
     env.assertContains('Could not send query to cluster', str(error_holder[0]))
+
+
+def _hybrid_score_groups(response):
+    """Ordered list of (score, set-of-keys) groups for a hybrid reply.
+
+    Docs sharing a combined RRF score are grouped together, so a comparison ignores the order
+    within a tie (broken by doc id on the tail, which is intentionally not cross-shard stable)
+    while still asserting the per-branch ranks: the score sequence and the docs at each score."""
+    results, _ = get_results_from_hybrid_response(response)
+    groups = []
+    for key, fields in results.items():
+        score = fields.get('__score')
+        if groups and groups[-1][0] == score:
+            groups[-1][1].add(key)
+        else:
+            groups.append((score, {key}))
+    return groups
+
+
+@skip(cluster=False)
+def test_dist_hybrid_rrf_score_tie_order_is_stable(env):
+    """RRF scoring must stay stable regardless of which shard serves as coordinator. The numeric
+    SEARCH branch (all text scores 0) and low-cardinality vectors force per-branch ties."""
+    n_docs = 1000
+    dim = 3
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'n', 'NUMERIC', 'SORTABLE',
+               'text', 'TEXT',
+               'vector', 'VECTOR', 'FLAT', '6',
+               'TYPE', 'FLOAT32', 'DIM', str(dim), 'DISTANCE_METRIC', 'L2').ok()
+
+    with env.getClusterConnectionIfNeeded() as con:
+        for i in range(n_docs):
+            vec = np.array([float(i % 10), float((i * 2) % 10), float((i * 3) % 10)], dtype=np.float32)
+            con.execute_command('HSET', f'doc:{i}', 'n', i, 'text', f'document {i}', 'vector', vec.tobytes())
+    waitForIndex(env, 'idx')
+
+    # WINDOW = n_docs so every matching doc is returned, with no tie straddling the window cutoff.
+    query_vec = np.array([5.0] * dim, dtype=np.float32).tobytes()
+    query = ('FT.HYBRID', 'idx',
+             'SEARCH', f'@n:[0 {n_docs}]',
+             'VSIM', '@vector', '$BLOB', 'KNN', '2', 'K', str(n_docs),
+             'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'WINDOW', str(n_docs),
+             'LIMIT', '0', str(n_docs),
+             'PARAMS', '2', 'BLOB', query_vec)
+
+    expected = _hybrid_score_groups(env.cmd(*query))
+    env.assertGreater(len(expected), 0, message='query returned no results')
+
+    for i, shard in enumerate(env.getOSSMasterNodesConnectionList()):
+        got = _hybrid_score_groups(shard.execute_command(*query))
+        env.assertEqual(got, expected, message=f'shard {i} returned different scores/docs', depth=1)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** In cluster mode, `FT.HYBRID` with RRF scoring can return different results across runs. RRF derives a document's combined score from its **rank** within each branch, and the per-branch sorters run on the coordinator over results streamed in from the shards. When two documents tie on a branch score there is no tiebreaker on the coordinator, so their relative order — and therefore their ranks — is decided by the order in which the shards' results happen to arrive, which is non-deterministic by design. Example: if shard A's `(a, score=0)` arrives before shard B's `(b, score=0)`, `a` is ranked 1 and `b` is ranked 2; on a later run B may arrive first, so `b` is ranked 1 and `a` is ranked 2. Different per-branch ranks produce different RRF scores for the same dataset.

2. **Change:** On the coordinator RRF path, break per-branch score ties by the document key (`__key`). `__key` is already present in hybrid query results — it is the identifier used to merge the same document across the search and vector subqueries — so it gives a stable order independent of shard arrival order at no extra fetch cost. The per-branch by-score sorters defer to the existing by-fields comparator over `__key`, reusing its missing-value policy. Intent is threaded through `PLN_ArrangeStep.scoreTieBreakField` and resolved to an `RLookupKey` during pipeline construction, so the plan layer expresses intent and the pipeline layer owns key resolution. Standalone (single shard) is unaffected and keeps its existing tiebreak.

3. **Outcome:** RRF scoring is stable across runs regardless of shard arrival order — the combined scores and the set of documents at each score no longer depend on it.

#### Scope note
This fixes the **per-branch** RRF determinism (the root cause). Ordering *within* an identical combined RRF score is still resolved by the tail merge sorter and is intentionally out of scope here; it can be addressed separately by applying the same `__key` tiebreak to the tail arrange step.

#### Which additional issues this PR fixes
1. MOD-12438

#### Main objects this PR modified
1. `PLN_ArrangeStep` (`src/aggregate/aggregate_plan.h`) — new `scoreTieBreakField`
2. `setupCoordinatorArrangeSteps` (`src/coord/hybrid/dist_hybrid.c`) — set `__key` tiebreak for RRF branches
3. `getArrangeRP` (`src/pipeline/pipeline_construction.c`) — resolve the field to an `RLookupKey`
4. `RPSorter` / `cmpByScore` / `RPSorter_NewByScore` (`src/result_processor.{c,h}`) — score-tie key, deferring to `SearchResult_CmpByFields`
5. `tests/pytests/test_hybrid_dist.py` — cross-shard RRF stability test

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: `FT.HYBRID` RRF queries now return a consistent result order across cluster shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
