### PR TITLE
MOD-15880: Disk - aggregate indexes total block count

### DIFF
--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -67,8 +67,7 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     info.total_active_write_threads += activeWrites;
     BGIndexerInProgress |= sp->scan_in_progress;
     info.total_num_docs_in_indexes += sp->stats.scoring.numDocuments;
-    info.total_inverted_index_blocks +=
-        __atomic_load_n(&sp->stats.totalInvertedIndexBlocks, __ATOMIC_RELAXED);
+    info.total_inverted_index_blocks += IndexSpec_TotalBlockCount(sp);
 
     // Index errors metrics
     size_t index_error_count = IndexSpec_GetIndexErrorCount(sp);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1921,6 +1921,11 @@ size_t IndexSpec_GetIndexErrorCount(const IndexSpec *sp) {
   return IndexError_ErrorCount(&sp->stats.indexError);
 }
 
+size_t IndexSpec_TotalBlockCount(IndexSpec *sp) {
+  return sp->diskSpec ? SearchDisk_GetInvertedIndexTotalBlocks(sp->diskSpec) 
+      : __atomic_load_n(&sp->stats.totalInvertedIndexBlocks, __ATOMIC_RELAXED);
+}
+
 // Assuming the spec is properly locked for writing before calling this function.
 void IndexSpec_AddTerm(IndexSpec *sp, const char *term, size_t len) {
   // Payload is NULL so TRIE_ERR_PAYLOAD_OVERFLOW cannot occur

--- a/src/spec.h
+++ b/src/spec.h
@@ -510,6 +510,9 @@ void IndexSpec_GetStats(IndexSpec *sp, RSIndexStats *stats);
 /* Get the number of indexing failures */
 size_t IndexSpec_GetIndexErrorCount(const IndexSpec *sp);
 
+/* Get the count of total blocks*/
+size_t IndexSpec_TotalBlockCount(IndexSpec *sp);
+
 /*
  * Parse an index spec from redis command arguments.
  * Returns REDISMODULE_ERR if there's a parsing error.


### PR DESCRIPTION
Add `IndexSpec_TotalBlockCount` to conditionally call `SearchDisk_GetInvertedIndexTotalBlocks` if the index is disk based.
This will allow INFO to output the total block count for all disk indexes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
