### PR TITLE
[MOD-14872] qast: handle QN_NOT in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -981,19 +981,6 @@ bool AREQ_CheckTimedOut(AREQ *areq) {
   return AREQ_TimedOut(areq);
 }
 
-static QueryIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
-  RS_LOG_ASSERT(qn->type == QN_NOT, "query node type should be not")
-  QueryIterator *child = NULL;
-  bool currently_notSubtree = q->notSubtree;
-  q->notSubtree = true;
-  child = Query_EvalNode_Rs(q, qn->children[0]);
-  q->notSubtree = currently_notSubtree;
-
-  t_docId maxDocId = q->sctx->spec->diskSpec ? SearchDisk_GetMaxDocId(q->sctx->spec->diskSpec) : q->docTable->maxDocId;
-  return NewNotIterator(child, maxDocId, qn->opts.weight, q->sctx->time.timeout,
-                        q->bcTimeoutAreq, q);
-}
-
 static QueryIterator *Query_EvalNumericNode(QueryEvalCtx *q, QueryNode *node) {
   RS_LOG_ASSERT(node->type == QN_NUMERIC, "query node type should be numeric")
 
@@ -1468,6 +1455,7 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
     case QN_NULL:
     case QN_MISSING:
     case QN_OPTIONAL:
+    case QN_NOT:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n);
     case QN_TOKEN:
@@ -1478,8 +1466,6 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
       return Query_EvalUnionNode(q, n);
     case QN_TAG:
       return Query_EvalTagNode(q, n);
-    case QN_NOT:
-      return Query_EvalNotNode(q, n);
     case QN_PREFIX:
       return Query_EvalPrefixNode(q, n);
     case QN_LEXRANGE:

--- a/src/query.c
+++ b/src/query.c
@@ -1109,7 +1109,7 @@ static QueryIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
   // We want to get results with all the matching children (`quickExit == false`), unless:
   // 1. We are a `Not` sub-tree, so we only care about the set of IDs
   // 2. The node's weight is 0, which means the sub-tree is not relevant for scoring.
-  bool quickExit = q->notSubtree || qn->opts.weight == 0;
+  bool quickExit = q->inNotSubTree || qn->opts.weight == 0;
   QueryIterator *ret = NewUnionIterator(iters, QueryNode_NumChildren(qn), quickExit, qn->opts.weight, QN_UNION, NULL, q->config);
   return ret;
 }
@@ -1444,7 +1444,7 @@ static QueryIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
   // We want to get results with all the matching children (`quickExit == false`), unless:
   // 1. We are a `Not` sub-tree, so we only care about the set of IDs
   // 2. The node's weight is 0, which means the sub-tree is not relevant for scoring.
-  bool quickExit = q->notSubtree || qn->opts.weight == 0;
+  bool quickExit = q->inNotSubTree || qn->opts.weight == 0;
   return NewUnionIterator(iters, QueryNode_NumChildren(qn), quickExit, qn->opts.weight, QN_TAG, NULL, q->config);
 }
 

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -23,7 +23,12 @@ typedef struct QueryEvalCtx {
   DocTable *docTable;
   uint32_t reqFlags;
   IteratorsConfig *config;
-  bool notSubtree;
+  // True while evaluating the subtree below a `NOT` node. A `NOT` only cares
+  // whether a document matches its child, never the child's score, so a
+  // descendant `UNION` may quick-exit on its first matching branch instead of
+  // visiting every branch to accumulate a score. Saved and restored around the
+  // child evaluation so nested `NOT`s (e.g. `-(-foo)`) keep it set correctly.
+  bool inNotSubTree;
   // AREQ to use for the Blocked Client Timeout dispatch. Non-NULL means
   // iterators poll `AREQ_CheckTimedOut` against this request; NULL means
   // iterators fall back to the in-pipeline clock-based timeout (low-level

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -24,9 +24,9 @@ use rqe_iterators::{
     },
 };
 
-type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext>;
+type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext<'index>>;
 type NotOptimizedFfi<'index> =
-    NotOptimized<'index, NewWildcardIterator<'index>, CRQEIterator, AnyTimeoutContext>;
+    NotOptimized<'index, NewWildcardIterator<'index>, CRQEIterator, AnyTimeoutContext<'index>>;
 
 /// Enum holding both NOT iterator variants with concrete [`CRQEIterator`] child.
 ///
@@ -170,11 +170,11 @@ impl<'index> rqe_iterators::interop::ProfileChildren<'index> for NotIteratorEnum
 /// 3 and 4 of [`NewNotIterator()`]). When `bc_timeout_areq` is non-null, it
 /// must uphold the [`TimeoutContextBlockedClient::new`] safety contract for
 /// the lifetime of the returned context.
-unsafe fn build_timeout_context(
+unsafe fn build_timeout_context<'req>(
     timeout: timespec,
     bc_timeout_areq: *mut AREQ,
     q: NonNull<ffi::QueryEvalCtx>,
-) -> AnyTimeoutContext {
+) -> AnyTimeoutContext<'req> {
     match NonNull::new(bc_timeout_areq) {
         Some(areq) => {
             // SAFETY: caller guarantees `areq` upholds the

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn QAST_Iterate(
         docTable: unsafe { &raw mut (*spec).docs },
         reqFlags: reqflags,
         config: &raw mut qast.config,
-        notSubtree: false,
+        inNotSubTree: false,
         bcTimeoutAreq: bc_timeout_areq,
     };
 

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
@@ -33,6 +33,10 @@ pub struct MockQueryEvalCtx {
     doc_table: *mut ffi::DocTable,
     config: *mut IteratorsConfig,
     qctx: *mut ffi::QueryEvalCtx,
+    /// Backing allocation for `qctx.bcTimeoutAreq`, lazily created by
+    /// [`MockQueryEvalCtx::enable_blocked_client_timeout`]; null when no
+    /// Blocked Client Timeout source has been wired in.
+    areq: *mut ffi::AREQ,
 }
 
 impl Drop for MockQueryEvalCtx {
@@ -56,6 +60,9 @@ impl Drop for MockQueryEvalCtx {
             dealloc(self.doc_table.cast(), Layout::new::<ffi::DocTable>());
             drop(Box::from_raw(self.config));
             dealloc(self.qctx.cast(), Layout::new::<ffi::QueryEvalCtx>());
+            if !self.areq.is_null() {
+                dealloc(self.areq.cast(), Layout::new::<ffi::AREQ>());
+            }
         }
     }
 }
@@ -131,6 +138,7 @@ impl MockQueryEvalCtx {
                 doc_table,
                 config,
                 qctx,
+                areq: std::ptr::null_mut(),
             }
         }
     }
@@ -164,5 +172,28 @@ impl MockQueryEvalCtx {
     pub fn enable_disk_mode(&mut self) {
         // SAFETY: `self.spec` is a valid, exclusively-owned allocation.
         unsafe { (*self.spec).diskSpec = std::ptr::NonNull::dangling().as_ptr() }
+    }
+
+    /// Wire a real, zeroed [`ffi::AREQ`] into `bcTimeoutAreq` so that the
+    /// Blocked Client Timeout source is selected (simulating a
+    /// background-executed request).
+    ///
+    /// The allocation is owned by this mock and freed on drop. It is zeroed,
+    /// so its `RequestSyncCtx::timedOut` flag reads as "not timed out": a code
+    /// path that probes the timeout (via `AREQ_CheckTimedOut`) sees a valid,
+    /// non-expired request.
+    pub fn enable_blocked_client_timeout(&mut self) {
+        // SAFETY: `ffi::AREQ` is a `#[repr(C)]` POD struct, so an all-zero bit
+        // pattern is a valid (non-expired) instance; the allocation is checked
+        // non-null and stored for cleanup in `Drop`.
+        unsafe {
+            if self.areq.is_null() {
+                let areq = alloc_zeroed(Layout::new::<ffi::AREQ>()).cast::<ffi::AREQ>();
+                assert!(!areq.is_null());
+                self.areq = areq;
+            }
+            // SAFETY: `self.qctx` is a valid, exclusively-owned allocation.
+            (*self.qctx).bcTimeoutAreq = self.areq;
+        }
     }
 }

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
@@ -126,7 +126,7 @@ impl MockQueryEvalCtx {
             (*qctx).reqFlags = flags.bits();
             (*qctx).config = (config as *mut IteratorsConfig).cast();
             (*qctx).tokenId = 0;
-            (*qctx).notSubtree = false;
+            (*qctx).inNotSubTree = false;
 
             Self {
                 sctx,

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -14,7 +14,11 @@ use std::ptr::NonNull;
 use query_flags::QEFlags;
 use rlookup::MetricRequest;
 use rqe_core::DocId;
-use rqe_iterators::IteratorsConfig;
+use rqe_iterators::{
+    IteratorsConfig,
+    not_reducer::TIMEOUT_CHECK_GRANULARITY,
+    utils::{AnyTimeoutContext, TimeoutContextBlockedClient},
+};
 use search_disk::SearchDiskHandle;
 
 /// Safe wrapper around [`ffi::QueryEvalCtx`].
@@ -48,6 +52,14 @@ impl QueryEvalContext {
     /// 2. All pointer fields within the [`ffi::QueryEvalCtx`] (`sctx`, `opts`,
     ///    `status`, `metricRequestsP`, `docTable`, `config`) and the nested
     ///    `sctx.spec` pointer must themselves be valid, non-null pointers.
+    ///    The nested `sctx.spec.diskSpec` pointer may be null (in-memory mode);
+    ///    when non-null it must point to a valid
+    ///    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec).
+    ///    `bcTimeoutAreq` may be null; when non-null it must point to a valid
+    ///    [`AREQ`](ffi::AREQ) that stays valid not just for the lifetime of the returned
+    ///    context, but for the lifetime of every timeout context and iterator
+    ///    derived from it (e.g. via
+    ///    [`build_timeout_context`](QueryEvalContext::build_timeout_context)).
     /// 3. The caller must have exclusive access to the pointer for the
     ///    lifetime of the returned [`QueryEvalContext`].
     ///
@@ -187,5 +199,38 @@ impl QueryEvalContext {
         let prev = inner.notSubtree;
         inner.notSubtree = value;
         prev
+    }
+
+    /// Build the [`AnyTimeoutContext`] a query iterator should use for this
+    /// evaluation.
+    ///
+    /// When a Blocked Client Timeout request is wired into the context
+    /// (`bcTimeoutAreq` non-null) the iterator polls that request's timeout
+    /// flag. Otherwise the Clock Based Timeout (or [`NoTimeout`], when timeout
+    /// checks are skipped or no deadline is set) is derived from `sctx.time`.
+    ///
+    /// The returned [`AnyTimeoutContext`] carries no lifetime tying it back to
+    /// this wrapper: in the Blocked Client case it holds a raw pointer to the
+    /// [`AREQ`](ffi::AREQ). Invariant (2) of [`new`](QueryEvalContext::new) requires that
+    /// [`AREQ`](ffi::AREQ) to outlive every iterator built from this context, so probing it
+    /// after the wrapper is dropped (e.g. from C) stays sound.
+    ///
+    /// [`NoTimeout`]: rqe_iterators::utils::NoTimeout
+    pub fn build_timeout_context(&self) -> AnyTimeoutContext {
+        match NonNull::new(self.as_ref().bcTimeoutAreq) {
+            Some(areq) => {
+                // SAFETY: invariant (2) of `new` guarantees a non-null
+                // `bcTimeoutAreq` points to a valid `AREQ` that stays valid for
+                // the lifetime of every iterator built from this context — which
+                // is exactly the span the resulting timeout context (and the
+                // iterator holding it) requires, satisfying the
+                // `TimeoutContextBlockedClient::new` contract.
+                let timeout = unsafe { TimeoutContextBlockedClient::new(areq) };
+                AnyTimeoutContext::BlockedClient(timeout)
+            }
+            // No Blocked Client Timeout source: derive the Clock Based Timeout
+            // (or `NoTimeout`) from `sctx.time`.
+            None => AnyTimeoutContext::from_sctx(self.sctx(), TIMEOUT_CHECK_GRANULARITY),
+        }
     }
 }

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -209,22 +209,20 @@ impl QueryEvalContext {
     /// flag. Otherwise the Clock Based Timeout (or [`NoTimeout`], when timeout
     /// checks are skipped or no deadline is set) is derived from `sctx.time`.
     ///
-    /// The returned [`AnyTimeoutContext`] carries no lifetime tying it back to
-    /// this wrapper: in the Blocked Client case it holds a raw pointer to the
-    /// [`AREQ`](ffi::AREQ). Invariant (2) of [`new`](QueryEvalContext::new) requires that
-    /// [`AREQ`](ffi::AREQ) to outlive every iterator built from this context, so probing it
-    /// after the wrapper is dropped (e.g. from C) stays sound.
+    /// The returned [`AnyTimeoutContext`] borrows `self`: its `'_` lifetime ties
+    /// it (and any iterator built from it) to this wrapper, so it cannot outlive
+    /// the context.
     ///
     /// [`NoTimeout`]: rqe_iterators::utils::NoTimeout
-    pub fn build_timeout_context(&self) -> AnyTimeoutContext {
+    pub fn build_timeout_context(&self) -> AnyTimeoutContext<'_> {
         match NonNull::new(self.as_ref().bcTimeoutAreq) {
             Some(areq) => {
                 // SAFETY: invariant (2) of `new` guarantees a non-null
-                // `bcTimeoutAreq` points to a valid `AREQ` that stays valid for
-                // the lifetime of every iterator built from this context — which
-                // is exactly the span the resulting timeout context (and the
-                // iterator holding it) requires, satisfying the
-                // `TimeoutContextBlockedClient::new` contract.
+                // `bcTimeoutAreq` points to a valid `AREQ` that outlives every
+                // iterator built from this context. The returned context borrows
+                // `self`, so its lifetime cannot exceed that of `self` (and hence
+                // of the `AREQ`), satisfying the `TimeoutContextBlockedClient::new`
+                // contract that `'req` not outlive the request.
                 let timeout = unsafe { TimeoutContextBlockedClient::new(areq) };
                 AnyTimeoutContext::BlockedClient(timeout)
             }

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -37,7 +37,7 @@ use search_disk::SearchDiskHandle;
 ///   token iterator created during evaluation.
 /// - `numTokens` — incremented when term-expansion nodes (prefix, fuzzy, …)
 ///   produce additional iterators beyond those counted by the parser.
-/// - `notSubtree` — temporarily set to `true` while evaluating the child of
+/// - `inNotSubTree` — temporarily set to `true` while evaluating the child of
 ///   a `NOT` node so that descendant `UNION` nodes know they can exit early
 ///   on the first match. Restored to its previous value afterwards.
 pub struct QueryEvalContext(NonNull<ffi::QueryEvalCtx>);
@@ -189,15 +189,15 @@ impl QueryEvalContext {
     /// When `true`, `UNION` nodes may exit early on the first matching child
     /// because the NOT semantics only need to know *whether* a match exists,
     /// not its score.
-    pub const fn not_subtree(&self) -> bool {
-        self.as_ref().notSubtree
+    pub const fn in_not_sub_tree(&self) -> bool {
+        self.as_ref().inNotSubTree
     }
 
-    /// Set the `notSubtree` flag, returning the previous value.
-    pub const fn set_not_subtree(&mut self, value: bool) -> bool {
+    /// Set the `inNotSubTree` flag, returning the previous value.
+    pub const fn set_in_not_sub_tree(&mut self, value: bool) -> bool {
         let inner = self.as_mut();
-        let prev = inner.notSubtree;
-        inner.notSubtree = value;
+        let prev = inner.inNotSubTree;
+        inner.inNotSubTree = value;
         prev
     }
 

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -9,6 +9,7 @@
 
 use query::{QueryEvalContext, mock::MockQueryEvalCtx};
 use query_flags::QEFlag;
+use rqe_iterators::utils::AnyTimeoutContext;
 
 #[test]
 fn sctx_returns_inner_ref() {
@@ -117,4 +118,36 @@ fn next_token_id_post_increments() {
     assert_eq!(ctx.next_token_id(), 0);
     assert_eq!(ctx.next_token_id(), 1);
     assert_eq!(ctx.next_token_id(), 2);
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "clock-based path calls libc::clock_gettime(CLOCK_MONOTONIC_RAW), unsupported by Miri"
+)]
+fn build_timeout_context_without_blocked_client_uses_sctx() {
+    // No `bcTimeoutAreq` wired in → the source is derived from `sctx.time`, never
+    // the Blocked Client path. The mock's zeroed `sctx.time` is a past deadline,
+    // so the clock-based variant is selected.
+    let mut mock = MockQueryEvalCtx::new();
+    let ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
+
+    assert!(matches!(
+        ctx.build_timeout_context(),
+        AnyTimeoutContext::Clock(_)
+    ));
+}
+
+#[test]
+fn build_timeout_context_prefers_blocked_client_when_wired() {
+    // A non-null `bcTimeoutAreq` selects the Blocked Client Timeout source,
+    // overriding `sctx.time` — mirroring the C evaluator's NOT-node behavior.
+    let mut mock = MockQueryEvalCtx::new();
+    mock.enable_blocked_client_timeout();
+    let ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
+
+    assert!(matches!(
+        ctx.build_timeout_context(),
+        AnyTimeoutContext::BlockedClient(_)
+    ));
 }

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -90,24 +90,24 @@ fn config_returns_iterators_config() {
 }
 
 #[test]
-fn not_subtree_default_false() {
+fn in_not_sub_tree_default_false() {
     let mut mock = MockQueryEvalCtx::new();
     let ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
-    assert!(!ctx.not_subtree());
+    assert!(!ctx.in_not_sub_tree());
 }
 
 #[test]
-fn set_not_subtree_returns_previous_and_updates() {
+fn set_in_not_sub_tree_returns_previous_and_updates() {
     let mut mock = MockQueryEvalCtx::new();
     let mut ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
 
-    let prev = ctx.set_not_subtree(true);
+    let prev = ctx.set_in_not_sub_tree(true);
     assert!(!prev);
-    assert!(ctx.not_subtree());
+    assert!(ctx.in_not_sub_tree());
 
-    let prev = ctx.set_not_subtree(false);
+    let prev = ctx.set_in_not_sub_tree(false);
     assert!(prev);
-    assert!(!ctx.not_subtree());
+    assert!(!ctx.in_not_sub_tree());
 }
 
 #[test]

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -22,6 +22,7 @@ use rqe_iterators::{
     id_list::IdListSorted,
     interop::RQEIteratorWrapper,
     inverted_index::new_missing_iterator,
+    not_reducer::{NewNotIterator, new_not_iterator},
     optional_reducer::{NewOptionalIterator, new_optional_iterator},
 };
 
@@ -159,6 +160,7 @@ pub fn eval_node<'index>(
         QueryNode::Ids { keys, doc_ids } => Some(eval_ids(ctx, keys, doc_ids)),
         QueryNode::Missing { field } => eval_missing(ctx, field).map(Evaluated::RustLeaf),
         QueryNode::Optional => Some(eval_optional(ctx, node)),
+        QueryNode::Not => Some(eval_not(ctx, node)),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
         _ => eval_node_c(ctx, node),
@@ -389,6 +391,62 @@ fn eval_optional<'index>(
         NewOptionalIterator::OptionalOptimized(opt) => Evaluated::RustCompound(
             NonNull::new(RQEIteratorWrapper::boxed_new_compound(opt))
                 .expect("optional iterator must not be null"),
+        ),
+    }
+}
+
+/// `QN_NOT` — logical negation: matches every document *not* matched by its
+/// single child.
+fn eval_not<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) -> Evaluated<'index> {
+    debug_assert_eq!(
+        node.num_children(),
+        1,
+        "a not node must have exactly one child"
+    );
+
+    // Evaluate the child with the "not-subtree" flag set. A NOT only cares
+    // *whether* a document matches its child, never the child's score, so any
+    // descendant `UNION` may stop at its first matching branch instead of
+    // visiting every branch to accumulate a score. Setting the flag lets those
+    // unions take that cheaper quick exit path.
+    //
+    // The previous value is saved and restored rather than just cleared: NOT
+    // nodes can nest (e.g. `-(-foo)`), and the outer NOT must keep the flag set
+    // while the inner one is being evaluated and after it returns.
+    let prev_not_subtree = ctx.set_not_subtree(true);
+    let child_node = node.child(0);
+    let child = eval_child_iterator(ctx, &child_node);
+    ctx.set_not_subtree(prev_not_subtree);
+
+    // SAFETY: the preconditions of `new_not_iterator` map to
+    // `QueryEvalContext::new` invariants:
+    // 1. `query` is a valid, non-null `QueryEvalCtx` — invariant (1).
+    // 2. `query.sctx` is valid and non-null — invariant (2).
+    // 3. `query.sctx.spec` is valid and non-null — invariant (2).
+    // 4. `spec.rule`, when non-null, is a valid `SchemaRule` — part of (1).
+    // 5. The wildcard-iterator preconditions hold for the same reasons
+    //    as in `eval_wildcard` (a properly initialised spec with its
+    //    `existingDocs` index, valid `docTable`, and
+    //    `diskSpec`/`SEARCH_ENTERPRISE_ITERATORS` when on disk).
+    let outcome = unsafe {
+        new_not_iterator(
+            child,
+            ctx.max_doc_id(),
+            node.opts().weight,
+            ctx.build_timeout_context(),
+            ctx.as_non_null(),
+        )
+    };
+    match outcome {
+        NewNotIterator::ReducedWildcard(wc) => Evaluated::RustLeaf(Box::new(wc)),
+        NewNotIterator::ReducedEmpty(empty) => Evaluated::RustLeaf(Box::new(empty)),
+        NewNotIterator::Not(it) => Evaluated::RustCompound(
+            NonNull::new(RQEIteratorWrapper::boxed_new_compound(it))
+                .expect("not iterator must not be null"),
+        ),
+        NewNotIterator::NotOptimized(it) => Evaluated::RustCompound(
+            NonNull::new(RQEIteratorWrapper::boxed_new_compound(it))
+                .expect("not iterator must not be null"),
         ),
     }
 }

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -413,10 +413,10 @@ fn eval_not<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) -> E
     // The previous value is saved and restored rather than just cleared: NOT
     // nodes can nest (e.g. `-(-foo)`), and the outer NOT must keep the flag set
     // while the inner one is being evaluated and after it returns.
-    let prev_not_subtree = ctx.set_not_subtree(true);
+    let prev_in_not_sub_tree = ctx.set_in_not_sub_tree(true);
     let child_node = node.child(0);
     let child = eval_child_iterator(ctx, &child_node);
-    ctx.set_not_subtree(prev_not_subtree);
+    ctx.set_in_not_sub_tree(prev_in_not_sub_tree);
 
     // SAFETY: the preconditions of `new_not_iterator` map to
     // `QueryEvalContext::new` invariants:

--- a/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
@@ -286,6 +286,63 @@ fn eval_optional_wildcard_child_passes_through() {
 }
 
 // ---------------------------------------------------------------------------
+// QN_NOT → Not / Wildcard / Empty (via the reducer shortcircuits)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_not_empty_child_falls_back_to_wildcard() {
+    // A child that produces no results (here a QN_NULL → Empty) makes the
+    // reducer shortcircuit to a wildcard over the whole index: NOT(nothing)
+    // matches everything.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(3);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let null_child = MockQueryNode::new(QueryNodeType::Null);
+    let mut not = MockQueryNode::new(QueryNodeType::Not);
+    not.opts_mut().weight = 1.0;
+    not.set_children(&[null_child.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    for expected in [1, 2, 3] {
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_not_wildcard_child_reduces_to_empty() {
+    // A wildcard child means NOT matches nothing → empty iterator.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(5);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut wc_child = MockQueryNode::new(QueryNodeType::Wildcard);
+    wc_child.opts_mut().weight = 1.0;
+    let mut not = MockQueryNode::new(QueryNodeType::Not);
+    not.opts_mut().weight = 1.0;
+    not.set_children(&[wc_child.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    assert_eq!(it.type_(), IteratorType::Empty);
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+// ---------------------------------------------------------------------------
 // QN_MISSING → Missing inverted-index iterator
 //
 // These require a real `IndexSpec` with a populated `missingFieldDict`, which
@@ -608,6 +665,167 @@ mod optional {
         assert_eq!(it.type_(), IteratorType::OptionalOptimized);
         // `existingDocs` is null in the term context, so the backing wildcard is
         // empty and the iterator yields nothing — but it must drain cleanly.
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QN_NOT → Not, wrapping a real child iterator.
+//
+// The non-shortcircuit path needs a child that is neither empty nor a
+// wildcard. A QN_IDS child resolving to a real document provides one, which
+// requires the full-FFI `TestContext`.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: `TestContext` and SDS creation call into the C library,
+// which Miri cannot execute.
+#[cfg(not(miri))]
+mod not {
+    use ffi::IndexFlags_Index_StoreFreqs;
+    use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+    use super::*;
+
+    #[test]
+    fn eval_not_wraps_real_child_in_not() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        // Three documents → maxDocId == 3; the NOT iterator yields every doc id
+        // *except* those matched by the child.
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        let id_c = context.add_document("doc_c");
+        assert_eq!((id_a, id_b, id_c), (1, 2, 3));
+
+        // Disable timeout checks so the (clock-based) default deadline of the
+        // zero-initialised `QueryEvalCtx` does not expire the iterator.
+        let mut sctx = context.sctx;
+        // SAFETY: `context.sctx` is a valid, exclusively-owned `RedisSearchCtx`.
+        unsafe { sctx.as_mut().time.skipTimeoutChecks = true };
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // QN_IDS child resolving to the middle document only.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
+        ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+
+        let mut not = MockQueryNode::new(QueryNodeType::Not);
+        not.opts_mut().weight = 1.0;
+        not.set_children(&[ids_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Not);
+        // Every id except the one matched by the child (doc 2).
+        for expected in [1, 3] {
+            let r = it.read().unwrap().expect("should have a result");
+            assert_eq!(r.doc_id, expected);
+        }
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_not_none_child_falls_back_to_wildcard() {
+        let _guard = GlobalGuard::default();
+        // Term context: the field exists but has no entry in `missingFieldDict`,
+        // so a QN_MISSING child makes `eval_node` return `None` — i.e. a NULL
+        // child pointer. This is distinct from a structurally-empty child (an
+        // `Empty` *iterator*, a non-null pointer handled by the reducer): here
+        // the NULL-child branch of `eval_not` builds a NOT over an `Empty`,
+        // which always reduces to a wildcard over the whole index — NOT(nothing)
+        // matches everything.
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        // Two documents → docTable maxDocId == 2; the wildcard fallback walks
+        // every id. `add_document` only touches the DocTable, never the
+        // `missingFieldDict`, so the QN_MISSING child still evaluates to `None`.
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // QN_MISSING child for a field with no missing values → evaluates to None.
+        let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
+        missing_child.set_missing_field(context.field_spec());
+
+        let mut not = MockQueryNode::new(QueryNodeType::Not);
+        not.opts_mut().weight = 1.0;
+        not.set_children(&[missing_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("a not node always yields an iterator")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Wildcard);
+        for expected in [1, 2] {
+            let r = it.read().unwrap().expect("should have a result");
+            assert_eq!(r.doc_id, expected);
+        }
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+    }
+
+    #[test]
+    fn eval_not_optimized_index_wraps_child_in_not_optimized() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        // `index_all` makes the reducer take the optimized (wildcard-backed)
+        // path, so `eval_not` must forward a `NotOptimized` variant.
+        // SAFETY: no iterator from this context is alive yet.
+        context.spec_write().rule_mut().set_index_all(true);
+
+        // Disable timeout checks so the (clock-based) default deadline of the
+        // zero-initialised `QueryEvalCtx` does not expire the iterator.
+        let mut sctx = context.sctx;
+        // SAFETY: `context.sctx` is a valid, exclusively-owned `RedisSearchCtx`.
+        unsafe { sctx.as_mut().time.skipTimeoutChecks = true };
+
+        let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        // QN_IDS child resolving to a real document → neither empty nor a
+        // wildcard, so the reducer skips its shortcircuits and reaches the
+        // optimized constructor.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
+        ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+
+        let mut not = MockQueryNode::new(QueryNodeType::Not);
+        not.opts_mut().weight = 1.0;
+        not.set_children(&[ids_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::NotOptimized);
+        // `existingDocs` is null in the term context, so the backing wildcard is
+        // empty: there are no "existing" documents to negate against, so the
+        // optimized NOT yields nothing — but it must drain cleanly.
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -8,6 +8,7 @@
 */
 
 use std::{
+    marker::PhantomData,
     ptr::NonNull,
     time::{Duration, Instant},
 };
@@ -116,28 +117,40 @@ impl TimeoutContext for TimeoutContextClock {
 /// the cost of a relaxed atomic load through the named extern is already
 /// in the same order of magnitude as a counter bump, and avoiding the
 /// counter keeps the hot path branch-free.
-pub struct TimeoutContextBlockedClient {
+///
+/// The `'req` lifetime tracks the borrow of the [`AREQ`] this context probes,
+/// so the type system prevents the context (and any iterator holding it) from
+/// outliving the request.
+pub struct TimeoutContextBlockedClient<'req> {
     /// [`AREQ`] pointer forwarded verbatim to [`AREQ_CheckTimedOut`].
     areq: NonNull<AREQ>,
+    /// Ties the context to the borrow of the [`AREQ`] it points at.
+    _areq: PhantomData<&'req AREQ>,
 }
 
-impl TimeoutContextBlockedClient {
+impl<'req> TimeoutContextBlockedClient<'req> {
     /// Build a new context wrapping `areq`.
     ///
     /// # Safety
     ///
     /// * `areq` must point to a valid [`AREQ`] (as defined in
-    ///   `src/aggregate/aggregate.h`).
-    /// * The pointee must outlive every iterator that holds this context.
+    ///   `src/aggregate/aggregate.h`) for the whole of `'req`.
+    /// * The caller must pick `'req` so that it does not outlive the [`AREQ`];
+    ///   since `'req` is otherwise unconstrained by the arguments, it is the
+    ///   caller's responsibility to bound it (e.g. by tying the returned
+    ///   context to a borrow that the request outlives).
     /// * The `RequestSyncCtx::timedOut` flag inside the [`AREQ`] must be safe
     ///   to read with relaxed semantics from any thread.
     #[inline(always)]
     pub const unsafe fn new(areq: NonNull<AREQ>) -> Self {
-        Self { areq }
+        Self {
+            areq,
+            _areq: PhantomData,
+        }
     }
 }
 
-impl TimeoutContext for TimeoutContextBlockedClient {
+impl TimeoutContext for TimeoutContextBlockedClient<'_> {
     /// Probe the AREQ timed-out flag via [`AREQ_CheckTimedOut`] and translate
     /// its `bool` reply into the iterator-level [`Result`].
     #[inline(always)]
@@ -178,16 +191,20 @@ impl TimeoutContext for NoTimeout {
 /// well-predicted branch on top of the inner variant's own work.
 ///
 /// [`check_timeout`]: TimeoutContext::check_timeout
-pub enum AnyTimeoutContext {
+///
+/// The `'req` lifetime is carried by the [`BlockedClient`](Self::BlockedClient)
+/// variant (the other two borrow nothing) and ties the context to the [`AREQ`]
+/// it probes, so it cannot outlive the request.
+pub enum AnyTimeoutContext<'req> {
     /// No timeout source: every probe is a no-op.
     NoTimeout(NoTimeout),
     /// Clock Based Timeout: amortized clock check.
     Clock(TimeoutContextClock),
     /// Blocked Client Timeout: relaxed atomic load against the AREQ flag.
-    BlockedClient(TimeoutContextBlockedClient),
+    BlockedClient(TimeoutContextBlockedClient<'req>),
 }
 
-impl AnyTimeoutContext {
+impl<'req> AnyTimeoutContext<'req> {
     /// Builds the timeout context from a search context's time settings.
     ///
     /// `skipTimeoutChecks` (or the absence of a deadline) opts out of timeout
@@ -207,7 +224,7 @@ impl AnyTimeoutContext {
     }
 }
 
-impl TimeoutContext for AnyTimeoutContext {
+impl TimeoutContext for AnyTimeoutContext<'_> {
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
         match self {


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/10081
- PR is using `master` as base so benchmarks are compared against it.
- You can just review the top commit directly.

Port the `QN_NOT` evaluation from C to the Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
