### PR TITLE
[MOD-16023] FT.AGGREGATE coordinator: sticky CoordRequestCtx timeout policy (fix TOCTOU)

### DIFF
--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -86,7 +86,10 @@ void CoordRequestCtx_SetRequest(CoordRequestCtx *ctx, void *req) {
     hreq->syncCtx.requiresAggregateResultsSync =
         (ctx->timeoutPolicy == TimeoutPolicy_ReturnStrict);
   } else if (ctx->type == COMMAND_AGGREGATE) {
-    ((AREQ *)req)->useReplyCallback = ctx->useReplyCallback;
+    AREQ *areq = (AREQ *)req;
+    areq->useReplyCallback = ctx->useReplyCallback;
+    areq->syncCtx.requiresAggregateResultsSync =
+        (ctx->timeoutPolicy == TimeoutPolicy_ReturnStrict);
   } else {
     COORD_REQUEST_CTX_UNSUPPORTED_TYPE();
   }

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -86,11 +86,11 @@ void CoordRequestCtx_SetRequest(CoordRequestCtx *ctx, void *req) {
     hreq->syncCtx.requiresAggregateResultsSync =
         (ctx->timeoutPolicy == TimeoutPolicy_ReturnStrict);
   } else if (ctx->type == COMMAND_AGGREGATE) {
-    // NB: do not derive requiresAggregateResultsSync here. The FT.CURSOR READ
-    // path attaches an existing cursor AREQ (aggregate_exec.c) via a ctx whose
-    // timeoutPolicy is left at the default, so deriving it here would clear the
-    // flag the cursor set at WITHCURSOR time. The query exec path sets it
-    // explicitly from the sticky policy instead.
+    // Do not derive requiresAggregateResultsSync here: the FT.CURSOR READ path
+    // attaches an existing cursor AREQ (aggregate_exec.c) via a ctx whose
+    // timeoutPolicy is left at the default, so deriving it would clear the flag
+    // the cursor set at WITHCURSOR time. The query exec path sets it explicitly
+    // from the request-captured policy instead.
     ((AREQ *)req)->useReplyCallback = ctx->useReplyCallback;
   } else {
     COORD_REQUEST_CTX_UNSUPPORTED_TYPE();

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -86,10 +86,12 @@ void CoordRequestCtx_SetRequest(CoordRequestCtx *ctx, void *req) {
     hreq->syncCtx.requiresAggregateResultsSync =
         (ctx->timeoutPolicy == TimeoutPolicy_ReturnStrict);
   } else if (ctx->type == COMMAND_AGGREGATE) {
-    AREQ *areq = (AREQ *)req;
-    areq->useReplyCallback = ctx->useReplyCallback;
-    areq->syncCtx.requiresAggregateResultsSync =
-        (ctx->timeoutPolicy == TimeoutPolicy_ReturnStrict);
+    // NB: do not derive requiresAggregateResultsSync here. The FT.CURSOR READ
+    // path attaches an existing cursor AREQ (aggregate_exec.c) via a ctx whose
+    // timeoutPolicy is left at the default, so deriving it here would clear the
+    // flag the cursor set at WITHCURSOR time. The query exec path sets it
+    // explicitly from the sticky policy instead.
+    ((AREQ *)req)->useReplyCallback = ctx->useReplyCallback;
   } else {
     COORD_REQUEST_CTX_UNSUPPORTED_TYPE();
   }

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -669,8 +669,11 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   AREQ *r = AREQ_New();
 
   // Sticky dispatch-time policy (CoordRequestCtx), not AREQ_New's RSGlobalConfig
-  // re-read; CoordRequestCtx_SetRequest derives requiresAggregateResultsSync from it.
+  // re-read, so the BG sync wiring agrees with the armed timeout callbacks.
   RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
+  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
+    r->syncCtx.requiresAggregateResultsSync = true;
+  }
   CoordRequestCtx_SetRequest(reqCtx, r);
   CoordRequestCtx_UnlockSetRequest(reqCtx);
 
@@ -968,6 +971,9 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // CMD, index, expr, args...
   r = &debug_req->r;
 
