### PR TITLE
ci: fix duplicate allow-users key breaking Codex CI triage step

### DIFF
--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -66,9 +66,10 @@ runs:
         # the bare form under `allow-users` and the suffixed form under
         # `allow-bot-users`.
         allow-bots: true
-        allow-users: github-merge-queue
+        allow-users: |
+          github-merge-queue
+          ${{ inputs.allow-users }}
         allow-bot-users: github-merge-queue[bot]
-        allow-users: ${{ inputs.allow-users }}
 
     - name: Read triage output
       id: read

--- a/.github/actions/codex-ci-triage/action.yml
+++ b/.github/actions/codex-ci-triage/action.yml
@@ -65,10 +65,14 @@ runs:
         # bare form and never consults `allow-bot-users`, so we list
         # the bare form under `allow-users` and the suffixed form under
         # `allow-bot-users`.
+        #
+        # `codex-action` parses `allow-users` as a comma-separated list
+        # (it splits on "," then trims each entry), so the built-in
+        # merge-queue actor and the caller input must be joined with a
+        # comma, NOT a newline. A trailing comma (empty `inputs.allow-users`)
+        # is harmless: the action filters out empty entries.
         allow-bots: true
-        allow-users: |
-          github-merge-queue
-          ${{ inputs.allow-users }}
+        allow-users: github-merge-queue,${{ inputs.allow-users }}
         allow-bot-users: github-merge-queue[bot]
 
     - name: Read triage output


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `codex-ci-triage` composite action defined the `allow-users` input key twice in the same `with:` block of the codex step. YAML mapping keys must be unique, so the GitHub Actions template parser rejected the manifest with `'allow-users' is already defined` and the **Run Codex CI triage** step never executed (e.g. [Daily CI Report run 27524320267](https://github.com/RediSearch/RediSearch/actions/runs/27524320267/job/81348398235)).
2. **Change:** Merge the two values into a single `allow-users` list so both the bare `github-merge-queue` actor (seen on `schedule` events) and the caller-provided `inputs.allow-users` are honored.
3. **Outcome:** The action manifest loads correctly and the triage step runs again.

#### Which additional issues this PR fixes
N/A

#### Main objects this PR modified
1. `.github/actions/codex-ci-triage/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
