### PR TITLE
[MOD-16267] Fix RETURN_STRICT safe-loader GIL deadlock on client timeout

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -193,6 +193,12 @@ typedef struct RequestSyncCtx {
   RS_Atomic(bool) aggregatingResults;    // CAS claim: BG winner runs the pipeline; timeout-callback winner skips it and replies empty
   bool aggregateResultsClaimLost;        // BG lost the CAS claim to the timeout callback
   bool aggregateResultsDone;             // Set at completion; guarded by aggregateResultsLock
+  /* Deadlock-avoidance handshake for the RP_SAFE_LOADER. Set true by the BG
+   * worker just before it tries to acquire the GIL, cleared after it releases
+   * the GIL; guarded by aggregateResultsLock. The main-thread timeout callback
+   * reads it (under the same lock) to detect a worker parked at the GIL gate and
+   * preempt it (reply empty) instead of deadlocking in Wait while holding the GIL. */
+  bool safeLoaderHoldingGIL;
   pthread_mutex_t aggregateResultsLock;
   pthread_cond_t aggregateResultsCond;
 
@@ -211,6 +217,7 @@ static inline void RequestSyncCtx_Init(RequestSyncCtx *ctx) {
   ctx->aggregatingResults = false;
   ctx->aggregateResultsClaimLost = false;
   ctx->aggregateResultsDone = false;
+  ctx->safeLoaderHoldingGIL = false;
   pthread_mutex_init(&ctx->aggregateResultsLock, NULL);
   pthread_cond_init(&ctx->aggregateResultsCond, NULL);
   ctx->abortWakeChannel = NULL;
@@ -595,6 +602,28 @@ static inline bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
 bool AREQ_TryClaimAggregateResults(AREQ *req);
 void AREQ_SignalAggregateResultsComplete(AREQ *req);
 void AREQ_WaitForAggregateResultsComplete(AREQ *req);
+
+/* RP_SAFE_LOADER GIL handshake (deadlock avoidance for RETURN_STRICT).
+ *
+ * All three helpers are gated on `requiresAggregateResultsSync`: when the
+ * request does not use the aggregate-results sync protocol (FAIL/RETURN
+ * policies) they are no-ops (EnterGIL returns true, Preempt returns false), so
+ * the safe loader takes the GIL exactly as before.
+ *
+ * EnterGIL: called by the BG worker under aggregateResultsLock just before it
+ *   acquires the GIL. If the timeout callback already fired (timedOut), returns
+ *   false WITHOUT marking the worker as holding the GIL, so the worker bails
+ *   (returns RS_RESULT_TIMEDOUT) instead of blocking on a GIL the main thread
+ *   holds while waiting. Otherwise marks safeLoaderHoldingGIL and returns true.
+ * ExitGIL: called by the worker after it releases the GIL; clears the flag.
+ * TimeoutPreemptSafeLoaderGIL: called by the main-thread timeout callback after
+ *   it loses the claim and before Wait; returns true if the worker is parked at
+ *   the GIL gate (safeLoaderHoldingGIL), telling the callback to reply empty and
+ *   return instead of deadlocking. Reads/writes timedOut+holding under the lock
+ *   so the worker's EnterGIL and this check form a race-free Dekker handshake. */
+bool RequestSyncCtx_SafeLoaderEnterGIL(RequestSyncCtx *sync);
+void RequestSyncCtx_SafeLoaderExitGIL(RequestSyncCtx *sync);
+bool RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(RequestSyncCtx *sync);
 
 /* Reset the per-cursor-read sync state on a coordinator RETURN_STRICT cursor
  * read so the next chunk starts from a clean slate. Resets:

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -610,7 +610,11 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req);
  * EnterGIL (BG worker, before taking the GIL): if the timeout already fired,
  *   returns false without marking holding so the worker bails instead of blocking
  *   on the GIL the main thread holds; otherwise marks safeLoaderHoldingGIL.
- * ExitGIL (BG worker, after releasing the GIL): clears the flag.
+ * ExitGIL (BG worker, while still holding the GIL, before releasing it): clears
+ *   the flag. The timeout callback only runs on the main thread while it holds
+ *   the GIL, so it cannot observe the flag while the worker holds it; clearing
+ *   before the release prevents a timeout in the release->clear gap from seeing
+ *   a stale holding == true and preempting away already-loaded results.
  * TimeoutPreemptSafeLoaderGIL (main-thread timeout callback, before Wait): returns
  *   true if the worker is parked at the GIL gate, so the callback replies empty
  *   instead of deadlocking. The shared aggregateResultsLock makes EnterGIL and

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -193,11 +193,10 @@ typedef struct RequestSyncCtx {
   RS_Atomic(bool) aggregatingResults;    // CAS claim: BG winner runs the pipeline; timeout-callback winner skips it and replies empty
   bool aggregateResultsClaimLost;        // BG lost the CAS claim to the timeout callback
   bool aggregateResultsDone;             // Set at completion; guarded by aggregateResultsLock
-  /* Deadlock-avoidance handshake for the RP_SAFE_LOADER. Set true by the BG
-   * worker just before it tries to acquire the GIL, cleared after it releases
-   * the GIL; guarded by aggregateResultsLock. The main-thread timeout callback
-   * reads it (under the same lock) to detect a worker parked at the GIL gate and
-   * preempt it (reply empty) instead of deadlocking in Wait while holding the GIL. */
+  /* RP_SAFE_LOADER deadlock-avoidance handshake. Set by the BG worker just before
+   * it takes the GIL, cleared after it releases it; guarded by aggregateResultsLock.
+   * The timeout callback reads it (same lock) to detect a worker parked at the GIL
+   * gate and preempt it instead of deadlocking in Wait while holding the GIL. */
   bool safeLoaderHoldingGIL;
   pthread_mutex_t aggregateResultsLock;
   pthread_cond_t aggregateResultsCond;
@@ -603,24 +602,19 @@ bool AREQ_TryClaimAggregateResults(AREQ *req);
 void AREQ_SignalAggregateResultsComplete(AREQ *req);
 void AREQ_WaitForAggregateResultsComplete(AREQ *req);
 
-/* RP_SAFE_LOADER GIL handshake (deadlock avoidance for RETURN_STRICT).
+/* RP_SAFE_LOADER GIL handshake (deadlock avoidance for RETURN_STRICT). Reached
+ * only on the sync path: the loader links its syncCtx only when
+ * requiresAggregateResultsSync is set, and the Preempt callers are the
+ * RETURN_STRICT timeout callbacks, so no in-helper policy gate is needed.
  *
- * All three helpers are gated on `requiresAggregateResultsSync`: when the
- * request does not use the aggregate-results sync protocol (FAIL/RETURN
- * policies) they are no-ops (EnterGIL returns true, Preempt returns false), so
- * the safe loader takes the GIL exactly as before.
- *
- * EnterGIL: called by the BG worker under aggregateResultsLock just before it
- *   acquires the GIL. If the timeout callback already fired (timedOut), returns
- *   false WITHOUT marking the worker as holding the GIL, so the worker bails
- *   (returns RS_RESULT_TIMEDOUT) instead of blocking on a GIL the main thread
- *   holds while waiting. Otherwise marks safeLoaderHoldingGIL and returns true.
- * ExitGIL: called by the worker after it releases the GIL; clears the flag.
- * TimeoutPreemptSafeLoaderGIL: called by the main-thread timeout callback after
- *   it loses the claim and before Wait; returns true if the worker is parked at
- *   the GIL gate (safeLoaderHoldingGIL), telling the callback to reply empty and
- *   return instead of deadlocking. Reads/writes timedOut+holding under the lock
- *   so the worker's EnterGIL and this check form a race-free Dekker handshake. */
+ * EnterGIL (BG worker, before taking the GIL): if the timeout already fired,
+ *   returns false without marking holding so the worker bails instead of blocking
+ *   on the GIL the main thread holds; otherwise marks safeLoaderHoldingGIL.
+ * ExitGIL (BG worker, after releasing the GIL): clears the flag.
+ * TimeoutPreemptSafeLoaderGIL (main-thread timeout callback, before Wait): returns
+ *   true if the worker is parked at the GIL gate, so the callback replies empty
+ *   instead of deadlocking. The shared aggregateResultsLock makes EnterGIL and
+ *   this check a race-free Dekker handshake. */
 bool RequestSyncCtx_SafeLoaderEnterGIL(RequestSyncCtx *sync);
 void RequestSyncCtx_SafeLoaderExitGIL(RequestSyncCtx *sync);
 bool RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(RequestSyncCtx *sync);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -54,15 +54,14 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
 static int prepareExecutionPlan(AREQ *req, QueryError *status);
 static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-// Wrapper for AREQ_DecrRef to match BlockedClientFreePrivDataCB signature
-static void AREQ_DecrRefWrapper(void *privdata) {
-  AREQ_DecrRef((AREQ *)privdata);
-}
-
-// freePrivData for shard/standalone BlockCursorClientWithTimeout. Drains any cursor
-// parked in storedReplyState before releasing our AREQ ref (no-op on the happy
-// path, where CursorReadReplyCallback already cleared it).
-static void ShardCursorBlockClient_FreeAREQ(void *privdata) {
+// freePrivData for the query/cursor-read block clients. Drains any cursor parked
+// in storedReplyState before releasing our AREQ ref, then decrefs the AREQ.
+// AREQ_CleanUpStoredCursor is a guarded no-op on the happy path (the reply
+// callback already cleared the stash) and for queries that never reserved a
+// cursor, so this is safe to use unconditionally for both paths. Disposing the
+// stash here is what prevents the RETURN_STRICT preempt path from leaking the
+// cursor reserved by an initial WITHCURSOR query (see MOD-8477 / PR #10085).
+static void BlockClient_FreeAREQ(void *privdata) {
   AREQ *req = (AREQ *)privdata;
   AREQ_CleanUpStoredCursor(req);
   AREQ_DecrRef(req);
@@ -1796,7 +1795,7 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
 // Shard FT.CURSOR READ FAIL-path reply callback.
 // Mirrors QueryReplyCallbackbut uses a different privdata type (BlockedCursorNode).
 // Not invoked if the timeout fired first.
-// The BlockedCursorNode reference is released by FreeCursorNode → ShardCursorBlockClient_FreeAREQ after this callback.
+// The BlockedCursorNode reference is released by FreeCursorNode → BlockClient_FreeAREQ after this callback.
 // Can be consolidated with QueryReplyCallback - See MOD-15038.
 static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
@@ -1837,7 +1836,7 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
 
     // Take a reference for BlockedQueryNode to access in timeout/reply callbacks.
     AREQ_IncrRef(r);
-    blockClientCtx.freePrivData = AREQ_DecrRefWrapper;
+    blockClientCtx.freePrivData = BlockClient_FreeAREQ;
     blockClientCtx.privdata = r;
     blockClientCtx.ast = &r->ast;
     RSTimeoutPolicy policy = r->reqConfig.timeoutPolicy;
@@ -2309,7 +2308,7 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
       // Extra ref owned by the BlockedCursorNode, released in FreeCursorNode.
       AREQ_IncrRef(req);
       blockClientCtx.privdata        = req;
-      blockClientCtx.freePrivData    = ShardCursorBlockClient_FreeAREQ;
+      blockClientCtx.freePrivData    = BlockClient_FreeAREQ;
       blockClientCtx.replyCallback   = CursorReadReplyCallback;
       blockClientCtx.timeoutCallback =
           cursor->queryTimeoutPolicy == TimeoutPolicy_Fail ? CursorReadTimeoutFailCallback

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -425,9 +425,8 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
       *rc = RS_RESULT_TIMEDOUT;
       return;
     }
-    // We own the production phase: link this request's sync context into the safe
-    // loaders so they perform the GIL deadlock-avoidance handshake with the
-    // timeout callback.
+    // We own the production phase: link the sync context into the safe loaders so
+    // they perform the GIL deadlock-avoidance handshake with the timeout callback.
     RPSafeLoader_SetSyncCtx(AREQ_QueryProcessingCtx(req), &req->syncCtx);
   }
 
@@ -1611,9 +1610,8 @@ static int QueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStri
   }
 
   // Deadlock avoidance: if the BG worker is parked at the safe-loader GIL gate,
-  // it cannot progress while this callback holds the GIL, so Wait would deadlock.
-  // Preempt it and reply empty; the worker finishes once we release the GIL and
-  // teardown frees its unconsumed results. See the handshake contract in aggregate.h.
+  // Wait would deadlock (it needs the GIL we hold). Preempt it and reply empty;
+  // the worker finishes once we release the GIL. See aggregate.h.
   if (RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(&req->syncCtx)) {
     single_shard_common_query_reply_empty(ctx, argv, argc, 0, QUERY_ERROR_CODE_TIMED_OUT);
     return REDISMODULE_OK;
@@ -1773,9 +1771,8 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
   }
 
   // Deadlock avoidance: if the BG worker is parked at the safe-loader GIL gate,
-  // Wait would deadlock (the worker needs the GIL this callback holds). Preempt
-  // it and reply with an exhausted cursor (id 0); the worker finishes once we
-  // release the GIL and teardown frees its stashed cursor and results.
+  // Wait would deadlock (it needs the GIL we hold). Preempt it and reply with an
+  // exhausted cursor (id 0); the worker finishes once we release the GIL.
   if (RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(&req->syncCtx)) {
     return cursor_read_empty_reply_timeout(ctx, 0, IsInternal(req));
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -425,6 +425,10 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
       *rc = RS_RESULT_TIMEDOUT;
       return;
     }
+    // We own the production phase: link this request's sync context into the safe
+    // loaders so they perform the GIL deadlock-avoidance handshake with the
+    // timeout callback.
+    RPSafeLoader_SetSyncCtx(AREQ_QueryProcessingCtx(req), &req->syncCtx);
   }
 
   startPipelineCommon(&ctx, rp, results, r, rc);
@@ -1606,6 +1610,15 @@ static int QueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStri
     return REDISMODULE_OK;
   }
 
+  // Deadlock avoidance: if the BG worker is parked at the safe-loader GIL gate,
+  // it cannot progress while this callback holds the GIL, so Wait would deadlock.
+  // Preempt it and reply empty; the worker finishes once we release the GIL and
+  // teardown frees its unconsumed results. See the handshake contract in aggregate.h.
+  if (RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(&req->syncCtx)) {
+    single_shard_common_query_reply_empty(ctx, argv, argc, 0, QUERY_ERROR_CODE_TIMED_OUT);
+    return REDISMODULE_OK;
+  }
+
   // Sync with the background thread
   AREQ_WaitForAggregateResultsComplete(req);
 
@@ -1757,6 +1770,14 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
     // normal RETURN_STRICT cursor shape; when the worker observes the failed
     // claim, it parks the already-taken cursor for the advertised id.
     return cursor_read_empty_reply_timeout(ctx, node->cursorId, IsInternal(req));
+  }
+
+  // Deadlock avoidance: if the BG worker is parked at the safe-loader GIL gate,
+  // Wait would deadlock (the worker needs the GIL this callback holds). Preempt
+  // it and reply with an exhausted cursor (id 0); the worker finishes once we
+  // release the GIL and teardown frees its stashed cursor and results.
+  if (RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(&req->syncCtx)) {
+    return cursor_read_empty_reply_timeout(ctx, 0, IsInternal(req));
   }
 
   // The worker owns the stored-results phase. Wait for it to store a

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1145,14 +1145,11 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
  * serializes the worker's "set holding, then check timedOut" against the main
  * thread's "set timedOut, then check holding", making the two race-free. */
 bool RequestSyncCtx_SafeLoaderEnterGIL(RequestSyncCtx *sync) {
-  // Gate: only requests using the aggregate-results sync protocol take part in
-  // the handshake. For all other policies this is a no-op (take the GIL as usual).
-  if (!sync->requiresAggregateResultsSync) return true;
   bool proceed;
   pthread_mutex_lock(&sync->aggregateResultsLock);
   if (RS_AtomicBoolLoadRelaxed(&sync->timedOut)) {
-    // Timeout callback already fired: do NOT mark holding, bail so the worker
-    // does not block on the GIL the main thread is holding while it waits.
+    // Timeout already fired: do not mark holding, bail instead of blocking on the
+    // GIL the main thread holds while it waits.
     proceed = false;
   } else {
     sync->safeLoaderHoldingGIL = true;
@@ -1163,14 +1160,12 @@ bool RequestSyncCtx_SafeLoaderEnterGIL(RequestSyncCtx *sync) {
 }
 
 void RequestSyncCtx_SafeLoaderExitGIL(RequestSyncCtx *sync) {
-  if (!sync->requiresAggregateResultsSync) return;
   pthread_mutex_lock(&sync->aggregateResultsLock);
   sync->safeLoaderHoldingGIL = false;
   pthread_mutex_unlock(&sync->aggregateResultsLock);
 }
 
 bool RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(RequestSyncCtx *sync) {
-  if (!sync->requiresAggregateResultsSync) return false;
   bool holding;
   pthread_mutex_lock(&sync->aggregateResultsLock);
   holding = sync->safeLoaderHoldingGIL;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1141,11 +1141,49 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);
 }
 
+/* See aggregate.h for the full handshake contract. The aggregateResultsLock
+ * serializes the worker's "set holding, then check timedOut" against the main
+ * thread's "set timedOut, then check holding", making the two race-free. */
+bool RequestSyncCtx_SafeLoaderEnterGIL(RequestSyncCtx *sync) {
+  // Gate: only requests using the aggregate-results sync protocol take part in
+  // the handshake. For all other policies this is a no-op (take the GIL as usual).
+  if (!sync->requiresAggregateResultsSync) return true;
+  bool proceed;
+  pthread_mutex_lock(&sync->aggregateResultsLock);
+  if (RS_AtomicBoolLoadRelaxed(&sync->timedOut)) {
+    // Timeout callback already fired: do NOT mark holding, bail so the worker
+    // does not block on the GIL the main thread is holding while it waits.
+    proceed = false;
+  } else {
+    sync->safeLoaderHoldingGIL = true;
+    proceed = true;
+  }
+  pthread_mutex_unlock(&sync->aggregateResultsLock);
+  return proceed;
+}
+
+void RequestSyncCtx_SafeLoaderExitGIL(RequestSyncCtx *sync) {
+  if (!sync->requiresAggregateResultsSync) return;
+  pthread_mutex_lock(&sync->aggregateResultsLock);
+  sync->safeLoaderHoldingGIL = false;
+  pthread_mutex_unlock(&sync->aggregateResultsLock);
+}
+
+bool RequestSyncCtx_TimeoutPreemptSafeLoaderGIL(RequestSyncCtx *sync) {
+  if (!sync->requiresAggregateResultsSync) return false;
+  bool holding;
+  pthread_mutex_lock(&sync->aggregateResultsLock);
+  holding = sync->safeLoaderHoldingGIL;
+  pthread_mutex_unlock(&sync->aggregateResultsLock);
+  return holding;
+}
+
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
   RS_AtomicBoolStoreRelaxed(&req->syncCtx.aggregatingResults, false);
   req->syncCtx.aggregateResultsClaimLost = false;
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
+  req->syncCtx.safeLoaderHoldingGIL = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);
   RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, false);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -144,6 +144,7 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 #define SYNC_POINT_BEFORE_CURSOR_READ_SEND_CHUNK        "BeforeCursorReadSendChunk"
 #define SYNC_POINT_BEFORE_CURSOR_READ_SPEC_PROMOTE      "BeforeCursorReadSpecPromote"
 #define SYNC_POINT_BEFORE_AGGREGATE_RESULTS_CLAIM       "BeforeAggregateResultsClaim"
+#define SYNC_POINT_BEFORE_SAFE_LOADER_GIL_LOCK          "BeforeSafeLoaderGILLock"
 #define SYNC_POINT_BEFORE_HYBRID_RESULTS_CLAIM          "BeforeHybridResultsClaim"
 #define SYNC_POINT_BEFORE_RPNET_START                   "BeforeRPNetStart"
 #define SYNC_POINT_BEFORE_RPNET_NEXT                    "BeforeRPNetNext"

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -145,6 +145,8 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 #define SYNC_POINT_BEFORE_CURSOR_READ_SPEC_PROMOTE      "BeforeCursorReadSpecPromote"
 #define SYNC_POINT_BEFORE_AGGREGATE_RESULTS_CLAIM       "BeforeAggregateResultsClaim"
 #define SYNC_POINT_BEFORE_SAFE_LOADER_GIL_LOCK          "BeforeSafeLoaderGILLock"
+#define SYNC_POINT_AFTER_SAFE_LOADER_GIL_HANDSHAKE      "AfterSafeLoaderGILHandshake"
+#define SYNC_POINT_BEFORE_SAFE_LOADER_EXIT_GIL          "BeforeSafeLoaderExitGIL"
 #define SYNC_POINT_BEFORE_HYBRID_RESULTS_CLAIM          "BeforeHybridResultsClaim"
 #define SYNC_POINT_BEFORE_RPNET_START                   "BeforeRPNetStart"
 #define SYNC_POINT_BEFORE_RPNET_NEXT                    "BeforeRPNetNext"

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1181,9 +1181,8 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   if (isQueryProfile) rs_wall_clock_init(&rpStartTime);
 
 #ifdef ENABLE_ASSERT
