### PR TITLE
ci: document expected skipped runs on auto-backport agent workflows

### DIFF
--- a/.github/workflows/task-backport_pr-agent-fix.yml
+++ b/.github/workflows/task-backport_pr-agent-fix.yml
@@ -18,6 +18,13 @@ name: Fix CI failures on auto-backport PR (Codex agent)
 # relax) and removes the need for a once-per-PR throttle label.
 #
 # Behavior is defined by .github/codex/prompts/pr-backport-auto-fix.md.
+#
+# Expected "skipped" runs — this is normal, not a misconfiguration:
+#   GitHub creates a workflow run for EVERY comment (the `on:` trigger cannot
+#   filter on comment body) and only then evaluates the job `if:` below, so any
+#   comment that isn't `/backport-agent-fix` produces a run whose single job is
+#   skipped. These `issue_comment` skips live only in the Actions tab — they are
+#   never attached to a PR as a check and never block merging.
 
 on:
   issue_comment:

--- a/.github/workflows/task-backport_pr-agent.yml
+++ b/.github/workflows/task-backport_pr-agent.yml
@@ -20,6 +20,18 @@ name: Backport merged pull request (Codex agent)
 #
 # Behavior is defined by .github/codex/prompts/pr-backport-auto.md. This workflow
 # only resolves inputs, writes a small context file, and invokes Codex.
+#
+# Expected "skipped" runs — this is normal, not a misconfiguration:
+#   GitHub creates a workflow run for EVERY matching event and only then
+#   evaluates the job `if:` below. There is no `on:`-level filter for label
+#   name, comment body, or merged state, so any non-matching event (a label
+#   added to an unrelated PR, an ordinary comment, a closed-but-unmerged PR)
+#   produces a run whose single job is skipped. Skipped jobs report success and
+#   never block merging. The `issue_comment` skips live only in the Actions tab;
+#   the `pull_request_target: labeled` skips show as a grey check on the PR.
+#   Suppressing them entirely would mean dropping the `labeled` trigger (losing
+#   the "label an already-merged PR" auto-path, which `/backport-agent` already
+#   covers) — a deliberate trade-off we have chosen NOT to make here.
 
 on:
   pull_request_target:


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The agent-driven auto-backport workflows trigger on `pull_request_target` (`closed`, `labeled`) and `issue_comment` (`created`). GitHub creates a workflow run for **every** matching event and only then evaluates the job-level `if:`, so non-matching events (a label added to an unrelated PR, any ordinary comment, a closed-but-unmerged PR) surface as **"skipped"** runs. This looks like noise / a misconfiguration.
2. **Change:** Add explanatory notes above the `on:` block of both workflows describing exactly why the skipped runs appear and that they are harmless. No functional change to triggers or logic.
3. **Outcome:** The skipped runs are now documented as expected behavior. The notes also record the one real lever for suppressing the PR-attached skips (dropping the `labeled` trigger, whose use case `/backport-agent` already covers) as a deliberately-untaken trade-off.

Context on why this is documentation rather than a code fix:
- Skipped jobs report success and **never block merging**.
- There is no `on:`-level filter for label name, comment body, or merged state — gating only happens in the job `if:`, which is what produces the skipped status.
- The `issue_comment` skips live only in the Actions tab (never attached to a PR); only `pull_request_target: labeled` skips show as a grey check on the PR. The same per-comment behavior exists for the legacy manual backport flow (`task-backport_pr.yml`).

#### Which additional issues this PR fixes
_None._

#### Main objects this PR modified
1. `.github/workflows/task-backport_pr-agent.yml` — note above `on:`
2. `.github/workflows/task-backport_pr-agent-fix.yml` — note above `on:`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
