### PR TITLE
[MOD-15897] Trie - extract terms-trie logic into term_store.{c,h}

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -24,6 +24,7 @@
 #include "rmutil/util.h"
 #include "rmutil/rm_assert.h"
 #include "trie/trie.h"
+#include "term_store.h"
 #include "rmalloc.h"
 #include "config.h"
 #include "cursor.h"
@@ -501,7 +502,7 @@ size_t IndexSpec_collect_text_overhead(const IndexSpec *sp) {
   // Traverse the fields and calculates the overhead of the text suffixes
   size_t overhead = 0;
   // Collect overhead from sp->terms
-  overhead += TrieType_MemUsage(sp->terms);
+  overhead += TermStore_TermsMemUsage(sp->terms);
   // Collect overhead from sp->suffix
   if (sp->suffix) {
     // TODO: Count the values' memory as well
@@ -1928,11 +1929,10 @@ size_t IndexSpec_TotalBlockCount(IndexSpec *sp) {
 
 // Assuming the spec is properly locked for writing before calling this function.
 void IndexSpec_AddTerm(IndexSpec *sp, const char *term, size_t len) {
-  // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur
-  int isNew = Trie_InsertStringBuffer(sp->terms, (char *)term, len, 1, 1, NULL, 1);
-  if (isNew == TRIE_OK_NEW) {
+  size_t addedBytes;
+  if (TermStore_AddTerm(sp->terms, term, len, &addedBytes)) {
     sp->stats.scoring.numTerms++;
-    sp->stats.termsSize += len;
+    sp->stats.termsSize += addedBytes;
   }
 }
 
@@ -2399,7 +2399,7 @@ static void initializeIndexSpec(IndexSpec *sp, const HiddenString *name, IndexFl
   sp->stats.indexError = IndexError_Init();
 
   sp->fieldIdToIndex = array_new(t_fieldIndex, 0);
-  sp->terms = NewTrie(NULL, Trie_Sort_Lex);
+  sp->terms = TermStore_NewTermsTrie();
 
   IndexSpec_InitLock(sp);
   // First, initialise fields IndexError for every field
@@ -3560,7 +3560,7 @@ void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp, int contextFlags) {
   // assume it was not set in when the RDB will be loaded as well
   if (sp->diskSpec && storeDiskRdbData) {
     IndexScoringStats_RdbSave(rdb, &sp->stats.scoring);
-    TrieType_GenericSave(rdb, sp->terms, false, true);
+    TermStore_RdbSaveTerms(rdb, sp->terms);
     SearchDisk_IndexSpecRdbSave(rdb, sp->diskSpec);
   }
 
@@ -3689,7 +3689,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
     if (sp->terms) {
       TrieType_Free(sp->terms);
     }
-    sp->terms = TrieType_GenericLoad(rdb, false, true, Trie_Sort_Lex);
+    sp->terms = TermStore_RdbLoadTerms(rdb, true);
     RS_LOG_ASSERT(sp->terms, "Failed to load terms trie");
 
     // Load disk metadata (max_doc_id, deleted_ids) into the spec. Stashed
@@ -3841,13 +3841,13 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
   /* For version 3 or up - load the generic trie */
   if (encver >= 3) {
-    sp->terms = TrieType_GenericLoad(rdb, false, false, Trie_Sort_Lex);
+    sp->terms = TermStore_RdbLoadTerms(rdb, false);
     if (sp->terms == NULL) {
       StrongRef_Release(spec_ref);
       return NULL;
     }
   } else {
-    sp->terms = NewTrie(NULL, Trie_Sort_Lex);
+    sp->terms = TermStore_NewTermsTrie();
   }
 
   if (sp->flags & Index_HasCustomStopwords) {
@@ -4968,14 +4968,7 @@ void IndexSpec_ReleaseWriteLock(IndexSpec* sp) {
 // Returns true if the term was completely emptied and deleted from the trie.
 bool IndexSpec_DecrementTrieTermCount(IndexSpec* sp, const char* term, size_t term_len,
                                   size_t doc_count_decrement) {
-  if (!sp->terms || doc_count_decrement == 0) {
-    return false;
-  }
-  // Decrement the numDocs count for this term in the trie
-  // If numDocs reaches 0, the node will be deleted
-  TrieDecrResult result = Trie_DecrementNumDocs(sp->terms, term, term_len, doc_count_decrement);
-  RS_ASSERT(result != TRIE_DECR_NOT_FOUND);
-  return result == TRIE_DECR_DELETED;
+  return TermStore_DecrTerm(sp->terms, term, term_len, doc_count_decrement);
 }
 
 // Update IndexScoringStats based on compaction delta

--- a/src/term_store.c
+++ b/src/term_store.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+#include "term_store.h"
+
+#include "rmutil/rm_assert.h"
+
+Trie *TermStore_NewTermsTrie(void) {
+  return NewTrie(NULL, Trie_Sort_Lex);
+}
+
+bool TermStore_AddTerm(Trie *terms, const char *term, size_t len, size_t *addedBytes) {
+  // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur
+  int rc = Trie_InsertStringBuffer(terms, (char *)term, len, 1, 1, NULL, 1);
+  if (rc == TRIE_OK_NEW) {
+    *addedBytes = len;
+    return true;
+  }
+  return false;
+}
+
+bool TermStore_DecrTerm(Trie *terms, const char *term, size_t len, size_t decr) {
+  if (!terms || decr == 0) {
+    return false;
+  }
+  // Decrement the numDocs count for this term in the trie
+  // If numDocs reaches 0, the node will be deleted
+  TrieDecrResult result = Trie_DecrementNumDocs(terms, term, len, decr);
+  RS_ASSERT(result != TRIE_DECR_NOT_FOUND);
+  return result == TRIE_DECR_DELETED;
+}
+
+size_t TermStore_TermsMemUsage(const Trie *terms) {
+  return TrieType_MemUsage(terms);
+}
+
+void TermStore_RdbSaveTerms(RedisModuleIO *rdb, Trie *terms) {
+  TrieType_GenericSave(rdb, terms, false, true);
+}
+
+Trie *TermStore_RdbLoadTerms(RedisModuleIO *rdb, bool withNumDocs) {
+  return TrieType_GenericLoad(rdb, false, withNumDocs, Trie_Sort_Lex);
+}

--- a/src/term_store.h
+++ b/src/term_store.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+#ifndef TERM_STORE_H__
+#define TERM_STORE_H__
+
+#include "trie/trie.h"
+
+#include "redismodule.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Trie *TermStore_NewTermsTrie(void);
+
+bool TermStore_AddTerm(Trie *terms, const char *term, size_t len, size_t *addedBytes);
+
+bool TermStore_DecrTerm(Trie *terms, const char *term, size_t len, size_t decr);
+
+size_t TermStore_TermsMemUsage(const Trie *terms);
+
+void TermStore_RdbSaveTerms(RedisModuleIO *rdb, Trie *terms);
+
+Trie *TermStore_RdbLoadTerms(RedisModuleIO *rdb, bool withNumDocs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TERM_STORE_H__


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `spec.c` (~5000 lines) carries the full TEXT terms-trie lifecycle inline — creation, `AddTerm`, term-count decrement, memory accounting, and RDB save/load.
2. **Change**: Move that logic into a new dependency-light `term_store` module (depends only on `trie/trie.h`). `spec.c` now delegates through `TermStore_*`. The terms-trie stats (`numTerms`/`termsSize`) stay in `IndexSpec`: `TermStore_AddTerm` returns whether the term was new plus its byte length, and `spec.c` folds that into `sp->stats`.
3. **Outcome**: A cohesive seam around the terms trie, separable from the rest of the index spec. RDB behavior is preserved byte-for-byte: save uses `saveNumDocs=true`; the disk load path uses `withNumDocs=true` and the legacy (encver>=3) path uses `withNumDocs=false`, matching the prior call sites.

The suffix trie is deliberately left in `spec.c`/`suffix.c`: it is about to migrate behind the `TermSuffixIndex` FFI boundary, and terms and suffix will diverge in type at that point, so they are not bundled here.

#### Main objects this PR modified
1. `src/term_store.c`, `src/term_store.h` (new)
2. `src/spec.c`

#### Performance

  Benchmarked the only hot-path wrapper, `TermStore_AddTerm` (reached via   `IndexSpec_AddTerm` during indexing, gated to first-occurrence-per-term).   

Microbench: 50k distinct-term inserts, master-equivalent direct   `Trie_InsertStringBuffer` vs the wrapper, production build (`RelWithDebInfo`   `-O3`, no LTO), 20 reps, random-interleaved.

  | Path | Median CPU | cv |
  |---|---|---|
  | Direct insert (master-equiv) | 8.41 ms | 1.8% |
  | `TermStore_AddTerm` (this PR) | 8.35 ms | 2.0% |

  ~168 ns/insert on both; 0.7% delta with the wrapper nominally *faster* — i.e.   noise, inside each path's stddev. No measurable overhead; under LTO (prod/CI)   the wrapper inlines away entirely. No need to `static inline`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes