### PR TITLE
[8.10] Adapt CI for release branch

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,9 +15,15 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
+    # TODO: Switch to the latest 8.10 release/pre-release line once it is ready.
+    runs-on: ubuntu-slim
+    outputs:
+      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
+    steps:
+      - run: echo "Dummy step to set output"
+    # uses: ./.github/workflows/task-get-latest-tag.yml
+    # with:
+    #   repo: redis/redis
 
   lint:
     permissions:
@@ -31,8 +37,10 @@ jobs:
       compare-advisories-to-base: true
       advisories-base-ref: ${{ github.event.merge_group.base_sha }}
 
-  build-unique-oses:
-    needs: get-latest-redis-tag
+  test-matrix:
+    # MQ is the 8.10 release gate, so run the full supported matrix with full tests.
+    needs: [get-latest-redis-tag, lint]
+    if: ${{ !cancelled() && !failure() }}
     permissions:
       contents: read
       packages: write
@@ -41,37 +49,20 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'macos-26,alpine:3.23,intel'
+      platform: all
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      options: skip-tests,fail-fast
-      rejson-branch: master
-
-  test-ubuntu:
-    # Always run tests for merge queue submissions, including text-only PRs.
-    needs: get-latest-redis-tag
-    permissions:
-      contents: read
-      packages: write
-      id-token: write # OIDC role assumption for sccache S3 (used inside task-test.yml)
-      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside task-test.yml)
-    uses: ./.github/workflows/flow-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:noble
-      architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
-      options: unit-tests,coordinator,standalone,rejson,fail-fast
+      job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,fail-fast,sanitize' }}
       separate-coordinator-job: true
+      # TODO: Switch to '8.10' once RedisJSON has a matching release branch.
       rejson-branch: master
 
   pr-validation:
     needs:
       - get-latest-redis-tag
       - lint
-      - build-unique-oses
-      - test-ubuntu
+      - test-matrix
     runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -28,10 +28,8 @@ jobs:
     with:
       platform: all
       architecture: all
-      # Track unstable so nightly catches upstream Redis breakage; PR/merge
-      # CI uses the latest release.
-      redis-ref: unstable
-      job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
+      redis-ref: 3cd464263b03b425ffae2e23db24df3dc9346871
+      job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
       rejson-branch: master
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,9 +12,12 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
+    # TODO: Switch to the latest 8.10 release/pre-release line once it is ready.
+    runs-on: ubuntu-slim
+    outputs:
+      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
+    steps:
+      - run: echo "Dummy step to set output"
 
   check-what-changed:
     uses: ./.github/workflows/task-check-changes.yml
@@ -41,8 +44,9 @@ jobs:
     uses: ./.github/workflows/generate-basic-matrix.yml
     with:
       include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
-      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
-      include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
+      # Keep version-branch PRs lightweight: coverage/sanitize are label-forced and draft-skipped.
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
+      include-sanitize: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
       separate-coordinator-job: true
 
   test-matrix:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -44,7 +44,8 @@ jobs:
     uses: ./.github/workflows/generate-basic-matrix.yml
     with:
       include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
-      # Keep version-branch PRs lightweight: coverage/sanitize are label-forced and draft-skipped.
+      # Keep version-branch PRs lightweight: coverage/sanitize are label-conditioned
+      # and run only when a non-draft PR workflow event sees enforce:coverage/enforce:sanitize.
       include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:coverage') }}
       include-sanitize: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
       separate-coordinator-job: true

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1901,7 +1901,7 @@ def test_create_multi_value_json():
 def test_index_multi_value_json():
     # Flaky under coverage (MOD-15571); skip only on coverage runs until the date below.
     if CODE_COVERAGE:
-        skipTestUntil("2026-06-12", reason="Flaky test under coverage, see MOD-15571")
+        skipTestUntil("2026-07-15", reason="Flaky test under coverage, see MOD-15571")
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
     dim = 4


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The new 8.10 branch inherited master CI behavior, where merge queue is optimized as a reduced master gate.
2. Change: Adapt 8.10 PR, merge queue, and nightly workflows to the release-branch pattern: pinned Redis, lightweight PR coverage/sanitize, full-matrix/full-test merge queue, and QUICK nightly.
3. Outcome: 8.10 gets the stricter release merge queue while keeping nightly less critical than master.

#### Which additional issues this PR fixes
1. N/A

#### Also Related to #9575

#### Main objects this PR modified
1. .github/workflows/event-merge-to-queue.yml
2. .github/workflows/event-pull_request.yml
3. .github/workflows/event-nightly.yml

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.