### PR TITLE
[MOD-15932] Trie - const-qualify read-only Trie/TrieNode accessors

### DIFF
--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -107,20 +107,20 @@ TrieNode *Trie_GetNode(Trie *t, const rune *str, t_len len, bool exact, int *off
   return TrieNode_Get(t->root, str, len, exact, offsetOut);
 }
 
-void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
+void Trie_IterateRange(const Trie *t, const rune *min, int minlen, bool includeMin,
                        const rune *max, int maxlen, bool includeMax,
                        TrieRangeCallback callback, void *ctx) {
   TrieNode_IterateRange(t->root, min, minlen, includeMin, max, maxlen, includeMax, callback, ctx);
 }
 
-void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
+void Trie_IterateContains(const Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                           bool skipTimeoutChecks) {
   TrieNode_IterateContains(t->root, str, nstr, prefix, suffix, callback, ctx, timeout,
                            skipTimeoutChecks);
 }
 
-void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
+void Trie_IterateWildcard(const Trie *t, const rune *str, int nstr,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                           bool skipTimeoutChecks) {
   TrieNode_IterateWildcard(t->root, str, nstr, callback, ctx, timeout, skipTimeoutChecks);
@@ -227,7 +227,7 @@ TrieIterator *Trie_IterateFuzzy(Trie *t, const char *str, size_t len, int maxDis
   return it;
 }
 
-Vector *Trie_CollectFuzzy(Trie *t, const char *str, size_t len, size_t num, int maxDist,
+Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num, int maxDist,
                           TrieMatchMode mode, int trim, int optimize) {
 
   if (len > TRIE_MAX_PREFIX * sizeof(rune)) {
@@ -449,7 +449,7 @@ void TrieType_RdbSave(RedisModuleIO *rdb, void *value) {
   TrieType_GenericSave(rdb, (Trie *)value, true, true);
 }
 
-void TrieType_GenericSave(RedisModuleIO *rdb, Trie *tree, bool savePayloads, bool saveNumDocs) {
+void TrieType_GenericSave(RedisModuleIO *rdb, const Trie *tree, bool savePayloads, bool saveNumDocs) {
   RedisModule_SaveUnsigned(rdb, tree->size);
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
   //  RedisModule_Log(ctx, "notice", "Trie: saving %zd nodes.", tree->size);

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -73,20 +73,20 @@ TrieNode *Trie_GetNode(Trie *t, const rune *str, t_len len, bool exact, int *off
 
 /* Iterate all nodes within a lexicographic range. Wraps TrieNode_IterateRange on the
  * trie's root. See TrieNode_IterateRange for parameter semantics. */
-void Trie_IterateRange(Trie *t, const rune *min, int minlen, bool includeMin,
+void Trie_IterateRange(const Trie *t, const rune *min, int minlen, bool includeMin,
                        const rune *max, int maxlen, bool includeMax,
                        TrieRangeCallback callback, void *ctx);
 
 /* Iterate all nodes that contain (or begin/end with) the given pattern. Wraps
  * TrieNode_IterateContains on the trie's root. See TrieNode_IterateContains for
  * parameter semantics. */
-void Trie_IterateContains(Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
+void Trie_IterateContains(const Trie *t, const rune *str, int nstr, bool prefix, bool suffix,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                           bool skipTimeoutChecks);
 
 /* Iterate all nodes matching a wildcard pattern. Wraps TrieNode_IterateWildcard on the
  * trie's root. See TrieNode_IterateWildcard for parameter semantics. */
-void Trie_IterateWildcard(Trie *t, const rune *str, int nstr,
+void Trie_IterateWildcard(const Trie *t, const rune *str, int nstr,
                           TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                           bool skipTimeoutChecks);
 
@@ -126,7 +126,7 @@ void TrieSearchResult_Free(TrieSearchResult *e);
 /* Collect the top `num` entries matching `str` within maxDist edit distance, ranked by score,
  * into a newly allocated Vector the caller must free. mode TRIE_MATCH_PREFIX matches `str` as a
  * prefix (tail unconstrained); otherwise the whole string within maxDist Levenshtein distance. */
-Vector *Trie_CollectFuzzy(Trie *t, const char *str, size_t len, size_t num, int maxDist,
+Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num, int maxDist,
                           TrieMatchMode mode, int trim, int optimize);
 
 /* Iterate entries matching `str` within maxDist edit distance, returning a TrieIterator the
@@ -143,7 +143,7 @@ int Trie_RandomKey(Trie *t, char **str, t_len *len, double *score);
 int TrieType_Register(RedisModuleCtx *ctx);
 void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDocs,
                            TrieSortMode sortMode);
-void TrieType_GenericSave(RedisModuleIO *rdb, Trie *t, bool savePayloads, bool saveNumDocs);
+void TrieType_GenericSave(RedisModuleIO *rdb, const Trie *t, bool savePayloads, bool saveNumDocs);
 void *TrieType_RdbLoad(RedisModuleIO *rdb, int encver);
 void TrieType_RdbSave(RedisModuleIO *rdb, void *value);
 size_t TrieType_MemUsage(const void *value);

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -930,7 +930,7 @@ static int rsbComparePrefix(const void *h, const void *e) {
   return rsbCompareCommon(h, e, 1);
 }
 
-static int rangeIterateSubTree(TrieNode *n, RangeCtx *r) {
+static int rangeIterateSubTree(const TrieNode *n, RangeCtx *r) {
   if (r->stop) return REDISEARCH_ERR;
 
   if (TimedOut_WithCounter(&r->timeout, &r->timeoutCounter)) {
@@ -963,7 +963,7 @@ static int rangeIterateSubTree(TrieNode *n, RangeCtx *r) {
  * Try to place as many of the common arguments in rangectx, so that the stack
  * size is not negatively impacted and prone to attack.
  */
-static void rangeIterate(TrieNode *n, const rune *min, int nmin, const rune *max, int nmax,
+static void rangeIterate(const TrieNode *n, const rune *min, int nmin, const rune *max, int nmax,
                          RangeCtx *r) {
   // Push string to stack
   r->buf = array_ensure_append(r->buf, n->str, n->len, rune);
@@ -1136,7 +1136,7 @@ void TrieNode_IterateRange(TrieNode *n, const rune *min, int nmin, bool includeM
   array_free(r.buf);
 }
 
-static void containsIterate(TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r);
+static void containsIterate(const TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r);
 
 // Contains iteration.
 void TrieNode_IterateContains(TrieNode *n, const rune *str, int nstr, bool prefix, bool suffix,
@@ -1186,7 +1186,7 @@ done:
 #define trimOne(n, r)  if (n->len) array_trimm_len(r->buf, 1)
 
 // check next char on node or children
-static void containsNext(TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r) {
+static void containsNext(const TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r) {
   if (n->len == localOffset || n->len == 0 ) {
     TrieNode **children = TrieNode_Children(n);
     for (t_len i = 0; i < n->numChildren && r->stop == 0; ++i) {
@@ -1201,7 +1201,7 @@ static void containsNext(TrieNode *n, t_len localOffset, t_len globalOffset, Ran
  * Try to place as many of the common arguments in rangectx, so that the stack
  * size is not negatively impacted and prone to attack.
  */
-static void containsIterate(TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r) {
+static void containsIterate(const TrieNode *n, t_len localOffset, t_len globalOffset, RangeCtx *r) {
   size_t len;
   char *str;
 
@@ -1252,7 +1252,7 @@ static void containsIterate(TrieNode *n, t_len localOffset, t_len globalOffset, 
   return;
 }
 
-static void wildcardIterate(TrieNode *n, RangeCtx *r) {
+static void wildcardIterate(const TrieNode *n, RangeCtx *r) {
   // timeout check
   if (TimedOut_WithCounter(&r->timeout, &r->timeoutCounter)) {
     r->stop = 1;
@@ -1296,7 +1296,7 @@ static void wildcardIterate(TrieNode *n, RangeCtx *r) {
   array_trimm_len(r->buf, n->len);
 }
 
-void TrieNode_IterateWildcard(TrieNode *n, const rune *str, int nstr,
+void TrieNode_IterateWildcard(const TrieNode *n, const rune *str, int nstr,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                               bool skipTimeoutChecks) {
   // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -156,7 +156,7 @@ void TrieNode_IterateContains(TrieNode *n, const rune *str, int nstr, bool prefi
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                               bool skipTimeoutChecks);
 
-void TrieNode_IterateWildcard(TrieNode *n, const rune *str, int nstr,
+void TrieNode_IterateWildcard(const TrieNode *n, const rune *str, int nstr,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                               bool skipTimeoutChecks);
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Several read-only functions in the trie module take a mutable `Trie *` / `TrieNode *` even though they only traverse the structure and never write to it.
2. **Change**: Qualify those parameters as `const`, where doing so requires no const-laundering cast and no call-site churn:
   - **Trie level**: `Trie_IterateRange`, `Trie_IterateContains`, `Trie_IterateWildcard`, `Trie_CollectFuzzy`, `TrieType_GenericSave` now take `const Trie *`. Each forwards `t->root` (a mutable-pointee `TrieNode *`, still yielded by a `const Trie *`) to the non-const node API, so const stops cleanly at the `Trie` boundary.
   - **Node level**: the static read-path helpers (`rangeIterate`, `rangeIterateSubTree`, `containsIterate`, `containsNext`, `wildcardIterate`) and the public `TrieNode_IterateWildcard` now take `const TrieNode *`.
3. **Outcome**: The read-only intent of these functions is documented in the type system. Compile-time only — no behavior change, identical codegen. Callers pass `Trie *` / `TrieNode *`, which converts implicitly; no call sites change.

### Intentionally left non-const

`TrieNode_Get` returns a mutable handle that some callers write through (`addSuffixTrie` via `Suffix_GetData`), so its input stays non-const rather than laundering const away. Its two callers `TrieNode_IterateRange` and `TrieNode_IterateContains` pass their node into it in their exact-match branches, so they stay non-const as well.

#### Which additional issues this PR fixes
1. MOD-15932

#### Main objects this PR modified
1. `src/trie/trie.c`, `src/trie/trie.h`
2. `src/trie/trie_node.c`, `src/trie/trie_node.h`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