-  // Sync point (debug): pause after buffering all results but before taking the
-  // GIL. The RETURN_STRICT deadlock tests park the worker here, fire the timeout
-  // callback, then release it via the predicate.
+  // Sync point: pause after buffering, before taking the GIL.
+  // Interruptible so a fired timeout callback can release the worker.
   SyncPoint_WaitUntil(SYNC_POINT_BEFORE_SAFE_LOADER_GIL_LOCK, SearchTime_IsTimedOut, &sctx->time);
 #endif
 
@@ -1195,10 +1194,8 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   }
 
 #ifdef ENABLE_ASSERT
-  // Sync point (debug): pause after the handshake marked us as holding the GIL
-  // gate (safeLoaderHoldingGIL == true) but before we take the Redis lock. The
-  // RETURN_STRICT preempt repro tests park the worker here so the timeout
-  // callback observes holding == true and takes the preempt branch.
+  // Sync point: pause holding the GIL gate (safeLoaderHoldingGIL == true),
+  // before the Redis lock, so a timeout callback observes it and preempts.
   SyncPoint_Wait(SYNC_POINT_AFTER_SAFE_LOADER_GIL_HANDSHAKE);
 #endif
 
@@ -1221,10 +1218,8 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   RedisModule_ThreadSafeContextUnlock(sctx->redisCtx);
 
 #ifdef ENABLE_ASSERT
-  // Sync point (debug): pause after clearing the handshake flag and releasing
-  // the Redis lock. The P2b regression test parks the worker here (interruptible
-  // via the timedOut predicate); the flag is already false, so a timeout
-  // callback waits for the stored results instead of preempting.
+  // Sync point: pause after clearing the flag and unlocking Redis. The
+  // flag is already false, so a timeout callback waits for results, not preempts.
   SyncPoint_WaitUntil(SYNC_POINT_BEFORE_SAFE_LOADER_EXIT_GIL, SearchTime_IsTimedOut, &sctx->time);
 #endif
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1194,17 +1194,39 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
     return RS_RESULT_TIMEDOUT;
   }
 
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): pause after the handshake marked us as holding the GIL
+  // gate (safeLoaderHoldingGIL == true) but before we take the Redis lock. The
+  // RETURN_STRICT preempt repro tests park the worker here so the timeout
+  // callback observes holding == true and takes the preempt branch.
+  SyncPoint_Wait(SYNC_POINT_AFTER_SAFE_LOADER_GIL_HANDSHAKE);
+#endif
+
   // Then, lock Redis to guarantee safe access to Redis keyspace
   RedisModule_ThreadSafeContextLock(sctx->redisCtx);
 
   rpSafeLoader_Load(self);
 
-  // Done loading. Unlock Redis
-  RedisModule_ThreadSafeContextUnlock(sctx->redisCtx);
-
+  // Clear the GIL-gate handshake flag while we still hold the Redis lock. The
+  // timeout callback only runs on the main thread while it holds the GIL, so it
+  // cannot observe the flag during this window; clearing before the unlock
+  // closes the race where a timeout landing in the unlock->clear gap sees a
+  // stale safeLoaderHoldingGIL == true and preempts, dropping already-loaded
+  // results. See aggregate.h.
   if (self->syncCtx) {
     RequestSyncCtx_SafeLoaderExitGIL(self->syncCtx);
   }
+
+  // Done loading. Unlock Redis
+  RedisModule_ThreadSafeContextUnlock(sctx->redisCtx);
+
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): pause after clearing the handshake flag and releasing
+  // the Redis lock. The P2b regression test parks the worker here (interruptible
+  // via the timedOut predicate); the flag is already false, so a timeout
+  // callback waits for the stored results instead of preempting.
+  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_SAFE_LOADER_EXIT_GIL, SearchTime_IsTimedOut, &sctx->time);
+#endif
 
   if (isQueryProfile) {
     // Add 1ns as epsilon value so we can verify that the GIL time is greater than 0.

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1019,6 +1019,12 @@ typedef struct RPSafeLoader {
 
   // Search context
   RedisSearchCtx *sctx;
+
+  // Request sync context, set only for requests that use the BG/timeout-callback
+  // aggregate-results sync (NULL otherwise). When set, the loader performs the
+  // GIL deadlock-avoidance handshake before/after the GIL. The handshake is
+  // additionally gated on requiresAggregateResultsSync inside the helpers.
+  RequestSyncCtx *syncCtx;
 } RPSafeLoader;
 
 /************************* Safe Loader private functions *************************/
@@ -1174,6 +1180,26 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   bool isQueryProfile = rp->parent->isProfile;
   rs_wall_clock rpStartTime;
   if (isQueryProfile) rs_wall_clock_init(&rpStartTime);
+
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): pause after the safe loader has buffered all results
+  // (and won the aggregate-results claim) but before acquiring the GIL. The
+  // RETURN-STRICT cursor-read deadlock test parks the worker here, fires the
+  // main-thread timeout callback (which loses the claim and blocks in
+  // AREQ_WaitForAggregateResultsComplete while holding the GIL), then relies on
+  // the predicate to release the worker so it proceeds into the GIL lock below.
+  SyncPoint_WaitUntil(SYNC_POINT_BEFORE_SAFE_LOADER_GIL_LOCK, SearchTime_IsTimedOut, &sctx->time);
+#endif
+
+  // Deadlock-avoidance handshake (RETURN_STRICT only; syncCtx is NULL otherwise
+  // and the helpers no-op for non-sync policies). Mark that we are about to take
+  // the GIL so the main-thread timeout callback can preempt us; if it already
+  // timed out, bail without taking the GIL the main thread may be holding while
+  // it waits. See aggregate.h for the contract.
+  if (self->syncCtx && !RequestSyncCtx_SafeLoaderEnterGIL(self->syncCtx)) {
+    return RS_RESULT_TIMEDOUT;
+  }
+
   // Then, lock Redis to guarantee safe access to Redis keyspace
   RedisModule_ThreadSafeContextLock(sctx->redisCtx);
 
@@ -1181,6 +1207,10 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
 
   // Done loading. Unlock Redis
   RedisModule_ThreadSafeContextUnlock(sctx->redisCtx);
+
+  if (self->syncCtx) {
+    RequestSyncCtx_SafeLoaderExitGIL(self->syncCtx);
+  }
 
   if (isQueryProfile) {
     // Add 1ns as epsilon value so we can verify that the GIL time is greater than 0.
@@ -1225,6 +1255,7 @@ static ResultProcessor *RPSafeLoader_New(RedisSearchCtx *sctx, RLookup *lk, cons
 
   sl->last_buffered_rc = RS_RESULT_OK;
   sl->sctx = sctx;
+  sl->syncCtx = NULL;
 
   sl->base_loader.base.Next = rpSafeLoaderNext_Accumulate;
   sl->base_loader.base.Free = rpSafeLoaderFree;
@@ -1302,6 +1333,7 @@ static ResultProcessor *RPSafeLoader_New_FromPlainLoader(RPLoader *loader) {
   sl->curr_result_index = 0;
 
   sl->last_buffered_rc = RS_RESULT_OK;
+  sl->syncCtx = NULL;
 
   sl->base_loader.base.Next = rpSafeLoaderNext_Accumulate;
   sl->base_loader.base.Free = rpSafeLoaderFree;
@@ -1330,6 +1362,19 @@ void SetLoadersForBG(QueryProcessingCtx *qctx) {
   }
   // Update the endProc to the new head in case it was changed
   qctx->endProc = dummyHead.upstream;
+}
+
+// Link the request sync context into every RP_SAFE_LOADER in the pipeline so
+// they can perform the RETURN_STRICT GIL deadlock-avoidance handshake. Called on
+// the BG worker for requests that use the aggregate-results sync protocol.
+void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct RequestSyncCtx *sync) {
+  ResultProcessor *rp = qctx->endProc;
+  while (rp) {
+    if (rp->type == RP_SAFE_LOADER) {
+      ((RPSafeLoader *)rp)->syncCtx = sync;
+    }
+    rp = rp->upstream;
+  }
 }
 
 void SetLoadersForMainThread(QueryProcessingCtx *qctx) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1020,10 +1020,9 @@ typedef struct RPSafeLoader {
   // Search context
   RedisSearchCtx *sctx;
 
-  // Request sync context, set only for requests that use the BG/timeout-callback
-  // aggregate-results sync (NULL otherwise). When set, the loader performs the
-  // GIL deadlock-avoidance handshake before/after the GIL. The handshake is
-  // additionally gated on requiresAggregateResultsSync inside the helpers.
+  // Request sync context; non-NULL only for RETURN_STRICT requests that use the
+  // aggregate-results sync. When set, the loader performs the GIL deadlock-
+  // avoidance handshake around the GIL (see aggregate.h).
   RequestSyncCtx *syncCtx;
 } RPSafeLoader;
 
@@ -1182,20 +1181,15 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   if (isQueryProfile) rs_wall_clock_init(&rpStartTime);
 
 #ifdef ENABLE_ASSERT
-  // Sync point (debug): pause after the safe loader has buffered all results
-  // (and won the aggregate-results claim) but before acquiring the GIL. The
-  // RETURN-STRICT cursor-read deadlock test parks the worker here, fires the
-  // main-thread timeout callback (which loses the claim and blocks in
-  // AREQ_WaitForAggregateResultsComplete while holding the GIL), then relies on
-  // the predicate to release the worker so it proceeds into the GIL lock below.
+  // Sync point (debug): pause after buffering all results but before taking the
+  // GIL. The RETURN_STRICT deadlock tests park the worker here, fire the timeout
+  // callback, then release it via the predicate.
   SyncPoint_WaitUntil(SYNC_POINT_BEFORE_SAFE_LOADER_GIL_LOCK, SearchTime_IsTimedOut, &sctx->time);
 #endif
 
-  // Deadlock-avoidance handshake (RETURN_STRICT only; syncCtx is NULL otherwise
-  // and the helpers no-op for non-sync policies). Mark that we are about to take
-  // the GIL so the main-thread timeout callback can preempt us; if it already
-  // timed out, bail without taking the GIL the main thread may be holding while
-  // it waits. See aggregate.h for the contract.
+  // Deadlock-avoidance handshake (syncCtx non-NULL only for RETURN_STRICT). Mark
+  // that we are about to take the GIL so the timeout callback can preempt us; if
+  // it already timed out, bail instead of blocking. See aggregate.h.
   if (self->syncCtx && !RequestSyncCtx_SafeLoaderEnterGIL(self->syncCtx)) {
     return RS_RESULT_TIMEDOUT;
   }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -188,10 +188,16 @@ ResultProcessor *RPPager_New(size_t offset, size_t limit);
  *
  *******************************************************************************************************************/
 struct AREQ;
+struct RequestSyncCtx;
 ResultProcessor *RPLoader_New(RedisSearchCtx *sctx, uint32_t reqflags, RLookup *lk, const RLookupKey **keys, size_t nkeys, bool forceLoad, uint32_t *outStateflags);
 
 void SetLoadersForBG(QueryProcessingCtx *qctx);
 void SetLoadersForMainThread(QueryProcessingCtx *qctx);
+
+/* Link the request sync context into every RP_SAFE_LOADER in the pipeline so
+ * they can perform the RETURN_STRICT GIL deadlock-avoidance handshake (see
+ * aggregate.h). No-op for pipelines without safe loaders. */
+void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct RequestSyncCtx *sync);
 
 /** Creates a new Highlight processor */
 ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -6267,6 +6267,199 @@ class TestShardTimeout:
         self._run_return_strict_no_deadlock_at_safe_loader_gil(
             ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name'], 'FT.AGGREGATE')
 
+    def test_return_strict_cursor_read_preempt_no_use_after_free(self):
+        """P1: RETURN_STRICT FT.CURSOR READ must not free the cursor under the worker.
+
+        The cursor was created with LOAD, so the BG cursor-read pipeline runs the
+        safe loader. The worker wins the claim, marks itself at the GIL gate
+        (safeLoaderHoldingGIL == true), and parks at AfterSafeLoaderGILHandshake -
+        after the handshake but before taking the Redis lock. The timeout callback
+        loses the claim, observes holding == true, and takes the preempt branch:
+        it replies with an exhausted cursor (id 0) and returns immediately. The
+        blocked-client free callback (ShardCursorBlockClient_FreeAREQ) then drains
+        req->storedReplyState.cursor - freeing the cursor (stashed before
+        sendChunk) and dropping its AREQ reference - while the worker is still
+        parked. Releasing the worker makes it resume sendChunk and keep using the
+        freed cursor/AREQ: a use-after-free (caught under SAN, otherwise a crash).
+
+        Detects the bug: releasing the worker after the cursor was freed must not
+        corrupt memory; the cursor-read thread finishes and the server survives.
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+        sync_point = 'AfterSafeLoaderGILHandshake'
+
+        prev_policy, cursor_id, _, _, _, _ = _setup_return_strict_cursor_state(env)
+
+        try:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+            result = []
+            try:
+                t_query = threading.Thread(
+                    target=call_and_store,
+                    args=(env.cmd, ['FT.CURSOR', 'READ', 'idx', str(cursor_id)], result),
+                    daemon=True,
+                )
+                t_query.start()
+                blocked_client_id = wait_for_blocked_query_client(
+                    env, 'FT.CURSOR|READ', 'Client for FT.CURSOR|READ not found')
+                # Worker won the claim, set safeLoaderHoldingGIL, and parked after
+                # the handshake (before taking the GIL).
+                wait_for_condition(
+                    lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+                    f'worker never reached {sync_point}'
+                )
+                # Fire the deadline: the callback preempts (holding == true), replies
+                # cursor id 0, and the free callback frees the cursor while the
+                # worker is still parked.
+                env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+                wait_for_client_unblocked(env, blocked_client_id)
+            finally:
+                # Release the parked worker: it resumes sendChunk and (pre-fix)
+                # touches the freed cursor/AREQ.
+                env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+                env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+            t_query.join(timeout=10)
+            env.assertFalse(t_query.is_alive(),
+                            message="Cursor read thread hung after preempt")
+            env.assertEqual(len(result), 1, message="Expected one cursor read result")
+            # Server must still be responsive (no UAF crash).
+            env.expect('PING').true()
+        finally:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
+
+    def test_return_strict_initial_withcursor_preempt_no_cursor_leak(self):
+        """P2a: initial RETURN_STRICT FT.AGGREGATE WITHCURSOR must not orphan its cursor.
+
+        The initial WITHCURSOR query reserves a cursor and stashes it in
+        storedReplyState.cursor before sendChunk. The worker wins the claim, marks
+        itself at the GIL gate, and parks at AfterSafeLoaderGILHandshake. The
+        timeout callback loses the claim, observes holding == true, and preempts:
+        it sends an empty cursor-id-0 reply and returns, skipping the normal
+        AREQ_ReplyWithStoredResults path that would pause/free the reserved cursor.
+        The query blocked-client free callback only decrefs the AREQ, so the cursor
+        stays in the global lookup with pos == -1: unreachable by FT.CURSOR READ
+        and not idle-GC eligible, i.e. leaked on every such timeout.
+
+        Detects the bug: after the worker finishes, the global cursor count must
+        return to the pre-query baseline (no orphaned cursor).
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+        sync_point = 'AfterSafeLoaderGILHandshake'
+
+        prev_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict').ok()
+        baseline_total = _coord_cursor_total(env)
+
+        try:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+            result = []
+            try:
+                t_query = threading.Thread(
+                    target=call_and_store,
+                    args=(env.cmd, ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name',
+                                    'WITHCURSOR', 'COUNT', '10'], result),
+                    daemon=True,
+                )
+                t_query.start()
+                blocked_client_id = wait_for_blocked_query_client(env, 'FT.AGGREGATE')
+                # Worker reserved the cursor, set safeLoaderHoldingGIL, and parked.
+                wait_for_condition(
+                    lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+                    f'worker never reached {sync_point}'
+                )
+                # Fire the deadline: the callback preempts with an empty cursor-id-0
+                # reply, skipping the cursor pause/free path.
+                env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+                wait_for_client_unblocked(env, blocked_client_id)
+            finally:
+                env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+                env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+            t_query.join(timeout=10)
+            env.assertFalse(t_query.is_alive(), message="Aggregate thread hung after preempt")
+            env.assertEqual(len(result), 1, message="Expected one aggregate result")
+            _, reply_cursor_id = result[0]
+            env.assertEqual(reply_cursor_id, 0,
+                            message="Preempted WITHCURSOR reply must advertise an exhausted cursor")
+            # The reserved cursor must not be orphaned: the global count returns to
+            # baseline once the worker finishes (pre-fix it stays at baseline + 1).
+            _wait_for_cursor_cleanup(env, baseline_total + 1,
+                                     'initial WITHCURSOR preempt timeout')
+        finally:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
+
+    def test_return_strict_stale_holding_flag_after_unlock_keeps_results(self):
+        """P2b: a timeout in the unlock->clear-flag window must not drop loaded results.
+
+        The worker wins the claim, takes the GIL gate, loads under the Redis lock,
+        and unlocks - but parks at BeforeSafeLoaderExitGIL before clearing
+        safeLoaderHoldingGIL. With the GIL already released, the worker no longer
+        needs it, yet the handshake flag is still set. The timeout callback loses
+        the claim, observes the stale holding == true, and takes the preempt
+        branch: it returns an empty reply instead of waiting for the already-loaded
+        partial results, losing data the RETURN_STRICT contract promises.
+
+        The park is interruptible via the timedOut predicate so the post-fix path
+        (flag cleared before unlock) does not deadlock; pre-fix the synchronous
+        callback observes the stale flag before the worker's poll clears it.
+
+        Detects the bug: the reply must carry the loaded rows (pre-fix it is empty).
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+        sync_point = 'BeforeSafeLoaderExitGIL'
+
+        prev_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict').ok()
+
+        try:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+            result = []
+            try:
+                t_query = threading.Thread(
+                    target=call_and_store,
+                    args=(env.cmd, ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name',
+                                    'LIMIT', '0', str(self.n_docs)], result),
+                    daemon=True,
+                )
+                t_query.start()
+                blocked_client_id = wait_for_blocked_query_client(env, 'FT.AGGREGATE')
+                # Worker loaded under the lock, unlocked, and parked before clearing
+                # the handshake flag (holding still true, GIL no longer held).
+                wait_for_condition(
+                    lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+                    f'worker never reached {sync_point}'
+                )
+                # Fire the deadline: pre-fix the callback observes the stale flag and
+                # preempts, dropping the loaded rows.
+                env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+                wait_for_client_unblocked(env, blocked_client_id)
+            finally:
+                env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+                env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+            t_query.join(timeout=10)
+            env.assertFalse(t_query.is_alive(), message="Aggregate thread hung after preempt")
+            env.assertEqual(len(result), 1, message="Expected one aggregate result")
+            reply = result[0]
+            env.assertGreater(len(reply.get('results', [])), 0,
+                              message="Loaded rows must survive a timeout in the "
+                                      "unlock->clear-flag window, got an empty reply")
+        finally:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
+
     def test_fail_dropped_index_during_queued_cursor_read(self):
         """FAIL cursor-read replies the stored error when the index is dropped while queued.
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -6268,7 +6268,7 @@ class TestShardTimeout:
             ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name'], 'FT.AGGREGATE')
 
     def test_return_strict_cursor_read_preempt_no_use_after_free(self):
-        """P1: RETURN_STRICT FT.CURSOR READ must not free the cursor under the worker.
+        """RETURN_STRICT FT.CURSOR READ must not free the cursor under the worker.
 
         The cursor was created with LOAD, so the BG cursor-read pipeline runs the
         safe loader. The worker wins the claim, marks itself at the GIL gate
@@ -6333,7 +6333,7 @@ class TestShardTimeout:
             env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
 
     def test_return_strict_initial_withcursor_preempt_no_cursor_leak(self):
-        """P2a: initial RETURN_STRICT FT.AGGREGATE WITHCURSOR must not orphan its cursor.
+        """Initial RETURN_STRICT FT.AGGREGATE WITHCURSOR must not orphan its cursor.
 
         The initial WITHCURSOR query reserves a cursor and stashes it in
         storedReplyState.cursor before sendChunk. The worker wins the claim, marks
@@ -6398,7 +6398,7 @@ class TestShardTimeout:
             env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
 
     def test_return_strict_stale_holding_flag_after_unlock_keeps_results(self):
-        """P2b: a timeout in the unlock->clear-flag window must not drop loaded results.
+        """A timeout in the unlock->clear-flag window must not drop loaded results.
 
         The worker wins the claim, takes the GIL gate, loads under the Redis lock,
         and unlocks - but parks at BeforeSafeLoaderExitGIL before clearing

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -6096,6 +6096,177 @@ class TestShardTimeout:
             resetAggregateResultsDebug(env)
             env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
 