+  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
+    r->syncCtx.requiresAggregateResultsSync = true;
+  }
   CoordRequestCtx_SetRequest(reqCtx, r);
   CoordRequestCtx_UnlockSetRequest(reqCtx);
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -482,9 +482,21 @@ static bool shouldCheckInPipelineTimeoutCoord(AREQ *req) {
          (req->reqConfig.timeoutPolicy == TimeoutPolicy_Return);
 }
 
+// AREQ_New / AREQ_Compile re-read RSGlobalConfig on the BG thread, so once the
+// request is compiled we force the config + pipeline ctx the request consults
+// onto the policy captured at dispatch (CoordRequestCtx). This avoids a TOCTOU
+// against a concurrent FT.CONFIG SET that would otherwise let the BG worker and
+// the armed timeout callbacks disagree on the policy. Mirrors the hybrid path's
+// applyCoordReqConfigTimeoutPolicy. The caller recomputes skipTimeoutChecks
+// (via AREQ_SetSkipTimeoutChecks) after this, so it picks up the sticky value.
+static void applyCoordReqConfigTimeoutPolicy(AREQ *r, RSTimeoutPolicy policy) {
+  r->reqConfig.timeoutPolicy = policy;
+  r->pipeline.qctx.timeoutPolicy = policy;
+}
+
 static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                IndexSpec *sp, specialCaseCtx **knnCtx_ptr, size_t numShards,
-                               QueryError *status) {
+                               RSTimeoutPolicy stickyTimeoutPolicy, QueryError *status) {
   AREQ_QueryProcessingCtx(r)->err = status;
   AREQ_AddRequestFlags(r, QEXEC_F_IS_AGGREGATE | QEXEC_F_BUILDPIPELINE_NO_ROOT);
   rs_wall_clock_init(&r->profileClocks.initClock);
@@ -506,6 +518,11 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   rc = AREQ_Compile(r, ctx, argv + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
+
+  // AREQ_Compile re-read the timeout policy from RSGlobalConfig on this BG
+  // thread; pin it back to the dispatch-time value before the pipeline ctx and
+  // skipTimeoutChecks are derived from it below.
+  applyCoordReqConfigTimeoutPolicy(r, stickyTimeoutPolicy);
 
   r->profile = printAggProfile;
 
@@ -656,7 +673,11 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // CMD, index, expr, args...
   AREQ *r = AREQ_New();
 
-  if (r->reqConfig.timeoutPolicy == TimeoutPolicy_ReturnStrict) {
+  // Use the policy captured at dispatch (sticky on CoordRequestCtx), not the
+  // value AREQ_New just re-read from RSGlobalConfig, so the sync wiring agrees
+  // with the armed timeout callbacks even if FT.CONFIG SET raced dispatch.
+  RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
+  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
     r->syncCtx.requiresAggregateResultsSync = true;
   }
   CoordRequestCtx_SetRequest(reqCtx, r);
@@ -677,7 +698,8 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     goto err;
   }
 
-  if (prepareForExecution(r, ctx, argv, argc, sp, &knnCtx, numShards, &status) != REDISMODULE_OK) {
+  if (prepareForExecution(r, ctx, argv, argc, sp, &knnCtx, numShards, stickyTimeoutPolicy,
+                          &status) != REDISMODULE_OK) {
     goto err;
   }
 
@@ -927,6 +949,11 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   MRCommand *cmd = NULL;
   size_t numShards = 0;
   RPNet *rpnet = NULL;
+  // Use the policy captured at dispatch (sticky on CoordRequestCtx), not the
+  // value AREQ_New re-reads from RSGlobalConfig, so the sync wiring agrees with
+  // the armed timeout callbacks even if FT.CONFIG SET raced dispatch. Declared
+  // here (before any `goto err`) to avoid jumping over its initialization.
+  RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
@@ -952,7 +979,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // CMD, index, expr, args...
   r = &debug_req->r;
 
-  if (r->reqConfig.timeoutPolicy == TimeoutPolicy_ReturnStrict) {
+  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
     r->syncCtx.requiresAggregateResultsSync = true;
   }
   CoordRequestCtx_SetRequest(reqCtx, r);
@@ -972,7 +999,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
   if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, sp, &knnCtx, numShards,
-                          &status) != REDISMODULE_OK) {
+                          stickyTimeoutPolicy, &status) != REDISMODULE_OK) {
     goto err;
   }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -482,13 +482,9 @@ static bool shouldCheckInPipelineTimeoutCoord(AREQ *req) {
          (req->reqConfig.timeoutPolicy == TimeoutPolicy_Return);
 }
 
-// AREQ_New / AREQ_Compile re-read RSGlobalConfig on the BG thread, so once the
-// request is compiled we force the config + pipeline ctx the request consults
-// onto the policy captured at dispatch (CoordRequestCtx). This avoids a TOCTOU
-// against a concurrent FT.CONFIG SET that would otherwise let the BG worker and
-// the armed timeout callbacks disagree on the policy. Mirrors the hybrid path's
-// applyCoordReqConfigTimeoutPolicy. The caller recomputes skipTimeoutChecks
-// (via AREQ_SetSkipTimeoutChecks) after this, so it picks up the sticky value.
+// Pin the request's config + tail-pipeline policy to the dispatch-time value
+// (CoordRequestCtx), undoing AREQ_New/AREQ_Compile's RSGlobalConfig re-read on
+// the BG thread. Avoids a TOCTOU with a concurrent FT.CONFIG SET (mirrors hybrid).
 static void applyCoordReqConfigTimeoutPolicy(AREQ *r, RSTimeoutPolicy policy) {
   r->reqConfig.timeoutPolicy = policy;
   r->pipeline.qctx.timeoutPolicy = policy;
@@ -519,9 +515,8 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   rc = AREQ_Compile(r, ctx, argv + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
-  // AREQ_Compile re-read the timeout policy from RSGlobalConfig on this BG
-  // thread; pin it back to the dispatch-time value before the pipeline ctx and
-  // skipTimeoutChecks are derived from it below.
+  // Pin back to the dispatch-time policy before skipTimeoutChecks / the pipeline
+  // ctx are derived from it below.
   applyCoordReqConfigTimeoutPolicy(r, stickyTimeoutPolicy);
 
   r->profile = printAggProfile;
@@ -673,11 +668,8 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // CMD, index, expr, args...
   AREQ *r = AREQ_New();
 
-  // Use the policy captured at dispatch (sticky on CoordRequestCtx), not the
-  // value AREQ_New just re-read from RSGlobalConfig, so the tail pipeline agrees
-  // with the armed timeout callbacks even if FT.CONFIG SET raced dispatch.
-  // CoordRequestCtx_SetRequest derives requiresAggregateResultsSync from the
-  // same sticky policy.
+  // Sticky dispatch-time policy (CoordRequestCtx), not AREQ_New's RSGlobalConfig
+  // re-read; CoordRequestCtx_SetRequest derives requiresAggregateResultsSync from it.
   RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
   CoordRequestCtx_SetRequest(reqCtx, r);
   CoordRequestCtx_UnlockSetRequest(reqCtx);
@@ -948,11 +940,8 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   MRCommand *cmd = NULL;
   size_t numShards = 0;
   RPNet *rpnet = NULL;
-  // Use the policy captured at dispatch (sticky on CoordRequestCtx), not the
-  // value AREQ_New re-reads from RSGlobalConfig, so the tail pipeline agrees with
-  // the armed timeout callbacks even if FT.CONFIG SET raced dispatch (the sync
-  // flag is derived from the same sticky policy in CoordRequestCtx_SetRequest).
-  // Declared here (before any `goto err`) to avoid jumping over its initialization.
+  // Sticky dispatch-time policy (see RSExecDistAggregate). Declared here, before
+  // any `goto err`, to avoid jumping over its initialization.
   RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -674,12 +674,11 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   AREQ *r = AREQ_New();
 
   // Use the policy captured at dispatch (sticky on CoordRequestCtx), not the
-  // value AREQ_New just re-read from RSGlobalConfig, so the sync wiring agrees
+  // value AREQ_New just re-read from RSGlobalConfig, so the tail pipeline agrees
   // with the armed timeout callbacks even if FT.CONFIG SET raced dispatch.
+  // CoordRequestCtx_SetRequest derives requiresAggregateResultsSync from the
+  // same sticky policy.
   RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
-  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
-    r->syncCtx.requiresAggregateResultsSync = true;
-  }
   CoordRequestCtx_SetRequest(reqCtx, r);
   CoordRequestCtx_UnlockSetRequest(reqCtx);
 
@@ -950,9 +949,10 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   size_t numShards = 0;
   RPNet *rpnet = NULL;
   // Use the policy captured at dispatch (sticky on CoordRequestCtx), not the
-  // value AREQ_New re-reads from RSGlobalConfig, so the sync wiring agrees with
-  // the armed timeout callbacks even if FT.CONFIG SET raced dispatch. Declared
-  // here (before any `goto err`) to avoid jumping over its initialization.
+  // value AREQ_New re-reads from RSGlobalConfig, so the tail pipeline agrees with
+  // the armed timeout callbacks even if FT.CONFIG SET raced dispatch (the sync
+  // flag is derived from the same sticky policy in CoordRequestCtx_SetRequest).
+  // Declared here (before any `goto err`) to avoid jumping over its initialization.
   RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
@@ -979,9 +979,6 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // CMD, index, expr, args...
   r = &debug_req->r;
 
-  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
-    r->syncCtx.requiresAggregateResultsSync = true;
-  }
   CoordRequestCtx_SetRequest(reqCtx, r);
   CoordRequestCtx_UnlockSetRequest(reqCtx);
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -492,7 +492,7 @@ static void applyCoordReqConfigTimeoutPolicy(AREQ *r, RSTimeoutPolicy policy) {
 
 static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                IndexSpec *sp, specialCaseCtx **knnCtx_ptr, size_t numShards,
-                               RSTimeoutPolicy stickyTimeoutPolicy, QueryError *status) {
+                               RSTimeoutPolicy requestTimeoutPolicy, QueryError *status) {
   AREQ_QueryProcessingCtx(r)->err = status;
   AREQ_AddRequestFlags(r, QEXEC_F_IS_AGGREGATE | QEXEC_F_BUILDPIPELINE_NO_ROOT);
   rs_wall_clock_init(&r->profileClocks.initClock);
@@ -517,7 +517,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   // Pin back to the dispatch-time policy before skipTimeoutChecks / the pipeline
   // ctx are derived from it below.
-  applyCoordReqConfigTimeoutPolicy(r, stickyTimeoutPolicy);
+  applyCoordReqConfigTimeoutPolicy(r, requestTimeoutPolicy);
 
   r->profile = printAggProfile;
 
@@ -668,10 +668,10 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // CMD, index, expr, args...
   AREQ *r = AREQ_New();
 
-  // Sticky dispatch-time policy (CoordRequestCtx), not AREQ_New's RSGlobalConfig
-  // re-read, so the BG sync wiring agrees with the armed timeout callbacks.
-  RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
-  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
+  // The global timeout policy may change before this background job is picked up.
+  // Use the policy captured from the original request.
+  RSTimeoutPolicy requestTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
+  if (requestTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
     r->syncCtx.requiresAggregateResultsSync = true;
   }
   CoordRequestCtx_SetRequest(reqCtx, r);
@@ -692,7 +692,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     goto err;
   }
 
-  if (prepareForExecution(r, ctx, argv, argc, sp, &knnCtx, numShards, stickyTimeoutPolicy,
+  if (prepareForExecution(r, ctx, argv, argc, sp, &knnCtx, numShards, requestTimeoutPolicy,
                           &status) != REDISMODULE_OK) {
     goto err;
   }
@@ -943,9 +943,10 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   MRCommand *cmd = NULL;
   size_t numShards = 0;
   RPNet *rpnet = NULL;
-  // Sticky dispatch-time policy (see RSExecDistAggregate). Declared here, before
-  // any `goto err`, to avoid jumping over its initialization.
-  RSTimeoutPolicy stickyTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
+  // The global timeout policy may change before this background job is picked up.
+  // Use the policy captured from the original request. Declared here, before any
+  // `goto err`, to avoid jumping over its initialization.
+  RSTimeoutPolicy requestTimeoutPolicy = CoordRequestCtx_GetTimeoutPolicy(reqCtx);
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
@@ -971,7 +972,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // CMD, index, expr, args...
   r = &debug_req->r;
 
-  if (stickyTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
+  if (requestTimeoutPolicy == TimeoutPolicy_ReturnStrict) {
     r->syncCtx.requiresAggregateResultsSync = true;
   }
   CoordRequestCtx_SetRequest(reqCtx, r);
@@ -991,7 +992,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
   if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, sp, &knnCtx, numShards,
-                          stickyTimeoutPolicy, &status) != REDISMODULE_OK) {
+                          requestTimeoutPolicy, &status) != REDISMODULE_OK) {
     goto err;
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -3786,7 +3786,10 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   handlerCtx.bcCtx.privdata = reqCtx;
   handlerCtx.bcCtx.free_privdata = DistCoordReqFreePrivData;
 
+  // Capture the policy on the main thread so BG and the timeout callback agree
+  // on one value (avoids a TOCTOU against a concurrent FT.CONFIG SET).
   RSTimeoutPolicy policy = RSGlobalConfig.requestConfigParams.timeoutPolicy;
+  CoordRequestCtx_SetTimeoutPolicy(reqCtx, policy);
   if (policy == TimeoutPolicy_Fail || policy == TimeoutPolicy_ReturnStrict) {
     handlerCtx.bcCtx.reply_callback = DistAggregateReplyCallback;
     handlerCtx.bcCtx.timeout_callback = (policy == TimeoutPolicy_Fail)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The coordinator FT.AGGREGATE path reads the timeout policy twice on different threads. `DistAggregateCommandImp` (main thread) arms the reply/timeout callbacks from `RSGlobalConfig.requestConfigParams.timeoutPolicy`, while `RSExecDistAggregate` / `DEBUG_RSExecDistAggregate` (background thread) re-derive `requiresAggregateResultsSync` and the tail-pipeline policy from the value `AREQ_New`/`AREQ_Compile` re-read from the global. A concurrent `FT.CONFIG SET` between dispatch and background execution can make the armed callbacks and the BG worker disagree on the policy (TOCTOU).
2. **Change:** Capture the policy once on the main thread via `CoordRequestCtx_SetTimeoutPolicy`, and read it back on the BG thread via `CoordRequestCtx_GetTimeoutPolicy` for the `requiresAggregateResultsSync` decision. After `AREQ_Compile`, pin `reqConfig.timeoutPolicy` and the tail pipeline `qctx` onto the dispatch-time value (new `applyCoordReqConfigTimeoutPolicy` helper) so `skipTimeoutChecks` and the tail pipeline run under the sticky policy. Applied identically to the standard and `_FT.DEBUG` paths.
3. **Outcome:** The BG worker no longer re-reads `RSGlobalConfig` for the policy; the policy is captured once at dispatch and read from `CoordRequestCtx`. An `FT.CONFIG SET` racing dispatch→BG can no longer make the armed callbacks and the BG sync wiring disagree. This is the FT.AGGREGATE counterpart of the FT.HYBRID fix in MOD-14075 / #9942.

#### Which additional issues this PR fixes
1. MOD-16023

#### Main objects this PR modified
1. `DistAggregateCommandImp` (`src/module.c`)
2. `RSExecDistAggregate`, `DEBUG_RSExecDistAggregate`, `prepareForExecution`, new `applyCoordReqConfigTimeoutPolicy` (`src/coord/dist_aggregate.c`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal correctness/consistency hardening with no user-visible behavior change. Verified empirically: the mismatch the fix prevents has no deterministic end-to-end observable (the RETURN_STRICT timeout callback's `TryClaim` wins whenever the BG skips the handshake, producing the same client reply either way), which is also why the FT.HYBRID counterpart (#9942) shipped without a dedicated race test.
