### PR TITLE
[MOD-15304] wire disk async field loader for HASH flex search

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -366,6 +366,27 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
 int parseAggPlan(ParseAggPlanContext *ctx, ArgsCursor *ac, bool isDiskIndex, QueryError *status);
 
 /**
+ * Reject field return on a disk (flex) index when loading is unsupported.
+ *
+ * For use by the standalone/shard executor (AREQ_ApplyContext), where the spec
+ * is bound and QEXEC_F_IS_SEARCH is set: allows field return only for a HASH
+ * FT.SEARCH (which loads via the disk async loader). JSON-on-disk and all
+ * non-search flex queries must use NOCONTENT / RETURN 0. No-op when flex is off.
+ */
+int FlexValidation_RejectFieldReturn(const IndexSpec *sp, uint32_t reqflags, QueryError *status);
+
+/**
+ * Reject JSON-on-disk field return before coordinator fan-out.
+ *
+ * The coordinator compiles every request as an aggregate (QEXEC_F_IS_SEARCH is
+ * not set), so it can only reject the case unsupported everywhere: JSON-on-disk
+ * field return. HASH-on-disk passes through and is enforced shard-side by
+ * FlexValidation_RejectFieldReturn. No-op when flex is off.
+ */
+int FlexValidation_RejectJsonFieldReturn(const IndexSpec *sp, uint32_t reqflags,
+                                         QueryError *status);
+
+/**
  * Initialize basic AREQ structure with search options and aggregation plan.
  */
 void initializeAREQ(AREQ *req);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -787,13 +787,11 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     FieldList_RestrictReturn(&req->outFields);
   }
 
-  // Currently we don't support loading fields from disk indexes
-  // We require the NOCONTENT flag to be set or a RETURN 0 clause to be specified
-  if (isDiskIndex && !(req->reqflags & QEXEC_F_SEND_NOFIELDS)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_FLEX_SEARCH_NOCONTENT_OR_RETURN0_REQUIRED, NULL);
-    return REDISMODULE_ERR;
-  }
-
+  // Field loading on disk (flex) indexes is validated later, once the spec is
+  // bound and the HASH/JSON document type is known: standalone/shard in
+  // AREQ_ApplyContext, coordinator pre-fan-out in prepareForExecution. At parse
+  // time `isDiskIndex` is the process-global flex flag and cannot distinguish
+  // HASH (loads via the async loader) from JSON (still unsupported).
   return REDISMODULE_OK;
 }
 
@@ -1495,6 +1493,41 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   return REDISMODULE_OK;
 }
 
+// True when a flex query returns no document fields (NOCONTENT, or RETURN 0,
+// both of which set QEXEC_F_SEND_NOFIELDS), so disk field loading is not needed.
+static inline bool flexQueryReturnsNoFields(uint32_t reqflags) {
+  return (reqflags & QEXEC_F_SEND_NOFIELDS) != 0;
+}
+
+// Standalone / shard executor validation: the spec is bound and QEXEC_F_IS_SEARCH
+// is reliable here. JSON-on-disk field loading is unsupported, and HASH-on-disk
+// loading is only wired on the FT.SEARCH output pipeline, so allow field return
+// only for a HASH FT.SEARCH. Everything else on a flex index still requires
+// NOCONTENT / RETURN 0.
+int FlexValidation_RejectFieldReturn(const IndexSpec *sp, uint32_t reqflags, QueryError *status) {
+  bool allowed =
+      flexQueryReturnsNoFields(reqflags) || (!isSpecJson(sp) && (reqflags & QEXEC_F_IS_SEARCH));
+  if (SearchDisk_IsEnabledForValidation() && !allowed) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_FLEX_SEARCH_NOCONTENT_OR_RETURN0_REQUIRED, NULL);
+    return REDISMODULE_ERR;
+  }
+  return REDISMODULE_OK;
+}
+
+// Coordinator pre-fan-out validation: QEXEC_F_IS_SEARCH is not set on the
+// coordinator (every request is compiled as an aggregate), so we can only reject
+// the universally-unsupported case here: JSON-on-disk field return. HASH-on-disk
+// passes through and is enforced shard-side by FlexValidation_RejectFieldReturn.
+int FlexValidation_RejectJsonFieldReturn(const IndexSpec *sp, uint32_t reqflags,
+                                         QueryError *status) {
+  if (SearchDisk_IsEnabledForValidation() && isSpecJson(sp) &&
+      !flexQueryReturnsNoFields(reqflags)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_FLEX_SEARCH_NOCONTENT_OR_RETURN0_REQUIRED, NULL);
+    return REDISMODULE_ERR;
+  }
+  return REDISMODULE_OK;
+}
+
 int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   // Sort through the applicable options:
   IndexSpec *index = sctx->spec;
@@ -1522,6 +1555,15 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
     QueryError_SetError(
         status, QUERY_ERROR_CODE_INVAL,
         "Cannot use HIGHLIGHT/SUMMARIZE because NOOFSETS was specified at index level");
+    return REDISMODULE_ERR;
+  }
+
+  // Disk (flex) field-loading validation, now that the spec is bound. JSON-on-disk
+  // loading is unsupported; HASH-on-disk loads via the async loader, but only on
+  // the FT.SEARCH output pipeline. Everything else still requires NOCONTENT /
+  // RETURN 0. (On the coordinator this is enforced pre-fan-out; see
+  // prepareForExecution.)
+  if (FlexValidation_RejectFieldReturn(index, reqFlags, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -507,6 +507,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   rc = AREQ_Compile(r, ctx, argv + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
+  // Reject JSON-on-disk field return before fanning out to shards. HASH-on-disk
+  // passes through and is enforced shard-side in AREQ_ApplyContext.
+  if (FlexValidation_RejectJsonFieldReturn(sp, AREQ_RequestFlags(r), status) != REDISMODULE_OK) {
+    return REDISMODULE_ERR;
+  }
+
   r->profile = printAggProfile;
 
   unsigned int dialect = r->reqConfig.dialectVersion;

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -6,6 +6,7 @@
 #include "iterators/hybrid_reader.h"
 #include "iterators_ffi.h"
 #include "util/misc.h"
+#include "search_disk.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -502,10 +503,24 @@ int buildOutputPipeline(Pipeline *pipeline, const AggregationPipelineParams* par
   // If we have explicit return and some of the keys' values are missing,
   // or if we don't have explicit return, meaning we use LOAD ALL
   if (loadkeys || !params->outFields->explicitReturn) {
-    rp = RPLoader_New(params->common.sctx, params->common.reqflags, lookup, loadkeys, array_len(loadkeys), forceLoad, outStateFlags);
-    if (isSpecJson(params->common.sctx->spec)) {
-      // On JSON, load all gets the serialized value of the doc, and doesn't make the fields available.
-      RLookup_DisableOptions(lookup, RLOOKUP_OPT_ALLLOADED);
+    RedisSearchCtx *sctx = params->common.sctx;
+    if (sctx->spec->diskSpec) {
+      // HASH-on-disk (flex): load fields from disk via the async loader. JSON-on-disk
+      // field loading is rejected earlier (AREQ_ApplyContext / coordinator), so a
+      // disk-backed spec here is always HASH. The async loader sets QEXEC_S_HAS_LOAD
+      // in outStateFlags itself, mirroring RPLoader_New.
+      RedisSearchDiskAPI *disk = SearchDisk_GetAPI();
+      RS_LOG_ASSERT(disk && disk->basic.newAsyncLoader, "disk async loader API not registered");
+      rp = disk->basic.newAsyncLoader(sctx, params->common.reqflags, lookup, loadkeys,
+                                      array_len(loadkeys), forceLoad, outStateFlags);
+    } else {
+      rp = RPLoader_New(sctx, params->common.reqflags, lookup, loadkeys, array_len(loadkeys),
+                        forceLoad, outStateFlags);
+      if (isSpecJson(sctx->spec)) {
+        // On JSON, load all gets the serialized value of the doc, and doesn't make the fields
+        // available.
+        RLookup_DisableOptions(lookup, RLOOKUP_OPT_ALLLOADED);
+      }
     }
     array_free(loadkeys);
     PUSH_RP();

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -217,8 +217,19 @@ const HEADERS: &[HeaderAllowlist] = &[
             "RedisModule_ReplyWithMap",
             "RedisModule_ReplyWithSimpleString",
             "RedisModule_ReplyWithStringBuffer",
+            "RedisModule_IsKeyInRam",
+            "RedisModule_OpenKey",
+            "RedisModule_CloseKey",
             "RedisModule_StringPtrLen",
+            "RedisModule_ThreadSafeContextLock",
+            "RedisModule_ThreadSafeContextUnlock",
         ],
+    },
+    HeaderAllowlist {
+        path: "src/doc_id_meta.h",
+        fns: &["DocIdMeta_Get"],
+        types: &[],
+        vars: &[],
     },
     HeaderAllowlist {
         path: "src/result_processor.h",
@@ -228,8 +239,13 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/rlookup_load_document.h",
-        fns: &["loadIndividualKeys", "sdslen_rust"],
-        types: &[],
+        fns: &[
+            "loadIndividualKeys",
+            "RLookup_LoadDocumentAll",
+            "RLookup_LoadDocumentIndividual",
+            "sdslen_rust",
+        ],
+        types: &["RLookupLoadOptions"],
         vars: &[],
     },
     HeaderAllowlist {
@@ -246,7 +262,15 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/search_ctx.h",
-        fns: &["NewSearchCtxC", "SearchCtx_Free"],
+        fns: &[
+            "NewSearchCtxC",
+            "RedisSearchCtx_LockSpecRead",
+            "RedisSearchCtx_UnlockSpec",
+            "SearchCtx_Free",
+            // RSE: the disk async loader checks request timeout between disk
+            // reads via this main-thread-owned flag accessor.
+            "SearchTime_IsTimedOut",
+        ],
         types: &[],
         vars: &[],
     },

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -20,6 +20,13 @@ extern "C" {
 typedef struct QueryIterator QueryIterator;
 typedef struct NumericFilter NumericFilter;
 typedef struct QueryError QueryError;
+// Forward declarations for the async field loader fn-ptr below. These are
+// compatible redeclarations of the canonical typedefs (result_processor.h,
+// search_ctx.h, rlookup.h) and avoid pulling those headers in here.
+typedef struct ResultProcessor ResultProcessor;
+typedef struct RedisSearchCtx RedisSearchCtx;
+typedef struct RLookup RLookup;
+typedef struct RLookupKey RLookupKey;
 
 // Forward declaration for HiddenString
 typedef struct HiddenString HiddenString;
@@ -264,6 +271,28 @@ typedef struct BasicDiskAPI {
    *         existing indexes via updateWriteBufferSize.
    */
   size_t (*updateBufferBudget)(RedisModuleCtx *ctx, RedisSearchDisk *disk, int percentage);
+
+  /**
+   * Create a result processor that loads document fields from disk asynchronously.
+   *
+   * Drop-in replacement for RPLoader_New on disk (flex) HASH indexes: the C
+   * pipeline calls this instead of RPLoader_New when the spec is backed by disk.
+   * The returned ResultProcessor must set QEXEC_S_HAS_LOAD in *outStateFlags when
+   * it will load fields, mirroring RPLoader_New, so downstream cursor handling
+   * (HasLoader) treats it as a loader.
+   *
+   * @param sctx          Search context (owns the spec and the disk handle)
+   * @param reqflags      Request flags (QEXEC_F_*)
+   * @param lk            Lookup the loaded fields are written into
+   * @param keys          Keys to load; NULL with nkeys 0 means "load all"
+   * @param nkeys         Number of entries in `keys`
+   * @param forceLoad     JSON multi-value compatibility flag; always false for HASH
+   * @param outStateFlags Out: OR'd with QEXEC_S_HAS_LOAD when loading is scheduled
+   * @return A new ResultProcessor, or NULL on allocation failure
+   */
+  ResultProcessor *(*newAsyncLoader)(RedisSearchCtx *sctx, uint32_t reqflags, RLookup *lk,
+                                     const RLookupKey **keys, size_t nkeys, bool forceLoad,
+                                     uint32_t *outStateFlags);
 } BasicDiskAPI;
 
 typedef struct IndexDiskAPI {

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -293,11 +293,39 @@ def _create_flex_search(env):
     env.expect('HSET', 'doc:1', 't', 'hello world').equal(1)
 
 
+def _create_flex_search_json(env):
+    env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SKIPINITIALSCAN', 'SCHEMA',
+               '$.t', 'AS', 't', 'TEXT').ok()
+
+
 @skip(cluster=True)
 @with_simulate_in_flex(True)
-def test_flex_search_requires_nocontent_or_return_0(env):
-    """In Flex mode, FT.SEARCH must use NOCONTENT (explicit) or RETURN 0."""
+def test_flex_search_hash_allows_default_return(env):
+    """On a HASH (flex) index, FT.SEARCH loads fields from disk via the async
+    loader, so NOCONTENT / RETURN 0 are no longer required."""
     _create_flex_search(env)
+
+    env.expect('FT.SEARCH', 'idx', 'hello').equal([1, 'doc:1', ['t', 'hello world']])
+
+
+@skip(cluster=True)
+@with_simulate_in_flex(True)
+def test_flex_search_json_requires_nocontent_or_return_0(env):
+    """JSON-on-disk field loading is unsupported, so FT.SEARCH on a JSON (flex)
+    index must still use NOCONTENT (explicit) or RETURN 0."""
+    _create_flex_search_json(env)
+
+    env.expect('FT.SEARCH', 'idx', 'hello') \
+        .error().contains('NOCONTENT or RETURN 0 must be provided in Redis Flex')
+
+
+@with_simulate_in_flex(True)
+def test_flex_search_json_requires_nocontent_or_return_0_on_coordinator(env):
+    """The coordinator rejects JSON-on-disk field return before fanning out to
+    shards (it cannot tell HASH from JSON until the spec is bound). Runs on
+    cluster to exercise prepareForExecution; harmlessly re-checks the standalone
+    path otherwise."""
+    _create_flex_search_json(env)
 
     env.expect('FT.SEARCH', 'idx', 'hello') \
         .error().contains('NOCONTENT or RETURN 0 must be provided in Redis Flex')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Field loading on a disk (flex) index is rejected at parse time in
   `parseQueryArgs` (`isDiskIndex && !NOFIELDS`). At that point no spec is bound and
   `isDiskIndex` is the process-global flex flag, so the reject cannot distinguish a
   HASH index (where on-disk field loading is being added) from a JSON index (where
   it is still unsupported). `RPLoader_New` also hard-asserts against disk indexes.

2. **Change:** Make the C codebase ready to load HASH-on-disk fields via the Rust
   async loader, and move the JSON/no-content reject to spec-aware sites:
   - `search_disk_api.h`: add `newAsyncLoader` to `BasicDiskAPI` (mirrors
     `RPLoader_New`'s signature; takes `const RLookupKey**`). The returned
     `ResultProcessor` is contracted to set `QEXEC_S_HAS_LOAD` in `*outStateFlags`
     itself, so downstream cursor handling (`HasLoader`) treats it as a loader.
   - `pipeline_construction.c`: in `buildOutputPipeline`, route disk-backed specs to
     `newAsyncLoader` instead of `RPLoader_New`.
   - `aggregate_request.c` / `dist_aggregate.c`: replace the parse-time reject with
     `FlexValidation_RejectFieldReturn` (standalone/shard, in `AREQ_ApplyContext`)
     and `FlexValidation_RejectJsonFieldReturn` (coordinator, pre-fan-out in
     `prepareForExecution`). Standalone allows field return only for a HASH
     `FT.SEARCH`; the coordinator — where `QEXEC_F_IS_SEARCH` is never set — rejects
     only the universally-unsupported JSON-on-disk case and lets HASH through for
     shard-side enforcement.
   - `ffi/build.rs`: expose `SearchTime_IsTimedOut` (async loader timeout check).

3. **Outcome:** HASH-on-disk `FT.SEARCH` with field return reaches the async loader;
   JSON-on-disk field return is still rejected (now at the coordinator pre-fan-out and
   on shards). **Inert on open-source RediSearch:** the `newAsyncLoader` branch is only
   reachable when a spec is disk-backed (`spec->diskSpec != NULL`), which requires the
   RSE disk backend. No config variable or capability flag is added.

#### Which additional issues this PR fixes
1. MOD-16088 (the FFI-allowlist commit; prerequisite for the RSE async-loader backend)

#### Main objects this PR modified
1. `BasicDiskAPI` (`newAsyncLoader` fn-ptr)
2. `buildOutputPipeline` loader routing
3. `AREQ_ApplyContext` / `prepareForExecution` flex field-return validation
4. `FlexValidation_RejectFieldReturn` / `FlexValidation_RejectJsonFieldReturn` (new)

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

`newAsyncLoader` is a new `BasicDiskAPI` (C↔Rust) function-pointer slot, populated by
the RSE backend. No public Redis command/API surface changes.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal plumbing; inert on open-source RediSearch. The user-facing capability
(HASH-on-disk field loading) is activated only when the RSE backend co-lands, whose
PR carries the release note.

---

### Co-land discipline (draft until then)

The `newAsyncLoader` C call site has **no NULL guard** by design (only a debug
`RS_LOG_ASSERT`). Between the RSE backend populating the table entry as `None` and
the follow-up that sets it to the real impl, a HASH-disk `FT.SEARCH RETURN` would call
a NULL fn-ptr. This PR must therefore co-land with:
- **PR-2** — RSE async-loader backend (registers the `newAsyncLoader` impl).
- **PR-3** — pipeline integration + flow tests.

Kept as **draft**; do not merge to `master` ahead of PR-2/PR-3.

### Testing / build notes

- New/changed flow tests in `test_flex_validation.py` cover the reject relocation and
  the HASH-allow path via `_SIMULATE_IN_FLEX` (the real `newAsyncLoader` invocation
  requires the RSE backend and is covered in PR-3).
- Changed C files were compile-checked via `compile_commands.json`; the Rust `ffi`
  crate builds. A full local module link is currently blocked by a pre-existing,
  unrelated macOS-arm64 issue compiling `deps/VectorSimilarity` SVE intrinsics
  (`SVE.cpp`/`SVE2.cpp`); CI (Linux) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)