### PR TITLE
[MOD-14873] qast: handle QN_OPTIONAL in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -994,13 +994,6 @@ static QueryIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
                         q->bcTimeoutAreq, q);
 }
 
-static QueryIterator *Query_EvalOptionalNode(QueryEvalCtx *q, QueryNode *qn) {
-  RS_LOG_ASSERT(qn->type == QN_OPTIONAL, "query node type should be optional");
-  RS_LOG_ASSERT(QueryNode_NumChildren(qn) == 1, "Optional node must have a single child");
-  t_docId maxDocId = q->sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec) : q->docTable->maxDocId;
-  return NewOptionalIterator(Query_EvalNode_Rs(q, qn->children[0]), q, maxDocId, qn->opts.weight);
-}
-
 static QueryIterator *Query_EvalNumericNode(QueryEvalCtx *q, QueryNode *node) {
   RS_LOG_ASSERT(node->type == QN_NUMERIC, "query node type should be numeric")
 
@@ -1474,6 +1467,7 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
     case QN_WILDCARD:
     case QN_NULL:
     case QN_MISSING:
+    case QN_OPTIONAL:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n);
     case QN_TOKEN:
@@ -1494,8 +1488,6 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
       return Query_EvalFuzzyNode(q, n);
     case QN_NUMERIC:
       return Query_EvalNumericNode(q, n);
-    case QN_OPTIONAL:
-      return Query_EvalOptionalNode(q, n);
     case QN_GEO:
       return Query_EvalGeofilterNode(q, n, n->opts.weight);
     case QN_VECTOR:

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1696,6 +1696,7 @@ dependencies = [
  "rlookup",
  "rqe_core",
  "rqe_iterators",
+ "search_disk",
  "workspace_hack",
 ]
 
@@ -2515,6 +2516,15 @@ dependencies = [
  "pretty_assertions",
  "redis_mock",
  "redisearch_rs",
+ "workspace_hack",
+]
+
+[[package]]
+name = "search_disk"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "rqe_core",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -143,6 +143,7 @@ rqe_iterator_type = { path = "./rqe_iterator_type" }
 rqe_iterators = { path = "./rqe_iterators" }
 rqe_iterators_test_utils = { path = "./rqe_iterators_test_utils" }
 schema_rule = { path = "./c_wrappers/schema_rule" }
+search_disk = { path = "./c_wrappers/search_disk" }
 search_result = { path = "./search_result" }
 slots_tracker = { path = "./slots_tracker" }
 sorting_vector = { path = "./sorting_vector" }

--- a/src/redisearch_rs/c_wrappers/query/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/query/Cargo.toml
@@ -22,6 +22,7 @@ query_node_type.workspace = true
 rlookup.workspace = true
 rqe_core.workspace = true
 rqe_iterators.workspace = true
+search_disk.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -15,6 +15,7 @@ use query_flags::QEFlags;
 use rlookup::MetricRequest;
 use rqe_core::DocId;
 use rqe_iterators::IteratorsConfig;
+use search_disk::SearchDiskHandle;
 
 /// Safe wrapper around [`ffi::QueryEvalCtx`].
 ///
@@ -148,13 +149,12 @@ impl QueryEvalContext {
     /// the disk index; otherwise it is read from the in-memory
     /// [`DocTable`](ffi::DocTable).
     pub fn max_doc_id(&self) -> DocId {
-        let disk_spec = self.spec().diskSpec;
-        if disk_spec.is_null() {
-            self.doc_table().maxDocId
-        } else {
-            // SAFETY: `disk_spec` is non-null (checked above) and, per invariant
-            // (1)/(2) of `new`, a valid `RedisSearchDiskIndexSpec`.
-            unsafe { ffi::SearchDisk_GetMaxDocId(disk_spec) }
+        // SAFETY: per invariant (1)/(2) of `new`, `spec.diskSpec` is either null
+        // or a valid `RedisSearchDiskIndexSpec`.
+        let disk = unsafe { SearchDiskHandle::new(self.spec().diskSpec) };
+        match disk {
+            Some(disk) => disk.max_doc_id(),
+            None => self.doc_table().maxDocId,
         }
     }
 

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -13,6 +13,7 @@ use std::ptr::NonNull;
 
 use query_flags::QEFlags;
 use rlookup::MetricRequest;
+use rqe_core::DocId;
 use rqe_iterators::IteratorsConfig;
 
 /// Safe wrapper around [`ffi::QueryEvalCtx`].
@@ -139,6 +140,22 @@ impl QueryEvalContext {
     pub fn doc_table(&self) -> &ffi::DocTable {
         // SAFETY: invariant (2) of `new`.
         unsafe { &*self.as_ref().docTable }
+    }
+
+    /// The highest document ID currently assigned in the index.
+    ///
+    /// In search-on-disk mode (`spec.diskSpec` non-null) the value comes from
+    /// the disk index; otherwise it is read from the in-memory
+    /// [`DocTable`](ffi::DocTable).
+    pub fn max_doc_id(&self) -> DocId {
+        let disk_spec = self.spec().diskSpec;
+        if disk_spec.is_null() {
+            self.doc_table().maxDocId
+        } else {
+            // SAFETY: `disk_spec` is non-null (checked above) and, per invariant
+            // (1)/(2) of `new`, a valid `RedisSearchDiskIndexSpec`.
+            unsafe { ffi::SearchDisk_GetMaxDocId(disk_spec) }
+        }
     }
 
     /// Request-type flags ([`QEFlags`] bitmask).

--- a/src/redisearch_rs/c_wrappers/search_disk/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/search_disk/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "search_disk"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ffi.workspace = true
+rqe_core.workspace = true
+workspace_hack.workspace = true

--- a/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Safe wrapper around a search-on-disk index handle.
+//!
+//! Search-on-disk stores an index in a [`ffi::RedisSearchDiskIndexSpec`] owned
+//! by the disk backend rather than in the in-memory structures. This crate
+//! exposes a thin, safe API over that handle so the rest of the Rust codebase
+//! can query it without scattering raw FFI calls and null checks across call
+//! sites.
+
+use std::ptr::NonNull;
+
+use rqe_core::DocId;
+
+/// A handle to a search-on-disk index ([`ffi::RedisSearchDiskIndexSpec`]).
+///
+/// Holds a non-null, valid pointer to the disk index spec for the lifetime of
+/// the handle, so its accessor methods are safe to call.
+pub struct SearchDiskHandle(NonNull<ffi::RedisSearchDiskIndexSpec>);
+
+impl SearchDiskHandle {
+    /// Wrap a raw `disk_spec` pointer, yielding [`None`] when it is null.
+    ///
+    /// A null `disk_spec` means the index is not backed by search-on-disk, so
+    /// there is no handle to wrap.
+    ///
+    /// # Safety
+    ///
+    /// When `disk_spec` is non-null it must point to a [valid]
+    /// [`ffi::RedisSearchDiskIndexSpec`] that remains valid for the lifetime of
+    /// the returned [`SearchDiskHandle`].
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub unsafe fn new(disk_spec: *mut ffi::RedisSearchDiskIndexSpec) -> Option<Self> {
+        NonNull::new(disk_spec).map(Self)
+    }
+
+    /// The highest document ID currently assigned in the disk index, or `0`
+    /// when the index is empty.
+    pub fn max_doc_id(&self) -> DocId {
+        // SAFETY: by the invariant established in `new`, the wrapped pointer is
+        // a valid `RedisSearchDiskIndexSpec`, which is exactly what
+        // `SearchDisk_GetMaxDocId` requires.
+        unsafe { ffi::SearchDisk_GetMaxDocId(self.0.as_ptr()) }
+    }
+}

--- a/src/redisearch_rs/c_wrappers/search_disk/tests/handle.rs
+++ b/src/redisearch_rs/c_wrappers/search_disk/tests/handle.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use search_disk::SearchDiskHandle;
+
+#[test]
+fn new_returns_none_for_null_spec() {
+    // SAFETY: a null `disk_spec` takes the `None` branch without being
+    // dereferenced, so the validity precondition is vacuously satisfied.
+    let handle = unsafe { SearchDiskHandle::new(std::ptr::null_mut()) };
+    assert!(handle.is_none());
+}

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -321,6 +321,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         types: &[],
         vars: &[],
     },
+    HeaderAllowlist {
+        path: "src/search_disk.h",
+        fns: &["SearchDisk_GetMaxDocId"],
+        types: &[],
+        vars: &[],
+    },
     // RSE: the entire disk API struct family lives in this header and is
     // consumed by `redisearch_disk` to bridge from C into the Rust storage
     // layer. None of these symbols are referenced by RediSearch itself.

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -93,9 +93,9 @@ pub fn eval_node<'index>(
     node: &QueryNodeRef,
 ) -> Option<Evaluated<'index>> {
     match node.as_enum() {
-        QueryNode::Null => Some(Evaluated::Rust(eval_null())),
-        QueryNode::Wildcard => Some(Evaluated::Rust(eval_wildcard(ctx, node))),
-        QueryNode::Ids { keys, doc_ids } => Some(Evaluated::Rust(eval_ids(ctx, keys, doc_ids))),
+        QueryNode::Null => Some(eval_null()),
+        QueryNode::Wildcard => Some(eval_wildcard(ctx, node)),
+        QueryNode::Ids { keys, doc_ids } => Some(eval_ids(ctx, keys, doc_ids)),
         QueryNode::Missing { field } => eval_missing(ctx, field).map(Evaluated::Rust),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
@@ -123,15 +123,15 @@ fn eval_node_c<'index>(
 }
 
 /// `QN_NULL` — stopword queries produce an empty iterator.
-fn eval_null<'index>() -> EvalResult<'index> {
-    Box::new(Empty)
+fn eval_null<'index>() -> Evaluated<'index> {
+    Evaluated::Rust(Box::new(Empty))
 }
 
 /// `QN_WILDCARD` — the `*` query that matches every document.
 fn eval_wildcard<'index>(
     ctx: &'index mut QueryEvalContext,
     node: &QueryNodeRef,
-) -> EvalResult<'index> {
+) -> Evaluated<'index> {
     let weight = node.opts().weight;
     // SAFETY: `new_wildcard_iterator` preconditions map to
     // `QueryEvalContext::new` invariants as follows:
@@ -149,7 +149,7 @@ fn eval_wildcard<'index>(
     // 8. `SEARCH_ENTERPRISE_ITERATORS` is initialised when `diskSpec` is
     //    non-null — the enterprise module sets it during `OnLoad`.
     let it = unsafe { rqe_iterators::wildcard::new_wildcard_iterator(ctx.as_non_null(), weight) };
-    Box::new(it)
+    Evaluated::Rust(Box::new(it))
 }
 
 /// `QN_IDS` — filter by explicit document key names.
@@ -167,7 +167,7 @@ fn eval_ids<'index>(
     ctx: &'index mut QueryEvalContext,
     keys: &[ffi::sds],
     doc_ids: Option<&[DocId]>,
-) -> EvalResult<'index> {
+) -> Evaluated<'index> {
     // Pre-resolved `doc_ids` are only produced on the search-on-disk path, so
     // they must be accompanied by a non-null `spec.diskSpec`. Guard the
     // invariant.
@@ -206,10 +206,10 @@ fn eval_ids<'index>(
         ids.dedup();
     }
 
-    Box::new(IdListSorted::with_result(
+    Evaluated::Rust(Box::new(IdListSorted::with_result(
         ids,
         RSIndexResult::build_virt().weight(1.0).build(),
-    ))
+    )))
 }
 
 /// `QN_MISSING` — matches documents where a field has no indexed value.

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -17,8 +17,12 @@ use std::ptr::NonNull;
 use index_result::RSIndexResult;
 use rqe_core::DocId;
 use rqe_iterators::{
-    Empty, RQEIteratorPrintable, c2rust::CRQEIterator, id_list::IdListSorted,
-    interop::RQEIteratorWrapper, inverted_index::new_missing_iterator,
+    Empty, RQEIteratorPrintable,
+    c2rust::CRQEIterator,
+    id_list::IdListSorted,
+    interop::RQEIteratorWrapper,
+    inverted_index::new_missing_iterator,
+    optional_reducer::{NewOptionalIterator, new_optional_iterator},
 };
 
 use crate::{QueryEvalContext, QueryNode, QueryNodeRef};
@@ -30,46 +34,103 @@ pub type EvalResult<'index> = Box<dyn RQEIteratorPrintable<'index> + 'index>;
 
 /// The outcome of evaluating a query node.
 ///
-/// A node is either built by Rust ([`Evaluated::Rust`]) or, while the dispatcher
-/// is only partially ported, by the C `Query_EvalNode` ([`Evaluated::C`]).
-/// Keeping the two apart means a C iterator can be handed straight back to C —
-/// without an intermediate Rust wrapper that would hide it from the C-side
-/// optimizer/profiler, and without a throwaway heap allocation.
-// TODO: Remove this enum once all the nodes types have been ported to Rust
+/// The variant records *how* the resulting iterator is currently represented,
+/// so it can be handed across the FFI boundary — or composed into a parent Rust
+/// iterator — without a redundant wrapper or allocation. Three shapes occur
+/// while the dispatcher is only partially ported:
+///
+/// - [`Evaluated::RustLeaf`] — a Rust iterator held as a trait object, not yet
+///   lowered to the C ABI.
+/// - [`Evaluated::C`] — an iterator *built by* the C [`ffi::Query_EvalNode`]
+///   dispatcher for a node type not yet ported. Handed straight back to C so the
+///   C-side optimizer/profiler keep seeing the original iterator.
+/// - [`Evaluated::RustCompound`] — an owning C-ABI handle that Rust built and
+///   already lowered, returned as-is rather than as a trait object (see the
+///   variant docs for the two cases that need this shape).
+// TODO: Remove this enum once all the node types have been ported to Rust
 // and C `Query_EvalNode` has been removed.
-#[must_use = "an unconsumed `Evaluated::C` leaks its owning C iterator; consume it via `into_c_iterator` or `into_boxed`"]
+#[must_use = "an unconsumed `Evaluated` may leak its owning iterator handle; consume it via `into_c_iterator` or `into_boxed`"]
 pub enum Evaluated<'index> {
-    /// An iterator implemented in Rust.
-    Rust(EvalResult<'index>),
-    /// An owning C iterator handle returned by [`ffi::Query_EvalNode`].
+    /// An iterator implemented in Rust, held as a boxed trait object.
+    ///
+    /// Lowered to the C ABI lazily (via [`RQEIteratorWrapper::boxed_new`]) only
+    /// if and when it crosses back to C.
+    RustLeaf(EvalResult<'index>),
+
+    /// An owning C iterator handle built by the C [`ffi::Query_EvalNode`]
+    /// dispatcher for a node type not yet ported to Rust.
     C(NonNull<ffi::QueryIterator>),
+
+    /// An owning C-ABI [`QueryIterator`](ffi::QueryIterator) handle that Rust
+    /// built and already lowered, returned as-is rather than as an
+    /// [`Evaluated::RustLeaf`] `Box<dyn …>`. Two cases need this shape:
+    ///
+    /// - A Rust *compound* iterator (e.g.
+    ///   [`Optional`](rqe_iterators::optional::Optional)) lowered via
+    ///   [`RQEIteratorWrapper::boxed_new_compound`]. It must reach the still
+    ///   C-driven optimizer and profiler as an
+    ///   `RQEIteratorWrapper<Compound<CRQEIterator>>`: only that shape carries the
+    ///   [`ProfileChildren`](rqe_iterators::interop::ProfileChildren) callback the
+    ///   profiler needs to recurse into the child, and keeps the child a concrete
+    ///   [`CRQEIterator`] so the optimizer's in-place tree rewrites keep working.
+    ///   Lowering it via [`RQEIteratorWrapper::boxed_new`] instead would drop the
+    ///   child's profile counters.
+    /// - A child iterator handed straight back unchanged — e.g. the optional
+    ///   reducer's wildcard passthrough, where the optional node collapses to its
+    ///   already-lowered wildcard child. Re-wrapping it as an [`Evaluated::RustLeaf`]
+    ///   `Box<dyn …>` would add a redundant [`RQEIteratorWrapper`] layer and hide
+    ///   the original iterator from the C-side optimizer and profiler.
+    ///
+    /// A freshly built Rust leaf (e.g. the optional reducer's wildcard *fallback*)
+    /// needs none of this and is returned as a plain [`Evaluated::RustLeaf`] instead.
+    ///
+    /// Lifecycle-wise this is identical to [`Evaluated::C`]: an owning handle
+    /// handed back untouched by [`into_c_iterator`](Self::into_c_iterator), or
+    /// re-wrapped as a [`CRQEIterator`] child by [`into_boxed`](Self::into_boxed).
+    /// The separate variant exists only to record that Rust, not C, built it.
+    //
+    // A typed `Box<dyn …>` (deferring the lowering to `into_c_iterator`) was
+    // considered and rejected: the compound's child must already be a concrete
+    // `CRQEIterator` for the C-side profiler/optimizer, so there is no pure-Rust
+    // subtree to preserve; every consumer (the C entrypoint, or an outer Rust
+    // compound) re-lowers to a handle anyway; and it would not cover the
+    // passthrough case, which is a child handle, not a compound.
+    //
+    // Once profiling and the optimizer no longer reach into the tree as C
+    // `*mut QueryIterator` nodes, these can hold pure-Rust `Box<dyn …>`
+    // children and this variant can fold back into `RustLeaf`.
+    RustCompound(NonNull<ffi::QueryIterator>),
 }
 
 impl<'index> Evaluated<'index> {
     /// Consume into an owning C [`QueryIterator`](ffi::QueryIterator) pointer.
     ///
-    /// A Rust iterator is wrapped via [`RQEIteratorWrapper::boxed_new`]; a C
-    /// iterator is returned as-is, so C-side introspection (optimizer, profiler)
-    /// keeps seeing the original C iterator.
+    /// An [`Evaluated::RustLeaf`] iterator is lowered via
+    /// [`RQEIteratorWrapper::boxed_new`]; an already-lowered handle
+    /// ([`Evaluated::C`] or [`Evaluated::RustCompound`]) is returned as-is, so
+    /// C-side introspection (optimizer, profiler) keeps seeing the same iterator.
     pub fn into_c_iterator(self) -> *mut ffi::QueryIterator {
         match self {
-            Evaluated::Rust(it) => RQEIteratorWrapper::boxed_new(it),
-            Evaluated::C(it) => it.as_ptr(),
+            Evaluated::RustLeaf(it) => RQEIteratorWrapper::boxed_new(it),
+            Evaluated::C(it) | Evaluated::RustCompound(it) => it.as_ptr(),
         }
     }
 
-    /// Consume into a boxed Rust iterator, wrapping a C iterator in a
-    /// [`CRQEIterator`] shim so it satisfies the Rust iterator trait.
+    /// Consume into a boxed Rust iterator, wrapping an already-lowered C-ABI
+    /// handle in a [`CRQEIterator`] shim so it satisfies the Rust iterator trait.
     ///
     /// Used by Rust consumers that compose evaluated children as trait objects.
     pub fn into_boxed(self) -> EvalResult<'index> {
         match self {
-            Evaluated::Rust(it) => it,
-            // SAFETY: `Evaluated::C` always holds a valid, owning `QueryIterator`
-            // with all required callbacks populated (it came from
-            // `ffi::Query_EvalNode`) — exactly the preconditions of
-            // `CRQEIterator::new`.
-            Evaluated::C(it) => Box::new(unsafe { CRQEIterator::new(it) }),
+            Evaluated::RustLeaf(it) => it,
+            Evaluated::C(it) | Evaluated::RustCompound(it) => {
+                // SAFETY: both handle variants hold a valid, owning `QueryIterator`
+                // with all required callbacks populated — `Evaluated::C` came from
+                // `ffi::Query_EvalNode`, `Evaluated::RustCompound` from
+                // `RQEIteratorWrapper::boxed_new_compound` — exactly the
+                // preconditions of `CRQEIterator::new`.
+                Box::new(unsafe { CRQEIterator::new(it) })
+            }
         }
     }
 }
@@ -82,7 +143,7 @@ pub fn qast_iterate<'index>(
     ctx: &'index mut QueryEvalContext,
     root: &QueryNodeRef,
 ) -> Evaluated<'index> {
-    eval_node(ctx, root).unwrap_or_else(|| Evaluated::Rust(Box::new(Empty)))
+    eval_node(ctx, root).unwrap_or_else(|| Evaluated::RustLeaf(Box::new(Empty)))
 }
 
 /// Evaluate a single query node, producing the corresponding iterator.
