### PR TITLE
[MOD-16020] tests: skip flaky RESP2 return-strict timeout coordinator tests

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4953,6 +4953,8 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             except Exception:
                 pass
 
+    @skip_until("2026-06-23", reason="Flaky on slow runners (macOS x86_64): "
+                "10s thread-join window too tight under return-strict timeout")
     def test_return_strict_one_shard_timesout_flat_aggregate_resp2(self):
         """RESP2 variant of test_return_strict_one_shard_timesout_flat_aggregate."""
         skipIfNoEnableAssert(self.env)
@@ -5010,6 +5012,9 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             shard_cmd='_FT.PROFILE',
             assert_reply=assert_profile_reply)
 
+    @skip_until("2026-06-23", reason="Flaky on slow runners (macOS x86_64): "
+                "claim-race is non-deterministic, background thread can win the "
+                "claim and return the post-processing reply shape")
     def test_return_strict_timeout_at_claim_sync_point_profile_hybrid_resp2(self):
         """RESP2 FT.PROFILE HYBRID early-timeout preserves the profile envelope.
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Two RESP2 coordinator tests added in #10139 are flaky on slow
   runners. The scheduled Periodic Master Validation job (macOS 26 x86_64,
   Redis 8.8.0) failed because:
   - test_return_strict_one_shard_timesout_flat_aggregate_resp2 - the query
     worker thread does not always join within the 10s window after
     CLIENT UNBLOCK ... TIMEOUT.
   - test_return_strict_timeout_at_claim_sync_point_profile_hybrid_resp2 -
     the claim-race is non-deterministic; on a slow runner the background
     thread can win TryClaim and return the post-processing reply shape
     instead of the asserted fast-path envelope.
   The same tests pass consistently on the faster Linux runners.

2. Change: Temporarily skip_until("2026-06-23") both tests to unblock
   master CI while a proper fix for the timing/synchronization is prepared.

3. Outcome: Master CI is green again; the tests will automatically resume
   running after the skip date, ensuring the follow-up fix is not forgotten.

#### Which additional issues this PR fixes
1. MOD-16020 (follow-up to #10139)

#### Main objects this PR modified
1. tests/pytests/test_blocked_client_timeout.py

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
