### PR TITLE
[8.8] [MOD-16047] tolerate missing internal query args

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -383,7 +383,9 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
     *papCtx->prefixesOffset = ac->offset - 1;
 
     ArgsCursor tmp = {0};
-    AC_GetVarArgs(ac, &tmp);
+    if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
+      RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
+    }
   } else if (AC_AdvanceIfMatch(ac, "BM25STD_TANH_FACTOR")) {
     if (AC_NumRemaining(ac) < 1) {
       QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Need an argument for BM25STD_TANH_FACTOR");

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1280,8 +1280,12 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   // Verify we got slots requested if needed
   if (IsInternal(req) && !req->querySlots) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_MISSING, "Internal query missing slots specification");
-    goto error;
+    // Coordinators older than 8.4 do not send a slots specification. Fall back to the
+    // current local slots so rolling upgrades across the 8.4 boundary keep working.
+    req->querySlots = ASM_FallbackToLocalSlots(ctx, &req->keySpaceVersion);
+    if (req->keySpaceVersion != INVALID_KEYSPACE_VERSION) {
+      ASM_KeySpaceVersionTracker_IncreaseQueryCount(req->keySpaceVersion);
+    }
   }
 
   // Define if we need a depleter in the pipeline to get accurate total results

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -383,9 +383,7 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
     *papCtx->prefixesOffset = ac->offset - 1;
 
     ArgsCursor tmp = {0};
-    if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
-      RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
-    }
+    AC_GetVarArgs(ac, &tmp);
   } else if (AC_AdvanceIfMatch(ac, "BM25STD_TANH_FACTOR")) {
     if (AC_NumRemaining(ac) < 1) {
       QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Need an argument for BM25STD_TANH_FACTOR");

--- a/src/asm_state_machine.h
+++ b/src/asm_state_machine.h
@@ -14,7 +14,6 @@
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
 #include <stdlib.h>
-#include <time.h>
 #include <pthread.h>
 
 // Sanitizer detection for leak tracking
@@ -268,12 +267,12 @@ static int ASM_AccountRequestFinished(uint32_t keySpaceVersion, size_t innerQuer
 static inline const RedisModuleSlotRangeArray *ASM_FallbackToLocalSlots(RedisModuleCtx *ctx,
                                                                         uint32_t *keySpaceVersion) {
   // Expected only while a rolling upgrade is in progress, but fires on every internal
-  // query for its duration - throttle to at most one log line per second.
-  static time_t lastLogged = 0;
-  time_t now = time(NULL);
-  time_t prev = __atomic_load_n(&lastLogged, __ATOMIC_RELAXED);
-  if (now != prev &&
-      __atomic_compare_exchange_n(&lastLogged, &prev, now, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+  // query for its duration - log the first occurrence and then every 100th to avoid
+  // flooding the log. Like the rest of this function (and the slots tracker access
+  // below), this runs on the main thread at query parse time, so the static counter
+  // needs no synchronization.
+  static uint64_t fallbackCount = 0;
+  if (fallbackCount++ % 100 == 0) {
     RedisModule_Log(ctx, "notice",
                     "Internal query received without " SLOTS_STR
                     " (sent by a coordinator older than 8.4?). "

--- a/src/asm_state_machine.h
+++ b/src/asm_state_machine.h
@@ -9,10 +9,12 @@
 #pragma once
 
 #include "slots_tracker.h"
+#include "slot_ranges.h"
 #include "util/khash.h"
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
 #include <stdlib.h>
+#include <time.h>
 #include <pthread.h>
 
 // Sanitizer detection for leak tracking
@@ -247,6 +249,44 @@ static int ASM_AccountRequestFinished(uint32_t keySpaceVersion, size_t innerQuer
     }
   }
   return REDISMODULE_OK;
+}
+
+/**
+ * Fallback for internal queries that arrived without a slots specification. Coordinators
+ * older than 8.4 predate the SLOTS_STR protocol argument, so during a rolling upgrade
+ * across the 8.4 boundary an old coordinator may still drive queries to this shard.
+ * Assume such queries target this shard's current local slots (the pre-8.4 semantics).
+ *
+ * Writes the captured keyspace version to `keySpaceVersion`. The caller is responsible for
+ * registering the query in the keyspace version tracker, exactly as it does for a
+ * coordinator-provided slots specification.
+ *
+ * @note Must be called from the slots tracker owner thread (main thread), like any other
+ * slots tracker access.
+ * @return The current local slots. The caller is responsible for freeing them with rm_free.
+ */
+static inline const RedisModuleSlotRangeArray *ASM_FallbackToLocalSlots(RedisModuleCtx *ctx,
+                                                                        uint32_t *keySpaceVersion) {
+  // Expected only while a rolling upgrade is in progress, but fires on every internal
+  // query for its duration - throttle to at most one log line per second.
+  static time_t lastLogged = 0;
+  time_t now = time(NULL);
+  time_t prev = __atomic_load_n(&lastLogged, __ATOMIC_RELAXED);
+  if (now != prev &&
+      __atomic_compare_exchange_n(&lastLogged, &prev, now, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+    RedisModule_Log(ctx, "notice",
+                    "Internal query received without " SLOTS_STR
+                    " (sent by a coordinator older than 8.4?). "
+                    "Falling back to the shard's current local slots");
+  }
+
+  RedisModuleSlotRangeArray *slots = slots_tracker_get_local_slots();
+  OptionSlotTrackerVersion version = slots_tracker_check_availability(slots);
+  // The local slots are trivially available (possibly with an unstable version during
+  // slot migrations, like any other query)
+  RS_LOG_ASSERT(version.is_some, "local slots must be available");
+  *keySpaceVersion = version.version;
+  return slots;
 }
 
 // END KEY SPACE VERSION QUERY TRACKER IMPLEMENTATION

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -133,19 +133,21 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
                              ARG_OPT_CALLBACK, handleIndexPrefixes, ctx,
                              ARG_OPT_END);
 
-        // Mandatory SLOTS_STR argument for internal requests
+        // SLOTS_STR argument for internal requests. Optional: coordinators older than 8.4
+        // do not send it, and the caller falls back to the current local slots (MOD-16047)
         ArgParser_AddSubArgsV(parser, SLOTS_STR, "Requested slots from coordinator",
                             &subArgs, 1, 1,
-                            ARG_OPT_REQUIRED,
+                            ARG_OPT_OPTIONAL,
                             ARG_OPT_CALLBACK, handleSlotsInfo, ctx,
                             ARG_OPT_END);
 
-        // Mandatory _COORD_DISPATCH_TIME argument for internal requests
+        // _COORD_DISPATCH_TIME argument for internal requests. Optional: coordinators older
+        // than 8.6 do not send it
         static_assert(sizeof(unsigned long long) == sizeof(rs_wall_clock_ns_t),
                       "rs_wall_clock_ns_t must be the same size as unsigned long long");
         ArgParser_AddULongLongV(parser, COORD_DISPATCH_TIME_STR, "Coordinator dispatch time",
                             (unsigned long long *)ctx->coordDispatchTime,
-                            ARG_OPT_REQUIRED,
+                            ARG_OPT_OPTIONAL,
                             ARG_OPT_END);
 
     }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -835,7 +835,11 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
 
   // Set slots info in both subqueries
   if (internal) {
-    RS_ASSERT(requestSlotRanges != NULL);
+    if (!requestSlotRanges) {
+      // Coordinators older than 8.4 do not send a slots specification. Fall back to the
+      // current local slots so rolling upgrades across the 8.4 boundary keep working.
+      requestSlotRanges = ASM_FallbackToLocalSlots(ctx, &keySpaceVersion);
+    }
     vectorRequest->querySlots = SlotRangeArray_Clone(requestSlotRanges);
     vectorRequest->keySpaceVersion = keySpaceVersion;
     if (vectorRequest->keySpaceVersion != INVALID_KEYSPACE_VERSION) {

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
@@ -336,17 +336,25 @@ pub unsafe extern "C" fn slots_tracker_get_local_slots() -> *mut SlotRangeArray 
             i32::try_from(local.len()).expect("local slot ranges count must fit in i32");
 
         let layout = local_slots_array_layout(local.len());
-        // SAFETY: layout has a non-zero size (it includes the num_ranges header)
+        // SAFETY: `layout` has a non-zero size (it includes the `num_ranges` header).
         let array = unsafe { std::alloc::alloc(layout) }.cast::<SlotRangeArray>();
         if array.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
 
-        // SAFETY: array points to a live allocation large enough for the header
-        // and `local.len()` ranges, per the layout above.
+        // SAFETY: `array` is a fresh, properly-aligned allocation for a SlotRangeArray
+        // header (per `layout`), so writing its `num_ranges` field is in bounds.
         unsafe {
-            (&raw mut (*array).num_ranges).write(num_ranges);
-            let ranges = (&raw mut (*array).ranges).cast::<SlotRange>();
+            (*array).num_ranges = num_ranges;
+        }
+
+        // SAFETY: `&raw mut` only computes the address of the trailing flexible array; the
+        // deref of `array` is sound because it points to the live allocation above.
+        let ranges = unsafe { &raw mut (*array).ranges }.cast::<SlotRange>();
+
+        // SAFETY: the allocation has room for `local.len()` ranges right after the header
+        // (per `layout`), and `local` cannot overlap the freshly allocated `array`.
+        unsafe {
             std::ptr::copy_nonoverlapping(local.as_ptr(), ranges, local.len());
         }
         array

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
@@ -332,8 +332,7 @@ pub unsafe extern "C" fn slots_tracker_has_fully_available_overlap(
 pub unsafe extern "C" fn slots_tracker_get_local_slots() -> *mut SlotRangeArray {
     with_tracker(|tracker| {
         let local = tracker.local_slot_ranges();
-        let num_ranges =
-            i32::try_from(local.len()).expect("local slot ranges count must fit in i32");
+        let num_ranges = local.len() as i32;
 
         let layout = local_slots_array_layout(local.len());
         // SAFETY: `layout` has a non-zero size (it includes the `num_ranges` header).

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
@@ -319,6 +319,48 @@ pub unsafe extern "C" fn slots_tracker_has_fully_available_overlap(
     with_tracker(|tracker| tracker.has_fully_available_overlap(ranges))
 }
 
+/// Returns the current local slot ranges as a newly allocated array.
+///
+/// The returned array is allocated with the Rust global allocator, which in the
+/// RediSearch module build forwards to `RedisModule_Alloc`. The caller owns the
+/// returned pointer and must free it with `RedisModule_Free` (`rm_free`).
+///
+/// # Safety
+///
+/// This function must be called from the main thread only.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slots_tracker_get_local_slots() -> *mut SlotRangeArray {
+    with_tracker(|tracker| {
+        let local = tracker.local_slot_ranges();
+        let num_ranges =
+            i32::try_from(local.len()).expect("local slot ranges count must fit in i32");
+
+        let layout = local_slots_array_layout(local.len());
+        // SAFETY: layout has a non-zero size (it includes the num_ranges header)
+        let array = unsafe { std::alloc::alloc(layout) }.cast::<SlotRangeArray>();
+        if array.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+
+        // SAFETY: array points to a live allocation large enough for the header
+        // and `local.len()` ranges, per the layout above.
+        unsafe {
+            (&raw mut (*array).num_ranges).write(num_ranges);
+            let ranges = (&raw mut (*array).ranges).cast::<SlotRange>();
+            std::ptr::copy_nonoverlapping(local.as_ptr(), ranges, local.len());
+        }
+        array
+    })
+}
+
+/// Computes the allocation layout of a `SlotRangeArray` holding `num_ranges` ranges.
+fn local_slots_array_layout(num_ranges: usize) -> std::alloc::Layout {
+    let (layout, _) = std::alloc::Layout::new::<SlotRangeArray>()
+        .extend(std::alloc::Layout::array::<SlotRange>(num_ranges).expect("layout overflow"))
+        .expect("layout overflow");
+    layout.pad_to_align()
+}
+
 /// Checks if all requested slots are available and returns version information.
 ///
 /// Return values (via OptionSlotTrackerVersion):

--- a/src/redisearch_rs/headers/slots_tracker.h
+++ b/src/redisearch_rs/headers/slots_tracker.h
@@ -134,6 +134,19 @@ void slots_tracker_remove_deleted_slots(const RedisModuleSlotRangeArray *ranges)
 bool slots_tracker_has_fully_available_overlap(const RedisModuleSlotRangeArray *ranges);
 
 /**
+ * Returns the current local slot ranges as a newly allocated array.
+ *
+ * The returned array is allocated with the Rust global allocator, which in the
+ * RediSearch module build forwards to `RedisModule_Alloc`. The caller owns the
+ * returned pointer and must free it with `RedisModule_Free` (`rm_free`).
+ *
+ * # Safety
+ *
+ * This function must be called from the main thread only.
+ */
+struct RedisModuleSlotRangeArray *slots_tracker_get_local_slots(void);
+
+/**
  * Checks if all requested slots are available and returns version information.
  *
  * Return values (via OptionSlotTrackerVersion):

--- a/src/redisearch_rs/headers/slots_tracker.h
+++ b/src/redisearch_rs/headers/slots_tracker.h
@@ -144,7 +144,7 @@ bool slots_tracker_has_fully_available_overlap(const RedisModuleSlotRangeArray *
  *
  * This function must be called from the main thread only.
  */
-struct RedisModuleSlotRangeArray *slots_tracker_get_local_slots(void);
+RedisModuleSlotRangeArray *slots_tracker_get_local_slots(void);
 
 /**
  * Checks if all requested slots are available and returns version information.

--- a/src/redisearch_rs/slots_tracker/src/slot_set.rs
+++ b/src/redisearch_rs/slots_tracker/src/slot_set.rs
@@ -170,6 +170,11 @@ impl SlotSet {
         self.ranges.is_empty()
     }
 
+    /// Returns the ranges of this set as a sorted, normalized slice.
+    pub(crate) fn as_ranges(&self) -> &[SlotRange] {
+        &self.ranges
+    }
+
     /// Checks the relationship between this set and input ranges in a single pass.
     ///
     /// Returns `CoverageRelation` indicating: `Equals`, `Covers`, or `NoMatch`.

--- a/src/redisearch_rs/slots_tracker/src/slots_tracker.rs
+++ b/src/redisearch_rs/slots_tracker/src/slots_tracker.rs
@@ -121,6 +121,11 @@ impl SlotsTracker {
         self.version
     }
 
+    /// Returns the local responsibility slot ranges as a sorted, normalized slice.
+    pub fn local_slot_ranges(&self) -> &[SlotRange] {
+        self.local.as_ranges()
+    }
+
     /// Increments the version counter using wrapping arithmetic.
     ///
     /// The version should be incremented whenever slots *become* partially available.
@@ -339,6 +344,35 @@ mod tests {
         assert_eq!(
             tracker,
             ([(0, 100)], [], [], Some(initial_version.increment()))
+        );
+    }
+
+    #[test]
+    fn test_local_slot_ranges_reflects_local_set() {
+        let mut tracker = SlotsTracker::new();
+        // A new tracker owns the full slot range
+        assert_eq!(
+            tracker.local_slot_ranges(),
+            &[SlotRange { start: 0, end: 16383 }]
+        );
+
+        tracker.set_local_slots(&[
+            SlotRange { start: 0, end: 100 },
+            SlotRange { start: 200, end: 300 },
+        ]);
+        assert_eq!(
+            tracker.local_slot_ranges(),
+            &[
+                SlotRange { start: 0, end: 100 },
+                SlotRange { start: 200, end: 300 },
+            ]
+        );
+
+        // Migrated-away slots are no longer local
+        tracker.mark_fully_available_slots(&[SlotRange { start: 200, end: 300 }]);
+        assert_eq!(
+            tracker.local_slot_ranges(),
+            &[SlotRange { start: 0, end: 100 }]
         );
     }
 

--- a/src/redisearch_rs/slots_tracker/src/slots_tracker.rs
+++ b/src/redisearch_rs/slots_tracker/src/slots_tracker.rs
@@ -353,23 +353,35 @@ mod tests {
         // A new tracker owns the full slot range
         assert_eq!(
             tracker.local_slot_ranges(),
-            &[SlotRange { start: 0, end: 16383 }]
+            &[SlotRange {
+                start: 0,
+                end: 16383
+            }]
         );
 
         tracker.set_local_slots(&[
             SlotRange { start: 0, end: 100 },
-            SlotRange { start: 200, end: 300 },
+            SlotRange {
+                start: 200,
+                end: 300,
+            },
         ]);
         assert_eq!(
             tracker.local_slot_ranges(),
             &[
                 SlotRange { start: 0, end: 100 },
-                SlotRange { start: 200, end: 300 },
+                SlotRange {
+                    start: 200,
+                    end: 300
+                },
             ]
         );
 
         // Migrated-away slots are no longer local
-        tracker.mark_fully_available_slots(&[SlotRange { start: 200, end: 300 }]);
+        tracker.mark_fully_available_slots(&[SlotRange {
+            start: 200,
+            end: 300,
+        }]);
         assert_eq!(
             tracker.local_slot_ranges(),
             &[SlotRange { start: 0, end: 100 }]

--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -772,10 +772,28 @@ def test_slots_info_errors(env: Env):
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC', 'SORTABLE').ok()
     env.expect('DEBUG', 'MARK-INTERNAL-CLIENT').ok()
 
-    env.expect('_FT.SEARCH', 'idx', '*').error().contains('Internal query missing slots specification')
     env.expect('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', 'invalid_slots_data').error().contains('Failed to deserialize _SLOTS_INFO data')
     env.expect('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', generate_slots(range(0, 0)), '_SLOTS_INFO', generate_slots(range(0, 0))).error().contains('_SLOTS_INFO already specified')
     env.expect('_FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@n', '$BLOB', '_SLOTS_INFO', generate_slots(range(0, 0)), '_SLOTS_INFO', generate_slots(range(0, 0)), 'PARAMS', '2', 'BLOB', b'\x00\x00\x00\x00').error().contains('_SLOTS_INFO: Argument specified multiple times')
+
+
+@skip(cluster=True)
+def test_missing_slots_info_fallback(env: Env):
+    """Internal queries that arrive without _SLOTS_INFO (as sent by coordinators older
+    than 8.4) must not fail; the shard falls back to its current local slots (MOD-16047)."""
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC', 'SORTABLE').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc:1', 'n', '1')
+    env.expect('DEBUG', 'MARK-INTERNAL-CLIENT').ok()
+
+    # _FT.SEARCH without _SLOTS_INFO falls back to the local slots and returns results
+    res = env.cmd('_FT.SEARCH', 'idx', '*')
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], 'doc:1')
+
+    # Same for _FT.AGGREGATE
+    res = env.cmd('_FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n')
+    env.assertEqual(res[1:], [['n', '1']])
 
 
 def info_modules_to_dict(conn):

--- a/tests/pytests/test_hybrid_internal.py
+++ b/tests/pytests/test_hybrid_internal.py
@@ -245,12 +245,13 @@ def test_hybrid_internal_without_coord_dispatch_time(env):
     setup_hybrid_test_data(env)
 
     query_vec = create_np_array_typed([0.0, 0.0], 'FLOAT32')
-    query = ('_FT.HYBRID', 'idx', 'SEARCH', '@description:running',
-             'VSIM', '@embedding', '$BLOB',
-             'WITHCURSOR', '_SLOTS_INFO', generate_slots(),
-             'PARAMS', '2', 'BLOB', query_vec.tobytes())
 
-    for shard_id, _ in get_shard_slot_ranges(env):
+    for shard_id, slots_data in get_shard_slot_ranges(env):
+        query = ('_FT.HYBRID', 'idx', 'SEARCH', '@description:running',
+                 'VSIM', '@embedding', '$BLOB',
+                 'WITHCURSOR', '_SLOTS_INFO', slots_data,
+                 'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
         if env.isCluster():
             shard_conn = env.getConnection(shardId=shard_id)
             shard_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')

--- a/tests/pytests/test_hybrid_internal.py
+++ b/tests/pytests/test_hybrid_internal.py
@@ -239,6 +239,30 @@ def test_hybrid_internal_without_slots_info(env):
         env.assertIn('SEARCH', result_dict)
 
 
+def test_hybrid_internal_without_coord_dispatch_time(env):
+    """_FT.HYBRID without _COORD_DISPATCH_TIME (as sent by coordinators older than 8.6)
+    must not fail."""
+    setup_hybrid_test_data(env)
+
+    query_vec = create_np_array_typed([0.0, 0.0], 'FLOAT32')
+    query = ('_FT.HYBRID', 'idx', 'SEARCH', '@description:running',
+             'VSIM', '@embedding', '$BLOB',
+             'WITHCURSOR', '_SLOTS_INFO', generate_slots(),
+             'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+    for shard_id, _ in get_shard_slot_ranges(env):
+        if env.isCluster():
+            shard_conn = env.getConnection(shardId=shard_id)
+            shard_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
+            result = shard_conn.execute_command(*query)
+        else:
+            result = env.cmd(*query)
+
+        result_dict = to_dict(remove_warnings(result))
+        env.assertIn('VSIM', result_dict)
+        env.assertIn('SEARCH', result_dict)
+
+
 def test_hybrid_internal_with_count_parameter(env):
     """Test _FT.HYBRID with WITHCURSOR and COUNT parameter"""
     setup_hybrid_test_data(env)

--- a/tests/pytests/test_hybrid_internal.py
+++ b/tests/pytests/test_hybrid_internal.py
@@ -215,6 +215,7 @@ def test_basic_hybrid_internal_withcursor(env):
         env.assertTrue(isinstance(search_cursor, (int, str)))
 
 
+@skip(cluster=True)
 def test_hybrid_internal_without_slots_info(env):
     """_FT.HYBRID without _SLOTS_INFO and _COORD_DISPATCH_TIME (as sent by older
     coordinators) must not fail; the shard falls back to its local slots (MOD-16047)."""
@@ -225,43 +226,29 @@ def test_hybrid_internal_without_slots_info(env):
              'VSIM', '@embedding', '$BLOB',
              'WITHCURSOR', 'PARAMS', '2', 'BLOB', query_vec.tobytes())
 
-    for shard_id, _ in get_shard_slot_ranges(env):
-        if env.isCluster():
-            shard_conn = env.getConnection(shardId=shard_id)
-            shard_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
-            result = shard_conn.execute_command(*query)
-        else:
-            result = env.cmd(*query)
-
-        # Should return a map with VSIM and SEARCH cursor IDs, like a fully-specified query
-        result_dict = to_dict(remove_warnings(result))
-        env.assertIn('VSIM', result_dict)
-        env.assertIn('SEARCH', result_dict)
+    # Should return a map with VSIM and SEARCH cursor IDs, like a fully-specified query
+    result = env.cmd(*query)
+    result_dict = to_dict(remove_warnings(result))
+    env.assertIn('VSIM', result_dict)
+    env.assertIn('SEARCH', result_dict)
 
 
+@skip(cluster=True)
 def test_hybrid_internal_without_coord_dispatch_time(env):
     """_FT.HYBRID without _COORD_DISPATCH_TIME (as sent by coordinators older than 8.6)
     must not fail."""
     setup_hybrid_test_data(env)
 
     query_vec = create_np_array_typed([0.0, 0.0], 'FLOAT32')
+    query = ('_FT.HYBRID', 'idx', 'SEARCH', '@description:running',
+             'VSIM', '@embedding', '$BLOB',
+             'WITHCURSOR', '_SLOTS_INFO', generate_slots(),
+             'PARAMS', '2', 'BLOB', query_vec.tobytes())
 
-    for shard_id, slots_data in get_shard_slot_ranges(env):
-        query = ('_FT.HYBRID', 'idx', 'SEARCH', '@description:running',
-                 'VSIM', '@embedding', '$BLOB',
-                 'WITHCURSOR', '_SLOTS_INFO', slots_data,
-                 'PARAMS', '2', 'BLOB', query_vec.tobytes())
-
-        if env.isCluster():
-            shard_conn = env.getConnection(shardId=shard_id)
-            shard_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
-            result = shard_conn.execute_command(*query)
-        else:
-            result = env.cmd(*query)
-
-        result_dict = to_dict(remove_warnings(result))
-        env.assertIn('VSIM', result_dict)
-        env.assertIn('SEARCH', result_dict)
+    result = env.cmd(*query)
+    result_dict = to_dict(remove_warnings(result))
+    env.assertIn('VSIM', result_dict)
+    env.assertIn('SEARCH', result_dict)
 
 
 def test_hybrid_internal_with_count_parameter(env):

--- a/tests/pytests/test_hybrid_internal.py
+++ b/tests/pytests/test_hybrid_internal.py
@@ -215,6 +215,30 @@ def test_basic_hybrid_internal_withcursor(env):
         env.assertTrue(isinstance(search_cursor, (int, str)))
 
 
+def test_hybrid_internal_without_slots_info(env):
+    """_FT.HYBRID without _SLOTS_INFO and _COORD_DISPATCH_TIME (as sent by older
+    coordinators) must not fail; the shard falls back to its local slots (MOD-16047)."""
+    setup_hybrid_test_data(env)
+
+    query_vec = create_np_array_typed([0.0, 0.0], 'FLOAT32')
+    query = ('_FT.HYBRID', 'idx', 'SEARCH', '@description:running',
+             'VSIM', '@embedding', '$BLOB',
+             'WITHCURSOR', 'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+    for shard_id, _ in get_shard_slot_ranges(env):
+        if env.isCluster():
+            shard_conn = env.getConnection(shardId=shard_id)
+            shard_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
+            result = shard_conn.execute_command(*query)
+        else:
+            result = env.cmd(*query)
+
+        # Should return a map with VSIM and SEARCH cursor IDs, like a fully-specified query
+        result_dict = to_dict(remove_warnings(result))
+        env.assertIn('VSIM', result_dict)
+        env.assertIn('SEARCH', result_dict)
+
+
 def test_hybrid_internal_with_count_parameter(env):
     """Test _FT.HYBRID with WITHCURSOR and COUNT parameter"""
     setup_hybrid_test_data(env)


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes [MOD-16047](https://redislabs.atlassian.net/browse/MOD-16047) for 8.8 rolling-upgrade compatibility.

### Argument handling

- `_INDEX_PREFIXES`: already known by this branch and optional; no change needed.
- `_SLOTS_INFO`: known by this branch and now optional via the receiver-side local-slots fallback, so coordinators older than 8.4 can drive this shard.
- `_COORD_DISPATCH_TIME`: known by this branch and optional for `_FT.HYBRID`, so coordinators older than 8.6 can drive this shard.

### Coverage

- Adds direct internal `_FT.HYBRID` coverage with `_SLOTS_INFO` present and `_COORD_DISPATCH_TIME` omitted.
- Keeps the direct internal missing-`_SLOTS_INFO` fallback coverage from the shared receiver-side fix.
- No mixed-version cluster test is required for this PR.

#### Which additional issues this PR fixes
1. MOD-16047

#### Main objects this PR modified
1. `hybrid_optional_args.c` / `parse_hybrid.c` / `aggregate_request.c` - internal args are optional where this branch understands them.
2. `slots_tracker` FFI - exposes local slots for fallback when `_SLOTS_INFO` is missing.
3. `test_hybrid_internal.py` / `test_asm.py` - direct internal-command coverage.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: RediSearch shards can continue serving internal search queries during rolling upgrades when coordinators and shards temporarily disagree on internal query arguments.

[MOD-16047]: https://redislabs.atlassian.net/browse/MOD-16047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