### PR TITLE
rqe_iterators_test_utils: fix TTL table init mutating a copy

### DIFF
--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -169,9 +169,9 @@ impl<'lock> IndexSpecWriteGuard<'lock> {
         self.0.monitorFieldExpiration = monitor;
     }
 
-    /// Returns the document table.
-    pub const fn doc_table(&self) -> ffi::DocTable {
-        self.0.docs
+    /// Returns a mutable reference to the spec's document table.
+    pub const fn doc_table_mut(&mut self) -> &mut ffi::DocTable {
+        &mut self.0.docs
     }
 
     /// Return a mutable reference to the `existingDocs` inverted index, if present.

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -853,11 +853,18 @@ impl TestContext {
         guard.set_monitor_document_expiration(true);
         guard.set_monitor_field_expiration(true);
 
-        let mut doc_table = guard.doc_table();
+        // `IndexSpecWriteGuard::doc_table()` returns a *copy* of the document
+        // table, so initializing `ttl` through it would leave the spec's real
+        // table untouched (and a later `TimeToLiveTable_Add` would dereference a
+        // NULL `ttl`). Borrow the spec's actual table through the guard instead,
+        // which keeps the guard as the sole mutable path to the spec.
+        let docs = guard.doc_table_mut();
 
-        // SAFETY: doc_table is a valid pointer to the spec's document table, and maxSize is properly initialized.
+        // SAFETY: `&mut docs.ttl` is a valid, writable `*mut *mut TimeToLiveTable`,
+        // and `maxSize` is initialized. The guard holds exclusive access to the
+        // spec, so the initialization does not race.
         unsafe {
-            ffi::TimeToLiveTable_VerifyInit(&mut doc_table.ttl, doc_table.maxSize as usize);
+            ffi::TimeToLiveTable_VerifyInit(&mut docs.ttl, docs.maxSize as usize);
         }
     }
 


### PR DESCRIPTION
`TestContext::verify_ttl_init` initialized the TTL table through
`IndexSpecWriteGuard::doc_table()`, which returns a *copy* of the DocTable.
The init therefore never reached the spec's real table, leaving ttl NULL;
a later `TimeToLiveTable_Add` then dereferenced NULL and crashed (hit by the
inverted_index numeric bencher's setup).

Add `IndexSpecWriteGuard::doc_table_mut()` and initialize the TTL table
through it. Borrowing the spec's real table through the guard keeps the
guard as the sole mutable path to the spec, avoiding the aliasing
violation that forming a second &mut from the raw spec pointer (while the
guard still held &mut IndexSpec) would have introduced.

Fixing regression from a90c3cdf0c13fdecc7049b53167ecf44f4f908dc

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
