### PR TITLE
[MOD-16020] FT.PROFILE return-strict timeout: preserve profile envelope for SEARCH/AGGREGATE/HYBRID

### DIFF
--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -159,14 +159,14 @@ static inline void debugCheckAndPauseAfterAggregateResult(AREQ *areq) {}
   * results path in `serializeAndReplyResults_*`; that path is independent
   * of this classifier.
   *
-  * Profile is excluded: it wraps every RP and is not yet supported under
-  * RETURN-STRICT drain.
+  * Profile (`FT.PROFILE`) interleaves an RP_PROFILE wrapper around every RP,
+  * so the classifier transparently skips RP_PROFILE wrappers while walking
+  * from `endProc`. The root proc type is read from `qctx->rootProc`, which
+  * always points at the real root (RP_INDEX / RP_NETWORK) regardless of
+  * profiling, and the drain itself walks `endProc->Next` which delegates
+  * through the profile wrappers.
   */
  bool pipelineCanYieldPartialResults(AREQ *r) {
-   if (IsProfile(r)) {
-     return false;
-   }
-
    QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(r);
    ResultProcessor *end = qctx->endProc;
    ResultProcessor *root = qctx->rootProc;
@@ -176,7 +176,8 @@ static inline void debugCheckAndPauseAfterAggregateResult(AREQ *areq) {}
    }
 
    ResultProcessor *rp = end;
-   while (rp->type == RP_PAGER_LIMITER || rp->type == RP_VECTOR_NORMALIZER) {
+   while (rp->type == RP_PROFILE || rp->type == RP_PAGER_LIMITER ||
+          rp->type == RP_VECTOR_NORMALIZER) {
      rp = rp->upstream;
      RS_ASSERT(rp);
    }

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -174,6 +174,16 @@ int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode,
     return REDISMODULE_OK;
 }
 
+int coord_hybrid_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, QueryErrorCode errCode) {
+    // Derive the profile flag from the command (argv[0] == "FT.PROFILE"), the
+    // same way parseProfileArgs detects it for aggregate. This keeps the empty
+    // reply envelope consistent with a successful FT.PROFILE ... HYBRID without
+    // the caller having to thread isProfile through, removing a foot-gun where
+    // the profile envelope could be dropped on the timeout fast path.
+    const bool isProfile = RMUtil_ArgIndex("FT.PROFILE", argv, 1) != -1;
+    return common_hybrid_query_reply_empty(ctx, errCode, false, isProfile);
+}
+
 // Single-shard empty reply for both SEARCH and AGGREGATE commands. Currently used during OOM conditions.
 // Uses the common helper which compiles the query and works for both command types.
 int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int execOptions, QueryErrorCode errCode) {

--- a/src/aggregate/reply_empty.h
+++ b/src/aggregate/reply_empty.h
@@ -31,6 +31,12 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
 // When isProfile is true, wraps the reply with profile structure.
 int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal, bool isProfile);
 
+// Coordinator empty reply for FT.HYBRID commands.
+// Derives the profile flag from the command itself (FT.PROFILE prefix) and
+// forwards to common_hybrid_query_reply_empty, so callers do not have to track
+// isProfile. Mirrors coord_aggregate_query_reply_empty.
+int coord_hybrid_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, QueryErrorCode errCode);
+
 // Single-shard empty reply for SEARCH and AGGREGATE commands.
 // Handles both RESP2 and RESP3 with command-appropriate formatting.
 // Works for both SEARCH and AGGREGATE by compiling query for format detection.

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1182,9 +1182,6 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 // Timeout callback for Coordinator HybridRequest execution
 // Called on the main thread when the blocking client times out (RETURN-STRICT policy only).
 int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  UNUSED(argv);
-  UNUSED(argc);
-
   CoordRequestCtx *CoordReqCtx = RedisModule_GetBlockedClientPrivateData(ctx);
   if (!CoordReqCtx) {
     // This shouldn't happen but handle gracefully
@@ -1218,8 +1215,10 @@ int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString
   if (!hreq || HybridRequest_TryClaimAggregateResults(hreq)) {
     // Either the request is NULL or we were able to claim the aggregation results.
     // That means that the background thread didn't reach the aggregation phase
-    // (startPipelineCommon) yet. Reply with empty results.
-    common_hybrid_query_reply_empty(ctx, QUERY_ERROR_CODE_TIMED_OUT, false, false);
+    // (startPipelineCommon) yet. Reply with empty results. coord_hybrid_query_reply_empty
+    // derives isProfile from the command so the profile envelope is preserved for
+    // FT.PROFILE ... HYBRID even on this fast path.
+    coord_hybrid_query_reply_empty(ctx, argv, argc, QUERY_ERROR_CODE_TIMED_OUT);
     return REDISMODULE_OK;
   }
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -3155,6 +3155,82 @@ class TestCoordinatorTimeout:
         env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
         env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
 
+    def test_return_strict_timeout_at_claim_sync_point_profile_hybrid(self):
+        """RETURN_STRICT FT.PROFILE HYBRID early-timeout preserves the profile envelope.
+
+        Profile counterpart of test_return_strict_timeout_at_claim_sync_point_hybrid.
+        The main-thread timeout callback wins TryClaim while BG is
+        parked before HybridRequest_TryClaimAggregateResults and replies empty via
+        the coordinator fast path. coord_hybrid_query_reply_empty must derive the
+        profile flag from the command (FT.PROFILE prefix) so the reply keeps the
+        {Results, Profile} envelope instead of a bare empty result.
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict')
+
+        before_info = info_modules_to_dict(env)
+        base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
+
+        sync_point = 'BeforeHybridResultsClaim'
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
+
+        query_args = [
+            'FT.PROFILE', 'hybrid_idx', 'HYBRID', 'QUERY',
+            'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB',
+            'PARAMS', '2', 'BLOB', self.hybrid_query_vec
+        ]
+        query_result = []
+        t_query = threading.Thread(
+            target=call_and_store,
+            args=(env.cmd, query_args, query_result),
+            daemon=True
+        )
+        t_query.start()
+
+        # Wait for BG to park at the sync point (before TryClaim).
+        wait_for_condition(
+            lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+            f'Timeout waiting for {sync_point} sync point'
+        )
+
+        # Fire the blocked-client timeout on the main thread while BG is parked.
+        # Main-thread callback wins TryClaim and replies empty + TIMEOUT warning.
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.PROFILE')
+        env.cmd('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT')
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        # Release BG so it can observe the lost claim and return from startPipelineHybrid.
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+
+        env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
+        result = query_result[0]
+        # The profile envelope must survive the early-timeout fast path.
+        env.assertContains('Results', result, message=f"Profile envelope dropped, got: {result}")
+        env.assertContains('Profile', result, message=f"Profile envelope dropped, got: {result}")
+        inner = result['Results']
+        env.assertEqual(inner['total_results'], 0, message=f"Expected 0 results, got: {inner}")
+        env.assertEqual(inner.get('results', []), [],
+                        message=f"Expected no rows, got {inner.get('results')}")
+        assert_timeout_warning(env, inner,
+                               message=f"FT.PROFILE HYBRID return-strict at claim sync point, got: {result}")
+
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                        str(base_warn_coord + 1),
+                        message="Coordinator timeout warning should be +1")
+        _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
+
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
     def test_return_strict_timeout_after_store_hybrid(self):
         """RETURN_STRICT timeout race after the BG hybrid pipeline has stored results.
 
@@ -4781,6 +4857,27 @@ class TestCoordinatorTimeoutReturnStrictResp2:
         for i in range(self.n_docs):
             conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
 
+        # Index with a vector field for FT.HYBRID tests (different prefix).
+        self.env.expect(
+            'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
+            'name', 'TEXT',
+            'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+            'DISTANCE_METRIC', 'L2'
+        ).ok()
+        for i in range(self.n_docs):
+            vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+            conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
+                                 'embedding', vec)
+
+        # Warmup hybrid query and store the query vector for tests.
+        self.hybrid_query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+        self.env.expect(
+            'FT.HYBRID', 'hybrid_idx',
+            'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB',
+            'PARAMS', '2', 'BLOB', self.hybrid_query_vec
+        ).noError()
+
     def _run_one_shard_timesout_resp2(self, *, coord_cmd_list, shard_cmd,
                                       assert_reply):
         """Drive a one-shard-timesout RESP2 query under RETURN_STRICT.
@@ -4865,8 +4962,8 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             env.assertTrue(isinstance(result, list),
                            message=f"RESP2 reply type ({type(result).__name__})")
             row_count = len(result) - 1
-            # Temporary until MOD-15971 defines deterministic internal cursor
-            # draining after RETURN_STRICT shard timeouts.
+            # Temporary until deterministic internal cursor draining after
+            # RETURN_STRICT shard timeouts is defined.
             env.assertGreaterEqual(row_count, expected_rows,
                                    message="trailing row count")
 
@@ -4901,8 +4998,8 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             env.assertTrue(profile_array,
                            message="RESP2 profile array must be non-empty")
             row_count = len(results_array) - 1
-            # Temporary until MOD-15971 defines deterministic internal cursor
-            # draining after RETURN_STRICT shard timeouts.
+            # Temporary until deterministic internal cursor draining after
+            # RETURN_STRICT shard timeouts is defined.
             env.assertGreaterEqual(row_count, expected_rows,
                                    message="trailing row count")
 
@@ -4912,6 +5009,105 @@ class TestCoordinatorTimeoutReturnStrictResp2:
                             'LIMIT', '0', str(self.n_docs)],
             shard_cmd='_FT.PROFILE',
             assert_reply=assert_profile_reply)
+
+    def test_return_strict_timeout_at_claim_sync_point_profile_hybrid_resp2(self):
+        """RESP2 FT.PROFILE HYBRID early-timeout preserves the profile envelope.
+
+        RESP2 counterpart of TestCoordinatorTimeout.
+        test_return_strict_timeout_at_claim_sync_point_profile_hybrid.
+        The main-thread timeout callback wins TryClaim while BG is
+        parked before HybridRequest_TryClaimAggregateResults and replies empty
+        via the coordinator fast path. coord_hybrid_query_reply_empty derives
+        the profile flag from the FT.PROFILE prefix, so the RESP2 reply must be
+        the two-element ``[results_array, profile_array]`` envelope rather than a
+        bare empty results map. Unlike the one-shard-timesout RESP2 case the
+        coordinator itself generates the timeout, so the coord warning metric
+        increments by 1.
+        """
+        env = self.env
+        skipIfNoEnableAssert(env)
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[1]
+        run_command_on_all_shards(env, 'CONFIG', 'SET',
+                                  ON_TIMEOUT_CONFIG, 'return-strict')
+
+        before_info = info_modules_to_dict(env)
+        base_warn_coord = int(
+            before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
+
+        sync_point = 'BeforeHybridResultsClaim'
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
+
+        query_args = [
+            'FT.PROFILE', 'hybrid_idx', 'HYBRID', 'QUERY',
+            'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB',
+            'PARAMS', '2', 'BLOB', self.hybrid_query_vec
+        ]
+        query_result = []
+        t_query = threading.Thread(
+            target=call_and_store,
+            args=(env.cmd, query_args, query_result),
+            daemon=True
+        )
+        t_query.start()
+
+        # Wait for BG to park at the sync point (before TryClaim).
+        wait_for_condition(
+            lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+            f'Timeout waiting for {sync_point} sync point'
+        )
+
+        # Fire the blocked-client timeout on the main thread while BG is parked.
+        # Main-thread callback wins TryClaim and replies empty + TIMEOUT warning.
+        blocked_client_id = wait_for_blocked_query_client(env, 'FT.PROFILE')
+        env.cmd('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT')
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        # Release BG so it can observe the lost claim and exit cleanly.
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+
+        env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
+        result = query_result[0]
+
+        # RESP2 profile reply: [results_array, profile_array].
+        env.assertTrue(isinstance(result, list),
+                       message=f"RESP2 reply type ({type(result).__name__}): {result!r}")
+        env.assertEqual(len(result), 2,
+                        message=f"RESP2 profile envelope shape: {result!r}")
+        results_array, profile_array = result[0], result[1]
+        env.assertTrue(isinstance(results_array, list),
+                       message=f"RESP2 results_array type: {results_array!r}")
+        env.assertTrue(profile_array,
+                       message="RESP2 profile array must be non-empty")
+
+        # The RESP2 results map flattens to a [key, value, ...] list.
+        inner = dict(zip(results_array[0::2], results_array[1::2]))
+        env.assertEqual(inner.get('total_results'), 0,
+                        message=f"Expected 0 results, got: {inner}")
+        env.assertEqual(inner.get('results', []), [],
+                        message=f"Expected no rows, got {inner.get('results')}")
+        warnings = inner.get('warnings', [])
+        env.assertTrue(warnings,
+                       message=f"inner results must carry a warning, got: {inner}")
+        env.assertContains('Timeout', warnings[0],
+                           message=f"inner results must carry the TIMEOUT warning, got: {inner}")
+
+        # The coordinator generated the timeout itself, so the coord warning
+        # metric increments by 1 (it is not relying on RESP2 shard propagation).
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                        str(base_warn_coord + 1),
+                        message="Coordinator timeout warning should be +1")
+        _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
+
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+        run_command_on_all_shards(env, 'CONFIG', 'SET',
+                                  ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
 
 class TestCoordinatorTimeoutCursorReadResp2:
     """RESP2 coverage for RETURN_STRICT FT.CURSOR READ timeout reply shape.

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4517,6 +4517,43 @@ class TestCoordinatorTimeout:
             assert_reply=assert_profile_partial_reply,
             expected_warning=[])
 
