### PR TITLE
MOD-16233: COLLECT: enforce '@' prefix requirement for field names

### DIFF
--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -213,7 +213,11 @@ bool CollectArgs_Parse(const ReducerOptions *options, CollectArgs *out) {
     return false;
   }
 
-  CollectParseCtx pctx = {.args = out, .options = options};
+  // COLLECT always requires field/sort names to carry an `@` prefix.
+  ReducerOptions strict_opts = *options;
+  strict_opts.strictPrefix = true;
+
+  CollectParseCtx pctx = {.args = out, .options = &strict_opts};
 
   ArgsCursor *ac = options->args;
   ArgParser *parser = ArgParser_New(ac, NULL);

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -14,6 +14,7 @@
 #include "gtest/gtest.h"
 
 #include "aggregate/reducer.h"
+#include "aggregate/reducers/collect_parse.h"
 #include "reducers_ffi.h"
 #include "spec.h"
 #include "config.h"
@@ -399,6 +400,28 @@ TEST_F(CollectParserTest, LocalFieldWithoutAtPrefix) {
   const RLookupKey *inputKey = RLookup_GetKey_Write(&lk, "remote_collect", RLOOKUP_F_NOFLAGS);
   expectErrorLocal({"FIELDS", "1", "price"}, inputKey,
       "Missing prefix: name requires '@' prefix");
+}
+
+TEST_F(CollectParserTest, FieldWithoutAtPrefixRejectedAtParseEvenWhenCallerNotStrict) {
+  std::vector<const char *> args = {"FIELDS", "1", "price"};
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, args.data(), args.size());
+  QueryError status = QueryError_Default();
+  ReducerOptions opts = REDUCEROPTS_INIT(
+    "COLLECT", &ac, &lk, NULL, &status,
+    false, // caller says non-strict
+    false, NULL, 0);
+
+  CollectArgs parsed = {0};
+  EXPECT_FALSE(CollectArgs_Parse(&opts, &parsed))
+      << "Expected parse failure but got success";
+  const char *user_error = QueryError_GetUserError(&status);
+  ASSERT_NE(user_error, nullptr);
+  EXPECT_TRUE(std::string(user_error).find("Missing prefix") != std::string::npos)
+      << "Expected error containing 'Missing prefix', got: " << user_error;
+
+  CollectArgs_Free(&parsed);
+  QueryError_ClearError(&status);
 }
 
 TEST_F(CollectParserTest, FieldEmptyAfterAt) {

--- a/tests/cpptests/test_cpp_collect.cpp
+++ b/tests/cpptests/test_cpp_collect.cpp
@@ -407,12 +407,11 @@ TEST_F(CollectParserTest, FieldWithoutAtPrefixRejectedAtParseEvenWhenCallerNotSt
   ArgsCursor ac;
   ArgsCursor_InitCString(&ac, args.data(), args.size());
   QueryError status = QueryError_Default();
-  ReducerOptions opts = REDUCEROPTS_INIT(
-    "COLLECT", &ac, &lk, NULL, &status,
-    false, // caller says non-strict
-    false, NULL, 0);
+  ReducerOptions opts = REDUCEROPTS_INIT("COLLECT", &ac, &lk, nullptr, &status,
+                                         false,  // caller says non-strict
+                                         false, nullptr, 0);
 
-  CollectArgs parsed = {0};
+  CollectArgs parsed = {};
   EXPECT_FALSE(CollectArgs_Parse(&opts, &parsed))
       << "Expected parse failure but got success";
   const char *user_error = QueryError_GetUserError(&status);

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -2056,3 +2056,53 @@ def test_chained_groupby_outer_collect_sortby_partial_ties():
     env.assertEqual(len(rows), 4)
     counts = [int(r['n']) for r in rows]
     env.assertEqual(counts, [2, 2, 1, 1])
+
+# ---------------------------------------------------------------------------
+# COLLECT requires prefixed field names
+# ---------------------------------------------------------------------------
+def test_collect_requires_prefixed_fields():
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_hash(env)
+
+    error_msg = "SEARCH_PARSE_ARGS Missing prefix"
+    # Missing '@' prefix on field name.
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '3',
+                'FIELDS', '1', 'name',
+            'AS', 'names').error().contains(error_msg)
+
+    # Missing '@' prefix on field name in SORTBY.
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '6',
+                'FIELDS', '1', '@name',
+                'SORTBY', '1', 'name',
+            'AS', 'names').error().contains(error_msg)
+
+@skip(no_json=True)
+def test_json_collect_requires_prefixed_fields():
+    env = Env(protocol=3)
+    enable_unstable_features(env)
+    _setup_priced_json(env)
+
+    error_msg = "SEARCH_PARSE_ARGS Missing prefix"
+    # Missing '@' prefix on field name.
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '3',
+                'FIELDS', '1', 'name',
+            'AS', 'names').error().contains(error_msg)
+
+    # Missing '@' prefix on field name in SORTBY.
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '6',
+                'FIELDS', '1', '@name',
+                'SORTBY', '1', 'name',
+            'AS', 'names').error().contains(error_msg)


### PR DESCRIPTION
## Description

1. Current: `COLLECT` could accept unprefixed field names in `FIELDS`.

2. Change: `COLLECT` now parses field and sort names with strict `@` prefix enforcement.

3. Outcome: Invalid `COLLECT` arguments are rejected consistently, and the reducer syntax is no longer ambiguous.

#### Which additional issues this PR fixes
1. MOD-16233

#### Main objects this PR modified
1. `src/aggregate/reducers/collect.c`
2. `tests/pytests/test_groupby_collect.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
