### PR TITLE
[8.2] [MOD-16047] ignore newer internal query args

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -366,6 +366,16 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
       RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
     }
+  } else if (AC_AdvanceIfMatch(ac, "_SLOTS_INFO")) {
+    // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.4 append a
+    // _SLOTS_INFO <binary> argument to internal queries. This version does not use it,
+    // but must consume the keyword and its single payload argument so that a newer
+    // coordinator can drive this shard during a rolling upgrade across the 8.4 boundary.
+    if (AC_NumRemaining(ac) < 1) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "_SLOTS_INFO missing argument");
+      return ARG_ERROR;
+    }
+    AC_Advance(ac); // skip the (binary) slots payload
   } else if (AC_AdvanceIfMatch(ac, "BM25STD_TANH_FACTOR")) {
     if (AC_NumRemaining(ac) < 1) {
       QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for BM25STD_TANH_FACTOR");

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -363,9 +363,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     req->prefixesOffset = ac->offset - 1;
 
     ArgsCursor tmp = {0};
-    if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
-      RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
-    }
+    AC_GetVarArgs(ac, &tmp);
   } else if (AC_AdvanceIfMatch(ac, "_SLOTS_INFO")) {
     // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.4 append a
     // _SLOTS_INFO <binary> argument to internal queries. This version does not use it,

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -372,6 +372,12 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     // but must consume the keyword and its single payload argument so that a newer
     // coordinator can drive this shard during a rolling upgrade across the 8.4 boundary.
     AC_Advance(ac); // skip the (binary) slots payload (no-op if absent)
+  } else if (AC_AdvanceIfMatch(ac, "_COORD_DISPATCH_TIME")) {
+    // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.6 append a
+    // _COORD_DISPATCH_TIME <ns> argument to internal queries. This version does not use
+    // it, but must consume it so newer coordinators can drive this shard during rolling
+    // upgrades.
+    AC_Advance(ac); // skip the dispatch-time payload (no-op if absent)
   } else if (AC_AdvanceIfMatch(ac, "BM25STD_TANH_FACTOR")) {
     if (AC_NumRemaining(ac) < 1) {
       QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for BM25STD_TANH_FACTOR");

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -371,11 +371,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     // _SLOTS_INFO <binary> argument to internal queries. This version does not use it,
     // but must consume the keyword and its single payload argument so that a newer
     // coordinator can drive this shard during a rolling upgrade across the 8.4 boundary.
-    if (AC_NumRemaining(ac) < 1) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "_SLOTS_INFO missing argument");
-      return ARG_ERROR;
-    }
-    AC_Advance(ac); // skip the (binary) slots payload
+    AC_Advance(ac); // skip the (binary) slots payload (no-op if absent)
   } else if (AC_AdvanceIfMatch(ac, "BM25STD_TANH_FACTOR")) {
     if (AC_NumRemaining(ac) < 1) {
       QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for BM25STD_TANH_FACTOR");

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -363,7 +363,9 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     req->prefixesOffset = ac->offset - 1;
 
     ArgsCursor tmp = {0};
-    AC_GetVarArgs(ac, &tmp);
+    if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
+      RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
+    }
   } else if (AC_AdvanceIfMatch(ac, "_SLOTS_INFO")) {
     // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.4 append a
     // _SLOTS_INFO <binary> argument to internal queries. This version does not use it,

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -188,12 +188,15 @@ def test_internal_slots_info_ignored(env):
 
     # The payload is opaque to this version; arbitrary bytes must be consumed and ignored.
     slots = b'\x01\x00\x00\x00\x00\x00\xff\x3f'
-    res = env.cmd('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', slots)
+    dispatch_time = '1000000'
+    res = env.cmd('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', slots,
+                  '_COORD_DISPATCH_TIME', dispatch_time)
     env.assertEqual(res[0], 1)
     env.assertEqual(res[1], 'doc:1')
 
     # Also when _SLOTS_INFO is followed by further arguments, and for _FT.AGGREGATE.
-    res = env.cmd('_FT.AGGREGATE', 'idx', '*', '_SLOTS_INFO', slots, 'LOAD', '1', '@n')
+    res = env.cmd('_FT.AGGREGATE', 'idx', '*', '_SLOTS_INFO', slots,
+                  '_COORD_DISPATCH_TIME', dispatch_time, 'LOAD', '1', '@n')
     env.assertEqual(res[1:], [['n', '1']])
 
 @skip(redis_less_than="7.9.227")

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -196,9 +196,6 @@ def test_internal_slots_info_ignored(env):
     res = env.cmd('_FT.AGGREGATE', 'idx', '*', '_SLOTS_INFO', slots, 'LOAD', '1', '@n')
     env.assertEqual(res[1:], [['n', '1']])
 
-    # A dangling _SLOTS_INFO with no payload is a parse error, not a silent accept.
-    env.expect('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO').error().contains('_SLOTS_INFO missing argument')
-
 @skip(redis_less_than="7.9.227")
 def test_acl_key_permissions_validation(env):
     """Tests that the key permission validation works properly"""

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -175,6 +175,30 @@ def test_internal_commands(env):
     env.expect('DEBUG', 'MARK-INTERNAL-CLIENT').ok()
     env.expect('_FT.SEARCH', 'idx', '*').equal([0])
 
+@skip(cluster=True)
+def test_internal_slots_info_ignored(env):
+    """Forward compatibility (MOD-16047): a newer (>=8.4) coordinator appends a
+    _SLOTS_INFO <binary> argument to internal queries. This version does not use it but
+    must accept and ignore it, so it can serve as a query target during a rolling upgrade
+    across the 8.4 boundary."""
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:1', 'n', '1')
+    env.expect('DEBUG', 'MARK-INTERNAL-CLIENT').ok()
+
+    # The payload is opaque to this version; arbitrary bytes must be consumed and ignored.
+    slots = b'\x01\x00\x00\x00\x00\x00\xff\x3f'
+    res = env.cmd('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', slots)
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], 'doc:1')
+
+    # Also when _SLOTS_INFO is followed by further arguments, and for _FT.AGGREGATE.
+    res = env.cmd('_FT.AGGREGATE', 'idx', '*', '_SLOTS_INFO', slots, 'LOAD', '1', '@n')
+    env.assertEqual(res[1:], [['n', '1']])
+
+    # A dangling _SLOTS_INFO with no payload is a parse error, not a silent accept.
+    env.expect('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO').error().contains('_SLOTS_INFO missing argument')
+
 @skip(redis_less_than="7.9.227")
 def test_acl_key_permissions_validation(env):
     """Tests that the key permission validation works properly"""


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes [MOD-16047](https://redislabs.atlassian.net/browse/MOD-16047) for the 8.2 side of rolling-upgrade compatibility.

### Argument handling

- `_INDEX_PREFIXES`: already known by 8.2 and optional; no change needed.
- `_SLOTS_INFO`: not used by 8.2; consume and ignore the keyword plus binary payload from coordinators >=8.4.
- `_COORD_DISPATCH_TIME`: not used by 8.2; consume and ignore the keyword plus dispatch-time payload from coordinators >=8.6.

### Coverage

- Adds direct internal `_FT.SEARCH` / `_FT.AGGREGATE` coverage with `_SLOTS_INFO` and `_COORD_DISPATCH_TIME` present and ignored.
- No mixed-version cluster test is required for this PR.

#### Which additional issues this PR fixes
1. MOD-16047

#### Main objects this PR modified
1. `aggregate_request.c` - consume and ignore newer coordinator-injected internal args.
2. `test_acl.py` - direct internal-command coverage.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: An 8.2 shard no longer rejects internal queries from newer coordinators because of `_SLOTS_INFO` or `_COORD_DISPATCH_TIME`, allowing search to keep working during rolling upgrades.


[MOD-16047]: https://redislabs.atlassian.net/browse/MOD-16047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