@@ -96,7 +157,8 @@ pub fn eval_node<'index>(
         QueryNode::Null => Some(eval_null()),
         QueryNode::Wildcard => Some(eval_wildcard(ctx, node)),
         QueryNode::Ids { keys, doc_ids } => Some(eval_ids(ctx, keys, doc_ids)),
-        QueryNode::Missing { field } => eval_missing(ctx, field).map(Evaluated::Rust),
+        QueryNode::Missing { field } => eval_missing(ctx, field).map(Evaluated::RustLeaf),
+        QueryNode::Optional => Some(eval_optional(ctx, node)),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
         _ => eval_node_c(ctx, node),
@@ -122,9 +184,28 @@ fn eval_node_c<'index>(
     NonNull::new(it).map(Evaluated::C)
 }
 
+/// Evaluate a child node into an owning [`CRQEIterator`] for use as a child of
+/// a Rust compound iterator.
+///
+/// A `None` child (no results) becomes a freshly boxed [`Empty`] so the
+/// reducer can apply its empty-child rules, since a missing child is
+/// equivalent to one that matches nothing.
+fn eval_child_iterator(ctx: &mut QueryEvalContext, child: &QueryNodeRef) -> CRQEIterator {
+    let ptr = match eval_node(&mut *ctx, child) {
+        Some(ev) => ev.into_c_iterator(),
+        None => RQEIteratorWrapper::boxed_new(Empty),
+    };
+    // `into_c_iterator` and `boxed_new` always return a valid, owning, non-null
+    // C `QueryIterator`.
+    let nn = NonNull::new(ptr).expect("evaluated child iterator must not be null");
+    // SAFETY: `nn` is a valid, owning C `QueryIterator` with all callbacks
+    // populated — exactly the precondition of `CRQEIterator::new`.
+    unsafe { CRQEIterator::new(nn) }
+}
+
 /// `QN_NULL` — stopword queries produce an empty iterator.
 fn eval_null<'index>() -> Evaluated<'index> {
-    Evaluated::Rust(Box::new(Empty))
+    Evaluated::RustLeaf(Box::new(Empty))
 }
 
 /// `QN_WILDCARD` — the `*` query that matches every document.
@@ -149,7 +230,7 @@ fn eval_wildcard<'index>(
     // 8. `SEARCH_ENTERPRISE_ITERATORS` is initialised when `diskSpec` is
     //    non-null — the enterprise module sets it during `OnLoad`.
     let it = unsafe { rqe_iterators::wildcard::new_wildcard_iterator(ctx.as_non_null(), weight) };
-    Evaluated::Rust(Box::new(it))
+    Evaluated::RustLeaf(Box::new(it))
 }
 
 /// `QN_IDS` — filter by explicit document key names.
@@ -206,7 +287,7 @@ fn eval_ids<'index>(
         ids.dedup();
     }
 
-    Evaluated::Rust(Box::new(IdListSorted::with_result(
+    Evaluated::RustLeaf(Box::new(IdListSorted::with_result(
         ids,
         RSIndexResult::build_virt().weight(1.0).build(),
     )))
@@ -250,4 +331,64 @@ fn eval_missing<'index>(
     // 4. `ii_ref` uses `DocIdsOnly`/`RawDocIdsOnly` encoding: the indexer only
     //    ever stores doc-ids-only inverted indexes in `missingFieldDict`.
     Some(unsafe { new_missing_iterator(ii_ref, sctx_nn, fs.index) })
+}
+
+/// `QN_OPTIONAL` — an optional match that boosts the score when its single
+/// child matches but does not exclude documents that don't.
+fn eval_optional<'index>(
+    ctx: &'index mut QueryEvalContext,
+    node: &QueryNodeRef,
+) -> Evaluated<'index> {
+    debug_assert_eq!(
+        node.num_children(),
+        1,
+        "an optional node must have exactly one child"
+    );
+
+    // Evaluate the child. A `None` child becomes an `Empty` iterator, which
+    // `new_optional_iterator` reduces to a wildcard fallback — an empty optional
+    // matches every document as a virtual hit.
+    let child_node = node.child(0);
+    let child = eval_child_iterator(ctx, &child_node);
+
+    // SAFETY: the preconditions of `new_optional_iterator` map to
+    // `QueryEvalContext::new` invariants:
+    // 1. `query` is a valid, non-null `QueryEvalCtx` — invariant (1).
+    // 2. `query.sctx` is valid and non-null — invariant (2).
+    // 3. `query.sctx.spec` is valid and non-null — invariant (2).
+    // 4. `spec.rule`, when non-null, is a valid `SchemaRule` — part of (1).
+    // 5-7. The wildcard-iterator preconditions hold for the same reasons
+    //    as in `eval_wildcard` (a properly initialised spec with its
+    //    `existingDocs` index, valid `docTable`, and
+    //    `diskSpec`/`SEARCH_ENTERPRISE_ITERATORS` when on disk).
+    let outcome = unsafe {
+        new_optional_iterator(
+            child,
+            node.opts().weight,
+            ctx.as_non_null(),
+            ctx.max_doc_id(),
+        )
+    };
+    match outcome {
+        // The child was structurally empty: the reducer built a fresh Rust
+        // wildcard leaf so every document is returned as a virtual hit.
+        NewOptionalIterator::WildcardFallback(wc) => Evaluated::RustLeaf(Box::new(wc)),
+        // The optional collapsed to its already-lowered wildcard child: hand the
+        // child's owning handle straight back, exactly as the former C path did,
+        // so the C-side optimizer/profiler keep seeing the original iterator. A
+        // plain `Evaluated::RustLeaf` would wrap it in a redundant `RQEIteratorWrapper`.
+        NewOptionalIterator::WildcardPassthrough(child) => {
+            Evaluated::RustCompound(child.into_raw())
+        }
+        // Genuine compound iterators: lower via `boxed_new_compound` so the
+        // profiler keeps the `ProfileChildren` callback into the child.
+        NewOptionalIterator::Optional(opt) => Evaluated::RustCompound(
+            NonNull::new(RQEIteratorWrapper::boxed_new_compound(opt))
+                .expect("optional iterator must not be null"),
+        ),
+        NewOptionalIterator::OptionalOptimized(opt) => Evaluated::RustCompound(
+            NonNull::new(RQEIteratorWrapper::boxed_new_compound(opt))
+                .expect("optional iterator must not be null"),
+        ),
+    }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
@@ -228,6 +228,64 @@ fn eval_ids_empty_keys() {
 }
 
 // ---------------------------------------------------------------------------
+// QN_OPTIONAL → Optional / Wildcard (via the reducer shortcircuits)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_optional_empty_child_falls_back_to_wildcard() {
+    // A child that produces no results (here a QN_NULL → Empty) makes the
+    // reducer shortcircuit to a wildcard over the whole index.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(3);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let null_child = MockQueryNode::new(QueryNodeType::Null);
+    let mut opt = MockQueryNode::new(QueryNodeType::Optional);
+    opt.opts_mut().weight = 1.0;
+    opt.set_children(&[null_child.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    for expected in [1, 2, 3] {
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_optional_wildcard_child_passes_through() {
+    // A wildcard child is returned as-is, with the optional node's weight
+    // applied to its results.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(5);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut wc_child = MockQueryNode::new(QueryNodeType::Wildcard);
+    wc_child.opts_mut().weight = 1.0;
+    let mut opt = MockQueryNode::new(QueryNodeType::Optional);
+    opt.opts_mut().weight = 2.0;
+    opt.set_children(&[wc_child.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    let r = it.read().unwrap().expect("should have a result");
+    assert_eq!(r.doc_id, 1);
+    assert_eq!(r.weight, 2.0);
+}
+
+// ---------------------------------------------------------------------------
 // QN_MISSING → Missing inverted-index iterator
 //
 // These require a real `IndexSpec` with a populated `missingFieldDict`, which
@@ -314,6 +372,15 @@ mod missing {
     }
 }
 
+/// Create an SDS string from `s`. The caller owns the result and must free
+/// it with [`ffi::sdsfree`].
+#[cfg(not(miri))]
+fn new_sds(s: &str) -> ffi::sds {
+    // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
+    // into a freshly allocated SDS string.
+    unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
+}
+
 // ---------------------------------------------------------------------------
 // QN_IDS → IdList, resolving key names through the DocTable
 //
@@ -330,14 +397,6 @@ mod ids_doctable {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-
-    /// Create an SDS string from `s`. The caller owns the result and must free
-    /// it with [`ffi::sdsfree`].
-    fn new_sds(s: &str) -> ffi::sds {
-        // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
-        // into a freshly allocated SDS string.
-        unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
-    }
 
     #[test]
     fn eval_ids_resolves_keys_through_doc_table() {
@@ -399,6 +458,158 @@ mod ids_doctable {
 
         assert!(it.at_eof());
         assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QN_OPTIONAL paths that need a real `IndexSpec`, so they rely on the
+// full-FFI `TestContext`:
+//
+// - wrapping a real child in an `Optional` (the non-shortcircuit path needs a
+//   child that is neither empty nor a wildcard — a QN_IDS child resolving to
+//   real documents provides one);
+// - a child that evaluates to `None` (here a QN_MISSING node for a field with
+//   no missing values), which yields a NULL child pointer and exercises the
+//   wildcard fallback distinct from the structurally-empty shortcircuit.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: `TestContext` and SDS creation call into the C library,
+// which Miri cannot execute.
+#[cfg(not(miri))]
+mod optional {
+    use ffi::IndexFlags_Index_StoreFreqs;
+    use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+    use super::*;
+
+    #[test]
+    fn eval_optional_wraps_real_child_in_optional() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        // Two documents → maxDocId == 2; the optional iterator yields every doc
+        // id, marking those matched by the child as real hits.
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // QN_IDS child resolving to the two known documents.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
+        let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
+        ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+
+        let mut opt = MockQueryNode::new(QueryNodeType::Optional);
+        opt.opts_mut().weight = 1.0;
+        opt.set_children(&[ids_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Optional);
+        // The optional iterator walks every document id in the index.
+        for expected in [1, 2] {
+            let r = it.read().unwrap().expect("should have a result");
+            assert_eq!(r.doc_id, expected);
+        }
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_optional_none_child_falls_back_to_wildcard() {
+        let _guard = GlobalGuard::default();
+        // Term context: the field exists but has no entry in `missingFieldDict`,
+        // so a QN_MISSING child makes `eval_node` return `None` — i.e. a NULL
+        // child pointer. This is distinct from a structurally-empty child (an
+        // `Empty` *iterator*, a non-null pointer), which the reducer handles via
+        // its own shortcircuit. Here the NULL-child branch of `eval_optional`
+        // substitutes a wildcard over the whole index, with weight dropped to 0.
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        // Two documents → docTable maxDocId == 2; the wildcard fallback walks
+        // every id. `add_document` only touches the DocTable, never the
+        // `missingFieldDict`, so the QN_MISSING child still evaluates to `None`.
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // QN_MISSING child for a field with no missing values → evaluates to None.
+        let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
+        missing_child.set_missing_field(context.field_spec());
+
+        let mut opt = MockQueryNode::new(QueryNodeType::Optional);
+        opt.opts_mut().weight = 1.0;
+        opt.set_children(&[missing_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("an optional node always yields an iterator")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Wildcard);
+        // Every doc id is a virtual hit, with the fallback weight of 0.
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 1);
+        assert_eq!(r.weight, 0.0);
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 2);
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+    }
+
+    #[test]
+    fn eval_optional_optimized_index_wraps_child_in_optional_optimized() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        // `index_all` makes the reducer take the optimized (wildcard-backed)
+        // path, so `eval_optional` must forward an `OptionalOptimized` variant.
+        // SAFETY: no iterator from this context is alive yet.
+        context.spec_write().rule_mut().set_index_all(true);
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // QN_IDS child resolving to a real document → neither empty nor a
+        // wildcard, so the reducer skips its shortcircuits and reaches the
+        // optimized constructor.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_a")];
+        let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
+        ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+
+        let mut opt = MockQueryNode::new(QueryNodeType::Optional);
+        opt.opts_mut().weight = 1.0;
+        opt.set_children(&[ids_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("an optional node always yields an iterator")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::OptionalOptimized);
+        // `existingDocs` is null in the term context, so the backing wildcard is
+        // empty and the iterator yields nothing — but it must drain cleanly.
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
 
         for key in keys {
             // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/9966

Port the `QN_OPTIONAL` evaluation from C to the Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
