### PR TITLE
[MOD-15932] Trie - use Trie_IterateAll for whole-trie enumeration in trie tests

### DIFF
--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -323,7 +323,7 @@ TEST_F(TrieTest, testLexOrder) {
   trieInsert(t, "bar");
   trieInsert(t, "help");
 
-  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
+  TrieIterator *iter = Trie_IterateAll(t);
   checkNext(iter, "bar");
   checkNext(iter, "foo");
   checkNext(iter, "helen");
@@ -336,7 +336,7 @@ TEST_F(TrieTest, testLexOrder) {
   Trie_Delete(t, "hello", 5);
   Trie_Delete(t, "world", 5);
 
-  iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
+  iter = Trie_IterateAll(t);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "help");
@@ -371,7 +371,7 @@ TEST_F(TrieTest, testScoreOrder) {
   trieInsertByScore(t, "help", 3);
   trieInsertByScore(t, "helen", 5);
 
-  TrieIterator *iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
+  TrieIterator *iter = Trie_IterateAll(t);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "hello");
@@ -384,7 +384,7 @@ TEST_F(TrieTest, testScoreOrder) {
   Trie_Delete(t, "world", 5);
   Trie_Delete(t, "bar", 3);
 
-  iter = Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX);
+  iter = Trie_IterateAll(t);
   checkNext(iter, "foo");
   checkNext(iter, "helen");
   checkNext(iter, "help");
@@ -414,8 +414,8 @@ static bool compareTrieContents(Trie *original, Trie *loaded) {
   }
 
   // Compare all entries using iterators
-  TrieIterator *origIter = Trie_IterateFuzzy(original, "", 0, 0, TRIE_MATCH_PREFIX);
-  TrieIterator *loadedIter = Trie_IterateFuzzy(loaded, "", 0, 0, TRIE_MATCH_PREFIX);
+  TrieIterator *origIter = Trie_IterateAll(original);
+  TrieIterator *loadedIter = Trie_IterateAll(loaded);
 
   std::unique_ptr<TrieIterator, std::function<void(TrieIterator *)>> origIterPtr(origIter, [](TrieIterator *iter) {
     TrieIterator_Free(iter);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Six call sites in `testLexOrder`, `testScoreOrder`, and `compareTrieContents` walk every trie entry via `Trie_IterateFuzzy(t, "", 0, 0, TRIE_MATCH_PREFIX)`. An empty prefix matches every node, so the DFA filter accepts everything while still paying per-node automaton-stack maintenance — enumeration disguised as fuzzy matching.
2. **Change:** Convert those six sites to `Trie_IterateAll`, the dedicated API for unfiltered traversal. `checkNext` only drives `TrieIterator_Next`, so the assertions (lex/score-ordered traversal, RDB-roundtrip equality) are unchanged.
3. **Outcome:** Test intent is legible at the call site; the test-side counterpart of the production empty-prefix→`Trie_IterateAll` cleanup. No behavior change.

Stacked on #10143 (base branch `memark-trie-fuzzy-rename`). The genuine fuzzy/trim regression test in the same file is left untouched.

#### Main objects this PR modified
1. `tests/cpptests/test_cpp_trie.cpp`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes