### PR TITLE
Deduplicate benchmark_group helper in rqe_iterators_bencher

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/empty.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/empty.rs
@@ -29,10 +29,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/id_list.rs
@@ -29,10 +29,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
@@ -196,10 +196,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     /// Sweep `NUM_CHILDREN_CASES` × `OVERLAP_CASES`, building a fresh `Intersection` from

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/mod.rs
@@ -40,8 +40,5 @@ fn benchmark_group<'a>(
     test: &str,
 ) -> BenchmarkGroup<'a, WallTime> {
     let label = format!("Iterator - InvertedIndex - {it_name} - {test}");
-    let mut group = c.benchmark_group(label);
-    group.measurement_time(MEASUREMENT_TIME);
-    group.warm_up_time(WARMUP_TIME);
-    group
+    super::group(c, &label, MEASUREMENT_TIME, WARMUP_TIME)
 }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/metric.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/metric.rs
@@ -46,10 +46,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/mod.rs
@@ -18,3 +18,20 @@ pub mod optional;
 pub mod optional_optimized;
 pub mod union;
 pub mod wildcard;
+
+use std::time::Duration;
+
+use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
+
+/// Create a Criterion benchmark group configured with the given measurement and warm-up times.
+fn group<'a>(
+    c: &'a mut Criterion,
+    name: &str,
+    measurement_time: Duration,
+    warm_up_time: Duration,
+) -> BenchmarkGroup<'a, WallTime> {
+    let mut group = c.benchmark_group(name);
+    group.measurement_time(measurement_time);
+    group.warm_up_time(warm_up_time);
+    group
+}

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
@@ -33,10 +33,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -59,10 +59,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     /// Dense child data: 99% of docs (all except every 100th doc).

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional.rs
@@ -36,10 +36,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional_optimized.rs
@@ -69,10 +69,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/union.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/union.rs
@@ -277,10 +277,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/wildcard.rs
@@ -28,10 +28,7 @@ impl Bencher {
         c: &'a mut Criterion,
         label: &str,
     ) -> BenchmarkGroup<'a, WallTime> {
-        let mut group = c.benchmark_group(label);
-        group.measurement_time(Self::MEASUREMENT_TIME);
-        group.warm_up_time(Self::WARMUP_TIME);
-        group
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
     }
 
     pub fn bench(&self, c: &mut Criterion) {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Each of the 11 bencher modules in `rqe_iterators_bencher` carried a byte-identical `benchmark_group` helper body — create the Criterion group, then set `measurement_time` and `warm_up_time`.
2. **Change:** Collapse that repeated body into a single crate-local `group()` free function in `benchers/mod.rs`. Each per-module `benchmark_group` now delegates to it while keeping its own label string and timing constants (`MEASUREMENT_TIME` / `WARMUP_TIME`).
3. **Outcome:** The mechanical Criterion setup lives in one place instead of 11. Net −16 LOC (28 insertions, 44 deletions). Benchmark group IDs and timing are byte-for-byte unchanged, so historical baselines remain comparable.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `rqe_iterators_bencher/src/benchers/mod.rs` — new `group()` helper
2. The 11 per-module `benchmark_group` helpers (empty, id_list, intersection, metric, not, not_optimized, optional, optional_optimized, union, wildcard, inverted_index)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes