### PR TITLE
[MOD-15932] Trie - clarify fuzzy-search API naming

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -614,9 +614,9 @@ static inline void addTerm(char *str, size_t tok_len, size_t numDocsInTerm, Quer
 }
 
 static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const char *str,
-                                           size_t len, int maxDist, int prefixMode,
+                                           size_t len, int maxDist, TrieMatchMode mode,
                                            QueryNodeOptions *opts) {
-  TrieIterator *it = Trie_IterateFuzzy(terms, str, len, maxDist, prefixMode);
+  TrieIterator *it = Trie_IterateFuzzy(terms, str, len, maxDist, mode);
   if (!it) return NULL;
 
   size_t itsSz = 0, itsCap = 8;
@@ -645,7 +645,7 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
   }
 
   // Add an iterator over the inverted index of the empty string for fuzzy search
-  if (!prefixMode && q->sctx->apiVersion >= 2 && len <= maxDist) {
+  if (mode == TRIE_MATCH_EDIT_DISTANCE && q->sctx->apiVersion >= 2 && len <= maxDist) {
     size_t rlen = 0;
     runeBuf buf;
     rune *runes = runeBufFill("", 1, &buf, &rlen);
@@ -655,7 +655,7 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
     addTerm("", 0, numDocsInEmpty, q, opts, &its, &itsSz, &itsCap);
   }
 
-  QueryNodeType type = prefixMode ? QN_PREFIX : QN_FUZZY;
+  QueryNodeType type = mode == TRIE_MATCH_PREFIX ? QN_PREFIX : QN_FUZZY;
   return NewUnionIterator(its, itsSz, true, opts->weight, type, str, q->config);
 }
 
@@ -932,7 +932,8 @@ static QueryIterator *Query_EvalFuzzyNode(QueryEvalCtx *q, QueryNode *qn) {
 
   if (!terms) return NULL;
 
-  return iterateExpandedTerms(q, terms, qn->pfx.tok.str, strlen(qn->pfx.tok.str), qn->fz.maxDist, 0, &qn->opts);
+  return iterateExpandedTerms(q, terms, qn->pfx.tok.str, strlen(qn->pfx.tok.str), qn->fz.maxDist,
+                              TRIE_MATCH_EDIT_DISTANCE, &qn->opts);
 }
 
 static QueryIterator *Query_EvalPhraseNode(QueryEvalCtx *q, QueryNode *qn) {

--- a/src/query.c
+++ b/src/query.c
@@ -616,7 +616,7 @@ static inline void addTerm(char *str, size_t tok_len, size_t numDocsInTerm, Quer
 static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const char *str,
                                            size_t len, int maxDist, int prefixMode,
                                            QueryNodeOptions *opts) {
-  TrieIterator *it = Trie_Iterate(terms, str, len, maxDist, prefixMode);
+  TrieIterator *it = Trie_IterateFuzzy(terms, str, len, maxDist, prefixMode);
   if (!it) return NULL;
 
   size_t itsSz = 0, itsCap = 8;

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -118,7 +118,7 @@ static bool SpellCheck_IsTermExistsInTrie(Trie *t, const char *term, size_t len,
   float score = 0;
   int dist = 0;
   bool retVal = false;
-  TrieIterator *it = Trie_Iterate(t, term, len, 0, 0);
+  TrieIterator *it = Trie_IterateFuzzy(t, term, len, 0, 0);
   // TrieIterator can be NULL when rune length exceed TRIE_MAX_PREFIX
   if (it == NULL) {
     return retVal;
@@ -141,7 +141,7 @@ static void SpellCheck_FindSuggestions(SpellCheckCtx *scCtx, Trie *t, const char
   int dist = 0;
   size_t suggestionLen;
 
-  TrieIterator *it = Trie_Iterate(t, term, len, (int)scCtx->distance, 0);
+  TrieIterator *it = Trie_IterateFuzzy(t, term, len, (int)scCtx->distance, 0);
   // TrieIterator can be NULL when rune length exceed TRIE_MAX_PREFIX
   if (it == NULL) {
     return;

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -118,7 +118,7 @@ static bool SpellCheck_IsTermExistsInTrie(Trie *t, const char *term, size_t len,
   float score = 0;
   int dist = 0;
   bool retVal = false;
-  TrieIterator *it = Trie_IterateFuzzy(t, term, len, 0, 0);
+  TrieIterator *it = Trie_IterateFuzzy(t, term, len, 0, TRIE_MATCH_EDIT_DISTANCE);
   // TrieIterator can be NULL when rune length exceed TRIE_MAX_PREFIX
   if (it == NULL) {
     return retVal;
@@ -141,7 +141,7 @@ static void SpellCheck_FindSuggestions(SpellCheckCtx *scCtx, Trie *t, const char
   int dist = 0;
   size_t suggestionLen;
 
-  TrieIterator *it = Trie_IterateFuzzy(t, term, len, (int)scCtx->distance, 0);
+  TrieIterator *it = Trie_IterateFuzzy(t, term, len, (int)scCtx->distance, TRIE_MATCH_EDIT_DISTANCE);
   // TrieIterator can be NULL when rune length exceed TRIE_MAX_PREFIX
   if (it == NULL) {
     return;

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -328,8 +328,8 @@ parse_error:
     goto end;
   }
 
-  res = Trie_Search(tree, s, len, options.numResults, options.maxDistance, 1, options.trim,
-                    options.optimize);
+  res = Trie_CollectFuzzy(tree, s, len, options.numResults, options.maxDistance, 1, options.trim,
+                          options.optimize);
   if (!res) {
     RedisModule_ReplyWithError(ctx, "Invalid query");
     goto end;

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -328,8 +328,8 @@ parse_error:
     goto end;
   }
 
-  res = Trie_CollectFuzzy(tree, s, len, options.numResults, options.maxDistance, 1, options.trim,
-                          options.optimize);
+  res = Trie_CollectFuzzy(tree, s, len, options.numResults, options.maxDistance, TRIE_MATCH_PREFIX,
+                          options.trim, options.optimize);
   if (!res) {
     RedisModule_ReplyWithError(ctx, "Invalid query");
     goto end;

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -186,8 +186,6 @@ void dfa_build(dfaNode *parent, SparseAutomaton *a, Vector *cache) {
     }
   }
   sparseVector_free(nv);
-
-  //}
 }
 
 DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, TrieMatchMode mode) {
@@ -273,7 +271,6 @@ FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx, runeTrans
       if (pdist) {
         *pdist = MIN(next->distance, minDist);
       }
-      //    if (fc->mode == TRIE_MATCH_PREFIX) next = NULL;
     }
     Vector_Push(fc->stack, next);
     Vector_Push(fc->distStack, MIN(next->distance, minDist));

--- a/src/trie/levenshtein.c
+++ b/src/trie/levenshtein.c
@@ -190,7 +190,7 @@ void dfa_build(dfaNode *parent, SparseAutomaton *a, Vector *cache) {
   //}
 }
 
-DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, int prefixMode) {
+DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, TrieMatchMode mode) {
   Vector *cache = NewVector(dfaNode *, 8);
 
   SparseAutomaton a = NewSparseAutomaton(str, len, maxDist);
@@ -205,7 +205,7 @@ DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, int prefixMode) {
   ret->stack = NewVector(dfaNode *, 8);
   ret->distStack = NewVector(int, 8);
   ret->a = a;
-  ret->prefixMode = prefixMode;
+  ret->mode = mode;
   Vector_Push(ret->stack, dr);
   Vector_Push(ret->distStack, (maxDist + 1));
 
@@ -273,12 +273,12 @@ FilterCode FilterFunc(rune b, void *ctx, int *matched, void *matchCtx, runeTrans
       if (pdist) {
         *pdist = MIN(next->distance, minDist);
       }
-      //    if (fc->prefixMode) next = NULL;
+      //    if (fc->mode == TRIE_MATCH_PREFIX) next = NULL;
     }
     Vector_Push(fc->stack, next);
     Vector_Push(fc->distStack, MIN(next->distance, minDist));
     return F_CONTINUE;
-  } else if (fc->prefixMode && *matched) {
+  } else if (fc->mode == TRIE_MATCH_PREFIX && *matched) {
     Vector_Push(fc->stack, NULL);
     Vector_Push(fc->distStack, minDist);
     return F_CONTINUE;

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -30,9 +30,9 @@
  *    standard scoring metric for approximate autocomplete and the basis of
  *    FT.SUGGET FUZZY ranking.
  *
- *    Admission criteria differ by mode (DFAFilter.prefixMode):
- *      - non-prefix: term T is admitted iff Lev(Q, T) <= maxDist.
- *      - prefix:     term T is admitted iff PED(Q, T) <= maxDist (some prefix
+ *    Admission criteria differ by mode (DFAFilter.mode):
+ *      - TRIE_MATCH_EDIT_DISTANCE: term T is admitted iff Lev(Q, T) <= maxDist.
+ *      - TRIE_MATCH_PREFIX:        term T is admitted iff PED(Q, T) <= maxDist (some prefix
  *                    of T is within maxDist of Q; the tail is unconstrained).
  *    *matchCtx reports PED in both modes; only in prefix mode does PED also
  *    gate admission. This is why the prefix example in FilterFunc can yield
@@ -97,6 +97,12 @@ int SparseAutomaton_IsMatch(SparseAutomaton *a, sparseVector *v);
 /* Can the current state lead to a possible match, or is this a dead end? */
 int SparseAutomaton_CanMatch(SparseAutomaton *a, sparseVector *v);
 
+/* How a DFAFilter admits terms: full edit distance vs. prefix edit distance. */
+typedef enum {
+    TRIE_MATCH_EDIT_DISTANCE = 0,  // admit T iff Lev(Q, T) <= maxDist
+    TRIE_MATCH_PREFIX        = 1,  // admit T iff PED(Q, T) <= maxDist (prefix mode)
+} TrieMatchMode;
+
 /* DFAFilter is a constructed DFA used to filter the traversal on the trie */
 typedef struct {
     // a cache of the DFA states, allowing us to reuse the same state whenever we need it
@@ -107,16 +113,16 @@ typedef struct {
     // accept-state distances along the path leading to it. Used to report the
     // cost of the best prefix match seen so far via matchCtx in FilterFunc.
     Vector *distStack;
-    // whether the filter works in prefix mode or not
-    int prefixMode;
+    // whether the filter matches full edit distance or prefix edit distance
+    TrieMatchMode mode;
 
     SparseAutomaton a;
 } DFAFilter;
 
 /* Create a new DFA filter  using a Levenshtein automaton, for the given string  and maximum
- * distance. If prefixMode is 1, we match prefixes within the given distance, and then continue
- * onwards to all suffixes. */
-DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, int prefixMode);
+ * distance. If mode is TRIE_MATCH_PREFIX, we match prefixes within the given distance, and then
+ * continue onwards to all suffixes. */
+DFAFilter *NewDFAFilter(rune *str, size_t len, int maxDist, TrieMatchMode mode);
 
 /* A callback function for the DFA Filter, passed to the Trie iterator.
  *

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -210,7 +210,7 @@ TrieIterator *Trie_IterateAll(Trie *t) {
 }
 
 TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int maxDist,
-                                int prefixMode) {
+                                TrieMatchMode mode) {
   size_t rlen;
   rune *runes = strToLowerRunes(prefix, len, &rlen);
   if (!runes || rlen > TRIE_MAX_PREFIX) {
@@ -220,7 +220,7 @@ TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int max
     return NULL;
   }
 
-  DFAFilter *fc = NewDFAFilter(runes, rlen, maxDist, prefixMode);
+  DFAFilter *fc = NewDFAFilter(runes, rlen, maxDist, mode);
 
   TrieIterator *it = TrieNode_Iterate(t->root, LoweringFilterFunc, StackPop, fc);
   rm_free(runes);
@@ -228,7 +228,7 @@ TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int max
 }
 
 Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int maxDist,
-                          int prefixMode, int trim, int optimize) {
+                          TrieMatchMode mode, int trim, int optimize) {
 
   if (len > TRIE_MAX_PREFIX * sizeof(rune)) {
     return NULL;
@@ -244,7 +244,7 @@ Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int
   heap_t *pq = rm_malloc(heap_sizeof(num));
   heap_init(pq, cmpEntries, NULL, num);
 
-  DFAFilter *fc = NewDFAFilter(runes, rlen, maxDist, prefixMode);
+  DFAFilter *fc = NewDFAFilter(runes, rlen, maxDist, mode);
 
   TrieIterator *it = TrieNode_Iterate(tree->root, FoldingFilterFunc, StackPop, fc);
   // TrieIterator *it = TrieNode_Iterate(tree->root,NULL, NULL, NULL);
@@ -271,7 +271,7 @@ Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int
       ent->score *= exp((double)-(2 * dist));
     }
     // in prefix mode we also factor in the total length of the suffix
-    if (prefixMode) {
+    if (mode == TRIE_MATCH_PREFIX) {
       ent->score /= sqrt(1 + (slen >= len ? slen - len : len - slen));
     }
 

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -209,7 +209,8 @@ TrieIterator *Trie_IterateAll(Trie *t) {
   return TrieNode_Iterate(t->root, NULL, NULL, NULL);
 }
 
-TrieIterator *Trie_Iterate(Trie *t, const char *prefix, size_t len, int maxDist, int prefixMode) {
+TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int maxDist,
+                                int prefixMode) {
   size_t rlen;
   rune *runes = strToLowerRunes(prefix, len, &rlen);
   if (!runes || rlen > TRIE_MAX_PREFIX) {
@@ -226,8 +227,8 @@ TrieIterator *Trie_Iterate(Trie *t, const char *prefix, size_t len, int maxDist,
   return it;
 }
 
-Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDist, int prefixMode,
-                    int trim, int optimize) {
+Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int maxDist,
+                          int prefixMode, int trim, int optimize) {
 
   if (len > TRIE_MAX_PREFIX * sizeof(rune)) {
     return NULL;

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -209,10 +209,10 @@ TrieIterator *Trie_IterateAll(Trie *t) {
   return TrieNode_Iterate(t->root, NULL, NULL, NULL);
 }
 
-TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int maxDist,
+TrieIterator *Trie_IterateFuzzy(Trie *t, const char *str, size_t len, int maxDist,
                                 TrieMatchMode mode) {
   size_t rlen;
-  rune *runes = strToLowerRunes(prefix, len, &rlen);
+  rune *runes = strToLowerRunes(str, len, &rlen);
   if (!runes || rlen > TRIE_MAX_PREFIX) {
     if (runes) {
       rm_free(runes);
@@ -227,14 +227,14 @@ TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int max
   return it;
 }
 
-Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int maxDist,
+Vector *Trie_CollectFuzzy(Trie *t, const char *str, size_t len, size_t num, int maxDist,
                           TrieMatchMode mode, int trim, int optimize) {
 
   if (len > TRIE_MAX_PREFIX * sizeof(rune)) {
     return NULL;
   }
   size_t rlen;
-  rune *runes = strToSingleCodepointFoldedRunes(s, len, &rlen);
+  rune *runes = strToSingleCodepointFoldedRunes(str, len, &rlen);
   // make sure query length does not overflow
   if (!runes || rlen > TRIE_MAX_PREFIX) {
     rm_free(runes);
@@ -246,8 +246,8 @@ Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int
 
   DFAFilter *fc = NewDFAFilter(runes, rlen, maxDist, mode);
 
-  TrieIterator *it = TrieNode_Iterate(tree->root, FoldingFilterFunc, StackPop, fc);
-  // TrieIterator *it = TrieNode_Iterate(tree->root,NULL, NULL, NULL);
+  TrieIterator *it = TrieNode_Iterate(t->root, FoldingFilterFunc, StackPop, fc);
+  // TrieIterator *it = TrieNode_Iterate(t->root,NULL, NULL, NULL);
   rune *rstr;
   t_len slen;
   float score;

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -125,17 +125,17 @@ void TrieSearchResult_Free(TrieSearchResult *e);
 
 /* Collect up to `num` best-scoring entries within maxDist edit distance of `s`, ranked
  * by score, into a newly allocated Vector the caller must free. Eager counterpart to
- * Trie_IterateFuzzy: it materializes a ranked top-N rather than streaming. If prefixMode
- * is 1 we match `s` as a prefix; otherwise we match strings within maxDist Levenshtein
- * distance. */
+ * Trie_IterateFuzzy: it materializes a ranked top-N rather than streaming. If mode is
+ * TRIE_MATCH_PREFIX we match `s` as a prefix; otherwise we match strings within maxDist
+ * Levenshtein distance. */
 Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int maxDist,
-                          int prefixMode, int trim, int optimize);
+                          TrieMatchMode mode, int trim, int optimize);
 
 /* Iterate the trie, using maxDist edit distance, returning a trie iterator that the
- * caller needs to free. If prefixMode is 1 we treat the string as only a prefix to iterate.
- * Otherwise we return an iterator to all strings within maxDist Levenshtein distance. */
+ * caller needs to free. If mode is TRIE_MATCH_PREFIX we treat the string as only a prefix to
+ * iterate. Otherwise we return an iterator to all strings within maxDist Levenshtein distance. */
 TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int maxDist,
-                                int prefixMode);
+                                TrieMatchMode mode);
 
 /* Get a random key from the trie, and put the node's score in the score pointer. Returns 0 if the
  * trie is empty and we cannot do that */

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -95,7 +95,7 @@ size_t Trie_Size(const Trie *t);
 
 /* Iterate every node in the trie with no filter or distance constraint. Wraps
  * TrieNode_Iterate on the trie's root with no filter. Prefer this over
- * Trie_Iterate with an empty prefix: both visit every terminal node in the
+ * Trie_IterateFuzzy with an empty prefix: both visit every terminal node in the
  * same order, but the empty-prefix DFA filter pays per-node stack maintenance
  * for a filter that accepts everything. */
 TrieIterator *Trie_IterateAll(Trie *t);
@@ -122,13 +122,20 @@ typedef enum {
 TrieDecrResult Trie_DecrementNumDocs(Trie *t, const char *s, size_t len, size_t delta);
 
 void TrieSearchResult_Free(TrieSearchResult *e);
-Vector *Trie_Search(Trie *tree, const char *s, size_t len, size_t num, int maxDist, int prefixMode,
-                    int trim, int optimize);
 
-/* Iterate  the trie, using maxDist edit distance, returning a trie iterator that the
- * caller needs to free. If prefixmode is 1 we treat the string as only a prefix to iterate.
- * Otherwise we return an iterator to all strings within maxDist Levenshtein distance */
-TrieIterator *Trie_Iterate(Trie *t, const char *prefix, size_t len, int maxDist, int prefixMode);
+/* Collect up to `num` best-scoring entries within maxDist edit distance of `s`, ranked
+ * by score, into a newly allocated Vector the caller must free. Eager counterpart to
+ * Trie_IterateFuzzy: it materializes a ranked top-N rather than streaming. If prefixMode
+ * is 1 we match `s` as a prefix; otherwise we match strings within maxDist Levenshtein
+ * distance. */
+Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int maxDist,
+                          int prefixMode, int trim, int optimize);
+
+/* Iterate the trie, using maxDist edit distance, returning a trie iterator that the
+ * caller needs to free. If prefixMode is 1 we treat the string as only a prefix to iterate.
+ * Otherwise we return an iterator to all strings within maxDist Levenshtein distance. */
+TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int maxDist,
+                                int prefixMode);
 
 /* Get a random key from the trie, and put the node's score in the score pointer. Returns 0 if the
  * trie is empty and we cannot do that */

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -123,18 +123,18 @@ TrieDecrResult Trie_DecrementNumDocs(Trie *t, const char *s, size_t len, size_t 
 
 void TrieSearchResult_Free(TrieSearchResult *e);
 
-/* Collect up to `num` best-scoring entries within maxDist edit distance of `s`, ranked
+/* Collect up to `num` best-scoring entries within maxDist edit distance of `str`, ranked
  * by score, into a newly allocated Vector the caller must free. Eager counterpart to
  * Trie_IterateFuzzy: it materializes a ranked top-N rather than streaming. If mode is
- * TRIE_MATCH_PREFIX we match `s` as a prefix; otherwise we match strings within maxDist
+ * TRIE_MATCH_PREFIX we match `str` as a prefix; otherwise we match strings within maxDist
  * Levenshtein distance. */
-Vector *Trie_CollectFuzzy(Trie *tree, const char *s, size_t len, size_t num, int maxDist,
+Vector *Trie_CollectFuzzy(Trie *t, const char *str, size_t len, size_t num, int maxDist,
                           TrieMatchMode mode, int trim, int optimize);
 
 /* Iterate the trie, using maxDist edit distance, returning a trie iterator that the
  * caller needs to free. If mode is TRIE_MATCH_PREFIX we treat the string as only a prefix to
  * iterate. Otherwise we return an iterator to all strings within maxDist Levenshtein distance. */
-TrieIterator *Trie_IterateFuzzy(Trie *t, const char *prefix, size_t len, int maxDist,
+TrieIterator *Trie_IterateFuzzy(Trie *t, const char *str, size_t len, int maxDist,
                                 TrieMatchMode mode);
 
 /* Get a random key from the trie, and put the node's score in the score pointer. Returns 0 if the

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -123,17 +123,15 @@ TrieDecrResult Trie_DecrementNumDocs(Trie *t, const char *s, size_t len, size_t 
 
 void TrieSearchResult_Free(TrieSearchResult *e);
 
-/* Collect up to `num` best-scoring entries within maxDist edit distance of `str`, ranked
- * by score, into a newly allocated Vector the caller must free. Eager counterpart to
- * Trie_IterateFuzzy: it materializes a ranked top-N rather than streaming. If mode is
- * TRIE_MATCH_PREFIX we match `str` as a prefix; otherwise we match strings within maxDist
- * Levenshtein distance. */
+/* Collect the top `num` entries matching `str` within maxDist edit distance, ranked by score,
+ * into a newly allocated Vector the caller must free. mode TRIE_MATCH_PREFIX matches `str` as a
+ * prefix (tail unconstrained); otherwise the whole string within maxDist Levenshtein distance. */
 Vector *Trie_CollectFuzzy(Trie *t, const char *str, size_t len, size_t num, int maxDist,
                           TrieMatchMode mode, int trim, int optimize);
 
-/* Iterate the trie, using maxDist edit distance, returning a trie iterator that the
- * caller needs to free. If mode is TRIE_MATCH_PREFIX we treat the string as only a prefix to
- * iterate. Otherwise we return an iterator to all strings within maxDist Levenshtein distance. */
+/* Iterate entries matching `str` within maxDist edit distance, returning a TrieIterator the
+ * caller must free. mode TRIE_MATCH_PREFIX matches `str` as a prefix (tail unconstrained);
+ * otherwise the whole string within maxDist Levenshtein distance. */
 TrieIterator *Trie_IterateFuzzy(Trie *t, const char *str, size_t len, int maxDist,
                                 TrieMatchMode mode);
 

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -323,7 +323,7 @@ TEST_F(TrieTest, testLexOrder) {
   trieInsert(t, "bar");
   trieInsert(t, "help");
 
-  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
+  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
   checkNext(iter, "bar");
   checkNext(iter, "foo");
   checkNext(iter, "helen");
@@ -336,7 +336,7 @@ TEST_F(TrieTest, testLexOrder) {
   Trie_Delete(t, "hello", 5);
   Trie_Delete(t, "world", 5);
 
-  iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
+  iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "help");
@@ -371,7 +371,7 @@ TEST_F(TrieTest, testScoreOrder) {
   trieInsertByScore(t, "help", 3);
   trieInsertByScore(t, "helen", 5);
 
-  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
+  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "hello");
@@ -384,7 +384,7 @@ TEST_F(TrieTest, testScoreOrder) {
   Trie_Delete(t, "world", 5);
   Trie_Delete(t, "bar", 3);
 
-  iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
+  iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "help");
@@ -414,8 +414,8 @@ static bool compareTrieContents(Trie *original, Trie *loaded) {
   }
 
   // Compare all entries using iterators
-  TrieIterator *origIter = Trie_IterateFuzzy(original, "", 0, 0, 1);
-  TrieIterator *loadedIter = Trie_IterateFuzzy(loaded, "", 0, 0, 1);
+  TrieIterator *origIter = Trie_IterateFuzzy(original, "", 0, 0, TRIE_MATCH_PREFIX);
+  TrieIterator *loadedIter = Trie_IterateFuzzy(loaded, "", 0, 0, TRIE_MATCH_PREFIX);
 
   std::unique_ptr<TrieIterator, std::function<void(TrieIterator *)>> origIterPtr(origIter, [](TrieIterator *iter) {
     TrieIterator_Free(iter);
@@ -1031,8 +1031,8 @@ TEST_F(TrieTest, testSearchTrimDropsTail) {
   trieInsertByScore(t, "hd", 1.0f);
   trieInsertByScore(t, "he", 1.0f);
 
-  // num=10, maxDist=0, prefixMode=1, trim=1, optimize=0
-  Vector *res = Trie_CollectFuzzy(t, "h", 1, 10, 0, 1, 1, 0);
+  // num=10, maxDist=0, mode=TRIE_MATCH_PREFIX, trim=1, optimize=0
+  Vector *res = Trie_CollectFuzzy(t, "h", 1, 10, 0, TRIE_MATCH_PREFIX, 1, 0);
   ASSERT_TRUE(res != NULL);
 
   // Only the dominant entry should survive the trim: 1.0 < 100.0 / 10.0.

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -323,7 +323,7 @@ TEST_F(TrieTest, testLexOrder) {
   trieInsert(t, "bar");
   trieInsert(t, "help");
 
-  TrieIterator *iter = Trie_Iterate(t, "", 0, 0, 1);
+  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
   checkNext(iter, "bar");
   checkNext(iter, "foo");
   checkNext(iter, "helen");
@@ -336,7 +336,7 @@ TEST_F(TrieTest, testLexOrder) {
   Trie_Delete(t, "hello", 5);
   Trie_Delete(t, "world", 5);
 
-  iter = Trie_Iterate(t, "", 0, 0, 1);
+  iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "help");
@@ -371,7 +371,7 @@ TEST_F(TrieTest, testScoreOrder) {
   trieInsertByScore(t, "help", 3);
   trieInsertByScore(t, "helen", 5);
 
-  TrieIterator *iter = Trie_Iterate(t, "", 0, 0, 1);
+  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "hello");
@@ -384,7 +384,7 @@ TEST_F(TrieTest, testScoreOrder) {
   Trie_Delete(t, "world", 5);
   Trie_Delete(t, "bar", 3);
 
-  iter = Trie_Iterate(t, "", 0, 0, 1);
+  iter = Trie_IterateFuzzy(t, "", 0, 0, 1);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "help");
@@ -414,8 +414,8 @@ static bool compareTrieContents(Trie *original, Trie *loaded) {
   }
 
   // Compare all entries using iterators
-  TrieIterator *origIter = Trie_Iterate(original, "", 0, 0, 1);
-  TrieIterator *loadedIter = Trie_Iterate(loaded, "", 0, 0, 1);
+  TrieIterator *origIter = Trie_IterateFuzzy(original, "", 0, 0, 1);
+  TrieIterator *loadedIter = Trie_IterateFuzzy(loaded, "", 0, 0, 1);
 
   std::unique_ptr<TrieIterator, std::function<void(TrieIterator *)>> origIterPtr(origIter, [](TrieIterator *iter) {
     TrieIterator_Free(iter);
@@ -1016,7 +1016,7 @@ TEST_F(TrieTest, testRdbSaveLoadWithNumDocs) {
   TrieIterator_Free(it);
 }
 
-// Regression: Trie_Search(trim=1) used to mutate ret->top before reading the
+// Regression: Trie_CollectFuzzy(trim=1) used to mutate ret->top before reading the
 // tail entries it was about to free. Vector_Get then returned 0 without
 // touching the out pointer, so TrieSearchResult_Free(h) ran on stack garbage
 // and the allocator aborted. This test forces the trim drop branch (one entry
@@ -1032,7 +1032,7 @@ TEST_F(TrieTest, testSearchTrimDropsTail) {
   trieInsertByScore(t, "he", 1.0f);
 
   // num=10, maxDist=0, prefixMode=1, trim=1, optimize=0
-  Vector *res = Trie_Search(t, "h", 1, 10, 0, 1, 1, 0);
+  Vector *res = Trie_CollectFuzzy(t, "h", 1, 10, 0, 1, 1, 0);
   ASSERT_TRUE(res != NULL);
 
   // Only the dominant entry should survive the trim: 1.0 < 100.0 / 10.0.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The two trie functions that drive Levenshtein/prefix fuzzy search were named `Trie_Iterate` and `Trie_Search` — names that hid the edit-distance nature and implied a semantic split that doesn't exist (both run the same `NewDFAFilter` automaton; they differ only in materialization). Their shared mode flag was an anonymous `int prefixMode`, and the two signatures disagreed on parameter names (`Trie *tree, const char *s` vs `Trie *t, const char *prefix`).
2. **Change:** Pure clarity refactor, no behavior change:
   - `Trie_Iterate` → `Trie_IterateFuzzy` (lazy `TrieIterator` stream), `Trie_Search` → `Trie_CollectFuzzy` (eager ranked top-N `Vector`). "Fuzzy" surfaces the edit-distance nature; "Collect" marks eager materialization (matching the existing `FGC_childCollect*` / COLLECT-reducer vocabulary) without borrowing "TopK", which means vector KNN elsewhere in the tree.
   - Replaced `int prefixMode` with `TrieMatchMode { TRIE_MATCH_EDIT_DISTANCE, TRIE_MATCH_PREFIX }`, threaded end-to-end through the public trie API, `NewDFAFilter`, and the `DFAFilter.mode` field. Values pinned to 0/1; the flag is query-time only and never persisted.
   - Unified both signatures to `(Trie *t, const char *str, ...)`, matching the sibling trie API (`Trie_IterateContains`/`Wildcard`, `Trie_GetNode`). Dropped the misleading `prefix` name — in edit-distance mode the string is a full term, not a prefix.
   - Streamlined the two header comments to be self-contained.
3. **Outcome:** Call sites read intent at a glance (e.g. `Trie_IterateFuzzy(t, term, len, 0, TRIE_MATCH_EDIT_DISTANCE)` instead of two anonymous trailing zeros), and the signatures now advertise the streaming-vs-materialized split.

#### Which additional issues this PR fixes
1. MOD-15932

#### Main objects this PR modified
1. `src/trie/trie.h`, `src/trie/trie.c` — public function renames, `TrieMatchMode` plumbing, param/comment cleanup
2. `src/trie/levenshtein.h`, `src/trie/levenshtein.c` — `TrieMatchMode` enum definition; `NewDFAFilter` signature + `DFAFilter.mode` field
3. `src/query.c`, `src/suggest.c`, `src/spell_check.c` — updated call sites (FT.SEARCH fuzzy, FT.SUGGET FUZZY, FT.SPELLCHECK)
4. `tests/cpptests/test_cpp_trie.cpp` — updated call sites

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