+    def test_return_strict_one_shard_timesout_profile_sortby_aggregate(self):
+        """FT.PROFILE AGGREGATE SORTBY wrapper around the drainable case.
+
+        SORTBY makes the shard-side RPSorter a buffering stage, so its heap
+        already holds the full per-shard set when the pause fires. The strict
+        drain must walk through the interleaved RP_PROFILE wrappers and pop
+        all of it, and the coord's RPNet must drain the timed-out shard's
+        reply through its own profile wrappers, so the merged ``Results``
+        carries the full globally-sorted set under the surviving ``Profile``
+        envelope.
+        """
+        skipIfNoEnableAssert(self.env)
+
+        def assert_profile_sorted_reply(env, result, expected_rows,
+                                        pause_after_n, other_docs):
+            env.assertContains('Results', result, message="Results key")
+            env.assertContains('Profile', result, message="Profile key")
+            inner = result['Results']
+            full_rows = self.n_docs
+            env.assertEqual(len(inner.get('results', [])), full_rows,
+                            message="rows in reply")
+            values = [row['extra_attributes']['name'] for row in inner['results']]
+            env.assertEqual(values, sorted(values),
+                            message="global sort order")
+            env.assertEqual(inner.get('warning', []), [TIMEOUT_WARNING],
+                            message="inner Results warning")
+
+        self._run_one_shard_timesout(
+            coord_cmd='FT.PROFILE', shard_cmd='_FT.PROFILE',
+            coord_cmd_prefix=['FT.PROFILE', 'idx', 'AGGREGATE',
+                              'QUERY', '*'],
+            query_args=['LOAD', '1', '@name',
+                        'SORTBY', '1', '@name',
+                        'LIMIT', '0', str(self.n_docs)],
+            assert_reply=assert_profile_sorted_reply,
+            expected_warning=[])
+
     # ------------------------------------------------------------------
     # Every shard times out: same RETURN_STRICT plumbing, but every
     # shard is parked and individually unblocked. With no coord deadline
@@ -4744,10 +4781,18 @@ class TestCoordinatorTimeoutReturnStrictResp2:
         for i in range(self.n_docs):
             conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
 
-    def test_return_strict_one_shard_timesout_flat_aggregate_resp2(self):
-        """RESP2 variant of test_return_strict_one_shard_timesout_flat_aggregate."""
+    def _run_one_shard_timesout_resp2(self, *, coord_cmd_list, shard_cmd,
+                                      assert_reply):
+        """Drive a one-shard-timesout RESP2 query under RETURN_STRICT.
+
+        Parks one non-coord shard at ``AggregateResults`` #pause_after_n,
+        fires ``CLIENT UNBLOCK ... TIMEOUT``, and hands the merged reply to
+        ``assert_reply(env, result, expected_rows)``. RESP2 has no warnings
+        slot in the shard reply, so the coord warning metric must stay
+        unchanged; this helper asserts that and the unrelated-metrics
+        invariant.
+        """
         env = self.env
-        skipIfNoEnableAssert(env)
 
         # CONFIG GET in RESP2 returns a flat [key, value] list, not a map.
         prev_on_timeout_policy = env.cmd('CONFIG', 'GET',
@@ -4770,10 +4815,7 @@ class TestCoordinatorTimeoutReturnStrictResp2:
         try:
             setPauseAfterAggregateResult(target_conn, pause_after_n)
 
-            full_cmd = ['FT.AGGREGATE', 'idx', '*',
-                        'LOAD', '1', '@name',
-                        'LIMIT', '0', str(self.n_docs),
-                        'TIMEOUT', '0']
+            full_cmd = list(coord_cmd_list) + ['TIMEOUT', '0']
             query_result = []
             t_query = threading.Thread(
                 target=call_and_store,
@@ -4783,7 +4825,7 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             t_query.start()
 
             blocked_client_id = _wait_shard_paused_after_aggregate_result(
-                target_conn, '_FT.AGGREGATE')
+                target_conn, shard_cmd)
             target_conn.execute_command('CLIENT', 'UNBLOCK',
                                         blocked_client_id, 'TIMEOUT')
             wait_for_client_unblocked(target_conn, blocked_client_id)
@@ -4794,14 +4836,7 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             env.assertEqual(len(query_result), 1, message="query result count")
             result = query_result[0]
 
-            # RESP2 FT.AGGREGATE: [total_results, doc1_fields, ...].
-            env.assertTrue(isinstance(result, list),
-                           message=f"RESP2 reply type ({type(result).__name__})")
-            row_count = len(result) - 1
-            # Temporary until MOD-15971 defines deterministic internal cursor
-            # draining after RETURN_STRICT shard timeouts.
-            env.assertGreaterEqual(row_count, expected_rows,
-                                   message="trailing row count")
+            assert_reply(env, result, expected_rows)
 
             # RESP2 has no warnings slot, so the coord warning metric
             # must NOT increment despite the shard timing out.
@@ -4820,6 +4855,63 @@ class TestCoordinatorTimeoutReturnStrictResp2:
                                           prev_on_timeout_policy)
             except Exception:
                 pass
+
+    def test_return_strict_one_shard_timesout_flat_aggregate_resp2(self):
+        """RESP2 variant of test_return_strict_one_shard_timesout_flat_aggregate."""
+        skipIfNoEnableAssert(self.env)
+
+        def assert_flat_reply(env, result, expected_rows):
+            # RESP2 FT.AGGREGATE: [total_results, doc1_fields, ...].
+            env.assertTrue(isinstance(result, list),
+                           message=f"RESP2 reply type ({type(result).__name__})")
+            row_count = len(result) - 1
+            # Temporary until MOD-15971 defines deterministic internal cursor
+            # draining after RETURN_STRICT shard timeouts.
+            env.assertGreaterEqual(row_count, expected_rows,
+                                   message="trailing row count")
+
+        self._run_one_shard_timesout_resp2(
+            coord_cmd_list=['FT.AGGREGATE', 'idx', '*',
+                            'LOAD', '1', '@name',
+                            'LIMIT', '0', str(self.n_docs)],
+            shard_cmd='_FT.AGGREGATE',
+            assert_reply=assert_flat_reply)
+
+    def test_return_strict_one_shard_timesout_profile_aggregate_resp2(self):
+        """RESP2 FT.PROFILE AGGREGATE one-shard timeout reply shape.
+
+        The RESP2 profile reply is a two-element array
+        ``[results_array, profile_array]``. The inner ``results_array``
+        mirrors the flat aggregate shape ``[total_results, row1, ...]``,
+        and the profile envelope must survive the timeout fast path. RESP2
+        carries no warnings slot, so the coord warning metric stays
+        unchanged.
+        """
+        skipIfNoEnableAssert(self.env)
+
+        def assert_profile_reply(env, result, expected_rows):
+            # RESP2 FT.PROFILE: [results_array, profile_array].
+            env.assertTrue(isinstance(result, list),
+                           message=f"RESP2 reply type ({type(result).__name__})")
+            env.assertEqual(len(result), 2,
+                            message=f"RESP2 profile envelope shape: {result!r}")
+            results_array, profile_array = result[0], result[1]
+            env.assertTrue(isinstance(results_array, list),
+                           message="RESP2 profile results_array type")
+            env.assertTrue(profile_array,
+                           message="RESP2 profile array must be non-empty")
+            row_count = len(results_array) - 1
+            # Temporary until MOD-15971 defines deterministic internal cursor
+            # draining after RETURN_STRICT shard timeouts.
+            env.assertGreaterEqual(row_count, expected_rows,
+                                   message="trailing row count")
+
+        self._run_one_shard_timesout_resp2(
+            coord_cmd_list=['FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*',
+                            'LOAD', '1', '@name',
+                            'LIMIT', '0', str(self.n_docs)],
+            shard_cmd='_FT.PROFILE',
+            assert_reply=assert_profile_reply)
 
 class TestCoordinatorTimeoutCursorReadResp2:
     """RESP2 coverage for RETURN_STRICT FT.CURSOR READ timeout reply shape.
@@ -6614,6 +6706,107 @@ class TestShardTimeout:
             ['FT.AGGREGATE', 'idx', '*', 'LIMIT', '0', str(limit)], 'FT.AGGREGATE',
             pause_after_n=limit - 1, expected_rows=limit - 1)
 
+    # --- Scenario 5: FT.PROFILE wrapper around a RETURN_STRICT timeout ---
+    # Profiling interleaves an RP_PROFILE wrapper around every RP,
+    # so qctx->endProc is an RP_PROFILE and every real RP is separated by a
+    # profile wrapper. The reply must still carry the {Results, Profile}
+    # envelope, the inner Results must hold the partial rows + TIMEOUT
+    # warning, and -- when the pipeline is drainable -- the post-timeout drain
+    # must walk through the profile wrappers and pop the buffered tail.
+
+    def _run_return_strict_timeout_profile(
+            self, profile_type, query_args, pause_after_n, expected_rows):
+        env = self.env
+        skipIfNoEnableAssert(env)
+
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict')
+
+        before_info = info_modules_to_dict(env)
+        base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
+
+        resetAggregateResultsDebug(env)
+        setPauseAfterAggregateResult(env, pause_after_n)
+
+        full_cmd = ['FT.PROFILE', 'idx', profile_type, 'QUERY', '*'] + list(query_args)
+        query_result = []
+        t_query = threading.Thread(
+            target=call_and_store,
+            args=(env.cmd, full_cmd, query_result),
+            daemon=True,
+        )
+        t_query.start()
+
+        blocked_client_id = _wait_shard_paused_after_aggregate_result(env, 'FT.PROFILE')
+        env.cmd('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT')
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        resetAggregateResultsDebug(env)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+
+        env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
+        result = query_result[0]
+
+        # Envelope must survive the timeout fast path.
+        env.assertContains('Results', result, message="Results key in profile envelope")
+        env.assertContains('Profile', result, message="Profile key in profile envelope")
+
+        inner = result['Results']
+        env.assertEqual(len(inner.get('results', [])), expected_rows,
+                        message=f"Expected {expected_rows} row(s) in inner Results, "
+                                f"got {inner.get('results')}")
+        VerifyTimeoutWarningResp3(env, inner,
+                                  message="inner Results must carry the TIMEOUT warning")
+
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                        str(base_warn_coord + 1),
+                        message="Coordinator timeout warning should be +1")
+        _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
+
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
+    def test_return_strict_timeout_profile_search(self):
+        """FT.PROFILE SEARCH NOCONTENT drains the sorter heap under timeout.
+
+        NOCONTENT search ends in RPPager -> RPSorter (no RPLoader), so the
+        pipeline is drainable. The worker is parked after the first yielded
+        row; firing the timeout makes AggregateResults exit with that single
+        buffered row, then the strict drain walks through the RP_PROFILE
+        wrappers and pops the rest of the sorter heap. The full window is
+        returned inside the Results envelope alongside the Profile data.
+        """
+        self._run_return_strict_timeout_profile(
+            'SEARCH', ['NOCONTENT', 'LIMIT', '0', str(self.n_docs)],
+            pause_after_n=1, expected_rows=self.n_docs)
+
+    def test_return_strict_timeout_profile_sortby_aggregate(self):
+        """FT.PROFILE AGGREGATE SORTBY drains the sorter heap under timeout.
+
+        SORTBY inserts a fully-buffering RPSorter, so the heap already holds
+        the whole window when the worker is parked after the first yielded
+        row. The post-timeout drain pops the remaining rows through the
+        profile wrappers, and the inner Results carries the full, drained
+        set plus the TIMEOUT warning under the Profile envelope.
+        """
+        self._run_return_strict_timeout_profile(
+            'AGGREGATE', ['SORTBY', '1', '@name', 'LIMIT', '0', str(self.n_docs)],
+            pause_after_n=1, expected_rows=self.n_docs)
+
+    def test_return_strict_timeout_profile_flat_aggregate(self):
+        """FT.PROFILE AGGREGATE (flat) preserves the envelope on the buffered path.
+
+        A flat aggregate is RPIndex -> RPPager, which is not drainable, so
+        only the rows BG buffered before the timeout fired are emitted. This
+        confirms the {Results, Profile} envelope and the inner TIMEOUT
+        warning survive even when the strict drain contributes nothing.
+        """
+        self._run_return_strict_timeout_profile(
+            'AGGREGATE', ['LOAD', '1', '@name', 'LIMIT', '0', str(self.n_docs)],
+            pause_after_n=1, expected_rows=1)
+
 class TestShardTimeoutResp2:
     """Tests for shard timeout behavior with RESP2 protocol.
 
