### PR TITLE
build.sh: use correct lcov error class for coverage capture

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -321,7 +321,7 @@ prepare_coverage_capture() {
   start_group "Code Coverage Preparation"
   lcov --zerocounters      --directory $BINROOT --base-directory $ROOT
   lcov --capture --initial --directory $BINROOT --base-directory $ROOT -o $BINROOT/base.info \
-    --ignore-errors mismatch \
+    --ignore-errors inconsistent,corrupt,mismatch \
     --exclude '*/_deps/*'
   end_group
 }
@@ -337,25 +337,27 @@ capture_coverage() {
 
   # Capture coverage collected while running tests previously.
   # Threaded code (e.g. tiered SVS index) can produce gcov data where a function
-  # is reported "not hit" while its line is hit; lcov 2.0 treats this as a fatal
-  # "mismatch" error by default. Demote it to a warning so coverage
-  # post-processing doesn't flake the job.
+  # is reported "not hit" while its line is hit; lcov flags this as an
+  # 'inconsistent' data error, which becomes fatal (surfaced as 'corrupt') when a
+  # later command re-reads the affected trace file. Demote these to warnings so
+  # coverage post-processing doesn't flake the job. 'mismatch' is kept as well to
+  # cover lcov versions that classify the same disagreement under that name.
   lcov --capture --directory $BINROOT --base-directory $ROOT -o $BINROOT/test.info \
-    --ignore-errors mismatch \
+    --ignore-errors inconsistent,corrupt,mismatch \
     --exclude '*/_deps/*'
 
   # Accumulate results with the baseline captured before the test
   lcov --add-tracefile $BINROOT/base.info --add-tracefile $BINROOT/test.info -o $BINROOT/full.info \
-    --ignore-errors mismatch
+    --ignore-errors inconsistent,corrupt,mismatch
 
   # Extract only the coverage of the project source files
   lcov --output-file $BINROOT/source.info --extract $BINROOT/full.info \
-    --ignore-errors mismatch \
+    --ignore-errors inconsistent,corrupt,mismatch \
     "$ROOT/src/*" \
     "$ROOT/deps/thpool/*" \
 
   # Remove coverage for directories we don't want (ignore if no file matches)
-  lcov -o $BINROOT/$NAME.info --ignore-errors mismatch,unused --remove $BINROOT/source.info \
+  lcov -o $BINROOT/$NAME.info --ignore-errors inconsistent,corrupt,mismatch,unused --remove $BINROOT/source.info \
     "*/tests/*" \
 
   end_group


### PR DESCRIPTION
Commit 0d78f8c4 tried to tolerate the threaded-SVS gcov inconsistency by passing '--ignore-errors mismatch' to the lcov coverage calls, but the lcov 2.0 on the CI image classifies that disagreement as 'inconsistent' (surfaced as 'corrupt' when a later command re-reads the trace file), not 'mismatch'. The merge step therefore still aborted with:

  lcov: ERROR: (corrupt) unable to read trace file '.../test.info':
  lcov: ERROR: (inconsistent) svs_tiered.h:914: function ... not hit but line is

Pass '--ignore-errors inconsistent,corrupt,mismatch' to every lcov call that captures, merges, extracts, or reads a trace file. 'inconsistent,corrupt' are the classes actually raised; 'mismatch' is kept for robustness across lcov versions. The remove step keeps the pre-existing 'unused' class alongside them.

Verified locally: lcov 2.0-1 accepts all three classes, and a full 'COV=1' rebuild + flow suite (1932 tests, 0 failures) produces flow_standalone.info with no lcov abort.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
