### PR TITLE
[MOD-16147] Expose default EF_RUNTIME in FT.INFO output

### DIFF
--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -196,6 +196,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
           REPLY_KVSTR("distance_metric", VecSimMetric_ToString(hnsw_params.metric));
           REPLY_KVINT("M", hnsw_params.M);
           REPLY_KVINT("ef_construction", hnsw_params.efConstruction);
+          REPLY_KVINT("ef_runtime", hnsw_params.efRuntime);
           if (fs->vectorOpts.diskCtx.indexName) {
             REPLY_KVSTR("rerank", fs->vectorOpts.diskCtx.rerank ? "true" : "false");
           }

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -55,6 +55,10 @@ def test_vecsim_info():
                      "dim": dim, "flags": []}
     additional_params = {"M": 12, "ef_construction": 100} if alg == "HNSW" else {}
     info_expected.update(additional_params)
+    # EF_RUNTIME is not set at creation here, so FT.INFO must report the default
+    # (HNSW_DEFAULT_EF_RT). FLAT has no EF_RUNTIME.
+    if alg == "HNSW":
+      info_expected["ef_runtime"] = 10
     # for each data type
     for type in ["FLOAT32", "FLOAT64"]:
       info_expected["data_type"] = type
@@ -74,6 +78,15 @@ def test_vecsim_info():
 
         # drop index
         env.expect('FT.DROPINDEX', 'idx').ok()
+
+  # A non-default EF_RUNTIME set at creation must be surfaced in FT.INFO. This is the incident
+  # scenario (MOD-16147): a CRDB member's index was recreated with a different ef_runtime than its
+  # peer, causing a latency mismatch that was invisible because FT.INFO did not expose the value.
+  env.expect('FT.CREATE', 'idx_efr', 'SCHEMA', 'vec', 'VECTOR', 'HNSW', 8,
+             'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'EF_RUNTIME', 200).ok()
+  info = env.executeCommand('ft.info', 'idx_efr')
+  env.assertEqual(info["attributes"][0]["ef_runtime"], 200)
+  env.expect('FT.DROPINDEX', 'idx_efr').ok()
 
 def test_numeric_info(env):
   env.cmd('ft.create', 'idx1', 'SCHEMA', 'n', 'numeric')

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -84,8 +84,11 @@ def test_vecsim_info():
   # peer, causing a latency mismatch that was invisible because FT.INFO did not expose the value.
   env.expect('FT.CREATE', 'idx_efr', 'SCHEMA', 'vec', 'VECTOR', 'HNSW', 8,
              'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'EF_RUNTIME', 200).ok()
-  info = env.executeCommand('ft.info', 'idx_efr')
-  env.assertEqual(info["attributes"][0]["ef_runtime"], 200)
+  # The non-default value must also survive an RDB save/reload (serialization round-trip), so it
+  # stays visible after a restart/replica load - the exact context of the CRDB incident.
+  for _ in env.reloadingIterator():
+    info = env.executeCommand('ft.info', 'idx_efr')
+    env.assertEqual(info["attributes"][0]["ef_runtime"], 200)
   env.expect('FT.DROPINDEX', 'idx_efr').ok()
 
 def test_numeric_info(env):

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -98,7 +98,8 @@ def testRDBCompatibility_vecsim():
           'dim', 2,
           'distance_metric', 'L2',
           'M', 16,
-          'ef_construction', 200
+          'ef_construction', 200,
+          'ef_runtime', 10
         ], [
           'identifier', 'flat_vec',
           'attribute', 'flat_vec',


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current**: HNSW vector fields carry a default `EF_RUNTIME` (set at `FT.CREATE`, overridable per query), but `FT.INFO` never exposed it. When an index was created with a non-default `EF_RUNTIME`, there was no way to read the effective value.
2. **Change**: Emit the stored `efRuntime` as `ef_runtime` in the HNSW field attributes of `FT.INFO`, next to the existing `M` / `ef_construction`. The field is always populated (defaulted to `HNSW_DEFAULT_EF_RT` at creation, overridden by a user-supplied `EF_RUNTIME`), so the reported value is the effective default.
3. **Outcome**: Customers and support can see an index's default `EF_RUNTIME` directly from `FT.INFO`. This makes per-member configuration drift visible — the exact gap behind the CRDB latency incident, where one Active-Active member was recreated with a different `ef_runtime` than its peer.

#### Which additional issues this PR fixes
1. MOD-16147
2. Incident context: ICM 788539131 (RCA: RED-196020 / RED-196529)

#### Main objects this PR modified
1. `src/info/info_command.c` — `fillReplyWithIndexInfo()`: emit `ef_runtime` for the TIERED+HNSW branch.
2. `tests/pytests/test_info.py` — `test_vecsim_info`: assert default (`10`) and a non-default (`200`) `ef_runtime` surface in `FT.INFO`.

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

API note: additive only — a new `ef_runtime` key in the HNSW field attributes of the `FT.INFO` reply. No existing field changed or removed. FLAT/SVS fields are unaffected (no `EF_RUNTIME`).

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

`FT.INFO` now reports the default `EF_RUNTIME` of HNSW vector fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
