### PR TITLE
[8.6-rse] [MOD-16015] FT.CREATE: reject RERANK on HNSW vector fields in RAM mode

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -866,6 +866,11 @@ static int parseVectorField_hnsw(IndexSpec *sp, FieldSpec *fs, VecSimParams *par
         return 0;
       }
     } else if (AC_AdvanceIfMatch(&subAc, VECSIM_RERANK)) {
+      if (!isSpecOnDiskForValidation(sp)) {
+        QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
+          "RERANK is only supported for disk-based vector indexes");
+        return 0;
+      }
       if (*rerank) {
         QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
           "Duplicate RERANK parameter");

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -406,6 +406,59 @@ def test_flex_disk_hnsw_rerank_requires_true_value(env):
 
 
 @skip(cluster=True)
+@with_simulate_in_flex(False)
+def test_ram_hnsw_rerank_rejected(env):
+    # In RAM mode RERANK is a disk-only option and must be rejected outright,
+    # including the otherwise-valid RERANK TRUE form (MOD-16015). The disk guard
+    # is the first check in the RERANK branch, so it short-circuits before the
+    # duplicate / missing-arg / value checks and never reads what follows the
+    # keyword. We therefore reject every RERANK form identically:
+    #   - RERANK TRUE: the form the bug silently accepted.
+    #   - RERANK FALSE: a valid value that is still disk-only in RAM mode.
+    #   - RERANK with no value: the guard fires before the missing-arg check.
+    #   - duplicate RERANK: pins the guard's precedence over the other RERANK
+    #     checks, so reordering them would surface as a regression here.
+    err = 'RERANK is only supported for disk-based vector indexes'
+
+    env.expect(
+        'FT.CREATE', 'idx_true', 'ON', 'HASH', 'SCHEMA',
+        'v', 'VECTOR', 'HNSW', '8',
+        'TYPE', 'FLOAT32',
+        'DIM', '2',
+        'DISTANCE_METRIC', 'L2',
+        'RERANK', 'TRUE',
+    ).error().contains(err)
+
+    env.expect(
+        'FT.CREATE', 'idx_false', 'ON', 'HASH', 'SCHEMA',
+        'v', 'VECTOR', 'HNSW', '8',
+        'TYPE', 'FLOAT32',
+        'DIM', '2',
+        'DISTANCE_METRIC', 'L2',
+        'RERANK', 'FALSE',
+    ).error().contains(err)
+
+    env.expect(
+        'FT.CREATE', 'idx_no_value', 'ON', 'HASH', 'SCHEMA',
+        'v', 'VECTOR', 'HNSW', '7',
+        'TYPE', 'FLOAT32',
+        'DIM', '2',
+        'DISTANCE_METRIC', 'L2',
+        'RERANK',
+    ).error().contains(err)
+
+    env.expect(
+        'FT.CREATE', 'idx_dup', 'ON', 'HASH', 'SCHEMA',
+        'v', 'VECTOR', 'HNSW', '10',
+        'TYPE', 'FLOAT32',
+        'DIM', '2',
+        'DISTANCE_METRIC', 'L2',
+        'RERANK', 'TRUE',
+        'RERANK', 'TRUE',
+    ).error().contains(err)
+
+
+@skip(cluster=True)
 @with_simulate_in_flex(True)
 def test_disk_vector_query_validation(env: Env):
 


### PR DESCRIPTION
Backport of #10109 to **8.6-rse**.

## Original PR
https://github.com/RediSearch/RediSearch/pull/10109

## Describe the changes in the pull request
1. **Current:** On 8.6-rse, `FT.CREATE ... HNSW ... RERANK TRUE` in RAM mode is silently accepted and the value discarded (it only flows into `VecSimDiskContext.rerank` when `sp->diskSpec` is set, which never happens in RAM mode).
2. **Change:** Adds an early guard at the top of the `RERANK` branch in `parseVectorField_hnsw()` that rejects `RERANK` outright when the spec is not on disk, with `RERANK is only supported for disk-based vector indexes`. Every RERANK form returns the same error in RAM mode; the disk path is unchanged.
3. **Outcome:** RAM-mode `FT.CREATE` no longer silently accepts a disk-only option.

#### Which additional issues this PR fixes
1. MOD-16015

#### Main objects this PR modified
1. `src/spec.c` — `parseVectorField_hnsw()` RERANK parsing
2. `tests/pytests/test_flex_validation.py` — new `test_ram_hnsw_rerank_rejected`

## Changes from original
Not a clean cherry-pick. `src/spec.c` conflicted: master refactored the RERANK duplicate-detection from `*rerank` to `rerank_seen`, while 8.6-rse still uses `if (*rerank)`. Resolution keeps 8.6-rse's existing `if (*rerank)` check and inserts only the new disk guard above it. The test addition applied cleanly. Build green; `test_flex_validation:test_ram_hnsw_rerank_rejected` passes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: `FT.CREATE` now rejects `RERANK` on HNSW vector fields in RAM mode (including `RERANK TRUE`) with `RERANK is only supported for disk-based vector indexes`, instead of silently accepting and ignoring `RERANK TRUE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)