### PR TITLE
[MOD-16246] auto-backport agent: grant workflows permission for workflow-file backports

### DIFF
--- a/.github/workflows/task-backport_pr-agent-fix.yml
+++ b/.github/workflows/task-backport_pr-agent-fix.yml
@@ -25,7 +25,9 @@ on:
 
 # The default GITHUB_TOKEN stays read-only: every write (checkout, `gh`,
 # `git push`, PR comment) goes through the scoped App token minted below,
-# whose `permission-*` inputs carry the write grants.
+# whose `permission-*` inputs carry the write grants. That includes
+# `workflows: write`, so a fix commit touching .github/workflows/* can be
+# pushed (see the token step for the full rationale).
 permissions:
   contents: read
   actions: read
@@ -71,6 +73,11 @@ jobs:
           permission-contents: write       # push fix commits to the PR branch
           permission-pull-requests: write  # comment on the backport PR
           permission-actions: read         # read failed-run logs via gh api
+          # A fix commit that edits a file under .github/workflows/ produces a
+          # workflow blob GitHub will not let a `workflows`-less App push (see
+          # the create workflow's token step for the full rationale). Requires
+          # the redis-pr-app App itself to be granted the "Workflows" permission.
+          permission-workflows: write
 
       # Check out master first so the resolve script in
       # `scripts/auto_backport/` and the auto-fix prompt file in

--- a/.github/workflows/task-backport_pr-agent.yml
+++ b/.github/workflows/task-backport_pr-agent.yml
@@ -29,7 +29,10 @@ on:
 
 # The default GITHUB_TOKEN stays read-only: every write (checkout, `gh`,
 # `git push`, PR open/label/comment) goes through the scoped App token
-# minted below, whose `permission-*` inputs carry the write grants.
+# minted below, whose `permission-*` inputs carry the write grants. That
+# includes `workflows: write`, since a backport can re-merge a
+# .github/workflows/* file into a blob GitHub will not let a `workflows`-less
+# App push (see the token step for the full rationale).
 permissions:
   contents: read
 
@@ -99,6 +102,17 @@ jobs:
           # above (which only governs the unused default GITHUB_TOKEN).
           permission-contents: write       # push backport-agent/* branches
           permission-pull-requests: write  # open / label / comment on PRs
+          # A backport that re-merges a file under .github/workflows/ (e.g. a
+          # three-way auto-merge of task-backport_pr.yml onto a release branch
+          # whose copy has diverged from master) produces a workflow blob that
+          # does not already exist in the repo. GitHub then refuses the push from
+          # a GitHub App token unless it carries the `workflows` grant — even
+          # though `contents: write` would otherwise allow it, and even when the
+          # cherry-pick is clean. Clean-apply backports whose resulting workflow
+          # blobs match an existing one (e.g. onto a branch level with master) do
+          # not need this, but we cannot know that before pushing.
+          # `permission-*` can only attenuate the App's installed grants.
+          permission-workflows: write
 
       - name: Checkout master (with full history)
         uses: actions/checkout@v6


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The auto-backport agent mints a GitHub App token scoped to `contents: write` + `pull-requests: write` (the fix flow also `actions: read`). When a backport cherry-pick re-merges a file under `.github/workflows/` — e.g. a three-way auto-merge of `task-backport_pr.yml` onto a release branch whose copy has diverged from master — the resulting workflow blob does not already exist anywhere in the repo. GitHub then refuses the App's push with `refusing to allow a GitHub App to create or update workflow ... without 'workflows' permission`, even when the cherry-pick is otherwise clean and `contents: write` would allow it.

   This is exactly why backporting #9912 succeeded onto **8.8** (`#10070` — clean apply, resulting blob byte-identical to master's, which satisfies GitHub's carve-out for already-existing blobs) but was **rejected onto 8.6** (the diverged file forced an auto-merge that produced a novel blob). The agent caught the rejection, marked 8.6 `skipped`, and posted a summary, so the Actions job stayed green while no backport PR was created.

2. **Change:** Add `permission-workflows: write` to the `create-github-app-token` step in both `task-backport_pr-agent.yml` (create flow) and `task-backport_pr-agent-fix.yml` (fix flow), with comments explaining the novel-blob rule.

3. **Outcome:** Backports (and fix commits) that touch `.github/workflows/*` can be pushed by the agent.

> [!IMPORTANT]
> **Required operational step before this takes effect (org/App admin):** the `redis-pr-app` GitHub App must be granted the **Workflows** repository permission (Read and write). The `permission-*` inputs can only *attenuate* the App's installed grants — they cannot add to them — so this code change is inert until the App itself is granted Workflows.

**Tradeoff:** this widens the agent's standing privilege, so a mis-resolved or injected backport could alter CI workflow definitions on a `backport-agent/*` branch. Blast radius stays bounded: the bot still cannot merge, force-push, or push to protected release branches, and every backport PR still requires human review and merge.

#### Which additional issues this PR fixes
1. MOD-16246
2. Follow-up to MOD-15536 (#9912)

#### Main objects this PR modified
1. `.github/workflows/task-backport_pr-agent.yml`
2. `.github/workflows/task-backport_pr-agent-fix.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI/automation-only change with no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
