### PR TITLE
[MOD-14459] Fix hll_load cache invalidation and harden against invalid register values

### DIFF
--- a/src/aggregate/reducers/count_distinct.c
+++ b/src/aggregate/reducers/count_distinct.c
@@ -212,7 +212,9 @@ static int hllsumAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
     }
   } else {
     // Not yet initialized - make this our first register and continue.
-    hll_load(ctr, registers, regsz);
+    if (hll_load(ctr, registers, regsz) != 0) {
+      return 0;
+    }
   }
   return 1;
 }

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -19,6 +19,9 @@
 
 #define INVALID_CACHE_CARDINALITY SIZE_MAX
 
+// 2^32 — the size of the 32-bit hash domain, used in the large-range correction
+#define HLL_HASH_SPACE ((double)(1ULL << 32))
+
 static inline uint8_t _hll_rank(uint32_t hash, uint8_t max) {
   uint8_t rank = hash ? __builtin_ctz(hash) : 32; // index of first set bit
   return (rank > max ? max : rank) + 1;
@@ -106,8 +109,8 @@ size_t hll_count(const struct HLL *hll) {
     if (zeros)
       estimate = hll->size * log((double)hll->size / zeros);
 
-  } else if (estimate > (1.0 / 30.0) * 4294967296.0 && estimate < 4294967296.0) {
-    estimate = -4294967296.0 * log(1.0 - estimate / 4294967296.0);
+  } else if (estimate > (1.0 / 30.0) * HLL_HASH_SPACE && estimate < HLL_HASH_SPACE) {
+    estimate = -HLL_HASH_SPACE * log(1.0 - estimate / HLL_HASH_SPACE);
   }
 
   ((struct HLL*)hll)->cachedCard = estimate; // cache the current estimate

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -107,7 +107,13 @@ size_t hll_count(const struct HLL *hll) {
       estimate = hll->size * log((double)hll->size / zeros);
 
   } else if (estimate > (1.0 / 30.0) * 4294967296.0) {
-    estimate = -4294967296.0 * log(1.0 - (estimate / 4294967296.0));
+    double x = 1.0 - estimate / 4294967296.0;
+    if (x > 0.0) {
+      estimate = -4294967296.0 * log(x);
+    }
+    // x <= 0 means estimate >= 2^32: the large-range correction is out of domain
+    // (log of a non-positive value is undefined). Keep the raw estimate; it already
+    // saturates the 32-bit hash space and no correction can improve it.
   }
 
   ((struct HLL*)hll)->cachedCard = estimate; // cache the current estimate

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -106,14 +106,8 @@ size_t hll_count(const struct HLL *hll) {
     if (zeros)
       estimate = hll->size * log((double)hll->size / zeros);
 
-  } else if (estimate > (1.0 / 30.0) * 4294967296.0) {
-    double x = 1.0 - estimate / 4294967296.0;
-    if (x > 0.0) {
-      estimate = -4294967296.0 * log(x);
-    }
-    // x <= 0 means estimate >= 2^32: the large-range correction is out of domain
-    // (log of a non-positive value is undefined). Keep the raw estimate; it already
-    // saturates the 32-bit hash space and no correction can improve it.
+  } else if (estimate > (1.0 / 30.0) * 4294967296.0 && estimate < 4294967296.0) {
+    estimate = -4294967296.0 * log(1.0 - estimate / 4294967296.0);
   }
 
   ((struct HLL*)hll)->cachedCard = estimate; // cache the current estimate
@@ -149,22 +143,21 @@ int hll_load(struct HLL *hll, const void *registers, uint32_t size) {
     return -1; // size must be a power of 2 - a single bit set
   }
 
-  // Since `size` is a power of 2, the number of trailing zeros is the log2 of `size`
-  if (hll_init(hll, __builtin_ctz(size)) == -1) return -1;
-
-  // Reject impossible rank values before they can reach hll_count's shift expression.
-  // Valid ranks are in [0, rank_bits+1]; anything higher cannot be produced by _hll_rank
-  // and would cause undefined behaviour (shift count >= 32) in hll_count.
-  uint8_t max_rank = hll->rank_bits + 1;
+  // Reject impossible rank values before allocating, consistent with the rest of this
+  // function's failure paths (all of which return before any allocation). Valid ranks are
+  // in [0, rank_bits+1]; anything higher cannot be produced by _hll_rank and would cause
+  // undefined behaviour (shift count >= 32) in hll_count.
+  uint8_t bits = __builtin_ctz(size); // log2(size), since size is a power of 2
+  if (bits < 4 || bits > 20) return -1; // same constraint as hll_init; check before dereferencing registers
+  uint8_t max_rank = (32 - bits) + 1;
   const uint8_t *regs = (const uint8_t *)registers;
   for (uint32_t i = 0; i < size; i++) {
     if (regs[i] > max_rank) {
-      hll_destroy(hll);
-      *hll = (struct HLL){0}; // reset bits/size/rank_bits so callers that ignore the
-                               // return value don't call hll_count on a NULL registers
       return -1;
     }
   }
+
+  if (hll_init(hll, bits) == -1) return -1;
 
   memcpy(hll->registers, registers, size * sizeof(*hll->registers));
   hll->cachedCard = INVALID_CACHE_CARDINALITY; // Invalidate the cache populated by hll_init

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -91,7 +91,7 @@ size_t hll_count(const struct HLL *hll) {
 
   double sum = 0;
   for (uint32_t i = 0; i < hll->size; i++) {
-    sum += 1.0 / (1 << hll->registers[i]);
+    sum += 1.0 / (1u << hll->registers[i]);
   }
 
   double estimate = alpha_mm / sum;
@@ -119,6 +119,15 @@ int hll_merge(struct HLL *dst, const struct HLL *src) {
     return -1;
   }
 
+  // Validate source registers before merging; an impossible rank (e.g. from
+  // untrusted external data) would propagate into dst and cause UB in hll_count.
+  uint8_t max_rank = dst->rank_bits + 1;
+  for (uint32_t i = 0; i < src->size; i++) {
+    if (src->registers[i] > max_rank) {
+      return -1;
+    }
+  }
+
   for (uint32_t i = 0; i < src->size; i++) {
     if (dst->registers[i] < src->registers[i]) {
       dst->registers[i] = src->registers[i];
@@ -137,7 +146,20 @@ int hll_load(struct HLL *hll, const void *registers, uint32_t size) {
   // Since `size` is a power of 2, the number of trailing zeros is the log2 of `size`
   if (hll_init(hll, __builtin_ctz(size)) == -1) return -1;
 
+  // Reject impossible rank values before they can reach hll_count's shift expression.
+  // Valid ranks are in [0, rank_bits+1]; anything higher cannot be produced by _hll_rank
+  // and would cause undefined behaviour (shift count >= 32) in hll_count.
+  uint8_t max_rank = hll->rank_bits + 1;
+  const uint8_t *regs = (const uint8_t *)registers;
+  for (uint32_t i = 0; i < size; i++) {
+    if (regs[i] > max_rank) {
+      hll_destroy(hll);
+      return -1;
+    }
+  }
+
   memcpy(hll->registers, registers, size * sizeof(*hll->registers));
+  hll->cachedCard = INVALID_CACHE_CARDINALITY; // Invalidate the cache populated by hll_init
 
   return 0;
 }

--- a/src/hll/hll.c
+++ b/src/hll/hll.c
@@ -154,6 +154,8 @@ int hll_load(struct HLL *hll, const void *registers, uint32_t size) {
   for (uint32_t i = 0; i < size; i++) {
     if (regs[i] > max_rank) {
       hll_destroy(hll);
+      *hll = (struct HLL){0}; // reset bits/size/rank_bits so callers that ignore the
+                               // return value don't call hll_count on a NULL registers
       return -1;
     }
   }

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -21,6 +21,59 @@ def testInfo(env):
     env.assertGreater(float(idx_info['key_table_size_mb']), 0)
     env.assertGreater(float(idx_info['vector_index_sz_mb']), 0)
 
+@skip(cluster=False)
+def testCountDistinctishAcrossShards():
+    """COUNT_DISTINCTISH is distributed as a per-shard HLL reducer (REDUCER_T_HLL),
+    merged on the coordinator by HLL_SUM (a register-wise max of the per-shard
+    HLL registers, see `distributeCountDistinctish` in `src/coord/dist_plan.cpp`).
+
+    This merge is only correct if every shard maps the same logical value to the
+    same HLL register/rank pair, i.e. the hash fed into the per-shard HLL
+    (`RSValue_HashStable`) must be deterministic across processes. If a
+    per-process-randomized hash (`RSValue_Hash`) were used instead, the same
+    `n_values` distinct values would map to unrelated registers on each shard,
+    and the merged HLL would estimate roughly `n_values * env.shardsCount`
+    distinct values instead of `n_values`.
+
+    To make the difference observable, every distinct tag value is written to
+    enough documents that (with overwhelming probability) each shard sees all
+    `n_values` of them.
+    """
+    env = Env(shardsCount=2)
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'group', 'TAG', 'category', 'TAG').ok()
+
+    n_values = 50
+    docs_per_value = 20
+    for j in range(n_values):
+        for i in range(docs_per_value):
+            conn.execute_command('HSET', f'doc:{j}:{i}', 'group', 'all', 'category', f'cat{j}')
+
+    # COUNT_DISTINCT (exact) has no entry in `reducerDistributors_g`, so a GROUPBY
+    # step containing it is never distributed (see `distributeGroupStep`): it runs
+    # entirely on the coordinator over raw rows gathered from all shards, and is
+    # therefore unaffected by per-shard hash seeds. Issued in its own query so it
+    # doesn't drag the COUNT_DISTINCTISH query (below) into the same fate.
+    res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                   'GROUPBY', '1', '@group',
+                   'REDUCE', 'COUNT_DISTINCT', '1', '@category', 'AS', 'exact')
+    exact_count = int(to_dict(res[1])['exact'])
+    env.assertEqual(exact_count, n_values)
+
+    # COUNT_DISTINCTISH is the only reducer in this GROUPBY step and is in
+    # `reducerDistributors_g`, so this step *is* distributed into per-shard HLL
+    # reducers merged via HLL_SUM. The result must be close to the exact count.
+    # With a stable cross-process hash, the merged HLL is ~idempotent across
+    # shards and estimates ~n_values. With a per-process-randomized hash, it
+    # would instead estimate ~n_values * env.shardsCount, well outside this
+    # tolerance for shardsCount >= 2.
+    res = env.cmd('FT.AGGREGATE', 'idx', '*',
+                   'GROUPBY', '1', '@group',
+                   'REDUCE', 'COUNT_DISTINCTISH', '1', '@category', 'AS', 'approx')
+    approx_count = int(to_dict(res[1])['approx'])
+    env.assertAlmostEqual(exact_count, approx_count, delta=exact_count * 0.20)
+
 @skip(cluster=True)
 def test_required_fields(env):
     # Testing coordinator<-> shard `_REQUIRED_FIELDS` protocol

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -22,7 +22,7 @@ def testInfo(env):
     env.assertGreater(float(idx_info['vector_index_sz_mb']), 0)
 
 @skip(cluster=False)
-def testCountDistinctishAcrossShards():
+def test_count_distinctish_across_shards():
     """COUNT_DISTINCTISH is distributed as a per-shard HLL reducer (REDUCER_T_HLL),
     merged on the coordinator by HLL_SUM (a register-wise max of the per-shard
     HLL registers, see `distributeCountDistinctish` in `src/coord/dist_plan.cpp`).


### PR DESCRIPTION
## Describe the changes in the pull request

**Current**:
- `hll_load` called `hll_init` (which sets `cachedCard = 0`) and then overwrote the
  registers via `memcpy`, but did not invalidate the cache. As a result, `hll_count`
  always returned the stale cached value of `0` after `hll_load`, making
  `COUNT_DISTINCTISH` always estimate zero distinct values.
- `hll_count`'s shift expression `1 << registers[i]` is undefined behaviour for register
  values above 31. After the cache fix above made `hll_count` actually compute over
  loaded bytes, a crafted `HLL_SUM` payload with register value 255 could trigger UB
  or crash the server. Register values this large are impossible in a legitimately-built
  sketch (`_hll_rank` caps at `rank_bits + 1`, which is at most 29 for the smallest
  valid precision), so they can only come from a user-controlled string field.

**Change**:
- `hll_load` now sets `cachedCard = INVALID_CACHE_CARDINALITY` after copying registers,
  so `hll_count` computes the actual cardinality instead of returning a stale zero.
- `hll_load` and `hll_merge` validate all register values against the maximum rank
  producible for the sketch's precision (`rank_bits + 1`) and return an error if any
  register exceeds it, rejecting crafted payloads before they reach the shift expression.
- `hll_count` uses `1u << rank` instead of `1 << rank` as defence in depth.

**Outcome**:
- `COUNT_DISTINCTISH` correctly estimates distinct values and produces results that can
  be merged across cluster shards by `HLL_SUM`.
- `HLL_SUM` rejects payloads with impossible register values instead of triggering UB.
- `testCountDistinctishAcrossShards` verifies that the cross-shard estimate from
  `COUNT_DISTINCTISH` is within 20% of the exact count.

#### Which additional issues this PR fixes
1. MOD-14459

#### Main objects this PR modified
1. `src/hll/hll.c` — cache invalidation fix and register validation
2. `tests/pytests/test_coordinator.py` — `testCountDistinctishAcrossShards`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes