### PR TITLE
[codex] Add interface compatibility review guidance

### DIFF
--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -228,13 +228,18 @@ Acceptable compatibility patterns:
 - Keep legacy aliases while supported callers may still use them.
 - Preserve prior internal execution paths when adding ACL checks, or prove the caller
   still runs under the intended user/context.
+- Add compatibility tests for changed producer/consumer pairs. Cover old producer to
+  new consumer and new producer to old consumer when both versions can coexist, or
+  document why one direction cannot happen.
 - Add focused before/after corpus tests for dependency changes that affect parsing,
   normalization, tokenization, sorting, matching, or serialization.
 - Version serialized data and retain old-version readers.
 
-When an interface is tightened, require tests or documented verification that old and
-new callers both work, or explicitly call out the change as breaking with its intended
-release and upgrade impact.
+When an interface is tightened, require automated tests for old and new forms, including
+mixed-version producer/consumer interaction when the system can run mixed versions. If
+automated mixed-version coverage is impractical, require a documented manual verification
+plan with exact versions and commands, or explicitly call out the change as breaking with
+its intended release and upgrade impact.
 
 #### 2k. PR description
 

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -195,7 +195,8 @@ that can trigger it.
 Treat every accepted input/output boundary as a compatibility contract. This includes
 public commands, internal commands, coordinator-to-shard commands, replication/restore
 commands, debug commands, cursor/profile/config subcommands, serialized payloads, RDB
-formats, RESP reply shapes, reducer inputs, and command registration metadata.
+formats, RESP reply shapes, reducer inputs, command registration metadata, and library
+behavior that affects accepted input or observable output.
 
 Internal commands count. A command being `_FT.*`, `FT._*`, proxy-filtered, debug-only,
 or not documented for users does not make incompatible changes safe.
@@ -214,6 +215,10 @@ Flag as blocking unless the PR has an explicit compatibility story when it:
 - Changes who can execute a command or access an index/keyspace, including ACL
   category changes, key-spec changes, user-context changes in `RedisModule_Call`, or
   newly added permission checks.
+- Changes or upgrades a dependency in a way that may alter parsing, normalization,
+  tokenization, case-folding, collation/sort order, matching, scoring, or
+  serialization behavior. For example, a Unicode library change can affect indexed
+  terms, query matching, and results for existing data.
 - Changes serialized formats without versioning and old-format readers.
 
 Acceptable compatibility patterns:
@@ -223,6 +228,8 @@ Acceptable compatibility patterns:
 - Keep legacy aliases while supported callers may still use them.
 - Preserve prior internal execution paths when adding ACL checks, or prove the caller
   still runs under the intended user/context.
+- Add focused before/after corpus tests for dependency changes that affect parsing,
+  normalization, tokenization, sorting, matching, or serialization.
 - Version serialized data and retain old-version readers.
 
 When an interface is tightened, require tests or documented verification that old and

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -201,8 +201,17 @@ behavior that affects accepted input or observable output.
 Internal commands count. A command being `_FT.*`, `FT._*`, proxy-filtered, debug-only,
 or not documented for users does not make incompatible changes safe.
 
+Review both backward and forward compatibility on every changed interface. Backward
+compatibility means new code can consume input, replies, or data produced by older
+supported versions. Forward compatibility means older supported consumers can tolerate
+what new producers send on mixed-version or independently upgraded paths. This usually
+requires keeping the old form until a version/capability gate allows the new form, or
+ensuring old consumers already ignore unknown optional fields.
+
 Flag as blocking unless the PR has an explicit compatibility story when it:
 - Adds a new mandatory argument, token, subcommand field, or serialized field.
+- Sends a new optional argument, token, reply element, or serialized field to a consumer
+  that may be old or independently upgraded and does not ignore unknown fields.
 - Makes an optional argument required.
 - Removes or renames an accepted command, alias, argument, token, reply field, or
   serialized field.

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -201,17 +201,22 @@ behavior that affects accepted input or observable output.
 Internal commands count. A command being `_FT.*`, `FT._*`, proxy-filtered, debug-only,
 or not documented for users does not make incompatible changes safe.
 
-Review both backward and forward compatibility on every changed interface. Backward
-compatibility means new code can consume input, replies, or data produced by older
-supported versions. Forward compatibility means older supported consumers can tolerate
-what new producers send on mixed-version or independently upgraded paths. This usually
-requires keeping the old form until a version/capability gate allows the new form, or
-ensuring old consumers already ignore unknown optional fields.
+Review mixed-version compatibility on every changed interface. New code must stay
+compatible with older supported versions in both roles:
+- As a consumer, new code must continue to accept input, replies, and persisted data
+  produced by older versions.
+- As a producer, new code must not send or write a new form to older supported consumers
+  unless the change is gated by version/capability negotiation, older consumers are
+  known to ignore it, or the upgrade path guarantees they cannot observe it.
+
+Do not assume that making a new field optional in the new parser is enough. If the new
+producer sends that field to an older parser that rejects unknown arguments, the change
+is still breaking.
 
 Flag as blocking unless the PR has an explicit compatibility story when it:
 - Adds a new mandatory argument, token, subcommand field, or serialized field.
 - Sends a new optional argument, token, reply element, or serialized field to a consumer
-  that may be old or independently upgraded and does not ignore unknown fields.
+  that may be an older supported version and is not known to ignore unknown fields.
 - Makes an optional argument required.
 - Removes or renames an accepted command, alias, argument, token, reply field, or
   serialized field.
@@ -237,9 +242,9 @@ Acceptable compatibility patterns:
 - Keep legacy aliases while supported callers may still use them.
 - Preserve prior internal execution paths when adding ACL checks, or prove the caller
   still runs under the intended user/context.
-- Add compatibility tests for changed producer/consumer pairs. Cover old producer to
-  new consumer and new producer to old consumer when both versions can coexist, or
-  document why one direction cannot happen.
+- Add compatibility tests for changed producer/consumer pairs. Cover new consumers with
+  old producer output and new producers against older supported consumers when both
+  versions can coexist, or document why one direction cannot happen.
 - Add focused before/after corpus tests for dependency changes that affect parsing,
   normalization, tokenization, sorting, matching, or serialization.
 - Version serialized data and retain old-version readers.

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -71,6 +71,10 @@ git diff origin/master...FETCH_HEAD -- '*.c' '*.h'
 Read the full source of every C file that was added or significantly modified so that you
 have complete context (not just the diff hunks).
 
+If the diff changes accepted input syntax, command registration, internal command
+construction, serialized formats, or reply shapes, inspect both the producer and
+consumer sides of that interface.
+
 **When reviewing source files or directories**, read the full source of every `.c` and `.h`
 file and review them in their entirety.
 
@@ -186,7 +190,46 @@ Check especially for:
 For any security-sensitive finding, state the concrete impact and the input or code path
 that can trigger it.
 
-#### 2j. PR description
+#### 2j. Interface and compatibility changes
+
+Treat every accepted input/output boundary as a compatibility contract. This includes
+public commands, internal commands, coordinator-to-shard commands, replication/restore
+commands, debug commands, cursor/profile/config subcommands, serialized payloads, RDB
+formats, RESP reply shapes, reducer inputs, and command registration metadata.
+
+Internal commands count. A command being `_FT.*`, `FT._*`, proxy-filtered, debug-only,
+or not documented for users does not make incompatible changes safe.
+
+Flag as blocking unless the PR has an explicit compatibility story when it:
+- Adds a new mandatory argument, token, subcommand field, or serialized field.
+- Makes an optional argument required.
+- Removes or renames an accepted command, alias, argument, token, reply field, or
+  serialized field.
+- Rejects input that was previously accepted.
+- Changes argument order, arity, parser strictness, type requirements, defaults, or
+  error behavior.
+- Changes RESP2/RESP3 reply shape consumed by another component.
+- Changes command registration names, aliases, key specs, ACL categories,
+  internal/proxy flags, or arity.
+- Changes who can execute a command or access an index/keyspace, including ACL
+  category changes, key-spec changes, user-context changes in `RedisModule_Call`, or
+  newly added permission checks.
+- Changes serialized formats without versioning and old-format readers.
+
+Acceptable compatibility patterns:
+- Accept both old and new forms during a transition period.
+- Parse new fields optionally and use fallback behavior when absent.
+- Gate new syntax by explicit version or capability negotiation.
+- Keep legacy aliases while supported callers may still use them.
+- Preserve prior internal execution paths when adding ACL checks, or prove the caller
+  still runs under the intended user/context.
+- Version serialized data and retain old-version readers.
+
+When an interface is tightened, require tests or documented verification that old and
+new callers both work, or explicitly call out the change as breaking with its intended
+release and upgrade impact.
+
+#### 2k. PR description
 
 Only applies when reviewing a PR (not files or commits directly):
 - Exactly one release notes checkbox is checked (`This PR requires release notes`


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The C code-review skill covers memory safety, threading, Redis Module API usage, security, and PR metadata, but does not explicitly require compatibility review for command and interface changes.
2. Change: Add interface compatibility review guidance that treats public commands, internal commands, serialized formats, reply shapes, command registration metadata, ACL changes, and key-spec changes as compatibility contracts.
3. Outcome: Reviewers should flag newly mandatory arguments, removed accepted inputs, tightened parsing, changed command registration, and permission changes unless the PR includes a compatibility story, fallback, versioning, or documented breaking-change impact.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `.skills/code-review/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
