### PR TITLE
[2.8] [MOD-16047] ignore newer internal query args

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -325,9 +325,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     // _INDEX_PREFIXES <count> <prefix...>. This version does not use it, but must
     // consume it so newer coordinators can drive this shard during rolling upgrades.
     ArgsCursor tmp = {0};
-    if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
-      RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
-    }
+    AC_GetVarArgs(ac, &tmp);
   } else if (IsInternal(req) && AC_AdvanceIfMatch(ac, "_SLOTS_INFO")) {
     // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.4 append
     // _SLOTS_INFO <binary>. Consume and ignore the opaque payload.

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -320,6 +320,22 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     if (parseValueFormat(&req->reqflags, ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
+  } else if (IsInternal(req) && AC_AdvanceIfMatch(ac, "_INDEX_PREFIXES")) {
+    // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.0 append
+    // _INDEX_PREFIXES <count> <prefix...>. This version does not use it, but must
+    // consume it so newer coordinators can drive this shard during rolling upgrades.
+    ArgsCursor tmp = {0};
+    if (AC_GetVarArgs(ac, &tmp) != AC_OK) {
+      RS_LOG_ASSERT(false, "Bad arguments for _INDEX_PREFIXES (coordinator)");
+    }
+  } else if (IsInternal(req) && AC_AdvanceIfMatch(ac, "_SLOTS_INFO")) {
+    // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.4 append
+    // _SLOTS_INFO <binary>. Consume and ignore the opaque payload.
+    AC_Advance(ac);
+  } else if (IsInternal(req) && AC_AdvanceIfMatch(ac, "_COORD_DISPATCH_TIME")) {
+    // Forward compatibility (MOD-16047): coordinators on RediSearch >= 8.6 append
+    // _COORD_DISPATCH_TIME <ns>. Consume and ignore the payload.
+    AC_Advance(ac);
   } else {
     return ARG_UNKNOWN;
   }

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4135,6 +4135,20 @@ def test_internal_commands(env):
         fail_eval_call(r, env, ['SEARCH.CLUSTERREFRESH'])
         fail_eval_call(r, env, ['SEARCH.CLUSTERINFO'])
 
+@skip(cluster=False)
+def test_internal_protocol_args_ignored(env):
+    """Forward compatibility (MOD-16047): newer coordinators inject internal
+    arguments that this branch does not use, but old shards must consume them."""
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+
+    prefixes = ('_INDEX_PREFIXES', '1', 'doc:')
+    slots_info = ('_SLOTS_INFO', b'\x01\x00\x00\x00\x00\x00\xff\x3f')
+    dispatch_time = ('_COORD_DISPATCH_TIME', '1000000')
+
+    env.expect('_FT.SEARCH', 'idx', '*', *prefixes, *slots_info, *dispatch_time).noError()
+    env.expect('_FT.AGGREGATE', 'idx', '*', *prefixes, *slots_info, *dispatch_time,
+               'LOAD', '1', '@n').noError()
+
 def test_timeout_non_strict_policy(env):
     """Tests that we get the wanted behavior for the non-strict timeout policy.
     `ON_TIMEOUT RETURN` - return partial results.

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4138,16 +4138,23 @@ def test_internal_commands(env):
 @skip(cluster=False)
 def test_internal_protocol_args_ignored(env):
     """Forward compatibility (MOD-16047): newer coordinators inject internal
-    arguments that this branch does not use, but old shards must consume them."""
+    arguments that this branch does not use.
+
+    During rolling upgrades, 2.x shards can receive internal arguments appended by
+    newer coordinators. The shard must consume and ignore those arguments, and the
+    command reply must keep the same structure as a normal local shard reply.
+    """
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    env.expect('HSET', 'doc:1', 'n', '1').equal(1)
 
     prefixes = ('_INDEX_PREFIXES', '1', 'doc:')
     slots_info = ('_SLOTS_INFO', b'\x01\x00\x00\x00\x00\x00\xff\x3f')
     dispatch_time = ('_COORD_DISPATCH_TIME', '1000000')
 
-    env.expect('_FT.SEARCH', 'idx', '*', *prefixes, *slots_info, *dispatch_time).noError()
-    env.expect('_FT.AGGREGATE', 'idx', '*', *prefixes, *slots_info, *dispatch_time,
-               'LOAD', '1', '@n').noError()
+    env.expect('_FT.SEARCH', 'idx', '*', 'RETURN', '1', 'n', *prefixes, *slots_info,
+               *dispatch_time).equal([1, 'doc:1', ['n', '1']])
+    env.expect('_FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n', *prefixes, *slots_info,
+               *dispatch_time).equal([1, ['n', '1']])
 
 def test_timeout_non_strict_policy(env):
     """Tests that we get the wanted behavior for the non-strict timeout policy.


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes [MOD-16047](https://redislabs.atlassian.net/browse/MOD-16047) for 2.8 rolling-upgrade compatibility.

### Argument handling

- `_INDEX_PREFIXES`: not known by 2.8; consume and ignore the count-prefixed payload from coordinators >=8.0.
- `_SLOTS_INFO`: not known by 2.8; consume and ignore the single binary payload from coordinators >=8.4.
- `_COORD_DISPATCH_TIME`: not known by 2.8; consume and ignore the single dispatch-time payload from coordinators >=8.6.

### Coverage

- Adds a cluster-only direct internal `_FT.SEARCH` / `_FT.AGGREGATE` test that passes all three injected args and verifies they are accepted.
- No mixed-version cluster test is required for this PR.

#### Which additional issues this PR fixes
1. MOD-16047

#### Main objects this PR modified
1. `aggregate_request.c` - consume and ignore the three newer coordinator-injected internal args.
2. `test.py` - direct internal-command coverage.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: Older RediSearch shards no longer reject internal queries from newer coordinators during rolling upgrades solely because of newer internal protocol arguments.

[MOD-16047]: https://redislabs.atlassian.net/browse/MOD-16047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