### PR TITLE
Spec - dedup suffix-trie enable into IndexSpec_EnableSuffixForField

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1512,7 +1512,7 @@ static bool validateDiskJsonSinglePath(const IndexSpec *sp, const FieldSpec *fs,
   return true;
 }
 
-static void IndexSpec_EnableSuffixForField(IndexSpec *sp, const FieldSpec *fs) {
+static void IndexSpec_EnsureSuffixForField(IndexSpec *sp, const FieldSpec *fs) {
   if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_HasSuffixTrie(fs)) {
     sp->suffixMask |= FIELD_BIT(fs);
     sp->flags |= Index_HasSuffixTrie;
@@ -1671,7 +1671,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     if (FieldSpec_IsPhonetics(fs)) {
       sp->flags |= Index_HasPhonetic;
     }
-    IndexSpec_EnableSuffixForField(sp, fs);
+    IndexSpec_EnsureSuffixForField(sp, fs);
   }
 
   // If we successfully modified the schema, we need to update the spec cache
@@ -3636,7 +3636,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
     if (FieldSpec_IsSortable(fs)) {
       sp->numSortableFields++;
     }
-    IndexSpec_EnableSuffixForField(sp, fs);
+    IndexSpec_EnsureSuffixForField(sp, fs);
   }
   // After loading all the fields, we can build the spec cache
   sp->spcache = IndexSpec_BuildSpecCache(sp);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1513,13 +1513,12 @@ static bool validateDiskJsonSinglePath(const IndexSpec *sp, const FieldSpec *fs,
 }
 
 static void IndexSpec_EnableSuffixForField(IndexSpec *sp, const FieldSpec *fs) {
-  if (!(FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_HasSuffixTrie(fs))) {
-    return;
-  }
-  sp->suffixMask |= FIELD_BIT(fs);
-  sp->flags |= Index_HasSuffixTrie;
-  if (!sp->suffix) {
-    sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
+  if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_HasSuffixTrie(fs)) {
+    sp->suffixMask |= FIELD_BIT(fs);
+    sp->flags |= Index_HasSuffixTrie;
+    if (!sp->suffix) {
+      sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
+    }
   }
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1512,6 +1512,17 @@ static bool validateDiskJsonSinglePath(const IndexSpec *sp, const FieldSpec *fs,
   return true;
 }
 
+static void IndexSpec_EnableSuffixForField(IndexSpec *sp, const FieldSpec *fs) {
+  if (!(FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_HasSuffixTrie(fs))) {
+    return;
+  }
+  sp->suffixMask |= FIELD_BIT(fs);
+  sp->flags |= Index_HasSuffixTrie;
+  if (!sp->suffix) {
+    sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
+  }
+}
+
 /**
  * Add fields to an existing (or newly created) index. If the addition fails,
  */
@@ -1661,13 +1672,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     if (FieldSpec_IsPhonetics(fs)) {
       sp->flags |= Index_HasPhonetic;
     }
-    if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_HasSuffixTrie(fs)) {
-      sp->suffixMask |= FIELD_BIT(fs);
-      if (!sp->suffix) {
-        sp->flags |= Index_HasSuffixTrie;
-        sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
-      }
-    }
+    IndexSpec_EnableSuffixForField(sp, fs);
   }
 
   // If we successfully modified the schema, we need to update the spec cache
@@ -3632,13 +3637,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
     if (FieldSpec_IsSortable(fs)) {
       sp->numSortableFields++;
     }
-    if (FieldSpec_HasSuffixTrie(fs) && FIELD_IS(fs, INDEXFLD_T_FULLTEXT)) {
-      sp->flags |= Index_HasSuffixTrie;
-      sp->suffixMask |= FIELD_BIT(fs);
-      if (!sp->suffix) {
-        sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
-      }
-    }
+    IndexSpec_EnableSuffixForField(sp, fs);
   }
   // After loading all the fields, we can build the spec cache
   sp->spcache = IndexSpec_BuildSpecCache(sp);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The field-add path and the RDB-load path each carried an identical inline block that, for a `WITHSUFFIXTRIE` TEXT field, set the suffix mask bit, set the `Index_HasSuffixTrie` flag, and lazily created the suffix trie.
2. **Change**: Collapse both into a single `static` helper `IndexSpec_EnableSuffixForField`.
3. **Outcome**: One chokepoint for enabling the suffix trie. This also prepares the imminent `TermSuffixIndex` FFI port: the `NewTrie(...)` call becomes `NewTermSuffixIndex()` in one place instead of two.

Behavior is unchanged: the flag ends up set iff at least one qualifying field exists, and the suffix trie is created once on the first such field. The two originals differed only in where they set the flag (inside vs outside the lazy-create guard), which produced the same end state.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified
1. `src/spec.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes