### PR TITLE
[MOD-16278] geoshape iterator: add micro benchmarks

### DIFF
--- a/src/geometry/geometry_api.h
+++ b/src/geometry/geometry_api.h
@@ -21,6 +21,19 @@ GeometryIndex *GeometryIndexFactory(GEOMETRY_COORDS tag);
 const GeometryApi *GeometryApi_Get(const GeometryIndex *index);
 const char *GeometryCoordsToName(GEOMETRY_COORDS tag);
 
+// Benchmark/test-only constructor. Builds a GeoShape query iterator directly
+// from a caller-provided list of document IDs, bypassing the R-tree spatial
+// query, so the iterator's read/skip_to machinery can be micro-benchmarked
+// against the Rust re-implementation (`NewGeometryQueryIterator`). The IDs are
+// copied into the iterator's own storage (the original `ids` buffer is left
+// untouched and is not adopted). `allocated` must point to a `size_t` that
+// outlives the returned iterator: the iterator's allocator holds a reference to
+// it for memory accounting. Mirrors the production construction in
+// `RTree::query` (timeout checks skipped when `sctx->time.skipTimeoutChecks`).
+QueryIterator *NewGeometryQueryIterator_Bench(const RedisSearchCtx *sctx,
+                                              const FieldFilterContext *filterCtx, t_docId *ids,
+                                              size_t num, size_t *allocated);
+
 struct GeometryApi {
   void (*freeIndex)(GeometryIndex *index);
   int (*addGeomStr)(GeometryIndex *index, GEOMETRY_FORMAT format, const char *str, size_t len,

--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "query_iterator.hpp"
+#include "geometry_api.h"
 #include "doc_table.h"
 #include "iterators_ffi.h"
 #include "search_ctx.h"
@@ -168,3 +169,21 @@ QueryIterator CPPQueryIterator::init_base() {
 }
 }  // namespace GeoShape
 }  // namespace RediSearch
+
+extern "C" QueryIterator *NewGeometryQueryIterator_Bench(const RedisSearchCtx *sctx,
+                                                         const FieldFilterContext *filterCtx,
+                                                         t_docId *ids, std::size_t num,
+                                                         std::size_t *allocated) {
+  using RediSearch::GeoShape::CPPQueryIterator;
+  using alloc_type = RediSearch::Allocator::TrackingAllocator<CPPQueryIterator>;
+  auto alloc = alloc_type{*allocated};
+  const auto qi = std::allocator_traits<alloc_type>::allocate(alloc, 1);
+  // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks when skipTimeoutChecks is set,
+  // mirroring RTree::query.
+  const uint32_t timeoutCounter =
+      (sctx && sctx->time.skipTimeoutChecks) ? REDISEARCH_UNINITIALIZED : 0;
+  const auto range = std::ranges::subrange{ids, ids + num};
+  std::allocator_traits<alloc_type>::construct(alloc, qi, sctx, filterCtx, range, *allocated,
+                                               timeoutCounter);
+  return qi->base();
+}

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -90,6 +90,14 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        // Benchmark-only GeoShape iterator constructor, used by
+        // `rqe_iterators_bencher` to compare against the Rust implementation.
+        path: "src/geometry/geometry_api.h",
+        fns: &["NewGeometryQueryIterator_Bench"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/iterators/hybrid_reader.h",
         fns: &[
             "HybridIterator_GetChild",

--- a/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
@@ -202,6 +202,69 @@ where
     }
 }
 
+/// Returns the index of the first ID in `ids` that is `>= doc_id`.
+///
+/// `ids` must be a non-empty, ascending slice whose last element is `>= doc_id`,
+/// so a match is guaranteed to exist.
+///
+/// The search has two phases: an exponential ("galloping") probe that brackets
+/// `doc_id` in a window growing as `1, 2, 4, …`, followed by a binary search
+/// within that window. Two deliberate choices make this fast on the large id
+/// buffers a geometry query produces:
+///
+/// * **Galloping, not a single bounded guess.** A sorted-id list with unique IDs
+///   can bound the match to `doc_id - last_doc_id` entries ahead, but the
+///   geometry index may yield *duplicate* IDs, so consecutive entries can repeat
+///   and that bound is unsound. Galloping makes no uniqueness assumption: it
+///   discovers a valid window by probing, and stays cache-friendly when the
+///   match is near the cursor — the common case for forward skips.
+/// * **A hand-rolled branchy search, not [`slice::partition_point`].** The
+///   standard search is branchless; benchmarks show it consistently slower here,
+///   both over the full (cold, multi-megabyte) tail — where its data-dependent
+///   probes serialize cache misses the branchy form lets the CPU speculate past
+///   — and even within the small galloped window, where its general setup
+///   dominates.
+///
+/// Lower-bound semantics are preserved: when `doc_id` is duplicated, the index
+/// of its *first* occurrence is returned.
+#[inline]
+fn lower_bound(ids: &[DocId], doc_id: DocId) -> usize {
+    debug_assert!(!ids.is_empty(), "tail must be non-empty");
+    debug_assert!(
+        *ids.last().expect("non-empty tail") >= doc_id,
+        "a match must exist within the tail"
+    );
+
+    let len = ids.len();
+
+    // Exponential phase: grow `hi` until `ids[hi] >= doc_id` (or `hi` runs off
+    // the end). Every doubling is guarded by a confirmed `ids[hi] < doc_id`, so
+    // afterwards `ids[hi >> 1] < doc_id` whenever `hi >= 2`.
+    let mut hi = 1;
+    // SAFETY: the `hi < len` guard short-circuits before the index, so `hi` is
+    // always in bounds when dereferenced.
+    while hi < len && unsafe { *ids.get_unchecked(hi) } < doc_id {
+        hi <<= 1;
+    }
+
+    // Binary search the bracketed, inclusive range `[bottom, top]`. `ids[top]`
+    // is `>= doc_id` (the loop either stopped on it, or it is the clamped last
+    // element, which the precondition guarantees is `>= doc_id`), so the answer
+    // lies in the range.
+    let mut bottom = hi >> 1;
+    let mut top = hi.min(len - 1);
+    while bottom < top {
+        let mid = (bottom + top) >> 1;
+        // SAFETY: `bottom <= mid < top <= len - 1`, so `mid` is in bounds.
+        if unsafe { *ids.get_unchecked(mid) } < doc_id {
+            bottom = mid + 1;
+        } else {
+            top = mid;
+        }
+    }
+    bottom
+}
+
 impl<'index, T, E, M> RQEIterator<'index> for GeoShape<'index, T, E, M>
 where
     T: TimeoutContext,
@@ -246,9 +309,11 @@ where
             return Ok(None);
         }
 
-        // Binary search for the first ID >= `doc_id` within the unread tail.
+        // Find the first ID >= `doc_id` within the unread tail. The tail is
+        // non-empty and its last element is >= `doc_id` (both guaranteed above),
+        // so a match always exists.
         let tail = &self.ids[self.offset..];
-        let idx = self.offset + tail.partition_point(|&id| id < doc_id);
+        let idx = self.offset + lower_bound(tail, doc_id);
         let found = self.ids[idx];
         self.offset = idx + 1;
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
@@ -125,6 +125,45 @@ fn skip_to_lands_on_first_of_duplicates() {
     assert!(matches!(it.read(), Ok(None)));
 }
 
+#[test]
+fn skip_to_handles_long_duplicate_runs() {
+    // IDs spaced 10 apart, each repeated three times. With duplicates present,
+    // `skip_to` cannot bound its search by `doc_id - last_doc_id`, so it brackets
+    // the match by galloping; this exercises targets that land inside a long run
+    // of equal IDs and targets that fall in the gap between runs — neither is
+    // reached by the small shared fixtures.
+    let ids: Vec<u64> = (1..=100u64)
+        .flat_map(|v| {
+            let id = v * 10;
+            [id, id, id]
+        })
+        .collect();
+
+    // Target equal to a present ID: lands on the first of its three copies, and
+    // the other two are still yielded by the following reads.
+    let mut it = plain(ids.clone());
+    let Ok(Some(SkipToOutcome::Found(res))) = it.skip_to(500) else {
+        panic!("expected Found(500)");
+    };
+    assert_eq!(res.doc_id, 500);
+    assert_eq!(it.last_doc_id(), 500);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 500);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 500);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 510);
+
+    // Target in the gap between two runs: lands on the first copy of the next
+    // run (NotFound), which is then consumed by the following reads.
+    let mut it = plain(ids);
+    let Ok(Some(SkipToOutcome::NotFound(res))) = it.skip_to(505) else {
+        panic!("expected NotFound landing on 510");
+    };
+    assert_eq!(res.doc_id, 510);
+    assert_eq!(it.last_doc_id(), 510);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 510);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 510);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 520);
+}
+
 #[apply(id_cases)]
 fn read(#[case] case: &[u64]) {
     let mut it = plain(case.to_vec());

--- a/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/benches/iterators.rs
@@ -31,6 +31,11 @@ fn benchmark_id_list(c: &mut Criterion) {
     bencher.bench(c);
 }
 
+fn benchmark_geo_shape(c: &mut Criterion) {
+    let bencher = benchers::geo_shape::Bencher::default();
+    bencher.bench(c);
+}
+
 fn benchmark_metric(c: &mut Criterion) {
     let bencher = benchers::metric::Bencher::default();
     bencher.bench(c);
@@ -171,6 +176,7 @@ criterion_group!(
     benches,
     benchmark_empty,
     benchmark_id_list,
+    benchmark_geo_shape,
     benchmark_metric,
     benchmark_not_iterator,
     benchmark_not_optimized_iterator,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/geo_shape.rs
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Benchmark the geometry (GEOSHAPE) query iterator.
+
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
+use rqe_core::DocId;
+use rqe_iterators::{NoOpChecker, NoTracker, RQEIterator, geo_shape::GeoShape, utils::NoTimeout};
+
+use crate::ffi::{
+    GeoBenchCtx, IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_OK, QueryIterator,
+};
+
+/// The Rust [`GeoShape`] configured the way the sorted-id-list benchmark needs:
+/// no timeout, no field-expiration, no memory tracking.
+type RustGeoShape = GeoShape<'static, NoTimeout, NoOpChecker, NoTracker>;
+
+/// Owns a C++ [`QueryIterator`] and frees it on drop.
+///
+/// The C arms must not call `Free` inside the measured routine: the Rust arm
+/// lets `iter_batched_ref` drop its iterator (deallocating its id vector)
+/// *outside* the timed routine, so freeing the C++ iterator inside the routine
+/// would make the C numbers include teardown work the Rust numbers exclude.
+/// Wrapping it here moves the `Free`/vector-deallocation into `Drop`, which
+/// `iter_batched_ref` also runs outside the measured routine, so both arms time
+/// only the read/skip loop.
+struct CGeoShape(QueryIterator);
+
+impl CGeoShape {
+    #[inline(always)]
+    fn new(ctx: &GeoBenchCtx, ids: &[DocId]) -> Self {
+        Self(QueryIterator::new_geo_shape_cpp(ctx, ids))
+    }
+}
+
+impl std::ops::Deref for CGeoShape {
+    type Target = QueryIterator;
+
+    #[inline(always)]
+    fn deref(&self) -> &QueryIterator {
+        &self.0
+    }
+}
+
+impl Drop for CGeoShape {
+    fn drop(&mut self) {
+        self.0.free();
+    }
+}
+
+#[derive(Default)]
+pub struct Bencher {
+    /// Context shared by every C++ iterator (the Rust side needs none).
+    ctx: GeoBenchCtx,
+}
+
+impl Bencher {
+    const MEASUREMENT_TIME: Duration = Duration::from_millis(500);
+    const WARMUP_TIME: Duration = Duration::from_millis(200);
+
+    /// Number of matched documents the iterator walks over.
+    const NUM_DOCS: DocId = 1_000_000;
+    /// Stride between `skip_to` targets.
+    const SKIP_TO_STEP: DocId = 100;
+    /// Spacing between document IDs in the sparse data set.
+    const SPARSE_STEP: DocId = 1000;
+
+    fn benchmark_group<'a>(
+        &self,
+        c: &'a mut Criterion,
+        label: &str,
+    ) -> BenchmarkGroup<'a, WallTime> {
+        super::group(c, label, Self::MEASUREMENT_TIME, Self::WARMUP_TIME)
+    }
+
+    /// Contiguous matches: every document ID from 1 to `NUM_DOCS`.
+    fn dense_ids() -> Vec<DocId> {
+        (1..=Self::NUM_DOCS).collect()
+    }
+
+    /// Spread-out matches: `NUM_DOCS` IDs spaced `SPARSE_STEP` apart, so most
+    /// `skip_to` targets land between entries (a `NOTFOUND` result).
+    fn sparse_ids() -> Vec<DocId> {
+        (1..=Self::NUM_DOCS)
+            .map(|x| x * Self::SPARSE_STEP)
+            .collect()
+    }
+
+    /// Build a Rust [`GeoShape`] over `ids` (no timeout/expiration/tracking).
+    fn rust_iter(ids: Vec<DocId>) -> RustGeoShape {
+        GeoShape::new(ids, NoTimeout, NoOpChecker, NoTracker)
+    }
+
+    pub fn bench(&self, c: &mut Criterion) {
+        self.read(c);
+        self.skip_to_dense(c);
+        self.skip_to_sparse(c);
+    }
+
+    /// Benchmark reading every matched document in order.
+    fn read(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - GeoShape - Read");
+
+        group.bench_function("Rust", |b| {
+            let ids = Self::dense_ids();
+            b.iter_batched_ref(
+                || Self::rust_iter(ids.clone()),
+                |it| {
+                    while let Ok(Some(current)) = it.read() {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            let ids = Self::dense_ids();
+            b.iter_batched_ref(
+                || CGeoShape::new(&self.ctx, &ids),
+                |it| {
+                    while it.read() == IteratorStatus_ITERATOR_OK {
+                        black_box(it.current());
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark `skip_to` over contiguous matches (every target hits exactly).
+    fn skip_to_dense(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - GeoShape - SkipTo Dense");
+
+        group.bench_function("Rust", |b| {
+            let ids = Self::dense_ids();
+            b.iter_batched_ref(
+                || Self::rust_iter(ids.clone()),
+                |it| {
+                    while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                    {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            let ids = Self::dense_ids();
+            b.iter_batched_ref(
+                || CGeoShape::new(&self.ctx, &ids),
+                |it| {
+                    loop {
+                        let target = it.last_doc_id() + Self::SKIP_TO_STEP;
+                        if it.skip_to(target) == IteratorStatus_ITERATOR_EOF {
+                            break;
+                        }
+                        black_box(it.current());
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Benchmark `skip_to` over spread-out matches (most targets miss).
+    fn skip_to_sparse(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Iterator - GeoShape - SkipTo Sparse");
+
+        group.bench_function("Rust", |b| {
+            let ids = Self::sparse_ids();
+            b.iter_batched_ref(
+                || Self::rust_iter(ids.clone()),
+                |it| {
+                    while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + Self::SKIP_TO_STEP)
+                    {
+                        black_box(current);
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function("C", |b| {
+            let ids = Self::sparse_ids();
+            b.iter_batched_ref(
+                || CGeoShape::new(&self.ctx, &ids),
+                |it| {
+                    loop {
+                        let target = it.last_doc_id() + Self::SKIP_TO_STEP;
+                        if it.skip_to(target) == IteratorStatus_ITERATOR_EOF {
+                            break;
+                        }
+                        black_box(it.current());
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+}

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/mod.rs
@@ -8,6 +8,7 @@
 */
 
 pub mod empty;
+pub mod geo_shape;
 pub mod id_list;
 pub mod intersection;
 pub mod inverted_index;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -10,9 +10,10 @@
 pub use ffi::{
     IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreByteOffsets,
     IndexFlags_Index_StoreFieldFlags, IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreNumeric,
-    IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_OK,
-    RedisModule_Alloc, RedisModule_Free, ValidateStatus,
+    IndexFlags_Index_StoreTermOffsets, IteratorStatus, IteratorStatus_ITERATOR_EOF,
+    IteratorStatus_ITERATOR_OK, RedisModule_Alloc, RedisModule_Free, ValidateStatus,
 };
+use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSQueryTerm};
 use iterators_ffi::intersection::NewIntersectionIterator;
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
@@ -46,6 +47,27 @@ impl QueryIterator {
         };
 
         Self(unsafe { iterators_ffi::id_list::NewSortedIdListIterator(ids_ptr, num, 1.0) })
+    }
+
+    /// Create the C++ GeoShape iterator (`NewGeometryQueryIterator_Bench`) over
+    /// a copy of `ids`. The iterator copies the ids internally, so `ids` is left
+    /// untouched.
+    #[inline(always)]
+    pub fn new_geo_shape_cpp(ctx: &GeoBenchCtx, ids: &[DocId]) -> Self {
+        // SAFETY: `ctx.sctx`/`ctx.filter_ctx` are valid for the iterator's
+        // lifetime; `ids`/`ids.len()` describe a valid (read-only) buffer the
+        // C++ side copies from; `ctx.allocated` outlives the iterator. The
+        // filter-context pointer is cast to the bindgen-generated (opaque) type;
+        // it has the same layout as `field::FieldFilterContext`.
+        Self(unsafe {
+            ffi::NewGeometryQueryIterator_Bench(
+                ctx.sctx,
+                ptr::from_ref(&ctx.filter_ctx).cast(),
+                ids.as_ptr() as *mut DocId,
+                ids.len(),
+                ctx.allocated,
+            )
+        })
     }
 
     /// Give up ownership of the raw pointer without calling `Free`.
@@ -213,6 +235,57 @@ fn free_search_ctx(sctx: *mut ffi::RedisSearchCtx) {
     unsafe {
         RedisModule_Free.unwrap()((*sctx).spec as *mut c_void);
         RedisModule_Free.unwrap()(sctx as *mut c_void);
+    }
+}
+
+/// Owns the minimal context needed to construct geometry-query iterators in
+/// benchmarks, shared by the Rust and C++ constructors so both see identical
+/// inputs.
+///
+/// The search context has a zeroed spec — so its document table has no TTL and
+/// field-expiration is disabled — and timeout checks are skipped, isolating the
+/// benchmark to the iterator's read/skip machinery. The filter context selects
+/// an invalid field index, the second guard that keeps field-expiration off.
+pub struct GeoBenchCtx {
+    sctx: *mut ffi::RedisSearchCtx,
+    filter_ctx: FieldFilterContext,
+    /// Externally-owned memory counter both iterators report into. Heap-boxed so
+    /// its address is stable and outlives every iterator built from this context
+    /// (the C++ iterator's allocator holds a reference to it).
+    allocated: *mut usize,
+}
+
+impl Default for GeoBenchCtx {
+    fn default() -> Self {
+        let sctx = new_search_ctx();
+        // Skip timeout checks: the Rust iterator selects `NoTimeout`, the C++
+        // iterator a `REDISEARCH_UNINITIALIZED` counter, so neither probes the
+        // clock in the measured loop.
+        //
+        // SAFETY: `sctx` was just returned by `new_search_ctx`, which allocates
+        // and zero-initializes a valid `RedisSearchCtx`, so the dereference and
+        // field write are in-bounds and properly aligned.
+        unsafe {
+            (*sctx).time.skipTimeoutChecks = true;
+        }
+
+        Self {
+            sctx,
+            filter_ctx: FieldFilterContext {
+                field: FieldMaskOrIndex::index_invalid(),
+                predicate: FieldExpirationPredicate::Default,
+            },
+            allocated: Box::into_raw(Box::new(0usize)),
+        }
+    }
+}
+
+impl Drop for GeoBenchCtx {
+    fn drop(&mut self) {
+        free_search_ctx(self.sctx);
+        // SAFETY: `allocated` was created with `Box::into_raw` and is not freed
+        // anywhere else.
+        drop(unsafe { Box::from_raw(self.allocated) });
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

  | Benchmark | Rust | C | Speedup (Rust vs C) |
  |---|---|---|---|
  | Read | 1.862 ms | 6.515 ms | **3.50× faster** |
  | SkipTo Dense | 452.99 µs | 754.12 µs | **1.66× faster** |
  | SkipTo Sparse | 3.593 ms | 13.875 ms | **3.86× faster** |

Those benchmarks actually found a regression in the `skip_to` code path from the C++ version so the first commit is fixing that.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
