### PR TITLE
[MOD-15932] Trie - Replace empty-prefix DFA trie iteration with Trie_IterateAll

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -472,13 +472,12 @@ DEBUG_COMMAND(DumpTerms) {
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;
-  int dist = 0;
   size_t termLen;
 
   RedisModule_ReplyWithArray(ctx, Trie_Size(sctx->spec->terms));
 
-  TrieIterator *it = Trie_Iterate(sctx->spec->terms, "", 0, 0, 1);
-  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, &dist)) {
+  TrieIterator *it = Trie_IterateAll(sctx->spec->terms);
+  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, NULL)) {
     char *res = runesToStr(rstr, slen, &termLen);
     RedisModule_ReplyWithStringBuffer(ctx, res, termLen);
     rm_free(res);

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -78,13 +78,12 @@ void Dictionary_Dump(RedisModuleCtx *ctx, const char *dictName) {
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;
-  int dist = 0;
   size_t termLen;
 
   RedisModule_ReplyWithSet(ctx, Trie_Size(t));
 
-  TrieIterator *it = Trie_Iterate(t, "", 0, 0, 1);
-  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, &dist)) {
+  TrieIterator *it = Trie_IterateAll(t);
+  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, NULL)) {
     char *res = runesToStr(rstr, slen, &termLen);
     RedisModule_ReplyWithStringBuffer(ctx, res, termLen);
     rm_free(res);
@@ -162,13 +161,12 @@ static void Propagate_Dict(RedisModuleCtx* ctx, const char* dictName, Trie* trie
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;
-  int dist = 0;
 
   RedisModuleString **terms = rm_malloc(Trie_Size(trie) * sizeof(RedisModuleString*));
   size_t termsCount = 0;
 
-  TrieIterator *it = Trie_Iterate(trie, "", 0, 0, 1);
-  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, &dist)) {
+  TrieIterator *it = Trie_IterateAll(trie);
+  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, NULL)) {
     char *res = runesToStr(rstr, slen, &termLen);
     terms[termsCount++] = RedisModule_CreateString(NULL, res, termLen);
     rm_free(res);

--- a/src/fork_gc/terms.c
+++ b/src/fork_gc/terms.c
@@ -17,12 +17,11 @@
 #include "obfuscation/hidden.h"
 
 void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
-  TrieIterator *iter = Trie_Iterate(sctx->spec->terms, "", 0, 0, 1);
+  TrieIterator *iter = Trie_IterateAll(sctx->spec->terms);
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;
-  int dist = 0;
-  while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, NULL, &dist)) {
+  while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, NULL, NULL)) {
     size_t termLen;
     char *term = runesToStr(rstr, slen, &termLen);
     InvertedIndex *idx = Redis_OpenInvertedIndex(sctx->spec, term, termLen, DONT_CREATE_INDEX, NULL);

--- a/src/spec.c
+++ b/src/spec.c
@@ -3306,11 +3306,10 @@ void IndexSpec_DropLegacyIndexFromKeySpace(IndexSpec *sp) {
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;
-  int dist = 0;
   size_t termLen;
 
-  TrieIterator *it = Trie_Iterate(ctx.spec->terms, "", 0, 0, 1);
-  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, &dist)) {
+  TrieIterator *it = Trie_IterateAll(ctx.spec->terms);
+  while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, NULL, NULL)) {
     char *res = runesToStr(rstr, slen, &termLen);
     RedisModuleString *keyName = Legacy_fmtRedisTermKey(&ctx, res, strlen(res));
     Redis_LegacyDropScanHandler(ctx.redisCtx, keyName, &ctx);

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -158,14 +158,13 @@ static void SpellCheck_FindSuggestions(SpellCheckCtx *scCtx, Trie *t, const char
 }
 
 RS_Suggestion **spellCheck_GetSuggestions(RS_Suggestions *s) {
-  TrieIterator *iter = Trie_Iterate(s->suggestionsTrie, "", 0, 0, 1);
+  TrieIterator *iter = Trie_IterateAll(s->suggestionsTrie);
   RS_Suggestion **ret = array_new(RS_Suggestion *, Trie_Size(s->suggestionsTrie));
   rune *rstr = NULL;
   t_len slen = 0;
   float score = 0;
-  int dist = 0;
   size_t termLen;
-  while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, NULL, &dist)) {
+  while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, NULL, NULL)) {
     char *res = runesToStr(rstr, slen, &termLen);
     array_append(ret, RS_SuggestionCreate(res, termLen, score));
   }

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -94,9 +94,10 @@ void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
 size_t Trie_Size(const Trie *t);
 
 /* Iterate every node in the trie with no filter or distance constraint. Wraps
- * TrieNode_Iterate on the trie's root with no filter. Used by debug paths that
- * want raw traversal; production code should prefer Trie_Iterate with a
- * prefix/maxDist. */
+ * TrieNode_Iterate on the trie's root with no filter. Prefer this over
+ * Trie_Iterate with an empty prefix: both visit every terminal node in the
+ * same order, but the empty-prefix DFA filter pays per-node stack maintenance
+ * for a filter that accepts everything. */
 TrieIterator *Trie_IterateAll(Trie *t);
 
 /* Result codes for Trie_DecrementNumDocs */


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Six call sites walk every term in a trie via `Trie_Iterate(t, "", 0, 0, 1)`. With an empty prefix in prefix mode, the DFA filter accepts every node, so it adds no filtering — but each visited edge still pays DFA stack maintenance (`Vector` push/pop and realloc churn). In the fork-GC child this churn also dirties copy-on-write pages. Profiling of the `Trie_Iterate` DFA path showed ~72% of self-time in `Vector_*` maintenance.
2. Change: Swap all six sites to `Trie_IterateAll` (no filter), drop the write-only `dist` locals (only the DFA filter wrote to them, always 0 with an empty prefix), and pass NULL for the `matchCtx` out-param — safe because the only dereference site is `it->filter(...)`, guarded by `if (it->filter)`, and `Trie_IterateAll` constructs the iterator with no filter. `TrieType_GenericSave` already uses this exact pattern. Also update the `Trie_IterateAll` doc comment, which previously steered production code toward the filtered path.
3. Outcome: Identical traversal output (same DFS order, same terminal-node set) with less allocator traffic on full-trie walks: fork-GC term collection, `FT.SPELLCHECK` suggestion collection, `FT.DICTDUMP`, dict slot-migration propagation, legacy-index cleanup on RDB load, and `FT.DEBUG DUMP_TERMS`.

Verified locally: full build clean, C/C++ unit tests 883/883, pytests 1924/1924. These cover the spellcheck, dict dump, GC, debug-command, and RDB-compatibility paths. The one site without OSS test coverage is `Propagate_Dict` (cluster slot migration); it is the same mechanical swap with the same equivalence argument.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `FGC_childCollectTerms` (src/fork_gc/terms.c)
2. `spellCheck_GetSuggestions` (src/spell_check.c)
3. `Dictionary_Dump`, `Propagate_Dict` (src/dictionary.c)
4. `IndexSpec_DropLegacyIndexFromKeySpace` (src/spec.c)
5. `DUMP_TERMS` debug command (src/debug_commands.c)
6. `Trie_IterateAll` doc comment (src/trie/trie.h)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
