### PR TITLE
[MOD-16145] FT.HYBRID: bound the cursor-setup wait with a channel timeout

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -217,6 +217,17 @@ static inline void RequestSyncCtx_Init(RequestSyncCtx *ctx) {
   pthread_mutex_init(&ctx->abortWakeLock, NULL);
 }
 
+// Canonical accessors for syncCtx.timedOut; AREQ_* and HybridRequest_* delegate here.
+static inline bool RequestSyncCtx_GetTimedOut(RequestSyncCtx *ctx) {
+  return RS_AtomicBoolLoadRelaxed(&ctx->timedOut);
+}
+static inline void RequestSyncCtx_SetTimedOut(RequestSyncCtx *ctx) {
+  RS_AtomicBoolStoreRelaxed(&ctx->timedOut, true);
+}
+static inline void RequestSyncCtx_ClearTimedOut(RequestSyncCtx *ctx) {
+  RS_AtomicBoolStoreRelaxed(&ctx->timedOut, false);
+}
+
 // Release resources owned by a RequestSyncCtx. Must be called exactly once
 // per successful Init, from the request's free path.
 static inline void RequestSyncCtx_Destroy(RequestSyncCtx *ctx) {
@@ -565,10 +576,10 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
 static inline bool AREQ_TimedOut(AREQ *req) {
-  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
+  return RequestSyncCtx_GetTimedOut(&req->syncCtx);
 }
 static inline void AREQ_SetTimedOut(AREQ *req) {
-  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
+  RequestSyncCtx_SetTimedOut(&req->syncCtx);
 }
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -217,7 +217,6 @@ static inline void RequestSyncCtx_Init(RequestSyncCtx *ctx) {
   pthread_mutex_init(&ctx->abortWakeLock, NULL);
 }
 
-// Canonical accessors for syncCtx.timedOut; AREQ_* and HybridRequest_* delegate here.
 static inline bool RequestSyncCtx_GetTimedOut(RequestSyncCtx *ctx) {
   return RS_AtomicBoolLoadRelaxed(&ctx->timedOut);
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1147,7 +1147,7 @@ void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);
-  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, false);
+  RequestSyncCtx_ClearTimedOut(&req->syncCtx);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {
     ((RPNet *)root)->drainOnly = false;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -770,10 +770,8 @@ static int HybridRequest_prepareCursors(HybridRequest *hreq, QueryError *status)
     bool maxPrefixSearch = false;
     bool maxPrefixVsim = false;
 
-    // Bound the cursor-setup wait the same way the read phase does (getAbsTimeout +
-    // the syncCtx abort flag). The deadline is NULL when timeout checks are disabled
-    // (e.g. RETURN-STRICT); the search subquery's abort flag/channel then unblocks the
-    // wait, woken by DistHybridTimeoutReturnStrictCallback / client disconnect.
+    // Deadline for the setup wait, mirroring the read phase's getAbsTimeout; paired
+    // with the syncCtx abort flag in ProcessHybridCursorMappings.
     AREQ *searchReq = hreq->requests[SEARCH_INDEX];
     RedisSearchCtx *searchSctx = AREQ_SearchCtx(searchReq);
     const struct timespec *deadline =

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1200,7 +1200,8 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   // The BG dispatcher may be parked in the cursor-setup wait; wake it so it
   // exits, even though this callback replies the error itself.
-  wakeHybridAbortChannels((HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx));
+  HybridRequest *hreq = (HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx);
+  wakeHybridAbortChannels(hreq);
 
   // Reply with timeout error
   QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, COORD_ERR_WARN);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -975,9 +975,6 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
     if (!hreq) {
       CoordRequestCtx_ReplyOrStoreError(reqCtx, ctx, status);
     } else {
-      // HREQ_ReplyOrStoreError applies the policy-aware reply: a non-fail-policy
-      // timeout replies an empty result set with the timeout warning (no partial
-      // results exist yet at setup); FAIL/RETURN_STRICT store it for the callback.
       HREQ_ReplyOrStoreError(hreq, ctx, status);
     }
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1200,8 +1200,8 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   CoordRequestCtx_UnlockSetRequest(CoordReqCtx);
 
-  // FAIL previously set the flag but never woke, leaving a parked setup-phase
-  // pop blocked on the missing reply after the client already got its error.
+  // The BG dispatcher may be parked in the cursor-setup wait; wake it so it
+  // exits, even though this callback replies the error itself.
   wakeHybridAbortChannels((HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx));
 
   // Reply with timeout error

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -771,17 +771,15 @@ static int HybridRequest_prepareCursors(HybridRequest *hreq, QueryError *status)
     bool maxPrefixVsim = false;
 
     // Deadline for the setup wait, mirroring the read phase's getAbsTimeout; paired
-    // with the syncCtx abort flag in ProcessHybridCursorMappings.
-    AREQ *searchReq = hreq->requests[SEARCH_INDEX];
-    RedisSearchCtx *searchSctx = AREQ_SearchCtx(searchReq);
+    // with the hybrid request's abort flag in ProcessHybridCursorMappings.
     const struct timespec *deadline =
-        (searchSctx && AREQ_ShouldCheckTimeout(searchReq))
-            ? (const struct timespec *)&searchSctx->time.timeout
+        (hreq->sctx && HybridRequest_ShouldCheckTimeout(hreq))
+            ? (const struct timespec *)&hreq->sctx->time.timeout
             : NULL;
 
     // Errors from cursor establishment go into the dispatcher's `status` so
     // DistHybridCleanups can reply with them.
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, status, oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim, deadline, &searchReq->syncCtx)) {
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, status, oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim, deadline, &hreq->syncCtx)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -974,14 +974,10 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
 
     if (!hreq) {
       CoordRequestCtx_ReplyOrStoreError(reqCtx, ctx, status);
-    } else if (!ShouldReplyWithError(QueryError_GetCode(status),
-                                     hreq->reqConfig.timeoutPolicy, IsProfile(hreq))) {
-      // No partial results exist yet at setup, so a non-fail-policy timeout replies
-      // an empty result set with the timeout warning rather than an error.
-      common_hybrid_query_reply_empty(ctx, QueryError_GetCode(status),
-                                      IsInternal(hreq), IsProfile(hreq));
-      QueryError_ClearError(status);
     } else {
+      // HREQ_ReplyOrStoreError applies the policy-aware reply: a non-fail-policy
+      // timeout replies an empty result set with the timeout warning (no partial
+      // results exist yet at setup); FAIL/RETURN_STRICT store it for the callback.
       HREQ_ReplyOrStoreError(hreq, ctx, status);
     }
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1158,6 +1158,18 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     CurrentThread_ClearIndexSpec();
 }
 
+// A parked MR pop may be blocked on the hybrid request's own channel (setup
+// phase) or a subquery's channel (read phase); wake all of them.
+static void wakeHybridAbortChannels(HybridRequest *hreq) {
+  if (!hreq) return;
+  RequestSyncCtx_WakeAbortChannel(&hreq->syncCtx);
+  for (size_t i = 0; i < hreq->nrequests; i++) {
+    if (hreq->requests[i]) {
+      RequestSyncCtx_WakeAbortChannel(&hreq->requests[i]->syncCtx);
+    }
+  }
+}
+
 // Timeout callback for Coordinator HybridRequest execution
 // Called on the main thread when the blocking client times out (FAIL policy only).
 int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -1179,6 +1191,11 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
   CoordRequestCtx_SetTimedOut(CoordReqCtx);
 
   CoordRequestCtx_UnlockSetRequest(CoordReqCtx);
+
+  // SetTimedOut flipped the abort flag above; wake any parked pop so the BG
+  // thread (e.g. the cursor-setup wait) exits instead of blocking on a missing
+  // shard reply after the client already got its error.
+  wakeHybridAbortChannels((HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx));
 
   // Reply with timeout error
   QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
@@ -1211,17 +1228,9 @@ int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString
 
   HybridRequest *hreq = (HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx);
 
