### PR TITLE
[MOD-10044] Support for EXPLAINSCORE for FT.HYBRID

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2444,6 +2444,12 @@
         ]
       },
       {
+        "name": "explainscore",
+        "type": "pure-token",
+        "token": "EXPLAINSCORE",
+        "optional": true
+      },
+      {
         "name": "params",
         "type": "block",
         "optional": true,

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2725,6 +2725,12 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
         },
       },
       {
+        .name = "explainscore",
+        .token = "EXPLAINSCORE",
+        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      },
+      {
         .name = "params",
         .type = REDISMODULE_ARG_TYPE_BLOCK,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -333,6 +333,13 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
     MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
   }
 
+  // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
+  // tree and the shard's merger wraps it. The coordinator reassembles the
+  // results as-is.
+  if (RMUtil_ArgIndex("EXPLAINSCORE", argv, argc) != -1) {
+    MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"));
+  }
+
   // Add WITHCURSOR
   MRCommand_Append(xcmd, "WITHCURSOR", strlen("WITHCURSOR"));
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -233,6 +233,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 // modification by the command modifier callback in SHARD_K_RATIO optimization).
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
+                            bool sendExplainScore,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex) {
   RS_ASSERT(outKArgIndex != NULL);
@@ -335,8 +336,10 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it. The coordinator reassembles the
-  // results as-is.
-  if (RMUtil_ArgIndex("EXPLAINSCORE", argv, argc) != -1) {
+  // results as-is. The gate is the parsed top-level flag, not an argv text
+  // scan: a SEARCH query token or PARAMS value equal to "EXPLAINSCORE" must
+  // not look like the user requested the option.
+  if (sendExplainScore) {
     MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"));
   }
 
@@ -683,8 +686,9 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Construct the command string
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized,
-                                 sp, &hreq->kArgIndex);
+    HybridRequest_buildMRCommand(argv, argc, profileOptions,
+                                 (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0,
+                                 &xcmd, serialized, sp, &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -335,10 +335,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   }
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
-  // tree and the shard's merger wraps it. The coordinator reassembles the
-  // results as-is. The gate is the parsed top-level flag, not an argv text
-  // scan: a SEARCH query token or PARAMS value equal to "EXPLAINSCORE" must
-  // not look like the user requested the option.
+  // tree and the shard's merger wraps it.
   if (sendExplainScore) {
     MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"));
   }
@@ -686,8 +683,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Construct the command string
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions,
-                                 (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0,
+    bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
+    HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
                                  &xcmd, serialized, sp, &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -669,6 +669,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     for (size_t i = 0; i < hreq->nrequests; i++) {
         AREQ *areq = hreq->requests[i];
         if (AGGPLN_Distribute(AREQ_AGGPlan(areq), status) != REDISMODULE_OK) {
+            HybridPipelineParams_Cleanup(&hybridParams);
             return REDISMODULE_ERR;
         }
     }
@@ -678,6 +679,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     arrayof(char*) serialized = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, lookups, status);
     if (!serialized) {
+      HybridPipelineParams_Cleanup(&hybridParams);
       return REDISMODULE_ERR;
     }
 

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,6 +31,7 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 // For testing purposes
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
+                            bool sendExplainScore,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex);
 

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -12,82 +12,13 @@
 #include "rpnet.h"
 #include "rmr/reply.h"
 #include "rmr/rmr.h"
-#include "hiredis/sds.h"
 #include "coord/dist_utils.h"
 #include "debug_commands.h"
-#include "score_explain.h"
+#include "score_explain_mr.h"
 #include "rmalloc.h"
 
 
 #define CURSOR_EOF 0
-
-
-// Duplicate a string MRReply into a heap-allocated NUL-terminated buffer via
-// rm_malloc (so SEDestroy's rm_free is balanced).
-static char *mrReplyDupString(const MRReply *r) {
-  size_t len = 0;
-  const char *s = MRReply_String(r, &len);
-  if (!s) {
-    char *empty = rm_malloc(1);
-    empty[0] = '\0';
-    return empty;
-  }
-  char *out = rm_malloc(len + 1);
-  memcpy(out, s, len);
-  out[len] = '\0';
-  return out;
-}
-
-// Recursively fill an RSScoreExplain node from a wire-format MRReply.
-//
-// The shard-side serializer (SEReply / recExplainReply) emits each non-leaf
-// node as a 2-element array [str, [children...]] and each leaf as a bare
-// string. Reconstruct the same tree so the coordinator-side SEReply produces
-// identical output downstream.
-static void mrReplyFillScoreExplain(RSScoreExplain *node, const MRReply *r) {
-  if (!r) {
-    node->str = rm_strdup("");
-    node->numChildren = 0;
-    node->children = NULL;
-    return;
-  }
-  const int type = MRReply_Type(r);
-  if (type == MR_REPLY_STRING || type == MR_REPLY_STATUS) {
-    node->str = mrReplyDupString(r);
-    node->numChildren = 0;
-    node->children = NULL;
-    return;
-  }
-  if (type == MR_REPLY_ARRAY && MRReply_Length(r) == 2) {
-    node->str = mrReplyDupString(MRReply_ArrayElement(r, 0));
-    const MRReply *childArr = MRReply_ArrayElement(r, 1);
-    if (childArr && MRReply_Type(childArr) == MR_REPLY_ARRAY) {
-      const size_t n = MRReply_Length(childArr);
-      node->numChildren = (int)n;
-      node->children = n ? rm_calloc(n, sizeof(RSScoreExplain)) : NULL;
-      for (size_t i = 0; i < n; i++) {
-        mrReplyFillScoreExplain(&node->children[i], MRReply_ArrayElement(childArr, i));
-      }
-    } else {
-      node->numChildren = 0;
-      node->children = NULL;
-    }
-    return;
-  }
-  // Unexpected shape: fall back to a placeholder leaf so the tree stays
-  // well-formed and SEDestroy will free it cleanly.
-  node->str = rm_strdup("<malformed explain>");
-  node->numChildren = 0;
-  node->children = NULL;
-}
-
-// Build an RSScoreExplain tree from the shard's wire-format explain reply.
-// Returns a heap-allocated root suitable for SearchResult_SetScoreExplain.
-static RSScoreExplain *mrReplyToScoreExplain(const MRReply *r) {
-  RSScoreExplain *root = rm_calloc(1, sizeof(RSScoreExplain));
-  mrReplyFillScoreExplain(root, r);
-  return root;
-}
 
 static RSValue *MRReply_ToValue(MRReply *r) {
   if (!r) return RSValue_NullStatic();
@@ -707,25 +638,23 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   // The score is optional, in hybrid we need the score for the sorter and hybrid merger
   // We expect for it to exist in hybrid since we send WITHSCORES to the shard and we should use resp3
   // when opening shard connections.
-  //
-  // With EXPLAINSCORE the shard wraps the score as a 2-element array
-  // [score, explain-tree]. Reconstruct the RSScoreExplain so the
-  // coordinator's hybrid merger can wrap it.
   if (score) {
-    const int scoreType = MRReply_Type(score);
-    if (scoreType == MR_REPLY_DOUBLE) {
-      SearchResult_SetScore(r, MRReply_Double(score));
-    } else if (scoreType == MR_REPLY_ARRAY && MRReply_Length(score) == 2) {
+    const bool expectExplain = (nc->areq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
+    if (expectExplain) {
+      RS_LOG_ASSERT(MRReply_Type(score) == MR_REPLY_ARRAY &&
+                        MRReply_Length(score) == SE_REPLY_NODE_ARITY,
+                    "EXPLAINSCORE expected score paired with explain tree");
       const MRReply *scoreValue = MRReply_ArrayElement(score, 0);
       const MRReply *explainReply = MRReply_ArrayElement(score, 1);
       RS_LOG_ASSERT(scoreValue && MRReply_Type(scoreValue) == MR_REPLY_DOUBLE,
                     "invalid score record");
       SearchResult_SetScore(r, MRReply_Double(scoreValue));
       if (explainReply) {
-        SearchResult_SetScoreExplain(r, mrReplyToScoreExplain(explainReply));
+        SearchResult_SetScoreExplain(r, SE_FromMRReply(explainReply));
       }
     } else {
-      RS_LOG_ASSERT(0, "invalid score record");
+      RS_LOG_ASSERT(MRReply_Type(score) == MR_REPLY_DOUBLE, "invalid score record");
+      SearchResult_SetScore(r, MRReply_Double(score));
     }
   }
 

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -15,10 +15,79 @@
 #include "hiredis/sds.h"
 #include "coord/dist_utils.h"
 #include "debug_commands.h"
+#include "score_explain.h"
+#include "rmalloc.h"
 
 
 #define CURSOR_EOF 0
 
+
+// Duplicate a string MRReply into a heap-allocated NUL-terminated buffer via
+// rm_malloc (so SEDestroy's rm_free is balanced).
+static char *mrReplyDupString(const MRReply *r) {
+  size_t len = 0;
+  const char *s = MRReply_String(r, &len);
+  if (!s) {
+    char *empty = rm_malloc(1);
+    empty[0] = '\0';
+    return empty;
+  }
+  char *out = rm_malloc(len + 1);
+  memcpy(out, s, len);
+  out[len] = '\0';
+  return out;
+}
+
+// Recursively fill an RSScoreExplain node from a wire-format MRReply.
+//
+// The shard-side serializer (SEReply / recExplainReply) emits each non-leaf
+// node as a 2-element array [str, [children...]] and each leaf as a bare
+// string. Reconstruct the same tree so the coordinator-side SEReply produces
+// identical output downstream.
+static void mrReplyFillScoreExplain(RSScoreExplain *node, const MRReply *r) {
+  if (!r) {
+    node->str = rm_strdup("");
+    node->numChildren = 0;
+    node->children = NULL;
+    return;
+  }
+  const int type = MRReply_Type(r);
+  if (type == MR_REPLY_STRING || type == MR_REPLY_STATUS) {
+    node->str = mrReplyDupString(r);
+    node->numChildren = 0;
+    node->children = NULL;
+    return;
+  }
+  if (type == MR_REPLY_ARRAY && MRReply_Length(r) == 2) {
+    node->str = mrReplyDupString(MRReply_ArrayElement(r, 0));
+    const MRReply *childArr = MRReply_ArrayElement(r, 1);
+    if (childArr && MRReply_Type(childArr) == MR_REPLY_ARRAY) {
+      const size_t n = MRReply_Length(childArr);
+      node->numChildren = (int)n;
+      node->children = n ? rm_calloc(n, sizeof(RSScoreExplain)) : NULL;
+      for (size_t i = 0; i < n; i++) {
+        mrReplyFillScoreExplain(&node->children[i], MRReply_ArrayElement(childArr, i));
+      }
+    } else {
+      node->numChildren = 0;
+      node->children = NULL;
+    }
+    return;
+  }
+  // Unexpected shape: fall back to a placeholder leaf so the tree stays
+  // well-formed and SEDestroy will free it cleanly.
+  node->str = rm_strdup("<malformed explain>");
+  node->numChildren = 0;
+  node->children = NULL;
+}
+
+// Build an RSScoreExplain tree from the shard's wire-format explain reply.
+// Returns a heap-allocated root suitable for SearchResult_SetScoreExplain.
+static RSScoreExplain *mrReplyToScoreExplain(const MRReply *r) {
+  RSScoreExplain *root = rm_calloc(1, sizeof(RSScoreExplain));
+  mrReplyFillScoreExplain(root, r);
+  return root;
+}
 
 static RSValue *MRReply_ToValue(MRReply *r) {
   if (!r) return RSValue_NullStatic();
@@ -637,10 +706,27 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
   // The score is optional, in hybrid we need the score for the sorter and hybrid merger
   // We expect for it to exist in hybrid since we send WITHSCORES to the shard and we should use resp3
-  // when opening shard connections
+  // when opening shard connections.
+  //
+  // With EXPLAINSCORE the shard wraps the score as a 2-element array
+  // [score, explain-tree]. Reconstruct the RSScoreExplain so the
+  // coordinator's hybrid merger can wrap it.
   if (score) {
-    RS_LOG_ASSERT(MRReply_Type(score) == MR_REPLY_DOUBLE, "invalid score record");
-    SearchResult_SetScore(r, MRReply_Double(score));
+    const int scoreType = MRReply_Type(score);
+    if (scoreType == MR_REPLY_DOUBLE) {
+      SearchResult_SetScore(r, MRReply_Double(score));
+    } else if (scoreType == MR_REPLY_ARRAY && MRReply_Length(score) == 2) {
+      MRReply *scoreValue = MRReply_ArrayElement(score, 0);
+      MRReply *explainReply = MRReply_ArrayElement(score, 1);
+      RS_LOG_ASSERT(scoreValue && MRReply_Type(scoreValue) == MR_REPLY_DOUBLE,
+                    "invalid score record");
+      SearchResult_SetScore(r, MRReply_Double(scoreValue));
+      if (explainReply) {
+        SearchResult_SetScoreExplain(r, mrReplyToScoreExplain(explainReply));
+      }
+    } else {
+      RS_LOG_ASSERT(0, "invalid score record");
+    }
   }
 
   for (size_t i = 0; i < fields_length; i += 2) {

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -716,8 +716,8 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
     if (scoreType == MR_REPLY_DOUBLE) {
       SearchResult_SetScore(r, MRReply_Double(score));
     } else if (scoreType == MR_REPLY_ARRAY && MRReply_Length(score) == 2) {
-      MRReply *scoreValue = MRReply_ArrayElement(score, 0);
-      MRReply *explainReply = MRReply_ArrayElement(score, 1);
+      const MRReply *scoreValue = MRReply_ArrayElement(score, 0);
+      const MRReply *explainReply = MRReply_ArrayElement(score, 1);
       RS_LOG_ASSERT(scoreValue && MRReply_Type(scoreValue) == MR_REPLY_DOUBLE,
                     "invalid score record");
       SearchResult_SetScore(r, MRReply_Double(scoreValue));

--- a/src/coord/score_explain_mr.c
+++ b/src/coord/score_explain_mr.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "score_explain_mr.h"
+#include "rmalloc.h"
+#include "rmutil/rm_assert.h"
+#include <string.h>
+
+// Allocate via rm_malloc so SEDestroy's rm_free is balanced.
+static char *dupStringReply(const MRReply *r) {
+  size_t len = 0;
+  const char *s = MRReply_String(r, &len);
+  RS_LOG_ASSERT(s, "SE_FromMRReply: expected a string reply for explain node label");
+  char *out = rm_malloc(len + 1);
+  memcpy(out, s, len);
+  out[len] = '\0';
+  return out;
+}
+
+static void fillFromMRReply(RSScoreExplain *node, const MRReply *r) {
+  RS_LOG_ASSERT(r, "SE_FromMRReply: NULL reply node");
+  const int type = MRReply_Type(r);
+  if (type == MR_REPLY_STRING || type == MR_REPLY_STATUS) {
+    node->str = dupStringReply(r);
+    node->numChildren = 0;
+    node->children = NULL;
+    return;
+  }
+  RS_LOG_ASSERT(type == MR_REPLY_ARRAY && MRReply_Length(r) == SE_REPLY_NODE_ARITY,
+                "SE_FromMRReply: malformed explain node (serializer/deserializer mismatch)");
+
+  node->str = dupStringReply(MRReply_ArrayElement(r, 0));
+  const MRReply *childArr = MRReply_ArrayElement(r, 1);
+  RS_LOG_ASSERT(childArr && MRReply_Type(childArr) == MR_REPLY_ARRAY,
+                "SE_FromMRReply: malformed explain node children");
+
+  const size_t n = MRReply_Length(childArr);
+  node->numChildren = (int)n;
+  node->children = n ? rm_calloc(n, sizeof(RSScoreExplain)) : NULL;
+  for (size_t i = 0; i < n; i++) {
+    fillFromMRReply(&node->children[i], MRReply_ArrayElement(childArr, i));
+  }
+}
+
+RSScoreExplain *SE_FromMRReply(const MRReply *r) {
+  RSScoreExplain *root = rm_calloc(1, sizeof(RSScoreExplain));
+  fillFromMRReply(root, r);
+  return root;
+}

--- a/src/coord/score_explain_mr.h
+++ b/src/coord/score_explain_mr.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include "rmr/reply.h"
+#include "score_explain.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Arity of a non-leaf wire node emitted by recExplainReply in score_explain.c.
+#define SE_REPLY_NODE_ARITY 2
+
+// Inverse of SEReply: reconstruct an RSScoreExplain tree from a shard reply.
+// The returned root is heap-owned by the caller — release with SEDestroy.
+// Any shape that SEReply could not have produced aborts.
+RSScoreExplain *SE_FromMRReply(const MRReply *r);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -190,9 +190,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
 
   int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, status, false, EXEC_NO_FLAGS);
   if (rc != REDISMODULE_OK) {
-    if (hybridParams.scoringCtx) {
-      HybridScoringContext_Free(hybridParams.scoringCtx);
-    }
+    HybridPipelineParams_Cleanup(&hybridParams);
     HybridRequest_DecrRef(hreq);
     return NULL;
   }
@@ -206,9 +204,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   // Set request flags from hybridParams
   hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
   if (HybridRequest_BuildPipeline(hreq, &hybridParams, false, status) != REDISMODULE_OK) {
-    if (hybridParams.scoringCtx) {
-      HybridScoringContext_Free(hybridParams.scoringCtx);
-    }
+    HybridPipelineParams_Cleanup(&hybridParams);
     HybridRequest_DecrRef(hreq);
     return NULL;
   }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -11,7 +11,6 @@
 #include "search_result_ffi.h"
 #include "parse_hybrid.h"
 #include "hybrid_request.h"
-#include "hybrid_search_result.h"
 #include "aggregate/aggregate_exec_common.h"
 #include "debug_commands.h"
 
@@ -598,14 +597,7 @@ static inline void freeHybridParams(HybridPipelineParams *hybridParams) {
   if (hybridParams == NULL) {
     return;
   }
-  if (hybridParams->scoringCtx) {
-    HybridScoringContext_Free(hybridParams->scoringCtx);
-    hybridParams->scoringCtx = NULL;
-  }
-  if (hybridParams->explainCtx) {
-    HybridExplainContext_Free(hybridParams->explainCtx);
-    hybridParams->explainCtx = NULL;
-  }
+  HybridPipelineParams_Cleanup(hybridParams);
   rm_free(hybridParams);
 }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -11,6 +11,7 @@
 #include "search_result_ffi.h"
 #include "parse_hybrid.h"
 #include "hybrid_request.h"
+#include "hybrid_search_result.h"
 #include "aggregate/aggregate_exec_common.h"
 #include "debug_commands.h"
 
@@ -600,6 +601,10 @@ static inline void freeHybridParams(HybridPipelineParams *hybridParams) {
   if (hybridParams->scoringCtx) {
     HybridScoringContext_Free(hybridParams->scoringCtx);
     hybridParams->scoringCtx = NULL;
+  }
+  if (hybridParams->explainCtx) {
+    HybridExplainContext_Free(hybridParams->explainCtx);
+    hybridParams->explainCtx = NULL;
   }
   rm_free(hybridParams);
 }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -7,6 +7,7 @@
 #include "hybrid/hybrid_scoring.h"
 #include "hybrid/hybrid_lookup_context.h"
 #include "hybrid/hybrid_lookup_context.h"
+#include "hybrid/hybrid_search_result.h"
 #include "document.h"
 #include "aggregate/aggregate_plan.h"
 #include "aggregate/aggregate.h"
@@ -157,9 +158,14 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     // to create missing keys
     bool createMissingKeys = (req->reqflags & QEXEC_AGG_LOAD_ALL) != 0;
     HybridLookupContext *lookupCtx = HybridLookupContext_New(req->requests, tailLookup, createMissingKeys);
+    HybridExplainContext *explainCtx = NULL;
+    if (req->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) {
+      explainCtx = HybridExplainContext_Build(req->requests[SEARCH_INDEX], req->requests[VECTOR_INDEX]);
+    }
     ResultProcessor *merger = RPHybridMerger_New(params->aggregationParams.common.sctx,
                                                  params->scoringCtx, upstreams, req->nrequests,
-                                                 docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx);
+                                                 docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx,
+                                                 explainCtx);
     params->scoringCtx = NULL; // ownership transferred to merger
     QITR_PushRP(&req->tailPipeline->qctx, merger);
     // Build the aggregation part of the tail pipeline for final result processing

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -158,10 +158,9 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     // to create missing keys
     bool createMissingKeys = (req->reqflags & QEXEC_AGG_LOAD_ALL) != 0;
     HybridLookupContext *lookupCtx = HybridLookupContext_New(req->requests, tailLookup, createMissingKeys);
-    HybridExplainContext *explainCtx = NULL;
-    if (req->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) {
-      explainCtx = HybridExplainContext_Build(req->requests[SEARCH_INDEX], req->requests[VECTOR_INDEX]);
-    }
+    // Built at parse time (parseHybridCommand) and carried on params; take ownership here.
+    HybridExplainContext *explainCtx = params->explainCtx;
+    params->explainCtx = NULL; // ownership transferred to merger
     ResultProcessor *merger = RPHybridMerger_New(params->aggregationParams.common.sctx,
                                                  params->scoringCtx, upstreams, req->nrequests,
                                                  docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx,

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -127,6 +127,20 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req) {
   }
 }
 
+void HybridPipelineParams_Cleanup(HybridPipelineParams *params) {
+    if (!params) {
+        return;
+    }
+    if (params->scoringCtx) {
+        HybridScoringContext_Free(params->scoringCtx);
+        params->scoringCtx = NULL;
+    }
+    if (params->explainCtx) {
+        HybridExplainContext_Free(params->explainCtx);
+        params->explainCtx = NULL;
+    }
+}
+
 int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params, QueryError *status) {
     // Array to collect upstream from each individual request pipeline
     arrayof(ResultProcessor*) upstreams = array_new(ResultProcessor *, req->nrequests);
@@ -158,9 +172,8 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     // to create missing keys
     bool createMissingKeys = (req->reqflags & QEXEC_AGG_LOAD_ALL) != 0;
     HybridLookupContext *lookupCtx = HybridLookupContext_New(req->requests, tailLookup, createMissingKeys);
-    // Built at parse time (parseHybridCommand) and carried on params; take ownership here.
     HybridExplainContext *explainCtx = params->explainCtx;
-    params->explainCtx = NULL; // ownership transferred to merger
+    params->explainCtx = NULL; // ownership transferred to merger (built in parseHybridCommand)
     ResultProcessor *merger = RPHybridMerger_New(params->aggregationParams.common.sctx,
                                                  params->scoringCtx, upstreams, req->nrequests,
                                                  docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx,

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -234,6 +234,17 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req);
 int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params, QueryError *status);
 
 /**
+ * Free the heap-owned members of a HybridPipelineParams (scoring and EXPLAINSCORE
+ * contexts) and NULL them out, without freeing the params struct itself.
+ *
+ * Safe to call repeatedly and after ownership has been transferred to the merger
+ * (the relevant pointers are NULLed on transfer, so this becomes a no-op). Use it
+ * to release a stack- or caller-owned HybridPipelineParams on an error path before
+ * the merge pipeline is built; freeHybridParams() calls it for heap-allocated params.
+ */
+void HybridPipelineParams_Cleanup(HybridPipelineParams *params);
+
+/**
  * Build the complete hybrid search pipeline.
  * This function orchestrates the construction of both the depletion and merge pipelines.
  *

--- a/src/hybrid/hybrid_scoring.c
+++ b/src/hybrid/hybrid_scoring.c
@@ -1,6 +1,9 @@
 #include "hybrid/hybrid_scoring.h"
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
 
  /* Get scoring function based on scoring type */
  HybridScoringFunction GetScoringFunction(HybridScoringType scoringType) {
@@ -136,6 +139,24 @@ HybridScoringContext* HybridScoringContext_NewLinear(const double *weights, size
  */
 HybridScoringContext* HybridScoringContext_NewDefault(void) {
     return HybridScoringContext_NewRRF(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW, false);
+}
+
+char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx) {
+  RS_ASSERT(scoringCtx);
+  char *buf = NULL;
+  if (scoringCtx->scoringType == HYBRID_SCORING_RRF) {
+    rm_asprintf(&buf, "Hybrid score (RRF: window=%zu, constant=%.2f)",
+                scoringCtx->rrfCtx.window, scoringCtx->rrfCtx.constant);
+  } else {
+    RS_ASSERT(scoringCtx->scoringType == HYBRID_SCORING_LINEAR);
+    const double *w = scoringCtx->linearCtx.linearWeights;
+    const size_t numWeights = scoringCtx->linearCtx.numWeights;
+    const double alpha = numWeights > 0 ? w[0] : 0.0;
+    const double beta = numWeights > 1 ? w[1] : 0.0;
+    rm_asprintf(&buf, "Hybrid score (LINEAR: alpha=%.4f, beta=%.4f, window=%zu)",
+                alpha, beta, scoringCtx->linearCtx.window);
+  }
+  return buf;
 }
 
 /**

--- a/src/hybrid/hybrid_scoring.c
+++ b/src/hybrid/hybrid_scoring.c
@@ -1,7 +1,7 @@
 #include "hybrid/hybrid_scoring.h"
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
-#include <stdarg.h>
+#include "hiredis/sds.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -141,36 +141,6 @@ HybridScoringContext* HybridScoringContext_NewDefault(void) {
     return HybridScoringContext_NewRRF(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW, false);
 }
 
-// Grow `buf` so writing `need + 1` bytes at offset `len` fits.
-static char *ensureCap(char *buf, size_t *cap, size_t len, size_t need) {
-  if (len + need + 1 > *cap) {
-    size_t newCap = *cap ? *cap * 2 : 128;
-    while (newCap < len + need + 1) newCap *= 2;
-    buf = rm_realloc(buf, newCap);
-    *cap = newCap;
-  }
-  return buf;
-}
-
-// Append a printf-formatted chunk to a growable rm_malloc buffer; bumps `*len`.
-static char *appendFmt(char *buf, size_t *len, size_t *cap, const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  va_list ap2;
-  va_copy(ap2, ap);
-  int n = vsnprintf(NULL, 0, fmt, ap);
-  va_end(ap);
-  if (n < 0) {
-    va_end(ap2);
-    return buf;
-  }
-  buf = ensureCap(buf, cap, *len, (size_t)n);
-  vsnprintf(buf + *len, *cap - *len, fmt, ap2);
-  va_end(ap2);
-  *len += (size_t)n;
-  return buf;
-}
-
 // Branch labels used by the formula formatter's "no match" placeholders.
 static const char *sourceLabelForIndex(size_t i) {
   if (i == 0) return "text";
@@ -183,20 +153,18 @@ char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
                                          size_t num_sources, double finalScore) {
   RS_ASSERT(scoringCtx && values && has_value && num_sources > 0);
 
-  size_t len = 0, cap = 0;
-  char *buf = NULL;
-
-  buf = appendFmt(buf, &len, &cap, "final score: ");
+  // sds owns growth + formatting; we convert to rm_malloc at the end so the
+  // caller (RSScoreExplain wrapper) can free it with rm_free.
+  sds buf = sdsnew("final score: ");
 
   if (scoringCtx->scoringType == HYBRID_SCORING_RRF) {
     const double k = scoringCtx->rrfCtx.constant;
     for (size_t i = 0; i < num_sources; i++) {
-      if (i > 0) buf = appendFmt(buf, &len, &cap, " + ");
+      if (i > 0) buf = sdscat(buf, " + ");
       if (has_value[i]) {
-        buf = appendFmt(buf, &len, &cap,
-                        "1 / (constant %.2f + rank %.0f)", k, values[i]);
+        buf = sdscatprintf(buf, "1 / (constant %.2f + rank %.0f)", k, values[i]);
       } else {
-        buf = appendFmt(buf, &len, &cap, "0 [%s: no match]", sourceLabelForIndex(i));
+        buf = sdscatprintf(buf, "0 [%s: no match]", sourceLabelForIndex(i));
       }
     }
   } else {
@@ -204,18 +172,21 @@ char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
     const double *w = scoringCtx->linearCtx.linearWeights;
     const size_t numWeights = scoringCtx->linearCtx.numWeights;
     for (size_t i = 0; i < num_sources; i++) {
-      if (i > 0) buf = appendFmt(buf, &len, &cap, " + ");
+      if (i > 0) buf = sdscat(buf, " + ");
       if (has_value[i]) {
         const double wi = i < numWeights ? w[i] : 0.0;
-        buf = appendFmt(buf, &len, &cap, "%.4f * %.4f", wi, values[i]);
+        buf = sdscatprintf(buf, "%.4f * %.4f", wi, values[i]);
       } else {
-        buf = appendFmt(buf, &len, &cap, "0 [%s: no match]", sourceLabelForIndex(i));
+        buf = sdscatprintf(buf, "0 [%s: no match]", sourceLabelForIndex(i));
       }
     }
   }
 
-  buf = appendFmt(buf, &len, &cap, " = %.17g", finalScore);
-  return buf;
+  buf = sdscatprintf(buf, " = %.17g", finalScore);
+
+  char *result = rm_strdup(buf);
+  sdsfree(buf);
+  return result;
 }
 
 char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx) {

--- a/src/hybrid/hybrid_scoring.c
+++ b/src/hybrid/hybrid_scoring.c
@@ -141,6 +141,83 @@ HybridScoringContext* HybridScoringContext_NewDefault(void) {
     return HybridScoringContext_NewRRF(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW, false);
 }
 
+// Grow `buf` so writing `need + 1` bytes at offset `len` fits.
+static char *ensureCap(char *buf, size_t *cap, size_t len, size_t need) {
+  if (len + need + 1 > *cap) {
+    size_t newCap = *cap ? *cap * 2 : 128;
+    while (newCap < len + need + 1) newCap *= 2;
+    buf = rm_realloc(buf, newCap);
+    *cap = newCap;
+  }
+  return buf;
+}
+
+// Append a printf-formatted chunk to a growable rm_malloc buffer; bumps `*len`.
+static char *appendFmt(char *buf, size_t *len, size_t *cap, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  va_list ap2;
+  va_copy(ap2, ap);
+  int n = vsnprintf(NULL, 0, fmt, ap);
+  va_end(ap);
+  if (n < 0) {
+    va_end(ap2);
+    return buf;
+  }
+  buf = ensureCap(buf, cap, *len, (size_t)n);
+  vsnprintf(buf + *len, *cap - *len, fmt, ap2);
+  va_end(ap2);
+  *len += (size_t)n;
+  return buf;
+}
+
+// Branch labels used by the formula formatter's "no match" placeholders.
+static const char *sourceLabelForIndex(size_t i) {
+  if (i == 0) return "text";
+  if (i == 1) return "vector";
+  return "source";
+}
+
+char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
+                                         const double *values, const bool *has_value,
+                                         size_t num_sources, double finalScore) {
+  RS_ASSERT(scoringCtx && values && has_value && num_sources > 0);
+
+  size_t len = 0, cap = 0;
+  char *buf = NULL;
+
+  buf = appendFmt(buf, &len, &cap, "final score: ");
+
+  if (scoringCtx->scoringType == HYBRID_SCORING_RRF) {
+    const double k = scoringCtx->rrfCtx.constant;
+    for (size_t i = 0; i < num_sources; i++) {
+      if (i > 0) buf = appendFmt(buf, &len, &cap, " + ");
+      if (has_value[i]) {
+        buf = appendFmt(buf, &len, &cap,
+                        "1 / (constant %.2f + rank %.0f)", k, values[i]);
+      } else {
+        buf = appendFmt(buf, &len, &cap, "0 [%s: no match]", sourceLabelForIndex(i));
+      }
+    }
+  } else {
+    RS_ASSERT(scoringCtx->scoringType == HYBRID_SCORING_LINEAR);
+    const double *w = scoringCtx->linearCtx.linearWeights;
+    const size_t numWeights = scoringCtx->linearCtx.numWeights;
+    for (size_t i = 0; i < num_sources; i++) {
+      if (i > 0) buf = appendFmt(buf, &len, &cap, " + ");
+      if (has_value[i]) {
+        const double wi = i < numWeights ? w[i] : 0.0;
+        buf = appendFmt(buf, &len, &cap, "%.4f * %.4f", wi, values[i]);
+      } else {
+        buf = appendFmt(buf, &len, &cap, "0 [%s: no match]", sourceLabelForIndex(i));
+      }
+    }
+  }
+
+  buf = appendFmt(buf, &len, &cap, " = %.17g", finalScore);
+  return buf;
+}
+
 char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx) {
   RS_ASSERT(scoringCtx);
   char *buf = NULL;

--- a/src/hybrid/hybrid_scoring.c
+++ b/src/hybrid/hybrid_scoring.c
@@ -189,7 +189,7 @@ char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
   return result;
 }
 
-char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx) {
+char *HybridScoring_FormatHybridScoreNode(const HybridScoringContext *scoringCtx) {
   RS_ASSERT(scoringCtx);
   char *buf = NULL;
   if (scoringCtx->scoringType == HYBRID_SCORING_RRF) {

--- a/src/hybrid/hybrid_scoring.c
+++ b/src/hybrid/hybrid_scoring.c
@@ -148,6 +148,38 @@ static const char *sourceLabelForIndex(size_t i) {
   return "source";
 }
 
+static sds appendRRFFinalScoreTerms(sds buf, const HybridScoringContext *scoringCtx,
+                                    const double *ranks, const bool *has_rank,
+                                    size_t num_sources) {
+  const double k = scoringCtx->rrfCtx.constant;
+  for (size_t i = 0; i < num_sources; i++) {
+    if (i > 0) buf = sdscat(buf, " + ");
+    if (has_rank[i]) {
+      buf = sdscatprintf(buf, "1 / (constant %.2f + rank %.0f)", k, ranks[i]);
+    } else {
+      buf = sdscatprintf(buf, "0 [%s: no match]", sourceLabelForIndex(i));
+    }
+  }
+  return buf;
+}
+
+static sds appendLinearFinalScoreTerms(sds buf, const HybridScoringContext *scoringCtx,
+                                       const double *scores, const bool *has_score,
+                                       size_t num_sources) {
+  const double *w = scoringCtx->linearCtx.linearWeights;
+  const size_t numWeights = scoringCtx->linearCtx.numWeights;
+  for (size_t i = 0; i < num_sources; i++) {
+    if (i > 0) buf = sdscat(buf, " + ");
+    if (has_score[i]) {
+      const double wi = i < numWeights ? w[i] : 0.0;
+      buf = sdscatprintf(buf, "%.4f * %.4f", wi, scores[i]);
+    } else {
+      buf = sdscatprintf(buf, "0 [%s: no match]", sourceLabelForIndex(i));
+    }
+  }
+  return buf;
+}
+
 char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
                                          const double *values, const bool *has_value,
                                          size_t num_sources, double finalScore) {
@@ -158,28 +190,10 @@ char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
   sds buf = sdsnew("final score: ");
 
   if (scoringCtx->scoringType == HYBRID_SCORING_RRF) {
-    const double k = scoringCtx->rrfCtx.constant;
-    for (size_t i = 0; i < num_sources; i++) {
-      if (i > 0) buf = sdscat(buf, " + ");
-      if (has_value[i]) {
-        buf = sdscatprintf(buf, "1 / (constant %.2f + rank %.0f)", k, values[i]);
-      } else {
-        buf = sdscatprintf(buf, "0 [%s: no match]", sourceLabelForIndex(i));
-      }
-    }
+    buf = appendRRFFinalScoreTerms(buf, scoringCtx, values, has_value, num_sources);
   } else {
     RS_ASSERT(scoringCtx->scoringType == HYBRID_SCORING_LINEAR);
-    const double *w = scoringCtx->linearCtx.linearWeights;
-    const size_t numWeights = scoringCtx->linearCtx.numWeights;
-    for (size_t i = 0; i < num_sources; i++) {
-      if (i > 0) buf = sdscat(buf, " + ");
-      if (has_value[i]) {
-        const double wi = i < numWeights ? w[i] : 0.0;
-        buf = sdscatprintf(buf, "%.4f * %.4f", wi, values[i]);
-      } else {
-        buf = sdscatprintf(buf, "0 [%s: no match]", sourceLabelForIndex(i));
-      }
-    }
+    buf = appendLinearFinalScoreTerms(buf, scoringCtx, values, has_value, num_sources);
   }
 
   buf = sdscatprintf(buf, " = %.17g", finalScore);

--- a/src/hybrid/hybrid_scoring.h
+++ b/src/hybrid/hybrid_scoring.h
@@ -55,7 +55,8 @@ double HybridRRFScore(HybridScoringContext *scoringCtx, const double *ranks, con
 double HybridLinearScore(HybridScoringContext *scoringCtx, const double *scores, const bool *has_score, const size_t num_sources);
 
 /**
- * Format the hybrid envelope line (root of the EXPLAINSCORE wrapper).
+ * Format the hybrid score node label (the inner node of the EXPLAINSCORE
+ * wrapper that holds the text + vector branches).
  *
  * For RRF: "Hybrid score (RRF: window=W, constant=K)".
  * For LINEAR: "Hybrid score (LINEAR: alpha=A, beta=B, window=W)" (assumes the
@@ -64,7 +65,7 @@ double HybridLinearScore(HybridScoringContext *scoringCtx, const double *scores,
  * The returned string is heap-allocated with rm_malloc and must be freed by
  * the caller (or transferred to an RSScoreExplain node, which frees it).
  */
-char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx);
+char *HybridScoring_FormatHybridScoreNode(const HybridScoringContext *scoringCtx);
 
 /**
  * Format the outer "final score: …" line as a formula, mirroring the style

--- a/src/hybrid/hybrid_scoring.h
+++ b/src/hybrid/hybrid_scoring.h
@@ -54,6 +54,18 @@ double HybridRRFScore(HybridScoringContext *scoringCtx, const double *ranks, con
 
 double HybridLinearScore(HybridScoringContext *scoringCtx, const double *scores, const bool *has_score, const size_t num_sources);
 
+/**
+ * Format the hybrid envelope line (root of the EXPLAINSCORE wrapper).
+ *
+ * For RRF: "Hybrid score (RRF: window=W, constant=K)".
+ * For LINEAR: "Hybrid score (LINEAR: alpha=A, beta=B, window=W)" (assumes the
+ * two-source hybrid layout — text=weight[0], vector=weight[1]).
+ *
+ * The returned string is heap-allocated with rm_malloc and must be freed by
+ * the caller (or transferred to an RSScoreExplain node, which frees it).
+ */
+char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx);
+
 
 
 #ifdef __cplusplus

--- a/src/hybrid/hybrid_scoring.h
+++ b/src/hybrid/hybrid_scoring.h
@@ -66,6 +66,27 @@ double HybridLinearScore(HybridScoringContext *scoringCtx, const double *scores,
  */
 char *HybridScoring_FormatEnvelope(const HybridScoringContext *scoringCtx);
 
+/**
+ * Format the outer "final score: …" line as a formula, mirroring the style
+ * of existing TEXT EXPLAINSCORE lines (which show how the score was
+ * computed, not just its value).
+ *
+ *   RRF, both matched:
+ *     "final score: 1 / (constant K + rank N1) + 1 / (constant K + rank N2) = S"
+ *   RRF, text-only:
+ *     "final score: 1 / (constant K + rank N1) + 0 [vector: no match] = S"
+ *   LINEAR, both matched:
+ *     "final score: A * X + B * Y = S"
+ *   LINEAR, text-only:
+ *     "final score: A * X + 0 [vector: no match] = S"
+ *
+ * The returned string is heap-allocated with rm_malloc and must be freed by
+ * the caller (or transferred to an RSScoreExplain node, which frees it).
+ */
+char *HybridScoring_FormatFinalScoreLine(const HybridScoringContext *scoringCtx,
+                                         const double *values, const bool *has_value,
+                                         size_t num_sources, double finalScore);
+
 
 
 #ifdef __cplusplus

--- a/src/hybrid/hybrid_search_result.c
+++ b/src/hybrid/hybrid_search_result.c
@@ -324,7 +324,11 @@ static RSScoreExplain *buildHybridScoreExplain(HybridSearchResult *hybridResult,
                                                const double *values,
                                                double finalScore) {
   RSScoreExplain *outer = rm_calloc(1, sizeof(RSScoreExplain));
-  rm_asprintf(&outer->str, "final score: %.17g", finalScore);
+  // Outer line is a formula, not just the value — matches the existing TEXT
+  // EXPLAINSCORE convention (e.g. "(0.29 = Weight 1.00 * IDF 0.29 * …)").
+  outer->str = HybridScoring_FormatFinalScoreLine(
+      scoringCtx, values, hybridResult->hasResults,
+      hybridResult->numSources, finalScore);
 
   RSScoreExplain *envelope = rm_calloc(1, sizeof(RSScoreExplain));
   envelope->str = HybridScoring_FormatEnvelope(scoringCtx);

--- a/src/hybrid/hybrid_search_result.c
+++ b/src/hybrid/hybrid_search_result.c
@@ -24,6 +24,7 @@
 
 void HybridExplainContext_Free(HybridExplainContext *ctx) {
   if (!ctx) return;
+  rm_free(ctx->textScorerName);
   rm_free(ctx->vectorBranchEnvelope);
   rm_free(ctx);
 }
@@ -33,13 +34,14 @@ HybridExplainContext *HybridExplainContext_Build(const struct AREQ *searchReq, c
 
   HybridExplainContext *ctx = rm_calloc(1, sizeof(HybridExplainContext));
 
-  // Borrowed: the string is owned by searchopts (or by RSGlobalConfig).
-  // AREQ_ApplyContext resolves scorerName to the configured default before
-  // we get here, but we fall back defensively in case that ever changes.
-  ctx->textScorerName = searchReq->searchopts.scorerName;
-  if (!ctx->textScorerName) {
-    ctx->textScorerName = RSGlobalConfig.defaultScorer;
-  }
+  // Duplicate the resolved scorer name: searchopts.scorerName may point into
+  // RSGlobalConfig.defaultScorer, which FT.CONFIG SET DEFAULT_SCORER frees and
+  // replaces. AREQ_ApplyContext resolves scorerName to the configured default
+  // before we get here, but we fall back defensively in case that ever changes.
+  const char *resolved = searchReq->searchopts.scorerName
+                             ? searchReq->searchopts.scorerName
+                             : RSGlobalConfig.defaultScorer;
+  ctx->textScorerName = resolved ? rm_strdup(resolved) : NULL;
 
   // Vector branch envelope: identify the retrieval mode and any salient params.
   // Read from the parsed-time snapshot on ParsedVectorData, since the live
@@ -313,7 +315,7 @@ static RSScoreExplain *buildVectorBranch(const HybridSearchResult *hybridResult,
 //
 // Layout (MOD-10044):
 //   "final score: <S>"
-//     └── envelope from HybridScoring_FormatEnvelope
+//     └── hybrid score node from HybridScoring_FormatHybridScoreNode
 //           ├── text branch sub-tree
 //           └── vector branch sub-tree
 static RSScoreExplain *buildHybridScoreExplain(const HybridSearchResult *hybridResult,
@@ -332,20 +334,20 @@ static RSScoreExplain *buildHybridScoreExplain(const HybridSearchResult *hybridR
       scoringCtx, values, hybridResult->hasResults,
       hybridResult->numSources, finalScore);
 
-  RSScoreExplain *envelope = rm_calloc(1, sizeof(RSScoreExplain));
-  envelope->str = HybridScoring_FormatEnvelope(scoringCtx);
+  RSScoreExplain *hybridNode = rm_calloc(1, sizeof(RSScoreExplain));
+  hybridNode->str = HybridScoring_FormatHybridScoreNode(scoringCtx);
 
   RSScoreExplain *textBranch = buildTextBranch(hybridResult, scoringCtx, explainCtx, textValue);
   RSScoreExplain *vectorBranch = buildVectorBranch(hybridResult, scoringCtx, explainCtx, vectorValue);
 
-  envelope->numChildren = 2;
-  envelope->children = rm_calloc(2, sizeof(RSScoreExplain));
-  moveScoreExplainInto(&envelope->children[0], textBranch);
-  moveScoreExplainInto(&envelope->children[1], vectorBranch);
+  hybridNode->numChildren = 2;
+  hybridNode->children = rm_calloc(2, sizeof(RSScoreExplain));
+  moveScoreExplainInto(&hybridNode->children[0], textBranch);
+  moveScoreExplainInto(&hybridNode->children[1], vectorBranch);
 
   outer->numChildren = 1;
   outer->children = rm_calloc(1, sizeof(RSScoreExplain));
-  moveScoreExplainInto(&outer->children[0], envelope);
+  moveScoreExplainInto(&outer->children[0], hybridNode);
 
   return outer;
 }

--- a/src/hybrid/hybrid_search_result.c
+++ b/src/hybrid/hybrid_search_result.c
@@ -28,7 +28,7 @@ void HybridExplainContext_Free(HybridExplainContext *ctx) {
   rm_free(ctx);
 }
 
-HybridExplainContext *HybridExplainContext_Build(struct AREQ *searchReq, struct AREQ *vectorReq) {
+HybridExplainContext *HybridExplainContext_Build(const struct AREQ *searchReq, const struct AREQ *vectorReq) {
   RS_ASSERT(searchReq && vectorReq);
 
   HybridExplainContext *ctx = rm_calloc(1, sizeof(HybridExplainContext));
@@ -57,7 +57,7 @@ HybridExplainContext *HybridExplainContext_Build(struct AREQ *searchReq, struct 
                   "vector branch (RANGE: radius=%.4f)", pvd->explainRangeRadius);
     }
   } else {
-    rm_asprintf(&ctx->vectorBranchEnvelope, "vector branch (KNN)");
+    ctx->vectorBranchEnvelope = rm_strdup("vector branch (KNN)");
   }
   return ctx;
 }
@@ -185,30 +185,29 @@ static void moveScoreExplainInto(RSScoreExplain *dst, RSScoreExplain *src) {
 //                  └── <existing scorer subtree>
 //
 // When the text sub-result is absent (no match), emit a leaf placeholder.
-static RSScoreExplain *buildTextBranch(HybridSearchResult *hybridResult,
-                                       HybridScoringContext *scoringCtx,
+static RSScoreExplain *buildTextBranch(const HybridSearchResult *hybridResult,
+                                       const HybridScoringContext *scoringCtx,
                                        const HybridExplainContext *explainCtx,
-                                       const double *values) {
+                                       double textValue) {
   const bool hasText = hybridResult->hasResults[SEARCH_INDEX];
   const bool isRRF = (scoringCtx->scoringType == HYBRID_SCORING_RRF);
 
   RSScoreExplain *parent = rm_calloc(1, sizeof(RSScoreExplain));
 
   if (!hasText) {
-    rm_asprintf(&parent->str, isRRF ? "text rank = <no match>"
-                                    : "text contribution = <no match>");
+    parent->str = rm_strdup(isRRF ? "text rank = <no match>"
+                                  : "text contribution = <no match>");
     return parent;
   }
 
   if (isRRF) {
-    rm_asprintf(&parent->str, "text rank = %.0f", values[SEARCH_INDEX]);
+    rm_asprintf(&parent->str, "text rank = %.0f", textValue);
   } else {
     const double alpha = scoringCtx->linearCtx.numWeights > 0
                              ? scoringCtx->linearCtx.linearWeights[0]
                              : 0.0;
-    const double x = values[SEARCH_INDEX];
     rm_asprintf(&parent->str, "text contribution = %.4f * %.4f = %.4f",
-                alpha, x, alpha * x);
+                alpha, textValue, alpha * textValue);
   }
 
   // Inner scorer node, always present (per MOD-10044: "explicitly include the
@@ -237,7 +236,7 @@ static RSScoreExplain *buildTextBranch(HybridSearchResult *hybridResult,
     scorerNode->numChildren = n;
     scorerNode->children = rm_calloc(n, sizeof(RSScoreExplain));
     rm_asprintf(&scorerNode->children[0].str, "normalized text score = %.4f",
-                values[SEARCH_INDEX]);
+                textValue);
     if (scorerSubtree) {
       moveScoreExplainInto(&scorerNode->children[1], scorerSubtree);
     }
@@ -259,10 +258,10 @@ static RSScoreExplain *buildTextBranch(HybridSearchResult *hybridResult,
 //             ├── "matched within radius = true/false"   # RANGE only
 //             ├── "vector contribution = beta * Y = beta*Y"
 //             └── "normalized vector score = Y"
-static RSScoreExplain *buildVectorBranch(HybridSearchResult *hybridResult,
-                                         HybridScoringContext *scoringCtx,
+static RSScoreExplain *buildVectorBranch(const HybridSearchResult *hybridResult,
+                                         const HybridScoringContext *scoringCtx,
                                          const HybridExplainContext *explainCtx,
-                                         const double *values) {
+                                         double vectorValue) {
   const bool hasVector = hybridResult->hasResults[VECTOR_INDEX];
   const bool isRRF = (scoringCtx->scoringType == HYBRID_SCORING_RRF);
   const bool isRange = (explainCtx->vectorMode == VECSIM_QT_RANGE);
@@ -285,21 +284,20 @@ static RSScoreExplain *buildVectorBranch(HybridSearchResult *hybridResult,
 
   if (isRRF) {
     if (hasVector) {
-      rm_asprintf(&children[slot++].str, "vector rank = %.0f", values[VECTOR_INDEX]);
+      rm_asprintf(&children[slot++].str, "vector rank = %.0f", vectorValue);
     } else {
-      rm_asprintf(&children[slot++].str, "vector rank = <no match>");
+      children[slot++].str = rm_strdup("vector rank = <no match>");
     }
   } else {
     if (hasVector) {
       const double beta = scoringCtx->linearCtx.numWeights > 1
                               ? scoringCtx->linearCtx.linearWeights[1]
                               : 0.0;
-      const double y = values[VECTOR_INDEX];
       rm_asprintf(&children[slot++].str,
-                  "vector contribution = %.4f * %.4f = %.4f", beta, y, beta * y);
-      rm_asprintf(&children[slot++].str, "normalized vector score = %.4f", y);
+                  "vector contribution = %.4f * %.4f = %.4f", beta, vectorValue, beta * vectorValue);
+      rm_asprintf(&children[slot++].str, "normalized vector score = %.4f", vectorValue);
     } else {
-      rm_asprintf(&children[slot++].str, "vector contribution = <no match>");
+      children[slot++].str = rm_strdup("vector contribution = <no match>");
     }
   }
 
@@ -318,11 +316,15 @@ static RSScoreExplain *buildVectorBranch(HybridSearchResult *hybridResult,
 //     └── envelope from HybridScoring_FormatEnvelope
 //           ├── text branch sub-tree
 //           └── vector branch sub-tree
-static RSScoreExplain *buildHybridScoreExplain(HybridSearchResult *hybridResult,
-                                               HybridScoringContext *scoringCtx,
+static RSScoreExplain *buildHybridScoreExplain(const HybridSearchResult *hybridResult,
+                                               const HybridScoringContext *scoringCtx,
                                                const HybridExplainContext *explainCtx,
-                                               const double *values,
+                                               double textValue, double vectorValue,
                                                double finalScore) {
+  // Local stack array threaded into HybridScoring_FormatFinalScoreLine, which
+  // takes the generic (values, hasResults, numSources) tuple.
+  const double values[HYBRID_REQUEST_NUM_SUBQUERIES] = {textValue, vectorValue};
+
   RSScoreExplain *outer = rm_calloc(1, sizeof(RSScoreExplain));
   // Outer line is a formula, not just the value — matches the existing TEXT
   // EXPLAINSCORE convention (e.g. "(0.29 = Weight 1.00 * IDF 0.29 * …)").
@@ -333,8 +335,8 @@ static RSScoreExplain *buildHybridScoreExplain(HybridSearchResult *hybridResult,
   RSScoreExplain *envelope = rm_calloc(1, sizeof(RSScoreExplain));
   envelope->str = HybridScoring_FormatEnvelope(scoringCtx);
 
-  RSScoreExplain *textBranch = buildTextBranch(hybridResult, scoringCtx, explainCtx, values);
-  RSScoreExplain *vectorBranch = buildVectorBranch(hybridResult, scoringCtx, explainCtx, values);
+  RSScoreExplain *textBranch = buildTextBranch(hybridResult, scoringCtx, explainCtx, textValue);
+  RSScoreExplain *vectorBranch = buildVectorBranch(hybridResult, scoringCtx, explainCtx, vectorValue);
 
   envelope->numChildren = 2;
   envelope->children = rm_calloc(2, sizeof(RSScoreExplain));
@@ -368,15 +370,19 @@ SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoring
 
   RS_ASSERT(primary && targetIndex != -1);
 
-  // Snapshot per-source values before calculateHybridScore overwrites the
-  // primary. For RRF these are 1-based ranks; for LINEAR they are raw scores.
-  double *values = NULL;
+  // Snapshot per-source values as scalars before SearchResult_SetScore
+  // overwrites the primary. For RRF these are 1-based ranks; for LINEAR they
+  // are raw scores. Only needed (and only valid) when EXPLAINSCORE is on —
+  // FT.HYBRID always pairs exactly two sub-queries (text + vector); the
+  // generic N-upstream form has no EXPLAINSCORE rendering.
+  double textValue = 0.0, vectorValue = 0.0;
   if (explainCtx) {
-    values = rm_calloc(hybridResult->numSources, sizeof(double));
-    for (size_t i = 0; i < hybridResult->numSources; i++) {
-      values[i] = hybridResult->hasResults[i]
-                      ? SearchResult_GetScore(hybridResult->searchResults[i])
-                      : 0.0;
+    RS_ASSERT(hybridResult->numSources == HYBRID_REQUEST_NUM_SUBQUERIES);
+    if (hybridResult->hasResults[SEARCH_INDEX]) {
+      textValue = SearchResult_GetScore(hybridResult->searchResults[SEARCH_INDEX]);
+    }
+    if (hybridResult->hasResults[VECTOR_INDEX]) {
+      vectorValue = SearchResult_GetScore(hybridResult->searchResults[VECTOR_INDEX]);
     }
   }
 
@@ -393,9 +399,9 @@ SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoring
   // Build the wrapper before transferring ownership: it moves the search
   // sub-result's RSScoreExplain (if any) into one of its children.
   if (explainCtx) {
-    RSScoreExplain *wrapper = buildHybridScoreExplain(hybridResult, scoringCtx, explainCtx, values, finalScore);
+    RSScoreExplain *wrapper = buildHybridScoreExplain(hybridResult, scoringCtx, explainCtx,
+                                                      textValue, vectorValue, finalScore);
     SearchResult_SetScoreExplain(primary, wrapper);
-    rm_free(values);
   }
 
   // Detach the primary so the dict destructor (HybridSearchResult_Free) does

--- a/src/hybrid/hybrid_search_result.c
+++ b/src/hybrid/hybrid_search_result.c
@@ -175,6 +175,60 @@ static void moveScoreExplainInto(RSScoreExplain *dst, RSScoreExplain *src) {
   rm_free(src);
 }
 
+// Detach and return the search sub-result's RSScoreExplain (or NULL).
+// The caller takes ownership; the source no longer points to it.
+static RSScoreExplain *takeTextSubresultScoreExplain(const HybridSearchResult *hybridResult) {
+  SearchResult *textResult = hybridResult->searchResults[SEARCH_INDEX];
+  RSScoreExplain *scorerSubtree = SearchResult_GetScoreExplainMut(textResult);
+  if (scorerSubtree) {
+    SearchResult_SetScoreExplain(textResult, NULL);
+  }
+  return scorerSubtree;
+}
+
+static char *formatTextBranchLabel(const HybridScoringContext *scoringCtx, bool isRRF,
+                                   double textValue) {
+  char *out = NULL;
+  if (isRRF) {
+    rm_asprintf(&out, "text rank = %.0f", textValue);
+  } else {
+    const double alpha = scoringCtx->linearCtx.numWeights > 0
+                             ? scoringCtx->linearCtx.linearWeights[0]
+                             : 0.0;
+    rm_asprintf(&out, "text contribution = %.4f * %.4f = %.4f",
+                alpha, textValue, alpha * textValue);
+  }
+  return out;
+}
+
+// Takes ownership of `scorerSubtree` (may be NULL).
+static RSScoreExplain *buildTextScorerNode(const HybridExplainContext *explainCtx, bool isRRF,
+                                           double textValue, RSScoreExplain *scorerSubtree) {
+  RSScoreExplain *node = rm_calloc(1, sizeof(RSScoreExplain));
+  rm_asprintf(&node->str, "Text scorer: %s",
+              explainCtx->textScorerName ? explainCtx->textScorerName : "<default>");
+
+  if (isRRF) {
+    if (scorerSubtree) {
+      node->numChildren = 1;
+      node->children = rm_calloc(1, sizeof(RSScoreExplain));
+      moveScoreExplainInto(&node->children[0], scorerSubtree);
+    }
+    return node;
+  }
+
+  // LINEAR: extra "normalized text score = X" sibling so the formula in the
+  // parent line is fully derivable from the children.
+  const int n = scorerSubtree ? 2 : 1;
+  node->numChildren = n;
+  node->children = rm_calloc(n, sizeof(RSScoreExplain));
+  rm_asprintf(&node->children[0].str, "normalized text score = %.4f", textValue);
+  if (scorerSubtree) {
+    moveScoreExplainInto(&node->children[1], scorerSubtree);
+  }
+  return node;
+}
+
 // Build the text branch sub-tree.
 //
 //   RRF:    "text rank = N"
@@ -202,47 +256,11 @@ static RSScoreExplain *buildTextBranch(const HybridSearchResult *hybridResult,
     return parent;
   }
 
-  if (isRRF) {
-    rm_asprintf(&parent->str, "text rank = %.0f", textValue);
-  } else {
-    const double alpha = scoringCtx->linearCtx.numWeights > 0
-                             ? scoringCtx->linearCtx.linearWeights[0]
-                             : 0.0;
-    rm_asprintf(&parent->str, "text contribution = %.4f * %.4f = %.4f",
-                alpha, textValue, alpha * textValue);
-  }
+  parent->str = formatTextBranchLabel(scoringCtx, isRRF, textValue);
 
-  // Inner scorer node, always present (per MOD-10044: "explicitly include the
-  // scorer name").
-  RSScoreExplain *scorerNode = rm_calloc(1, sizeof(RSScoreExplain));
-  rm_asprintf(&scorerNode->str, "Text scorer: %s",
-              explainCtx->textScorerName ? explainCtx->textScorerName : "<default>");
-
-  // Take ownership of the text sub-result's score_explain (if any).
-  SearchResult *textResult = hybridResult->searchResults[SEARCH_INDEX];
-  RSScoreExplain *scorerSubtree = SearchResult_GetScoreExplainMut(textResult);
-  if (scorerSubtree) {
-    SearchResult_SetScoreExplain(textResult, NULL);
-  }
-
-  if (isRRF) {
-    if (scorerSubtree) {
-      scorerNode->numChildren = 1;
-      scorerNode->children = rm_calloc(1, sizeof(RSScoreExplain));
-      moveScoreExplainInto(&scorerNode->children[0], scorerSubtree);
-    }
-  } else {
-    // LINEAR: extra "normalized text score = X" sibling so the formula in the
-    // parent line is fully derivable from the children.
-    const int n = scorerSubtree ? 2 : 1;
-    scorerNode->numChildren = n;
-    scorerNode->children = rm_calloc(n, sizeof(RSScoreExplain));
-    rm_asprintf(&scorerNode->children[0].str, "normalized text score = %.4f",
-                textValue);
-    if (scorerSubtree) {
-      moveScoreExplainInto(&scorerNode->children[1], scorerSubtree);
-    }
-  }
+  RSScoreExplain *scorerSubtree = takeTextSubresultScoreExplain(hybridResult);
+  RSScoreExplain *scorerNode =
+      buildTextScorerNode(explainCtx, isRRF, textValue, scorerSubtree);
 
   parent->numChildren = 1;
   parent->children = rm_calloc(1, sizeof(RSScoreExplain));

--- a/src/hybrid/hybrid_search_result.c
+++ b/src/hybrid/hybrid_search_result.c
@@ -14,8 +14,53 @@
 #include "query_error_ffi.h"
 #include "score_explain.h"
 #include "hybrid_scoring.h"
+#include "hybrid_request.h"
+#include "aggregate/aggregate.h"
+#include "vector_index.h"
+#include "config.h"
 #include <string.h>
+#include <stdio.h>
 #include <assert.h>
+
+void HybridExplainContext_Free(HybridExplainContext *ctx) {
+  if (!ctx) return;
+  rm_free(ctx->vectorBranchEnvelope);
+  rm_free(ctx);
+}
+
+HybridExplainContext *HybridExplainContext_Build(struct AREQ *searchReq, struct AREQ *vectorReq) {
+  RS_ASSERT(searchReq && vectorReq);
+
+  HybridExplainContext *ctx = rm_calloc(1, sizeof(HybridExplainContext));
+
+  // Borrowed: the string is owned by searchopts (or by RSGlobalConfig).
+  // AREQ_ApplyContext resolves scorerName to the configured default before
+  // we get here, but we fall back defensively in case that ever changes.
+  ctx->textScorerName = searchReq->searchopts.scorerName;
+  if (!ctx->textScorerName) {
+    ctx->textScorerName = RSGlobalConfig.defaultScorer;
+  }
+
+  // Vector branch envelope: identify the retrieval mode and any salient params.
+  // Read from the parsed-time snapshot on ParsedVectorData, since the live
+  // VectorQuery has already been transferred into the AST by AREQ_ApplyContext.
+  const ParsedVectorData *pvd = vectorReq->parsedVectorData;
+  ctx->vectorMode = pvd ? pvd->explainQueryType : VECSIM_QT_KNN;
+
+  if (pvd && pvd->explainQueryType == VECSIM_QT_RANGE) {
+    if (pvd->explainRangeEpsilon) {
+      rm_asprintf(&ctx->vectorBranchEnvelope,
+                  "vector branch (RANGE: radius=%.4f, epsilon=%s)",
+                  pvd->explainRangeRadius, pvd->explainRangeEpsilon);
+    } else {
+      rm_asprintf(&ctx->vectorBranchEnvelope,
+                  "vector branch (RANGE: radius=%.4f)", pvd->explainRangeRadius);
+    }
+  } else {
+    rm_asprintf(&ctx->vectorBranchEnvelope, "vector branch (KNN)");
+  }
+  return ctx;
+}
 
 /**
  * Constructor for HybridSearchResult.
@@ -120,20 +165,192 @@ static void mergeRLookupRowsFromSourcesIntoTarget(HybridSearchResult *hybridResu
   }
 }
 
-/**
- * Main function to merge SearchResults from multiple upstreams into a single comprehensive result.
- *
- * PRIMARY RESULT SELECTION:
- * The "primary result" is the first non-null SearchResult found in index order (0, 1, 2...).
- * This prefers search results (index 0) over vector results (index 1) when both exist for RSIndexResult.
- *
- * The primary result is the SearchResult we merge into and return to the downstream processor.
- * This function transfers ownership of the primary result from the HybridSearchResult to the caller.
- */
-SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoringContext *scoringCtx, HybridLookupContext *lookupCtx) {
+// Shallow-copy `src`'s root struct into `dst` and free the now-empty `src`
+// container. The string + children pointers are transferred; `src` must not
+// be used after this call.
+static void moveScoreExplainInto(RSScoreExplain *dst, RSScoreExplain *src) {
+  *dst = *src;
+  rm_free(src);
+}
+
+// Build the text branch sub-tree.
+//
+//   RRF:    "text rank = N"
+//             └── "Text scorer: <NAME>"
+//                  └── <existing scorer subtree>
+//
+//   LINEAR: "text contribution = alpha * X = alpha*X"
+//             └── "Text scorer: <NAME>"
+//                  ├── "normalized text score = X"
+//                  └── <existing scorer subtree>
+//
+// When the text sub-result is absent (no match), emit a leaf placeholder.
+static RSScoreExplain *buildTextBranch(HybridSearchResult *hybridResult,
+                                       HybridScoringContext *scoringCtx,
+                                       const HybridExplainContext *explainCtx,
+                                       const double *values) {
+  const bool hasText = hybridResult->hasResults[SEARCH_INDEX];
+  const bool isRRF = (scoringCtx->scoringType == HYBRID_SCORING_RRF);
+
+  RSScoreExplain *parent = rm_calloc(1, sizeof(RSScoreExplain));
+
+  if (!hasText) {
+    rm_asprintf(&parent->str, isRRF ? "text rank = <no match>"
+                                    : "text contribution = <no match>");
+    return parent;
+  }
+
+  if (isRRF) {
+    rm_asprintf(&parent->str, "text rank = %.0f", values[SEARCH_INDEX]);
+  } else {
+    const double alpha = scoringCtx->linearCtx.numWeights > 0
+                             ? scoringCtx->linearCtx.linearWeights[0]
+                             : 0.0;
+    const double x = values[SEARCH_INDEX];
+    rm_asprintf(&parent->str, "text contribution = %.4f * %.4f = %.4f",
+                alpha, x, alpha * x);
+  }
+
+  // Inner scorer node, always present (per MOD-10044: "explicitly include the
+  // scorer name").
+  RSScoreExplain *scorerNode = rm_calloc(1, sizeof(RSScoreExplain));
+  rm_asprintf(&scorerNode->str, "Text scorer: %s",
+              explainCtx->textScorerName ? explainCtx->textScorerName : "<default>");
+
+  // Take ownership of the text sub-result's score_explain (if any).
+  SearchResult *textResult = hybridResult->searchResults[SEARCH_INDEX];
+  RSScoreExplain *scorerSubtree = SearchResult_GetScoreExplainMut(textResult);
+  if (scorerSubtree) {
+    SearchResult_SetScoreExplain(textResult, NULL);
+  }
+
+  if (isRRF) {
+    if (scorerSubtree) {
+      scorerNode->numChildren = 1;
+      scorerNode->children = rm_calloc(1, sizeof(RSScoreExplain));
+      moveScoreExplainInto(&scorerNode->children[0], scorerSubtree);
+    }
+  } else {
+    // LINEAR: extra "normalized text score = X" sibling so the formula in the
+    // parent line is fully derivable from the children.
+    const int n = scorerSubtree ? 2 : 1;
+    scorerNode->numChildren = n;
+    scorerNode->children = rm_calloc(n, sizeof(RSScoreExplain));
+    rm_asprintf(&scorerNode->children[0].str, "normalized text score = %.4f",
+                values[SEARCH_INDEX]);
+    if (scorerSubtree) {
+      moveScoreExplainInto(&scorerNode->children[1], scorerSubtree);
+    }
+  }
+
+  parent->numChildren = 1;
+  parent->children = rm_calloc(1, sizeof(RSScoreExplain));
+  moveScoreExplainInto(&parent->children[0], scorerNode);
+  return parent;
+}
+
+// Build the vector branch sub-tree.
+//
+//   RRF:    "vector branch (KNN)" or "vector branch (RANGE: …)"
+//             ├── "matched within radius = true/false"   # RANGE only
+//             └── "vector rank = M"                     # or "<no match>"
+//
+//   LINEAR: "vector branch (KNN)" or "vector branch (RANGE: …)"
+//             ├── "matched within radius = true/false"   # RANGE only
+//             ├── "vector contribution = beta * Y = beta*Y"
+//             └── "normalized vector score = Y"
+static RSScoreExplain *buildVectorBranch(HybridSearchResult *hybridResult,
+                                         HybridScoringContext *scoringCtx,
+                                         const HybridExplainContext *explainCtx,
+                                         const double *values) {
+  const bool hasVector = hybridResult->hasResults[VECTOR_INDEX];
+  const bool isRRF = (scoringCtx->scoringType == HYBRID_SCORING_RRF);
+  const bool isRange = (explainCtx->vectorMode == VECSIM_QT_RANGE);
+
+  RSScoreExplain *parent = rm_calloc(1, sizeof(RSScoreExplain));
+  parent->str = rm_strdup(explainCtx->vectorBranchEnvelope);
+
+  // Compute child slots:
+  //   RANGE: + "matched within radius = …"
+  //   RRF: + "vector rank = M" / "<no match>"
+  //   LINEAR: + "vector contribution = …" + "normalized vector score = …" (when matched)
+  //   LINEAR no-match: + single placeholder
+  size_t slot = 0;
+  RSScoreExplain children[3] = {0};
+
+  if (isRange) {
+    rm_asprintf(&children[slot++].str, "matched within radius = %s",
+                hasVector ? "true" : "false");
+  }
+
+  if (isRRF) {
+    if (hasVector) {
+      rm_asprintf(&children[slot++].str, "vector rank = %.0f", values[VECTOR_INDEX]);
+    } else {
+      rm_asprintf(&children[slot++].str, "vector rank = <no match>");
+    }
+  } else {
+    if (hasVector) {
+      const double beta = scoringCtx->linearCtx.numWeights > 1
+                              ? scoringCtx->linearCtx.linearWeights[1]
+                              : 0.0;
+      const double y = values[VECTOR_INDEX];
+      rm_asprintf(&children[slot++].str,
+                  "vector contribution = %.4f * %.4f = %.4f", beta, y, beta * y);
+      rm_asprintf(&children[slot++].str, "normalized vector score = %.4f", y);
+    } else {
+      rm_asprintf(&children[slot++].str, "vector contribution = <no match>");
+    }
+  }
+
+  parent->numChildren = (int)slot;
+  parent->children = rm_calloc(slot, sizeof(RSScoreExplain));
+  for (size_t i = 0; i < slot; i++) {
+    parent->children[i] = children[i];
+  }
+  return parent;
+}
+
+// Build the per-document RSScoreExplain wrapper for a hybrid result.
+//
+// Layout (MOD-10044):
+//   "final score: <S>"
+//     └── envelope from HybridScoring_FormatEnvelope
+//           ├── text branch sub-tree
+//           └── vector branch sub-tree
+static RSScoreExplain *buildHybridScoreExplain(HybridSearchResult *hybridResult,
+                                               HybridScoringContext *scoringCtx,
+                                               const HybridExplainContext *explainCtx,
+                                               const double *values,
+                                               double finalScore) {
+  RSScoreExplain *outer = rm_calloc(1, sizeof(RSScoreExplain));
+  rm_asprintf(&outer->str, "final score: %.17g", finalScore);
+
+  RSScoreExplain *envelope = rm_calloc(1, sizeof(RSScoreExplain));
+  envelope->str = HybridScoring_FormatEnvelope(scoringCtx);
+
+  RSScoreExplain *textBranch = buildTextBranch(hybridResult, scoringCtx, explainCtx, values);
+  RSScoreExplain *vectorBranch = buildVectorBranch(hybridResult, scoringCtx, explainCtx, values);
+
+  envelope->numChildren = 2;
+  envelope->children = rm_calloc(2, sizeof(RSScoreExplain));
+  moveScoreExplainInto(&envelope->children[0], textBranch);
+  moveScoreExplainInto(&envelope->children[1], vectorBranch);
+
+  outer->numChildren = 1;
+  outer->children = rm_calloc(1, sizeof(RSScoreExplain));
+  moveScoreExplainInto(&outer->children[0], envelope);
+
+  return outer;
+}
+
+SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoringContext *scoringCtx,
+                                 HybridLookupContext *lookupCtx, const HybridExplainContext *explainCtx) {
   RS_ASSERT(hybridResult && scoringCtx);
 
-  // Find the primary result (first non-null result)
+  // Pick the "primary" — first non-null source in index order. This biases
+  // toward the text branch (SEARCH_INDEX=0) when both branches matched, so
+  // the merged result keeps the search-side RSIndexResult.
   SearchResult *primary = NULL;
   int8_t targetIndex = -1;
   for (size_t i = 0; i < hybridResult->numSources; i++) {
@@ -147,21 +364,42 @@ SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoring
 
   RS_ASSERT(primary && targetIndex != -1);
 
-  // Calculate hybrid score by combining scores from all sources
-  SearchResult_SetScore(primary, calculateHybridScore(hybridResult, scoringCtx));
+  // Snapshot per-source values before calculateHybridScore overwrites the
+  // primary. For RRF these are 1-based ranks; for LINEAR they are raw scores.
+  double *values = NULL;
+  if (explainCtx) {
+    values = rm_calloc(hybridResult->numSources, sizeof(double));
+    for (size_t i = 0; i < hybridResult->numSources; i++) {
+      values[i] = hybridResult->hasResults[i]
+                      ? SearchResult_GetScore(hybridResult->searchResults[i])
+                      : 0.0;
+    }
+  }
 
-  // Merge flags from all upstreams
+  double finalScore = calculateHybridScore(hybridResult, scoringCtx);
+  SearchResult_SetScore(primary, finalScore);
+
   for (size_t i = 0; i < hybridResult->numSources; i++) {
     if (hybridResult->hasResults[i] && i != targetIndex) {
       RS_ASSERT(hybridResult->searchResults[i]);
       SearchResult_MergeFlags(primary, hybridResult->searchResults[i]);
     }
   }
-  // Transfer ownership: Remove primary result from HybridSearchResult to prevent double-free
+
+  // Build the wrapper before transferring ownership: it moves the search
+  // sub-result's RSScoreExplain (if any) into one of its children.
+  if (explainCtx) {
+    RSScoreExplain *wrapper = buildHybridScoreExplain(hybridResult, scoringCtx, explainCtx, values, finalScore);
+    SearchResult_SetScoreExplain(primary, wrapper);
+    rm_free(values);
+  }
+
+  // Detach the primary so the dict destructor (HybridSearchResult_Free) does
+  // not double-free it.
   hybridResult->searchResults[targetIndex] = NULL;
   hybridResult->hasResults[targetIndex] = false;
-  // Merge field data into primary result's rowdata
-  // Create temporary row for merging (avoids modifying primary while reading from it)
+  // Use a temporary row in the merge to avoid modifying `primary` while we
+  // still read from it.
   mergeRLookupRowsFromSourcesIntoTarget(hybridResult, lookupCtx, primary);
   return primary;
 }

--- a/src/hybrid/hybrid_search_result.h
+++ b/src/hybrid/hybrid_search_result.h
@@ -13,11 +13,42 @@
 #include "result_processor.h"
 #include "hybrid_scoring.h"
 #include "hybrid_lookup_context.h"
+#include "vector_index.h"
 #include "util/arr/arr.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Per-query info needed to render the EXPLAINSCORE wrapper. Built once at
+ * pipeline construction (when EXPLAINSCORE is set) and stored on the merger.
+ * The fields here describe context that is constant across all yielded rows
+ * — per-doc values (ranks, scores, scorer subtree) are filled in by the
+ * merger as it runs.
+ */
+typedef struct HybridExplainContext {
+  // Borrowed: lifetime tied to the search sub-AREQ's searchopts.
+  const char *textScorerName;
+  // Owned: e.g. "vector branch (KNN)" or "vector branch (RANGE: radius=…, epsilon=…)".
+  char *vectorBranchEnvelope;
+  // Vector retrieval mode of the VSIM sub-query.
+  VectorQueryType vectorMode;
+} HybridExplainContext;
+
+void HybridExplainContext_Free(HybridExplainContext *ctx);
+
+/**
+ * Build an EXPLAINSCORE context from the two hybrid sub-AREQs.
+ *
+ * Reads the search sub-query's resolved scorer name and the vector
+ * sub-query's retrieval mode (and, for RANGE, radius + optional epsilon
+ * QueryAttribute) and freezes them into strings the merger reuses per row.
+ *
+ * Returned context is owned by the caller (the hybrid merger).
+ */
+struct AREQ;
+HybridExplainContext *HybridExplainContext_Build(struct AREQ *searchReq, struct AREQ *vectorReq);
 
 /**
  * HybridSearchResult structure that stores SearchResults from multiple sources.
@@ -59,8 +90,16 @@ double calculateHybridScore(HybridSearchResult *hybridResult, HybridScoringConte
  *
  * The primary result is the SearchResult we merge into and return to the downstream processor.
  * This function transfers ownership of the primary result from the HybridSearchResult to the caller.
+ *
+ * When `explainCtx` is non-NULL, an RSScoreExplain wrapper describing the
+ * hybrid combine is attached to the merged result. The wrapper shape is
+ * specified in MOD-10044: an outer "final score" node, a per-method envelope
+ * (RRF/LINEAR with the fusion parameters), and per-branch sub-trees that
+ * graft the text scorer's existing explanation under a "Text scorer:" node
+ * and label the vector branch by retrieval mode.
  */
-SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoringContext *scoringCtx, HybridLookupContext *lookupCtx);
+SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoringContext *scoringCtx,
+                                 HybridLookupContext *lookupCtx, const HybridExplainContext *explainCtx);
 
 #ifdef __cplusplus
 }

--- a/src/hybrid/hybrid_search_result.h
+++ b/src/hybrid/hybrid_search_result.h
@@ -92,11 +92,7 @@ double calculateHybridScore(HybridSearchResult *hybridResult, HybridScoringConte
  * This function transfers ownership of the primary result from the HybridSearchResult to the caller.
  *
  * When `explainCtx` is non-NULL, an RSScoreExplain wrapper describing the
- * hybrid combine is attached to the merged result. The wrapper shape is
- * specified in MOD-10044: an outer "final score" node, a per-method envelope
- * (RRF/LINEAR with the fusion parameters), and per-branch sub-trees that
- * graft the text scorer's existing explanation under a "Text scorer:" node
- * and label the vector branch by retrieval mode.
+ * hybrid combine is attached to the merged result.
  */
 SearchResult* mergeSearchResults(HybridSearchResult *hybridResult, HybridScoringContext *scoringCtx,
                                  HybridLookupContext *lookupCtx, const HybridExplainContext *explainCtx);

--- a/src/hybrid/hybrid_search_result.h
+++ b/src/hybrid/hybrid_search_result.h
@@ -28,8 +28,11 @@ extern "C" {
  * merger as it runs.
  */
 typedef struct HybridExplainContext {
-  // Borrowed: lifetime tied to the search sub-AREQ's searchopts.
-  const char *textScorerName;
+  // Owned. Resolved scorer name (defaults to RSGlobalConfig.defaultScorer when
+  // the search sub-query did not specify one). Duplicated at build time so a
+  // concurrent FT.CONFIG SET DEFAULT_SCORER cannot pull the string out from
+  // under a long-running query while we render the explain wrapper.
+  char *textScorerName;
   // Owned: e.g. "vector branch (KNN)" or "vector branch (RANGE: radius=…, epsilon=…)".
   char *vectorBranchEnvelope;
   // Vector retrieval mode of the VSIM sub-query.

--- a/src/hybrid/hybrid_search_result.h
+++ b/src/hybrid/hybrid_search_result.h
@@ -21,11 +21,9 @@ extern "C" {
 #endif
 
 /**
- * Per-query info needed to render the EXPLAINSCORE wrapper. Built once at
- * pipeline construction (when EXPLAINSCORE is set) and stored on the merger.
- * The fields here describe context that is constant across all yielded rows
- * — per-doc values (ranks, scores, scorer subtree) are filled in by the
- * merger as it runs.
+ * Per-query info needed to render the EXPLAINSCORE wrapper. The fields here
+ * describe context that is constant across all yielded rows — per-doc values
+ * (ranks, scores, scorer subtree) are filled in by the merger as it runs.
  */
 typedef struct HybridExplainContext {
   // Owned. Resolved scorer name (defaults to RSGlobalConfig.defaultScorer when
@@ -48,7 +46,9 @@ void HybridExplainContext_Free(HybridExplainContext *ctx);
  * sub-query's retrieval mode (and, for RANGE, radius + optional epsilon
  * QueryAttribute) and freezes them into strings the merger reuses per row.
  *
- * Returned context is owned by the caller (the hybrid merger).
+ * Must be called after AREQ_ApplyContext on both sub-queries (it relies on the
+ * resolved scorer name and the still-intact ParsedVectorData snapshot).
+ * Returned context is owned by the caller.
  */
 struct AREQ;
 HybridExplainContext *HybridExplainContext_Build(const struct AREQ *searchReq, const struct AREQ *vectorReq);

--- a/src/hybrid/hybrid_search_result.h
+++ b/src/hybrid/hybrid_search_result.h
@@ -48,7 +48,7 @@ void HybridExplainContext_Free(HybridExplainContext *ctx);
  * Returned context is owned by the caller (the hybrid merger).
  */
 struct AREQ;
-HybridExplainContext *HybridExplainContext_Build(struct AREQ *searchReq, struct AREQ *vectorReq);
+HybridExplainContext *HybridExplainContext_Build(const struct AREQ *searchReq, const struct AREQ *vectorReq);
 
 /**
  * HybridSearchResult structure that stores SearchResults from multiple sources.

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -218,9 +218,12 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
 
     ArgParser_Free(parser);
 
+    // EXPLAINSCORE implies emitting the per-result score: the reply path pairs
+    // the score with its explanation, so without QEXEC_F_SEND_SCORES neither
+    // would be written. FT.HYBRID does not expose a user-facing WITHSCORES, so
+    // we set the flag here on the user's behalf.
     if ((*(ctx->reqFlags) & QEXEC_F_SEND_SCOREEXPLAIN)) {
-        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "EXPLAINSCORE is not yet supported by FT.HYBRID");
-        return REDISMODULE_ERR;
+        *(ctx->reqFlags) |= QEXEC_F_SEND_SCORES;
     }
 
     // Apply optimization for skipping rich results collection when possible

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -226,6 +226,18 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
         *(ctx->reqFlags) |= QEXEC_F_SEND_SCORES;
     }
 
+    // EXPLAINSCORE is incompatible with GROUPBY: the grouper consumes per-document
+    // SearchResults (and their score_explain wrappers) and emits aggregate rows
+    // whose score_explain is empty, while the hybrid reply path still opens a
+    // [score, explain] array. Reject the combination at parse time rather than
+    // emit a malformed one-element score array.
+    if ((ctx->specifiedArgs & SPECIFIED_ARG_EXPLAINSCORE) &&
+        (ctx->specifiedArgs & SPECIFIED_ARG_GROUPBY)) {
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                            "EXPLAINSCORE is not supported with GROUPBY");
+        return REDISMODULE_ERR;
+    }
+
     // Apply optimization for skipping rich results collection when possible
     applyRichResultsOptimization(ctx);
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -536,6 +536,24 @@ final:
   // Set default scoreField using vector field name (can be done during parsing)
   VectorQuery_SetDefaultScoreField(vq, pvd->fieldName, strlen(pvd->fieldName));
 
+  // Snapshot the fields used by EXPLAINSCORE wrapper rendering. applyVectorQuery
+  // (called later by AREQ_ApplyContext) transfers `vq` ownership into the AST and
+  // nulls pvd->query, so the explain plumbing reads from these copies instead.
+  pvd->explainQueryType = vq->type;
+  if (vq->type == VECSIM_QT_RANGE) {
+    pvd->explainRangeRadius = vq->range.radius;
+  }
+  for (size_t i = 0; i < array_len(vq->params.params); i++) {
+    const VecSimRawParam *p = &vq->params.params[i];
+    if (p->name && p->nameLen == strlen(VECSIM_EPSILON) &&
+        !strncasecmp(p->name, VECSIM_EPSILON, p->nameLen)) {
+      pvd->explainRangeEpsilon = rm_malloc(p->valLen + 1);
+      memcpy(pvd->explainRangeEpsilon, p->value, p->valLen);
+      pvd->explainRangeEpsilon[p->valLen] = '\0';
+      break;
+    }
+  }
+
   // Store the completed ParsedVectorData in AREQ
   vreq->parsedVectorData = pvd;
 
@@ -583,6 +601,14 @@ static void copyHybridConfigToSubquery(AREQ *subqueryRequest,
   // Copy score sending flags if enabled
   if (mergeReqflags & QEXEC_F_SEND_SCORES) {
     subqueryRequest->reqflags |= QEXEC_F_SEND_SCORES;
+  }
+
+  // EXPLAINSCORE only makes sense on the text branch: the search scorer is
+  // what allocates the per-result RSScoreExplain that the hybrid merger
+  // wraps. The vector branch has no equivalent producer.
+  if ((mergeReqflags & QEXEC_F_SEND_SCOREEXPLAIN) &&
+      (subqueryRequest->reqflags & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY)) {
+    subqueryRequest->reqflags |= QEXEC_F_SEND_SCOREEXPLAIN;
   }
 
   // Copy request configuration using the helper function

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -965,11 +965,10 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
     goto error;
   }
 
-  // Build the EXPLAINSCORE context now, while the data it reads is final but still
-  // available: AREQ_ApplyContext has resolved the search scorer name, and the
-  // vector sub-query's ParsedVectorData snapshot is still intact (the live
-  // VectorQuery is moved into the AST by AREQ_ApplyContext). Ownership is held by
-  // hybridParams and transferred to the merger in HybridRequest_BuildMergePipeline.
+  // Build here, after AREQ_ApplyContext on both sub-queries: it has resolved the
+  // search scorer name, and the vector ParsedVectorData snapshot is still intact
+  // (the live VectorQuery is moved into the AST by the same call, so reading it
+  // any later would be too late).
   if (*mergeReqflags & QEXEC_F_SEND_SCOREEXPLAIN) {
     hybridParams->explainCtx = HybridExplainContext_Build(searchRequest, vectorRequest);
   }
@@ -1002,9 +1001,6 @@ error:
   if (mergeSearchopts.params) {
     Param_DictFree(mergeSearchopts.params);
   }
-  if (hybridParams->scoringCtx) {
-    HybridScoringContext_Free(hybridParams->scoringCtx);
-    hybridParams->scoringCtx = NULL;
-  }
+  HybridPipelineParams_Cleanup(hybridParams);
   return REDISMODULE_ERR;
 }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -776,6 +776,7 @@ static bool parseSubqueriesCount(ArgsCursor *ac, QueryError *status) {
 int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
                        RedisSearchCtx *sctx, ParseHybridCommandCtx *parsedCmdCtx,
                        QueryError *status, bool internal, ProfileOptions profileOptions) {
+  REDISMODULE_NOT_USED(ctx);
   HybridPipelineParams *hybridParams = parsedCmdCtx->hybridParams;
   hybridParams->scoringCtx = HybridScoringContext_NewDefault();
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -32,6 +32,7 @@
 #include "cursor.h"
 #include "info/info_redis/block_client.h"
 #include "hybrid/hybrid_request.h"
+#include "hybrid/hybrid_search_result.h"
 #include "hybrid/parse/hybrid_optional_args.h"
 #include "asm_state_machine.h"
 #include "hybrid/parse/hybrid_callbacks.h"
@@ -962,6 +963,15 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   if (AREQ_ApplyContext(vectorRequest, vectorRequest->sctx, status) != REDISMODULE_OK) {
     AddValidationErrorContext(vectorRequest, status);
     goto error;
+  }
+
+  // Build the EXPLAINSCORE context now, while the data it reads is final but still
+  // available: AREQ_ApplyContext has resolved the search scorer name, and the
+  // vector sub-query's ParsedVectorData snapshot is still intact (the live
+  // VectorQuery is moved into the AST by AREQ_ApplyContext). Ownership is held by
+  // hybridParams and transferred to the merger in HybridRequest_BuildMergePipeline.
+  if (*mergeReqflags & QEXEC_F_SEND_SCOREEXPLAIN) {
+    hybridParams->explainCtx = HybridExplainContext_Build(searchRequest, vectorRequest);
   }
 
   // thread safe context

--- a/src/hybrid/vector_query_utils.c
+++ b/src/hybrid/vector_query_utils.c
@@ -28,5 +28,9 @@ void ParsedVectorData_Free(ParsedVectorData *pvd) {
     rm_free(pvd->vectorScoreFieldAlias);
   }
 
+  if (pvd->explainRangeEpsilon) {
+    rm_free(pvd->explainRangeEpsilon);
+  }
+
   rm_free(pvd);
 }

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -31,6 +31,12 @@ typedef struct {
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set
   uint32_t queryNodeFlags;     // QueryNode flags to be applied when creating the vector node
   bool skipFilterIntegration;  // true to make vector node root without filter wrapping (RANGE without explicit FILTER)
+
+  // EXPLAINSCORE snapshot: applyVectorQuery later nulls `query`, so we keep a
+  // copy of the fields needed to render the hybrid explain envelope.
+  VectorQueryType explainQueryType;
+  double explainRangeRadius;        // valid only when explainQueryType == VECSIM_QT_RANGE
+  char *explainRangeEpsilon;        // OWNED, NULL if user did not set EPSILON
 } ParsedVectorData;
 
 void ParsedVectorData_Free(ParsedVectorData *pvd);

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -7,8 +7,7 @@
 extern "C" {
 #endif
 
-// Forward declaration: the full definition lives in hybrid/hybrid_search_result.h,
-// which is not (and need not be) included here — we only reference it by pointer.
+// Referenced only by pointer here; defined in hybrid/hybrid_search_result.h.
 typedef struct HybridExplainContext HybridExplainContext;
 
 /**
@@ -145,11 +144,10 @@ typedef struct HybridPipelineParams {
      *  free it during cleanup. Can be NULL for default scoring behavior. */
     HybridScoringContext *scoringCtx;
 
-    /** EXPLAINSCORE wrapper context, built at parse time when EXPLAINSCORE is set.
-     *  Describes the constant-across-rows scoring context (resolved text scorer
-     *  name, vector retrieval mode/envelope). Ownership transfers to the hybrid
-     *  merger in HybridRequest_BuildMergePipeline; freed by freeHybridParams if the
-     *  merge pipeline is never built. NULL ⇒ no EXPLAINSCORE wrapping. */
+    /** EXPLAINSCORE wrapper context (see HybridExplainContext), built at parse
+     *  time when EXPLAINSCORE is set. Ownership transfers to the hybrid merger in
+     *  HybridRequest_BuildMergePipeline; freed via HybridPipelineParams_Cleanup if
+     *  the merge pipeline is never built. NULL ⇒ no EXPLAINSCORE wrapping. */
     HybridExplainContext *explainCtx;
 } HybridPipelineParams;
 

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -7,6 +7,10 @@
 extern "C" {
 #endif
 
+// Forward declaration: the full definition lives in hybrid/hybrid_search_result.h,
+// which is not (and need not be) included here — we only reference it by pointer.
+typedef struct HybridExplainContext HybridExplainContext;
+
 /**
  * Common parameters shared across different pipeline types in RediSearch.
  * This struct contains the core components needed by all pipeline operations,
@@ -140,6 +144,13 @@ typedef struct HybridPipelineParams {
      *  are combined and scored. The pipeline takes ownership of this pointer and will
      *  free it during cleanup. Can be NULL for default scoring behavior. */
     HybridScoringContext *scoringCtx;
+
+    /** EXPLAINSCORE wrapper context, built at parse time when EXPLAINSCORE is set.
+     *  Describes the constant-across-rows scoring context (resolved text scorer
+     *  name, vector retrieval mode/envelope). Ownership transfers to the hybrid
+     *  merger in HybridRequest_BuildMergePipeline; freed by freeHybridParams if the
+     *  merge pipeline is never built. NULL ⇒ no EXPLAINSCORE wrapping. */
+    HybridExplainContext *explainCtx;
 } HybridPipelineParams;
 
 /**

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2163,6 +2163,7 @@ dictType dictTypeHybridSearchResult = {
  const RLookupKey *docKey;        // Key for reading document key when dmd is not available
  RPStatus* upstreamReturnCodes;   // Final return codes from each upstream
  HybridLookupContext *lookupCtx;  // Lookup context for field merging
+ HybridExplainContext *explainCtx; // EXPLAINSCORE wrapper context; NULL ⇒ no wrapping
 
 } RPHybridMerger;
 
@@ -2276,7 +2277,7 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
   HybridSearchResult *hybridResult = (HybridSearchResult*)dictGetVal(entry);
   RS_ASSERT(hybridResult);
 
-  SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx);
+  SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx, self->explainCtx);
   if (!mergedResult) {
     return RS_RESULT_ERROR;
   }
@@ -2372,6 +2373,10 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
      HybridLookupContext_Free(self->lookupCtx);
    }
 
+   if (self->explainCtx) {
+     HybridExplainContext_Free(self->explainCtx);
+   }
+
    // Free the processor itself
    rm_free(self);
  }
@@ -2392,7 +2397,8 @@ ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx,
                                     const RLookupKey *docKey,
                                     const RLookupKey *scoreKey,
                                     RPStatus *subqueriesReturnCodes,
-                                    HybridLookupContext *lookupCtx) {
+                                    HybridLookupContext *lookupCtx,
+                                    HybridExplainContext *explainCtx) {
   RPHybridMerger *ret = rm_calloc(1, sizeof(*ret));
 
   ret->sctx = sctx;
@@ -2410,6 +2416,8 @@ ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx,
   ret->scoreKey = scoreKey;
 
   ret->docKey = docKey;
+
+  ret->explainCtx = explainCtx;
 
   // Store reference to the hybrid request's subqueries return codes array
   RS_ASSERT(subqueriesReturnCodes);

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -328,9 +328,14 @@ StrongRef DepleterSync_New(unsigned int num_depleters, bool take_index_lock);
  * Merges results from multiple upstream processors using a hybrid scoring function.
  * Takes results from all upstreams and applies the provided function to combine their scores.
  *******************************************************************************************************************/
+// Forward declaration; full type is in hybrid/hybrid_search_result.h
+typedef struct HybridExplainContext HybridExplainContext;
+
 /*
  * Creates a new Hybrid Merger processor.
  * Note: RPHybridMerger takes ownership of hybridScoringCtx and is responsible for freeing it.
+ * `explainCtx` is optional: pass NULL to disable EXPLAINSCORE wrapping. When
+ * non-NULL, RPHybridMerger takes ownership of the struct (frees it on Free).
  * @param scoreKey Optional key for writing scores as fields when no LOAD step is provided
  */
 ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx,
@@ -340,7 +345,8 @@ ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx,
                                     const RLookupKey *docKey,
                                     const RLookupKey *scoreKey,
                                     RPStatus *subqueriesReturnCodes,
-                                    HybridLookupContext *lookupCtx);
+                                    HybridLookupContext *lookupCtx,
+                                    HybridExplainContext *explainCtx);
 
 /*
  * Returns NULL if the processor is not a HybridMerger or if scoreKey is NULL.

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -13,6 +13,8 @@
 #include "redisearch_rs/headers/query_error.h"
 #include "hybrid/hybrid_cursor_mappings.h"
 
+#include <string_view>
+
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
 
 extern "C" {
@@ -432,12 +434,11 @@ TEST_F(HybridBuildMRCommandTest, testMinimalCommand) {
 // option, not by argv text. A SEARCH query token or PARAMS value equal to
 // "EXPLAINSCORE" must not trigger forwarding; sendExplainScore=true must.
 TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
-    auto countToken = [](const MRCommand *cmd, const char *tok) {
-        size_t tokLen = strlen(tok);
+    auto countToken = [](const MRCommand *cmd, std::string_view tok) {
         int n = 0;
         for (int i = 0; i < cmd->num; i++) {
-            if (cmd->lens[i] == tokLen &&
-                strncasecmp(cmd->strs[i], tok, tokLen) == 0) {
+            if (cmd->lens[i] == tok.size() &&
+                strncasecmp(cmd->strs[i], tok.data(), tok.size()) == 0) {
                 n++;
             }
         }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -18,6 +18,7 @@
 extern "C" {
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                                   ProfileOptions profileOptions,
+                                  bool sendExplainScore,
                                   MRCommand *xcmd, arrayof(char *) serialized,
                                   IndexSpec *sp, int *outKArgIndex);
 }
@@ -121,7 +122,8 @@ protected:
         // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                     /*sendExplainScore=*/false, &xcmd,
                                      nullptr, testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
@@ -193,7 +195,8 @@ protected:
         // Build MR command
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                     /*sendExplainScore=*/false, &xcmd,
                                      nullptr, nullptr, &kArgIndex);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
@@ -238,7 +241,8 @@ protected:
       // Build MR command (not testing SHARD_K_RATIO here)
       MRCommand xcmd;
       int kArgIndex = -1;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
+      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                   /*sendExplainScore=*/false, &xcmd,
                                    nullptr, sp, &kArgIndex);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -422,6 +426,79 @@ TEST_F(HybridBuildMRCommandTest, testMinimalCommand) {
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "idx", "SEARCH", "test", "VSIM", "@vec", "data"
     });
+}
+
+// EXPLAINSCORE forwarding to the shard is driven by the parsed top-level
+// option, not by argv text. A SEARCH query token or PARAMS value equal to
+// "EXPLAINSCORE" must not trigger forwarding; sendExplainScore=true must.
+TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
+    auto countToken = [](const MRCommand *cmd, const char *tok) {
+        size_t tokLen = strlen(tok);
+        int n = 0;
+        for (int i = 0; i < cmd->num; i++) {
+            if (cmd->lens[i] == tokLen &&
+                strncasecmp(cmd->strs[i], tok, tokLen) == 0) {
+                n++;
+            }
+        }
+        return n;
+    };
+
+    {
+        std::vector<const char *> input = {
+            "FT.HYBRID", "test_idx", "SEARCH", "EXPLAINSCORE",
+            "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
+        RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
+
+        MRCommand xcmd;
+        int kArgIndex = -1;
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                     /*sendExplainScore=*/false, &xcmd,
+                                     nullptr, nullptr, &kArgIndex);
+
+        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+            << "EXPLAINSCORE in the search query must not be re-appended as a "
+               "top-level shard option";
+        MRCommand_Free(&xcmd);
+    }
+
+    {
+        std::vector<const char *> input = {
+            "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
+            "VSIM", "@vector_field", "$BLOB",
+            "PARAMS", "4", "param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA,
+            nullptr};
+        RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
+
+        MRCommand xcmd;
+        int kArgIndex = -1;
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                     /*sendExplainScore=*/false, &xcmd,
+                                     nullptr, nullptr, &kArgIndex);
+
+        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+            << "EXPLAINSCORE as a PARAMS value must not be re-appended as a "
+               "top-level shard option";
+        MRCommand_Free(&xcmd);
+    }
+
+    {
+        std::vector<const char *> input = {
+            "FT.HYBRID", "test_idx", "SEARCH", "hello",
+            "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
+        RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
+
+        MRCommand xcmd;
+        int kArgIndex = -1;
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                     /*sendExplainScore=*/true, &xcmd,
+                                     nullptr, nullptr, &kArgIndex);
+
+        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+            << "EXPLAINSCORE should be appended exactly once when the parsed "
+               "flag is set";
+        MRCommand_Free(&xcmd);
+    }
 }
 
 // Test SHARD_K_RATIO modifies K value in distributed command with multiple shards

--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -224,7 +224,7 @@ ResultProcessor* CreateLinearHybridMerger(ResultProcessor **upstreams, size_t nu
   // Use static dummy search context for tests (with skipTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
-  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx, NULL);
+  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, nullptr, nullptr, dummyReturnCodes, lookupCtx, nullptr);
 }
 
 // Helper function to create hybrid merger with RRF scoring
@@ -239,7 +239,7 @@ ResultProcessor* CreateRRFHybridMerger(ResultProcessor **upstreams, size_t numUp
   // Use static dummy search context for tests (with skipTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
-  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx, NULL);
+  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, nullptr, nullptr, dummyReturnCodes, lookupCtx, nullptr);
 }
 
 
@@ -1447,7 +1447,7 @@ TEST_F(HybridMergerTest, testUpstreamReturnCodes) {
   // Use static dummy search context for tests (with skipTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
-  ResultProcessor *hybridMerger = RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, 3, NULL, NULL, returnCodes, lookupCtx, NULL);
+  ResultProcessor *hybridMerger = RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, 3, nullptr, nullptr, returnCodes, lookupCtx, nullptr);
 
   // Process results - this should capture the return codes
   SearchResult r = SearchResult_New();

--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -224,7 +224,7 @@ ResultProcessor* CreateLinearHybridMerger(ResultProcessor **upstreams, size_t nu
   // Use static dummy search context for tests (with skipTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
-  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx);
+  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx, NULL);
 }
 
 // Helper function to create hybrid merger with RRF scoring
@@ -239,7 +239,7 @@ ResultProcessor* CreateRRFHybridMerger(ResultProcessor **upstreams, size_t numUp
   // Use static dummy search context for tests (with skipTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
-  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx);
+  return RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx, NULL);
 }
 
 
@@ -1447,7 +1447,7 @@ TEST_F(HybridMergerTest, testUpstreamReturnCodes) {
   // Use static dummy search context for tests (with skipTimeoutChecks = true)
   RedisSearchCtx *sctx = GetDummySearchCtx();
 
-  ResultProcessor *hybridMerger = RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, 3, NULL, NULL, returnCodes, lookupCtx);
+  ResultProcessor *hybridMerger = RPHybridMerger_New(sctx, hybridScoringCtx, upstreams, 3, NULL, NULL, returnCodes, lookupCtx, NULL);
 
   // Process results - this should capture the return codes
   SearchResult r = SearchResult_New();

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -757,6 +757,26 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
   }
 }
 
+TEST_F(ParseHybridTest, testExternalCommandWithWithScores) {
+  // WITHSCORES is an internal-only flag used by the coordinator to ferry per-shard
+  // scores back to the aggregator. The public FT.HYBRID command must reject it.
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+        "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA, "WITHSCORES");
+
+  QueryError status = QueryError_Default();
+  ArgsCursor ac = {0};
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
+  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
+  EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Public FT.HYBRID should reject WITHSCORES";
+  QueryError_ClearError(&status);
+
+  // Clean up any partial allocations from the failed parse
+  if (result.vector && result.vector->ast.root) {
+    QAST_Destroy(&result.vector->ast);
+    result.vector->ast.root = NULL;
+  }
+}
+
 TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
         "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA, "_NUM_SSTRING", SLOTS_STR);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1310,12 +1310,6 @@ TEST_F(ParseHybridTest, testCombineRRFWithOddArgumentCount) {
   testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "RRF expects pairs of key value arguments, argument count must be an even number");
 }
 
-TEST_F(ParseHybridTest, testExplainScore) {
-  // Test EXPLAINSCORE - currently should fail with specific error
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "EXPLAINSCORE", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "EXPLAINSCORE is not yet supported by FT.HYBRID");
-}
-
 // ============================================================================
 // DIALECT ERROR TESTS - Testing DIALECT is not supported
 // ============================================================================

--- a/tests/pytests/test_hybrid_explainscore.py
+++ b/tests/pytests/test_hybrid_explainscore.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
 """End-to-end shape tests for FT.HYBRID EXPLAINSCORE (MOD-10044).
 
 The explain tree follows a fixed layout:
@@ -114,7 +121,9 @@ def test_hybrid_explainscore_rrf_knn():
 
 
 def test_hybrid_explainscore_rrf_range():
-    """RRF + RANGE: vector branch envelope identifies RANGE with radius/epsilon."""
+    """RRF + RANGE: vector branch envelope identifies RANGE with radius/epsilon.
+    Also assert the outer RRF formula and per-branch rank lines (mirrors what
+    we check for RRF+KNN so each variant locks down its own scoring shape)."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     setup_index(env, vec_algo='HNSW')
     blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
@@ -131,8 +140,16 @@ def test_hybrid_explainscore_rrf_range():
         _, _, tokens = _score_and_tokens(env, fields, key)
         joined = ' | '.join(tokens)
 
-        env.assertTrue(any('Hybrid score (RRF:' in t for t in tokens),
+        # Outer line is the RRF formula: "1 / (constant K + rank N) + …".
+        env.assertTrue(any(t.startswith('final score: 1 / (constant ')
+                           and ' + 1 / (constant ' in t and ' = ' in t for t in tokens),
+                       message=f'missing RRF formula in outer line, got {joined!r}')
+        env.assertTrue(any('Hybrid score (RRF: window=' in t and 'constant=' in t for t in tokens),
                        message=f'missing RRF envelope in {joined!r}')
+        env.assertTrue(any(t.startswith('text rank = ') for t in tokens),
+                       message=f'missing "text rank = …" in {joined!r}')
+        env.assertTrue(any(t.startswith('vector rank = ') for t in tokens),
+                       message=f'missing "vector rank = …" in {joined!r}')
         # Envelope must call out RANGE and surface radius + epsilon.
         env.assertTrue(any('vector branch (RANGE:' in t and 'radius=0.7000' in t
                            and 'epsilon=0.5' in t for t in tokens),
@@ -178,7 +195,9 @@ def test_hybrid_explainscore_linear_knn():
 
 
 def test_hybrid_explainscore_linear_range():
-    """LINEAR + RANGE: combines the LINEAR envelope with a RANGE vector branch."""
+    """LINEAR + RANGE: combines the LINEAR envelope with a RANGE vector branch.
+    Also assert the outer LINEAR formula and the per-branch contribution lines,
+    so the scoring shape is locked down for this variant too."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     setup_index(env, vec_algo='HNSW')
     blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
@@ -192,10 +211,18 @@ def test_hybrid_explainscore_linear_range():
     results, total = get_results_from_hybrid_response(response)
     env.assertGreater(total, 0)
 
+    saw_matched = False
     for key, fields in results.items():
         _, _, tokens = _score_and_tokens(env, fields, key)
         joined = ' | '.join(tokens)
 
+        # Outer line: "final score: 0.6000 * X + 0.4000 * Y = S" (or, for
+        # docs that miss the vector branch, "0.6000 * X + 0 [vector: no match] = S").
+        env.assertTrue(any(t.startswith('final score: 0.6000 * ')
+                           and ' = ' in t
+                           and (' + 0.4000 * ' in t or '0 [vector: no match]' in t)
+                           for t in tokens),
+                       message=f'missing LINEAR formula in outer line, got {joined!r}')
         env.assertTrue(any('Hybrid score (LINEAR: alpha=0.6000' in t
                            and 'beta=0.4000' in t for t in tokens),
                        message=f'missing LINEAR envelope in {joined!r}')
@@ -204,6 +231,22 @@ def test_hybrid_explainscore_linear_range():
                        message=f'missing RANGE envelope in {joined!r}')
         env.assertTrue(any('matched within radius = ' in t for t in tokens),
                        message=f'missing "matched within radius" in {joined!r}')
+
+        # text contribution is always present (every result has a text match).
+        env.assertTrue(any('text contribution = 0.6000 *' in t for t in tokens),
+                       message=f'missing text-contribution formula in {joined!r}')
+        env.assertTrue(any(t.startswith('normalized text score = ') for t in tokens),
+                       message=f'missing normalized text score in {joined!r}')
+
+        # vector contribution only when the doc is within the RANGE radius.
+        if any('matched within radius = true' in t for t in tokens):
+            saw_matched = True
+            env.assertTrue(any('vector contribution = 0.4000 *' in t for t in tokens),
+                           message=f'missing vector-contribution formula in {joined!r}')
+            env.assertTrue(any(t.startswith('normalized vector score = ') for t in tokens),
+                           message=f'missing normalized vector score in {joined!r}')
+    env.assertTrue(saw_matched,
+                   message='expected at least one doc inside the RANGE radius')
 
 
 def test_hybrid_explainscore_scorer_name_propagates():
@@ -419,3 +462,230 @@ def test_hybrid_explainscore_full_shape_rrf_knn_doc1():
             False,
             message='shape mismatch:\n  ' + '\n  '.join(errors) +
                     f'\n\nactual score field:\n{actual_pretty}')
+
+
+def _bm25_subtree(decimal):
+    """The standalone-side BM25STD subtree, used as a leaf in shape templates."""
+    return [
+        [
+            _Re(rf'Final BM25 : words BM25 {decimal} \* document score {decimal}'),
+            [
+                [
+                    _Re(rf'\(Weight {decimal} \* children BM25 {decimal}\)'),
+                    [
+                        _Re(r'shoes: \(.+\)'),
+                        _Re(r'\+shoe: \(.+\)'),
+                    ],
+                ],
+            ],
+        ],
+    ]
+
+
+def _assert_shape(env, score_field, expected):
+    errors = _shape_errors(expected, score_field)
+    if errors:
+        actual_pretty = json.dumps(_to_jsonable(score_field), indent=2)
+        env.assertTrue(
+            False,
+            message='shape mismatch:\n  ' + '\n  '.join(errors) +
+                    f'\n\nactual score field:\n{actual_pretty}')
+
+
+def test_hybrid_explainscore_full_shape_rrf_range_doc1():
+    """Locked-down structural shape for an RRF+RANGE reply.
+
+    All four corpus docs sit inside the radius (squared L2 distance 0.5 from
+    query [0.5,0.5] vs radius 0.7), so each doc has both a text and a vector
+    rank. Ranks under HNSW range aren't pinned (the traversal order isn't
+    distance-tied on ties), so the per-rank lines use regex matchers; the
+    nesting itself is fully pinned.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    if env.isCluster():
+        env.skip()
+    setup_index(env, vec_algo='HNSW')
+
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'RANGE', '4', 'RADIUS', '0.7', 'EPSILON', '0.5',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, _ = get_results_from_hybrid_response(response)
+    env.assertTrue('doc:1' in results, message=f'doc:1 missing from {list(results)}')
+    fields = results['doc:1']
+
+    decimal = r'[0-9]+(?:\.[0-9]+)?'
+
+    expected_score_field = [
+        _Re(rf'{decimal}'),                                              # raw score
+        [
+            _Re(rf'final score: 1 / \(constant 60\.00 \+ rank {decimal}\) \+ '
+                rf'1 / \(constant 60\.00 \+ rank {decimal}\) = {decimal}'),
+            [
+                [
+                    'Hybrid score (RRF: window=20, constant=60.00)',
+                    [
+                        [   # text branch
+                            _Re(rf'text rank = {decimal}'),
+                            [
+                                [
+                                    'Text scorer: BM25STD',
+                                    _bm25_subtree(decimal),
+                                ],
+                            ],
+                        ],
+                        [   # vector branch (RANGE)
+                            'vector branch (RANGE: radius=0.7000, epsilon=0.5)',
+                            [
+                                'matched within radius = true',
+                                _Re(rf'vector rank = {decimal}'),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+    _assert_shape(env, fields['score'], expected_score_field)
+
+
+def test_hybrid_explainscore_full_shape_linear_range_doc1():
+    """Locked-down structural shape for a LINEAR+RANGE reply.
+
+    Same matched-by-radius corpus as the RRF+RANGE test. LINEAR adds the
+    "normalized text score" sibling under the scorer node and the explicit
+    "vector contribution" + "normalized vector score" rows under the vector
+    branch — those extra children are what this test pins down.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    if env.isCluster():
+        env.skip()
+    setup_index(env, vec_algo='HNSW')
+
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'RANGE', '4', 'RADIUS', '0.7', 'EPSILON', '0.5',
+                       'COMBINE', 'LINEAR', '4', 'ALPHA', '0.7', 'BETA', '0.3',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, _ = get_results_from_hybrid_response(response)
+    env.assertTrue('doc:1' in results, message=f'doc:1 missing from {list(results)}')
+    fields = results['doc:1']
+
+    decimal = r'[0-9]+(?:\.[0-9]+)?'
+
+    expected_score_field = [
+        _Re(rf'{decimal}'),                                              # raw score
+        [
+            _Re(rf'final score: 0\.7000 \* {decimal} \+ 0\.3000 \* {decimal} = {decimal}'),
+            [
+                [
+                    'Hybrid score (LINEAR: alpha=0.7000, beta=0.3000, window=20)',
+                    [
+                        [   # text branch
+                            _Re(rf'text contribution = 0\.7000 \* {decimal} = {decimal}'),
+                            [
+                                [
+                                    'Text scorer: BM25STD',
+                                    [
+                                        _Re(rf'normalized text score = {decimal}'),
+                                    ] + _bm25_subtree(decimal),
+                                ],
+                            ],
+                        ],
+                        [   # vector branch (RANGE)
+                            'vector branch (RANGE: radius=0.7000, epsilon=0.5)',
+                            [
+                                'matched within radius = true',
+                                _Re(rf'vector contribution = 0\.3000 \* {decimal} = {decimal}'),
+                                _Re(rf'normalized vector score = {decimal}'),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+    _assert_shape(env, fields['score'], expected_score_field)
+
+
+def test_hybrid_explainscore_full_shape_text_only_no_vector():
+    """Single-branch match: text matches but the vector RANGE has no hits.
+
+    Pins down the placeholder shape — the outer formula reports the dropped
+    term as "0 [vector: no match]", and the vector branch carries
+    "matched within radius = false" + "vector rank = <no match>" as siblings.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    if env.isCluster():
+        env.skip()
+    setup_index(env, vec_algo='HNSW')
+
+    # Far-away query vector + tiny radius → no doc clears the RANGE filter.
+    blob = np.array([10.0, 10.0]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'RANGE', '2', 'RADIUS', '0.001',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, _ = get_results_from_hybrid_response(response)
+    env.assertTrue('doc:1' in results, message=f'doc:1 missing from {list(results)}')
+    fields = results['doc:1']
+
+    decimal = r'[0-9]+(?:\.[0-9]+)?'
+
+    expected_score_field = [
+        _Re(rf'{decimal}'),                                              # raw score
+        [
+            _Re(rf'final score: 1 / \(constant 60\.00 \+ rank {decimal}\) \+ '
+                rf'0 \[vector: no match\] = {decimal}'),
+            [
+                [
+                    'Hybrid score (RRF: window=20, constant=60.00)',
+                    [
+                        [   # text branch (present)
+                            _Re(rf'text rank = {decimal}'),
+                            [
+                                [
+                                    'Text scorer: BM25STD',
+                                    _bm25_subtree(decimal),
+                                ],
+                            ],
+                        ],
+                        [   # vector branch (no match)
+                            _Re(r'vector branch \(RANGE: radius=0\.0010\)'),
+                            [
+                                'matched within radius = false',
+                                'vector rank = <no match>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+    _assert_shape(env, fields['score'], expected_score_field)
+
+
+def test_hybrid_explainscore_rejected_with_groupby():
+    """EXPLAINSCORE is incompatible with GROUPBY: the grouper clears the
+    per-document SearchResult (including the score_explain wrapper) and emits
+    aggregate rows whose score_explain is empty, while the hybrid reply path
+    still opens a [score, explain] array. The combination must be rejected at
+    parse time."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env)
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    env.expect('FT.HYBRID', 'idx',
+               'SEARCH', 'shoes',
+               'VSIM', '@embedding', '$BLOB',
+               'EXPLAINSCORE',
+               'GROUPBY', '1', '@description',
+               'PARAMS', '2', 'BLOB', blob).error().contains(
+                   'EXPLAINSCORE is not supported with GROUPBY')

--- a/tests/pytests/test_hybrid_explainscore.py
+++ b/tests/pytests/test_hybrid_explainscore.py
@@ -18,8 +18,10 @@ import json
 import re
 
 from RLTest import Env
-from includes import *
-from common import *
+# `includes` configures RLTest defaults as a side effect (e.g. decode_responses);
+# the import is required even though we don't reference its names directly.
+import includes  # noqa: F401
+from common import get_results_from_hybrid_response, np
 
 
 def setup_index(env, vec_algo='FLAT'):

--- a/tests/pytests/test_hybrid_explainscore.py
+++ b/tests/pytests/test_hybrid_explainscore.py
@@ -14,6 +14,9 @@ These tests assert the salient tokens in each variant rather than the full
 tree, so the existing TEXT-scorer subtree can evolve without breaking us.
 """
 
+import json
+import re
+
 from RLTest import Env
 from includes import *
 from common import *
@@ -252,3 +255,165 @@ def test_hybrid_explainscore_text_only_match_branch_placeholder():
             break
     env.assertTrue(saw_no_match,
                    message='expected at least one doc with vector branch missing')
+
+
+# ----------------------------------------------------------------------------
+# Structural snapshot helpers
+#
+# These let one test pin down the entire reply shape for a chosen document
+# while staying robust against scorer-internal value drift. The template is a
+# tree of literals + regex/predicate matchers; mismatches are reported with
+# their JSON path and the offending actual fragment.
+# ----------------------------------------------------------------------------
+
+
+class _Re:
+    """Regex matcher for a string (or bytes) leaf in a shape template."""
+    def __init__(self, pattern):
+        self.pattern = re.compile(pattern)
+
+    def __call__(self, x):
+        if isinstance(x, (bytes, bytearray)):
+            x = x.decode('utf-8', errors='replace')
+        return isinstance(x, str) and self.pattern.fullmatch(x) is not None
+
+    def __repr__(self):
+        return f'_Re({self.pattern.pattern!r})'
+
+
+class _Near:
+    """Predicate matcher for a numeric leaf (RESP2 sends doubles as strings).
+    Wrapped in a class so mismatch reports get a useful repr."""
+    def __init__(self, expected, tol=1e-9):
+        self.expected = expected
+        self.tol = tol
+
+    def __call__(self, x):
+        s = x.decode('utf-8', errors='replace') if isinstance(x, (bytes, bytearray)) else x
+        try:
+            return abs(float(s) - self.expected) <= self.tol
+        except (TypeError, ValueError):
+            return False
+
+    def __repr__(self):
+        return f'_Near({self.expected!r}, tol={self.tol!r})'
+
+
+def _near(expected, tol=1e-9):
+    return _Near(expected, tol)
+
+
+def _norm(x):
+    return x.decode('utf-8', errors='replace') if isinstance(x, (bytes, bytearray)) else x
+
+
+def _to_jsonable(x):
+    if isinstance(x, (bytes, bytearray)):
+        return x.decode('utf-8', errors='replace')
+    if isinstance(x, (list, tuple)):
+        return [_to_jsonable(c) for c in x]
+    return x
+
+
+def _shape_errors(template, actual, path='$'):
+    """Return a list of human-readable mismatches between template and actual."""
+    # Order matters: strings and lists are also callables in Python's terms,
+    # so check them first.
+    if isinstance(template, str):
+        return [] if _norm(actual) == template else [f'{path}: expected {template!r}, got {_norm(actual)!r}']
+    if isinstance(template, list):
+        if not isinstance(actual, (list, tuple)):
+            return [f'{path}: expected list of len {len(template)}, got {type(actual).__name__}']
+        errs = []
+        if len(template) != len(actual):
+            errs.append(f'{path}: expected list len {len(template)}, got len {len(actual)}')
+        for i, (t, a) in enumerate(zip(template, actual)):
+            errs.extend(_shape_errors(t, a, path=f'{path}[{i}]'))
+        return errs
+    if callable(template):
+        if not template(actual):
+            return [f'{path}: {_norm(actual)!r} did not satisfy {template!r}']
+        return []
+    return [f'{path}: unsupported template {template!r}']
+
+
+def test_hybrid_explainscore_full_shape_rrf_knn_doc1():
+    """Locked-down structural shape for an RRF+KNN reply.
+
+    For the four-doc deterministic corpus, doc:1 ("red shoes" with vector
+    [0,0]) lands at text rank 1 (BM25 ties broken by docID) and vector rank
+    1 (all docs equidistant from query vector [0.5,0.5]; ties broken by
+    docID). The template below pins down every node in the wrapper; the BM25
+    sub-tree leaves use regex so the existing FT.SEARCH-side scorer numerics
+    can evolve without breaking us.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    # Per-doc ranks aren't stable across shards (the hybrid merger assigns
+    # ranks from its own consumption order, which depends on cursor reads).
+    if env.isCluster():
+        env.skip()
+    setup_index(env)
+
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, _ = get_results_from_hybrid_response(response)
+    env.assertTrue('doc:1' in results, message=f'doc:1 missing from {list(results)}')
+    fields = results['doc:1']
+    env.assertTrue('score' in fields, message=f'no score field on doc:1: {fields}')
+
+    # Expected RRF score: 1/(60+1) + 1/(60+1) = 2/61 = 0.0327868852…
+    expected_rrf_score = 2.0 / 61.0
+    decimal = r'[0-9]+(?:\.[0-9]+)?'
+
+    expected_score_field = [
+        _near(expected_rrf_score),                                  # raw score
+        [                                                            # explain tree
+            _Re(rf'final score: 1 / \(constant 60\.00 \+ rank 1\) \+ '
+                rf'1 / \(constant 60\.00 \+ rank 1\) = {decimal}'),
+            [
+                [
+                    'Hybrid score (RRF: window=20, constant=60.00)',
+                    [
+                        [   # text branch
+                            'text rank = 1',
+                            [
+                                [
+                                    'Text scorer: BM25STD',
+                                    [
+                                        [
+                                            _Re(rf'Final BM25 : words BM25 {decimal} \* document score {decimal}'),
+                                            [
+                                                [
+                                                    _Re(rf'\(Weight {decimal} \* children BM25 {decimal}\)'),
+                                                    [
+                                                        _Re(r'shoes: \(.+\)'),
+                                                        _Re(r'\+shoe: \(.+\)'),
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [   # vector branch
+                            'vector branch (KNN)',
+                            ['vector rank = 1'],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+
+    errors = _shape_errors(expected_score_field, fields['score'])
+    if errors:
+        actual_pretty = json.dumps(_to_jsonable(fields['score']), indent=2)
+        env.assertTrue(
+            False,
+            message='shape mismatch:\n  ' + '\n  '.join(errors) +
+                    f'\n\nactual score field:\n{actual_pretty}')

--- a/tests/pytests/test_hybrid_explainscore.py
+++ b/tests/pytests/test_hybrid_explainscore.py
@@ -75,7 +75,8 @@ def _score_and_tokens(env, fields, key):
 
 
 def test_hybrid_explainscore_rrf_knn():
-    """RRF + KNN: per-branch rank lines, KNN envelope, BM25STD default scorer."""
+    """RRF + KNN: per-branch rank lines, KNN envelope, BM25STD default scorer.
+    The outer "final score:" line carries the RRF formula (1/(K+rank))."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     setup_index(env)
     blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
@@ -91,8 +92,10 @@ def test_hybrid_explainscore_rrf_knn():
         _, _, tokens = _score_and_tokens(env, fields, key)
         joined = ' | '.join(tokens)
 
-        env.assertTrue(any('final score:' in t for t in tokens),
-                       message=f'missing outer "final score:" in {joined!r}')
+        # Outer line is a formula, not just the value.
+        env.assertTrue(any(t.startswith('final score: 1 / (constant ')
+                           and ' + 1 / (constant ' in t and ' = ' in t for t in tokens),
+                       message=f'missing RRF formula in outer line, got {joined!r}')
         env.assertTrue(any('Hybrid score (RRF: window=' in t and 'constant=' in t for t in tokens),
                        message=f'missing RRF envelope in {joined!r}')
         env.assertTrue(any(t.startswith('text rank = ') for t in tokens),
@@ -134,7 +137,8 @@ def test_hybrid_explainscore_rrf_range():
 
 
 def test_hybrid_explainscore_linear_knn():
-    """LINEAR + KNN: envelope shows alpha/beta/window, contribution formula visible."""
+    """LINEAR + KNN: envelope shows alpha/beta/window, contribution formula visible.
+    The outer "final score:" line shows the weighted-sum formula."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     setup_index(env)
     blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
@@ -151,6 +155,10 @@ def test_hybrid_explainscore_linear_knn():
         _, _, tokens = _score_and_tokens(env, fields, key)
         joined = ' | '.join(tokens)
 
+        # Outer line: "final score: 0.7000 * X + 0.3000 * Y = S"
+        env.assertTrue(any(t.startswith('final score: 0.7000 * ')
+                           and ' + 0.3000 * ' in t and ' = ' in t for t in tokens),
+                       message=f'missing LINEAR formula in outer line, got {joined!r}')
         env.assertTrue(any('Hybrid score (LINEAR: alpha=0.7000' in t
                            and 'beta=0.3000' in t and 'window=' in t for t in tokens),
                        message=f'missing LINEAR envelope in {joined!r}')
@@ -215,7 +223,9 @@ def test_hybrid_explainscore_scorer_name_propagates():
 
 def test_hybrid_explainscore_text_only_match_branch_placeholder():
     """When a doc matches text but not the vector RANGE, the vector branch
-    shows "matched within radius = false" and a missing-match placeholder."""
+    shows "matched within radius = false", the per-branch sub-tree carries
+    a "<no match>" placeholder, and the outer formula records the dropped
+    term as "0 [vector: no match]"."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     setup_index(env, vec_algo='HNSW')
     # A very small radius so no vector match exists for any doc, but text matches.
@@ -236,6 +246,9 @@ def test_hybrid_explainscore_text_only_match_branch_placeholder():
             saw_no_match = True
             env.assertTrue(any('<no match>' in t for t in tokens),
                            message=f'expected "<no match>" placeholder in {tokens!r}')
+            env.assertTrue(any(t.startswith('final score: ')
+                               and '0 [vector: no match]' in t for t in tokens),
+                           message=f'expected dropped term in outer formula, got {tokens!r}')
             break
     env.assertTrue(saw_no_match,
                    message='expected at least one doc with vector branch missing')

--- a/tests/pytests/test_hybrid_explainscore.py
+++ b/tests/pytests/test_hybrid_explainscore.py
@@ -1,0 +1,241 @@
+"""End-to-end shape tests for FT.HYBRID EXPLAINSCORE (MOD-10044).
+
+The explain tree follows a fixed layout:
+
+    final score: <S>
+    └── Hybrid score (<METHOD>: …fusion params…)
+        ├── <text branch>
+        │   └── Text scorer: <NAME>
+        │       └── …existing scorer subtree…
+        └── vector branch (<MODE>[: …])
+            └── …per-mode rows…
+
+These tests assert the salient tokens in each variant rather than the full
+tree, so the existing TEXT-scorer subtree can evolve without breaking us.
+"""
+
+from RLTest import Env
+from includes import *
+from common import *
+
+
+def setup_index(env, vec_algo='FLAT'):
+    """Index with one text field and one vector field, plus four deterministic docs."""
+    conn = env.getClusterConnectionIfNeeded()
+    if vec_algo == 'HNSW':
+        env.expect('FT.CREATE', 'idx', 'SCHEMA',
+                   'description', 'TEXT',
+                   'embedding', 'VECTOR', 'HNSW', 8, 'TYPE', 'FLOAT32', 'DIM', 2,
+                   'DISTANCE_METRIC', 'L2', 'EF_RUNTIME', '10').ok()
+    else:
+        env.expect('FT.CREATE', 'idx', 'SCHEMA',
+                   'description', 'TEXT',
+                   'embedding', 'VECTOR', 'FLAT', 6, 'TYPE', 'FLOAT32', 'DIM', 2,
+                   'DISTANCE_METRIC', 'L2').ok()
+    docs = {
+        'doc:1': ('red shoes',                              [0.0, 0.0]),
+        'doc:2': ('red running shoes',                      [1.0, 0.0]),
+        'doc:3': ('running gear and many different shoes',  [0.0, 1.0]),
+        'doc:4': ('blue shoes',                             [1.0, 1.0]),
+    }
+    for key, (text, vec) in docs.items():
+        conn.execute_command('HSET', key, 'description', text,
+                             'embedding', np.array(vec).astype(np.float32).tobytes())
+
+
+def _walk_explain(node, found):
+    """Flatten every string token in an explain tree (regardless of nesting)."""
+    if isinstance(node, (bytes, bytearray)):
+        found.append(node.decode('utf-8', errors='replace'))
+    elif isinstance(node, str):
+        found.append(node)
+    elif isinstance(node, (list, tuple)):
+        for child in node:
+            _walk_explain(child, found)
+
+
+def _flatten_tokens(score_field):
+    """Return all string tokens from the [score_value, explain_tree] pair."""
+    tokens = []
+    _walk_explain(score_field, tokens)
+    return tokens
+
+
+def _score_and_tokens(env, fields, key):
+    """Verify that `fields['score']` is `[<value>, <explain_tree>]` and return both."""
+    env.assertTrue('score' in fields, message=f'no score in {key}: {fields}')
+    score_field = fields['score']
+    env.assertTrue(isinstance(score_field, (list, tuple)),
+                   message=f'score should be array, got {type(score_field)}: {score_field}')
+    env.assertEqual(len(score_field), 2,
+                    message=f'score should be [value, explain], got {score_field}')
+    score_value, explain = score_field
+    float(score_value)  # parses cleanly
+    return score_value, explain, _flatten_tokens(score_field)
+
+
+def test_hybrid_explainscore_rrf_knn():
+    """RRF + KNN: per-branch rank lines, KNN envelope, BM25STD default scorer."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env)
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, total = get_results_from_hybrid_response(response)
+    env.assertGreater(total, 0)
+
+    for key, fields in results.items():
+        _, _, tokens = _score_and_tokens(env, fields, key)
+        joined = ' | '.join(tokens)
+
+        env.assertTrue(any('final score:' in t for t in tokens),
+                       message=f'missing outer "final score:" in {joined!r}')
+        env.assertTrue(any('Hybrid score (RRF: window=' in t and 'constant=' in t for t in tokens),
+                       message=f'missing RRF envelope in {joined!r}')
+        env.assertTrue(any(t.startswith('text rank = ') for t in tokens),
+                       message=f'missing "text rank = …" in {joined!r}')
+        env.assertTrue(any(t == 'vector branch (KNN)' for t in tokens),
+                       message=f'missing KNN envelope in {joined!r}')
+        env.assertTrue(any(t.startswith('vector rank = ') for t in tokens),
+                       message=f'missing "vector rank = …" in {joined!r}')
+        env.assertTrue(any(t.startswith('Text scorer: ') for t in tokens),
+                       message=f'missing scorer name in {joined!r}')
+
+
+def test_hybrid_explainscore_rrf_range():
+    """RRF + RANGE: vector branch envelope identifies RANGE with radius/epsilon."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env, vec_algo='HNSW')
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'RANGE', '4', 'RADIUS', '0.7', 'EPSILON', '0.5',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, total = get_results_from_hybrid_response(response)
+    env.assertGreater(total, 0)
+
+    for key, fields in results.items():
+        _, _, tokens = _score_and_tokens(env, fields, key)
+        joined = ' | '.join(tokens)
+
+        env.assertTrue(any('Hybrid score (RRF:' in t for t in tokens),
+                       message=f'missing RRF envelope in {joined!r}')
+        # Envelope must call out RANGE and surface radius + epsilon.
+        env.assertTrue(any('vector branch (RANGE:' in t and 'radius=0.7000' in t
+                           and 'epsilon=0.5' in t for t in tokens),
+                       message=f'missing RANGE envelope in {joined!r}')
+        env.assertTrue(any('matched within radius = ' in t for t in tokens),
+                       message=f'missing "matched within radius" in {joined!r}')
+
+
+def test_hybrid_explainscore_linear_knn():
+    """LINEAR + KNN: envelope shows alpha/beta/window, contribution formula visible."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env)
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'COMBINE', 'LINEAR', '4', 'ALPHA', '0.7', 'BETA', '0.3',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, total = get_results_from_hybrid_response(response)
+    env.assertGreater(total, 0)
+
+    for key, fields in results.items():
+        _, _, tokens = _score_and_tokens(env, fields, key)
+        joined = ' | '.join(tokens)
+
+        env.assertTrue(any('Hybrid score (LINEAR: alpha=0.7000' in t
+                           and 'beta=0.3000' in t and 'window=' in t for t in tokens),
+                       message=f'missing LINEAR envelope in {joined!r}')
+        env.assertTrue(any('text contribution = 0.7000 *' in t for t in tokens),
+                       message=f'missing text-contribution formula in {joined!r}')
+        env.assertTrue(any('vector contribution = 0.3000 *' in t for t in tokens),
+                       message=f'missing vector-contribution formula in {joined!r}')
+        env.assertTrue(any(t.startswith('normalized text score = ') for t in tokens),
+                       message=f'missing normalized text score in {joined!r}')
+        env.assertTrue(any(t.startswith('normalized vector score = ') for t in tokens),
+                       message=f'missing normalized vector score in {joined!r}')
+
+
+def test_hybrid_explainscore_linear_range():
+    """LINEAR + RANGE: combines the LINEAR envelope with a RANGE vector branch."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env, vec_algo='HNSW')
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'RANGE', '4', 'RADIUS', '0.7', 'EPSILON', '0.5',
+                       'COMBINE', 'LINEAR', '4', 'ALPHA', '0.6', 'BETA', '0.4',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, total = get_results_from_hybrid_response(response)
+    env.assertGreater(total, 0)
+
+    for key, fields in results.items():
+        _, _, tokens = _score_and_tokens(env, fields, key)
+        joined = ' | '.join(tokens)
+
+        env.assertTrue(any('Hybrid score (LINEAR: alpha=0.6000' in t
+                           and 'beta=0.4000' in t for t in tokens),
+                       message=f'missing LINEAR envelope in {joined!r}')
+        env.assertTrue(any('vector branch (RANGE:' in t and 'radius=0.7000' in t
+                           and 'epsilon=0.5' in t for t in tokens),
+                       message=f'missing RANGE envelope in {joined!r}')
+        env.assertTrue(any('matched within radius = ' in t for t in tokens),
+                       message=f'missing "matched within radius" in {joined!r}')
+
+
+def test_hybrid_explainscore_scorer_name_propagates():
+    """An explicit SCORER on the SEARCH sub-query shows up in the "Text scorer:" label."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env)
+    blob = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes', 'SCORER', 'TFIDF',
+                       'VSIM', '@embedding', '$BLOB',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, total = get_results_from_hybrid_response(response)
+    env.assertGreater(total, 0)
+
+    for key, fields in results.items():
+        _, _, tokens = _score_and_tokens(env, fields, key)
+        joined = ' | '.join(tokens)
+        env.assertTrue(any(t == 'Text scorer: TFIDF' for t in tokens),
+                       message=f'expected "Text scorer: TFIDF" label, got {joined!r}')
+
+
+def test_hybrid_explainscore_text_only_match_branch_placeholder():
+    """When a doc matches text but not the vector RANGE, the vector branch
+    shows "matched within radius = false" and a missing-match placeholder."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    setup_index(env, vec_algo='HNSW')
+    # A very small radius so no vector match exists for any doc, but text matches.
+    blob = np.array([10.0, 10.0]).astype(np.float32).tobytes()
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'shoes',
+                       'VSIM', '@embedding', '$BLOB',
+                       'RANGE', '2', 'RADIUS', '0.001',
+                       'EXPLAINSCORE',
+                       'PARAMS', '2', 'BLOB', blob)
+    results, total = get_results_from_hybrid_response(response)
+    env.assertGreater(total, 0)
+
+    saw_no_match = False
+    for key, fields in results.items():
+        _, _, tokens = _score_and_tokens(env, fields, key)
+        if any('matched within radius = false' in t for t in tokens):
+            saw_no_match = True
+            env.assertTrue(any('<no match>' in t for t in tokens),
+                           message=f'expected "<no match>" placeholder in {tokens!r}')
+            break
+    env.assertTrue(saw_no_match,
+                   message='expected at least one doc with vector branch missing')


### PR DESCRIPTION
This change adds `EXPLAINSCORE` to `FT.HYBRID`. It tries to follow the existing feature for other queries.

`FT. HYBRID` deserialises the explain from the search subq to preserve the "nested array" reply, similar to what is done for `FT.SEARCH` itself.

# Example

Index:
```
FT.CREATE idx SCHEMA description TEXT embedding VECTOR HNSW 8 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 EF_RUNTIME 10
```

Query:
```
FT.HYBRID idx SEARCH shoes VSIM @embedding $BLOB RANGE 4 RADIUS 0.7 EPSILON 0.5 COMBINE LINEAR 4 ALPHA 0.6 BETA 0.4 EXPLAINSCORE PARAMS 2 BLOB blob
```

Result in python-ish for one doc of the result:
```
{
   "score": [
      "0.6118851536088037",
      [
         "final score: 0.6000 * 0.5754 + 0.4000 * 0.6667 = 0.61188515360880369",
         [
            [
               "Hybrid score (LINEAR: alpha=0.6000, beta=0.4000, window=20)",
               [
                  [
                     "text contribution = 0.6000 * 0.5754 = 0.3452",
                     [
                        [
                           "Text scorer: BM25STD",
                           [
                              "normalized text score = 0.5754",
                              [
                                 "Final BM25 : words BM25 0.58 * document score 1.00",
                                 [
                                    [
                                       "(Weight 1.00 * children BM25 0.58)",
                                       [
                                          "shoes: (0.29 = Weight 1.00 * IDF 0.29 * (F 1.00 * (k1 1.2 + 1)) / (F 1.00 + k1 1.2 * (1 - b 0.75 + b 0.75 * Doc Len 5 / Average Doc Len 5.00)))",
                                          "+shoe: (0.29 = Weight 1.00 * IDF 0.29 * (F 1.00 * (k1 1.2 + 1)) / (F 1.00 + k1 1.2 * (1 - b 0.75 + b 0.75 * Doc Len 5 / Average Doc Len 5.00)))"
                                       ]
                                    ]
                                 ]
                              ]
                           ]
                        ]
                     ]
                  ],
                  [
                     "vector branch (RANGE: radius=0.7000, epsilon=0.5)",
                     [
                        "matched within radius = true",
                        "vector contribution = 0.4000 * 0.6667 = 0.2667",
                        "normalized vector score = 0.6667"
                     ]
                  ]
               ]
            ]
         ]
      ]
   ],
   "__key": "doc:3",
   "__score": "0.611885153609"
}
```

#### Main objects this PR modified
1. Enables EXPLAINSCORE in FT.HYBRID

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes