### PR TITLE
[MOD-16221] Skip mixed coordinator burst test on macOS

### DIFF
--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -92,12 +92,7 @@ def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pendin
     )
 
 
-# Skipped on macOS: the test drives the coordinator into RQ saturation by firing
-# a large burst of concurrent connections, then polls FT.DEBUG COORD_THREADS for
-# saturation. On the slow, single-IO-thread macOS CI runners (kern.ipc.somaxconn
-# defaults to 128 < burst size) the monitoring poll gets starved by the burst it
-# is measuring and the saturation wait times out. The drain/deadlock behavior
-# under test is platform-independent, so Linux cluster coverage is sufficient.
+# Skipped on macOS: the saturation burst times out on the slow macOS CI runners.
 @skip(cluster=False, macos=True)
 def test_search_and_aggregate_burst():
     env = Env(

--- a/tests/pytests/test_burst_drains_without_deadlock.py
+++ b/tests/pytests/test_burst_drains_without_deadlock.py
@@ -92,7 +92,13 @@ def _print_debug_stats(label, env, coord_initial_jobs_done, coord_initial_pendin
     )
 
 
-@skip(cluster=False)
+# Skipped on macOS: the test drives the coordinator into RQ saturation by firing
+# a large burst of concurrent connections, then polls FT.DEBUG COORD_THREADS for
+# saturation. On the slow, single-IO-thread macOS CI runners (kern.ipc.somaxconn
+# defaults to 128 < burst size) the monitoring poll gets starved by the burst it
+# is measuring and the saturation wait times out. The drain/deadlock behavior
+# under test is platform-independent, so Linux cluster coverage is sufficient.
+@skip(cluster=False, macos=True)
 def test_search_and_aggregate_burst():
     env = Env(
         testName='Search and aggregate burst',


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `test_burst_drains_without_deadlock.py::test_search_and_aggregate_burst` drives the coordinator request queue (RQ) into saturation by firing a large burst of concurrent connections (240 threads, each opening its own connection while shard workers are paused), then polls `FT.DEBUG COORD_THREADS stats` to detect that the RQ reached capacity before resuming the workers.
2. **Change:** Skip the test on macOS by adding `macos=True` to the existing `@skip` decorator.
3. **Outcome:** The test runs only on Linux cluster runners (where it is reliable) and no longer flakes on the macOS x86_64 Periodic Master Validation job.

### Why

On the slow, single-IO-thread macOS CI runners the burst overwhelms the coordinator node's event loop. The macOS default `kern.ipc.somaxconn` is 128 — below the 240-connection burst — so the connection storm starves the test's own monitoring connection: the `FT.DEBUG COORD_THREADS stats` poll blocks in `sendall` and the saturation wait times out (observed `jobs_seen=16` vs threshold `50`, failing after ~22s). The poll is racing the very saturation it is trying to measure.

The drain/deadlock property this test guards (regression for MOD-14268, coordinator deadlock under mixed `FT.SEARCH + FT.AGGREGATE` load) is platform-independent, so Linux cluster coverage is sufficient. A prior unflake attempt (MOD-15300 / #9645) only relaxed the threshold arithmetic and did not address this race.

Failing run: https://github.com/RediSearch/RediSearch/actions/runs/27267446256/job/80528156225

#### Which additional issues this PR fixes
1. MOD-15300

#### Main objects this PR modified
1. `tests/pytests/test_burst_drains_without_deadlock.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