@@ -6625,10 +6818,11 @@ class TestShardTimeoutResp2:
         skipTest(cluster=True)
 
         self.env = Env(protocol=2, moduleArgs='WORKERS 1 TIMEOUT 0')
+        self.n_docs = 100
 
         conn = getConnectionByEnv(self.env)
         self.env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc', 'SCHEMA', 'name', 'TEXT').ok()
-        for i in range(10):
+        for i in range(self.n_docs):
             conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
 
     def test_remaining_timeout_exhausted_before_shard_execution_resp2(self):
@@ -6662,6 +6856,110 @@ class TestShardTimeoutResp2:
                                         message=f"Expected 0 total results in RESP2 {cmd_type}, got: {res}")
                 finally:
                     env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
+
+    # --- FT.PROFILE wrapper around a RETURN_STRICT timeout (RESP2) ---
+    # RESP2 mirror of the standalone TestShardTimeout profile cases.
+    # The RESP2 profile reply is a two-element array
+    # ``[results_array, profile_array]`` (vs the RESP3 {Results, Profile}
+    # map). The envelope must survive the timeout fast path, the inner
+    # results_array must hold the partial/drained rows, and -- being a
+    # single shard that is also the coord -- the coord warning metric bumps.
+    def _run_return_strict_timeout_profile_resp2(
+            self, profile_type, query_args, pause_after_n, expected_rows):
+        env = self.env
+        skipIfNoEnableAssert(env)
+
+        # CONFIG GET in RESP2 returns a flat [key, value] list, not a map.
+        prev_on_timeout_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[1]
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return-strict')
+
+        before_info = info_modules_to_dict(env)
+        base_warn_coord = int(before_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC])
+
+        resetAggregateResultsDebug(env)
+        setPauseAfterAggregateResult(env, pause_after_n)
+
+        full_cmd = ['FT.PROFILE', 'idx', profile_type, 'QUERY', '*'] + list(query_args)
+        query_result = []
+        t_query = threading.Thread(
+            target=call_and_store,
+            args=(env.cmd, full_cmd, query_result),
+            daemon=True,
+        )
+        t_query.start()
+
+        blocked_client_id = _wait_shard_paused_after_aggregate_result(env, 'FT.PROFILE')
+        env.cmd('CLIENT', 'UNBLOCK', blocked_client_id, 'TIMEOUT')
+        wait_for_client_unblocked(env, blocked_client_id)
+
+        resetAggregateResultsDebug(env)
+
+        t_query.join(timeout=10)
+        env.assertFalse(t_query.is_alive(), message="Query thread should have finished")
+
+        env.assertEqual(len(query_result), 1, message="Expected 1 result from query thread")
+        result = query_result[0]
+
+        # RESP2 FT.PROFILE envelope: [results_array, profile_array].
+        env.assertTrue(isinstance(result, list),
+                       message=f"RESP2 reply type ({type(result).__name__})")
+        env.assertEqual(len(result), 2,
+                        message=f"RESP2 profile envelope shape: {result!r}")
+        results_array, profile_array = result[0], result[1]
+        env.assertTrue(isinstance(results_array, list),
+                       message="RESP2 profile results_array type")
+        env.assertTrue(profile_array,
+                       message="RESP2 profile array must be non-empty")
+        # results_array = [total_results, *rows]; only the trailing rows count.
+        env.assertEqual(len(results_array) - 1, expected_rows,
+                        message=f"Expected {expected_rows} row(s) in inner results, "
+                                f"got {results_array}")
+
+        # Standalone RESP2 still bumps the coord-side warning metric: the
+        # shard is also the coord, so the timeout warning is tracked locally.
+        after_info = info_modules_to_dict(env)
+        env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
+                        str(base_warn_coord + 1),
+                        message="Coordinator timeout warning should be +1")
+        _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
+
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_on_timeout_policy)
+
+    def test_return_strict_timeout_profile_search_resp2(self):
+        """RESP2 FT.PROFILE SEARCH NOCONTENT drains the sorter heap under timeout.
+
+        RESP2 counterpart of test_return_strict_timeout_profile_search:
+        NOCONTENT search is drainable (RPPager -> RPSorter), so the strict
+        drain walks through the RP_PROFILE wrappers and pops the full window
+        into the inner results_array of the [results, profile] envelope.
+        """
+        self._run_return_strict_timeout_profile_resp2(
+            'SEARCH', ['NOCONTENT', 'LIMIT', '0', str(self.n_docs)],
+            pause_after_n=1, expected_rows=self.n_docs)
+
+    def test_return_strict_timeout_profile_sortby_aggregate_resp2(self):
+        """RESP2 FT.PROFILE AGGREGATE SORTBY drains the sorter heap under timeout.
+
+        RESP2 counterpart of test_return_strict_timeout_profile_sortby_aggregate:
+        the buffering RPSorter already holds the whole window, so the
+        post-timeout drain pops the remaining rows through the profile
+        wrappers into the inner results_array.
+        """
+        self._run_return_strict_timeout_profile_resp2(
+            'AGGREGATE', ['SORTBY', '1', '@name', 'LIMIT', '0', str(self.n_docs)],
+            pause_after_n=1, expected_rows=self.n_docs)
+
+    def test_return_strict_timeout_profile_flat_aggregate_resp2(self):
+        """RESP2 FT.PROFILE AGGREGATE (flat) preserves the envelope on the buffered path.
+
+        RESP2 counterpart of test_return_strict_timeout_profile_flat_aggregate:
+        a flat aggregate (RPIndex -> RPPager) is not drainable, so only the
+        rows buffered before the timeout fired are emitted, while the
+        [results, profile] envelope still survives.
+        """
+        self._run_return_strict_timeout_profile_resp2(
+            'AGGREGATE', ['LOAD', '1', '@name', 'LIMIT', '0', str(self.n_docs)],
+            pause_after_n=1, expected_rows=1)
 
 class TestNoDeadlockQueryWithConcurrentWriter:
     """MOD-15364: BG query holds the spec read lock; a concurrent writer


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current:** Under the `return-strict` timeout policy, an `FT.PROFILE` query that times out on the early/fast path — before the background worker claims the aggregation phase — replied with a *bare* empty result, dropping the `{Results, Profile}` profile envelope. `FT.SEARCH`/`FT.AGGREGATE` self-derived the profile flag from the command, but the coordinator `FT.HYBRID` fast path hard-coded `isProfile=false`, so the envelope was lost. Separately, the drainable-pipeline classifier bailed out entirely for profiled queries, so partial results could not be drained after a strict timeout.

2. **Change:**
   - Added `coord_hybrid_query_reply_empty`, which self-derives `isProfile` from `argv` (the `FT.PROFILE` prefix), mirroring the aggregate helper, and routed `DistHybridTimeoutReturnStrictCallback`'s fast path through it. Removes the caller-supplied-bool foot-gun.
   - Extended `pipelineCanYieldPartialResults` to transparently skip `RP_PROFILE` wrappers while classifying the pipeline, so profiled SEARCH/AGGREGATE queries drain buffered rows after a strict timeout like their non-profiled counterparts.
   - Added standalone + coordinator tests across RESP2 and RESP3 for SEARCH, AGGREGATE, and HYBRID.

3. **Outcome:** `FT.PROFILE ... SEARCH|AGGREGATE|HYBRID` now preserves the `{Results, Profile}` envelope (RESP3) / `[results, profile]` envelope (RESP2) on the `return-strict` early-timeout path, in both standalone and coordinator modes, and drainable pipelines still return their partial rows under the surviving profile envelope.

Note: `FT.PROFILE ... WITHCURSOR` is rejected at the command surface (`"FT.PROFILE does not support cursor"`), so the `FT.CURSOR` read-timeout path is out of scope — it can never carry a public profile envelope.

#### Which additional issues this PR fixes
1. MOD-16020

#### Main objects this PR modified
1. `coord_hybrid_query_reply_empty` (new) — `src/aggregate/reply_empty.c` / `.h`
2. `DistHybridTimeoutReturnStrictCallback` — `src/coord/hybrid/dist_hybrid.c`
3. `pipelineCanYieldPartialResults` — `src/aggregate/aggregate_exec_common.c`
4. Tests — `tests/pytests/test_blocked_client_timeout.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
