### PR TITLE
[MOD-15334] Top K: Tiebreak ascending toggle

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2964,6 +2964,7 @@ dependencies = [
  "rqe_iterator_type",
  "rqe_iterators",
  "rqe_iterators_test_utils",
+ "rstest",
  "top_k",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -32,6 +32,7 @@ index_spec.workspace = true
 [dev-dependencies]
 top_k = { path = ".", features = ["unittest", "test-utils"] }
 redis_mock.workspace = true
+rstest.workspace = true
 rqe_iterators = { workspace = true, features = ["unittest"] }
 rqe_iterators_test_utils.workspace = true
 redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -15,6 +15,8 @@ use std::num::NonZeroUsize;
 
 use rqe_core::DocId;
 
+use crate::iterator::TiebreakStrategy::{self, HigherDocIdWins, LowerDocIdWins};
+
 /// A (doc_id, score) pair stored in the heap.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScoredResult {
@@ -32,13 +34,12 @@ pub struct ScoredResult {
 /// - `compare(a, b) == Less`  → `a` is **better** than `b`.
 /// - `compare(a, b) == Greater` → `a` is **worse** than `b` (= heap-max, evicted first).
 ///
-/// On equal scores the tie-breaker uses `tiebreak_ascending` (see [`TopKHeap::new`]).
+/// On equal scores the tie-breaker uses `tiebreak_strategy` (see [`TopKHeap::new`]).
 struct HeapEntry {
     result: ScoredResult,
     /// Cached comparison function so [`Ord`] can be implemented without extra state.
     compare: fn(f64, f64) -> Ordering,
-    /// On equal scores, whether a lower (`true`) or higher (`false`) `doc_id` wins the tie.
-    tiebreak_ascending: bool,
+    tiebreak_strategy: TiebreakStrategy,
 }
 
 impl PartialEq for HeapEntry {
@@ -65,10 +66,9 @@ impl Ord for HeapEntry {
             Ordering::Greater => Ordering::Greater,
             Ordering::Equal => {
                 let id_ord = self.result.doc_id.cmp(&other.result.doc_id);
-                if self.tiebreak_ascending {
-                    id_ord
-                } else {
-                    id_ord.reverse()
+                match self.tiebreak_strategy {
+                    LowerDocIdWins => id_ord,
+                    HigherDocIdWins => id_ord.reverse(),
                 }
             }
         }
@@ -96,7 +96,7 @@ pub struct TopKHeap {
     inner: BinaryHeap<HeapEntry>,
     capacity: usize,
     compare: fn(f64, f64) -> Ordering,
-    tiebreak_ascending: bool,
+    tiebreak_strategy: TiebreakStrategy,
 }
 
 impl TopKHeap {
@@ -104,20 +104,18 @@ impl TopKHeap {
     ///
     /// `compare` determines score order (see type-level docs).
     ///
-    /// `tiebreak_ascending` breaks ties when two results share an equal score:
-    /// - `true`  — higher `doc_id` is evicted first.
-    /// - `false` — lower  `doc_id` is evicted first.
+    /// `tiebreak_strategy` breaks ties when two results share an equal score.
     pub fn new(
         capacity: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
-        tiebreak_ascending: bool,
+        tiebreak_strategy: TiebreakStrategy,
     ) -> Self {
         let capacity = capacity.into();
         Self {
             inner: BinaryHeap::with_capacity(capacity),
             capacity,
             compare,
-            tiebreak_ascending,
+            tiebreak_strategy,
         }
     }
 
@@ -154,7 +152,7 @@ impl TopKHeap {
         let entry = HeapEntry {
             result: ScoredResult { doc_id, score },
             compare: self.compare,
-            tiebreak_ascending: self.tiebreak_ascending,
+            tiebreak_strategy: self.tiebreak_strategy,
         };
 
         if !self.is_full() {
@@ -214,7 +212,7 @@ mod tests {
 
     #[test]
     fn heap_fewer_than_k_preserves_all() {
-        let mut heap = TopKHeap::new(non_zero_capacity(5), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(5), asc, LowerDocIdWins);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
@@ -229,7 +227,7 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, LowerDocIdWins);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
@@ -250,7 +248,7 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), desc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), desc, LowerDocIdWins);
         heap.push(1, 1.0);
         heap.push(2, 3.0);
         heap.push(3, 2.0);
@@ -270,7 +268,7 @@ mod tests {
 
     #[test]
     fn heap_capacity_one_keeps_best_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(1), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(1), asc, LowerDocIdWins);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
@@ -284,7 +282,7 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, LowerDocIdWins);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie)
@@ -299,7 +297,7 @@ mod tests {
 
     #[test]
     fn heap_exact_duplicate_not_inserted_when_full() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, LowerDocIdWins);
         heap.push(1, 1.0);
         heap.push(2, 2.0);
 
@@ -314,7 +312,7 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), desc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), desc, LowerDocIdWins);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie, regardless of sort direction)
@@ -331,7 +329,7 @@ mod tests {
     fn heap_tiebreak_desc_evicts_lower_doc_id() {
         // Mirrors cmpByFields behaviour when the last SORTBY key is DESC:
         // lower doc_id is considered worse and evicted first.
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, false);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, HigherDocIdWins);
         heap.push(3, 1.0);
         heap.push(5, 1.0);
         heap.push(10, 1.0); // third tied entry evicts doc_id 3 (lowest loses the tie)
@@ -353,11 +351,11 @@ mod tests {
             heap.push(10, 1.0);
         };
 
-        let mut asc_heap = TopKHeap::new(non_zero_capacity(2), asc, true);
+        let mut asc_heap = TopKHeap::new(non_zero_capacity(2), asc, LowerDocIdWins);
         push_all(&mut asc_heap);
         let asc_ids: Vec<DocId> = asc_heap.drain_sorted().iter().map(|r| r.doc_id).collect();
 
-        let mut desc_heap = TopKHeap::new(non_zero_capacity(2), asc, false);
+        let mut desc_heap = TopKHeap::new(non_zero_capacity(2), asc, HigherDocIdWins);
         push_all(&mut desc_heap);
         let desc_ids: Vec<DocId> = desc_heap.drain_sorted().iter().map(|r| r.doc_id).collect();
 
@@ -369,7 +367,7 @@ mod tests {
 
     #[test]
     fn heap_peek_worst_returns_eviction_candidate() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, LowerDocIdWins);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -379,7 +377,7 @@ mod tests {
 
     #[test]
     fn drain_sorted_best_first_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(4), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), asc, LowerDocIdWins);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
@@ -392,7 +390,7 @@ mod tests {
 
     #[test]
     fn drain_sorted_best_first_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(4), desc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), desc, LowerDocIdWins);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
@@ -405,7 +403,7 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, LowerDocIdWins);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -419,7 +417,7 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), desc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), desc, LowerDocIdWins);
         heap.push(1, 4.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
@@ -433,19 +431,19 @@ mod tests {
 
     #[test]
     fn pop_worst_on_empty_returns_none() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, LowerDocIdWins);
         assert!(heap.pop_worst().is_none());
     }
 
     #[test]
     fn peek_worst_on_empty_returns_none() {
-        let heap = TopKHeap::new(non_zero_capacity(3), asc, true);
+        let heap = TopKHeap::new(non_zero_capacity(3), asc, LowerDocIdWins);
         assert!(heap.peek_worst().is_none());
     }
 
     #[test]
     fn pop_worst_allows_reinsertion() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, LowerDocIdWins);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.pop_worst();
@@ -458,7 +456,7 @@ mod tests {
 
     #[test]
     fn heap_is_empty_and_is_full() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, LowerDocIdWins);
         assert!(heap.is_empty());
         assert!(!heap.is_full());
 

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -32,12 +32,13 @@ pub struct ScoredResult {
 /// - `compare(a, b) == Less`  → `a` is **better** than `b`.
 /// - `compare(a, b) == Greater` → `a` is **worse** than `b` (= heap-max, evicted first).
 ///
-/// Tie-breaking: equal scores → higher `doc_id` is considered worse (evicted first),
-/// so lower `doc_id` is kept.
+/// On equal scores the tie-breaker uses `tiebreak_ascending` (see [`TopKHeap::new`]).
 struct HeapEntry {
     result: ScoredResult,
     /// Cached comparison function so [`Ord`] can be implemented without extra state.
     compare: fn(f64, f64) -> Ordering,
+    /// On equal scores, whether a lower (`true`) or higher (`false`) `doc_id` wins the tie.
+    tiebreak_ascending: bool,
 }
 
 impl PartialEq for HeapEntry {
@@ -62,8 +63,14 @@ impl Ord for HeapEntry {
         match score_ord {
             Ordering::Less => Ordering::Less,
             Ordering::Greater => Ordering::Greater,
-            // Tie on score: higher doc_id is worse (evicted first) → Greater
-            Ordering::Equal => self.result.doc_id.cmp(&other.result.doc_id),
+            Ordering::Equal => {
+                let id_ord = self.result.doc_id.cmp(&other.result.doc_id);
+                if self.tiebreak_ascending {
+                    id_ord
+                } else {
+                    id_ord.reverse()
+                }
+            }
         }
     }
 }
@@ -89,17 +96,28 @@ pub struct TopKHeap {
     inner: BinaryHeap<HeapEntry>,
     capacity: usize,
     compare: fn(f64, f64) -> Ordering,
+    tiebreak_ascending: bool,
 }
 
 impl TopKHeap {
-    /// Creates a new heap that holds at most `capacity` elements,
-    /// using the supplied `compare` function to determine score order.
-    pub fn new(capacity: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+    /// Creates a new heap that holds at most `capacity` elements.
+    ///
+    /// `compare` determines score order (see type-level docs).
+    ///
+    /// `tiebreak_ascending` breaks ties when two results share an equal score:
+    /// - `true`  — higher `doc_id` is evicted first.
+    /// - `false` — lower  `doc_id` is evicted first.
+    pub fn new(
+        capacity: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
+        tiebreak_ascending: bool,
+    ) -> Self {
         let capacity = capacity.into();
         Self {
             inner: BinaryHeap::with_capacity(capacity),
             capacity,
             compare,
+            tiebreak_ascending,
         }
     }
 
@@ -136,6 +154,7 @@ impl TopKHeap {
         let entry = HeapEntry {
             result: ScoredResult { doc_id, score },
             compare: self.compare,
+            tiebreak_ascending: self.tiebreak_ascending,
         };
 
         if !self.is_full() {
@@ -195,7 +214,7 @@ mod tests {
 
     #[test]
     fn heap_fewer_than_k_preserves_all() {
-        let mut heap = TopKHeap::new(non_zero_capacity(5), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(5), asc, true);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
@@ -210,7 +229,7 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
@@ -231,7 +250,7 @@ mod tests {
 
     #[test]
     fn heap_evicts_worst_when_full_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), desc, true);
         heap.push(1, 1.0);
         heap.push(2, 3.0);
         heap.push(3, 2.0);
@@ -251,7 +270,7 @@ mod tests {
 
     #[test]
     fn heap_capacity_one_keeps_best_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(1), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(1), asc, true);
         heap.push(1, 5.0);
         heap.push(2, 3.0);
         heap.push(3, 4.0);
@@ -265,7 +284,7 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie)
@@ -280,7 +299,7 @@ mod tests {
 
     #[test]
     fn heap_exact_duplicate_not_inserted_when_full() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
         heap.push(1, 1.0);
         heap.push(2, 2.0);
 
@@ -295,7 +314,7 @@ mod tests {
 
     #[test]
     fn heap_tie_breaking_keeps_lower_doc_id_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), desc, true);
         heap.push(10, 1.0);
         heap.push(5, 1.0);
         heap.push(3, 1.0); // third tied entry evicts doc_id 10 (highest loses the tie, regardless of sort direction)
@@ -309,8 +328,48 @@ mod tests {
     }
 
     #[test]
+    fn heap_tiebreak_desc_evicts_lower_doc_id() {
+        // Mirrors cmpByFields behaviour when the last SORTBY key is DESC:
+        // lower doc_id is considered worse and evicted first.
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, false);
+        heap.push(3, 1.0);
+        heap.push(5, 1.0);
+        heap.push(10, 1.0); // third tied entry evicts doc_id 3 (lowest loses the tie)
+
+        let results = heap.drain_sorted();
+        let ids: Vec<DocId> = results.iter().map(|r| r.doc_id).collect();
+
+        assert!(ids.contains(&5));
+        assert!(ids.contains(&10));
+        assert!(!ids.contains(&3));
+    }
+
+    #[test]
+    fn heap_tiebreak_asc_and_desc_differ_on_same_input() {
+        // Confirms the two directions produce opposite retained sets.
+        let push_all = |heap: &mut TopKHeap| {
+            heap.push(3, 1.0);
+            heap.push(5, 1.0);
+            heap.push(10, 1.0);
+        };
+
+        let mut asc_heap = TopKHeap::new(non_zero_capacity(2), asc, true);
+        push_all(&mut asc_heap);
+        let asc_ids: Vec<DocId> = asc_heap.drain_sorted().iter().map(|r| r.doc_id).collect();
+
+        let mut desc_heap = TopKHeap::new(non_zero_capacity(2), asc, false);
+        push_all(&mut desc_heap);
+        let desc_ids: Vec<DocId> = desc_heap.drain_sorted().iter().map(|r| r.doc_id).collect();
+
+        // ASC tiebreak keeps lowest ids; DESC tiebreak keeps highest ids.
+        assert_eq!(asc_ids, vec![3, 5]);
+        // DESC best-first: id=10 is "better" (Less in Ord) because tiebreak is reversed.
+        assert_eq!(desc_ids, vec![10, 5]);
+    }
+
+    #[test]
     fn heap_peek_worst_returns_eviction_candidate() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -320,7 +379,7 @@ mod tests {
 
     #[test]
     fn drain_sorted_best_first_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(4), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), asc, true);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
@@ -333,7 +392,7 @@ mod tests {
 
     #[test]
     fn drain_sorted_best_first_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(4), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(4), desc, true);
         for (id, score) in [(1, 4.0), (2, 1.0), (3, 3.0), (4, 2.0)] {
             heap.push(id, score);
         }
@@ -346,7 +405,7 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_asc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
         heap.push(1, 2.0);
         heap.push(2, 5.0);
         heap.push(3, 3.0);
@@ -360,7 +419,7 @@ mod tests {
 
     #[test]
     fn pop_worst_removes_eviction_candidate_desc() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), desc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), desc, true);
         heap.push(1, 4.0);
         heap.push(2, 1.0);
         heap.push(3, 2.0);
@@ -374,19 +433,19 @@ mod tests {
 
     #[test]
     fn pop_worst_on_empty_returns_none() {
-        let mut heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(3), asc, true);
         assert!(heap.pop_worst().is_none());
     }
 
     #[test]
     fn peek_worst_on_empty_returns_none() {
-        let heap = TopKHeap::new(non_zero_capacity(3), asc);
+        let heap = TopKHeap::new(non_zero_capacity(3), asc, true);
         assert!(heap.peek_worst().is_none());
     }
 
     #[test]
     fn pop_worst_allows_reinsertion() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
         heap.push(1, 3.0);
         heap.push(2, 1.0);
         heap.pop_worst();
@@ -399,7 +458,7 @@ mod tests {
 
     #[test]
     fn heap_is_empty_and_is_full() {
-        let mut heap = TopKHeap::new(non_zero_capacity(2), asc);
+        let mut heap = TopKHeap::new(non_zero_capacity(2), asc, true);
         assert!(heap.is_empty());
         assert!(!heap.is_full());
 

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -88,6 +88,10 @@ pub struct TopKIterator<'index, S: ScoreSource> {
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
     compare: fn(f64, f64) -> Ordering,
+    /// Tie-break direction applied to every heap this iterator creates.
+    /// `true` evicts the higher `doc_id` first; `false` evicts the lower one.
+    /// See [`TopKHeap::new`].
+    tiebreak_ascending: bool,
     phase: Phase,
     /// Heap contents drained into score order for yielding.
     results: Vec<ScoredResult>,
@@ -103,18 +107,22 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// The execution mode is inferred from `child`:
     /// - `None` → [`TopKMode::Unfiltered`]
     /// - `Some(_)` → [`TopKMode::Batches`]
+    ///
+    /// `tiebreak_ascending` selects which `doc_id` wins on equal scores; see
+    /// [`TopKHeap::new`].
     pub fn new(
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
+        tiebreak_ascending: bool,
     ) -> Self {
         let mode = if child.is_some() {
             TopKMode::Batches
         } else {
             TopKMode::Unfiltered
         };
-        Self::_new_with_mode(source, child, k, compare, mode)
+        Self::_new_with_mode(source, child, k, compare, tiebreak_ascending, mode)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
@@ -127,9 +135,10 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
+        tiebreak_ascending: bool,
         mode: TopKMode,
     ) -> Self {
-        Self::_new_with_mode(source, child, k, compare, mode)
+        Self::_new_with_mode(source, child, k, compare, tiebreak_ascending, mode)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
@@ -138,10 +147,11 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
+        tiebreak_ascending: bool,
         mode: TopKMode,
     ) -> Self {
         Self {
-            heap: TopKHeap::new(k, compare),
+            heap: TopKHeap::new(k, compare, tiebreak_ascending),
             source,
             child,
             mode,
@@ -149,6 +159,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             direct_batch: None,
             k,
             compare,
+            tiebreak_ascending,
             phase: Phase::NotStarted,
             results: Vec::new(),
             yield_pos: 0,
@@ -226,7 +237,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
                     // rescans every match from scratch, so batch-phase entries
                     // are redundant. Keeping them would re-admit the same doc id
                     // (TopKHeap::push only de-dups against the worst element).
-                    self.heap = TopKHeap::new(self.k, self.compare);
+                    self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_ascending);
                     self.collect_adhoc()?;
                     return Ok(());
                 }
@@ -234,7 +245,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
                     // Clear the heap: the source restarts with new parameters
                     // (e.g. expanded numeric range) and will re-emit previously
                     // collected docs. Keeping stale entries would cause duplicates.
-                    self.heap = TopKHeap::new(self.k, self.compare);
+                    self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_ascending);
                     self.source.rewind();
                     if let Some(child) = &mut self.child {
                         child.rewind();
@@ -274,7 +285,10 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// the [`Yielding`](Phase::Yielding) phase.
     fn finalize_collection(&mut self) {
         // Replace heap with a fresh one; drain_sorted consumes the old one.
-        let old_heap = std::mem::replace(&mut self.heap, TopKHeap::new(self.k, self.compare));
+        let old_heap = std::mem::replace(
+            &mut self.heap,
+            TopKHeap::new(self.k, self.compare, self.tiebreak_ascending),
+        );
         self.results = old_heap.drain_sorted();
         self.yield_pos = 0;
         self.phase = Phase::Yielding;
@@ -371,7 +385,7 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
             child.rewind();
         }
         self.mode = self.initial_mode;
-        self.heap = TopKHeap::new(self.k, self.compare);
+        self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_ascending);
         self.direct_batch = None;
         self.results.clear();
         self.yield_pos = 0;

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -72,6 +72,12 @@ enum Phase {
     YieldingDirect,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TiebreakStrategy {
+    LowerDocIdWins,
+    HigherDocIdWins,
+}
+
 /// A generic top-k iterator parameterized over a [`ScoreSource`].
 ///
 /// Implements the execution mode described in the design doc:
@@ -88,10 +94,9 @@ pub struct TopKIterator<'index, S: ScoreSource> {
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
     compare: fn(f64, f64) -> Ordering,
-    /// Tie-break direction applied to every heap this iterator creates.
-    /// `true` evicts the higher `doc_id` first; `false` evicts the lower one.
-    /// See [`TopKHeap::new`].
-    tiebreak_ascending: bool,
+    /// selects which `doc_id` wins on equal scores; see
+    /// [`TopKHeap::new`].
+    tiebreak_strategy: TiebreakStrategy,
     phase: Phase,
     /// Heap contents drained into score order for yielding.
     results: Vec<ScoredResult>,
@@ -108,21 +113,21 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// - `None` → [`TopKMode::Unfiltered`]
     /// - `Some(_)` → [`TopKMode::Batches`]
     ///
-    /// `tiebreak_ascending` selects which `doc_id` wins on equal scores; see
+    /// `tiebreak_strategy` selects which `doc_id` wins on equal scores; see
     /// [`TopKHeap::new`].
     pub fn new(
         source: S,
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
-        tiebreak_ascending: bool,
+        tiebreak_strategy: TiebreakStrategy,
     ) -> Self {
         let mode = if child.is_some() {
             TopKMode::Batches
         } else {
             TopKMode::Unfiltered
         };
-        Self::_new_with_mode(source, child, k, compare, tiebreak_ascending, mode)
+        Self::_new_with_mode(source, child, k, compare, tiebreak_strategy, mode)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
@@ -135,10 +140,10 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
-        tiebreak_ascending: bool,
+        tiebreak_strategy: TiebreakStrategy,
         mode: TopKMode,
     ) -> Self {
-        Self::_new_with_mode(source, child, k, compare, tiebreak_ascending, mode)
+        Self::_new_with_mode(source, child, k, compare, tiebreak_strategy, mode)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
@@ -147,11 +152,11 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         child: Option<Box<dyn RQEIterator<'index> + 'index>>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
-        tiebreak_ascending: bool,
+        tiebreak_strategy: TiebreakStrategy,
         mode: TopKMode,
     ) -> Self {
         Self {
-            heap: TopKHeap::new(k, compare, tiebreak_ascending),
+            heap: TopKHeap::new(k, compare, tiebreak_strategy),
             source,
             child,
             mode,
@@ -159,7 +164,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
             direct_batch: None,
             k,
             compare,
-            tiebreak_ascending,
+            tiebreak_strategy,
             phase: Phase::NotStarted,
             results: Vec::new(),
             yield_pos: 0,
@@ -237,7 +242,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
                     // rescans every match from scratch, so batch-phase entries
                     // are redundant. Keeping them would re-admit the same doc id
                     // (TopKHeap::push only de-dups against the worst element).
-                    self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_ascending);
+                    self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_strategy);
                     self.collect_adhoc()?;
                     return Ok(());
                 }
@@ -245,7 +250,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
                     // Clear the heap: the source restarts with new parameters
                     // (e.g. expanded numeric range) and will re-emit previously
                     // collected docs. Keeping stale entries would cause duplicates.
-                    self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_ascending);
+                    self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_strategy);
                     self.source.rewind();
                     if let Some(child) = &mut self.child {
                         child.rewind();
@@ -287,7 +292,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         // Replace heap with a fresh one; drain_sorted consumes the old one.
         let old_heap = std::mem::replace(
             &mut self.heap,
-            TopKHeap::new(self.k, self.compare, self.tiebreak_ascending),
+            TopKHeap::new(self.k, self.compare, self.tiebreak_strategy),
         );
         self.results = old_heap.drain_sorted();
         self.yield_pos = 0;
@@ -385,7 +390,7 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
             child.rewind();
         }
         self.mode = self.initial_mode;
-        self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_ascending);
+        self.heap = TopKHeap::new(self.k, self.compare, self.tiebreak_strategy);
         self.direct_batch = None;
         self.results.clear();
         self.yield_pos = 0;

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -134,7 +134,7 @@ fn read_triggers_collection_on_first_call() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
 
     assert!(!it.at_eof());
     let result = it.read().unwrap().expect("should have a result");
@@ -146,7 +146,7 @@ fn rewind_resets_to_not_started() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
     it.read().unwrap();
     it.read().unwrap();
     let eof = it.read().unwrap();
@@ -166,7 +166,7 @@ fn rewind_resets_to_not_started() {
 #[test]
 fn eof_set_after_results_exhausted() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
     it.read().unwrap();
     let eof = it.read().unwrap();
     assert!(eof.is_none());
@@ -178,7 +178,7 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
 
     assert_eq!(it.last_doc_id(), 0);
 
@@ -197,7 +197,7 @@ fn num_estimated_capped_at_k() {
         BatchStrategy::Continue
     })
     .with_num_estimated(100);
-    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc);
+    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc, true);
 
     assert_eq!(it.num_estimated(), 3);
 }
@@ -211,7 +211,7 @@ fn unfiltered_yields_batch_in_source_order() {
     let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc, true);
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(ids, vec![1, 2, 3]);
 }
@@ -219,7 +219,7 @@ fn unfiltered_yields_batch_in_source_order() {
 #[test]
 fn unfiltered_empty_source_is_immediate_eof() {
     let source = MockScoreSource::new(vec![], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
 }
@@ -230,7 +230,7 @@ fn unfiltered_empty_source_is_immediate_eof() {
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
@@ -242,7 +242,13 @@ fn revalidate_with_child_delegates_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
-    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(
+        source,
+        Some(child),
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        true,
+    );
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
@@ -252,14 +258,26 @@ fn revalidate_with_child_delegates_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
-    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(
+        source,
+        Some(child),
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        true,
+    );
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
 }
 
 #[test]
 fn unfiltered_timeout_propagated() {
-    let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(
+        TimingOutSource,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        true,
+    );
     assert!(matches!(
         it.read().unwrap_err(),
         rqe_iterators::RQEIteratorError::TimedOut
@@ -282,6 +300,7 @@ fn batches_overlap_intersection() {
         Some(make_child(vec![1, 3, 5])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![5, 3, 1]);
@@ -297,6 +316,7 @@ fn batches_disjoint_yields_nothing() {
         Some(make_child(vec![10, 20])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -312,6 +332,7 @@ fn batches_empty_child_yields_nothing() {
         Some(make_child(vec![])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -331,6 +352,7 @@ fn batches_multiple_batches() {
         Some(make_child(vec![1, 3, 4])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![3, 4, 1]);
@@ -352,6 +374,7 @@ fn strategy_stop_stops_after_first_batch() {
         Some(make_child(vec![1, 2, 3, 4])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids.len(), 2);
@@ -428,6 +451,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         Some(make_child(vec![1, 3])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
 
     // Session 1: the source returns one batch (doc 1, doc 3 land in the heap)
@@ -469,6 +493,7 @@ fn strategy_switch_to_adhoc() {
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     // Adhoc-only scores, doc 2 exactly once: 2(1.0), 3(2.0).
@@ -495,6 +520,7 @@ fn strategy_switch_to_batches_rewinds() {
         Some(make_child(vec![1, 2])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![1, 2]);
@@ -513,6 +539,7 @@ fn adhoc_scores_known_docs_only() {
         Some(make_child(vec![1, 2, 3, 4, 5])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
         TopKMode::AdhocBF,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -534,6 +561,7 @@ fn adhoc_early_stop_when_heap_full() {
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(2).unwrap(),
         asc,
+        true,
         TopKMode::AdhocBF,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -550,6 +578,7 @@ fn adhoc_child_eof_returns_what_was_found() {
         Some(make_child(vec![1, 2])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
         TopKMode::AdhocBF,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -564,8 +593,37 @@ fn adhoc_empty_child_is_eof() {
         Some(make_child(vec![])),
         NonZeroUsize::new(10).unwrap(),
         asc,
+        true,
         TopKMode::AdhocBF,
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
+}
+
+/// Drives a batches run where every match shares the same score and k is smaller
+/// than the number of matches, so the retained set is decided entirely by the
+/// tie-break direction.
+fn tied_scores_doc_ids(tiebreak_ascending: bool) -> Vec<DocId> {
+    let source = MockScoreSource::new(vec![vec![(3, 1.0), (5, 1.0), (10, 1.0)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+    let mut it = TopKIterator::new(
+        source,
+        Some(make_child(vec![3, 5, 10])),
+        NonZeroUsize::new(2).unwrap(),
+        asc,
+        tiebreak_ascending,
+    );
+    std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect()
+}
+
+#[test]
+fn tiebreak_ascending_keeps_lowest_doc_ids() {
+    assert_eq!(tied_scores_doc_ids(true), vec![3, 5]);
+}
+
+#[test]
+fn tiebreak_descending_keeps_highest_doc_ids() {
+    // With the old hard-coded `true`, this returned [3, 5] regardless of the flag.
+    assert_eq!(tied_scores_doc_ids(false), vec![10, 5]);
 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -12,12 +12,15 @@
 use std::{cmp::Ordering, num::NonZeroUsize};
 
 use rqe_core::DocId;
+use rstest::rstest;
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
 use top_k::{
-    BatchStrategy, ScoreSource, TopKIterator, TopKMode, mock::MockScoreBatch, mock::MockScoreSource,
+    BatchStrategy, ScoreSource, TopKIterator, TopKMode,
+    iterator::TiebreakStrategy::{self, LowerDocIdWins},
+    mock::{MockScoreBatch, MockScoreSource},
 };
 
 // ── Error path stubs ─────────────────────────────────────────────────────────────
@@ -134,7 +137,13 @@ fn read_triggers_collection_on_first_call() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
 
     assert!(!it.at_eof());
     let result = it.read().unwrap().expect("should have a result");
@@ -146,7 +155,13 @@ fn rewind_resets_to_not_started() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
     it.read().unwrap();
     it.read().unwrap();
     let eof = it.read().unwrap();
@@ -166,7 +181,13 @@ fn rewind_resets_to_not_started() {
 #[test]
 fn eof_set_after_results_exhausted() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
     it.read().unwrap();
     let eof = it.read().unwrap();
     assert!(eof.is_none());
@@ -178,7 +199,13 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
 
     assert_eq!(it.last_doc_id(), 0);
 
@@ -197,7 +224,13 @@ fn num_estimated_capped_at_k() {
         BatchStrategy::Continue
     })
     .with_num_estimated(100);
-    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc, true);
+    let it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(3).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
 
     assert_eq!(it.num_estimated(), 3);
 }
@@ -211,7 +244,13 @@ fn unfiltered_yields_batch_in_source_order() {
     let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(ids, vec![1, 2, 3]);
 }
@@ -219,7 +258,13 @@ fn unfiltered_yields_batch_in_source_order() {
 #[test]
 fn unfiltered_empty_source_is_immediate_eof() {
     let source = MockScoreSource::new(vec![], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
 }
@@ -230,7 +275,13 @@ fn unfiltered_empty_source_is_immediate_eof() {
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc, true);
+    let mut it = TopKIterator::new(
+        source,
+        None,
+        NonZeroUsize::new(5).unwrap(),
+        asc,
+        LowerDocIdWins,
+    );
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
@@ -247,7 +298,7 @@ fn revalidate_with_child_delegates_ok() {
         Some(child),
         NonZeroUsize::new(5).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
@@ -263,7 +314,7 @@ fn revalidate_with_child_delegates_aborted() {
         Some(child),
         NonZeroUsize::new(5).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
@@ -276,7 +327,7 @@ fn unfiltered_timeout_propagated() {
         None,
         NonZeroUsize::new(5).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     assert!(matches!(
         it.read().unwrap_err(),
@@ -300,7 +351,7 @@ fn batches_overlap_intersection() {
         Some(make_child(vec![1, 3, 5])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![5, 3, 1]);
@@ -316,7 +367,7 @@ fn batches_disjoint_yields_nothing() {
         Some(make_child(vec![10, 20])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -332,7 +383,7 @@ fn batches_empty_child_yields_nothing() {
         Some(make_child(vec![])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
@@ -352,7 +403,7 @@ fn batches_multiple_batches() {
         Some(make_child(vec![1, 3, 4])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![3, 4, 1]);
@@ -374,7 +425,7 @@ fn strategy_stop_stops_after_first_batch() {
         Some(make_child(vec![1, 2, 3, 4])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids.len(), 2);
@@ -451,7 +502,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         Some(make_child(vec![1, 3])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
 
     // Session 1: the source returns one batch (doc 1, doc 3 land in the heap)
@@ -493,7 +544,7 @@ fn strategy_switch_to_adhoc() {
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     // Adhoc-only scores, doc 2 exactly once: 2(1.0), 3(2.0).
@@ -520,7 +571,7 @@ fn strategy_switch_to_batches_rewinds() {
         Some(make_child(vec![1, 2])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![1, 2]);
@@ -539,7 +590,7 @@ fn adhoc_scores_known_docs_only() {
         Some(make_child(vec![1, 2, 3, 4, 5])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
         TopKMode::AdhocBF,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -561,7 +612,7 @@ fn adhoc_early_stop_when_heap_full() {
         Some(make_child(vec![1, 2, 3])),
         NonZeroUsize::new(2).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
         TopKMode::AdhocBF,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -578,7 +629,7 @@ fn adhoc_child_eof_returns_what_was_found() {
         Some(make_child(vec![1, 2])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
         TopKMode::AdhocBF,
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
@@ -593,7 +644,7 @@ fn adhoc_empty_child_is_eof() {
         Some(make_child(vec![])),
         NonZeroUsize::new(10).unwrap(),
         asc,
-        true,
+        LowerDocIdWins,
         TopKMode::AdhocBF,
     );
     assert!(it.read().unwrap().is_none());
@@ -603,7 +654,13 @@ fn adhoc_empty_child_is_eof() {
 /// Drives a batches run where every match shares the same score and k is smaller
 /// than the number of matches, so the retained set is decided entirely by the
 /// tie-break direction.
-fn tied_scores_doc_ids(tiebreak_ascending: bool) -> Vec<DocId> {
+#[rstest]
+#[case(TiebreakStrategy::LowerDocIdWins, vec![3, 5])]
+#[case(TiebreakStrategy::HigherDocIdWins, vec![10, 5])]
+fn tiebreak_strategy_selects_doc_ids(
+    #[case] tiebreak_strategy: TiebreakStrategy,
+    #[case] expected: Vec<DocId>,
+) {
     let source = MockScoreSource::new(vec![vec![(3, 1.0), (5, 1.0), (10, 1.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
@@ -612,18 +669,8 @@ fn tied_scores_doc_ids(tiebreak_ascending: bool) -> Vec<DocId> {
         Some(make_child(vec![3, 5, 10])),
         NonZeroUsize::new(2).unwrap(),
         asc,
-        tiebreak_ascending,
+        tiebreak_strategy,
     );
-    std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect()
-}
-
-#[test]
-fn tiebreak_ascending_keeps_lowest_doc_ids() {
-    assert_eq!(tied_scores_doc_ids(true), vec![3, 5]);
-}
-
-#[test]
-fn tiebreak_descending_keeps_highest_doc_ids() {
-    // With the old hard-coded `true`, this returned [3, 5] regardless of the flag.
-    assert_eq!(tied_scores_doc_ids(false), vec![10, 5]);
+    let doc_ids: Vec<DocId> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, expected);
 }

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -41,7 +41,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         &(n, k),
         |b, &(n, k)| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc);
+                let mut heap = TopKHeap::new(k, asc, true);
                 for i in 0..n {
                     heap.push(i as u64, i as f64);
                 }
@@ -58,7 +58,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         &(n, k),
         |b, &(n, k)| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc);
+                let mut heap = TopKHeap::new(k, asc, true);
                 for i in (0..n).rev() {
                     heap.push(i as u64, i as f64);
                 }
@@ -79,7 +79,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         BenchmarkId::new("insert_rand", format!("{n}→k{k}")),
         |b| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc);
+                let mut heap = TopKHeap::new(k, asc, true);
                 for &i in &scores {
                     heap.push(i, i as f64);
                 }
@@ -100,7 +100,7 @@ fn bench_heap_pop_all(c: &mut Criterion) {
         |b, &k| {
             b.iter_batched(
                 || {
-                    let mut heap = TopKHeap::new(k, asc);
+                    let mut heap = TopKHeap::new(k, asc, true);
                     for i in 0..k.get() {
                         heap.push(i as u64, i as f64);
                     }
@@ -135,7 +135,7 @@ fn bench_intersection_overlap(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it = TopKIterator::new(source, Some(child), k, asc);
+                    let mut it = TopKIterator::new(source, Some(child), k, asc, true);
                     while black_box(it.read()).unwrap().is_some() {}
                 },
                 BatchSize::SmallInput,
@@ -164,7 +164,7 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it = TopKIterator::new(source, Some(child), k, asc);
+                    let mut it = TopKIterator::new(source, Some(child), k, asc, true);
                     while black_box(it.read()).unwrap().is_some() {}
                 },
                 BatchSize::SmallInput,
@@ -198,8 +198,14 @@ fn bench_adhoc_vs_batches(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it =
-                        TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::AdhocBF);
+                    let mut it = TopKIterator::new_with_mode(
+                        source,
+                        Some(child),
+                        k,
+                        asc,
+                        true,
+                        TopKMode::AdhocBF,
+                    );
                     while it.read().unwrap().is_some() {}
                     black_box(it.at_eof())
                 },
@@ -218,8 +224,14 @@ fn bench_adhoc_vs_batches(c: &mut Criterion) {
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it =
-                        TopKIterator::new_with_mode(source, Some(child), k, asc, TopKMode::Batches);
+                    let mut it = TopKIterator::new_with_mode(
+                        source,
+                        Some(child),
+                        k,
+                        asc,
+                        true,
+                        TopKMode::Batches,
+                    );
                     while it.read().unwrap().is_some() {}
                     black_box(it.at_eof())
                 },

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -13,6 +13,7 @@
 //! comparable to the C iterator numbers — their purpose is to provide a
 //! regression guard for the shared skeleton before real sources are plugged in.
 
+use top_k::iterator::TiebreakStrategy::LowerDocIdWins;
 // Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
 use top_k_bencher as _;
 
@@ -41,7 +42,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         &(n, k),
         |b, &(n, k)| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc, true);
+                let mut heap = TopKHeap::new(k, asc, LowerDocIdWins);
                 for i in 0..n {
                     heap.push(i as u64, i as f64);
                 }
@@ -58,7 +59,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         &(n, k),
         |b, &(n, k)| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc, true);
+                let mut heap = TopKHeap::new(k, asc, LowerDocIdWins);
                 for i in (0..n).rev() {
                     heap.push(i as u64, i as f64);
                 }
@@ -79,7 +80,7 @@ fn bench_heap_insert(c: &mut Criterion) {
         BenchmarkId::new("insert_rand", format!("{n}→k{k}")),
         |b| {
             b.iter(|| {
-                let mut heap = TopKHeap::new(k, asc, true);
+                let mut heap = TopKHeap::new(k, asc, LowerDocIdWins);
                 for &i in &scores {
                     heap.push(i, i as f64);
                 }
@@ -100,7 +101,7 @@ fn bench_heap_pop_all(c: &mut Criterion) {
         |b, &k| {
             b.iter_batched(
                 || {
-                    let mut heap = TopKHeap::new(k, asc, true);
+                    let mut heap = TopKHeap::new(k, asc, LowerDocIdWins);
                     for i in 0..k.get() {
                         heap.push(i as u64, i as f64);
                     }


### PR DESCRIPTION
When we want to support query optimizer over numeric field, the sort mode will need explicit control over tie winners (checking doc id), this PR adds that.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