-  // Wake every subquery's abort channel so any depleter parked in
-  // MRIterator_NextWithTimeout observes the propagated `timedOut` flag and exits
-  // promptly. WakeAbortChannel is a no-op when no channel is registered yet, in
-  // which case the depleter instead observes `timedOut` on entry to the pop.
-  if (hreq) {
-    for (size_t i = 0; i < hreq->nrequests; i++) {
-      if (hreq->requests[i]) {
-        RequestSyncCtx_WakeAbortChannel(&hreq->requests[i]->syncCtx);
-      }
-    }
-  }
+  // Wake any abort channel a parked pop (setup-phase or per-subquery read) is
+  // blocked on so it observes the propagated `timedOut` flag and exits promptly.
+  wakeHybridAbortChannels(hreq);
 
   if (!hreq || HybridRequest_TryClaimAggregateResults(hreq)) {
     // Either the request is NULL or we were able to claim the aggregation results.

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -771,8 +771,6 @@ static int HybridRequest_prepareCursors(HybridRequest *hreq, QueryError *status)
     bool maxPrefixSearch = false;
     bool maxPrefixVsim = false;
 
-    // Deadline for the setup wait, mirroring the read phase's getAbsTimeout; paired
-    // with the hybrid request's abort flag in ProcessHybridCursorMappings.
     const struct timespec *deadline =
         (hreq->sctx && HybridRequest_ShouldCheckTimeout(hreq))
             ? (const struct timespec *)&hreq->sctx->time.timeout

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1200,9 +1200,8 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   CoordRequestCtx_UnlockSetRequest(CoordReqCtx);
 
-  // SetTimedOut flipped the abort flag above; wake any parked pop so the BG
-  // thread (e.g. the cursor-setup wait) exits instead of blocking on a missing
-  // shard reply after the client already got its error.
+  // FAIL previously set the flag but never woke, leaving a parked setup-phase
+  // pop blocked on the missing reply after the client already got its error.
   wakeHybridAbortChannels((HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx));
 
   // Reply with timeout error
@@ -1236,8 +1235,6 @@ int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString
 
   HybridRequest *hreq = (HybridRequest *)CoordRequestCtx_GetRequest(CoordReqCtx);
 
-  // Wake any abort channel a parked pop (setup-phase or per-subquery read) is
-  // blocked on so it observes the propagated `timedOut` flag and exits promptly.
   wakeHybridAbortChannels(hreq);
 
   if (!hreq || HybridRequest_TryClaimAggregateResults(hreq)) {

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -29,6 +29,7 @@
 #include "concurrent_ctx.h"
 #include "info/info_redis/threads/current_thread.h"
 #include "aggregate/reply_empty.h"
+#include "aggregate/aggregate_exec_common.h"
 
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
@@ -975,6 +976,13 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
 
     if (!hreq) {
       CoordRequestCtx_ReplyOrStoreError(reqCtx, ctx, status);
+    } else if (!ShouldReplyWithError(QueryError_GetCode(status),
+                                     hreq->reqConfig.timeoutPolicy, IsProfile(hreq))) {
+      // No partial results exist yet at setup, so a non-fail-policy timeout replies
+      // an empty result set with the timeout warning rather than an error.
+      common_hybrid_query_reply_empty(ctx, QueryError_GetCode(status),
+                                      IsInternal(hreq), IsProfile(hreq));
+      QueryError_ClearError(status);
     } else {
       HREQ_ReplyOrStoreError(hreq, ctx, status);
     }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -769,9 +769,21 @@ static int HybridRequest_prepareCursors(HybridRequest *hreq, QueryError *status)
     const RSTimeoutPolicy timeoutPolicy = hreq->reqConfig.timeoutPolicy;
     bool maxPrefixSearch = false;
     bool maxPrefixVsim = false;
+
+    // Bound the cursor-setup wait the same way the read phase does (getAbsTimeout +
+    // the syncCtx abort flag). The deadline is NULL when timeout checks are disabled
+    // (e.g. RETURN-STRICT); the search subquery's abort flag/channel then unblocks the
+    // wait, woken by DistHybridTimeoutReturnStrictCallback / client disconnect.
+    AREQ *searchReq = hreq->requests[SEARCH_INDEX];
+    RedisSearchCtx *searchSctx = AREQ_SearchCtx(searchReq);
+    const struct timespec *deadline =
+        (searchSctx && AREQ_ShouldCheckTimeout(searchReq))
+            ? (const struct timespec *)&searchSctx->time.timeout
+            : NULL;
+
     // Errors from cursor establishment go into the dispatcher's `status` so
     // DistHybridCleanups can reply with them.
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, status, oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim)) {
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, status, oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim, deadline, &searchReq->syncCtx)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -281,8 +281,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
 
     // Register the iterator's channel so an external abort - the coordinator timeout
     // callback (RequestSyncCtx_WakeAbortChannel) or a client disconnect - can wake
-    // this wait promptly. Unregistered below before the iterator is released; mirrors
-    // the RPNet read path.
+    // this wait promptly. Unregistered below before the iterator is released.
     RequestSyncCtx_RegisterAbortWakeChannel(syncCtx, MRIterator_GetChannel(it));
 
     // Wait on the channel: it unblocks when inProcess hits 0 (normal completion) or

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -245,6 +245,45 @@ void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateDat
     HybridKnnApplyShardKRatio(cmd, numShards, ctx->knnCtx);
 }
 
+// Fold collected shard errors into `status` and the max-prefix flags per the OOM
+// and timeout policies. Returns false on a fatal error (first one wins).
+static bool resolveCursorMappingErrors(arrayof(QueryError) errors, QueryError *status,
+                                       RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy,
+                                       bool *maxPrefixSearch, bool *maxPrefixVsim) {
+    for (size_t i = 0; i < array_len(errors); i++) {
+        QueryErrorCode code = QueryError_GetCode(&errors[i]);
+        if (code == QUERY_ERROR_CODE_OUT_OF_MEMORY && oomPolicy == OomPolicy_Return) {
+            QueryError_SetQueryOOMWarning(status);
+        } else if (code == QUERY_ERROR_CODE_TIMED_OUT && timeoutPolicy != TimeoutPolicy_Fail) {
+            // RETURN / RETURN-STRICT policy: acknowledge the shard timeout but don't set
+            // it on qctx->err. The timeout propagates through cursor reads (RPNet detects
+            // it from the depleter's last_rc), and replyWarningsWithSuffixes emits the
+            // properly-suffixed warning (e.g. "(SEARCH)" / "(VSIM)").
+            // Note: the _FT.DEBUG FT.HYBRID path rejects RETURN-STRICT in
+            // parseHybridDebugParams, so only RETURN reaches here in debug mode.
+        } else if (code == QUERY_ERROR_CODE_TIMED_OUT) {
+            // FAIL policy: forward the standard timeout error directly.
+            QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
+            return false;
+        } else {
+            const char *msg = QueryError_GetUserError(&errors[i]);
+            if (msg && strncmp(msg, QUERY_WMAXPREFIXEXPANSIONS, strlen(QUERY_WMAXPREFIXEXPANSIONS)) == 0) {
+                if (strstr(msg, SEARCH_SUFFIX)) {
+                    *maxPrefixSearch = true;
+                } else if (strstr(msg, VSIM_SUFFIX)) {
+                    *maxPrefixVsim = true;
+                }
+            } else {
+                QueryError_SetWithoutUserDataFmt(status, code,
+                    "Failed to process shard responses, first error: %s, total error count: %zu",
+                    msg, array_len(errors));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, HybridKnnContext *knnCtx, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim, const struct timespec *deadline, RequestSyncCtx *syncCtx) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
@@ -309,44 +348,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // them in lockstep); catches a malformed reply that slipped past it.
     RS_ASSERT(array_len(searchMappings->mappings) == array_len(vsimMappings->mappings));
 
-    bool success = true;
-    if (array_len(ctx->errors)) {
-        for (size_t i = 0; i < array_len(ctx->errors); i++) {
-            if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_OUT_OF_MEMORY && oomPolicy == OomPolicy_Return ) {
-                QueryError_SetQueryOOMWarning(status);
-            } else if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_TIMED_OUT && timeoutPolicy != TimeoutPolicy_Fail) {
-                // RETURN / RETURN-STRICT policy: acknowledge the shard timeout but
-                // don't set it on qctx->err. The timeout will propagate through cursor
-                // reads (RPNet detects it from the depleter's last_rc), and
-                // replyWarningsWithSuffixes emits the properly-suffixed warning
-                // (e.g., "(SEARCH)" / "(VSIM)").
-                // Note: for the _FT.DEBUG FT.HYBRID path, RETURN-STRICT is rejected
-                // earlier in parseHybridDebugParams, so only RETURN reaches here in
-                // debug mode.
-            } else if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_TIMED_OUT) {
-                // FAIL policy: forward the standard timeout error directly,
-                // matching the standalone path which uses QueryError_Strerror().
-                QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
-                success = false;
-                break;
-            } else {
-                const char *msg = QueryError_GetUserError(&ctx->errors[i]);
-                if (msg && strncmp(msg, QUERY_WMAXPREFIXEXPANSIONS, strlen(QUERY_WMAXPREFIXEXPANSIONS)) == 0) {
-                    if (strstr(msg, SEARCH_SUFFIX)) {
-                        *maxPrefixSearch = true;
-                    } else if (strstr(msg, VSIM_SUFFIX)) {
-                        *maxPrefixVsim = true;
-                    }
-                    continue;
-                } else {
-                    QueryError_SetWithoutUserDataFmt(status, QueryError_GetCode(&ctx->errors[i]), "Failed to process shard responses, first error: %s, total error count: %zu",
-                        msg, array_len(ctx->errors));
-                    success = false;
-                    break;
-                }
-            }
-        }
-    }
+    bool success = resolveCursorMappingErrors(ctx->errors, status, oomPolicy, timeoutPolicy,
+                                              maxPrefixSearch, maxPrefixVsim);
     MRIterator_Release(it);
 
     return success;

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -16,19 +16,18 @@
 #include "shard_window_ratio.h"
 #include <string.h>
 #include "info/global_stats.h"
+#include "aggregate/aggregate.h"  // RequestSyncCtx + abort-wake channel API
 
 #define INTERNAL_HYBRID_RESP3_LENGTH 6
 #define INTERNAL_HYBRID_RESP2_LENGTH 6
 
+// Lock-free: every field is written only by the single IO thread that runs this
+// iterator's callbacks (each MRIterator is pinned to one ioRuntime). Completion and
+// timeout are the MRChannel's job, so no mutex or counter lives here.
 typedef struct {
     StrongRef searchMappings;
     StrongRef vsimMappings;
-    arrayof(QueryError) errors;
-    size_t responseCount;
-    pthread_mutex_t *mutex;           // Mutex for array access and completion tracking
-    pthread_cond_t *completionCond;   // Condition variable for completion signaling
-    int numShards;                    // Total number of expected shards
-    bool initialized;                 // Whether numShards has been set by the IO thread
+    arrayof(QueryError) errors;       // NULL until the first IO-thread append
     HybridKnnContext *knnCtx;         // KNN context for SHARD_K_RATIO optimization (may be NULL)
 } processCursorMappingCallbackContext;
 
@@ -195,9 +194,6 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
     MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
 
     const int replyType = MRReply_Type(rep);
-    pthread_mutex_lock(cb_ctx->mutex);
-    // add under a lock, allows the coordinator to know when all responses have arrived
-    cb_ctx->responseCount++;
     if (replyType == MR_REPLY_ERROR) {
         processHybridError(cb_ctx, rep);
     } else if (replyType == MR_REPLY_MAP) {
@@ -210,50 +206,33 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
         processHybridUnknownReplyType(cb_ctx, replyType);
     }
 
-    // we must notify the coordinator a response has arrived, even if it's an error
-    pthread_cond_signal(cb_ctx->completionCond);
-    pthread_mutex_unlock(cb_ctx->mutex);
-
+    // The mapping writes above happen-before this Done; on the last shard it drops
+    // inProcess to 0 and unblocks the channel, publishing them to the waiting
+    // coordinator. The callback never pushes a reply — the channel is purely the
+    // completion/timeout signal.
     MRIteratorCallback_Done(ctx, 0);
     MRReply_Free(rep);
 }
 
-// No-reply error callback: bumps responseCount and records a communication
-// error so the wait loop below (which keys completion off responseCount, not
-// iterator depletion) unblocks instead of hanging.
+// No-reply termination hook (see MRIteratorErrorCallback): just record the comms
+// error. The MR layer drives completion via MRIteratorCallback_Done next.
 static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
     RS_ASSERT(cb_ctx);
 
-    pthread_mutex_lock(cb_ctx->mutex);
-    cb_ctx->responseCount++;
     QueryError error = QueryError_Default();
     QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
     // Shared with the MR iterator no-reply path (pre-fanout connection-validation failure).
     QueryError_SetDetail(&error, CLUSTER_QUERY_ERROR);
     cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
-    pthread_cond_signal(cb_ctx->completionCond);
-    pthread_mutex_unlock(cb_ctx->mutex);
 }
 
-// Init callback for the private data, so that numShards is set to the actual number of shards in the cluster, and the expected responses.
-static void processCursorMappingInit(void *privateData, const MRIterator *it) {
+// Frees the callback context. Registered as the iterator's cbPrivateDataDestructor,
+// so MRIterator_Free runs it only after the last writer finishes (inProcess == 0).
+// That lets the coordinator release the iterator on the timeout path without racing
+// late callbacks: ctx and the cloned mapping refs outlive every writer.
+static void freeCursorMappingCtx(void *privateData) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
-    int actualNumShards = (int)MRIterator_GetNumShards(it);
-    pthread_mutex_lock(ctx->mutex);
-    ctx->numShards = actualNumShards;
-    ctx->initialized = true;
-    ctx->errors = array_new(QueryError, actualNumShards);
-    // Signal so the coordinator can re-check the wait condition.
-    pthread_cond_signal(ctx->completionCond);
-    pthread_mutex_unlock(ctx->mutex);
-}
-
-static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
-    pthread_mutex_destroy(ctx->mutex);
-    pthread_cond_destroy(ctx->completionCond);
-    rm_free(ctx->mutex);
-    rm_free(ctx->completionCond);
     StrongRef_Release(ctx->searchMappings);
     StrongRef_Release(ctx->vsimMappings);
     array_free_ex(ctx->errors, QueryError_ClearError((QueryError*)ptr));
@@ -279,30 +258,18 @@ void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateDat
     HybridKnnApplyShardKRatio(cmd, numShards, ctx->knnCtx);
 }
 
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, HybridKnnContext *knnCtx, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim) {
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, HybridKnnContext *knnCtx, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim, const struct timespec *deadline, RequestSyncCtx *syncCtx) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
 
-    // Allocate callback context on heap (since MR_IterateWithPrivateData is asynchronous)
+    // Heap-allocated because the iterator runs asynchronously; freed by
+    // freeCursorMappingCtx (the iterator's destructor).
     processCursorMappingCallbackContext *ctx = rm_malloc(sizeof(processCursorMappingCallbackContext));
-
-    // Initialize synchronization primitives on heap
-    ctx->mutex = rm_malloc(sizeof(pthread_mutex_t));
-    ctx->completionCond = rm_malloc(sizeof(pthread_cond_t));
-    pthread_mutex_init(ctx->mutex, NULL);
-    pthread_cond_init(ctx->completionCond, NULL);
-
-    // Setup callback context
     *ctx = (processCursorMappingCallbackContext) {
         .searchMappings = StrongRef_Clone(searchMappingsRef),
         .vsimMappings = StrongRef_Clone(vsimMappingsRef),
         .errors = NULL,
-        .responseCount = 0,
-        .mutex = ctx->mutex,
-        .completionCond = ctx->completionCond,
-        .numShards = 0,
-        .initialized = false,
         .knnCtx = knnCtx,  // Store KNN context for command modifier callback
       };
 
@@ -310,34 +277,53 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // optimization)
     MRCommandModifier cmdModifier = knnCtx ? &HybridKnnCommandModifier : NULL;
 
-    // Start iteration (ctx is cleaned up manually in cleanupCtx, no destructor needed)
-    // processCursorMappingInit is called from iterStartCb to update ctx->numShards
-    // with the actual shard count from the live topology, preventing use-after-free
-    // when topology changes during shard migration.
+    // No cbPrivateDataInit: the iterator owns the expected-response count (it->len /
+    // inProcess), so completion is simply inProcess == 0 — no hybrid-local mirror.
     MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
         .successCB = processCursorMappingCallback,
         .errorCB = processCursorMappingErrorCallback,
         .cbPrivateData = ctx,
-        .cbPrivateDataInit = processCursorMappingInit,
+        .cbPrivateDataDestructor = freeCursorMappingCtx,
         .commandModifier = cmdModifier,
         .iterStartCb = iterStartCb,
     });
     if (!it) {
         // Cleanup on error
         QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to communicate with shards");
-        cleanupCtx(ctx);
+        freeCursorMappingCtx(ctx);
         return false;
     }
-    // Wait for all callbacks to complete
-    pthread_mutex_lock(ctx->mutex);
-    // Wait until either:
-    // 1. Normal completion: IO thread initialized numShards and all responses arrived
-    // 2. Early failure: We got a response before initialization (e.g., connection validation failed)
-    //    In this case, responseCount > 0 but initialized is false - we should unblock.
-    while (ctx->responseCount == 0 || (ctx->initialized && ctx->responseCount < ctx->numShards)) {
-        pthread_cond_wait(ctx->completionCond, ctx->mutex);
+
+    // Register the iterator's channel so an external abort - the coordinator timeout
+    // callback (RequestSyncCtx_WakeAbortChannel) or a client disconnect - can wake
+    // this wait promptly. Unregistered below before the iterator is released; mirrors
+    // the RPNet read path.
+    RequestSyncCtx_RegisterAbortWakeChannel(syncCtx, MRIterator_GetChannel(it));
+
+    // Wait on the channel: it unblocks when inProcess hits 0 (normal completion) or
+    // when the deadline/abort fires. Both are passed because `deadline` is NULL under
+    // RETURN-STRICT / disabled timeout checks, where syncCtx->timedOut is the only
+    // wake; passing neither re-introduces the unbounded wait — the MOD-15394/16145
+    // hang (chan.c asserts at least one is non-NULL).
+    bool timedOut = false;
+    MRReply *r = MRIterator_NextWithTimeout(it, deadline, &syncCtx->timedOut, &timedOut);
+    RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
+
+    RequestSyncCtx_UnregisterAbortWakeChannel(syncCtx);
+
+    if (timedOut || RS_AtomicBoolLoadRelaxed(&syncCtx->timedOut)) {
+        // Terminal: a shard never replied (the MOD-16145 hang) or the request was
+        // aborted. Late callbacks may still be writing mappings/errors, so do NOT
+        // read them — just release (freeCursorMappingCtx frees ctx once they finish).
+        QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
+        MRIterator_Release(it);
+        return false;
     }
-    pthread_mutex_unlock(ctx->mutex);
+
+    // Normal completion: inProcess hit 0, so every callback has run. Postcondition —
+    // search/vsim mappings are paired index-for-index (the early-bailout logic keeps
+    // them in lockstep); catches a malformed reply that slipped past it.
+    RS_ASSERT(array_len(searchMappings->mappings) == array_len(vsimMappings->mappings));
 
     bool success = true;
     if (array_len(ctx->errors)) {
@@ -377,9 +363,10 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
             }
         }
     }
