### PR TITLE
[MOD-16327] Record on-oom `return` empty replies in query-warning INFO stats

### DIFF
--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -50,6 +50,18 @@ static int empty_sendChunk_common(RedisModuleCtx *ctx, AREQ *req) {
     return REDISMODULE_OK;
 }
 
+// Records the empty-reply condition (OOM or timeout) in the global query-warning
+// stats. Without this, an `oom`/`timeout` policy of `return` would reply with empty
+// results and leave no trace in INFO (search_*_total_query_warnings_oom/timeout),
+// making a silently-emptied query impossible to diagnose from stats alone.
+static void updateEmptyReplyWarningStats(QueryErrorCode errCode) {
+    if (errCode == QUERY_ERROR_CODE_OUT_OF_MEMORY) {
+        QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_COORD, 1, COORD_ERR_WARN);
+    } else if (errCode == QUERY_ERROR_CODE_TIMED_OUT) {
+        QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
+    }
+}
+
 // Coordinator empty reply for FT.SEARCH commands. Currently used during OOM conditions.
 // Creates a minimal searchRequestCtx with OOM flag and uses sendSearchResults_EmptyResults.
 int coord_search_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, QueryErrorCode errCode) {
@@ -69,6 +81,7 @@ int coord_search_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv
     // Handle known errors supported by empty reply module
     req.queryOOM = errCode == QUERY_ERROR_CODE_OUT_OF_MEMORY;
     req.timedOut = errCode == QUERY_ERROR_CODE_TIMED_OUT;
+    updateEmptyReplyWarningStats(errCode);
 
     sendSearchResults_EmptyResults(reply, &req);
 
@@ -99,6 +112,7 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
     if (errCode == QUERY_ERROR_CODE_OUT_OF_MEMORY) {
         QueryError_SetQueryOOMWarning(&status);
     }
+    updateEmptyReplyWarningStats(errCode);
 
     int ret = empty_sendChunk_common(ctx, req);
     QueryError_ClearError(&status);
@@ -215,6 +229,7 @@ int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString
     if (errCode == QUERY_ERROR_CODE_OUT_OF_MEMORY) {
         QueryError_SetQueryOOMWarning(&status);
     }
+    updateEmptyReplyWarningStats(errCode);
 
     int ret = empty_sendChunk_common(ctx, req);
     QueryError_ClearError(&status);

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -75,6 +75,36 @@ class testOomStandaloneBehavior:
         res = self.env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@name')
         self.env.assertEqual(res, [0])
 
+def _query_oom_warning_total(conn):
+    # Sum the global OOM query-warning counters (shard + coord buckets) from INFO MODULES.
+    # An `on-oom return` empty reply must bump one of these, otherwise the silently-emptied
+    # query leaves no trace in INFO and is undiagnosable from stats alone.
+    info = conn.execute_command('INFO MODULES')
+    total = 0
+    for line in info.splitlines():
+        key = line.split(':', 1)[0]
+        if key.endswith('total_query_warnings_oom') and ('shard' in key or 'coord' in key):
+            total += int(line.split(':', 1)[1])
+    return total
+
+@skip(cluster=True)
+@env_spec(protocol=3)
+def test_oom_return_increments_query_warning_stats(env):
+    # An `on-oom return` empty reply must be recorded in the global query-warning stats
+    # (search_*_total_query_warnings_oom), so an operator can tell queries are being
+    # silently emptied by the OOM guardrail.
+    _common_test_scenario(env)
+    verify_shard_init(env.getConnection())
+    change_oom_policy(env, 'return')
+
+    conn = env.getConnection()
+    before = _query_oom_warning_total(conn)
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*'), [0])
+    env.assertEqual(env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@name'), [0])
+    after = _query_oom_warning_total(conn)
+    env.assertEqual(after - before, 2,
+                    message=f"expected +2 OOM query warnings, before={before} after={after}")
+
 @skip(cluster=True)
 @env_spec(protocol=3)
 def test_oom_verbosity_standalone(env):


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** When the search OOM guardrail fires with `oom policy: return` (the default), `FT.SEARCH`/`FT.AGGREGATE` return an empty result set but increment **no** global stat. The coordinator empty-reply paths (`coord_search_query_reply_empty`, `coord_aggregate_query_reply_empty`) and the single-shard path (`single_shard_common_query_reply_empty`) call neither `QueryErrorsGlobalStats_UpdateError` (only the `fail` policy does) nor `QueryWarningsGlobalStats_UpdateWarning`. So an instance silently emptying **every** query under memory pressure looks healthy in `INFO MODULES`: `search_*_total_query_warnings_oom == 0`, `search_total_queries_processed == 0`. The only signals are the empty client replies and the Redis-core `maxmemory` log lines.
2. **Change:** Increment `QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_COORD / TIMED_OUT)` from the three command empty-reply entry points, via a small `updateEmptyReplyWarningStats()` helper.
3. **Outcome:** `on-oom return` (and `on-timeout return`) empty replies are now observable in `INFO MODULES` (`search_*_total_query_warnings_oom` / `_timeout`), so operators/support can detect when the guardrail is silently emptying queries.

Scope note: the per-reply `warning` field (RESP3) already surfaces the OOM condition to the client; this PR is specifically about the **global INFO counters** being silent. `FT.HYBRID` already increments its counter on the internal shard→coord path and is left unchanged.

#### Which additional issues this PR fixes
1. MOD-16327
2. Found while investigating MOD-16159

#### Main objects this PR modified
1. `src/aggregate/reply_empty.c` — new `updateEmptyReplyWarningStats()` helper, called from `coord_search_query_reply_empty`, `coord_aggregate_query_reply_empty`, `single_shard_common_query_reply_empty`
2. `tests/pytests/test_query_oom.py` — standalone test asserting `search_*_total_query_warnings_oom` rises on an `on-oom return` empty reply

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: OOM/timeout `return`-policy empty query replies are now counted in the `INFO MODULES` query-warning stats, making the guardrail's silent-empty behavior observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
