### PR TITLE
[MOD-16145] test: repro for FT.HYBRID hang on an unresponsive shard

### DIFF
--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -152,6 +152,10 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 #define SYNC_POINT_RPNET_WAITING_FOR_REPLY              "RpnetWaitingForReply"
 #define SYNC_POINT_BEFORE_QI_TIMEOUT_CHECK              "BeforeQITimeoutCheck"
 #define SYNC_POINT_AFTER_SCHEDULE_DEPLETERS             "AfterScheduleDepleters"
+// Stalls a shard's internal (_FT.HYBRID) background execution before it produces
+// its cursor-mapping reply, so the coordinator's ProcessHybridCursorMappings sees
+// an alive-but-unresponsive shard (no reply, no disconnect).
+#define SYNC_POINT_BEFORE_HYBRID_SHARD_REPLY            "BeforeHybridShardReply"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1223,6 +1223,15 @@ static void blockedClientHybridCtx_destroy(blockedClientHybridCtx *BCHCtx) {
  * @param BCHCtx The blocked client context containing the request
  */
 static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
+#ifdef ENABLE_ASSERT
+  // Test hook: stall a shard's internal cursor-mapping reply on the worker
+  // thread while its main thread stays responsive, so the coordinator blocks in
+  // ProcessHybridCursorMappings waiting for a reply that never arrives (no
+  // disconnect). Exercises the bounded-wait timeout path.
+  if (BCHCtx->internal) {
+    SyncPoint_Wait(SYNC_POINT_BEFORE_HYBRID_SHARD_REPLY);
+  }
+#endif
   StrongRef hybrid_ref = BCHCtx->hybrid_ref;
   HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   HybridPipelineParams *hybridParams = BCHCtx->hybridParams;

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -109,3 +109,83 @@ def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     env.assertEqual(len(error_holder), 1,
                     message=f'Expected a communication error, got results: {result_holder}')
     env.assertContains('Could not send query to cluster', str(error_holder[0]))
+
+
+@skip(cluster=False)
+@require_enable_assert
+def test_dist_hybrid_unresponsive_shard_does_not_hang(env):
+    """A shard that received _FT.HYBRID and stays connected but never produces its
+    cursor-mapping reply must not hang FT.HYBRID. The coordinator's setup-phase
+    wait (ProcessHybridCursorMappings) must be bounded by the request timeout
+    rather than blocking on the missing reply indefinitely.
+
+    Distinct from test_dist_hybrid_shard_dispatch_failure_does_not_hang, where the
+    shard never replies because the dispatch itself fails (the MR layer drives
+    completion via the error callback). Here the shard is alive and the dispatch
+    succeeds; only the bounded wait can unblock the coordinator.
+
+    The BeforeHybridShardReply sync point parks the internal _FT.HYBRID worker
+    before it emits the cursor-mapping reply; the shard's main thread stays
+    responsive so IS_WAITING / SIGNAL still work."""
+    conn, query_vec, doc_vec = _setup_hybrid_index(env)
+    for i in range(20):
+        conn.execute_command('HSET', f'doc{i}', 'name', 'hello', 'embedding', doc_vec)
+
+    # Bound the request with a finite timeout. The test harness defaults to
+    # TIMEOUT 0 (unlimited); under the default RETURN policy a finite timeout is
+    # what arms the coordinator's cursor-setup deadline. (Bounding the unlimited
+    # case is tracked separately.)
+    env.expect(config_cmd(), 'SET', 'TIMEOUT', '500').ok()
+
+    sync_point = 'BeforeHybridShardReply'
+    # Arm every shard: the cursor-mapping fan-out may land the internal _FT.HYBRID
+    # on any subset of shards (incl. the coordinator's own). Whichever shard runs
+    # it parks on its worker thread before replying.
+    shard_conns = [env.getConnection(s) for s in range(1, env.shardsCount + 1)]
+    for sc in shard_conns:
+        sc.execute_command(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+        sc.execute_command(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
+
+    def any_shard_waiting():
+        return any(sc.execute_command(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1
+                   for sc in shard_conns)
+
+    error_holder = []
+    result_holder = []
+    def run_hybrid_query(c, errors, results):
+        try:
+            results.append(c.execute_command(
+                'FT.HYBRID', 'idx',
+                'SEARCH', '*',
+                'VSIM', '@embedding', '$BLOB',
+                'PARAMS', '2', 'BLOB', query_vec
+            ))
+        except Exception as e:
+            errors.append(e)
+
+    query_conn = env.getConnection()
+    query_thread = threading.Thread(
+        target=run_hybrid_query,
+        args=(query_conn, error_holder, result_holder),
+        daemon=True
+    )
+    query_thread.start()
+    try:
+        # Confirm a shard is parked before emitting its cursor-mapping reply.
+        wait_for_condition(
+            lambda: (any_shard_waiting(), {}),
+            f'Timeout waiting for {sync_point} sync point on any shard'
+        )
+
+        # The coordinator must bound the wait and return instead of blocking
+        # forever on the missing shard reply.
+        query_thread.join(timeout=10)
+        env.assertFalse(query_thread.is_alive(),
+                        message='FT.HYBRID hung waiting for an unresponsive shard')
+    finally:
+        # Release the parked shard(s) so the background reply drains and the env
+        # tears down cleanly, regardless of whether the assertion above passed.
+        for sc in shard_conns:
+            sc.execute_command(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point)
+            sc.execute_command(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+        query_thread.join(timeout=10)

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -131,61 +131,36 @@ def test_dist_hybrid_unresponsive_shard_does_not_hang(env):
     for i in range(20):
         conn.execute_command('HSET', f'doc{i}', 'name', 'hello', 'embedding', doc_vec)
 
-    # Bound the request with a finite timeout. The test harness defaults to
-    # TIMEOUT 0 (unlimited); under the default RETURN policy a finite timeout is
-    # what arms the coordinator's cursor-setup deadline. (Bounding the unlimited
-    # case is tracked separately.)
+    # A finite timeout arms the coordinator's cursor-setup deadline; the harness
+    # defaults to TIMEOUT 0 (unlimited). (Bounding the unlimited case is separate.)
     env.expect(config_cmd(), 'SET', 'TIMEOUT', '500').ok()
 
+    # Arm on every shard: the fan-out may land the internal _FT.HYBRID on any of
+    # them (incl. the coordinator's own).
     sync_point = 'BeforeHybridShardReply'
-    # Arm every shard: the cursor-mapping fan-out may land the internal _FT.HYBRID
-    # on any subset of shards (incl. the coordinator's own). Whichever shard runs
-    # it parks on its worker thread before replying.
-    shard_conns = [env.getConnection(s) for s in range(1, env.shardsCount + 1)]
-    for sc in shard_conns:
-        sc.execute_command(debug_cmd(), 'SYNC_POINT', 'CLEAR')
-        sc.execute_command(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
-
-    def any_shard_waiting():
-        return any(sc.execute_command(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1
-                   for sc in shard_conns)
-
-    error_holder = []
-    result_holder = []
-    def run_hybrid_query(c, errors, results):
-        try:
-            results.append(c.execute_command(
-                'FT.HYBRID', 'idx',
-                'SEARCH', '*',
-                'VSIM', '@embedding', '$BLOB',
-                'PARAMS', '2', 'BLOB', query_vec
-            ))
-        except Exception as e:
-            errors.append(e)
-
-    query_conn = env.getConnection()
-    query_thread = threading.Thread(
-        target=run_hybrid_query,
-        args=(query_conn, error_holder, result_holder),
-        daemon=True
-    )
-    query_thread.start()
+    run_command_on_all_shards(env, debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
     try:
-        # Confirm a shard is parked before emitting its cursor-mapping reply.
-        wait_for_condition(
-            lambda: (any_shard_waiting(), {}),
-            f'Timeout waiting for {sync_point} sync point on any shard'
-        )
+        done = threading.Event()
+        def run_query():
+            try:
+                env.getConnection().execute_command(
+                    'FT.HYBRID', 'idx', 'SEARCH', '*',
+                    'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vec)
+            except Exception:
+                pass  # a timeout error is the expected outcome; we only assert it returns
+            finally:
+                done.set()
+        threading.Thread(target=run_query, daemon=True).start()
 
-        # The coordinator must bound the wait and return instead of blocking
-        # forever on the missing shard reply.
-        query_thread.join(timeout=10)
-        env.assertFalse(query_thread.is_alive(),
-                        message='FT.HYBRID hung waiting for an unresponsive shard')
+        # Confirm the stall is actually exercised, then require the query to
+        # return at the deadline rather than block on the missing reply.
+        wait_for_condition(
+            lambda: (1 in run_command_on_all_shards(env, debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point), {}),
+            f'Timeout waiting for {sync_point} sync point on any shard')
+        env.assertTrue(done.wait(timeout=10),
+                       message='FT.HYBRID hung waiting for an unresponsive shard')
     finally:
-        # Release the parked shard(s) so the background reply drains and the env
-        # tears down cleanly, regardless of whether the assertion above passed.
-        for sc in shard_conns:
-            sc.execute_command(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point)
-            sc.execute_command(debug_cmd(), 'SYNC_POINT', 'CLEAR')
-        query_thread.join(timeout=10)
+        # SIGNAL wakes a parked worker; CLEAR disarms so a worker arriving late
+        # doesn't park, letting the background reply drain and the env tear down.
+        run_command_on_all_shards(env, debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point)
+        run_command_on_all_shards(env, debug_cmd(), 'SYNC_POINT', 'CLEAR')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** There is no deterministic test for the FT.HYBRID coordinator hang where a shard is *alive and connected but silent* — it accepted `_FT.HYBRID`, but never produces its cursor-mapping reply and never disconnects. Existing coverage only exercises dispatch failure / disconnect, where the MR layer drives completion via the error callback.
2. **Change:** Add a `BeforeHybridShardReply` sync point (ENABLE_ASSERT-only, gated on `BCHCtx->internal` so it affects only the shard-side `_FT.HYBRID` worker) that parks the worker before it emits its cursor-mapping reply, while the shard's main thread stays responsive. `test_dist_hybrid_unresponsive_shard_does_not_hang` arms it on every shard and asserts FT.HYBRID returns rather than blocking indefinitely in `ProcessHybridCursorMappings`.
3. **Outcome:** A repro that pins the exact stall family behind MOD-16145.

> [!IMPORTANT]
> **Dependency / merge ordering.** This test passes **only with the bounded-wait fix** (#10110). On `master` (pre-fix) the unbounded wait ignores the request timeout, so the test hangs until the parked shard is released in `finally`. This PR is intentionally a **draft**; do not merge it ahead of the fix. The test is bounded by `TIMEOUT 500` under the default `RETURN` policy, which is what arms the coordinator's cursor-setup deadline once the fix is present.

#### Which additional issues this PR fixes
1. MOD-16145
2. Test companion to #10110

#### Main objects this PR modified
1. `src/debug_commands.h` — `SYNC_POINT_BEFORE_HYBRID_SHARD_REPLY` macro
2. `src/hybrid/hybrid_exec.c` — `ENABLE_ASSERT` sync-point hook in `HREQ_Execute_Callback`
3. `tests/pytests/test_hybrid_dist.py` — `test_dist_hybrid_unresponsive_shard_does_not_hang`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes