### PR TITLE
[MOD-16259] Make suffix-trie wildcard queries on TEXT fields case-insensitive

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -777,12 +777,16 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
     // all modifier fields are supported
     if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
        (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
+      // TEXT terms are stored lowercased, so recheck against the lowercased
+      // pattern (Suffix_CB_Wildcard matches cstr) to stay case-insensitive.
+      size_t lcstrlen;
+      char *lcstr = runesToStr(str, nstr, &lcstrlen);
       SuffixCtx sufCtx = {
         .trie = spec->suffix,
         .rune = str,
         .runelen = nstr,
-        .cstr = token->str,
-        .cstrlen = token->len,
+        .cstr = lcstr,
+        .cstrlen = lcstrlen,
         .type = SUFFIX_TYPE_WILDCARD,
         .callback = charIterCb, // the difference is weather the function receives char or rune
         .cbCtx = &ctx,
@@ -793,6 +797,7 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
         // if suffix trie cannot be used, use brute force
         fallbackBruteForce = true;
       }
+      rm_free(lcstr);
     } else {
       QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC, "Contains query on fields without WITHSUFFIXTRIE support");
     }

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -398,3 +398,31 @@ def testTextSuffixTrieMaxPrefixExpansions():
 
     # Restore default
     run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
+
+@skip(cluster=True)
+def testSuffixTrieWildcardCaseInsensitiveText():
+    """MOD-16259: wildcard queries on a WITHSUFFIXTRIE TEXT field match
+    case-insensitively, identically to a plain TEXT field."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env.expect(config_cmd(), 'set', 'MINPREFIX', 1).ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CREATE', 'idx_w',  'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE')
+    conn.execute_command('FT.CREATE', 'idx_no', 'SCHEMA', 't', 'TEXT')
+    conn.execute_command('HSET', 'doc:1', 't', 'apple')
+
+    # The suffix trie must not change which docs a wildcard query returns.
+    for q in ("w'ap*'", "w'AP*'", "w'A*'", "w'*PL*'", "w'*LE'", "w'XY*'"):
+        with_suffix = env.cmd('FT.SEARCH', 'idx_w',  q, 'NOCONTENT')
+        plain       = env.cmd('FT.SEARCH', 'idx_no', q, 'NOCONTENT')
+        env.assertEqual(with_suffix, plain, message=q)
+
+@skip(cluster=True)
+def testSuffixTrieWildcardCaseSensitiveTag():
+    """MOD-16259: CASESENSITIVE TAG wildcard matching stays byte-exact."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env.expect(config_cmd(), 'set', 'MINPREFIX', 1).ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'WITHSUFFIXTRIE', 'CASESENSITIVE')
+    conn.execute_command('HSET', 'doc:1', 't', 'Apple')
+    env.expect('FT.SEARCH', 'idx', "@t:{w'A*'}", 'NOCONTENT').equal([1, 'doc:1'])
+    env.expect('FT.SEARCH', 'idx', "@t:{w'a*'}", 'NOCONTENT').equal([0])

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -410,10 +410,28 @@ def testSuffixTrieWildcardCaseInsensitiveText():
     conn.execute_command('FT.CREATE', 'idx_no', 'SCHEMA', 't', 'TEXT')
     conn.execute_command('HSET', 'doc:1', 't', 'apple')
 
-    # The suffix trie must not change which docs a wildcard query returns.
-    for q in ("w'ap*'", "w'AP*'", "w'A*'", "w'*PL*'", "w'*LE'", "w'XY*'"):
+    match = [1, 'doc:1']
+    miss  = [0]
+    # query -> expected result. Covers '*' and '?' wildcards in both cases.
+    expected = {
+        "w'ap*'":   match,
+        "w'AP*'":   match,
+        "w'A*'":    match,
+        "w'*PL*'":  match,
+        "w'*LE'":   match,
+        "w'appl?'": match,
+        "w'?pple'": match,
+        "w'?PPL?'": match,
+        "w'AP?LE'": match,
+        "w'XY*'":   miss,
+        "w'?Z*'":   miss,
+    }
+    for q, exp in expected.items():
         with_suffix = env.cmd('FT.SEARCH', 'idx_w',  q, 'NOCONTENT')
         plain       = env.cmd('FT.SEARCH', 'idx_no', q, 'NOCONTENT')
+        # Tightly assert the answer, and that the suffix trie does not change it.
+        env.assertEqual(with_suffix, exp,   message=q)
+        env.assertEqual(plain,       exp,   message=q)
         env.assertEqual(with_suffix, plain, message=q)
 
 @skip(cluster=True)

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -401,7 +401,7 @@ def testTextSuffixTrieMaxPrefixExpansions():
 
 @skip(cluster=True)
 def testSuffixTrieWildcardCaseInsensitiveText():
-    """MOD-16259: wildcard queries on a WITHSUFFIXTRIE TEXT field match
+    """Wildcard queries on a WITHSUFFIXTRIE TEXT field match
     case-insensitively, identically to a plain TEXT field."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     env.expect(config_cmd(), 'set', 'MINPREFIX', 1).ok()
@@ -418,7 +418,7 @@ def testSuffixTrieWildcardCaseInsensitiveText():
 
 @skip(cluster=True)
 def testSuffixTrieWildcardCaseSensitiveTag():
-    """MOD-16259: CASESENSITIVE TAG wildcard matching stays byte-exact."""
+    """CASESENSITIVE TAG wildcard matching stays byte-exact."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     env.expect(config_cmd(), 'set', 'MINPREFIX', 1).ok()
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -429,9 +429,8 @@ def testSuffixTrieWildcardCaseInsensitiveText():
     for q, exp in expected.items():
         with_suffix = env.cmd('FT.SEARCH', 'idx_w',  q, 'NOCONTENT')
         plain       = env.cmd('FT.SEARCH', 'idx_no', q, 'NOCONTENT')
-        env.assertEqual(with_suffix, exp,   message=q)
-        env.assertEqual(plain,       exp,   message=q)
-        env.assertEqual(with_suffix, plain, message=q)
+        env.assertEqual(with_suffix, exp, message=q)
+        env.assertEqual(plain,       exp, message=q)
 
 @skip(cluster=True)
 def testSuffixTrieWildcardCaseSensitiveTag():

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -429,7 +429,6 @@ def testSuffixTrieWildcardCaseInsensitiveText():
     for q, exp in expected.items():
         with_suffix = env.cmd('FT.SEARCH', 'idx_w',  q, 'NOCONTENT')
         plain       = env.cmd('FT.SEARCH', 'idx_no', q, 'NOCONTENT')
-        # Tightly assert the answer, and that the suffix trie does not change it.
         env.assertEqual(with_suffix, exp,   message=q)
         env.assertEqual(plain,       exp,   message=q)
         env.assertEqual(with_suffix, plain, message=q)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Wildcard queries (`w'...'`, DIALECT 2) on a `WITHSUFFIXTRIE` TEXT field re-validate candidates against the original-case query bytes (`SuffixCtx.cstr`) via byte-exact `Wildcard_MatchChar`, while TEXT terms are stored lowercased. Uppercase patterns such as `w'AP*'` therefore silently return nothing, even though the identical query on a plain TEXT field matches case-insensitively.
2. **Change:** Feed the suffix-trie recheck the lowercased pattern (via `runesToStr` on the already-lowercased rune buffer) instead of the raw query bytes, matching how terms are stored. The `CASESENSITIVE` TAG path is a separate code path and is untouched.
3. **Outcome:** Wildcard matching on `WITHSUFFIXTRIE` TEXT fields is now case-insensitive and behaves identically to a plain TEXT field.

Fixture `HSET doc:1 t apple`, all queries `DIALECT 2`:

| Query | plain TEXT | WITHSUFFIXTRIE before | WITHSUFFIXTRIE after |
| --- | --- | --- | --- |
| `w'ap*'` | Match | Match | Match |
| `w'AP*'` | Match | **Miss** | Match |
| `w'*PL*'` | Match | **Miss** | Match |
| `w'*LE'` | Match | **Miss** | Match |
| `w'XY*'` (absent) | Miss | Miss | Miss |

#### Which additional issues this PR fixes
1. MOD-16259
2. Pre-existing bug; also removes the would-be `w'A*'` regression from #9945 (MOD-16001) once that rebases on this.

#### Main objects this PR modified
1. `Query_EvalWildcardQueryNode` (`src/query.c`)
2. `tests/pytests/test_contains.py` — case-insensitivity parity test + `CASESENSITIVE` TAG guard

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes case-sensitive wildcard matching on `WITHSUFFIXTRIE` TEXT fields — uppercase patterns like `w'AP*'` now match case-insensitively, consistent with plain TEXT fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)