### PR TITLE
[8.8] [MOD-16304] Fix TEXT PHONETIC matches after non-TEXT schema fields

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -689,7 +689,7 @@ int DefaultExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
       t_fieldMask fm = (*ctx->currentNode)->opts.fieldMask;
       for (size_t ii = 0; ii < ctx->handle->spec->numFields; ++ii) {
         const FieldSpec *fs = ctx->handle->spec->fields + ii;
-        if (!(fm & FIELD_BIT(fs))) {
+        if (!FieldSpec_IsIndexableTextInMask(fs, fm)) {
           continue;
         }
         if (FieldSpec_IsPhonetics(fs)) {

--- a/src/field_spec.h
+++ b/src/field_spec.h
@@ -151,6 +151,7 @@ typedef struct FieldSpec {
 #define FieldSpec_IsNoStem(fs) ((fs)->options & FieldSpec_NoStemming)
 #define FieldSpec_IsPhonetics(fs) ((fs)->options & FieldSpec_Phonetics)
 #define FieldSpec_IsIndexable(fs) (0 == ((fs)->options & FieldSpec_NotIndexable))
+#define FieldSpec_IsIndexableText(fs) (FIELD_IS((fs), INDEXFLD_T_FULLTEXT) && FieldSpec_IsIndexable(fs))
 #define FieldSpec_HasSuffixTrie(fs) ((fs)->options & FieldSpec_WithSuffixTrie)
 #define FieldSpec_IsUndefinedOrder(fs) ((fs)->options & FieldSpec_UndefinedOrder)
 #define FieldSpec_IndexesEmpty(fs) ((fs)->options & FieldSpec_IndexEmpty)

--- a/src/spec.c
+++ b/src/spec.c
@@ -233,7 +233,7 @@ const FieldSpec *IndexSpec_GetField(const IndexSpec *spec, const HiddenString *n
 // Assuming the spec is properly locked before calling this function.
 t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len) {
   const FieldSpec *fs = IndexSpec_GetFieldWithLength(spec, name, len);
-  if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !FieldSpec_IsIndexable(fs)) return 0;
+  if (!fs || !FieldSpec_IsIndexableText(fs)) return 0;
 
   return FIELD_BIT(fs);
 }
@@ -244,17 +244,15 @@ int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
     return 0;
   }
 
-  if (fm == 0 || fm == (t_fieldMask)-1) {
+  if (fm == 0 || fm == RS_FIELDMASK_ALL) {
     // No fields -- implicit phonetic match!
     return 1;
   }
 
   for (size_t ii = 0; ii < sp->numFields; ++ii) {
-    if (fm & ((t_fieldMask)1 << ii)) {
-      const FieldSpec *fs = sp->fields + ii;
-      if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && (FieldSpec_IsPhonetics(fs))) {
-        return 1;
-      }
+    const FieldSpec *fs = sp->fields + ii;
+    if (FieldSpec_IsIndexableTextInMask(fs, fm) && FieldSpec_IsPhonetics(fs)) {
+      return 1;
     }
   }
   return 0;
@@ -263,13 +261,13 @@ int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
 // Assuming the spec is properly locked before calling this function.
 int IndexSpec_CheckAllowSlopAndInorder(const IndexSpec *spec, t_fieldMask fm, QueryError *status) {
   for (size_t ii = 0; ii < spec->numFields; ++ii) {
-    if (fm & ((t_fieldMask)1 << ii)) {
-      const FieldSpec *fs = spec->fields + ii;
-      if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && (FieldSpec_IsUndefinedOrder(fs))) {
-        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_BAD_ORDER_OPTION,
-                               "slop/inorder are not supported for field with undefined ordering", " `%s`", HiddenString_GetUnsafe(fs->fieldName, NULL));
-        return 0;
-      }
+    const FieldSpec *fs = spec->fields + ii;
+    if (FieldSpec_IsIndexableTextInMask(fs, fm) && FieldSpec_IsUndefinedOrder(fs)) {
+      QueryError_SetWithUserDataFmt(
+          status, QUERY_ERROR_CODE_BAD_ORDER_OPTION,
+          "slop/inorder are not supported for field with undefined ordering", " `%s`",
+          HiddenString_GetUnsafe(fs->fieldName, NULL));
+      return 0;
     }
   }
   return 1;
@@ -288,8 +286,7 @@ const FieldSpec *IndexSpec_GetFieldBySortingIndex(const IndexSpec *sp, uint16_t 
 // Assuming the spec is properly locked before calling this function.
 const char *IndexSpec_GetFieldNameByBit(const IndexSpec *sp, t_fieldMask id) {
   for (int i = 0; i < sp->numFields; i++) {
-    if (FIELD_BIT(&sp->fields[i]) == id && FIELD_IS(&sp->fields[i], INDEXFLD_T_FULLTEXT) &&
-      FieldSpec_IsIndexable(&sp->fields[i])) {
+    if (FieldSpec_IsIndexableText(&sp->fields[i]) && FIELD_BIT(&sp->fields[i]) == id) {
       return HiddenString_GetUnsafe(sp->fields[i].fieldName, NULL);
     }
   }
@@ -299,8 +296,7 @@ const char *IndexSpec_GetFieldNameByBit(const IndexSpec *sp, t_fieldMask id) {
 // Get the field spec by the field mask.
 const FieldSpec *IndexSpec_GetFieldByBit(const IndexSpec *sp, t_fieldMask id) {
   for (int i = 0; i < sp->numFields; i++) {
-    if (FIELD_BIT(&sp->fields[i]) == id && FIELD_IS(&sp->fields[i], INDEXFLD_T_FULLTEXT) &&
-        FieldSpec_IsIndexable(&sp->fields[i])) {
+    if (FieldSpec_IsIndexableText(&sp->fields[i]) && FIELD_BIT(&sp->fields[i]) == id) {
       return &sp->fields[i];
     }
   }
@@ -311,7 +307,7 @@ const FieldSpec *IndexSpec_GetFieldByBit(const IndexSpec *sp, t_fieldMask id) {
 arrayof(FieldSpec *) IndexSpec_GetFieldsByMask(const IndexSpec *sp, t_fieldMask mask) {
   arrayof(FieldSpec *) res = array_new(FieldSpec *, 2);
   for (int i = 0; i < sp->numFields; i++) {
-    if (mask & FIELD_BIT(sp->fields + i) && FIELD_IS(sp->fields + i, INDEXFLD_T_FULLTEXT)) {
+    if (FieldSpec_IsIndexableTextInMask(sp->fields + i, mask)) {
       array_append(res, sp->fields + i);
     }
   }
@@ -1660,7 +1656,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     if (FieldSpec_IsPhonetics(fs)) {
       sp->flags |= Index_HasPhonetic;
     }
-    if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_HasSuffixTrie(fs)) {
+    if (FieldSpec_IsIndexableText(fs) && FieldSpec_HasSuffixTrie(fs)) {
       sp->suffixMask |= FIELD_BIT(fs);
       if (!sp->suffix) {
         sp->flags |= Index_HasSuffixTrie;
@@ -3448,7 +3444,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
     if (FieldSpec_IsSortable(fs)) {
       sp->numSortableFields++;
     }
-    if (FieldSpec_HasSuffixTrie(fs) && FIELD_IS(fs, INDEXFLD_T_FULLTEXT)) {
+    if (FieldSpec_HasSuffixTrie(fs) && FieldSpec_IsIndexableText(fs)) {
       sp->flags |= Index_HasSuffixTrie;
       sp->suffixMask |= FIELD_BIT(fs);
       if (!sp->suffix) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -289,6 +289,7 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
   ((spec)->flags & Index_StoreFieldFlags)
 
 #define FIELD_BIT(fs) (((t_fieldMask)1) << (fs)->ftId)
+#define FieldSpec_IsIndexableTextInMask(fs, fm) (FieldSpec_IsIndexableText(fs) && ((fm) & FIELD_BIT(fs)))
 
 //---------------------------------------------------------------------------------------------
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -17,6 +17,41 @@ def test_1304(env):
   env.expect('FT.EXPLAIN idx -\\20*').equal('NOT{\n  PREFIX{20*}\n}\n')
 
 @skip(cluster=True)
+def test_10140_phonetic_after_non_text_field(env):
+  env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'phonetic:',
+             'SCHEMA', 'filingDate', 'TAG', 'chunkText', 'TEXT', 'PHONETIC', 'dm:en').ok()
+  env.cmd('HSET', 'phonetic:1', 'chunkText', 'cash', 'filingDate', '2026-06-15')
+
+  env.expect('FT.SEARCH', 'idx', '@chunkText:kash', 'NOCONTENT').equal([1, 'phonetic:1'])
+
+@skip(cluster=True)
+def test_10140_phonetic_after_noindex_text_field(env):
+  env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'phonetic:',
+             'SCHEMA', 'ignored', 'TEXT', 'NOINDEX',
+             'chunkText', 'TEXT', 'PHONETIC', 'dm:en').ok()
+  env.cmd('HSET', 'phonetic:1', 'ignored', 'skip me', 'chunkText', 'cash')
+
+  env.expect('FT.SEARCH', 'idx', '@chunkText:kash', 'NOCONTENT').equal([1, 'phonetic:1'])
+  env.expect('FT.SEARCH', 'idx', '@chunkText:(kash)=>{$phonetic:true}', 'NOCONTENT') \
+     .equal([1, 'phonetic:1'])
+
+@skip(cluster=True)
+def test_10140_empty_query_after_noindex_text_field(env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'ignored', 'TEXT', 'NOINDEX', 'text', 'TEXT').ok()
+
+  env.expect('FT.SEARCH', 'idx', '@text:("")') \
+     .error().contains('Use `INDEXEMPTY` in field creation')
+
+@skip(cluster=True, no_json=True)
+def test_10140_slop_after_noindex_text_field(env):
+  env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
+             '$.ignored', 'AS', 'ignored', 'TEXT', 'NOINDEX',
+             '$.text[*]', 'AS', 'text', 'TEXT').ok()
+
+  env.expect('FT.SEARCH', 'idx', '@text:(hello world)=>{$slop:1}') \
+     .error().contains('with undefined ordering')
+
+@skip(cluster=True)
 def test_1414(env):
   env.expect('FT.CREATE idx SCHEMA txt1 TEXT').equal('OK')
   env.cmd('hset', 'doc', 'foo', 'hello', 'bar', 'world')


### PR DESCRIPTION
Backport of #10145 to 8.8.

## Original PR
https://github.com/RediSearch/RediSearch/pull/10145

## Changes from original
Resolved `src/spec.c` conflicts because 8.8 keeps suffix-trie mask setup inline in `IndexSpec_AddFieldsInternal` and `IndexSpec_RdbLoad`, while master uses `IndexSpec_EnsureSuffixForField()`. The backport applies the same `FieldSpec_IsIndexableText(fs)` guard to those inline `FIELD_BIT` sites instead. No behavior differences intended.

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: TEXT field mask checks could use schema field positions or evaluate `FIELD_BIT` for `TEXT NOINDEX` fields.
2. Change: Backport #10145's field-mask helpers and guards to 8.8.
3. Outcome: Field-qualified phonetic/slop/inorder/empty-text checks use text field ids safely and skip `TEXT NOINDEX` fields before `FIELD_BIT`.

#### Which additional issues this PR fixes
1. MOD-16304
2. #10140

#### Main objects this PR modified
1. `src/spec.c` / `src/spec.h` / `src/field_spec.h` - use text field ids and guarded text-field mask checks.
2. `src/ext/default.c` - guard explicit phonetic field-mask validation.
3. `tests/pytests/test_issues.py` - add focused regression coverage.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes searches on TEXT PHONETIC fields declared after non-TEXT or `TEXT NOINDEX` schema fields so phonetic equivalents match as expected.

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.