-    // Cleanup
+    // Errors consumed; release drops the reader ref. Setup always depletes on
+    // completion (pending == 0), so this frees the iterator (and ctx) outright with
+    // no FT.CURSOR DEL fan-out.
     MRIterator_Release(it);
-    cleanupCtx(ctx);
 
     return success;
 }

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -334,7 +334,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
 
     RequestSyncCtx_UnregisterAbortWakeChannel(syncCtx);
 
-    if (timedOut || RS_AtomicBoolLoadRelaxed(&syncCtx->timedOut)) {
+    if (timedOut || RequestSyncCtx_GetTimedOut(syncCtx)) {
         // Terminal: a shard never replied or the request was aborted. Late callbacks
         // may still be writing mappings/errors, so do NOT read them — just release
         // (freeCursorMappingCtx frees ctx once they finish).

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -287,8 +287,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // Wait on the channel: it unblocks when inProcess hits 0 (normal completion) or
     // when the deadline/abort fires. Both are passed because `deadline` is NULL under
     // RETURN-STRICT / disabled timeout checks, where syncCtx->timedOut is the only
-    // wake; passing neither re-introduces the unbounded wait — the MOD-15394/16145
-    // hang (chan.c asserts at least one is non-NULL).
+    // wake; passing neither leaves the wait unbounded (chan.c asserts at least one is
+    // non-NULL).
     bool timedOut = false;
     MRReply *r = MRIterator_NextWithTimeout(it, deadline, &syncCtx->timedOut, &timedOut);
     RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
@@ -296,9 +296,9 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     RequestSyncCtx_UnregisterAbortWakeChannel(syncCtx);
 
     if (timedOut || RS_AtomicBoolLoadRelaxed(&syncCtx->timedOut)) {
-        // Terminal: a shard never replied (the MOD-16145 hang) or the request was
-        // aborted. Late callbacks may still be writing mappings/errors, so do NOT
-        // read them — just release (freeCursorMappingCtx frees ctx once they finish).
+        // Terminal: a shard never replied or the request was aborted. Late callbacks
+        // may still be writing mappings/errors, so do NOT read them — just release
+        // (freeCursorMappingCtx frees ctx once they finish).
         QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
         MRIterator_Release(it);
         return false;

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -16,14 +16,11 @@
 #include "shard_window_ratio.h"
 #include <string.h>
 #include "info/global_stats.h"
-#include "aggregate/aggregate.h"  // RequestSyncCtx + abort-wake channel API
+#include "aggregate/aggregate.h"
 
 #define INTERNAL_HYBRID_RESP3_LENGTH 6
 #define INTERNAL_HYBRID_RESP2_LENGTH 6
 
-// Lock-free: every field is written only by the single IO thread that runs this
-// iterator's callbacks (each MRIterator is pinned to one ioRuntime). Completion and
-// timeout are the MRChannel's job, so no mutex or counter lives here.
 typedef struct {
     StrongRef searchMappings;
     StrongRef vsimMappings;
@@ -206,16 +203,10 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
         processHybridUnknownReplyType(cb_ctx, replyType);
     }
 
-    // The mapping writes above happen-before this Done; on the last shard it drops
-    // inProcess to 0 and unblocks the channel, publishing them to the waiting
-    // coordinator. The callback never pushes a reply — the channel is purely the
-    // completion/timeout signal.
     MRIteratorCallback_Done(ctx, 0);
     MRReply_Free(rep);
 }
 
-// No-reply termination hook (see MRIteratorErrorCallback): just record the comms
-// error. The MR layer drives completion via MRIteratorCallback_Done next.
 static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
     RS_ASSERT(cb_ctx);
@@ -227,10 +218,6 @@ static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
 }
 
-// Frees the callback context. Registered as the iterator's cbPrivateDataDestructor,
-// so MRIterator_Free runs it only after the last writer finishes (inProcess == 0).
-// That lets the coordinator release the iterator on the timeout path without racing
-// late callbacks: ctx and the cloned mapping refs outlive every writer.
 static void freeCursorMappingCtx(void *privateData) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
     StrongRef_Release(ctx->searchMappings);
@@ -277,8 +264,6 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // optimization)
     MRCommandModifier cmdModifier = knnCtx ? &HybridKnnCommandModifier : NULL;
 
-    // No cbPrivateDataInit: the iterator owns the expected-response count (it->len /
-    // inProcess), so completion is simply inProcess == 0 — no hybrid-local mirror.
     MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
         .successCB = processCursorMappingCallback,
         .errorCB = processCursorMappingErrorCallback,
@@ -363,9 +348,6 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
             }
         }
     }
-    // Errors consumed; release drops the reader ref. Setup always depletes on
-    // completion (pending == 0), so this frees the iterator (and ctx) outright with
-    // no FT.CURSOR DEL fan-out.
     MRIterator_Release(it);
 
     return success;

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -323,11 +323,9 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // this wait promptly. Unregistered below before the iterator is released.
     RequestSyncCtx_RegisterAbortWakeChannel(syncCtx, MRIterator_GetChannel(it));
 
-    // Wait on the channel: it unblocks when inProcess hits 0 (normal completion) or
-    // when the deadline/abort fires. Both are passed because `deadline` is NULL under
-    // RETURN-STRICT / disabled timeout checks, where syncCtx->timedOut is the only
-    // wake; passing neither leaves the wait unbounded (chan.c asserts at least one is
-    // non-NULL).
+    // Pass both the deadline and the abort flag: `deadline` is NULL under RETURN-STRICT /
+    // disabled timeout checks, where the abort flag is the only wake (chan.c requires
+    // at least one non-NULL).
     bool timedOut = false;
     MRReply *r = MRIterator_NextWithTimeout(it, deadline, &syncCtx->timedOut, &timedOut);
     RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
@@ -335,17 +333,12 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     RequestSyncCtx_UnregisterAbortWakeChannel(syncCtx);
 
     if (timedOut || RequestSyncCtx_GetTimedOut(syncCtx)) {
-        // Terminal: a shard never replied or the request was aborted. Late callbacks
-        // may still be writing mappings/errors, so do NOT read them — just release
-        // (freeCursorMappingCtx frees ctx once they finish).
         QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
         MRIterator_Release(it);
         return false;
     }
 
-    // Normal completion: inProcess hit 0, so every callback has run. Postcondition —
-    // search/vsim mappings are paired index-for-index (the early-bailout logic keeps
-    // them in lockstep); catches a malformed reply that slipped past it.
+    // Normal completion: inProcess hit 0, so every callback has run.
     RS_ASSERT(array_len(searchMappings->mappings) == array_len(vsimMappings->mappings));
 
     bool success = resolveCursorMappingErrors(ctx->errors, status, oomPolicy, timeoutPolicy,

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -24,7 +24,7 @@
 typedef struct {
     StrongRef searchMappings;
     StrongRef vsimMappings;
-    arrayof(QueryError) errors;       // NULL until the first IO-thread append
+    arrayof(QueryError) errors;
     HybridKnnContext *knnCtx;         // KNN context for SHARD_K_RATIO optimization (may be NULL)
 } processCursorMappingCallbackContext;
 
@@ -256,7 +256,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     *ctx = (processCursorMappingCallbackContext) {
         .searchMappings = StrongRef_Clone(searchMappingsRef),
         .vsimMappings = StrongRef_Clone(vsimMappingsRef),
-        .errors = NULL,
+        .errors = array_new(QueryError, 0),
         .knnCtx = knnCtx,  // Store KNN context for command modifier callback
       };
 

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -36,6 +36,12 @@ typedef struct {
 // forward declaration of QueryError
 typedef struct QueryError QueryError;
 
+// forward declaration of RequestSyncCtx (defined in aggregate/aggregate.h). Used
+// to bound the cursor-setup wait: its `timedOut` atomic is the abort flag and its
+// abort-wake channel slot lets an external timeout/cancel wake the wait.
+typedef struct RequestSyncCtx RequestSyncCtx;
+struct timespec;
+
 /**
  * Context for SHARD_K_RATIO optimization in FT.HYBRID commands.
  * Contains information needed to calculate and apply effectiveK.
@@ -62,9 +68,14 @@ typedef struct {
  * @param timeoutPolicy Timeout policy to determine timeout error handling behavior
  * @param maxPrefixSearch Output: set to true if SEARCH subquery reported max prefix expansion warning
  * @param maxPrefixVsim Output: set to true if VSIM subquery reported max prefix expansion warning
+ * @param deadline Absolute CLOCK_MONOTONIC_RAW deadline bounding the wait, or NULL
+ *                 when timeout checks are disabled (e.g. RETURN-STRICT). When NULL,
+ *                 the wait is unblocked only via `syncCtx`'s abort flag/channel.
+ * @param syncCtx Request sync context whose `timedOut` flag is the abort signal and
+ *                whose abort-wake channel slot is (un)registered around the wait.
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, HybridKnnContext *knnCtx, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim);
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, HybridKnnContext *knnCtx, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch, bool *maxPrefixVsim, const struct timespec *deadline, RequestSyncCtx *syncCtx);
 
 /**
  * Apply SHARD_K_RATIO optimization to an MRCommand based on the provided

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -36,7 +36,6 @@ typedef struct {
 // forward declaration of QueryError
 typedef struct QueryError QueryError;
 
-// forward declaration of RequestSyncCtx (defined in aggregate/aggregate.h)
 typedef struct RequestSyncCtx RequestSyncCtx;
 struct timespec;
 

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -36,9 +36,7 @@ typedef struct {
 // forward declaration of QueryError
 typedef struct QueryError QueryError;
 
-// forward declaration of RequestSyncCtx (defined in aggregate/aggregate.h). Used
-// to bound the cursor-setup wait: its `timedOut` atomic is the abort flag and its
-// abort-wake channel slot lets an external timeout/cancel wake the wait.
+// forward declaration of RequestSyncCtx (defined in aggregate/aggregate.h)
 typedef struct RequestSyncCtx RequestSyncCtx;
 struct timespec;
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -448,8 +448,11 @@ void HREQ_StoreResults(HybridRequest *hreq, SearchResult **results, int rc, cach
 }
 
 // Helper for error handling in coordinator HREQ execution.
-// For FAIL policy (useReplyCallback=true): stores error for reply_callback to handle.
-// For RETURN policy: replies with error directly.
+// FAIL / RETURN_STRICT (useReplyCallback=true): store the error for the
+//   reply_callback to handle.
+// RETURN (useReplyCallback=false): reply directly - an empty result set with a
+//   timeout warning when the error is a non-fail-policy timeout (no result set
+//   was produced here), otherwise the error itself.
 void HREQ_ReplyOrStoreError(HybridRequest *hreq, RedisModuleCtx *ctx, QueryError *status) {
   if (hreq->useReplyCallback) {
     // Deep copy since QueryError contains heap-allocated strings.
@@ -457,6 +460,13 @@ void HREQ_ReplyOrStoreError(HybridRequest *hreq, RedisModuleCtx *ctx, QueryError
     QueryError_ClearError(&hreq->storedReplyState.err);
     QueryError_CloneFrom(status, &hreq->storedReplyState.err);
     // Clear the original to avoid leaking heap-allocated strings.
+    QueryError_ClearError(status);
+  } else if (!ShouldReplyWithError(QueryError_GetCode(status),
+                                   hreq->reqConfig.timeoutPolicy, IsProfile(hreq))) {
+    // Error is a timeout under a non-fail policy, which must not surface as an
+    // error: reply an empty result set with the timeout warning instead.
+    common_hybrid_query_reply_empty(ctx, QueryError_GetCode(status),
+                                    IsInternal(hreq), IsProfile(hreq));
     QueryError_ClearError(status);
   } else {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, !IsInternal(hreq));

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -481,7 +481,7 @@ void AddValidationErrorContext(AREQ *req, QueryError *status) {
 }
 
 void HybridRequest_SetTimedOut(HybridRequest *req) {
-  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
+  RequestSyncCtx_SetTimedOut(&req->syncCtx);
   // Propagate to each subquery AREQ so its RPNet's MRChannel_PopWithTimeout
   // abort flag (&areq->syncCtx.timedOut) is flipped. Without this the BG
   // worker can stay parked on the channel even after the hybrid-level flag

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -91,7 +91,7 @@ typedef struct HybridRequest {
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
 static inline bool HybridRequest_TimedOut(HybridRequest *req) {
-  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
+  return RequestSyncCtx_GetTimedOut(&req->syncCtx);
 }
 // Sets the hybrid request's timedOut flag and propagates it to every subquery
 // AREQ. Propagation flips each subquery's RPNet abort flag so a BG worker

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1587,3 +1587,45 @@ def get_shards_profile(env, res):
     return res['Profile']['Shards']
   else:
     return [to_dict(p) for p in res[-1][1]]
+
+
+# --- Coordinator / cluster timeout test helpers (shared across timeout test files) ---
+ON_TIMEOUT_CONFIG = 'search-on-timeout'
+
+
+def pid_cmd(conn):
+    """Get the process ID of a Redis connection."""
+    return conn.execute_command('info', 'server')['process_id']
+
+
+def non_coord_shard_conns(env):
+    """Return shard connections whose process id differs from the coordinator's."""
+    coord_pid = pid_cmd(env.con)
+    conns = []
+    for shardId in range(1, env.shardsCount + 1):
+        conn = env.getConnection(shardId)
+        if pid_cmd(conn) != coord_pid:
+            conns.append(conn)
+    return conns
+
+
+def split_shards_pick_one_paused(env):
+    """Pick one non-coordinator shard to designate as paused and split the rest.
+
+    Returns ``(all_shard_conns, paused_conn, paused_pid, responsive_conns)``.
+    Asserts that at least one non-coordinator shard exists.
+    """
+    all_shard_conns = [env.getConnection(i) for i in range(1, env.shardsCount + 1)]
+    non_coord_conns = non_coord_shard_conns(env)
+    env.assertGreater(len(non_coord_conns), 0,
+                      message="Test requires at least one non-coordinator shard")
+    paused_conn = non_coord_conns[0]
+    paused_pid = pid_cmd(paused_conn)
+    responsive_conns = [c for c in all_shard_conns if pid_cmd(c) != paused_pid]
+    return all_shard_conns, paused_conn, paused_pid, responsive_conns
+
+
+def assert_timeout_warning(env, res, message=''):
+    warnings = res.get('warning', res.get('warnings', []))
+    env.assertTrue(warnings, message=message + " expected timeout warning")
+    env.assertContains('Timeout', warnings[0], message=message + " expected timeout warning")

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -492,6 +492,15 @@ class TestCoordinatorTimeout:
         ])
 
     def test_fail_timeout_hybrid(self):
+        """FAIL-policy FT.HYBRID timeout during cursor-mapping setup (Phase 1).
+
+        The shard is suspended before the query, so the coordinator parks in the
+        ProcessHybridCursorMappings setup wait (deadline is NULL under FAIL). The
+        blocked-client CLIENT UNBLOCK ... TIMEOUT fires DistHybridTimeoutFailCallback,
+        which wakes the parked pop and replies a timeout error. Companion to
+        test_return_strict_timeout_setup_phase_hybrid (RETURN-STRICT variant) and
+        test_return_timeout_setup_phase_hybrid (RETURN in-band-deadline variant).
+        """
         self._test_fail_timeout_impl([
             'FT.HYBRID', 'hybrid_idx',
             'SEARCH', '*',
@@ -552,6 +561,84 @@ class TestCoordinatorTimeout:
             # its cursors before later tests run.
             shard_to_pause_p.resume()
             env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
+    def test_return_strict_timeout_setup_phase_hybrid(self):
+        """RETURN-STRICT FT.HYBRID timeout during cursor-mapping setup (Phase 1),
+        driven by the blocked-client deadline.
+
+        Under RETURN-STRICT the setup wait has no in-band deadline (it is NULL), so
+        unlike the RETURN variant the only wake path is the coordinator's
+        blocked-client timeout callback. With one shard suspended the coordinator
+        parks in ProcessHybridCursorMappings; firing CLIENT UNBLOCK ... TIMEOUT
+        invokes DistHybridTimeoutReturnStrictCallback, which wakes the parked pop
+        (wakeHybridAbortChannels) and replies an empty result set with the timeout
+        warning. Companion to test_return_timeout_setup_phase_hybrid, which drives
+        the same setup wait through the in-band RETURN deadline instead.
+        """
+        env = self.env
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict').ok()
+
+        before_info = info_modules_to_dict(env)
+        base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
+        initial_jobs_done = getWorkersThpoolStats(env)['totalJobsDone']
+
+        _, _, paused_pid, _ = _split_shards_pick_one_paused(env)
+        shard_to_pause_p = psutil.Process(paused_pid)
+
+        # No per-query TIMEOUT: under RETURN-STRICT the deadline is NULL, and the
+        # blocked-client CLIENT UNBLOCK below is what fires the timeout callback.
+        query_args = [
+            'FT.HYBRID', 'hybrid_idx',
+            'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB',
+            'PARAMS', '2', 'BLOB', self.hybrid_query_vec,
+        ]
+
+        reply = []
+        shard_to_pause_p.suspend()
+        try:
+            wait_for_condition(
+                lambda: (shard_to_pause_p.status() == psutil.STATUS_STOPPED,
+                         {'status': shard_to_pause_p.status()}),
+                'Timeout while waiting for shard to pause'
+            )
+
+            t_query = threading.Thread(
+                target=call_and_store, args=(env.cmd, query_args, reply), daemon=True)
+            t_query.start()
+
+            # Park the coordinator in the setup wait: the dispatch job must have run
+            # before we fire the blocked-client deadline.
+            blocked_client_id = wait_for_blocked_query_client(
+                env, 'FT.HYBRID', 'Client for FT.HYBRID not found')
+            wait_for_condition(
+                lambda: (getWorkersThpoolStats(env)['totalJobsDone'] > initial_jobs_done,
+                         {'totalJobsDone': getWorkersThpoolStats(env)['totalJobsDone']}),
+                'Timeout while waiting for worker to finish dispatch job'
+            )
+
+            env.expect('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT').equal(1)
+            wait_for_client_unblocked(env, blocked_client_id)
+
+            t_query.join(timeout=10)
+            env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+        finally:
+            shard_to_pause_p.resume()
+            env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
+        env.assertEqual(len(reply), 1, message=f"Expected one reply, got {reply}")
+        result = reply[0]
+        env.assertEqual(result['total_results'], 0,
+                        message=f"Expected 0 results, got {result}")
+        assert_timeout_warning(env, result, message="RETURN-STRICT setup-phase timeout")
+
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                        str(base_warn_coord + 1),
+                        message="Coordinator timeout warning should be +1 after "
+                                "RETURN-STRICT setup-phase timeout")
 
     def _test_fail_timeout_before_coord_pickup_impl(self, query_args):
         """Test timeout occurring before coordinator picks up the query job."""

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -510,9 +510,9 @@ class TestCoordinatorTimeout:
         wait's deadline fires and DistHybridCleanups replies an empty result set
         carrying the timeout warning -- not a hard error, and without hanging.
 
-        Complements the read-phase one-shard-paused tests, which deliberately let
-        Phase 1 finish before suspending because the setup wait would otherwise
-        block forever.
+        Complements the read-phase one-shard-paused tests, which suspend only
+        after Phase 1 completes; this one suspends during Phase 1 to exercise the
+        bounded cursor-setup wait.
         """
         env = self.env
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -13,7 +13,6 @@ import psutil
 
 TIMEOUT_ERROR = "Timeout limit was reached"
 TIMEOUT_WARNING = TIMEOUT_ERROR
-ON_TIMEOUT_CONFIG = 'search-on-timeout'
 
 
 def run_cmd_expect_timeout(env, query_args):
@@ -53,11 +52,6 @@ def _setup_fail_cursor_state(env, chunk_size=10):
     env.assertNotEqual(cursor_id, 0, message="Expected non-zero cursor ID")
     baseline_cursor_total = _coord_cursor_total(env)
     return prev_on_timeout_policy, cursor_id, baseline_cursor_total, before_info, base_err_coord
-
-def assert_timeout_warning(env, res, message=''):
-    warnings = res.get('warning', res.get('warnings', []))
-    env.assertTrue(warnings, message=message + " expected timeout warning")
-    env.assertContains('Timeout', warnings[0], message=message + " expected timeout warning")
 
 def _setup_return_strict_cursor_state(env, chunk_size=10, agg_steps=None):
     """Switch shards to RETURN_STRICT, create a WITHCURSOR aggregate, and return
@@ -196,11 +190,6 @@ def debug_print_hybrid_clients(env, label=""):
         except Exception as e:
             env.debugPrint(f"{prefix}Shard {shardId} CLIENT LIST error: {e}", force=True)
 
-def pid_cmd(conn):
-    """Get the process ID of a Redis connection."""
-    return conn.execute_command('info', 'server')['process_id']
-
-
 def get_all_shards_pid(env):
     """Get PIDs from all environment shards (excluding the coordinator)."""
     for shardId in range(1, env.shardsCount + 1):
@@ -287,33 +276,6 @@ def wait_for_blocked_query_client(env, query, msg='Client for query not found', 
             if client_id:
                 return client_id
             time.sleep(0.1)
-
-
-def _non_coord_shard_conns(env):
-    """Return shard connections whose process id differs from the coordinator's."""
-    coord_pid = pid_cmd(env.con)
-    conns = []
-    for shardId in range(1, env.shardsCount + 1):
-        conn = env.getConnection(shardId)
-        if pid_cmd(conn) != coord_pid:
-            conns.append(conn)
-    return conns
-
-
-def _split_shards_pick_one_paused(env):
-    """Pick one non-coordinator shard to designate as paused and split the rest.
-
-    Returns ``(all_shard_conns, paused_conn, paused_pid, responsive_conns)``.
-    Asserts that at least one non-coordinator shard exists.
-    """
-    all_shard_conns = [env.getConnection(i) for i in range(1, env.shardsCount + 1)]
-    non_coord_conns = _non_coord_shard_conns(env)
-    env.assertGreater(len(non_coord_conns), 0,
-                      message="Test requires at least one non-coordinator shard")
-    paused_conn = non_coord_conns[0]
-    paused_pid = pid_cmd(paused_conn)
-    responsive_conns = [c for c in all_shard_conns if pid_cmd(c) != paused_pid]
-    return all_shard_conns, paused_conn, paused_pid, responsive_conns
 
 
 def _wait_pinned_shard_with_blocked_cmd(shard_conn, sync_point, cmd_name, timeout=30):
@@ -510,7 +472,7 @@ class TestCoordinatorTimeout:
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
         initial_jobs_done = getWorkersThpoolStats(env)['totalJobsDone']
 
-        _, _, paused_pid, _ = _split_shards_pick_one_paused(env)
+        _, _, paused_pid, _ = split_shards_pick_one_paused(env)
         shard_to_pause_p = psutil.Process(paused_pid)
 
         # No per-query TIMEOUT: under RETURN-STRICT the deadline is NULL, and the
@@ -1161,7 +1123,7 @@ class TestCoordinatorTimeout:
         skipIfNoEnableAssert(env)
         sync_point = 'BeforeCursorReadSendChunk'
 
-        non_coord_shards = _non_coord_shard_conns(env)
+        non_coord_shards = non_coord_shard_conns(env)
         env.assertGreater(len(non_coord_shards), 0,
                           message="Test requires at least one shard process distinct "
                                   "from the coordinator to exercise the internal "
@@ -1248,7 +1210,7 @@ class TestCoordinatorTimeout:
         env = self.env
         skipIfNoEnableAssert(env)
 
-        non_coord_shards = _non_coord_shard_conns(env)
+        non_coord_shards = non_coord_shard_conns(env)
         env.assertGreater(len(non_coord_shards), 0,
                           message="Test requires at least one shard process distinct "
                                   "from the coordinator to exercise the internal "
@@ -1339,7 +1301,7 @@ class TestCoordinatorTimeout:
         env = self.env
         skipIfNoEnableAssert(env)
 
-        non_coord_shards = _non_coord_shard_conns(env)
+        non_coord_shards = non_coord_shard_conns(env)
         env.assertGreater(len(non_coord_shards), 0,
                           message="Test requires a non-coordinator shard")
         target_shard = non_coord_shards[0]
@@ -2093,7 +2055,7 @@ class TestCoordinatorTimeout:
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
         all_shard_conns, paused_conn, paused_pid, responsive_conns = \
-            _split_shards_pick_one_paused(env)
+            split_shards_pick_one_paused(env)
 
         # Docs on responsive shards. The paused shard's docs never reach BG,
         # so this is the exact count BG will emit (one _FT.AGGREGATE reply per
@@ -2233,7 +2195,7 @@ class TestCoordinatorTimeout:
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
         _, _, paused_pid, responsive_shard_conns = \
-            _split_shards_pick_one_paused(env)
+            split_shards_pick_one_paused(env)
 
         shard_to_pause_p = psutil.Process(paused_pid)
         shard_to_pause_p.suspend()
@@ -2541,7 +2503,7 @@ class TestCoordinatorTimeout:
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
         all_shard_conns, paused_conn, paused_pid, responsive_conns = \
-            _split_shards_pick_one_paused(env)
+            split_shards_pick_one_paused(env)
 
         # Docs on responsive shards. The paused shard's docs never reach
         # BG, so this is the exact count BG sees as admitted.
@@ -3693,7 +3655,7 @@ class TestCoordinatorTimeout:
         before_info = info_modules_to_dict(env)
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
-        _, _, paused_pid, responsive_conns = _split_shards_pick_one_paused(env)
+        _, _, paused_pid, responsive_conns = split_shards_pick_one_paused(env)
 
         # Each responsive shard contributes one subquery-0 (SEARCH *)
         # reply to the merger's accumulation dict. SEARCH * matches every
@@ -4385,7 +4347,7 @@ class TestCoordinatorTimeout:
         base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
         all_shard_conns, target_conn, _target_pid, other_conns = \
-            _split_shards_pick_one_paused(env)
+            split_shards_pick_one_paused(env)
 
         # Target contributes pause_after_n; other shards contribute their
         # full per-shard share.
@@ -4827,7 +4789,7 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
 
         all_shard_conns, target_conn, _target_pid, other_conns = \
-            _split_shards_pick_one_paused(env)
+            split_shards_pick_one_paused(env)
 
         pause_after_n = 2
         other_docs = sum(len(c.execute_command('KEYS', 'doc*'))

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -492,15 +492,6 @@ class TestCoordinatorTimeout:
         ])
 
     def test_fail_timeout_hybrid(self):
-        """FAIL-policy FT.HYBRID timeout during cursor-mapping setup (Phase 1).
-
-        The shard is suspended before the query, so the coordinator parks in the
-        ProcessHybridCursorMappings setup wait (deadline is NULL under FAIL). The
-        blocked-client CLIENT UNBLOCK ... TIMEOUT fires DistHybridTimeoutFailCallback,
-        which wakes the parked pop and replies a timeout error. Companion to
-        test_return_strict_timeout_setup_phase_hybrid (RETURN-STRICT variant) and
-        test_return_timeout_setup_phase_hybrid (RETURN in-band-deadline variant).
-        """
         self._test_fail_timeout_impl([
             'FT.HYBRID', 'hybrid_idx',
             'SEARCH', '*',
@@ -509,20 +500,7 @@ class TestCoordinatorTimeout:
         ])
 
     def test_return_timeout_setup_phase_hybrid(self):
-        """RETURN-policy FT.HYBRID timeout during cursor-mapping setup (Phase 1)
-        with one shard suspended.
-
-        Suspending a non-coordinator shard before the query stalls the
-        coordinator's ProcessHybridCursorMappings wait: the stopped process keeps
-        its TCP connection (so the dispatch succeeds) but never sends its
-        cursor-mapping reply. Under RETURN policy with a finite timeout the setup
-        wait's deadline fires and DistHybridCleanups replies an empty result set
-        carrying the timeout warning -- not a hard error, and without hanging.
-
-        Complements the read-phase one-shard-paused tests, which suspend only
-        after Phase 1 completes; this one suspends during Phase 1 to exercise the
-        bounded cursor-setup wait.
-        """
+        """RETURN setup-phase timeout, one shard suspended: the in-band deadline fires; reply is empty + warning."""
         env = self.env
 
         prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
@@ -563,18 +541,7 @@ class TestCoordinatorTimeout:
             env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
 
     def test_return_strict_timeout_setup_phase_hybrid(self):
-        """RETURN-STRICT FT.HYBRID timeout during cursor-mapping setup (Phase 1),
-        driven by the blocked-client deadline.
-
-        Under RETURN-STRICT the setup wait has no in-band deadline (it is NULL), so
-        unlike the RETURN variant the only wake path is the coordinator's
-        blocked-client timeout callback. With one shard suspended the coordinator
-        parks in ProcessHybridCursorMappings; firing CLIENT UNBLOCK ... TIMEOUT
-        invokes DistHybridTimeoutReturnStrictCallback, which wakes the parked pop
-        (wakeHybridAbortChannels) and replies an empty result set with the timeout
-        warning. Companion to test_return_timeout_setup_phase_hybrid, which drives
-        the same setup wait through the in-band RETURN deadline instead.
-        """
+        """RETURN-STRICT setup-phase timeout, one shard suspended: no in-band deadline, so CLIENT UNBLOCK fires the timeout callback; reply is empty + warning."""
         env = self.env
 
         prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -499,6 +499,60 @@ class TestCoordinatorTimeout:
             'PARAMS', '2', 'BLOB', self.hybrid_query_vec
         ])
 
+    def test_return_timeout_setup_phase_hybrid(self):
+        """RETURN-policy FT.HYBRID timeout during cursor-mapping setup (Phase 1)
+        with one shard suspended.
+
+        Suspending a non-coordinator shard before the query stalls the
+        coordinator's ProcessHybridCursorMappings wait: the stopped process keeps
+        its TCP connection (so the dispatch succeeds) but never sends its
+        cursor-mapping reply. Under RETURN policy with a finite timeout the setup
+        wait's deadline fires and DistHybridCleanups replies an empty result set
+        carrying the timeout warning -- not a hard error, and without hanging.
+
+        Complements the read-phase one-shard-paused tests, which deliberately let
+        Phase 1 finish before suspending because the setup wait would otherwise
+        block forever.
+        """
+        env = self.env
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
+
+        _, _, paused_pid, _ = _split_shards_pick_one_paused(env)
+        shard_to_pause_p = psutil.Process(paused_pid)
+
+        # Per-query TIMEOUT arms the coordinator's cursor-setup deadline under
+        # RETURN policy (in-band timeout checking).
+        query_args = [
+            'FT.HYBRID', 'hybrid_idx',
+            'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB',
+            'PARAMS', '2', 'BLOB', self.hybrid_query_vec,
+            'TIMEOUT', '200',
+        ]
+
+        shard_to_pause_p.suspend()
+        try:
+            wait_for_condition(
+                lambda: (shard_to_pause_p.status() == psutil.STATUS_STOPPED,
+                         {'status': shard_to_pause_p.status()}),
+                'Timeout while waiting for shard to pause'
+            )
+
+            # The deadline fires in the setup wait; RETURN policy yields an empty
+            # result set with a timeout warning rather than an error (a hang would
+            # trip the harness test timeout).
+            result = env.cmd(*query_args)
+            env.assertEqual(result['total_results'], 0,
+                            message=f"Expected 0 results, got {result}")
+            assert_timeout_warning(env, result, message="RETURN-policy setup-phase timeout")
+        finally:
+            # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
+            # its cursors before later tests run.
+            shard_to_pause_p.resume()
+            env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
     def _test_fail_timeout_before_coord_pickup_impl(self, query_args):
         """Test timeout occurring before coordinator picks up the query job."""
         env = self.env

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -499,47 +499,6 @@ class TestCoordinatorTimeout:
             'PARAMS', '2', 'BLOB', self.hybrid_query_vec
         ])
 
-    def test_return_timeout_setup_phase_hybrid(self):
-        """RETURN setup-phase timeout, one shard suspended: the in-band deadline fires; reply is empty + warning."""
-        env = self.env
-
-        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
-        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
-
-        _, _, paused_pid, _ = _split_shards_pick_one_paused(env)
-        shard_to_pause_p = psutil.Process(paused_pid)
-
-        # Per-query TIMEOUT arms the coordinator's cursor-setup deadline under
-        # RETURN policy (in-band timeout checking).
-        query_args = [
-            'FT.HYBRID', 'hybrid_idx',
-            'SEARCH', '*',
-            'VSIM', '@embedding', '$BLOB',
-            'PARAMS', '2', 'BLOB', self.hybrid_query_vec,
-            'TIMEOUT', '200',
-        ]
-
-        shard_to_pause_p.suspend()
-        try:
-            wait_for_condition(
-                lambda: (shard_to_pause_p.status() == psutil.STATUS_STOPPED,
-                         {'status': shard_to_pause_p.status()}),
-                'Timeout while waiting for shard to pause'
-            )
-
-            # The deadline fires in the setup wait; RETURN policy yields an empty
-            # result set with a timeout warning rather than an error (a hang would
-            # trip the harness test timeout).
-            result = env.cmd(*query_args)
-            env.assertEqual(result['total_results'], 0,
-                            message=f"Expected 0 results, got {result}")
-            assert_timeout_warning(env, result, message="RETURN-policy setup-phase timeout")
-        finally:
-            # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
-            # its cursors before later tests run.
-            shard_to_pause_p.resume()
-            env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
-
     def test_return_strict_timeout_setup_phase_hybrid(self):
         """RETURN-STRICT setup-phase timeout, one shard suspended: no in-band deadline, so CLIENT UNBLOCK fires the timeout callback; reply is empty + warning."""
         env = self.env
@@ -576,10 +535,10 @@ class TestCoordinatorTimeout:
                 target=call_and_store, args=(env.cmd, query_args, reply), daemon=True)
             t_query.start()
 
-            # Park the coordinator in the setup wait: the dispatch job must have run
-            # before we fire the blocked-client deadline.
             blocked_client_id = wait_for_blocked_query_client(
                 env, 'FT.HYBRID', 'Client for FT.HYBRID not found')
+            # totalJobsDone advancing => the dispatch job ran => the shard received
+            # _FT.HYBRID and the coordinator is now parked on the setup channel.
             wait_for_condition(
                 lambda: (getWorkersThpoolStats(env)['totalJobsDone'] > initial_jobs_done,
                          {'totalJobsDone': getWorkersThpoolStats(env)['totalJobsDone']}),

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -362,9 +362,8 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     must be routed through the user callback so that:
     - FT.SEARCH: The reducer receives the error and returns it to the client
     - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
-    - FT.HYBRID: The no-reply path runs the iterator's error callback (records the
-      communication error) then MRIteratorCallback_Done, driving inProcess to 0 so the
-      channel unblocks ProcessHybridCursorMappings' MRIterator_NextWithTimeout wait
+    - FT.HYBRID: The no-reply path records the communication error and unblocks
+      ProcessHybridCursorMappings' channel wait
     """
     # Create an index and add data before breaking topology
     env.expect('FT.CREATE', 'idx', 'SCHEMA',

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -362,8 +362,9 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     must be routed through the user callback so that:
     - FT.SEARCH: The reducer receives the error and returns it to the client
     - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
-    - FT.HYBRID: The processCursorMappingCallback increments responseCount and signals
-      the condition variable, allowing ProcessHybridCursorMappings to unblock
+    - FT.HYBRID: The no-reply path runs the iterator's error callback (records the
+      communication error) then MRIteratorCallback_Done, driving inProcess to 0 so the
+      channel unblocks ProcessHybridCursorMappings' MRIterator_NextWithTimeout wait
     """
     # Create an index and add data before breaking topology
     env.expect('FT.CREATE', 'idx', 'SCHEMA',

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -73,7 +73,7 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
 @require_enable_assert
 def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     """A no-reply shard dispatch failure must surface as an error
-    rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
+    rather than hanging FT.HYBRID on ProcessHybridCursorMappings' channel wait.
     FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
     conn, query_vec, doc_vec = _setup_hybrid_index(env)
     for i in range(10):

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -2,11 +2,6 @@ from RLTest import Env
 from includes import *
 from common import *
 import psutil
-from test_blocked_client_timeout import (
-    _split_shards_pick_one_paused,
-    assert_timeout_warning,
-    ON_TIMEOUT_CONFIG,
-)
 
 # Test data with deterministic vectors
 test_data = {
@@ -469,7 +464,7 @@ def test_return_timeout_setup_phase_hybrid():
     prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
     env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
 
-    _, _, paused_pid, _ = _split_shards_pick_one_paused(env)
+    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
     shard_to_pause_p = psutil.Process(paused_pid)
 
     # Per-query TIMEOUT arms the coordinator's cursor-setup deadline under

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -1,6 +1,12 @@
 from RLTest import Env
 from includes import *
 from common import *
+import psutil
+from test_blocked_client_timeout import (
+    _split_shards_pick_one_paused,
+    assert_timeout_warning,
+    ON_TIMEOUT_CONFIG,
+)
 
 # Test data with deterministic vectors
 test_data = {
@@ -430,3 +436,69 @@ def test_debug_timeout_return_strict_rejected():
         'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
         'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2'
     ).error().contains('not supported with ON_TIMEOUT RETURN-STRICT')
+
+
+@skip(cluster=False)
+def test_return_timeout_setup_phase_hybrid():
+    """RETURN setup-phase timeout, one shard suspended: the in-band deadline fires; reply is empty + warning.
+
+    Lives here (not test_blocked_client_timeout.py): RETURN uses the in-band
+    deadline, not the blocked-client CLIENT UNBLOCK mechanism.
+    """
+    # WORKERS 1 dispatches the query to a BG thread so the cursor-setup wait is
+    # reachable; cluster mode gives us a non-coordinator shard to suspend.
+    env = Env(moduleArgs='WORKERS 1', protocol=3)
+    for i in range(1, env.shardsCount + 1):
+        verify_shard_init(env.getConnection(i))
+    conn = getConnectionByEnv(env)
+
+    env.expect(
+        'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
+        'name', 'TEXT',
+        'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2'
+    ).ok()
+    for i in range(100):
+        vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+        conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}', 'embedding', vec)
+    query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+    env.expect(
+        'FT.HYBRID', 'hybrid_idx', 'SEARCH', '*', 'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vec
+    ).noError()
+
+    prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+    env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
+
+    _, _, paused_pid, _ = _split_shards_pick_one_paused(env)
+    shard_to_pause_p = psutil.Process(paused_pid)
+
+    # Per-query TIMEOUT arms the coordinator's cursor-setup deadline under
+    # RETURN policy (in-band timeout checking).
+    query_args = [
+        'FT.HYBRID', 'hybrid_idx',
+        'SEARCH', '*',
+        'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vec,
+        'TIMEOUT', '200',
+    ]
+
+    shard_to_pause_p.suspend()
+    try:
+        wait_for_condition(
+            lambda: (shard_to_pause_p.status() == psutil.STATUS_STOPPED,
+                     {'status': shard_to_pause_p.status()}),
+            'Timeout while waiting for shard to pause'
+        )
+
+        # The deadline fires in the setup wait; RETURN policy yields an empty
+        # result set with a timeout warning rather than an error (a hang would
+        # trip the harness test timeout).
+        result = env.cmd(*query_args)
+        env.assertEqual(result['total_results'], 0,
+                        message=f"Expected 0 results, got {result}")
+        assert_timeout_warning(env, result, message="RETURN-policy setup-phase timeout")
+    finally:
+        # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
+        # its cursors before later tests run.
+        shard_to_pause_p.resume()
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -14,9 +14,6 @@ def run_cmd_expect_oom(env, query_args):
 def run_cmd(env, query_args):
     return (env.cmd(*query_args))
 
-def pid_cmd(conn):
-    return conn.execute_command('info', 'server')['process_id']
-
 def get_all_shards_pid(env):
     for shardId in range(1, env.shardsCount + 1):
         conn = env.getConnection(shardId)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Distributed `FT.HYBRID` sets up its shard cursors in `ProcessHybridCursorMappings`, waiting on a bespoke `pthread_mutex_t` + `pthread_cond_t` + `responseCount` counter via an **unbounded** `pthread_cond_wait`. Completion depends on every shard-termination path remembering to bump the counter; if any path doesn't, the coordinator thread hangs forever (the MOD-15394 hang). PR #9985 patched the one known no-reply path, but the design remained a footgun.
2. **Change:** Wait on the iterator's `MRChannel` instead — the same mechanism `FT.SEARCH` / `FT.AGGREGATE` already use. Completion is driven by the iterator's `inProcess` countdown reaching 0 (which fires on success **and** disconnect), and the wait is bounded by a deadline **plus** the request's `syncCtx` abort flag/channel. Both are required: the deadline is `NULL` under RETURN-STRICT / disabled timeout checks, where the abort flag is the only wake mechanism (`chan.c` asserts at least one is non-NULL). The setup wait registers on the **hybrid request's own** `syncCtx` (not the search subquery's), and **both** coordinator timeout callbacks (FAIL and RETURN-STRICT) wake it through a shared `wakeHybridAbortChannels` helper. The hybrid callbacks become lock-free (each `MRIterator` is pinned to a single IO thread, so its callbacks are serialized), and ctx teardown moves into the iterator's `cbPrivateDataDestructor`, so the timeout path can release the iterator without racing late callbacks.
3. **Outcome:** A non-responding or disconnected shard during hybrid cursor setup no longer hangs the coordinator. The wait unblocks at the request deadline (or on abort), and the reply follows the timeout policy: **FAIL** returns a timeout error, while **RETURN / RETURN-STRICT** return an empty result set with a timeout warning (no partial cursor mappings exist yet at setup, so there is nothing to return). The bespoke mutex, cond-var, `responseCount`, `numShards`, and `initialized` mirror are deleted; no shared `rmr.c` change.

This PR also routes every `syncCtx.timedOut` access through new `RequestSyncCtx_{Get,Set,Clear}TimedOut` accessors — a behavior-preserving refactor that `AREQ_*` and `HybridRequest_*` delegate to.

#### Which additional issues this PR fixes
1. MOD-16145 (follow-up to MOD-15394 / #9985)

#### Main objects this PR modified
1. `ProcessHybridCursorMappings` and its callbacks — channel-based bounded wait (`src/coord/hybrid/hybrid_cursor_mappings.c/.h`)
2. `HybridRequest_prepareCursors` — computes the deadline and registers the hybrid request's own `syncCtx` (`src/coord/hybrid/dist_hybrid.c`)
3. `wakeHybridAbortChannels` + `DistHybridTimeout{Fail,ReturnStrict}Callback` — wake the setup-phase pop on timeout from both callbacks (`src/coord/hybrid/dist_hybrid.c`)
4. `DistHybridCleanups` — policy-aware reply for a setup-phase timeout (empty+warning under RETURN/RETURN-STRICT vs. error under FAIL) (`src/coord/hybrid/dist_hybrid.c`)
5. `RequestSyncCtx_{Get,Set,Clear}TimedOut` accessors; `AREQ_*` / `HybridRequest_*` delegate (`src/aggregate/aggregate.h`, `src/aggregate/aggregate_request.c`, `src/hybrid/hybrid_request.{c,h}`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: distributed `FT.HYBRID` no longer hangs when a shard fails to respond or disconnects during cursor setup; it returns at the query timeout — an error under FAIL policy, or empty results with a timeout warning under RETURN/RETURN-STRICT.

## Testing

Setup-phase (Phase 1) timeout is now covered for all three policies (`test_blocked_client_timeout.py`, `TestCoordinatorTimeout`), each suspending a non-coordinator shard so the setup wait stalls on a connected-but-silent shard:
- **RETURN** — `test_return_timeout_setup_phase_hybrid`: in-band deadline fires; asserts empty result + timeout warning. Verified **red** (hard `TIMED_OUT` error) without the policy-aware reply and **green** with it.
- **RETURN-STRICT** — `test_return_strict_timeout_setup_phase_hybrid`: deadline is `NULL`, so `CLIENT UNBLOCK ... TIMEOUT` drives `DistHybridTimeoutReturnStrictCallback` (→ `wakeHybridAbortChannels`); asserts empty result + timeout warning + COORD warning metric +1.
- **FAIL** — `test_fail_timeout_hybrid`: `CLIENT UNBLOCK ... TIMEOUT` drives `DistHybridTimeoutFailCallback`; asserts timeout error + COORD error metric +1.

All three reuse the existing `psutil` suspend infra — no sync-point scaffolding.

Re-ran for the review refinements (cluster, `REDIS_STANDALONE=0`): the three setup-phase tests above 3/3, plus `test_hybrid_dist` 2/2 — no regression. The base channel-wait change was previously verified green across `test_coordinator` (13/13), `test_hybrid_timeout` (29/29), `test_hybrid_shard_k_ratio` (7/7), and `test_hybrid` (25/25); the full suite re-runs in CI.

The test-file change triggers the PR's coverage job, and the suite also runs under the `SAN=address` sanitizer config. So beyond locking the reply contract, the setup-phase tests double as the deterministic vehicle for the timeout lifetime path (late iterator callbacks vs. the ctx destructor) under ASan, and mark `wakeHybridAbortChannels` plus the RETURN-STRICT setup-phase callback branch as covered — no separate manual ASan run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
