### PR TITLE
stopwords: fix out-of-bounds write in AddStopWordsListToInfo on empty list

### DIFF
--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -259,10 +259,11 @@ void AddStopWordsListToInfo(RedisModuleInfoCtx *ctx, struct StopWordList *sl) {
     stopwords = array_ensure_append_n(stopwords, "\",", 2);
   }
   // NUL-terminate: an empty list gets a fresh NUL, otherwise the trailing comma becomes one.
-  if (array_len(stopwords) == 0) {
+  uint32_t stopwords_len = array_len(stopwords);
+  if (stopwords_len == 0) {
     stopwords = array_ensure_append_1(stopwords, "\0");
   } else {
-    stopwords[array_len(stopwords) - 1] = '\0';
+    stopwords[stopwords_len - 1] = '\0';
   }
   RedisModule_InfoAddFieldCString(ctx, "stop_words", stopwords);
   array_free(stopwords);

--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -258,7 +258,12 @@ void AddStopWordsListToInfo(RedisModuleInfoCtx *ctx, struct StopWordList *sl) {
     stopwords = array_ensure_append_n(stopwords, str, len);
     stopwords = array_ensure_append_n(stopwords, "\",", 2);
   }
-  stopwords[array_len(stopwords)-1] = '\0';
+  // NUL-terminate: an empty list gets a fresh NUL, otherwise the trailing comma becomes one.
+  if (array_len(stopwords) == 0) {
+    stopwords = array_ensure_append_1(stopwords, "\0");
+  } else {
+    stopwords[array_len(stopwords) - 1] = '\0';
+  }
   RedisModule_InfoAddFieldCString(ctx, "stop_words", stopwords);
   array_free(stopwords);
   TrieMapIterator_Free(it);

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -769,6 +769,11 @@ void RMCK_LogIOError(RedisModuleIO *io, const char *levelstr, const char *fmt, .
   va_end(ap);
 }
 
+int RMCK_InfoAddFieldCString(RedisModuleInfoCtx *ctx, const char *field, const char *value) {
+  ctx->fields.emplace_back(field, value);
+  return REDISMODULE_OK;
+}
+
 void *RMCK_LoadDataTypeFromStringEncver(const RedisModuleString *str,
                                         const RedisModuleType *mt,
                                         int encver) {
@@ -1795,6 +1800,9 @@ static void registerApis() {
   REGISTER_API(IsIOError);
   REGISTER_API(LogIOError);
   REGISTER_API(GetContextFromIO);
+
+  // Info
+  REGISTER_API(InfoAddFieldCString);
   // Serialization
   REGISTER_API(LoadDataTypeFromStringEncver);
   REGISTER_API(SaveDataTypeToString);

--- a/tests/cpptests/redismock/redismock.h
+++ b/tests/cpptests/redismock/redismock.h
@@ -23,6 +23,12 @@ struct RedisModuleIO {
   bool error_flag = false;
 };
 
+// Minimal INFO-context recorder: RMCK_InfoAddFieldCString appends the
+// (field, value) pairs a module writes, so tests can assert on them.
+struct RedisModuleInfoCtx {
+  std::vector<std::pair<std::string, std::string>> fields;
+};
+
 std::vector<std::vector<std::string>> &RMCK_GetPropagatedCommands(RedisModuleCtx *ctx);
 
 // External interface for clearing KeyMeta storage

--- a/tests/cpptests/test_cpp_stopwords.cpp
+++ b/tests/cpptests/test_cpp_stopwords.cpp
@@ -48,7 +48,6 @@ TEST_F(StopwordsInfoTest, testInfoEmptyList) {
   ASSERT_EQ(info.fields[0].second, "");
 
   StopWordList_Unref(sl);
-  StopWordList_FreeGlobals();
 }
 
 TEST_F(StopwordsInfoTest, testInfoTerm) {
@@ -67,7 +66,6 @@ TEST_F(StopwordsInfoTest, testInfoTerm) {
   ASSERT_EQ(info.fields[0].second, "\"foo\"");
 
   StopWordList_Unref(sl);
-  StopWordList_FreeGlobals();
 }
 
 TEST_F(StopwordsInfoTest, testInfoNullList) {

--- a/tests/cpptests/test_cpp_stopwords.cpp
+++ b/tests/cpptests/test_cpp_stopwords.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "gtest/gtest.h"
+#include "redismock/redismock.h"
+
+#include "stopwords.h"
+#include "rmalloc.h"
+#include "util/arr.h"
+
+#include <cstring>
+
+class StopwordsInfoTest : public ::testing::Test {};
+
+// Stock the allocator's freelist with dirty blocks of the size
+// AddStopWordsListToInfo allocates for its render buffer, so that a missing
+// NUL terminator shows up as garbage instead of depending on the block
+// happening to be zero-filled.
+static void dirtyRenderBufferBlocks() {
+  const size_t renderBufSize = sizeof(array_hdr_t) + 512;
+  void *blocks[8];
+  for (auto &block : blocks) {
+    block = rm_malloc(renderBufSize);
+    memset(block, 'X', renderBufSize);
+  }
+  for (auto &block : blocks) {
+    rm_free(block);
+  }
+}
+
+TEST_F(StopwordsInfoTest, testInfoEmptyList) {
+  StopWordList *sl = NewStopWordListCStr(NULL, 0);
+  ASSERT_TRUE(sl != nullptr);
+
+  dirtyRenderBufferBlocks();
+
+  RedisModuleInfoCtx info;
+  AddStopWordsListToInfo(&info, sl);
+
+  ASSERT_EQ(info.fields.size(), 1);
+  ASSERT_EQ(info.fields[0].first, "stop_words");
+  ASSERT_EQ(info.fields[0].second, "");
+
+  StopWordList_Unref(sl);
+  StopWordList_FreeGlobals();
+}
+
+TEST_F(StopwordsInfoTest, testInfoTerm) {
+  const char *terms[] = {"FOO"};
+  StopWordList *sl = NewStopWordListCStr(terms, 1);
+  ASSERT_TRUE(sl != nullptr);
+
+  dirtyRenderBufferBlocks();
+
+  RedisModuleInfoCtx info;
+  AddStopWordsListToInfo(&info, sl);
+
+  ASSERT_EQ(info.fields.size(), 1);
+  ASSERT_EQ(info.fields[0].first, "stop_words");
+  // Terms are stored lowercased.
+  ASSERT_EQ(info.fields[0].second, "\"foo\"");
+
+  StopWordList_Unref(sl);
+  StopWordList_FreeGlobals();
+}
+
+TEST_F(StopwordsInfoTest, testInfoNullList) {
+  RedisModuleInfoCtx info;
+  AddStopWordsListToInfo(&info, NULL);
+
+  ASSERT_TRUE(info.fields.empty());
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: For an empty stopword list, `AddStopWordsListToInfo` NUL-terminates its render buffer with `stopwords[array_len(stopwords)-1]`. `array_len()` returns `uint32_t`, so the index wraps to `UINT32_MAX` and the write lands 4GB past the buffer, crashing the process. The function is currently unreachable from commands — its only caller chain is the crash-report INFO path, which always passes `skip_unsafe_ops=true` and skips the stopwords section — so the bug is latent.
2. Change: Guard on `array_len() == 0` and append the NUL explicitly for the empty case; a non-empty list still gets its trailing comma replaced by the NUL. Covered by a new C++ unit test (`tests/cpptests/test_cpp_stopwords.cpp`), which required adding the first INFO-API mock (a `RedisModule_InfoAddFieldCString` recorder) to redismock. The first commit adds the test (crashing at that commit), the second fixes it.
3. Outcome: An empty stopword list renders as an empty `stop_words` value instead of an out-of-bounds write; the behavior is pinned by unit tests. Since the function is unreachable from any command, it cannot be covered by a Python flow test.

#### Which additional issues this PR fixes
1. None

#### Main objects this PR modified
1. `AddStopWordsListToInfo` (src/stopwords.c)
2. redismock — new `RedisModuleInfoCtx` recorder + `RMCK_InfoAddFieldCString`
3. New test suite `StopwordsInfoTest` (tests/cpptests/test_cpp_stopwords.cpp)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
