### PR TITLE
[MOD-16258] Add RediSearch release branch-out skill

### DIFF
--- a/.skills/branch-out-release/SKILL.md
+++ b/.skills/branch-out-release/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: branch-out-release
+description: Create a new RediSearch public release branch from master or prepare branch-out changes. Use when branching a version line such as 8.10 from master, setting initial version.h, copying GitHub branch protection, adapting release-branch CI gates, triggering validation, or documenting follow-up master-to-release sync policy.
+---
+
+# Branch Out Release
+
+Use this for RediSearch OSS release branch creation from `master`.
+
+## Workflow
+
+1. Resolve current state.
+   - Fetch `origin/master` and the latest release branch used as the template, usually the previous line such as `8.8`.
+   - Verify the target branch does not already exist:
+     `git ls-remote --heads origin <target-branch>`.
+   - Check current `master` validation before branch-out. Report the latest `Nightly Flow` status and distinguish infra failures from product/test failures.
+   - Use a clean worktree instead of the user's dirty checkout.
+
+2. Create the official branch.
+   - Branch from the selected `origin/master` SHA.
+   - Set `src/version.h` to the requested initial milestone. For `8.10`, this was `8.9.80`.
+   - Commit with a clear message such as `Initial 8.10 branch`.
+   - Push the new branch before applying branch protection.
+
+3. Add branch protection.
+   - Copy settings from the previous public release branch, not from memory.
+   - Create a new exact-pattern rule for the new branch, for example `8.10`.
+   - Do not modify the source branch rule and do not use a wildcard rule.
+   - Explicitly set every relevant value, including false/null-like settings, so GitHub does not fall back to new-rule defaults.
+   - Preserve required status check bindings. In this repo, `pr-validation` is bound to the GitHub Actions app and `license/cla` is unbound.
+   - Read back both source and target protection rules and compare. Only ids, URLs, pattern, and matching refs should differ.
+
+4. Adapt release-branch CI.
+   - Do this as a normal PR after protection is enabled.
+   - Compare the new branch against the previous release branch under `.github/workflows/`.
+   - The important release-branch behavior is:
+     - PR flow stays lightweight: Ubuntu quick tests; coverage and sanitize only when forced by labels.
+     - Merge queue is the release gate: full supported platform/architecture matrix, full tests, coverage/sanitize, fail-fast, separate coordinator jobs.
+     - Nightly is less critical than master: full matrix but `QUICK=1`, pinned Redis SHA, not Redis `unstable`.
+   - Pin Redis to the current release-branch SHA until there is a better release/pre-release line. For `8.8` and the initial `8.10` branch-out, this SHA was `3cd464263b03b425ffae2e23db24df3dc9346871`.
+   - Check whether `RedisJSON/RedisJSON` has a matching release branch:
+     `git ls-remote --heads git@github.com:RedisJSON/RedisJSON.git <target-branch>`.
+     Use the matching branch for PR/MQ only if it exists. Otherwise keep `master` and add a TODO in the workflow.
+   - Preserve newer master CI infrastructure unless it conflicts with the release-branch gating policy.
+
+5. Validate.
+   - Inspect diffs for `8.8`, `master`, and the new branch so release-only CI behavior is intentional.
+   - Manually trigger `Nightly Flow` on the new branch if needed:
+     `gh workflow run event-nightly.yml --repo RediSearch/RediSearch --ref <target-branch>`.
+   - Remember that scheduled workflows run from the default branch; use manual dispatch for release branch nightlies unless a dedicated schedule exists.
+
+6. Future sync policy.
+   - Prefer normal merges from `master` into the release branch while the release branch is still tracking master closely.
+   - Do not force-push or overwrite the official release branch.
+   - During master-to-release merges, preserve release-only files such as `src/version.h` and release-branch CI differences.
+   - Do not merge release branch version changes back into `master`.
+
+## PR Notes
+
+When opening PRs, use `.github/PULL_REQUEST_TEMPLATE.md`.
+
+- Branch creation/version or release CI changes are user/release-facing enough to require release notes unless the release manager says otherwise.
+- Skill-only documentation on `master` is internal-only and normally does not require release notes.

--- a/.skills/branch-out-release/SKILL.md
+++ b/.skills/branch-out-release/SKILL.md
@@ -31,11 +31,13 @@ Use this for RediSearch OSS release branch creation from `master`.
    - Read back both source and target protection rules and compare. Only ids, URLs, pattern, and matching refs should differ.
 
 4. Enable merge queue.
-   - Treat merge queue as a separate configuration surface from classic branch protection.
+   - For parity with existing release branches, enable the classic branch protection checkbox:
+     Settings -> Branches -> Branch protection rules -> edit the exact target branch rule -> Require merge queue.
+   - Do not use repository rulesets as the normal copy path. A ruleset `merge_queue` rule can make `repository.mergeQueue` non-null, but it is a different surface and does not check the classic branch protection UI box.
    - Read the previous release branch queue with `repository.mergeQueue(branch: "<source-branch>")`.
-   - Enable a queue for the new branch only, using a branch-scoped rule or settings entry for `refs/heads/<target-branch>`.
-   - Copy all queue parameters from the source branch. For `8.8` to initial `8.10`, the effective values were `mergeMethod=SQUASH`, `mergingStrategy=ALLGREEN`, `maximumEntriesToBuild=5`, `maximumEntriesToMerge=5`, `minimumEntriesToMerge=1`, `minimumEntriesToMergeWaitTime=300`, and `checkResponseTimeout=21600`.
-   - Read back `repository.mergeQueue(branch: "<target-branch>")` and compare. Only ids, URLs, labels/names, target refs, and current queue entries should differ.
+   - In the UI, copy every queue value that is exposed from the source branch to the target branch. For `8.8` to initial `8.10`, the effective values were `mergeMethod=SQUASH`, `mergingStrategy=ALLGREEN`, `maximumEntriesToBuild=5`, `maximumEntriesToMerge=5`, `minimumEntriesToMerge=1`, `minimumEntriesToMergeWaitTime=300`, and `checkResponseTimeout=21600`.
+   - Read back `repository.mergeQueue(branch: "<target-branch>")` and compare. Only ids, URLs, labels/names, target refs, and current queue entries should differ. If GitHub hides some queue fields in the UI, save the visible fields first, then use this readback to detect whether hidden defaults match the source branch.
+   - Do not enqueue release CI PRs until the target branch reports `isMergeQueueEnabled: true` for that PR.
 
 5. Adapt release-branch CI.
    - Do this as a normal PR after protection is enabled.

--- a/.skills/branch-out-release/SKILL.md
+++ b/.skills/branch-out-release/SKILL.md
@@ -33,8 +33,9 @@ Use this for RediSearch OSS release branch creation from `master`.
 4. Adapt release-branch CI.
    - Do this as a normal PR after protection is enabled.
    - Compare the new branch against the previous release branch under `.github/workflows/`.
-   - The important release-branch behavior is:
-     - PR flow stays lightweight: Ubuntu quick tests; coverage and sanitize only when forced by labels.
+   - The important release-branch CI invariants are:
+     - PR flow stays lightweight: Ubuntu quick tests by default. Coverage and sanitize are label-conditioned: they run only when a non-draft PR workflow event sees `enforce:coverage` or `enforce:sanitize`.
+       Adding those labels alone may not start a run; add the label before a push/update or rerun the workflow.
      - Merge queue is the release gate: full supported platform/architecture matrix, full tests, coverage/sanitize, fail-fast, separate coordinator jobs.
      - Nightly is less critical than master: full matrix but `QUICK=1`, pinned Redis SHA, not Redis `unstable`.
    - Pin Redis to the current release-branch SHA until there is a better release/pre-release line. For `8.8` and the initial `8.10` branch-out, this SHA was `3cd464263b03b425ffae2e23db24df3dc9346871`.

--- a/.skills/branch-out-release/SKILL.md
+++ b/.skills/branch-out-release/SKILL.md
@@ -30,7 +30,14 @@ Use this for RediSearch OSS release branch creation from `master`.
    - Preserve required status check bindings. In this repo, `pr-validation` is bound to the GitHub Actions app and `license/cla` is unbound.
    - Read back both source and target protection rules and compare. Only ids, URLs, pattern, and matching refs should differ.
 
-4. Adapt release-branch CI.
+4. Enable merge queue.
+   - Treat merge queue as a separate configuration surface from classic branch protection.
+   - Read the previous release branch queue with `repository.mergeQueue(branch: "<source-branch>")`.
+   - Enable a queue for the new branch only, using a branch-scoped rule or settings entry for `refs/heads/<target-branch>`.
+   - Copy all queue parameters from the source branch. For `8.8` to initial `8.10`, the effective values were `mergeMethod=SQUASH`, `mergingStrategy=ALLGREEN`, `maximumEntriesToBuild=5`, `maximumEntriesToMerge=5`, `minimumEntriesToMerge=1`, `minimumEntriesToMergeWaitTime=300`, and `checkResponseTimeout=21600`.
+   - Read back `repository.mergeQueue(branch: "<target-branch>")` and compare. Only ids, URLs, labels/names, target refs, and current queue entries should differ.
+
+5. Adapt release-branch CI.
    - Do this as a normal PR after protection is enabled.
    - Compare the new branch against the previous release branch under `.github/workflows/`.
    - The important release-branch CI invariants are:
@@ -44,13 +51,13 @@ Use this for RediSearch OSS release branch creation from `master`.
      Use the matching branch for PR/MQ only if it exists. Otherwise keep `master` and add a TODO in the workflow.
    - Preserve newer master CI infrastructure unless it conflicts with the release-branch gating policy.
 
-5. Validate.
+6. Validate.
    - Inspect diffs for `8.8`, `master`, and the new branch so release-only CI behavior is intentional.
    - Manually trigger `Nightly Flow` on the new branch if needed:
      `gh workflow run event-nightly.yml --repo RediSearch/RediSearch --ref <target-branch>`.
    - Remember that scheduled workflows run from the default branch; use manual dispatch for release branch nightlies unless a dedicated schedule exists.
 
-6. Future sync policy.
+7. Future sync policy.
    - Prefer normal merges from `master` into the release branch while the release branch is still tracking master closely.
    - Do not force-push or overwrite the official release branch.
    - During master-to-release merges, preserve release-only files such as `src/version.h` and release-branch CI differences.

--- a/.skills/branch-out-release/agents/openai.yaml
+++ b/.skills/branch-out-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Branch Out Release"
+  short_description: "Create RediSearch release branches from master safely"
+  default_prompt: "Branch a new RediSearch release line from master"


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Branching a new RediSearch release line requires remembering several repository-specific steps across GitHub branch protection, release CI, and validation.
2. Change: Add a repo-local Codex skill that documents the release branch-out workflow, including `version.h`, branch protection copy, release-branch CI adaptation, Redis/RedisJSON handling, nightly validation, and future master-to-release sync policy.
3. Outcome: Future release branches can be created consistently with less context loss.

#### Which additional issues this PR fixes
1. MOD-16258

#### Main objects this PR modified
1. `.skills/branch-out-release/SKILL.md`
2. `.skills/branch-out-release/agents/openai.yaml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
