### PR TITLE
CI: surface buried benchmark-failure root causes in triage

### DIFF
--- a/.github/actions/fetch-failed-run-logs/action.yml
+++ b/.github/actions/fetch-failed-run-logs/action.yml
@@ -109,9 +109,21 @@ runs:
           # -n: keep line numbers for locatability; cut: bound pathological long
           # lines (some log lines are multi-KB JSON); awk: dedupe preserving
           # order; head: bound total volume.
+          # The dedupe key strips the `grep -n` line-number prefix and the
+          # GH-Actions and Python-logger timestamps, so the same message
+          # repeated on many lines (e.g. recurring "Connection reset by peer"
+          # warnings) collapses to one entry instead of filling the cap and
+          # pushing the decisive CRITICAL/Traceback line out. Only `+` quantifiers
+          # are used (no `{n}` intervals) to stay portable across mawk/gawk.
           grep -nE -f "$PAT_FILE" "$OUTPUT_FILE" 2>/dev/null \
             | cut -c1-500 \
-            | awk '!seen[$0]++' \
+            | awk '{
+                key = $0
+                sub(/^[0-9]+:/, "", key)
+                gsub(/[0-9]+-[0-9]+-[0-9]+T[0-9:.]+Z/, "", key)
+                gsub(/[0-9]+-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+,[0-9]+/, "", key)
+                if (!seen[key]++) print
+              }' \
             | head -n "$MAX_KEY_LINES" > "$KEY_FILE"
           rm -f "$PAT_FILE"
           [ -s "$KEY_FILE" ] || { rm -f "$KEY_FILE"; KEY_FILE=""; }

--- a/.github/actions/fetch-failed-run-logs/action.yml
+++ b/.github/actions/fetch-failed-run-logs/action.yml
@@ -36,6 +36,25 @@ inputs:
       Ignored when `cap` is `false`.
     required: false
     default: '204800'
+  highlight-patterns:
+    description: >
+      Optional newline-separated list of extended-regex (`grep -E`) patterns.
+      When set, every line of the full log that matches any pattern is
+      extracted *before* the tail-cap and prepended under a
+      `KEY FAILURE LINES` banner, so a root cause buried mid-log survives
+      truncation. Empty (default) disables extraction, leaving behavior
+      byte-identical to before. Only meaningful together with `cap: 'true'`
+      (the banner is added on top, after the body has been capped); pairing it
+      with `cap: 'false'` is pointless because a caller's later external cap
+      would chop the banner back off.
+    required: false
+    default: ''
+  max-key-lines:
+    description: >
+      Cap on the number of extracted highlight lines (deduplicated, in log
+      order) prepended to the file. Bounds token spend when a pattern is noisy.
+    required: false
+    default: '150'
   cap:
     description: >
       If `true` (default), truncate `output-file` to its last `max-bytes`
@@ -59,6 +78,8 @@ runs:
         APPEND: ${{ inputs.append }}
         MAX_BYTES: ${{ inputs.max-bytes }}
         CAP: ${{ inputs.cap }}
+        HIGHLIGHT_PATTERNS: ${{ inputs.highlight-patterns }}
+        MAX_KEY_LINES: ${{ inputs.max-key-lines }}
       run: |
         set +e
         if [ "$APPEND" != "true" ]; then
@@ -75,10 +96,41 @@ runs:
             gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" >> "$OUTPUT_FILE" 2>&1
             printf '\n##[endgroup]\n' >> "$OUTPUT_FILE"
           done
+        # Extract high-signal lines from the *full* log before tail-capping, so a
+        # root cause buried mid-log (e.g. a benchmark that fails early while later
+        # benchmarks keep running and push the cause far above the tail) is not
+        # lost. Runs against the uncapped body; the banner is prepended after the
+        # cap below so it always survives.
+        KEY_FILE=""
+        if [ -n "$HIGHLIGHT_PATTERNS" ]; then
+          PAT_FILE="$(mktemp)"
+          printf '%s\n' "$HIGHLIGHT_PATTERNS" | grep -v '^[[:space:]]*$' > "$PAT_FILE"
+          KEY_FILE="$(mktemp)"
+          # -n: keep line numbers for locatability; cut: bound pathological long
+          # lines (some log lines are multi-KB JSON); awk: dedupe preserving
+          # order; head: bound total volume.
+          grep -nE -f "$PAT_FILE" "$OUTPUT_FILE" 2>/dev/null \
+            | cut -c1-500 \
+            | awk '!seen[$0]++' \
+            | head -n "$MAX_KEY_LINES" > "$KEY_FILE"
+          rm -f "$PAT_FILE"
+          [ -s "$KEY_FILE" ] || { rm -f "$KEY_FILE"; KEY_FILE=""; }
+        fi
         if [ "$CAP" = "true" ] && [ "$(wc -c < "$OUTPUT_FILE" 2>/dev/null || echo 0)" -gt "$MAX_BYTES" ]; then
           tail -c "$MAX_BYTES" "$OUTPUT_FILE" > "${OUTPUT_FILE}.tmp"
           printf '[truncated to last %s bytes]\n' "$MAX_BYTES" > "$OUTPUT_FILE"
           cat "${OUTPUT_FILE}.tmp" >> "$OUTPUT_FILE"
           rm "${OUTPUT_FILE}.tmp"
+        fi
+        if [ -n "$KEY_FILE" ]; then
+          {
+            printf '##[group]KEY FAILURE LINES (grepped from full pre-truncation log; line numbers included)\n'
+            cat "$KEY_FILE"
+            printf '##[endgroup]\n'
+            printf -- '--- full job log(s) follow (may be tail-truncated) ---\n'
+          } > "${OUTPUT_FILE}.tmp"
+          cat "$OUTPUT_FILE" >> "${OUTPUT_FILE}.tmp"
+          mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
+          rm -f "$KEY_FILE"
         fi
         exit 0

--- a/.github/codex/prompts/benchmark-triage.md
+++ b/.github/codex/prompts/benchmark-triage.md
@@ -17,6 +17,14 @@ directory: `failed-logs.txt`. Each failed job is preceded by a line like:
 
 If the file is missing, empty, or unreadable, output one line saying so and stop.
 
+The body of each job's logs may be **tail-truncated** to bound size. To compensate,
+the file usually opens with a `##[group]KEY FAILURE LINES` block: decisive lines
+(errors, tracebacks, the per-test status table, crash markers) grepped from the
+*full* pre-truncation log, with their original line numbers. **Read this block
+first** — it typically contains the actual root cause even when the truncated body
+below it does not. Only fall back to "cause is past the truncation boundary" if the
+KEY FAILURE LINES block is absent or genuinely uninformative.
+
 ## Task
 
 Classify each distinct failure and produce a Slack-bound triage summary.
@@ -36,6 +44,27 @@ Use exactly one of these labels per failure:
 
 Distinguish facts from inference. Use "the logs show" for facts and "likely" or
 "possible" for hypotheses. Do not invent test names, file paths, or numbers.
+
+### Reading the per-test status table and known infra flakes
+
+- The per-test summary table rows like
+  `|<setup>|<test>|server|exception|...` and `|...|client|exception|...` mean the
+  harness *marked the test failed* — they do **not** by themselves imply the Redis
+  server or client crashed. Always find the line that explains *why* (search the
+  KEY FAILURE LINES block for `CRITICAL:root:`, `Traceback`, `ERROR:root:`,
+  `Failing test....`). Do not report a `benchmark-crash` solely because the status
+  table says `exception`.
+- **Known infra flake — post-benchmark metrics export.** `redisbench_admin` runs
+  the benchmark, then pushes metrics to a central RedisTimeSeries instance. If that
+  export fails it logs `The benchmark itself completed successfully, but the metrics
+  export to RedisTimeSeries failed: ...` and then force-fails the test
+  (`CRITICAL:root:Exception during remote work ... Failing test....`), usually with
+  `Connection reset by peer` / `[Errno 104]` against a masked `***:***` host. This
+  is **not** a RediSearch regression, crash, or timeout — the benchmark passed and
+  only the metrics upload broke. Classify it `environment` with next step
+  `ignore-infra` (or `rerun-and-watch` if it recurs across many tests in one run).
+  Corroborating noise: repeated `WARNING ... Error while inserting datapoint` or
+  `Error while updating secondary data structures TSDB` against the same backend.
 
 ### Output
 
@@ -75,5 +104,6 @@ summarize the long tail in one line.
 
 - Do not propose code changes.
 - Do not include raw log excerpts longer than one line in the output.
-- If logs are truncated and the failure root cause is past the truncation
-  boundary, say `needs-more-evidence` rather than guessing.
+- If logs are truncated, the failure root cause is past the truncation boundary,
+  *and* the KEY FAILURE LINES block (if present) does not explain it, say
+  `needs-more-evidence` rather than guessing.

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -343,6 +343,27 @@ jobs:
       - uses: ./.github/actions/fetch-failed-run-logs
         with:
           github-token: ${{ github.token }}
+          # Benchmarks run sequentially and the runner keeps going after one
+          # fails, so a failing benchmark's root cause lands far above the
+          # tail-capped window (the final per-test summary table only reports a
+          # status, not the cause). Extract the decisive lines from the full log
+          # so they survive truncation. redisbench_admin / ftsb / memtier and
+          # crash markers:
+          highlight-patterns: |
+            CRITICAL:root:Exception during remote work
+            Failing test\.\.\.\.
+            ERROR:root:The benchmark returned an error exit status
+            RedisTimeSeries connection error while pushing metrics
+            The benchmark ran successfully but the post-benchmark metrics export failed
+            The benchmark itself completed successfully
+            Traceback \(most recent call last\)
+            ^Exception:
+            \|(server|client)\|(exception|error)\|
+            (Segmentation fault|signal SIG|core dumped|panicked at|AddressSanitizer|terminate called|Sanitizer)
+            Connection reset by peer
+            Connection refused
+            (Total Errors|Total Timeouts): [1-9]
+            ##\[error\]
       - name: Run Codex triage
         id: triage
         uses: ./.github/actions/codex-ci-triage


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Benchmark triage (`triage-benchmark-failures`) fetches failed-job logs via `fetch-failed-run-logs`, which tail-caps each job log to the last 200 KB. But benchmarks run sequentially and the runner keeps going after one fails, so a failing benchmark's root cause lands far above the retained window — only a bare per-test status table reaches the tail. The Codex prompt then sees `|server|exception|` rows and reports the cause as "past the truncation boundary".

   Concrete case ([run 27679514036](https://github.com/RediSearch/RediSearch/actions/runs/27679514036/job/81865070337)): `search-ftsb-1M-enwiki_abstract-hashes-gc` actually **passed** — only the post-benchmark metrics export to the central RedisTimeSeries instance reset (`Connection reset by peer`, errno 104), and `redisbench_admin` force-failed the test. The decisive `CRITICAL ... Failing test....` line was ~595 KB before the end of a 3.3 MB log, ~390 KB outside the 200 KB tail window, so triage classified it `[unknown] needs-more-evidence`.

2. **Change:**
   - `fetch-failed-run-logs`: add opt-in `highlight-patterns` / `max-key-lines`. Matching lines are grepped from the **full** pre-truncation log, deduped, and prepended under a `KEY FAILURE LINES` banner (with original line numbers) that survives the cap. Default empty → every existing caller is byte-identical.
   - `benchmark-runner`: pass `redisbench_admin`/ftsb/memtier + crash patterns to the benchmark triage fetch step.
   - `benchmark-triage` prompt: read the KEY block first; treat `|server|exception|` rows as "harness marked failed", not "server crashed"; recognize the "benchmark succeeded but metrics export to RedisTimeSeries failed" infra flake as `environment` / `ignore-infra`.

3. **Outcome:** Replaying the failing run through the new logic, 41 lines match (under the cap), the final file is 212 KB (bounded), and the root cause now sits at the top and survives. Triage would emit `[environment] ... metrics export to RedisTimeSeries reset (errno 104). Next: ignore-infra` instead of `[unknown] needs-more-evidence`.

#### Which additional issues this PR fixes

_None — internal CI tooling._

#### Main objects this PR modified

1. `.github/actions/fetch-failed-run-logs/action.yml`
2. `.github/workflows/benchmark-runner.yml`
3. `.github/codex/prompts/benchmark-triage.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal CI/triage tooling only; no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)