+    def test_return_strict_cursor_read_no_deadlock_at_safe_loader_gil(self):
+        """RETURN_STRICT cursor-read must not deadlock when the BG safe loader
+        needs the GIL while the timeout callback waits for completion.
+
+        The cursor was created with ``LOAD``, so the BG cursor-read pipeline runs
+        the background-safe loader (RPSafeLoader). The worker wins
+        AREQ_TryClaimAggregateResults, buffers the chunk, then parks at
+        BeforeSafeLoaderGILLock - right before RedisModule_ThreadSafeContextLock.
+        The main-thread timeout callback then loses the claim and blocks in
+        AREQ_WaitForAggregateResultsComplete while holding the GIL. The worker is
+        released by the timedOut predicate and tries to take the GIL: if the
+        callback never releases it, the worker can neither load nor signal
+        completion, so the callback waits forever and the server hangs.
+
+        Guards against that deadlock: the cursor-read thread must finish and the
+        callback must return a single reply.
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+        sync_point = 'BeforeSafeLoaderGILLock'
+
+        prev_policy, cursor_id, _, before_info, base_warn_coord, _ = \
+            _setup_return_strict_cursor_state(env)
+        base_err_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC])
+
+        try:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+            result = []
+            try:
+                t_query = threading.Thread(
+                    target=call_and_store,
+                    args=(env.cmd, ['FT.CURSOR', 'READ', 'idx', str(cursor_id)], result),
+                    daemon=True,
+                )
+                t_query.start()
+                blocked_client_id = wait_for_blocked_query_client(
+                    env, 'FT.CURSOR|READ', 'Client for FT.CURSOR|READ not found')
+                # Worker won the claim, buffered the chunk, and parked before the GIL.
+                wait_for_condition(
+                    lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+                    f'worker never reached {sync_point}'
+                )
+                # Fire the deadline. The callback loses the claim and waits for
+                # the worker; the worker is released by the timedOut predicate
+                # and must still be able to take the GIL and signal completion.
+                env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+                wait_for_client_unblocked(env, blocked_client_id)
+            finally:
+                # WaitUntil auto-releases when timedOut flips, but disarm + clear
+                # so the next test starts from a clean slate.
+                env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+                env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+            t_query.join(timeout=10)
+            env.assertFalse(t_query.is_alive(),
+                            message="Cursor read thread hung - safe-loader GIL deadlock")
+            env.assertEqual(len(result), 1, message="Expected one cursor read result")
+
+            after_info = info_modules_to_dict(env)
+            env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC],
+                            str(base_err_coord),
+                            message="RETURN_STRICT cursor-read timeout must not bump coord error metric")
+            env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                            str(base_warn_coord + 1),
+                            message="Coord timeout warning should be +1 after cursor-read timeout")
+
+            env.expect('FT.CURSOR', 'DEL', 'idx', str(cursor_id)).ok()
+        finally:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy).ok()
+
+    def _run_return_strict_no_deadlock_at_safe_loader_gil(self, query_args, cmd_name):
+        """RETURN_STRICT FT.SEARCH / FT.AGGREGATE must not deadlock when the BG
+        safe loader needs the GIL while the timeout callback runs.
+
+        The query loads document fields, so the BG pipeline runs the
+        background-safe loader (RPSafeLoader). The worker wins
+        AREQ_TryClaimAggregateResults, buffers the chunk, then parks at
+        BeforeSafeLoaderGILLock - right before RedisModule_ThreadSafeContextLock.
+        The main-thread QueryTimeoutReturnStrictCallback then loses the claim.
+        It must not block in AREQ_WaitForAggregateResultsComplete while holding
+        the GIL. The safe-loader GIL handshake makes that safe: either the worker
+        already marked itself at the GIL gate and the callback preempts it
+        (AREQ_TimeoutPreemptSafeLoaderGIL) and replies empty without waiting, or
+        the worker is released by the timedOut predicate and bails at
+        AREQ_SafeLoaderEnterGIL without taking the GIL. If the callback blocked
+        while the worker needed the GIL, neither could progress and the server
+        would hang (MOD-8477).
+
+        Guards against that deadlock: the query thread must finish and the
+        callback must return a single empty + TIMEOUT-warning reply.
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+        sync_point = 'BeforeSafeLoaderGILLock'
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict')
+
+        before_info = info_modules_to_dict(env)
+        base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
+        base_err_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC])
+
+        try:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+            query_result = []
+            try:
+                t_query = threading.Thread(
+                    target=call_and_store,
+                    args=(env.cmd, list(query_args), query_result),
+                    daemon=True,
+                )
+                t_query.start()
+                blocked_client_id = wait_for_blocked_query_client(env, cmd_name)
+                # Worker won the claim, buffered the chunk, and parked before the GIL.
+                wait_for_condition(
+                    lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+                    f'worker never reached {sync_point}'
+                )
+                # Fire the deadline. The callback loses the claim but must not
+                # wait: it replies empty and the worker, released by the timedOut
+                # predicate, takes the GIL and discards its buffer.
+                env.cmd('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT')
+                wait_for_client_unblocked(env, blocked_client_id)
+            finally:
+                # WaitUntil auto-releases when timedOut flips, but disarm + clear
+                # so the next test starts from a clean slate.
+                env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+                env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+
+            t_query.join(timeout=10)
+            env.assertFalse(t_query.is_alive(),
+                            message=f"{cmd_name} thread hung - safe-loader GIL deadlock")
+            env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
+            result = query_result[0]
+            # RETURN_STRICT contract: no rows are returned and a TIMEOUT warning is
+            # set. total_results is intentionally not asserted - the pipeline may
+            # have already produced (counted) some or all matches into the safe
+            # loader's buffer before parking at the GIL gate, so its value is not
+            # guaranteed.
+            env.assertEqual(result.get('results', []), [],
+                            message=f"Expected no rows, got {result.get('results')}")
+            env.assertEqual(result.get('warning', []), [TIMEOUT_WARNING],
+                            message=f"Expected TIMEOUT warning, got {result.get('warning', [])}")
+
+            after_info = info_modules_to_dict(env)
+            env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC],
+                            str(base_err_coord),
+                            message=f"RETURN_STRICT {cmd_name} timeout must not bump coord error metric")
+            env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                            str(base_warn_coord + 1),
+                            message=f"Coord timeout warning should be +1 after {cmd_name}")
+            _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
+        finally:
+            env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+            env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
+    def test_return_strict_no_deadlock_at_safe_loader_gil_search(self):
+        """RETURN_STRICT FT.SEARCH must not deadlock at the safe-loader GIL."""
+        self._run_return_strict_no_deadlock_at_safe_loader_gil(
+            ['FT.SEARCH', 'idx', '*'], 'FT.SEARCH')
+
+    def test_return_strict_no_deadlock_at_safe_loader_gil_aggregate(self):
+        """RETURN_STRICT FT.AGGREGATE with LOAD must not deadlock at the safe-loader GIL."""
+        self._run_return_strict_no_deadlock_at_safe_loader_gil(
+            ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@name'], 'FT.AGGREGATE')
+
     def test_fail_dropped_index_during_queued_cursor_read(self):
         """FAIL cursor-read replies the stored error when the index is dropped while queued.
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Under `ON_TIMEOUT RETURN_STRICT`, a background worker running the `RP_SAFE_LOADER` can park at the GIL gate (`RedisModule_ThreadSafeContextLock`) to load document fields while the main-thread timeout callback already holds the GIL and blocks in `AREQ_WaitForAggregateResultsComplete`. Neither side can make progress — a circular-wait deadlock (server hang). It affects `FT.CURSOR READ`, `FT.SEARCH`, and `FT.AGGREGATE` queries that load document fields.
2. **Change:** Add a mutex-guarded (Dekker-style) handshake on the request sync context (`RequestSyncCtx`):
   - The BG worker calls `RequestSyncCtx_SafeLoaderEnterGIL` right before taking the GIL. Under `aggregateResultsLock` it marks `safeLoaderHoldingGIL` and, if the timeout already fired (`timedOut`), bails (`RS_RESULT_TIMEDOUT`) **without** taking the GIL the main thread is holding.
   - The main-thread timeout callback calls `RequestSyncCtx_TimeoutPreemptSafeLoaderGIL`. If the worker is parked at the gate it replies empty (+ TIMEOUT warning) immediately instead of waiting.
   - The whole handshake is gated on `requiresAggregateResultsSync`, so FAIL/RETURN policies are unaffected. The safe loader now holds a `RequestSyncCtx *` instead of the full `AREQ *`.
3. **Outcome:** The circular wait is broken: the timeout callback always returns a single RETURN_STRICT reply (empty rows + TIMEOUT warning), and the worker unwinds once the GIL is released. No behavior change for non-RETURN_STRICT paths.

#### Which additional issues this PR fixes
1. MOD-8477

#### Main objects this PR modified
1. `RequestSyncCtx` + handshake helpers (`src/aggregate/aggregate.h`, `src/aggregate/aggregate_request.c`)
2. `RPSafeLoader` GIL gate and `RPSafeLoader_SetSyncCtx` (`src/result_processor.c` / `src/result_processor.h`)
3. Timeout callbacks + safe-loader linking (`src/aggregate/aggregate_exec.c`)
4. Regression tests (`tests/pytests/test_blocked_client_timeout.py`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes a server hang (deadlock) on `FT.SEARCH` / `FT.AGGREGATE` / `FT.CURSOR READ` under `ON_TIMEOUT RETURN_STRICT` when a client timeout fires while the background safe loader is acquiring the GIL.
