### PR TITLE
[MOD-14459] Fix RSValue comparison: full C-compatibility

### DIFF
--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -138,12 +138,15 @@ pub fn compare(
         (Value::Ref(r1), Value::Ref(r2)) => compare(r1, r2, num_to_str_cmp_fallback),
         (Value::Ref(r1), _) => compare(r1, v2, num_to_str_cmp_fallback),
         (_, Value::Ref(r2)) => compare(v1, r2, num_to_str_cmp_fallback),
+
         // Null is less than every other value; two nulls are equal.
         (Value::Null, Value::Null) => Ok(Ordering::Equal),
         (Value::Null, _) => Ok(Ordering::Less),
         (_, Value::Null) => Ok(Ordering::Greater),
+
         // Compare numbers and surface any NaN values as an error.
         (Value::Number(n1), Value::Number(n2)) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
+
         // All string types compare byte-wise, including cross-type String/RedisString pairs.
         (Value::String(s1), Value::String(s2)) => Ok(s1.as_bytes().cmp(s2.as_bytes())),
         (Value::RedisString(rs1), Value::RedisString(rs2)) => {
@@ -151,6 +154,7 @@ pub fn compare(
         }
         (Value::String(s1), Value::RedisString(rs2)) => Ok(s1.as_bytes().cmp(rs2.as_bytes())),
         (Value::RedisString(rs1), Value::String(s2)) => Ok(rs1.as_bytes().cmp(s2.as_bytes())),
+
         // When a number meets a string type, the string is first parsed as a number and
         // compared numerically. If parsing fails, the fallback applies (see compare_number_to_string).
         (Value::Number(n1), Value::String(s2)) => {
@@ -167,6 +171,7 @@ pub fn compare(
             compare_number_to_string(*n2, s1.as_bytes(), num_to_str_cmp_fallback)
                 .map(Ordering::reverse)
         }
+
         // Arrays are compared by their first element only: if both arrays are
         // non-empty, the result is the comparison of their first elements
         // (regardless of how the remaining elements or lengths compare); if
@@ -179,12 +184,15 @@ pub fn compare(
             (Some(i1), Some(i2)) => compare(i1, i2, num_to_str_cmp_fallback),
             _ => Ok(a1.len().cmp(&a2.len())),
         },
+
         // Maps cannot be compared.
         (Value::Map(_), Value::Map(_)) => Err(CompareError::MapComparison),
+
         // Trio values are compared by their left element.
         (Value::Trio(t1), Value::Trio(t2)) => {
             compare(t1.left(), t2.left(), num_to_str_cmp_fallback)
         }
+
         // A number compared against a trio attempts numeric conversion of the trio's left
         // element (following the same recursion as C's `RSValue_ToNumber`). On success,
         // compare numerically; if conversion fails, the trio as a whole is treated as an
@@ -197,6 +205,7 @@ pub fn compare(
             Some(n1) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
             None => compare_number_to_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse),
         },
+
         // Compare a number (regardless of value) to an 'unconvertible' type as if it is a
         // 'number-to-empty-string' comparison.
         (Value::Number(_), Value::Array(_) | Value::Map(_) | Value::Undefined) => {
@@ -205,6 +214,7 @@ pub fn compare(
         (Value::Array(_) | Value::Map(_) | Value::Undefined, Value::Number(_)) => {
             compare_number_to_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse)
         }
+
         // A string type compared against an incompatible type treats the other side as empty string.
         (
             Value::String(s1),
@@ -230,6 +240,7 @@ pub fn compare(
         ) => Err(CompareError::IncompatibleAgainstString(
             b""[..].cmp(rs2.as_bytes()),
         )),
+
         // All remaining pairs have no defined ordering.
         (
             Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -142,7 +142,7 @@ pub fn compare(
         (Value::Null, Value::Null) => Ok(Ordering::Equal),
         (Value::Null, _) => Ok(Ordering::Less),
         (_, Value::Null) => Ok(Ordering::Greater),
-        // NaN has no defined order; callers map `NaNFloat` to equal.
+        // Compare numbers and surface any NaN values as an error.
         (Value::Number(n1), Value::Number(n2)) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
         // All string types compare byte-wise, including cross-type String/RedisString pairs.
         (Value::String(s1), Value::String(s2)) => Ok(s1.as_bytes().cmp(s2.as_bytes())),
@@ -191,21 +191,19 @@ pub fn compare(
         // empty string — identical to the Array/Map/Undefined arms above.
         (Value::Number(n1), Value::Trio(t2)) => match try_value_as_number(t2.left()) {
             Some(n2) => n1.partial_cmp(&n2).ok_or(CompareError::NaNFloat),
-            None => compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Greater),
+            None => compare_number_to_unconvertible(num_to_str_cmp_fallback),
         },
         (Value::Trio(t1), Value::Number(n2)) => match try_value_as_number(t1.left()) {
             Some(n1) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
-            None => compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Less),
+            None => compare_number_to_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse),
         },
-        // A number compared against an array, map, or undefined is treated as a
-        // number-to-string comparison where the other side is the empty string:
-        // with the fallback enabled the number always wins (it never formats to
-        // an empty string); without it, `NoNumberToStringFallback` is returned.
+        // Compare a number (regardless of value) to an 'unconvertible' type as if it is a
+        // 'number-to-empty-string' comparison.
         (Value::Number(_), Value::Array(_) | Value::Map(_) | Value::Undefined) => {
-            compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Greater)
+            compare_number_to_unconvertible(num_to_str_cmp_fallback)
         }
         (Value::Array(_) | Value::Map(_) | Value::Undefined, Value::Number(_)) => {
-            compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Less)
+            compare_number_to_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse)
         }
         // A string type compared against an incompatible type treats the other side as empty string.
         (
@@ -263,18 +261,18 @@ fn compare_number_to_string(
     }
 }
 
-/// Compare a number to a value that cannot be converted to a number nor formatted
-/// as a non-empty string ([`Value::Array`], [`Value::Map`], or [`Value::Undefined`]).
+/// Compare a number type (regardless of the actual value) against an 'unconvertible'
+/// type ([`Value::Array`], [`Value::Map`], or [`Value::Undefined`]) as if it is a
+/// 'number-to-empty-string' comparison.
 ///
-/// Such values are treated as the empty string, against which a formatted number
-/// always compares as non-empty. `if_number_first` is the resulting [`Ordering`]
-/// from the perspective of the number-typed operand.
+/// If `num_to_str_cmp_fallback` is enabled then a string representation of
+/// a number will always be greater, so no need to actually do a comparison.
+/// If `num_to_str_cmp_fallback` is disabled then no comparison is possible.
 const fn compare_number_to_unconvertible(
     num_to_str_cmp_fallback: bool,
-    if_number_first: Ordering,
 ) -> Result<Ordering, CompareError> {
     if num_to_str_cmp_fallback {
-        Ok(if_number_first)
+        Ok(Ordering::Greater)
     } else {
         Err(CompareError::NoNumberToStringFallback)
     }

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -11,7 +11,6 @@ use crate::Value;
 use crate::util::{num_to_str, str_to_float};
 use query_error::{QueryError, QueryErrorCode};
 use std::cmp::Ordering;
-use std::ops::Deref;
 
 /// Errors that can occur when comparing two [`Value`]s.
 #[derive(Debug, PartialEq, Eq)]
@@ -120,10 +119,6 @@ pub fn cmp_fields<'a>(
 /// - `true` - the number is formatted as a string and a byte-wise
 ///   comparison is performed.
 /// - `false` - returns [`CompareError::NoNumberToStringFallback`].
-///
-/// [`Value::Trio`] values are compared by their left element.
-/// [`Value::Array`] values are compared lexicographically.
-/// [`Value::Map`] values cannot be compared and yield [`CompareError::MapComparison`].
 pub fn compare(
     v1: &Value,
     v2: &Value,
@@ -141,18 +136,23 @@ pub fn compare(
         (Value::RedisString(rs1), Value::RedisString(rs2)) => {
             Ok(rs1.as_bytes().cmp(rs2.as_bytes()))
         }
+        // Trio values are compared by their left element.
         (Value::Trio(t1), Value::Trio(t2)) => {
             compare(t1.left(), t2.left(), num_to_str_cmp_fallback)
         }
-        (Value::Array(a1), Value::Array(a2)) => {
-            for (i1, i2) in a1.iter().zip(a2.deref()) {
-                let cmp = compare(i1, i2, num_to_str_cmp_fallback)?;
-                if cmp != Ordering::Equal {
-                    return Ok(cmp);
-                }
-            }
-            Ok(a1.len().cmp(&a2.len()))
-        }
+        // Arrays are compared by their first element only: if both arrays are
+        // non-empty, the result is the comparison of their first elements
+        // (regardless of how the remaining elements or lengths compare); if
+        // either array is empty, the result is the comparison of their
+        // lengths — i.e. equal if both are empty, otherwise the empty one is
+        // `Ordering::Less`. The actual lengths beyond "empty vs. non-empty"
+        // never matter, since two non-empty arrays always fall into the
+        // first case.
+        (Value::Array(a1), Value::Array(a2)) => match (a1.first(), a2.first()) {
+            (Some(i1), Some(i2)) => compare(i1, i2, num_to_str_cmp_fallback),
+            _ => Ok(a1.len().cmp(&a2.len())),
+        },
+        // Maps cannot be compared.
         (Value::Map(_), Value::Map(_)) => Err(CompareError::MapComparison),
         (Value::Number(n1), Value::String(s2)) => {
             compare_number_to_string(*n1, s2.as_bytes(), num_to_str_cmp_fallback)
@@ -170,6 +170,19 @@ pub fn compare(
         }
         (Value::String(s1), Value::RedisString(rs2)) => Ok(s1.as_bytes().cmp(rs2.as_bytes())),
         (Value::RedisString(rs1), Value::String(s2)) => Ok(rs1.as_bytes().cmp(s2.as_bytes())),
+        // A number compared against a trio recurses into the trio's left element.
+        (Value::Number(_), Value::Trio(t2)) => compare(v1, t2.left(), num_to_str_cmp_fallback),
+        (Value::Trio(t1), Value::Number(_)) => compare(t1.left(), v2, num_to_str_cmp_fallback),
+        // A number compared against an array, map, or undefined is treated as a
+        // number-to-string comparison where the other side is the empty string:
+        // with the fallback enabled the number always wins (it never formats to
+        // an empty string); without it, `NoNumberToStringFallback` is returned.
+        (Value::Number(_), _) => {
+            compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Greater)
+        }
+        (_, Value::Number(_)) => {
+            compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Less)
+        }
         (Value::String(s1), _) => Err(CompareError::IncompatibleAgainstString(
             s1.as_bytes().cmp(b""),
         )),
@@ -204,6 +217,23 @@ fn compare_number_to_string(
         let mut buf = [0; 32];
         let n = num_to_str(number, &mut buf);
         Ok(buf[0..n].cmp(slice))
+    } else {
+        Err(CompareError::NoNumberToStringFallback)
+    }
+}
+
+/// Compare a number to a value that cannot be converted to a number nor formatted
+/// as a non-empty string ([`Value::Array`], [`Value::Map`], or [`Value::Undefined`]).
+///
+/// Such values are treated as the empty string, against which a formatted number
+/// always compares as non-empty. `if_number_first` is the resulting [`Ordering`]
+/// from the perspective of the number-typed operand.
+const fn compare_number_to_unconvertible(
+    num_to_str_cmp_fallback: bool,
+    if_number_first: Ordering,
+) -> Result<Ordering, CompareError> {
+    if num_to_str_cmp_fallback {
+        Ok(if_number_first)
     } else {
         Err(CompareError::NoNumberToStringFallback)
     }

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -185,9 +185,18 @@ pub fn compare(
         (Value::Trio(t1), Value::Trio(t2)) => {
             compare(t1.left(), t2.left(), num_to_str_cmp_fallback)
         }
-        // A number compared against a trio recurses into the trio's left element.
-        (Value::Number(_), Value::Trio(t2)) => compare(v1, t2.left(), num_to_str_cmp_fallback),
-        (Value::Trio(t1), Value::Number(_)) => compare(t1.left(), v2, num_to_str_cmp_fallback),
+        // A number compared against a trio attempts numeric conversion of the trio's left
+        // element (following the same recursion as C's `RSValue_ToNumber`). On success,
+        // compare numerically; if conversion fails, the trio as a whole is treated as an
+        // empty string — identical to the Array/Map/Undefined arms above.
+        (Value::Number(n1), Value::Trio(t2)) => match try_value_as_number(t2.left()) {
+            Some(n2) => n1.partial_cmp(&n2).ok_or(CompareError::NaNFloat),
+            None => compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Greater),
+        },
+        (Value::Trio(t1), Value::Number(n2)) => match try_value_as_number(t1.left()) {
+            Some(n1) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
+            None => compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Less),
+        },
         // A number compared against an array, map, or undefined is treated as a
         // number-to-string comparison where the other side is the empty string:
         // with the fallback enabled the number always wins (it never formats to
@@ -268,5 +277,21 @@ const fn compare_number_to_unconvertible(
         Ok(if_number_first)
     } else {
         Err(CompareError::NoNumberToStringFallback)
+    }
+}
+
+/// Try to extract a numeric value from a [`Value`], mirroring C's `RSValue_ToNumber`.
+///
+/// Numbers are returned directly, strings are parsed with [`str_to_float`], trios
+/// recurse into their left element, and references are transparently followed.
+/// All other types (null, array, map, undefined) yield `None`.
+fn try_value_as_number(v: &Value) -> Option<f64> {
+    match v {
+        Value::Ref(r) => try_value_as_number(r),
+        Value::Number(n) => Some(*n),
+        Value::String(s) => str_to_float(s.as_bytes()),
+        Value::RedisString(s) => str_to_float(s.as_bytes()),
+        Value::Trio(t) => try_value_as_number(t.left()),
+        _ => None,
     }
 }

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -199,20 +199,20 @@ pub fn compare(
         // empty string — identical to the Array/Map/Undefined arms above.
         (Value::Number(n1), Value::Trio(t2)) => match try_value_as_number(t2.left()) {
             Some(n2) => n1.partial_cmp(&n2).ok_or(CompareError::NaNFloat),
-            None => compare_number_to_unconvertible(num_to_str_cmp_fallback),
+            None => number_type_vs_unconvertible(num_to_str_cmp_fallback),
         },
         (Value::Trio(t1), Value::Number(n2)) => match try_value_as_number(t1.left()) {
             Some(n1) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
-            None => compare_number_to_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse),
+            None => number_type_vs_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse),
         },
 
         // Compare a number (regardless of value) to an 'unconvertible' type as if it is a
         // 'number-to-empty-string' comparison.
         (Value::Number(_), Value::Array(_) | Value::Map(_) | Value::Undefined) => {
-            compare_number_to_unconvertible(num_to_str_cmp_fallback)
+            number_type_vs_unconvertible(num_to_str_cmp_fallback)
         }
         (Value::Array(_) | Value::Map(_) | Value::Undefined, Value::Number(_)) => {
-            compare_number_to_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse)
+            number_type_vs_unconvertible(num_to_str_cmp_fallback).map(Ordering::reverse)
         }
 
         // A string type compared against an incompatible type treats the other side as empty string.
@@ -279,7 +279,7 @@ fn compare_number_to_string(
 /// If `num_to_str_cmp_fallback` is enabled then a string representation of
 /// a number will always be greater, so no need to actually do a comparison.
 /// If `num_to_str_cmp_fallback` is disabled then no comparison is possible.
-const fn compare_number_to_unconvertible(
+const fn number_type_vs_unconvertible(
     num_to_str_cmp_fallback: bool,
 ) -> Result<Ordering, CompareError> {
     if num_to_str_cmp_fallback {

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -114,31 +114,58 @@ pub fn cmp_fields<'a>(
 
 /// Compare two [`Value`]s, returning their [`Ordering`].
 ///
-/// When a number is compared to a string, the string is first parsed as a
-/// number. If parsing fails, behaviour depends on `num_to_str_cmp_fallback`:
-/// - `true` - the number is formatted as a string and a byte-wise
-///   comparison is performed.
-/// - `false` - returns [`CompareError::NoNumberToStringFallback`].
+/// The match arms and their precedence are dictated by compatibility with the C implementation
+/// (`RSValue_Cmp` in `value.c`). Notably:
+/// - References are always unwrapped first.
+/// - Null is less than everything else.
+/// - When a number meets a string, the string is attempted as a number before falling back.
+/// - String types (String and RedisString) are interchangeable and compare byte-wise.
+/// - Non-string, non-numeric types (Trio, Array, Map, Undefined) are treated as empty string
+///   when compared against a string type, and as incomparable against each other.
+///
+/// `num_to_str_cmp_fallback` controls what happens when a number meets a non-numeric string:
+/// - `true` — format the number as a string and compare byte-wise (used when no `QueryError`
+///   is available, i.e. in sorting paths).
+/// - `false` — return [`CompareError::NoNumberToStringFallback`] so the caller can record the
+///   error (used when a [`QueryError`] is present).
 pub fn compare(
     v1: &Value,
     v2: &Value,
     num_to_str_cmp_fallback: bool,
 ) -> Result<Ordering, CompareError> {
     match (v1, v2) {
+        // References are transparent — unwrap before comparing.
         (Value::Ref(r1), Value::Ref(r2)) => compare(r1, r2, num_to_str_cmp_fallback),
         (Value::Ref(r1), _) => compare(r1, v2, num_to_str_cmp_fallback),
         (_, Value::Ref(r2)) => compare(v1, r2, num_to_str_cmp_fallback),
+        // Null is less than every other value; two nulls are equal.
         (Value::Null, Value::Null) => Ok(Ordering::Equal),
         (Value::Null, _) => Ok(Ordering::Less),
         (_, Value::Null) => Ok(Ordering::Greater),
+        // NaN has no defined order; callers map `NaNFloat` to equal.
         (Value::Number(n1), Value::Number(n2)) => n1.partial_cmp(n2).ok_or(CompareError::NaNFloat),
+        // All string types compare byte-wise, including cross-type String/RedisString pairs.
         (Value::String(s1), Value::String(s2)) => Ok(s1.as_bytes().cmp(s2.as_bytes())),
         (Value::RedisString(rs1), Value::RedisString(rs2)) => {
             Ok(rs1.as_bytes().cmp(rs2.as_bytes()))
         }
-        // Trio values are compared by their left element.
-        (Value::Trio(t1), Value::Trio(t2)) => {
-            compare(t1.left(), t2.left(), num_to_str_cmp_fallback)
+        (Value::String(s1), Value::RedisString(rs2)) => Ok(s1.as_bytes().cmp(rs2.as_bytes())),
+        (Value::RedisString(rs1), Value::String(s2)) => Ok(rs1.as_bytes().cmp(s2.as_bytes())),
+        // When a number meets a string type, the string is first parsed as a number and
+        // compared numerically. If parsing fails, the fallback applies (see compare_number_to_string).
+        (Value::Number(n1), Value::String(s2)) => {
+            compare_number_to_string(*n1, s2.as_bytes(), num_to_str_cmp_fallback)
+        }
+        (Value::Number(n1), Value::RedisString(s2)) => {
+            compare_number_to_string(*n1, s2.as_bytes(), num_to_str_cmp_fallback)
+        }
+        (Value::String(s1), Value::Number(n2)) => {
+            compare_number_to_string(*n2, s1.as_bytes(), num_to_str_cmp_fallback)
+                .map(Ordering::reverse)
+        }
+        (Value::RedisString(s1), Value::Number(n2)) => {
+            compare_number_to_string(*n2, s1.as_bytes(), num_to_str_cmp_fallback)
+                .map(Ordering::reverse)
         }
         // Arrays are compared by their first element only: if both arrays are
         // non-empty, the result is the comparison of their first elements
@@ -154,22 +181,10 @@ pub fn compare(
         },
         // Maps cannot be compared.
         (Value::Map(_), Value::Map(_)) => Err(CompareError::MapComparison),
-        (Value::Number(n1), Value::String(s2)) => {
-            compare_number_to_string(*n1, s2.as_bytes(), num_to_str_cmp_fallback)
+        // Trio values are compared by their left element.
+        (Value::Trio(t1), Value::Trio(t2)) => {
+            compare(t1.left(), t2.left(), num_to_str_cmp_fallback)
         }
-        (Value::Number(n1), Value::RedisString(s2)) => {
-            compare_number_to_string(*n1, s2.as_bytes(), num_to_str_cmp_fallback)
-        }
-        (Value::String(s1), Value::Number(n2)) => {
-            compare_number_to_string(*n2, s1.as_bytes(), num_to_str_cmp_fallback)
-                .map(Ordering::reverse)
-        }
-        (Value::RedisString(s1), Value::Number(n2)) => {
-            compare_number_to_string(*n2, s1.as_bytes(), num_to_str_cmp_fallback)
-                .map(Ordering::reverse)
-        }
-        (Value::String(s1), Value::RedisString(rs2)) => Ok(s1.as_bytes().cmp(rs2.as_bytes())),
-        (Value::RedisString(rs1), Value::String(s2)) => Ok(rs1.as_bytes().cmp(s2.as_bytes())),
         // A number compared against a trio recurses into the trio's left element.
         (Value::Number(_), Value::Trio(t2)) => compare(v1, t2.left(), num_to_str_cmp_fallback),
         (Value::Trio(t1), Value::Number(_)) => compare(t1.left(), v2, num_to_str_cmp_fallback),
@@ -177,25 +192,42 @@ pub fn compare(
         // number-to-string comparison where the other side is the empty string:
         // with the fallback enabled the number always wins (it never formats to
         // an empty string); without it, `NoNumberToStringFallback` is returned.
-        (Value::Number(_), _) => {
+        (Value::Number(_), Value::Array(_) | Value::Map(_) | Value::Undefined) => {
             compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Greater)
         }
-        (_, Value::Number(_)) => {
+        (Value::Array(_) | Value::Map(_) | Value::Undefined, Value::Number(_)) => {
             compare_number_to_unconvertible(num_to_str_cmp_fallback, Ordering::Less)
         }
-        (Value::String(s1), _) => Err(CompareError::IncompatibleAgainstString(
+        // A string type compared against an incompatible type treats the other side as empty string.
+        (
+            Value::String(s1),
+            Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,
+        ) => Err(CompareError::IncompatibleAgainstString(
             s1.as_bytes().cmp(b""),
         )),
-        (_, Value::String(s2)) => Err(CompareError::IncompatibleAgainstString(
+        (
+            Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,
+            Value::String(s2),
+        ) => Err(CompareError::IncompatibleAgainstString(
             b""[..].cmp(s2.as_bytes()),
         )),
-        (Value::RedisString(rs1), _) => Err(CompareError::IncompatibleAgainstString(
+        (
+            Value::RedisString(rs1),
+            Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,
+        ) => Err(CompareError::IncompatibleAgainstString(
             rs1.as_bytes().cmp(b""),
         )),
-        (_, Value::RedisString(rs2)) => Err(CompareError::IncompatibleAgainstString(
+        (
+            Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,
+            Value::RedisString(rs2),
+        ) => Err(CompareError::IncompatibleAgainstString(
             b""[..].cmp(rs2.as_bytes()),
         )),
-        _ => Err(CompareError::IncompatibleTypes),
+        // All remaining pairs have no defined ordering.
+        (
+            Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,
+            Value::Trio(_) | Value::Array(_) | Value::Map(_) | Value::Undefined,
+        ) => Err(CompareError::IncompatibleTypes),
     }
 }
 

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -351,13 +351,59 @@ fn trio_vs_number_recurses_into_left_numeric() {
 }
 
 #[test]
-fn number_vs_trio_recurses_into_left_array() {
-    // The trio's left element is an array, so this falls into the
-    // number-vs-array case via recursion.
+fn number_vs_trio_with_non_numeric_left_uses_unconvertible_fallback() {
+    // Trio.left is an array, which cannot be converted to a number.
+    // The trio is therefore treated as an empty string: the number always wins
+    // in fallback mode.
     let n = Value::Number(1.0);
     let t = trio(array([Value::Number(1.0)]), Value::Null, Value::Null);
     let result = compare(&n, &t, true).unwrap();
     assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn number_vs_trio_with_non_numeric_string_left_is_greater_in_fallback() {
+    // Trio.left is a non-numeric string. C behaviour: conversion fails, then the
+    // trio is compared as an empty string against the number's "%f" form, so the
+    // number always wins. A direct recursion into String("abc") would incorrectly
+    // compare "1" against "abc", giving Less.
+    let n = Value::Number(1.0);
+    let t = trio(
+        Value::String(String::from_vec(b"abc".to_vec())),
+        Value::Null,
+        Value::Null,
+    );
+    let result = compare(&n, &t, true).unwrap();
+    assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn trio_with_non_numeric_string_left_vs_number_is_less_in_fallback() {
+    let n = Value::Number(1.0);
+    let t = trio(
+        Value::String(String::from_vec(b"abc".to_vec())),
+        Value::Null,
+        Value::Null,
+    );
+    let result = compare(&t, &n, true).unwrap();
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn number_vs_trio_with_non_numeric_string_left_returns_error_without_fallback() {
+    // Without fallback (qerr path), the same conversion failure must return
+    // NoNumberToStringFallback so the caller can record the error.
+    let n = Value::Number(1.0);
+    let t = trio(
+        Value::String(String::from_vec(b"abc".to_vec())),
+        Value::Null,
+        Value::Null,
+    );
+    let result = compare(&n, &t, false);
+    assert!(matches!(
+        result,
+        Err(CompareError::NoNumberToStringFallback)
+    ));
 }
 
 #[test]

--- a/src/redisearch_rs/value/tests/integration/comparison.rs
+++ b/src/redisearch_rs/value/tests/integration/comparison.rs
@@ -11,7 +11,7 @@
 
 use query_error::QueryError;
 use std::cmp::Ordering;
-use value::comparison::{CompareError, cmp_fields, compare};
+use value::comparison::{CompareError, cmp_fields, compare, compare_on_equality_only};
 use value::{Array, Map, SharedValue, String, Trio, Value};
 
 fn array(values: impl IntoIterator<Item = Value>) -> Value {
@@ -163,27 +163,45 @@ fn array_equal() {
 }
 
 #[test]
-fn array_differing_element() {
-    let a1 = array([Value::Number(1.0), Value::Number(2.0)]);
-    let a2 = array([Value::Number(1.0), Value::Number(1.0)]);
+fn array_differing_first_element() {
+    let a1 = array([Value::Number(2.0), Value::Number(1.0)]);
+    let a2 = array([Value::Number(1.0), Value::Number(99.0)]);
     let result = compare(&a1, &a2, false).unwrap();
     assert_eq!(result, Ordering::Greater);
 }
 
 #[test]
-fn array_shorter_is_less_when_prefix_matches() {
-    let a1 = array([Value::Number(1.0)]);
-    let a2 = array([Value::Number(1.0), Value::Number(2.0)]);
+fn array_only_first_element_is_compared() {
+    // Lengths and trailing elements differ, but the first elements match,
+    // so the arrays compare as equal.
+    let a1 = array([Value::Number(1.0), Value::Number(2.0)]);
+    let a2 = array([Value::Number(1.0)]);
+    let result = compare(&a1, &a2, false).unwrap();
+    assert_eq!(result, Ordering::Equal);
+}
+
+#[test]
+fn empty_array_is_less_than_non_empty_array() {
+    let a1 = Value::Array(Array::new(Box::new([])));
+    let a2 = array([Value::Number(1.0)]);
     let result = compare(&a1, &a2, false).unwrap();
     assert_eq!(result, Ordering::Less);
 }
 
 #[test]
-fn array_longer_is_greater_when_prefix_matches() {
-    let a1 = array([Value::Number(1.0), Value::Number(2.0)]);
-    let a2 = array([Value::Number(1.0)]);
+fn non_empty_array_is_greater_than_empty_array() {
+    let a1 = array([Value::Number(1.0)]);
+    let a2 = Value::Array(Array::new(Box::new([])));
     let result = compare(&a1, &a2, false).unwrap();
     assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn both_empty_arrays_are_equal() {
+    let a1 = Value::Array(Array::new(Box::new([])));
+    let a2 = Value::Array(Array::new(Box::new([])));
+    let result = compare(&a1, &a2, false).unwrap();
+    assert_eq!(result, Ordering::Equal);
 }
 
 #[test]
@@ -244,6 +262,102 @@ fn incompatible_types_returns_error() {
     let a = array([Value::Number(1.0)]);
     let result = compare(&t, &a, false);
     assert!(matches!(result, Err(CompareError::IncompatibleTypes)));
+}
+
+#[test]
+fn number_vs_array_with_fallback_is_greater() {
+    let n = Value::Number(1.0);
+    let a = array([Value::Number(1.0)]);
+    let result = compare(&n, &a, true).unwrap();
+    assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn array_vs_number_with_fallback_is_less() {
+    let a = array([Value::Number(1.0)]);
+    let n = Value::Number(1.0);
+    let result = compare(&a, &n, true).unwrap();
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn number_vs_array_without_fallback_returns_error() {
+    let n = Value::Number(1.0);
+    let a = array([Value::Number(1.0)]);
+    let result = compare(&n, &a, false);
+    assert!(matches!(
+        result,
+        Err(CompareError::NoNumberToStringFallback)
+    ));
+}
+
+#[test]
+fn number_vs_map_with_fallback_is_greater() {
+    let n = Value::Number(1.0);
+    let m = Value::Map(Map::new(Box::new([])));
+    let result = compare(&n, &m, true).unwrap();
+    assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn number_vs_undefined_with_fallback_is_greater() {
+    let n = Value::Number(1.0);
+    let result = compare(&n, &Value::Undefined, true).unwrap();
+    assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn undefined_vs_number_with_fallback_is_less() {
+    let n = Value::Number(1.0);
+    let result = compare(&Value::Undefined, &n, true).unwrap();
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn number_vs_array_equality_is_false() {
+    let n = Value::Number(1.0);
+    let a = array([Value::Number(1.0)]);
+    assert!(!compare_on_equality_only(&n, &a));
+    assert!(!compare_on_equality_only(&a, &n));
+}
+
+#[test]
+fn number_vs_map_equality_is_false() {
+    let n = Value::Number(1.0);
+    let m = Value::Map(Map::new(Box::new([])));
+    assert!(!compare_on_equality_only(&n, &m));
+}
+
+#[test]
+fn number_vs_undefined_equality_is_false() {
+    let n = Value::Number(1.0);
+    assert!(!compare_on_equality_only(&n, &Value::Undefined));
+}
+
+#[test]
+fn number_vs_trio_recurses_into_left_numeric() {
+    let n = Value::Number(2.0);
+    let t = trio(Value::Number(1.0), Value::Null, Value::Null);
+    let result = compare(&n, &t, false).unwrap();
+    assert_eq!(result, Ordering::Greater);
+}
+
+#[test]
+fn trio_vs_number_recurses_into_left_numeric() {
+    let n = Value::Number(2.0);
+    let t = trio(Value::Number(1.0), Value::Null, Value::Null);
+    let result = compare(&t, &n, false).unwrap();
+    assert_eq!(result, Ordering::Less);
+}
+
+#[test]
+fn number_vs_trio_recurses_into_left_array() {
+    // The trio's left element is an array, so this falls into the
+    // number-vs-array case via recursion.
+    let n = Value::Number(1.0);
+    let t = trio(array([Value::Number(1.0)]), Value::Null, Value::Null);
+    let result = compare(&n, &t, true).unwrap();
+    assert_eq!(result, Ordering::Greater);
 }
 
 #[test]


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The Rust `compare` function in `value/src/comparison.rs` had several divergences from the C `RSValue_Cmp` implementation: arrays were compared element-by-element (C only compares the first element), wildcard match arms silently covered types that should be named explicitly, and the function doc gave no context about why the logic is shaped the way it is.

2. **Change:**
   - Fix array comparison to match C: compare only the first element of non-empty arrays; fall back to length comparison when either array is empty.
   - Replace wildcard `_` arms with explicit `Value::Array(_) | Value::Map(_) | Value::Undefined` (and symmetric counterparts) so the match exhaustively names every type it handles.
   - Add inline comments to every match-arm group explaining the rule and, where relevant, the C-compatibility reason.
   - Rewrite the `compare` doc comment to lead with the C-compatibility context and clarify the `num_to_str_cmp_fallback` parameter semantics.
   - Remove an unused `use std::ops::Deref` import left over from the old array implementation.

3. **Outcome:** The Rust implementation is now verifiably aligned with `RSValue_Cmp`, all match arms are self-documenting, and future readers have enough context to understand the non-obvious ordering rules without consulting the C source.

#### Which additional issues this PR fixes
1. MOD-14459

#### Main objects this PR modified
1. `src/redisearch_rs/value/src/comparison.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes